### PR TITLE
[CWS] Use containerutils.ContainerID in user and group resolver

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -234,7 +234,7 @@ func (fh *EBPFFieldHandlers) ResolveRights(_ *model.Event, e *model.FileFields) 
 // ResolveChownUID resolves the ResolveProcessCacheEntry id of a chown event to a username
 func (fh *EBPFFieldHandlers) ResolveChownUID(ev *model.Event, e *model.ChownEvent) string {
 	if len(e.User) == 0 {
-		e.User, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.UID), string(ev.ContainerContext.ContainerID))
+		e.User, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.UID), ev.ContainerContext.ContainerID)
 	}
 	return e.User
 }
@@ -242,7 +242,7 @@ func (fh *EBPFFieldHandlers) ResolveChownUID(ev *model.Event, e *model.ChownEven
 // ResolveChownGID resolves the group id of a chown event to a group name
 func (fh *EBPFFieldHandlers) ResolveChownGID(ev *model.Event, e *model.ChownEvent) string {
 	if len(e.Group) == 0 {
-		e.Group, _ = fh.resolvers.UserGroupResolver.ResolveGroup(int(e.GID), string(ev.ContainerContext.ContainerID))
+		e.Group, _ = fh.resolvers.UserGroupResolver.ResolveGroup(int(e.GID), ev.ContainerContext.ContainerID)
 	}
 	return e.Group
 }
@@ -313,7 +313,7 @@ func (fh *EBPFFieldHandlers) ResolveProcessIsThread(_ *model.Event, process *mod
 // ResolveSetuidUser resolves the user of the Setuid event
 func (fh *EBPFFieldHandlers) ResolveSetuidUser(ev *model.Event, e *model.SetuidEvent) string {
 	if len(e.User) == 0 {
-		e.User, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.UID), string(ev.ContainerContext.ContainerID))
+		e.User, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.UID), ev.ContainerContext.ContainerID)
 	}
 	return e.User
 }
@@ -321,7 +321,7 @@ func (fh *EBPFFieldHandlers) ResolveSetuidUser(ev *model.Event, e *model.SetuidE
 // ResolveSetuidEUser resolves the effective user of the Setuid event
 func (fh *EBPFFieldHandlers) ResolveSetuidEUser(ev *model.Event, e *model.SetuidEvent) string {
 	if len(e.EUser) == 0 {
-		e.EUser, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.EUID), string(ev.ContainerContext.ContainerID))
+		e.EUser, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.EUID), ev.ContainerContext.ContainerID)
 	}
 	return e.EUser
 }
@@ -329,7 +329,7 @@ func (fh *EBPFFieldHandlers) ResolveSetuidEUser(ev *model.Event, e *model.Setuid
 // ResolveSetuidFSUser resolves the file-system user of the Setuid event
 func (fh *EBPFFieldHandlers) ResolveSetuidFSUser(ev *model.Event, e *model.SetuidEvent) string {
 	if len(e.FSUser) == 0 {
-		e.FSUser, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.FSUID), string(ev.ContainerContext.ContainerID))
+		e.FSUser, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.FSUID), ev.ContainerContext.ContainerID)
 	}
 	return e.FSUser
 }
@@ -337,7 +337,7 @@ func (fh *EBPFFieldHandlers) ResolveSetuidFSUser(ev *model.Event, e *model.Setui
 // ResolveSetgidGroup resolves the group of the Setgid event
 func (fh *EBPFFieldHandlers) ResolveSetgidGroup(ev *model.Event, e *model.SetgidEvent) string {
 	if len(e.Group) == 0 {
-		e.Group, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.GID), string(ev.ContainerContext.ContainerID))
+		e.Group, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.GID), ev.ContainerContext.ContainerID)
 	}
 	return e.Group
 }
@@ -345,7 +345,7 @@ func (fh *EBPFFieldHandlers) ResolveSetgidGroup(ev *model.Event, e *model.Setgid
 // ResolveSetgidEGroup resolves the effective group of the Setgid event
 func (fh *EBPFFieldHandlers) ResolveSetgidEGroup(ev *model.Event, e *model.SetgidEvent) string {
 	if len(e.EGroup) == 0 {
-		e.EGroup, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.EGID), string(ev.ContainerContext.ContainerID))
+		e.EGroup, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.EGID), ev.ContainerContext.ContainerID)
 	}
 	return e.EGroup
 }
@@ -353,7 +353,7 @@ func (fh *EBPFFieldHandlers) ResolveSetgidEGroup(ev *model.Event, e *model.Setgi
 // ResolveSetgidFSGroup resolves the file-system group of the Setgid event
 func (fh *EBPFFieldHandlers) ResolveSetgidFSGroup(ev *model.Event, e *model.SetgidEvent) string {
 	if len(e.FSGroup) == 0 {
-		e.FSGroup, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.FSGID), string(ev.ContainerContext.ContainerID))
+		e.FSGroup, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.FSGID), ev.ContainerContext.ContainerID)
 	}
 	return e.FSGroup
 }
@@ -383,7 +383,7 @@ func (fh *EBPFFieldHandlers) GetProcessCacheEntry(ev *model.Event, newEntryCb fu
 // ResolveFileFieldsGroup resolves the group id of the file to a group name
 func (fh *EBPFFieldHandlers) ResolveFileFieldsGroup(ev *model.Event, e *model.FileFields) string {
 	if len(e.Group) == 0 {
-		e.Group, _ = fh.resolvers.UserGroupResolver.ResolveGroup(int(e.GID), string(ev.ContainerContext.ContainerID))
+		e.Group, _ = fh.resolvers.UserGroupResolver.ResolveGroup(int(e.GID), ev.ContainerContext.ContainerID)
 	}
 	return e.Group
 }
@@ -403,7 +403,7 @@ func (fh *EBPFFieldHandlers) ResolveNetworkDeviceIfName(_ *model.Event, device *
 // ResolveFileFieldsUser resolves the user id of the file to a username
 func (fh *EBPFFieldHandlers) ResolveFileFieldsUser(ev *model.Event, e *model.FileFields) string {
 	if len(e.User) == 0 {
-		e.User, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.UID), string(ev.ContainerContext.ContainerID))
+		e.User, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.UID), ev.ContainerContext.ContainerID)
 	}
 	return e.User
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1632,7 +1632,7 @@ func (p *EBPFProbe) FlushDiscarders() error {
 }
 
 // RefreshUserCache refreshes the user cache
-func (p *EBPFProbe) RefreshUserCache(containerID string) error {
+func (p *EBPFProbe) RefreshUserCache(containerID containerutils.ContainerID) error {
 	return p.Resolvers.UserGroupResolver.RefreshCache(containerID)
 }
 
@@ -2508,7 +2508,7 @@ func (p *EBPFProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 
 		switch {
 		case action.InternalCallback != nil && rule.ID == bundled.RefreshUserCacheRuleID:
-			_ = p.RefreshUserCache(string(ev.ContainerContext.ContainerID))
+			_ = p.RefreshUserCache(ev.ContainerContext.ContainerID)
 
 		case action.InternalCallback != nil && rule.ID == bundled.RefreshSBOMRuleID && p.Resolvers.SBOMResolver != nil && len(ev.ContainerContext.ContainerID) > 0:
 			if err := p.Resolvers.SBOMResolver.RefreshSBOM(string(ev.ContainerContext.ContainerID)); err != nil {

--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -97,7 +98,7 @@ func (p *Probe) FlushDiscarders() error {
 }
 
 // RefreshUserCache refreshes the user cache
-func (p *Probe) RefreshUserCache(_ string) error {
+func (p *Probe) RefreshUserCache(_ containerutils.ContainerID) error {
 	return nil
 }
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1039,13 +1039,13 @@ func (p *EBPFResolver) SetProcessTTY(pce *model.ProcessCacheEntry) string {
 
 // SetProcessUsersGroups resolves and set users and groups
 func (p *EBPFResolver) SetProcessUsersGroups(pce *model.ProcessCacheEntry) {
-	pce.User, _ = p.userGroupResolver.ResolveUser(int(pce.Credentials.UID), string(pce.ContainerID))
-	pce.EUser, _ = p.userGroupResolver.ResolveUser(int(pce.Credentials.EUID), string(pce.ContainerID))
-	pce.FSUser, _ = p.userGroupResolver.ResolveUser(int(pce.Credentials.FSUID), string(pce.ContainerID))
+	pce.User, _ = p.userGroupResolver.ResolveUser(int(pce.Credentials.UID), pce.ContainerID)
+	pce.EUser, _ = p.userGroupResolver.ResolveUser(int(pce.Credentials.EUID), pce.ContainerID)
+	pce.FSUser, _ = p.userGroupResolver.ResolveUser(int(pce.Credentials.FSUID), pce.ContainerID)
 
-	pce.Group, _ = p.userGroupResolver.ResolveGroup(int(pce.Credentials.GID), string(pce.ContainerID))
-	pce.EGroup, _ = p.userGroupResolver.ResolveGroup(int(pce.Credentials.EGID), string(pce.ContainerID))
-	pce.FSGroup, _ = p.userGroupResolver.ResolveGroup(int(pce.Credentials.FSGID), string(pce.ContainerID))
+	pce.Group, _ = p.userGroupResolver.ResolveGroup(int(pce.Credentials.GID), pce.ContainerID)
+	pce.EGroup, _ = p.userGroupResolver.ResolveGroup(int(pce.Credentials.EGID), pce.ContainerID)
+	pce.FSGroup, _ = p.userGroupResolver.ResolveGroup(int(pce.Credentials.FSGID), pce.ContainerID)
 }
 
 // Get returns the cache entry for a specified pid

--- a/pkg/security/resolvers/usergroup/resolver_linux.go
+++ b/pkg/security/resolvers/usergroup/resolver_linux.go
@@ -16,6 +16,7 @@ import (
 	usergrouputils "github.com/DataDog/datadog-agent/pkg/security/common/usergrouputils"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"golang.org/x/time/rate"
@@ -38,8 +39,8 @@ type EntryCache struct {
 // Resolver resolves user and group ids to names
 type Resolver struct {
 	cgroupResolver *cgroup.Resolver
-	nsUserCache    *lru.Cache[string, *EntryCache]
-	nsGroupCache   *lru.Cache[string, *EntryCache]
+	nsUserCache    *lru.Cache[containerutils.ContainerID, *EntryCache]
+	nsGroupCache   *lru.Cache[containerutils.ContainerID, *EntryCache]
 }
 
 type containerFS struct {
@@ -75,11 +76,11 @@ func (fs *hostFS) Open(path string) (fs.File, error) {
 	return os.Open(path)
 }
 
-func (r *Resolver) getFilesystem(containerID string) (fs.FS, error) {
+func (r *Resolver) getFilesystem(containerID containerutils.ContainerID) (fs.FS, error) {
 	var fsys fs.FS
 
 	if containerID != "" {
-		cgroupEntry, found := r.cgroupResolver.GetWorkload(containerID)
+		cgroupEntry, found := r.cgroupResolver.GetWorkload(string(containerID))
 		if !found {
 			return nil, fmt.Errorf("failed to resolve container %s", containerID)
 		}
@@ -92,7 +93,7 @@ func (r *Resolver) getFilesystem(containerID string) (fs.FS, error) {
 }
 
 // RefreshCache refresh the user and group caches with data from files
-func (r *Resolver) RefreshCache(containerID string) error {
+func (r *Resolver) RefreshCache(containerID containerutils.ContainerID) error {
 	fsys, err := r.getFilesystem(containerID)
 	if err != nil {
 		return err
@@ -109,7 +110,7 @@ func (r *Resolver) RefreshCache(containerID string) error {
 	return nil
 }
 
-func (r *Resolver) refreshUserCache(containerID string, fsys fs.FS) (map[int]string, error) {
+func (r *Resolver) refreshUserCache(containerID containerutils.ContainerID, fsys fs.FS) (map[int]string, error) {
 	entryCache, found := r.nsUserCache.Get(containerID)
 	if !found {
 		// add the entry cache before we parse the fill so that we also
@@ -131,7 +132,7 @@ func (r *Resolver) refreshUserCache(containerID string, fsys fs.FS) (map[int]str
 	return entries, nil
 }
 
-func (r *Resolver) refreshGroupCache(containerID string, fsys fs.FS) (map[int]string, error) {
+func (r *Resolver) refreshGroupCache(containerID containerutils.ContainerID, fsys fs.FS) (map[int]string, error) {
 	entryCache, found := r.nsGroupCache.Get(containerID)
 	if !found {
 		entryCache = &EntryCache{rateLimiter: rate.NewLimiter(rate.Limit(refreshCacheRateLimit), refreshCacheRateBurst)}
@@ -152,7 +153,7 @@ func (r *Resolver) refreshGroupCache(containerID string, fsys fs.FS) (map[int]st
 }
 
 // ResolveUser resolves a user id to a username
-func (r *Resolver) ResolveUser(uid int, containerID string) (string, error) {
+func (r *Resolver) ResolveUser(uid int, containerID containerutils.ContainerID) (string, error) {
 	userCache, found := r.nsUserCache.Get(containerID)
 	if found {
 		cachedEntry, found := userCache.entries[uid]
@@ -181,7 +182,7 @@ func (r *Resolver) ResolveUser(uid int, containerID string) (string, error) {
 }
 
 // ResolveGroup resolves a group id to a group name
-func (r *Resolver) ResolveGroup(gid int, containerID string) (string, error) {
+func (r *Resolver) ResolveGroup(gid int, containerID containerutils.ContainerID) (string, error) {
 	groupCache, found := r.nsGroupCache.Get(containerID)
 	if found {
 		cachedEntry, found := groupCache.entries[gid]
@@ -211,18 +212,18 @@ func (r *Resolver) ResolveGroup(gid int, containerID string) (string, error) {
 
 // OnCGroupDeletedEvent is used to handle a CGroupDeleted event
 func (r *Resolver) OnCGroupDeletedEvent(sbom *cgroupModel.CacheEntry) {
-	r.nsGroupCache.Remove(string(sbom.CGroupID))
-	r.nsUserCache.Remove(string(sbom.CGroupID))
+	r.nsGroupCache.Remove(sbom.ContainerID)
+	r.nsUserCache.Remove(sbom.ContainerID)
 }
 
 // NewResolver instantiates a new user and group resolver
 func NewResolver(cgroupResolver *cgroup.Resolver) (*Resolver, error) {
-	nsUserCache, err := lru.New[string, *EntryCache](64)
+	nsUserCache, err := lru.New[containerutils.ContainerID, *EntryCache](64)
 	if err != nil {
 		return nil, err
 	}
 
-	nsGroupCache, err := lru.New[string, *EntryCache](64)
+	nsGroupCache, err := lru.New[containerutils.ContainerID, *EntryCache](64)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Switch to containerutils.ContainerID type instead of string for user/group resolver.

### Motivation

This allows not mixing cgroup and container ids.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->