### PR TITLE
[CWS] add additional fentry check for weak duplicated symbols

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -373,6 +374,19 @@ func (k *Version) HaveFentrySupport() bool {
 // HaveFentrySupportWithStructArgs returns whether the kernel supports fentry probes with struct arguments
 func (k *Version) HaveFentrySupportWithStructArgs() bool {
 	return k.commonFentryCheck("audit_set_loginuid")
+}
+
+// HaveFentryNoDuplicatedWeakSymbols returns whether the kernel supports fentry probes with struct arguments
+func (k *Version) HaveFentryNoDuplicatedWeakSymbols() bool {
+	var symbol string
+	switch runtime.GOARCH {
+	case "amd64":
+		symbol = "__ia32_sys_setregid16"
+	default:
+		return true
+	}
+
+	return k.commonFentryCheck(symbol)
 }
 
 // SupportBPFSendSignal returns true if the eBPF function bpf_send_signal is available

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -206,6 +206,12 @@ func (p *EBPFProbe) selectFentryMode() {
 		return
 	}
 
+	if !p.kernelVersion.HaveFentryNoDuplicatedWeakSymbols() {
+		p.useFentry = false
+		seclog.Warnf("fentry enabled but not supported with duplicated weak symbols, falling back to kprobe mode")
+		return
+	}
+
 	p.useFentry = true
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds an additional check for duplicated symbols, matching the cilium/ebpf issue https://github.com/cilium/ebpf/issues/894.

Basically the issue is that if the BTF blob from the kernel contains multiple entries matching the name of the hooked function, it's not possible to know which one to hook and the underlying lib returns an error. There is no clear way around this for now, so this PR adds a check against this to disable fentry if we believe we might be hit by that.

One especially important example of this is some syscalls on x64 that have one real definition and one weak one resulting in duplicated types in the BTF.

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->