### PR TITLE
[CWS] remove hash burst config, since we always have burst = 1

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -114,7 +114,6 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.event_types", []string{"exec", "open"})
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_file_size", (1<<20)*10) // 10 MB
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_hash_rate", 500)
-	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_hash_burst", 1000)
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.hash_algorithms", []string{"sha1", "sha256", "ssdeep"})
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.cache_size", 500)
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.replace", map[string]string{})

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -215,8 +215,6 @@ type RuntimeSecurityConfig struct {
 	HashResolverMaxFileSize int64
 	// HashResolverMaxHashRate defines the rate at which the hash resolver may compute hashes
 	HashResolverMaxHashRate int
-	// HashResolverMaxHashBurst defines the burst of files for which the hash resolver may compute a hash
-	HashResolverMaxHashBurst int
 	// HashResolverHashAlgorithms defines the hashes that hash resolver needs to compute
 	HashResolverHashAlgorithms []model.HashAlgorithm
 	// HashResolverEventTypes defines the list of event which files may be hashed
@@ -407,7 +405,6 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		HashResolverEventTypes:     parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.event_types")),
 		HashResolverMaxFileSize:    pkgconfigsetup.SystemProbe().GetInt64("runtime_security_config.hash_resolver.max_file_size"),
 		HashResolverHashAlgorithms: parseHashAlgorithmStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.hash_resolver.hash_algorithms")),
-		HashResolverMaxHashBurst:   pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_burst"),
 		HashResolverMaxHashRate:    pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.hash_resolver.max_hash_rate"),
 		HashResolverCacheSize:      pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.hash_resolver.cache_size"),
 		HashResolverReplace:        pkgconfigsetup.SystemProbe().GetStringMapString("runtime_security_config.hash_resolver.replace"),

--- a/pkg/security/resolvers/hash/resolver_linux.go
+++ b/pkg/security/resolvers/hash/resolver_linux.go
@@ -126,6 +126,12 @@ func NewResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInte
 		}
 	}
 
+	burst := 1
+	// if the rate limiter is disabled, set the burst to 0
+	if c.HashResolverMaxHashRate == 0 {
+		burst = 0
+	}
+
 	r := &Resolver{
 		opts: ResolverOpts{
 			Enabled:        true,
@@ -135,7 +141,7 @@ func NewResolver(c *config.RuntimeSecurityConfig, statsdClient statsd.ClientInte
 		},
 		cgroupResolver: cgroupResolver,
 		statsdClient:   statsdClient,
-		limiter:        rate.NewLimiter(rate.Limit(c.HashResolverMaxHashRate), c.HashResolverMaxHashBurst),
+		limiter:        rate.NewLimiter(rate.Limit(c.HashResolverMaxHashRate), burst),
 		cache:          cache,
 		hashCount:      make(map[model.EventType]map[model.HashAlgorithm]*atomic.Uint64),
 		hashMiss:       make(map[model.EventType]map[model.HashState]*atomic.Uint64),

--- a/pkg/security/resolvers/hash/resolver_test.go
+++ b/pkg/security/resolvers/hash/resolver_test.go
@@ -52,7 +52,6 @@ func TestResolver_ComputeHashes(t *testing.T) {
 				HashResolverEventTypes:     []model.EventType{model.ExecEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.SHA1, model.SHA256, model.MD5},
 				HashResolverMaxHashRate:    1,
-				HashResolverMaxHashBurst:   1,
 				HashResolverMaxFileSize:    1 << 20,
 			},
 			args: args{
@@ -89,7 +88,6 @@ func TestResolver_ComputeHashes(t *testing.T) {
 				HashResolverEventTypes:     []model.EventType{model.FileOpenEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.SHA1, model.SHA256, model.MD5},
 				HashResolverMaxHashRate:    1,
-				HashResolverMaxHashBurst:   1,
 				HashResolverMaxFileSize:    1 << 20,
 			},
 			args: args{
@@ -122,7 +120,6 @@ func TestResolver_ComputeHashes(t *testing.T) {
 				HashResolverEventTypes:     []model.EventType{model.ExecEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.SHA1, model.SHA256, model.MD5},
 				HashResolverMaxHashRate:    1,
-				HashResolverMaxHashBurst:   1,
 				HashResolverMaxFileSize:    1 << 10,
 			},
 			args: args{
@@ -159,7 +156,6 @@ func TestResolver_ComputeHashes(t *testing.T) {
 				HashResolverEventTypes:     []model.EventType{model.ExecEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.SHA1, model.SHA256, model.MD5},
 				HashResolverMaxHashRate:    1,
-				HashResolverMaxHashBurst:   1,
 				HashResolverMaxFileSize:    1 << 10,
 			},
 			args: args{
@@ -192,7 +188,6 @@ func TestResolver_ComputeHashes(t *testing.T) {
 				HashResolverEventTypes:     []model.EventType{model.ExecEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.SHA1, model.SHA256, model.MD5},
 				HashResolverMaxHashRate:    0,
-				HashResolverMaxHashBurst:   0,
 				HashResolverMaxFileSize:    1 << 10,
 			},
 			args: args{
@@ -307,7 +302,6 @@ func BenchmarkHashFunctions(b *testing.B) {
 				HashResolverEventTypes:     []model.EventType{model.ExecEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.SHA1},
 				HashResolverMaxHashRate:    math.MaxInt,
-				HashResolverMaxHashBurst:   math.MaxInt,
 				HashResolverMaxFileSize:    math.MaxInt64,
 			},
 			fileSizes: []fileCase{
@@ -364,7 +358,6 @@ func BenchmarkHashFunctions(b *testing.B) {
 				HashResolverEventTypes:     []model.EventType{model.ExecEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.SHA256},
 				HashResolverMaxHashRate:    math.MaxInt,
-				HashResolverMaxHashBurst:   math.MaxInt,
 				HashResolverMaxFileSize:    math.MaxInt64,
 			},
 			fileSizes: []fileCase{
@@ -421,7 +414,6 @@ func BenchmarkHashFunctions(b *testing.B) {
 				HashResolverEventTypes:     []model.EventType{model.ExecEventType},
 				HashResolverHashAlgorithms: []model.HashAlgorithm{model.MD5},
 				HashResolverMaxHashRate:    math.MaxInt,
-				HashResolverMaxHashBurst:   math.MaxInt,
 				HashResolverMaxFileSize:    math.MaxInt64,
 			},
 			fileSizes: []fileCase{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes the burst config for the hash resolver rate limiter. It's not useful since we always only reserve one token.

### Motivation

### Describe how to test/QA your changes

This code has unit tests, and this config is really an internal config that is not used in the wild.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->