### PR TITLE
[CWS-2966] add missing cws-instrumentation flags in attach mode

### DIFF
--- a/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
+++ b/cmd/cws-instrumentation/subcommands/tracecmd/trace.go
@@ -145,19 +145,17 @@ func Command() []*cobra.Command {
 					go func(set []int) {
 						defer wg.Done()
 
-						args := []string{"trace"}
+						args := []string{
+							"trace",
+							fmt.Sprintf(`--%s`, probeAddrOpt),
+							params.ProbeAddr,
+						}
 
-						if params.ProcScanDisabled {
-							args = append(args, fmt.Sprintf(`--%s`, disableProcScanOpt))
-						}
-						if params.Async {
-							args = append(args, fmt.Sprintf(`--%s`, asyncOpt))
-						}
 						if params.Verbose {
 							args = append(args, fmt.Sprintf(`--%s`, verboseOpt))
 						}
-						if params.StatsDisabled {
-							args = append(args, fmt.Sprintf(`--%s`, disableStatsOpt))
+						if params.Debug {
+							args = append(args, fmt.Sprintf(`--%s`, debugOpt))
 						}
 						if params.UID != -1 {
 							args = append(args, fmt.Sprintf(`--%s`, uidOpt), fmt.Sprintf(`%d`, params.UID))
@@ -165,7 +163,21 @@ func Command() []*cobra.Command {
 						if params.GID != -1 {
 							args = append(args, fmt.Sprintf(`--%s`, gidOpt), fmt.Sprintf(`%d`, params.GID))
 						}
-						args = append(args, fmt.Sprintf(`--%s`, probeAddrOpt), params.ProbeAddr)
+						if params.Async {
+							args = append(args, fmt.Sprintf(`--%s`, asyncOpt))
+						}
+						if params.StatsDisabled {
+							args = append(args, fmt.Sprintf(`--%s`, disableStatsOpt))
+						}
+						if params.ProcScanDisabled {
+							args = append(args, fmt.Sprintf(`--%s`, disableProcScanOpt))
+						}
+						if params.ScanProcEvery != "" {
+							args = append(args, fmt.Sprintf(`--%s`, scanProcEveryOpt), params.ScanProcEvery)
+						}
+						if params.SeccompDisabled {
+							args = append(args, fmt.Sprintf(`--%s`, disableSeccompOpt))
+						}
 
 						for _, pid := range set {
 							args = append(args, fmt.Sprintf(`--%s`, pidOpt), fmt.Sprintf(`%d`, pid))


### PR DESCRIPTION
### What does this PR do?

Some of the main cws-instrumentation flags were not passed to forked processes in attach mode (especially, no-seccomp flag). This PR adds all missing and organizes then in the same order was the flag definition hopefully ensuring we don't forget those in the future.

### Motivation

### Describe how to test/QA your changes

Tested manually, the core code is covered by tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->