### PR TITLE
[CWS-2966] add validation that `pid-per-tracer` is greater or equal to 1 in attach mode

### DIFF
--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -120,6 +120,10 @@ func Command() []*cobra.Command {
 
 			// attach mode
 			if n := len(params.PIDs); n > 0 {
+				if params.PIDPerTracer <= 0 {
+					return fmt.Errorf("%s option but be greater or equal to 1", pidPerTracer)
+				}
+
 				if n < params.PIDPerTracer {
 					return ptracer.Attach(params.PIDs, params.ProbeAddr, opts)
 				}


### PR DESCRIPTION
### What does this PR do?

This PR adds some validation to the pid per tracer flag in attach mode since:
- < 0 values make no sense since it's a count
- == 0 values trigger an infinite loop (we are trying to make groups of 0 elements from the list of PIDs)

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->