### PR TITLE
usm: config: Default USM configuration should not warn about using network_config.enable_http_monitoring

### DIFF
--- a/cmd/system-probe/config/adjust_usm.go
+++ b/cmd/system-probe/config/adjust_usm.go
@@ -19,7 +19,6 @@ const (
 
 func adjustUSM(cfg model.Config) {
 	if cfg.GetBool(smNS("enabled")) {
-		applyDefault(cfg, netNS("enable_http_monitoring"), true)
 		applyDefault(cfg, netNS("enable_https_monitoring"), true)
 		applyDefault(cfg, spNS("enable_runtime_compiler"), true)
 		applyDefault(cfg, spNS("enable_kernel_header_download"), true)
@@ -28,6 +27,7 @@ func adjustUSM(cfg model.Config) {
 	}
 
 	deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))
+	applyDefault(cfg, smNS("enable_http_monitoring"), true)
 	deprecateBool(cfg, netNS("enable_https_monitoring"), smNS("tls", "native", "enabled"))
 	deprecateBool(cfg, smNS("enable_go_tls_support"), smNS("tls", "go", "enabled"))
 	applyDefault(cfg, smNS("tls", "go", "enabled"), true)

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -483,7 +483,7 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 	assert.False(t, ia.data["feature_cws_security_profiles_enabled"].(bool))
 	assert.True(t, ia.data["feature_cws_remote_config_enabled"].(bool))
 	assert.False(t, ia.data["feature_networks_enabled"].(bool))
-	assert.False(t, ia.data["feature_networks_http_enabled"].(bool))
+	assert.True(t, ia.data["feature_networks_http_enabled"].(bool))
 	assert.False(t, ia.data["feature_networks_https_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_enabled"].(bool))
 	assert.False(t, ia.data["feature_usm_kafka_enabled"].(bool))

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -75,42 +75,48 @@ func TestDisablingProtocolClassification(t *testing.T) {
 }
 
 func TestEnableHTTPMonitoring(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		mock.NewSystemProbe(t)
+		cfg := New()
+		assert.True(t, cfg.EnableHTTPMonitoring)
+	})
+
 	t.Run("via deprecated YAML", func(t *testing.T) {
 		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("network_config.enable_http_monitoring", true)
+		mockSystemProbe.SetWithoutSource("network_config.enable_http_monitoring", false)
 		cfg := New()
 
-		assert.True(t, cfg.EnableHTTPMonitoring)
+		assert.False(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("via deprecated ENV variable", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "true")
+		t.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING", "false")
 		cfg := New()
 
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 
-		assert.True(t, cfg.EnableHTTPMonitoring)
+		assert.False(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("via YAML", func(t *testing.T) {
 		mockSystemProbe := mock.NewSystemProbe(t)
-		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_http_monitoring", true)
+		mockSystemProbe.SetWithoutSource("service_monitoring_config.enable_http_monitoring", false)
 		cfg := New()
 
-		assert.True(t, cfg.EnableHTTPMonitoring)
+		assert.False(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "true")
+		t.Setenv("DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP_MONITORING", "false")
 		cfg := New()
 
 		_, err := sysconfig.New("", "")
 		require.NoError(t, err)
 
-		assert.True(t, cfg.EnableHTTPMonitoring)
+		assert.False(t, cfg.EnableHTTPMonitoring)
 	})
 
 	t.Run("Deprecated is enabled, new is disabled", func(t *testing.T) {
@@ -147,12 +153,6 @@ func TestEnableHTTPMonitoring(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, cfg.EnableHTTPMonitoring)
-	})
-
-	t.Run("Not enabled", func(t *testing.T) {
-		mock.NewSystemProbe(t)
-		cfg := New()
-		assert.False(t, cfg.EnableHTTPMonitoring)
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR addresses a warning message generated when using the default configuration to enable USM.
The warning indicates that the configuration key `network_config.enable_http_monitoring` is deprecated and recommends using `service_monitoring_config.enable_http_monitoring` instead.
The change ensures that the warning is not generated for the default configuration.

### Motivation

Customers using the default configuration should not encounter warnings about deprecated configuration keys. This behavior may lead to confusion and unnecessary concerns, especially when no action is required for the default setup. The change improves the user experience and aligns with expected behavior.

### Describe how to test/QA your changes

Covered by UTs `TestEnableHTTPMonitoring`

Manual QA:

1. Use the default configuration to enable USM.
   ```yaml
   service_monitoring_config:
     enabled: true 
    ```
2. Verify that no warnings about the deprecated key is generated in the logs.
    ```
    SYS-PROBE | WARN | (pkg/util/log/log.go:881 in func1) | configuration key `network_config.enable_http_monitoring` is deprecated, use `service_monitoring_config.enable_http_monitoring` instead
    ```
3. Confirm that HTTP monitoring is enabled
    ```
    SYS-PROBE | INFO | (pkg/network/usm/ebpf_main.go:596 in initProtocols) | HTTP monitoring enabled
    ```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The issue was identified due to the following code snippet generating a warning:

```go
if cfg.GetBool(smNS("enabled")) {
    applyDefault(cfg, netNS("enable_http_monitoring"), true)
    ...
}

deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))
```

```go
if cfg.GetBool(smNS("enabled")) {
    applyDefault(cfg, netNS("enable_https_monitoring"), true)
    applyDefault(cfg, spNS("enable_runtime_compiler"), true)
    applyDefault(cfg, spNS("enable_kernel_header_download"), true)
    applyDefault(cfg, discoveryNS("enabled"), true)
}

deprecateBool(cfg, netNS("enable_http_monitoring"), smNS("enable_http_monitoring"))
applyDefault(cfg, smNS("enable_http_monitoring"), true)
```

This ensures default settings align with the new configuration key without generating unnecessary warnings.