### PR TITLE
[EBPF] PatternScaner testutil -  support matching finished log

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -465,6 +465,7 @@
 /pkg/util/pdhutil/                      @DataDog/windows-agent
 /pkg/util/winutil/                      @DataDog/windows-agent
 /pkg/util/testutil/flake                @DataDog/agent-devx-loops
+/pkg/util/testutil/patternscanner.go    @DataDog/universal-service-monitoring @DataDog/ebpf-platform
 /pkg/util/testutil/docker               @DataDog/universal-service-monitoring @DataDog/ebpf-platform
 /pkg/util/trie                          @DataDog/container-integrations
 /pkg/languagedetection                  @DataDog/processes @DataDog/universal-service-monitoring

--- a/pkg/network/usm/sharedlibraries/testutil/testutil.go
+++ b/pkg/network/usm/sharedlibraries/testutil/testutil.go
@@ -31,7 +31,8 @@ var mux sync.Mutex
 // handle to the given paths.
 func OpenFromProcess(t *testing.T, programExecutable string, paths ...string) (*exec.Cmd, error) {
 	cmd := exec.Command(programExecutable, paths...)
-	patternScanner := protocolstestutil.NewScanner(regexp.MustCompile("awaiting signal"), protocolstestutil.NoPattern, make(chan struct{}, 1))
+	patternScanner, err := protocolstestutil.NewScanner(regexp.MustCompile("awaiting signal"), protocolstestutil.NoPattern, make(chan struct{}, 1))
+	require.NoError(t, err, "failed to create pattern scanner")
 	cmd.Stdout = patternScanner
 	cmd.Stderr = patternScanner
 

--- a/pkg/network/usm/sharedlibraries/testutil/testutil.go
+++ b/pkg/network/usm/sharedlibraries/testutil/testutil.go
@@ -31,7 +31,7 @@ var mux sync.Mutex
 // handle to the given paths.
 func OpenFromProcess(t *testing.T, programExecutable string, paths ...string) (*exec.Cmd, error) {
 	cmd := exec.Command(programExecutable, paths...)
-	patternScanner := protocolstestutil.NewScanner(regexp.MustCompile("awaiting signal"), make(chan struct{}, 1))
+	patternScanner := protocolstestutil.NewScanner(regexp.MustCompile("awaiting signal"), protocolstestutil.NoPattern, make(chan struct{}, 1))
 	cmd.Stdout = patternScanner
 	cmd.Stderr = patternScanner
 

--- a/pkg/util/testutil/docker/run.go
+++ b/pkg/util/testutil/docker/run.go
@@ -29,7 +29,8 @@ func Run(t testing.TB, cfg LifecycleConfig) error {
 		// Ensuring no previous instances exists.
 		killPreviousInstances(cfg)
 
-		scanner := testutil.NewScanner(cfg.LogPattern(), make(chan struct{}, 1))
+		//TODO: in the following PR move the scanner to be a field of the LifecycleConfig
+		scanner := testutil.NewScanner(cfg.LogPattern(), nil, make(chan struct{}, 1))
 		// attempt to start the container/s
 		ctx, err = run(t, cfg, scanner)
 		if err != nil {

--- a/pkg/util/testutil/docker/run.go
+++ b/pkg/util/testutil/docker/run.go
@@ -10,6 +10,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"os/exec"
 	"testing"
 	"time"
@@ -24,13 +25,15 @@ import (
 func Run(t testing.TB, cfg LifecycleConfig) error {
 	var err error
 	var ctx context.Context
+	var scanner *testutil.PatternScanner
 	for i := 0; i < cfg.Retries(); i++ {
 		t.Helper()
 		// Ensuring no previous instances exists.
 		killPreviousInstances(cfg)
 
 		//TODO: in the following PR move the scanner to be a field of the LifecycleConfig
-		scanner := testutil.NewScanner(cfg.LogPattern(), testutil.NoPattern, make(chan struct{}, 1))
+		scanner, err = testutil.NewScanner(cfg.LogPattern(), testutil.NoPattern, make(chan struct{}, 1))
+		require.NoError(t, err, "failed to create pattern scanner")
 		// attempt to start the container/s
 		ctx, err = run(t, cfg, scanner)
 		if err != nil {

--- a/pkg/util/testutil/docker/run.go
+++ b/pkg/util/testutil/docker/run.go
@@ -10,10 +10,11 @@ package docker
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )

--- a/pkg/util/testutil/docker/run.go
+++ b/pkg/util/testutil/docker/run.go
@@ -30,7 +30,7 @@ func Run(t testing.TB, cfg LifecycleConfig) error {
 		killPreviousInstances(cfg)
 
 		//TODO: in the following PR move the scanner to be a field of the LifecycleConfig
-		scanner := testutil.NewScanner(cfg.LogPattern(), nil, make(chan struct{}, 1))
+		scanner := testutil.NewScanner(cfg.LogPattern(), testutil.NoPattern, make(chan struct{}, 1))
 		// attempt to start the container/s
 		ctx, err = run(t, cfg, scanner)
 		if err != nil {

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -45,7 +45,7 @@ type PatternScanner struct {
 // at least one of the startPattern/finishPattern should be provided.
 func NewScanner(startPattern, finishPattern *regexp.Regexp, doneChan chan struct{}) (*PatternScanner, error) {
 	if startPattern == nil && finishPattern == nil {
-		return nil, fmt.Errorf("at least one pattern should be provided")
+		return nil, errors.New("at least one pattern should be provided")
 	}
 	return &PatternScanner{
 		startPattern:  startPattern,

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -9,7 +9,7 @@
 package testutil
 
 import (
-	"fmt"
+	"errors"
 	"regexp"
 	"strings"
 	"sync"

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -16,7 +16,7 @@ import (
 )
 
 // NoPattern is a sugar syntax for empty pattern
-var NoPattern *regexp.Regexp = nil
+var NoPattern *regexp.Regexp
 
 // PatternScanner is a helper to scan logs for a given pattern.
 type PatternScanner struct {

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -106,6 +106,7 @@ func (ps *PatternScanner) matchPatterns(line string) {
 
 func (ps *PatternScanner) notifyAndStop() {
 	ps.stopOnce.Do(func() {
+		ps.buffers = append(ps.buffers, ps.lineBuf) // flush the last line
 		ps.stopped = true
 		close(ps.DoneChan)
 	})

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 )
 
+// NoPattern is a sugar syntax for empty pattern
 var NoPattern *regexp.Regexp = nil
 
 // PatternScanner is a helper to scan logs for a given pattern.


### PR DESCRIPTION
### What does this PR do?

Adds support to match log indicating the target process has finished

### Motivation

This can be used as an IPC between the caller (usually golang UT) and the target application (containerized or bare command)

### Describe how to test/QA your changes

all current tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
Currently the dockerutils just pass nil. In the following PR, I will change the dockerutils to receive the PatternScanner as part of their basic config struct.