### PR TITLE
[CWS] Use containerutils.ContainerID in cgroup resolver

### DIFF
--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -86,7 +87,7 @@ func NewEBPFLessHelloMsgEvent(acc *events.AgentContainerContext, msg *ebpfless.H
 	evt.Container.ID = msg.ContainerContext.ID
 
 	if tagger != nil {
-		tags, err := tags.GetTagsOfContainer(tagger, msg.ContainerContext.ID)
+		tags, err := tags.GetTagsOfContainer(tagger, containerutils.ContainerID(msg.ContainerContext.ID))
 		if err != nil {
 			seclog.Errorf("Failed to get tags for container %s: %v", msg.ContainerContext.ID, err)
 		} else {

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -84,7 +84,7 @@ func NewEBPFLessHelloMsgEvent(acc *events.AgentContainerContext, msg *ebpfless.H
 	evt := EBPFLessHelloMsgEvent{
 		NSID: msg.NSID,
 	}
-	evt.Container.ID = msg.ContainerContext.ID
+	evt.Container.ID = string(msg.ContainerContext.ID)
 
 	if tagger != nil {
 		tags, err := tags.GetTagsOfContainer(tagger, containerutils.ContainerID(msg.ContainerContext.ID))

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -525,7 +525,7 @@ func (fh *EBPFFieldHandlers) ResolveCGroupID(ev *model.Event, e *model.CGroupCon
 
 				entry.Process.CGroup.CGroupID = containerutils.CGroupID(cgroup)
 				entry.CGroup.CGroupID = containerutils.CGroupID(cgroup)
-				containerID, _ := containerutils.GetContainerFromCgroup(string(entry.CGroup.CGroupID))
+				containerID, _ := containerutils.GetContainerFromCgroup(entry.CGroup.CGroupID)
 				entry.Process.ContainerID = containerutils.ContainerID(containerID)
 				entry.ContainerID = containerutils.ContainerID(containerID)
 			} else {

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -578,7 +578,7 @@ func (fh *EBPFFieldHandlers) ResolveContainerCreatedAt(ev *model.Event, e *model
 // ResolveContainerTags resolves the container tags of the event
 func (fh *EBPFFieldHandlers) ResolveContainerTags(_ *model.Event, e *model.ContainerContext) []string {
 	if len(e.Tags) == 0 && e.ContainerID != "" {
-		e.Tags = fh.resolvers.TagsResolver.Resolve(string(e.ContainerID))
+		e.Tags = fh.resolvers.TagsResolver.Resolve(e.ContainerID)
 	}
 	return e.Tags
 }

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -190,7 +190,7 @@ func (fh *EBPFFieldHandlers) ResolveMountRootPath(ev *model.Event, e *model.Moun
 // ResolveContainerContext queries the cgroup resolver to retrieve the ContainerContext of the event
 func (fh *EBPFFieldHandlers) ResolveContainerContext(ev *model.Event) (*model.ContainerContext, bool) {
 	if ev.ContainerContext.ContainerID != "" && !ev.ContainerContext.Resolved {
-		if containerContext, _ := fh.resolvers.CGroupResolver.GetWorkload(string(ev.ContainerContext.ContainerID)); containerContext != nil {
+		if containerContext, _ := fh.resolvers.CGroupResolver.GetWorkload(ev.ContainerContext.ContainerID); containerContext != nil {
 			if containerContext.CGroupFlags.IsContainer() {
 				ev.ContainerContext = &containerContext.ContainerContext
 			}

--- a/pkg/security/probe/field_handlers_ebpfless.go
+++ b/pkg/security/probe/field_handlers_ebpfless.go
@@ -198,7 +198,7 @@ func (fh *EBPFLessFieldHandlers) ResolveContainerCreatedAt(ev *model.Event, e *m
 // ResolveContainerTags resolves the container tags of the event
 func (fh *EBPFLessFieldHandlers) ResolveContainerTags(_ *model.Event, e *model.ContainerContext) []string {
 	if len(e.Tags) == 0 && e.ContainerID != "" {
-		e.Tags = fh.resolvers.TagsResolver.Resolve(string(e.ContainerID))
+		e.Tags = fh.resolvers.TagsResolver.Resolve(e.ContainerID)
 	}
 	return e.Tags
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -54,7 +55,7 @@ type PlatformProbe interface {
 	GetFieldHandlers() model.FieldHandlers
 	DumpProcessCache(_ bool) (string, error)
 	AddDiscarderPushedCallback(_ DiscarderPushedCallback)
-	GetEventTags(_ string) []string
+	GetEventTags(_ containerutils.ContainerID) []string
 	GetProfileManager() interface{}
 	EnableEnforcement(bool)
 }
@@ -367,7 +368,7 @@ func (p *Probe) StatsPollingInterval() time.Duration {
 }
 
 // GetEventTags returns the event tags
-func (p *Probe) GetEventTags(containerID string) []string {
+func (p *Probe) GetEventTags(containerID containerutils.ContainerID) []string {
 	return p.PlatformProbe.GetEventTags(containerID)
 }
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -533,7 +533,7 @@ func (p *EBPFProbe) playSnapshot(notifyConsumers bool) {
 }
 
 func (p *EBPFProbe) sendAnomalyDetection(event *model.Event) {
-	tags := p.probe.GetEventTags(string(event.ContainerContext.ContainerID))
+	tags := p.probe.GetEventTags(event.ContainerContext.ContainerID)
 	if service := p.probe.GetService(event); service != "" {
 		tags = append(tags, "service:"+service)
 	}
@@ -1267,7 +1267,7 @@ func (p *EBPFProbe) AddDiscarderPushedCallback(cb DiscarderPushedCallback) {
 }
 
 // GetEventTags returns the event tags
-func (p *EBPFProbe) GetEventTags(containerID string) []string {
+func (p *EBPFProbe) GetEventTags(containerID containerutils.ContainerID) []string {
 	return p.Resolvers.TagsResolver.Resolve(containerID)
 }
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -810,12 +810,12 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		if pce != nil {
 			path, err := p.Resolvers.DentryResolver.Resolve(event.CgroupWrite.File.PathKey, true)
 			if err == nil && path != "" {
-				path = filepath.Dir(string(path))
-				pce.CGroup.CGroupID = containerutils.CGroupID(path)
-				pce.Process.CGroup.CGroupID = containerutils.CGroupID(path)
+				cgroupID := containerutils.CGroupID(filepath.Dir(string(path)))
+				pce.CGroup.CGroupID = cgroupID
+				pce.Process.CGroup.CGroupID = cgroupID
 				cgroupFlags := containerutils.CGroupFlags(event.CgroupWrite.CGroupFlags)
 				if cgroupFlags.IsContainer() {
-					containerID, _ := containerutils.GetContainerFromCgroup(path)
+					containerID, _ := containerutils.GetContainerFromCgroup(cgroupID)
 					pce.ContainerID = containerutils.ContainerID(containerID)
 					pce.Process.ContainerID = containerutils.ContainerID(containerID)
 				}

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -48,7 +48,7 @@ type client struct {
 	conn          net.Conn
 	probe         *EBPFLessProbe
 	nsID          uint64
-	containerID   string
+	containerID   containerutils.ContainerID
 	containerName string
 }
 
@@ -62,7 +62,7 @@ type EBPFLessProbe struct {
 	sync.Mutex
 
 	Resolvers         *resolvers.EBPFLessResolvers
-	containerContexts map[string]*ebpfless.ContainerContext
+	containerContexts map[containerutils.ContainerID]*ebpfless.ContainerContext
 
 	// Constants and configuration
 	opts         Opts
@@ -675,7 +675,7 @@ func NewEBPFLessProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFLess
 		cancelFnc:         cancelFnc,
 		clients:           make(map[net.Conn]*client),
 		processKiller:     processKiller,
-		containerContexts: make(map[string]*ebpfless.ContainerContext),
+		containerContexts: make(map[containerutils.ContainerID]*ebpfless.ContainerContext),
 	}
 
 	resolversOpts := resolvers.Opts{

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -632,7 +632,7 @@ func (p *EBPFLessProbe) DumpProcessCache(withArgs bool) (string, error) {
 func (p *EBPFLessProbe) AddDiscarderPushedCallback(_ DiscarderPushedCallback) {}
 
 // GetEventTags returns the event tags
-func (p *EBPFLessProbe) GetEventTags(containerID string) []string {
+func (p *EBPFLessProbe) GetEventTags(containerID containerutils.ContainerID) []string {
 	return p.Resolvers.TagsResolver.Resolve(containerID)
 }
 

--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -26,6 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -1455,7 +1456,7 @@ func (p *WindowsProbe) HandleActions(ctx *eval.Context, rule *rules.Rule) {
 func (p *WindowsProbe) AddDiscarderPushedCallback(_ DiscarderPushedCallback) {}
 
 // GetEventTags returns the event tags
-func (p *WindowsProbe) GetEventTags(_ string) []string {
+func (p *WindowsProbe) GetEventTags(_ containerutils.ContainerID) []string {
 	return nil
 }
 

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -9,6 +9,7 @@ package ebpfless
 import (
 	"encoding/json"
 
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"modernc.org/mathutil"
 )
@@ -93,7 +94,7 @@ const (
 
 // ContainerContext defines a container context
 type ContainerContext struct {
-	ID        string
+	ID        containerutils.ContainerID
 	CreatedAt uint64
 }
 
@@ -303,7 +304,7 @@ type SyscallMsg struct {
 	SpanContext  *SpanContext `json:",omitempty"`
 	Timestamp    uint64
 	Retval       int64
-	ContainerID  string
+	ContainerID  containerutils.ContainerID
 	Exec         *ExecSyscallMsg         `json:",omitempty"`
 	Open         *OpenSyscallMsg         `json:",omitempty"`
 	Fork         *ForkSyscallMsg         `json:",omitempty"`

--- a/pkg/security/ptracer/container_context.go
+++ b/pkg/security/ptracer/container_context.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 )
 
 // ECSMetadata defines ECS metadata
@@ -37,11 +38,11 @@ func retrieveECSMetadata(url string) (*ECSMetadata, error) {
 
 func retrieveEnvMetadata(ctx *ebpfless.ContainerContext) {
 	if id := os.Getenv("DD_CONTAINER_ID"); id != "" {
-		ctx.ID = id
+		ctx.ID = containerutils.ContainerID(id)
 	}
 }
 
-func newContainerContext(containerID string) (*ebpfless.ContainerContext, error) {
+func newContainerContext(containerID containerutils.ContainerID) (*ebpfless.ContainerContext, error) {
 	ctx := &ebpfless.ContainerContext{
 		ID: containerID,
 	}
@@ -54,7 +55,7 @@ func newContainerContext(containerID string) (*ebpfless.ContainerContext, error)
 		if data != nil {
 			if data.DockerID != "" && ctx.ID == "" {
 				// only set the container ID if we previously failed to retrieve it from proc
-				ctx.ID = data.DockerID
+				ctx.ID = containerutils.ContainerID(data.DockerID)
 			}
 		}
 	}

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 )
 
 const (
@@ -66,7 +67,7 @@ type CWSPtracerCtx struct {
 	wg           sync.WaitGroup
 	cancel       context.Context
 	cancelFnc    context.CancelFunc
-	containerID  string
+	containerID  containerutils.ContainerID
 	probeAddr    string
 	client       net.Conn
 	clientReady  chan bool

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -74,7 +74,7 @@ func getProcControlGroupsFromFile(path string) ([]controlGroup, error) {
 
 }
 
-func getContainerIDFromProcFS(cgroupPath string) (string, error) {
+func getContainerIDFromProcFS(cgroupPath string) (containerutils.ContainerID, error) {
 	cgroups, err := getProcControlGroupsFromFile(cgroupPath)
 	if err != nil {
 		return "", err
@@ -88,11 +88,11 @@ func getContainerIDFromProcFS(cgroupPath string) (string, error) {
 	return "", nil
 }
 
-func getCurrentProcContainerID() (string, error) {
+func getCurrentProcContainerID() (containerutils.ContainerID, error) {
 	return getContainerIDFromProcFS("/proc/self/cgroup")
 }
 
-func getProcContainerID(pid int) (string, error) {
+func getProcContainerID(pid int) (containerutils.ContainerID, error) {
 	return getContainerIDFromProcFS(fmt.Sprintf("/proc/%d/cgroup", pid))
 }
 

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -29,15 +29,15 @@ type CacheEntry struct {
 }
 
 // NewCacheEntry returns a new instance of a CacheEntry
-func NewCacheEntry(containerID string, cgroupFlags uint64, pids ...uint32) (*CacheEntry, error) {
+func NewCacheEntry(containerID containerutils.ContainerID, cgroupFlags uint64, pids ...uint32) (*CacheEntry, error) {
 	newCGroup := CacheEntry{
 		Deleted: atomic.NewBool(false),
 		CGroupContext: model.CGroupContext{
-			CGroupID:    containerutils.GetCgroupFromContainer(containerutils.ContainerID(containerID), containerutils.CGroupFlags(cgroupFlags)),
+			CGroupID:    containerutils.GetCgroupFromContainer(containerID, containerutils.CGroupFlags(cgroupFlags)),
 			CGroupFlags: containerutils.CGroupFlags(cgroupFlags),
 		},
 		ContainerContext: model.ContainerContext{
-			ContainerID: containerutils.ContainerID(containerID),
+			ContainerID: containerID,
 		},
 		PIDs: make(map[uint32]bool, 10),
 	}

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -285,7 +285,7 @@ func (resolver *Resolver) HashFileEvent(eventType model.EventType, ctrID contain
 	// add pid one for hash resolution outside of a container
 	rootPIDs := []uint32{1, pid}
 	if resolver.cgroupResolver != nil {
-		w, ok := resolver.cgroupResolver.GetWorkload(string(ctrID))
+		w, ok := resolver.cgroupResolver.GetWorkload(ctrID)
 		if ok {
 			rootPIDs = w.GetPIDs()
 		}

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -453,7 +453,7 @@ func (mr *Resolver) resolveMountPath(mountID uint32, device uint32, pid uint32, 
 	}
 
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
-	workload, _ := mr.cgroupsResolver.GetWorkload(string(containerID))
+	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
 	path, source, origin, err := mr.getMountPath(mountID, device, pid)
 	if err == nil {
@@ -494,7 +494,7 @@ func (mr *Resolver) resolveMount(mountID uint32, device uint32, pid uint32, cont
 	}
 
 	// force a resolution here to make sure the LRU keeps doing its job and doesn't evict important entries
-	workload, _ := mr.cgroupsResolver.GetWorkload(string(containerID))
+	workload, _ := mr.cgroupsResolver.GetWorkload(containerID)
 
 	mount, source, origin := mr.lookupMount(mountID, device, pid)
 	if mount != nil {

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -605,7 +605,7 @@ func (p *EBPFResolver) deleteEntry(pid uint32, exitTime time.Time) {
 	}
 
 	if p.cgroupResolver != nil {
-		p.cgroupResolver.DelPIDWithID(string(entry.ContainerID), entry.Pid)
+		p.cgroupResolver.DelPIDWithID(entry.ContainerID, entry.Pid)
 	}
 
 	entry.Exit(exitTime)

--- a/pkg/security/resolvers/process/resolver_ebpfless.go
+++ b/pkg/security/resolvers/process/resolver_ebpfless.go
@@ -104,7 +104,7 @@ func (p *EBPFLessResolver) AddForkEntry(key CacheResolverKey, ppid uint32, ts ui
 
 // NewEntry returns a new entry
 func (p *EBPFLessResolver) NewEntry(key CacheResolverKey, ppid uint32, file string, argv []string, argsTruncated bool,
-	envs []string, envsTruncated bool, ctrID string, ts uint64, tty string, source uint64) *model.ProcessCacheEntry {
+	envs []string, envsTruncated bool, ctrID containerutils.ContainerID, ts uint64, tty string, source uint64) *model.ProcessCacheEntry {
 
 	entry := p.processCacheEntryPool.Get()
 	entry.PIDContext.Pid = key.Pid
@@ -146,7 +146,7 @@ func (p *EBPFLessResolver) NewEntry(key CacheResolverKey, ppid uint32, file stri
 
 // AddExecEntry adds an entry to the local cache and returns the newly created entry
 func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, ppid uint32, file string, argv []string, argsTruncated bool,
-	envs []string, envsTruncated bool, ctrID string, ts uint64, tty string) *model.ProcessCacheEntry {
+	envs []string, envsTruncated bool, ctrID containerutils.ContainerID, ts uint64, tty string) *model.ProcessCacheEntry {
 	if key.Pid == 0 {
 		return nil
 	}
@@ -163,7 +163,7 @@ func (p *EBPFLessResolver) AddExecEntry(key CacheResolverKey, ppid uint32, file 
 
 // AddProcFSEntry add a procfs entry
 func (p *EBPFLessResolver) AddProcFSEntry(key CacheResolverKey, ppid uint32, file string, argv []string, argsTruncated bool,
-	envs []string, envsTruncated bool, ctrID string, ts uint64, tty string) *model.ProcessCacheEntry {
+	envs []string, envsTruncated bool, ctrID containerutils.ContainerID, ts uint64, tty string) *model.ProcessCacheEntry {
 	if key.Pid == 0 {
 		return nil
 	}

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -36,9 +36,9 @@ type Tagger interface {
 type Resolver interface {
 	Start(ctx context.Context) error
 	Stop() error
-	Resolve(id string) []string
-	ResolveWithErr(fid string) ([]string, error)
-	GetValue(id string, tag string) string
+	Resolve(id containerutils.ContainerID) []string
+	ResolveWithErr(fid containerutils.ContainerID) ([]string, error)
+	GetValue(id containerutils.ContainerID, tag string) string
 }
 
 // DefaultResolver represents a default resolver based directly on the underlying tagger
@@ -47,14 +47,14 @@ type DefaultResolver struct {
 }
 
 // Resolve returns the tags for the given id
-func (t *DefaultResolver) Resolve(id string) []string {
+func (t *DefaultResolver) Resolve(id containerutils.ContainerID) []string {
 	tags, _ := t.ResolveWithErr(id)
 	return tags
 }
 
 // ResolveWithErr returns the tags for the given id
-func (t *DefaultResolver) ResolveWithErr(id string) ([]string, error) {
-	return GetTagsOfContainer(t.tagger, containerutils.ContainerID(id))
+func (t *DefaultResolver) ResolveWithErr(id containerutils.ContainerID) ([]string, error) {
+	return GetTagsOfContainer(t.tagger, id)
 }
 
 // GetTagsOfContainer returns the tags for the given container id
@@ -69,7 +69,7 @@ func GetTagsOfContainer(tagger Tagger, containerID containerutils.ContainerID) (
 }
 
 // GetValue return the tag value for the given id and tag name
-func (t *DefaultResolver) GetValue(id string, tag string) string {
+func (t *DefaultResolver) GetValue(id containerutils.ContainerID, tag string) string {
 	return utils.GetTagValue(tag, t.Resolve(id))
 }
 

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -53,17 +54,17 @@ func (t *DefaultResolver) Resolve(id string) []string {
 
 // ResolveWithErr returns the tags for the given id
 func (t *DefaultResolver) ResolveWithErr(id string) ([]string, error) {
-	return GetTagsOfContainer(t.tagger, id)
+	return GetTagsOfContainer(t.tagger, containerutils.ContainerID(id))
 }
 
 // GetTagsOfContainer returns the tags for the given container id
 // exported to share the code with other non-resolver users of tagger
-func GetTagsOfContainer(tagger Tagger, containerID string) ([]string, error) {
+func GetTagsOfContainer(tagger Tagger, containerID containerutils.ContainerID) ([]string, error) {
 	if tagger == nil {
 		return nil, nil
 	}
 
-	entityID := types.NewEntityID(types.ContainerID, containerID)
+	entityID := types.NewEntityID(types.ContainerID, string(containerID))
 	return tagger.Tag(entityID, types.OrchestratorCardinality)
 }
 

--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -79,7 +79,7 @@ func (t *LinuxResolver) checkTags(workload *cgroupModel.CacheEntry) {
 
 // fetchTags fetches tags for the provided workload
 func (t *LinuxResolver) fetchTags(container *cgroupModel.CacheEntry) error {
-	newTags, err := t.ResolveWithErr(string(container.ContainerID))
+	newTags, err := t.ResolveWithErr(container.ContainerID)
 	if err != nil {
 		return fmt.Errorf("failed to resolve %s: %w", container.ContainerID, err)
 	}

--- a/pkg/security/resolvers/usergroup/resolver_linux.go
+++ b/pkg/security/resolvers/usergroup/resolver_linux.go
@@ -80,7 +80,7 @@ func (r *Resolver) getFilesystem(containerID containerutils.ContainerID) (fs.FS,
 	var fsys fs.FS
 
 	if containerID != "" {
-		cgroupEntry, found := r.cgroupResolver.GetWorkload(string(containerID))
+		cgroupEntry, found := r.cgroupResolver.GetWorkload(containerID)
 		if !found {
 			return nil, fmt.Errorf("failed to resolve container %s", containerID)
 		}

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -446,7 +446,7 @@ func (e *RuleEngine) RuleMatch(rule *rules.Rule, event eval.Event) bool {
 		// the container tags might not be resolved yet
 		if time.Unix(0, int64(ev.ContainerContext.CreatedAt)).Add(TagMaxResolutionDelay).After(time.Now()) {
 			extTagsCb = func() []string {
-				return e.probe.GetEventTags(string(containerID))
+				return e.probe.GetEventTags(containerID)
 			}
 		}
 	}

--- a/pkg/security/secl/containerutils/cgroup.go
+++ b/pkg/security/secl/containerutils/cgroup.go
@@ -56,11 +56,11 @@ func GetCGroupManager(cgroup string) (string, CGroupFlags) {
 }
 
 // GetContainerFromCgroup extracts the container ID from a cgroup name
-func GetContainerFromCgroup(cgroup string) (string, CGroupFlags) {
-	cgroup = strings.TrimLeft(cgroup, "/")
+func GetContainerFromCgroup(cgroup CGroupID) (ContainerID, CGroupFlags) {
+	cgroupID := strings.TrimLeft(string(cgroup), "/")
 	for runtimePrefix, runtimeFlag := range RuntimePrefixes {
-		if strings.HasPrefix(cgroup, runtimePrefix) {
-			return cgroup[len(runtimePrefix):], CGroupFlags(runtimeFlag)
+		if strings.HasPrefix(cgroupID, runtimePrefix) {
+			return ContainerID(cgroupID[len(runtimePrefix):]), CGroupFlags(runtimeFlag)
 		}
 	}
 	return "", 0

--- a/pkg/security/secl/containerutils/helpers.go
+++ b/pkg/security/secl/containerutils/helpers.go
@@ -34,7 +34,7 @@ func isSystemdCgroup(cgroup string) bool {
 }
 
 // FindContainerID extracts the first sub string that matches the pattern of a container ID along with the container flags induced from the container runtime prefix
-func FindContainerID(s string) (string, uint64) {
+func FindContainerID(s string) (ContainerID, uint64) {
 	match := containerIDPattern.FindIndex([]byte(s))
 	if match == nil {
 		if isSystemdCgroup(s) {
@@ -69,9 +69,9 @@ func FindContainerID(s string) (string, uint64) {
 	// it starts or/and ends the initial string
 
 	cgroupID := s[match[0]:match[1]]
-	containerID, flags := GetContainerFromCgroup(cgroupID)
+	containerID, flags := GetContainerFromCgroup(CGroupID(cgroupID))
 	if containerID == "" {
-		return cgroupID, uint64(flags)
+		return ContainerID(cgroupID), uint64(flags)
 	}
 
 	return containerID, uint64(flags)

--- a/pkg/security/secl/containerutils/helpers_test.go
+++ b/pkg/security/secl/containerutils/helpers_test.go
@@ -93,7 +93,7 @@ func TestFindContainerID(t *testing.T) {
 
 	for _, test := range testCases {
 		containerID, containerFlags := FindContainerID(test.input)
-		assert.Equal(t, test.output, containerID)
+		assert.Equal(t, test.output, string(containerID))
 		assert.Equal(t, uint64(test.flags), containerFlags, "wrong flags for container %s", containerID)
 	}
 }

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -621,7 +622,7 @@ func (ad *ActivityDump) resolveTags() error {
 	}
 
 	var err error
-	ad.Tags, err = ad.adm.resolvers.TagsResolver.ResolveWithErr(ad.Metadata.ContainerID)
+	ad.Tags, err = ad.adm.resolvers.TagsResolver.ResolveWithErr(containerutils.ContainerID(ad.Metadata.ContainerID))
 	if err != nil {
 		return fmt.Errorf("failed to resolve %s: %w", ad.Metadata.ContainerID, err)
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Switch to ContainerID and CGroupID types instead of string in cgroup resolver.

### Motivation

This allows not mixing cgroup and container ids.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->