### PR TITLE
omnibus: don't bother creating the xz package for heroku

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -211,7 +211,7 @@ package :msi do
 end
 
 package :xz do
-  skip_packager (!do_build && !BUILD_OCIRU)
+  skip_packager (!do_build && !BUILD_OCIRU) || heroku_target?
   compression_threads COMPRESSION_THREADS
   compression_level COMPRESSION_LEVEL
 end


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Stop generating the intermediate xz package on heroku

### Motivation

This package is used when build & packaging is split, which isn't the case for heroku, so we can save ourselves the trouble of generating a 100MB + 50MB (regular build + debug symbols) archive in each pipeline
### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->