### PR TITLE
[EBPF] docker testutils: store patternScanner in base config

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -56,6 +56,7 @@ import (
 	proccontainersmocks "github.com/DataDog/datadog-agent/pkg/process/util/containers/mocks"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	dockerutils "github.com/DataDog/datadog-agent/pkg/util/testutil/docker"
 )
 
@@ -795,13 +796,15 @@ func TestDocker(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
 
 	dir, _ := testutil.CurDir()
+	scanner, err := globalutils.NewScanner(regexp.MustCompile("Serving.*"), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("foo-server",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile("Serving.*"),
+		scanner,
 		dockerutils.EmptyEnv,
 		filepath.Join(dir, "testdata", "docker-compose.yml"))
-	err := dockerutils.Run(t, dockerCfg)
+	err = dockerutils.Run(t, dockerCfg)
 	require.NoError(t, err)
 
 	proc, err := procfs.NewDefaultFS()

--- a/pkg/network/protocols/amqp/server.go
+++ b/pkg/network/protocols/amqp/server.go
@@ -7,6 +7,7 @@ package amqp
 
 import (
 	"fmt"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -46,10 +47,12 @@ func RunServer(t testing.TB, serverAddr, serverPort string, enableTLS bool) erro
 
 	dir, _ := httpUtils.CurDir()
 
+	scanner, err := globalutils.NewScanner(startupRegexp, globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("amqp",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		startupRegexp,
+		scanner,
 		env,
 		filepath.Join(dir, "testdata", "docker-compose.yml"))
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/protocols/kafka/server.go
+++ b/pkg/network/protocols/kafka/server.go
@@ -8,6 +8,8 @@
 package kafka
 
 import (
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -40,10 +42,12 @@ func RunServer(t testing.TB, serverAddr, serverPort string) error {
 		return err
 	}
 
+	scanner, err := globalutils.NewScanner(regexp.MustCompile(`.*started \(kafka.server.KafkaServer\).*`), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("kafka",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile(`.*started \(kafka.server.KafkaServer\).*`),
+		scanner,
 		env,
 		filepath.Join(dir, "testdata", "docker-compose.yml"))
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/protocols/mongo/server.go
+++ b/pkg/network/protocols/mongo/server.go
@@ -7,6 +7,8 @@ package mongo
 
 import (
 	"fmt"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -31,10 +33,12 @@ func RunServer(t testing.TB, serverAddress, serverPort string) error {
 		"MONGO_PASSWORD=" + Pass,
 	}
 	dir, _ := testutil.CurDir()
+	scanner, err := globalutils.NewScanner(regexp.MustCompile(fmt.Sprintf(".*Waiting for connections.*port.*:%s.*", serverPort)), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("mongo",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile(fmt.Sprintf(".*Waiting for connections.*port.*:%s.*", serverPort)),
+		scanner,
 		env,
 		filepath.Join(dir, "testdata", "docker-compose.yml"))
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/protocols/mysql/server.go
+++ b/pkg/network/protocols/mysql/server.go
@@ -7,6 +7,7 @@ package mysql
 
 import (
 	"fmt"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -45,10 +46,12 @@ func RunServer(t testing.TB, serverAddr, serverPort string, withTLS bool) error 
 		env = append(env, "MYSQL_TLS_ARGS=--require-secure-transport --ssl-cert=/mysql-test/cert.pem.0 --ssl-key=/mysql-test/server.key")
 	}
 
+	scanner, err := globalutils.NewScanner(regexp.MustCompile(fmt.Sprintf(".*ready for connections.*port: %s.*", serverPort)), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("MYSQL",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile(fmt.Sprintf(".*ready for connections.*port: %s.*", serverPort)),
+		scanner,
 		env,
 		filepath.Join(dir, "testdata", "docker-compose.yml"))
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/protocols/postgres/server.go
+++ b/pkg/network/protocols/postgres/server.go
@@ -10,6 +10,7 @@ package postgres
 
 import (
 	"fmt"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	"io"
 	"os"
 	"path/filepath"
@@ -48,10 +49,13 @@ func RunServer(t testing.TB, serverAddr, serverPort string, enableTLS bool) erro
 		"ENCRYPTION_MODE=" + encryptionMode,
 		"TESTDIR=" + testDataDir,
 	}
+
+	scanner, err := globalutils.NewScanner(regexp.MustCompile(fmt.Sprintf(".*listening on IPv4 address \"0.0.0.0\", port %s", serverPort)), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("postgres",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile(fmt.Sprintf(".*listening on IPv4 address \"0.0.0.0\", port %s", serverPort)),
+		scanner,
 		env,
 		filepath.Join(testDataDir, "docker-compose.yml"))
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/protocols/redis/server.go
+++ b/pkg/network/protocols/redis/server.go
@@ -11,6 +11,7 @@ package redis
 
 import (
 	"fmt"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -42,10 +43,12 @@ func RunServer(t testing.TB, serverAddr, serverPort string, enableTLS bool) erro
 		env = append(env, args)
 	}
 
+	scanner, err := globalutils.NewScanner(regexp.MustCompile(".*Ready to accept connections"), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("redis",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile(".*Ready to accept connections"),
+		scanner,
 		env,
 		filepath.Join(dir, "testdata", "docker-compose.yml"))
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/protocols/tls/gotls/testutil/server.go
+++ b/pkg/network/protocols/tls/gotls/testutil/server.go
@@ -6,6 +6,8 @@
 package testutil
 
 import (
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
 	"regexp"
 	"testing"
 
@@ -21,10 +23,12 @@ func RunServer(t testing.TB, serverPort string) error {
 
 	t.Helper()
 	dir, _ := testutil.CurDir()
+	scanner, err := globalutils.NewScanner(regexp.MustCompile("go-httpbin listening on https://0.0.0.0:8080"), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("https-gotls",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile("go-httpbin listening on https://0.0.0.0:8080"),
+		scanner,
 		env,
 		dir+"/../testdata/docker-compose.yml")
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/protocols/tls/nodejs/nodejs.go
+++ b/pkg/network/protocols/tls/nodejs/nodejs.go
@@ -9,6 +9,8 @@
 package nodejs
 
 import (
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"path"
@@ -63,10 +65,12 @@ func RunServerNodeJS(t *testing.T, key, cert, serverPort string) error {
 		"TESTDIR=" + dir + "/testdata",
 	}
 
+	scanner, err := globalutils.NewScanner(regexp.MustCompile("Server running at https.*"), globalutils.NoPattern)
+	require.NoError(t, err, "failed to create pattern scanner")
 	dockerCfg := dockerutils.NewComposeConfig("nodejs-server",
 		dockerutils.DefaultTimeout,
 		dockerutils.DefaultRetries,
-		regexp.MustCompile("Server running at https.*"),
+		scanner,
 		env,
 		path.Join(dir, "testdata", "docker-compose.yml"))
 	return dockerutils.Run(t, dockerCfg)

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
+	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	"io"
 	"math/rand"
 	nethttp "net/http"
@@ -112,10 +113,12 @@ func (s *tlsSuite) TestHTTPSViaLibraryIntegration() {
 				require.NoError(t, err)
 
 				dir = path.Join(dir, "testdata", "musl")
+				scanner, err := globalutils.NewScanner(regexp.MustCompile("started"), globalutils.NoPattern)
+				require.NoError(t, err, "failed to create pattern scanner")
 				dockerCfg := dockerutils.NewComposeConfig("musl-alpine",
 					dockerutils.DefaultTimeout,
 					dockerutils.DefaultRetries,
-					regexp.MustCompile("started"),
+					scanner,
 					dockerutils.EmptyEnv,
 					path.Join(dir, "/docker-compose.yml"))
 				err = dockerutils.Run(t, dockerCfg)

--- a/pkg/network/usm/sharedlibraries/testutil/testutil.go
+++ b/pkg/network/usm/sharedlibraries/testutil/testutil.go
@@ -31,7 +31,7 @@ var mux sync.Mutex
 // handle to the given paths.
 func OpenFromProcess(t *testing.T, programExecutable string, paths ...string) (*exec.Cmd, error) {
 	cmd := exec.Command(programExecutable, paths...)
-	patternScanner, err := protocolstestutil.NewScanner(regexp.MustCompile("awaiting signal"), protocolstestutil.NoPattern, make(chan struct{}, 1))
+	patternScanner, err := protocolstestutil.NewScanner(regexp.MustCompile("awaiting signal"), protocolstestutil.NoPattern)
 	require.NoError(t, err, "failed to create pattern scanner")
 	cmd.Stdout = patternScanner
 	cmd.Stderr = patternScanner

--- a/pkg/util/testutil/docker/config.go
+++ b/pkg/util/testutil/docker/config.go
@@ -9,8 +9,9 @@ package docker
 
 import (
 	"fmt"
-	"regexp"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
 )
 
 const (
@@ -49,7 +50,7 @@ var _ LifecycleConfig = (*composeConfig)(nil)
 type LifecycleConfig interface {
 	Timeout() time.Duration
 	Retries() int
-	LogPattern() *regexp.Regexp
+	PatternScanner() *testutil.PatternScanner
 	Env() []string
 	Name() string
 	command() string
@@ -66,9 +67,9 @@ func (b baseConfig) Retries() int {
 	return b.retries
 }
 
-// LogPattern returns the regex pattern to match logs for readiness
-func (b baseConfig) LogPattern() *regexp.Regexp {
-	return b.logPattern
+// PatternScanner returns the patternScanner object used to match logs for readiness and completion of the target container/s
+func (b baseConfig) PatternScanner() *testutil.PatternScanner {
+	return b.patternScanner
 }
 
 // Env returns the environment variables to set for the container/s
@@ -83,11 +84,11 @@ func (b baseConfig) Name() string {
 
 // baseConfig contains shared configurations for both Docker and Docker Compose.
 type baseConfig struct {
-	name       string         // Container name for docker or an alias for docker-compose
-	timeout    time.Duration  // Timeout for the entire operation.
-	retries    int            // Number of retries for starting.
-	logPattern *regexp.Regexp // Regex pattern to match logs for readiness.
-	env        []string       // Environment variables to set.
+	name           string                   // Container name for docker or an alias for docker-compose
+	timeout        time.Duration            // Timeout for the entire operation.
+	retries        int                      // Number of retries for starting.
+	patternScanner *testutil.PatternScanner // Regex pattern to match logs for readiness.
+	env            []string                 // Environment variables to set.
 }
 
 // runConfig contains specific configurations for Docker containers, embedding BaseConfig.
@@ -153,16 +154,20 @@ func (c composeConfig) commandArgs(t subCommandType) []string {
 	}
 }
 
+func createBaseConfig(name string, timeout time.Duration, retries int, patternScanner *testutil.PatternScanner, env []string) baseConfig {
+	return baseConfig{
+		name:           name,
+		timeout:        timeout,
+		retries:        retries,
+		patternScanner: patternScanner,
+		env:            env,
+	}
+}
+
 // NewRunConfig creates a new runConfig instance for a single docker container.
-func NewRunConfig(name string, timeout time.Duration, retries int, logPattern *regexp.Regexp, env []string, imageName, binary string, binaryArgs []string, mounts map[string]string) LifecycleConfig {
+func NewRunConfig(name string, timeout time.Duration, retries int, patternScanner *testutil.PatternScanner, env []string, imageName, binary string, binaryArgs []string, mounts map[string]string) LifecycleConfig {
 	return runConfig{
-		baseConfig: baseConfig{
-			timeout:    timeout,
-			retries:    retries,
-			logPattern: logPattern,
-			env:        env,
-			name:       name,
-		},
+		baseConfig: createBaseConfig(name, timeout, retries, patternScanner, env),
 		ImageName:  imageName,
 		Binary:     binary,
 		BinaryArgs: binaryArgs,
@@ -171,15 +176,9 @@ func NewRunConfig(name string, timeout time.Duration, retries int, logPattern *r
 }
 
 // NewComposeConfig creates a new composeConfig instance for the docker-compose.
-func NewComposeConfig(name string, timeout time.Duration, retries int, logPattern *regexp.Regexp, env []string, file string) LifecycleConfig {
+func NewComposeConfig(name string, timeout time.Duration, retries int, patternScanner *testutil.PatternScanner, env []string, file string) LifecycleConfig {
 	return composeConfig{
-		baseConfig: baseConfig{
-			timeout:    timeout,
-			retries:    retries,
-			logPattern: logPattern,
-			env:        env,
-			name:       name,
-		},
-		File: file,
+		baseConfig: createBaseConfig(name, timeout, retries, patternScanner, env),
+		File:       file,
 	}
 }

--- a/pkg/util/testutil/docker/config.go
+++ b/pkg/util/testutil/docker/config.go
@@ -87,7 +87,7 @@ type baseConfig struct {
 	name           string                   // Container name for docker or an alias for docker-compose
 	timeout        time.Duration            // Timeout for the entire operation.
 	retries        int                      // Number of retries for starting.
-	patternScanner *testutil.PatternScanner // Regex pattern to match logs for readiness.
+	patternScanner *testutil.PatternScanner // Used to monitor container logs for known patterns.
 	env            []string                 // Environment variables to set.
 }
 

--- a/pkg/util/testutil/patternscanner.go
+++ b/pkg/util/testutil/patternscanner.go
@@ -43,14 +43,14 @@ type PatternScanner struct {
 
 // NewScanner returns a new instance of PatternScanner.
 // at least one of the startPattern/finishPattern should be provided.
-func NewScanner(startPattern, finishPattern *regexp.Regexp, doneChan chan struct{}) (*PatternScanner, error) {
+func NewScanner(startPattern, finishPattern *regexp.Regexp) (*PatternScanner, error) {
 	if startPattern == nil && finishPattern == nil {
 		return nil, errors.New("at least one pattern should be provided")
 	}
 	return &PatternScanner{
 		startPattern:  startPattern,
 		finishPattern: finishPattern,
-		DoneChan:      doneChan,
+		DoneChan:      make(chan struct{}, 1),
 		stopOnce:      sync.Once{},
 		// skip looking for start pattern if not provided
 		startPatternFound: startPattern == nil,


### PR DESCRIPTION
### What does this PR do?

Hold patternScanner as a baseconfig field, getting it from the caller (actual UTs)

_suggestion to review commit by commit_

### Motivation

Allow the caller to customize the required logs to monitor. Follow-up to this [PR](https://github.com/DataDog/datadog-agent/pull/31564).

### Describe how to test/QA your changes

All existing tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
- Encapsulated Done channel creation in PatternScanner ctor (to simplify the ctor)
- After this PR, I will rebase gpu UTs flaky tests fix [PR](https://github.com/DataDog/datadog-agent/pull/31544) to use the new API



