### PR TITLE
[CWS] Change tags retrieval retry logic

### DIFF
--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -102,8 +102,3 @@ func (cgce *CacheEntry) GetWorkloadSelectorCopy() *WorkloadSelector {
 		Tag:   cgce.WorkloadSelector.Tag,
 	}
 }
-
-// NeedsTagsResolution returns true if this workload is missing its tags
-func (cgce *CacheEntry) NeedsTagsResolution() bool {
-	return len(cgce.ContainerID) != 0 && !cgce.WorkloadSelector.IsReady()
-}

--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -88,7 +89,10 @@ func (t *LinuxResolver) checkTags(pendingWorkload *pendingWorkload) {
 				select {
 				case t.workloadsWithoutTags <- pendingWorkload:
 				default:
+					seclog.Warnf("Failed to requeue workload %s for tags retrieval", workload.ContainerID)
 				}
+			} else {
+				seclog.Debugf("Failed to resolve tags for workload %s", workload.ContainerID)
 			}
 			return
 		}

--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -16,11 +16,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
+type pendingWorkload struct {
+	*cgroupModel.CacheEntry
+	retries int
+}
+
 // LinuxResolver represents a default resolver based directly on the underlying tagger
 type LinuxResolver struct {
 	*DefaultResolver
 	*utils.Notifier[Event, *cgroupModel.CacheEntry]
-	workloadsWithoutTags chan *cgroupModel.CacheEntry
+	workloadsWithoutTags chan *pendingWorkload
 	cgroupResolver       *cgroup.Resolver
 }
 
@@ -30,7 +35,10 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 		return err
 	}
 
-	if err := t.cgroupResolver.RegisterListener(cgroup.CGroupCreated, t.checkTags); err != nil {
+	if err := t.cgroupResolver.RegisterListener(cgroup.CGroupCreated, func(cgce *cgroupModel.CacheEntry) {
+		workload := &pendingWorkload{CacheEntry: cgce, retries: 3}
+		t.checkTags(workload)
+	}); err != nil {
 		return err
 	}
 
@@ -46,12 +54,17 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 			case <-ctx.Done():
 				return
 			case <-delayerTick.C:
-				select {
-				case workload := <-t.workloadsWithoutTags:
-					t.checkTags(workload)
-				default:
-				}
 
+			WORKLOAD:
+				// we want to process approximately the number of workloads in the queue
+				for workloadCount := len(t.workloadsWithoutTags); workloadCount > 0; workloadCount-- {
+					select {
+					case workload := <-t.workloadsWithoutTags:
+						t.checkTags(workload)
+					default:
+						break WORKLOAD
+					}
+				}
 			}
 		}
 	}()
@@ -59,22 +72,29 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 	return nil
 }
 
+func needsTagsResolution(cgce *cgroupModel.CacheEntry) bool {
+	return len(cgce.ContainerID) != 0 && !cgce.WorkloadSelector.IsReady()
+}
+
 // checkTags checks if the tags of a workload were properly set
-func (t *LinuxResolver) checkTags(workload *cgroupModel.CacheEntry) {
-	// check if the workload tags were found
-	if workload.NeedsTagsResolution() {
-		// this is a container, try to resolve its tags now
-		if err := t.fetchTags(workload); err != nil || workload.NeedsTagsResolution() {
-			// push to the workloadsWithoutTags chan so that its tags can be resolved later
-			select {
-			case t.workloadsWithoutTags <- workload:
-			default:
+func (t *LinuxResolver) checkTags(pendingWorkload *pendingWorkload) {
+	workload := pendingWorkload.CacheEntry
+	// check if the workload tags were found or if it was deleted
+	if !workload.Deleted.Load() && needsTagsResolution(workload) {
+		// this is an alive cgroup, try to resolve its tags now
+		if err := t.fetchTags(workload); err != nil || needsTagsResolution(workload) {
+			if pendingWorkload.retries--; pendingWorkload.retries >= 0 {
+				// push to the workloadsWithoutTags chan so that its tags can be resolved later
+				select {
+				case t.workloadsWithoutTags <- pendingWorkload:
+				default:
+				}
 			}
 			return
 		}
-	}
 
-	t.NotifyListeners(WorkloadSelectorResolved, workload)
+		t.NotifyListeners(WorkloadSelectorResolved, workload)
+	}
 }
 
 // fetchTags fetches tags for the provided workload
@@ -92,7 +112,7 @@ func NewResolver(tagger Tagger, cgroupsResolver *cgroup.Resolver) *LinuxResolver
 	resolver := &LinuxResolver{
 		Notifier:             utils.NewNotifier[Event, *cgroupModel.CacheEntry](),
 		DefaultResolver:      NewDefaultResolver(tagger),
-		workloadsWithoutTags: make(chan *cgroupModel.CacheEntry, 100),
+		workloadsWithoutTags: make(chan *pendingWorkload, 100),
 		cgroupResolver:       cgroupsResolver,
 	}
 	return resolver


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Change the logic that retries fetching the tags of a container
when first resolution fails.

### Motivation

When we fail to resolve tags, we push the workload back into a queue
so that we retry later. But:
- we retry fetching tags for only one workload, every 10 seconds
- we don't check that the cgroup is still alive
- there is no limit on the number of retries. So if the tagger, for some reasons, fails to resolve the tags for a container, we'll try to resolve the tags for this container forever, filling the queue and potentially forbidding other workloads to be put into the queue.

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->