### PR TITLE
Increase extreme memory usage limit

### DIFF
--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -216,7 +216,7 @@ func TestChkRun(t *testing.T) {
 	diff1 := (pgaAfter1StRun - pgaBefore) / 1024
 	var extremePGAUsage float64
 	if isDbVersionGreaterOrEqualThan(&c, "12.2") {
-		extremePGAUsage = 1024
+		extremePGAUsage = 2048
 	} else {
 		extremePGAUsage = 8192
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR increases the limit for extreme PGA memory usage in integration tests.

### Motivation

In the CI environment, memory deallocation is slower, likely due to performance constraints, causing usage to slightly exceed the current limit. Testing with an older go-ora version (which has a [memory leak bug](https://github.com/sijms/go-ora/issues/477)) confirms the new limit properly raises the error when applicable.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->