### PR TITLE
[CWS] Fix GetEventTags prototype on macOS

### DIFF
--- a/pkg/security/probe/probe_others.go
+++ b/pkg/security/probe/probe_others.go
@@ -68,7 +68,7 @@ func (p *Probe) GetService(_ *model.Event) string {
 }
 
 // GetEventTags returns the event tags
-func (p *Probe) GetEventTags(_ string) []string {
+func (p *Probe) GetEventTags(_ containerutils.ContainerID) []string {
 	return nil
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix compilation of CWS on macOS.

### Motivation

Fix error:
```
# github.com/DataDog/datadog-agent/pkg/security/rules
pkg/security/rules/engine.go:449:33: cannot use containerID (variable of type containerutils.ContainerID) as string value in argument to e.probe.GetEventTags
```

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->