### PR TITLE
[ADXT-767] [lint] Exclude test/new-e2e from windows and macos linter

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -268,6 +268,7 @@ modules:
     lint_targets:
     - .
     - ./examples
+    should_test_condition: is_linux
     test_targets:
     - ./pkg/runner
     - ./pkg/utils/e2e/client


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Running linters for test/new-e2e on Windows caused us a lot of issue because the pulumi dependencies seem to cause too high memory usage.
The code should not be platform dependent so let's stop linting and testing on Windows specifically

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->