### PR TITLE
[CWS] Fix NetworkDeviceSerializer

### DIFF
--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1011,7 +1011,7 @@ func newNetworkDeviceSerializer(deviceCtx *model.NetworkDeviceContext, e *model.
 	return &NetworkDeviceSerializer{
 		NetNS:   deviceCtx.NetNS,
 		IfIndex: deviceCtx.IfIndex,
-		IfName:  e.FieldHandlers.ResolveNetworkDeviceIfName(e, &e.NetworkContext.Device),
+		IfName:  e.FieldHandlers.ResolveNetworkDeviceIfName(e, deviceCtx),
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR ensures we call the network device name resolver on the network device pointer provided as input, and not on the event network context device.

### Motivation

This prevented the `RawPacketEvent` from resolving its network device interface name since only the the generic `NetworkContext` is used.