### PR TITLE
[incident-32914] Disable worktree unit tests

### DIFF
--- a/tasks/unit_tests/libs/common/worktree_tests.py
+++ b/tasks/unit_tests/libs/common/worktree_tests.py
@@ -1,97 +1,104 @@
-import os
-import unittest
+# TODO(celian): Reintroduce these tests
 
-from invoke import Context
+"""
+NOTE: These tests are disabled since they use git commands that are not mocked yet.
+This breaks unit tests ran with macos runners.
+"""
 
-from tasks.libs.common.git import get_default_branch
-from tasks.libs.common.gomodules import get_default_modules
-from tasks.libs.common.worktree import agent_context, init_env, is_worktree
+# import os
+# import unittest
+
+# from invoke import Context
+
+# from tasks.libs.common.git import get_default_branch
+# from tasks.libs.common.gomodules import get_default_modules
+# from tasks.libs.common.worktree import agent_context, init_env, is_worktree
 
 
-def get_ctx():
-    return Context()
+# def get_ctx():
+#     return Context()
 
 
-class TestWorktree(unittest.TestCase):
-    def setUp(self):
-        # Pull only once
-        init_env(get_ctx(), '6.53.x')
-        os.environ['AGENT_WORKTREE_NO_PULL'] = '1'
+# class TestWorktree(unittest.TestCase):
+#     def setUp(self):
+#         # Pull only once
+#         init_env(get_ctx(), '6.53.x')
+#         os.environ['AGENT_WORKTREE_NO_PULL'] = '1'
 
-    def test_context_is_worktree_true(self):
-        with agent_context(get_ctx(), '6.53.x'):
-            self.assertTrue(is_worktree())
+#     def test_context_is_worktree_true(self):
+#         with agent_context(get_ctx(), '6.53.x'):
+#             self.assertTrue(is_worktree())
 
-    def test_context_is_worktree_false(self):
-        self.assertFalse(is_worktree())
+#     def test_context_is_worktree_false(self):
+#         self.assertFalse(is_worktree())
 
-    def test_context_nested(self):
-        with agent_context(get_ctx(), '6.53.x'):
-            with agent_context(get_ctx(), '6.53.x'):
-                self.assertTrue(is_worktree())
-            self.assertTrue(is_worktree())
+#     def test_context_nested(self):
+#         with agent_context(get_ctx(), '6.53.x'):
+#             with agent_context(get_ctx(), '6.53.x'):
+#                 self.assertTrue(is_worktree())
+#             self.assertTrue(is_worktree())
 
-    def test_context_pwd(self):
-        ctx = get_ctx()
+#     def test_context_pwd(self):
+#         ctx = get_ctx()
 
-        with agent_context(ctx, None, skip_checkout=True):
-            pwdnone = ctx.run('pwd').stdout
+#         with agent_context(ctx, None, skip_checkout=True):
+#             pwdnone = ctx.run('pwd').stdout
 
-        with agent_context(ctx, '6.53.x'):
-            pwd6 = ctx.run('pwd').stdout
+#         with agent_context(ctx, '6.53.x'):
+#             pwd6 = ctx.run('pwd').stdout
 
-        with agent_context(ctx, 'main'):
-            pwdmain = ctx.run('pwd').stdout
+#         with agent_context(ctx, 'main'):
+#             pwdmain = ctx.run('pwd').stdout
 
-        self.assertEqual(pwd6, pwdnone)
-        self.assertEqual(pwd6, pwdmain)
+#         self.assertEqual(pwd6, pwdnone)
+#         self.assertEqual(pwd6, pwdmain)
 
-    def test_context_modules(self):
-        ctx = get_ctx()
+#     def test_context_modules(self):
+#         ctx = get_ctx()
 
-        with agent_context(ctx, 'main'):
-            modules7 = get_default_modules()
+#         with agent_context(ctx, 'main'):
+#             modules7 = get_default_modules()
 
-        with agent_context(ctx, '6.53.x'):
-            modules6 = get_default_modules()
+#         with agent_context(ctx, '6.53.x'):
+#             modules6 = get_default_modules()
 
-        self.assertNotEqual(set(modules6.keys()), set(modules7.keys()))
+#         self.assertNotEqual(set(modules6.keys()), set(modules7.keys()))
 
-    def test_context_branch(self):
-        ctx = get_ctx()
+#     def test_context_branch(self):
+#         ctx = get_ctx()
 
-        with agent_context(ctx, 'main'):
-            branch7 = get_default_branch()
+#         with agent_context(ctx, 'main'):
+#             branch7 = get_default_branch()
 
-        with agent_context(ctx, '6.53.x'):
-            branch6 = get_default_branch()
+#         with agent_context(ctx, '6.53.x'):
+#             branch6 = get_default_branch()
 
-        self.assertNotEqual(branch6, branch7)
+#         self.assertNotEqual(branch6, branch7)
 
-    def test_context_no_checkout(self):
-        ctx = get_ctx()
+#     def test_context_no_checkout(self):
+#         ctx = get_ctx()
 
-        with agent_context(ctx, '6.53.x'):
-            branch6 = get_default_branch()
+#         with agent_context(ctx, '6.53.x'):
+#             branch6 = get_default_branch()
 
-        with agent_context(ctx, 'main'):
-            branch7 = get_default_branch()
+#         with agent_context(ctx, 'main'):
+#             branch7 = get_default_branch()
 
-        with agent_context(ctx, 'main', skip_checkout=True):
-            branch_no_checkout = get_default_branch()
+#         with agent_context(ctx, 'main', skip_checkout=True):
+#             branch_no_checkout = get_default_branch()
 
-        self.assertNotEqual(branch6, branch7)
-        self.assertEqual(branch7, branch_no_checkout)
+#         self.assertNotEqual(branch6, branch7)
+#         self.assertEqual(branch7, branch_no_checkout)
 
-    def test_context_no_checkout_error(self):
-        ctx = get_ctx()
+#     def test_context_no_checkout_error(self):
+#         ctx = get_ctx()
 
-        with agent_context(ctx, '6.53.x'):
-            pass
+#         with agent_context(ctx, '6.53.x'):
+#             pass
 
-        def switch_context():
-            # The current branch is not main
-            with agent_context(ctx, 'main', skip_checkout=True):
-                pass
+#         def switch_context():
+#             # The current branch is not main
+#             with agent_context(ctx, 'main', skip_checkout=True):
+#                 pass
 
-        self.assertRaises(AssertionError, switch_context)
+#         self.assertRaises(AssertionError, switch_context)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[incident-32914] 

Disables worktree unit tests because they break [tests_macos_gitlab_amd64](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/724170124).
Worktrees are not used for the moment

### Motivation

### Describe how to test/QA your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->