### PR TITLE
[tagger/remote] Make constructor private

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -97,7 +97,7 @@ type Options struct {
 
 // NewComponent returns a remote tagger
 func NewComponent(req Requires) (Provides, error) {
-	remoteTagger, err := NewRemoteTagger(req.Params, req.Config, req.Log, req.Telemetry)
+	remoteTagger, err := newRemoteTagger(req.Params, req.Config, req.Log, req.Telemetry)
 
 	if err != nil {
 		return Provides{}, err
@@ -116,9 +116,7 @@ func NewComponent(req Requires) (Provides, error) {
 	}, nil
 }
 
-// NewRemoteTagger creates a new remote tagger.
-// TODO: (components) remove once we pass the remote tagger instance to pkg/security/resolvers/tags/resolver.go
-func NewRemoteTagger(params tagger.RemoteParams, cfg config.Component, log log.Component, telemetryComp coretelemetry.Component) (tagger.Component, error) {
+func newRemoteTagger(params tagger.RemoteParams, cfg config.Component, log log.Component, telemetryComp coretelemetry.Component) (tagger.Component, error) {
 	telemetryStore := telemetry.NewStore(telemetryComp)
 
 	target, err := params.RemoteTarget(cfg)

--- a/comp/core/tagger/impl-remote/remote_test.go
+++ b/comp/core/tagger/impl-remote/remote_test.go
@@ -39,7 +39,7 @@ func TestStart(t *testing.T) {
 	log := logmock.New(t)
 	telemetry := nooptelemetry.GetCompatComponent()
 
-	remoteTagger, err := NewRemoteTagger(params, cfg, log, telemetry)
+	remoteTagger, err := newRemoteTagger(params, cfg, log, telemetry)
 	require.NoError(t, err)
 	err = remoteTagger.Start(context.TODO())
 	require.NoError(t, err)
@@ -61,7 +61,7 @@ func TestStartDoNotBlockIfServerIsNotAvailable(t *testing.T) {
 	log := logmock.New(t)
 	telemetry := nooptelemetry.GetCompatComponent()
 
-	remoteTagger, err := NewRemoteTagger(params, cfg, log, telemetry)
+	remoteTagger, err := newRemoteTagger(params, cfg, log, telemetry)
 	require.NoError(t, err)
 	err = remoteTagger.Start(context.TODO())
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Small cleanup in the remote tagger implementation.

There was a constructor that, as noted in the removed TODO comment, was only called by `pkg/security/resolvers/tags/resolver.go` but that's no longer the case, so it can be made private (still called by the public func just above).

### Describe how to test/QA your changes

Skip. Refactor covered by tests.
