### PR TITLE
[CWS] do not start/stop manually the remote tagger in the resolver

### DIFF
--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -13,7 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Event defines the tags event type
@@ -26,8 +25,6 @@ const (
 
 // Tagger defines a Tagger for the Tags Resolver
 type Tagger interface {
-	Start(ctx context.Context) error
-	Stop() error
 	Tag(entity types.EntityID, cardinality types.TagCardinality) ([]string, error)
 	GlobalTags(cardinality types.TagCardinality) ([]string, error)
 }
@@ -74,31 +71,13 @@ func (t *DefaultResolver) GetValue(id containerutils.ContainerID, tag string) st
 }
 
 // Start the resolver
-func (t *DefaultResolver) Start(ctx context.Context) error {
-	if t.tagger == nil {
-		return nil
-	}
-
-	go func() {
-		if err := t.tagger.Start(ctx); err != nil {
-			log.Errorf("failed to init tagger: %s", err)
-		}
-	}()
-
-	go func() {
-		<-ctx.Done()
-		_ = t.tagger.Stop()
-	}()
-
+func (t *DefaultResolver) Start(_ context.Context) error {
 	return nil
 }
 
 // Stop the resolver
 func (t *DefaultResolver) Stop() error {
-	if t.tagger == nil {
-		return nil
-	}
-	return t.tagger.Stop()
+	return nil
 }
 
 // NewDefaultResolver returns a new default tags resolver

--- a/pkg/security/tests/fake_tags_resolver.go
+++ b/pkg/security/tests/fake_tags_resolver.go
@@ -9,7 +9,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -24,16 +23,6 @@ import (
 type FakeTagger struct {
 	sync.Mutex
 	containerIDs []string
-}
-
-// Start the tagger
-func (fr *FakeTagger) Start(_ context.Context) error {
-	return nil
-}
-
-// Stop the tagger
-func (fr *FakeTagger) Stop() error {
-	return nil
 }
 
 // Tag returns the tags for the given id
@@ -68,16 +57,6 @@ func NewFakeTaggerDifferentImageNames() tags.Tagger {
 // FakeMonoTagger represents a fake mono tagger
 type FakeMonoTagger struct{}
 
-// Start the tagger
-func (fmr *FakeMonoTagger) Start(_ context.Context) error {
-	return nil
-}
-
-// Stop the tagger
-func (fmr *FakeMonoTagger) Stop() error {
-	return nil
-}
-
 // Tag returns the tags for the given id
 func (fmr *FakeMonoTagger) Tag(entity types.EntityID, _ types.TagCardinality) ([]string, error) {
 	return []string{"container_id:" + entity.GetID(), "image_name:fake_ubuntu", "image_tag:latest"}, nil
@@ -101,16 +80,6 @@ type FakeManualTagger struct {
 	containerToSelector map[string]*cgroupModel.WorkloadSelector
 	cpt                 int
 	nextSelectors       []*cgroupModel.WorkloadSelector
-}
-
-// Start the tagger
-func (fmr *FakeManualTagger) Start(_ context.Context) error {
-	return nil
-}
-
-// Stop the tagger
-func (fmr *FakeManualTagger) Stop() error {
-	return nil
 }
 
 // SpecifyNextSelector specifies the next image name and tag to be resolved


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where the remote tagger was `Start`ed and `Stop`ed both by the component lifecycle and by the CWS tags resolver causing some issues, especially some race around `t.stream` between the two run goroutines.

This PR simply removes the start/stop calls in the tags resolver.

### Motivation

### Describe how to test/QA your changes

Manually tested (with additional logs, showing that Start is really called only once). 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->