### PR TITLE
(fleet) cleanup installer_exec, remove the need to import repositories in the bootstrapper

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -41,12 +41,6 @@ const (
 type Installer interface {
 	IsInstalled(ctx context.Context, pkg string) (bool, error)
 
-	AvailableDiskSpace() (uint64, error)
-	State(pkg string) (repository.State, error)
-	States() (map[string]repository.State, error)
-	ConfigState(pkg string) (repository.State, error)
-	ConfigStates() (map[string]repository.State, error)
-
 	Install(ctx context.Context, url string, args []string) error
 	Remove(ctx context.Context, pkg string) error
 	Purge(ctx context.Context)
@@ -107,31 +101,6 @@ func NewInstaller(env *fleetEnv.Env) (Installer, error) {
 		userConfigsDir: paths.DefaultUserConfigsDir,
 		packagesDir:    paths.PackagesPath,
 	}, nil
-}
-
-// AvailableDiskSpace returns the available disk space.
-func (i *installerImpl) AvailableDiskSpace() (uint64, error) {
-	return i.packages.AvailableDiskSpace()
-}
-
-// State returns the state of a package.
-func (i *installerImpl) State(pkg string) (repository.State, error) {
-	return i.packages.GetState(pkg)
-}
-
-// States returns the states of all packages.
-func (i *installerImpl) States() (map[string]repository.State, error) {
-	return i.packages.GetStates()
-}
-
-// ConfigState returns the state of a package.
-func (i *installerImpl) ConfigState(pkg string) (repository.State, error) {
-	return i.configs.GetState(pkg)
-}
-
-// ConfigStates returns the states of all packages.
-func (i *installerImpl) ConfigStates() (map[string]repository.State, error) {
-	return i.configs.GetStates()
 }
 
 // IsInstalled checks if a package is installed.

--- a/pkg/fleet/internal/exec/installer_exec.go
+++ b/pkg/fleet/internal/exec/installer_exec.go
@@ -15,11 +15,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/fleet/internal/paths"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/fleet/env"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -197,40 +193,6 @@ func (i *InstallerExec) Setup(ctx context.Context) (err error) {
 		return fmt.Errorf("error running setup: %w\n%s", err, stderr.String())
 	}
 	return nil
-}
-
-// AvailableDiskSpace returns the available disk space.
-func (i *InstallerExec) AvailableDiskSpace() (uint64, error) {
-	repositories := repository.NewRepositories(paths.PackagesPath, paths.LocksPath)
-	return repositories.AvailableDiskSpace()
-}
-
-// State returns the state of a package.
-func (i *InstallerExec) State(pkg string) (repository.State, error) {
-	repositories := repository.NewRepositories(paths.PackagesPath, paths.LocksPath)
-	return repositories.Get(pkg).GetState()
-}
-
-// States returns the states of all packages.
-func (i *InstallerExec) States() (map[string]repository.State, error) {
-	repositories := repository.NewRepositories(paths.PackagesPath, paths.LocksPath)
-	states, err := repositories.GetStates()
-	log.Debugf("repositories states: %v", states)
-	return states, err
-}
-
-// ConfigState returns the state of a package's configuration.
-func (i *InstallerExec) ConfigState(pkg string) (repository.State, error) {
-	repositories := repository.NewRepositories(paths.ConfigsPath, paths.LocksPath)
-	return repositories.Get(pkg).GetState()
-}
-
-// ConfigStates returns the states of all packages' configurations.
-func (i *InstallerExec) ConfigStates() (map[string]repository.State, error) {
-	repositories := repository.NewRepositories(paths.ConfigsPath, paths.LocksPath)
-	states, err := repositories.GetStates()
-	log.Debugf("config repositories states: %v", states)
-	return states, err
 }
 
 // Close cleans up any resources.


### PR DESCRIPTION


This PR is a simple refactor to remove a dependency on repositories in installer_exec.

### Describe how to test/QA your changes

Covered by e2e