### PR TITLE
worktree: Use git clone instead of git worktree

### DIFF
--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -29,8 +29,14 @@ def init_env(ctx, branch: str | None = None):
     if not WORKTREE_DIRECTORY.is_dir():
         print(f'{color_message("Info", Color.BLUE)}: Cloning datadog agent into {WORKTREE_DIRECTORY}')
         remote = ctx.run("git remote get-url origin", hide=True).stdout.strip()
-        if not ctx.run(
-            f"git clone '{remote}' '{WORKTREE_DIRECTORY}' -b {branch or 'main'} --filter=blob:none", warn=True
+        # Try to use this option to reduce cloning time
+        if all(
+            not ctx.run(
+                f"git clone '{remote}' '{WORKTREE_DIRECTORY}' -b {branch or 'main'} {filter_option}",
+                warn=True,
+                hide=True,
+            )
+            for filter_option in ["--filter=blob:none", ""]
         ):
             raise Exit(
                 f'{color_message("Error", Color.RED)}: Cannot initialize worktree environment. You might want to reset the worktree directory with `inv worktree.remove`',

--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -27,7 +27,11 @@ def init_env(ctx, branch: str | None = None):
     """
 
     if not WORKTREE_DIRECTORY.is_dir():
-        if not ctx.run(f"git worktree add '{WORKTREE_DIRECTORY}' origin/{branch or 'main'}", warn=True):
+        print(f'{color_message("Info", Color.BLUE)}: Cloning datadog agent into {WORKTREE_DIRECTORY}')
+        remote = ctx.run("git remote get-url origin", hide=True).stdout.strip()
+        if not ctx.run(
+            f"git clone '{remote}' '{WORKTREE_DIRECTORY}' -b {branch or 'main'} --filter=blob:none", warn=True
+        ):
             raise Exit(
                 f'{color_message("Error", Color.RED)}: Cannot initialize worktree environment. You might want to reset the worktree directory with `inv worktree.remove`',
                 code=1,
@@ -47,7 +51,7 @@ def init_env(ctx, branch: str | None = None):
 def remove_env(ctx):
     """Will remove the environment for commands applying to a worktree."""
 
-    ctx.run(f"git worktree remove -f '{WORKTREE_DIRECTORY}'", warn=True)
+    ctx.run(f"rm -rf '{WORKTREE_DIRECTORY}'", warn=True)
 
 
 def is_worktree():


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[Incident 32894]

When using a worktree, we cannot have the main repo switched to the same branch as the worktree directory. 

This might raise the error `fatal: 'main' is already checked out at '~/go/src/github.com/DataDog/datadog-agent-worktree'`. Fixed this by using a git clone.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->