### PR TITLE
[CWS] switch arm64 fentry test to ubuntu 24.04

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -361,7 +361,7 @@ kmt_run_secagent_tests_arm64_fentry:
   parallel:
     matrix:
       - TAG:
-          - "amazon_2023"
+          - "ubuntu_24.04"
         TEST_SET: [cws_fentry]
   after_script:
     - !reference [.collect_outcomes_kmt]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

amazon 2023 is running on 6.1, and fentry are not supported on arm64 on kernel 6.1.

This PR switches this test to ubuntu 24.04, running on kernel 6.8.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->