### PR TITLE
[EBPF] fix flaky gpu-module test

### DIFF
--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -72,7 +72,8 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 	t := s.T()
 
 	probe := s.getProbe()
-	cmd := testutil.RunSample(t, testutil.CudaSample)
+	cmd, err := testutil.RunSample(t, testutil.CudaSample)
+	require.NoError(t, err)
 
 	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
 
@@ -115,7 +116,8 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 
 	probe := s.getProbe()
 
-	cmd := testutil.RunSample(t, testutil.CudaSample)
+	cmd, err := testutil.RunSample(t, testutil.CudaSample)
+	require.NoError(t, err)
 
 	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
 
@@ -145,14 +147,14 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 
 	sampleArgs := testutil.SampleArgs{
 		StartWaitTimeSec:      6, // default wait time for WaitForProgramsToBeTraced is 5 seconds, give margin to attach manually to avoid flakes
-		EndWaitTimeSec:        1, // We need the process to stay active a bit so we can inspect its environment variables, if it ends too quickly we get no information
 		CudaVisibleDevicesEnv: "1,2",
 		SelectedDevice:        1,
 	}
 	// Visible devices 1,2 -> selects 1 in that array -> global device index = 2
 	selectedGPU := testutil.GPUUUIDs[2]
 
-	cmd := testutil.RunSampleWithArgs(t, testutil.CudaSample, sampleArgs)
+	cmd, err := testutil.RunSampleWithArgs(t, testutil.CudaSample, sampleArgs)
+	require.NoError(t, err)
 	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackEnabled)
 
 	// Wait until the process finishes and we can get the stats. Run this instead of waiting for the process to finish
@@ -180,9 +182,7 @@ func (s *probeTestSuite) TestDetectsContainer() {
 
 	probe := s.getProbe()
 
-	args := testutil.GetDefaultArgs()
-	args.EndWaitTimeSec = 1
-	pid, cid := testutil.RunSampleInDockerWithArgs(t, testutil.CudaSample, testutil.MinimalDockerImage, args)
+	pid, cid := testutil.RunSampleInDocker(t, testutil.CudaSample, testutil.MinimalDockerImage)
 
 	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, pid, utils.ManualTracingFallbackDisabled)
 

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -11,10 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/maps"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
@@ -120,12 +119,6 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 
 	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
 
-	// Wait until the process finishes and we can get the stats. Run this instead of waiting for the process to finish
-	// so that we can time out correctly
-	require.Eventually(t, func() bool {
-		return !utils.IsProgramTraced(gpuModuleName, gpuAttacherName, cmd.Process.Pid)
-	}, 20*time.Second, 500*time.Millisecond, "process not stopped")
-
 	stats, err := probe.GetAndFlush()
 	require.NoError(t, err)
 	require.NotNil(t, stats)
@@ -156,12 +149,6 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 	require.NoError(t, err)
 	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackEnabled)
 
-	// Wait until the process finishes and we can get the stats. Run this instead of waiting for the process to finish
-	// so that we can time out correctly
-	require.Eventually(t, func() bool {
-		return !utils.IsProgramTraced(gpuModuleName, gpuAttacherName, cmd.Process.Pid)
-	}, 60*time.Second, 500*time.Millisecond, "process not stopped")
-
 	stats, err := probe.GetAndFlush()
 	require.NoError(t, err)
 	require.NotNil(t, stats)
@@ -181,12 +168,6 @@ func (s *probeTestSuite) TestDetectsContainer() {
 	pid, cid := testutil.RunSampleInDocker(t, testutil.CudaSample, testutil.MinimalDockerImage)
 
 	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, pid, utils.ManualTracingFallbackDisabled)
-
-	// Wait until the process finishes and we can get the stats. Run this instead of waiting for the process to finish
-	// so that we can time out correctly
-	require.Eventually(t, func() bool {
-		return !utils.IsProgramTraced(gpuModuleName, gpuAttacherName, pid)
-	}, 20*time.Second, 500*time.Millisecond, "process not stopped")
 
 	// Check that the stream handlers have the correct container ID assigned
 	for key, handler := range probe.consumer.streamHandlers {

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -20,6 +20,7 @@ import (
 	consumerstestutil "github.com/DataDog/datadog-agent/pkg/eventmonitor/consumers/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 )
 
 type probeTestSuite struct {
@@ -71,6 +72,7 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 	probe := s.getProbe()
 	cmd, err := testutil.RunSample(t, testutil.CudaSample)
 	require.NoError(t, err)
+	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
 	_ = cmd.Process.Kill()
 	_ = cmd.Wait()
 
@@ -115,6 +117,8 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 
 	cmd, err := testutil.RunSample(t, testutil.CudaSample)
 	require.NoError(t, err)
+	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
+
 	_ = cmd.Process.Kill()
 	_ = cmd.Wait()
 
@@ -146,6 +150,7 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 
 	cmd, err := testutil.RunSampleWithArgs(t, testutil.CudaSample, sampleArgs)
 	require.NoError(t, err)
+	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, cmd.Process.Pid, utils.ManualTracingFallbackDisabled)
 	_ = cmd.Process.Kill()
 	_ = cmd.Wait()
 
@@ -166,6 +171,7 @@ func (s *probeTestSuite) TestDetectsContainer() {
 	probe := s.getProbe()
 
 	pid, cid := testutil.RunSampleInDocker(t, testutil.CudaSample, testutil.MinimalDockerImage)
+	utils.WaitForProgramsToBeTraced(t, gpuModuleName, gpuAttacherName, pid, utils.ManualTracingFallbackDisabled)
 
 	// Check that the stream handlers have the correct container ID assigned
 	for key, handler := range probe.consumer.streamHandlers {

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 type probeTestSuite struct {
@@ -176,9 +175,6 @@ func (s *probeTestSuite) TestMultiGPUSupport() {
 
 func (s *probeTestSuite) TestDetectsContainer() {
 	t := s.T()
-
-	// Flaky test in CI, avoid failures on main for now.
-	flake.Mark(t)
 
 	probe := s.getProbe()
 

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -40,7 +40,7 @@ int main(int argc, char **argv) {
     cudaStream_t stream = 30;
 
     if (argc != 3) {
-        fprintf(stderr, "Usage: %s <wait-to-start-sec> <wait-to-end-sec> <device-index>\n", argv[0]);
+        fprintf(stderr, "Usage: %s <wait-to-start-sec> <device-index>\n", argv[0]);
         return 1;
     }
 
@@ -63,7 +63,7 @@ int main(int argc, char **argv) {
     cudaFree(ptr);
     cudaStreamSynchronize(stream);
 
-    // we don't exit to avoud flakiness when the process is terminated before it was hooked for gpu monitoring
+    // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)
     fprintf(stderr, "CUDA calls made. Press Enter to continue...\n");
     getchar();  // Wait for user input without consuming CPU

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -65,6 +65,8 @@ int main(int argc, char **argv) {
 
     // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)
+
+    //this line is used as a market by patternScanner to indicate the end of the program
     fprintf(stderr, "CUDA calls made.\n");
     fprintf(stderr, "Press Enter to continue...\n");
     pause();  // Wait for signal to finish the process

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -65,8 +65,9 @@ int main(int argc, char **argv) {
 
     // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)
-    fprintf(stderr, "CUDA calls made. Press Enter to continue...\n");
-    getchar();  // Wait for user input without consuming CPU
+    fprintf(stderr, "CUDA calls made.\n");
+    fprintf(stderr, "Press Enter to continue...\n");
+    pause();  // Wait for signal to finish the process
 
     return 0;
 }

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -68,7 +68,6 @@ int main(int argc, char **argv) {
 
     //this line is used as a market by patternScanner to indicate the end of the program
     fprintf(stderr, "CUDA calls made.\n");
-    fprintf(stderr, "Press Enter to continue...\n");
     pause();  // Wait for signal to finish the process
 
     return 0;

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
     int device = atoi(argv[2]);
 
     // This string is used by PatternScanner to validate a proper start of this sample program inside the container
-    fprintf(stderr, "Starting CudaSample program\n")
+    fprintf(stderr, "Starting CudaSample program\n");
     fprintf(stderr, "Waiting for %d seconds before starting\n", waitStart);
 
     // Give time for the eBPF program to load

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -39,15 +39,16 @@ cudaError_t cudaSetDevice(int device) {
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
 
-    if (argc != 4) {
+    if (argc != 3) {
         fprintf(stderr, "Usage: %s <wait-to-start-sec> <wait-to-end-sec> <device-index>\n", argv[0]);
         return 1;
     }
 
     int waitStart = atoi(argv[1]);
-    int waitEnd = atoi(argv[2]);
-    int device = atoi(argv[3]);
+    int device = atoi(argv[2]);
 
+    // This string is used by PatternScanner to validate a proper start of this sample program inside the container
+    fprintf(stderr, "Starting CudaSample program\n")
     fprintf(stderr, "Waiting for %d seconds before starting\n", waitStart);
 
     // Give time for the eBPF program to load
@@ -62,12 +63,10 @@ int main(int argc, char **argv) {
     cudaFree(ptr);
     cudaStreamSynchronize(stream);
 
-    fprintf(stderr, "CUDA calls made. Waiting for %d seconds before exiting\n", waitEnd);
-
-    // Give time for the agent to inspect this process and check environment variables/etc before this exits
-    sleep(waitEnd);
-
-    fprintf(stderr, "Exiting\n");
+    // we don't exit to avoud flakiness when the process is terminated before it was hooked for gpu monitoring
+    // the expected usage is to send a kill signal to the process (or stop the container that is running it)
+    fprintf(stderr, "CUDA calls made. Press Enter to continue...\n");
+    getchar();  // Wait for user input without consuming CPU
 
     return 0;
 }

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -88,7 +88,7 @@ func getBuiltSamplePath(t *testing.T, sample sampleName) string {
 // getDefaultArgs returns the default arguments for the sample binary
 func getDefaultArgs() SampleArgs {
 	return SampleArgs{
-		StartWaitTimeSec:      6,
+		StartWaitTimeSec:      5,
 		CudaVisibleDevicesEnv: "",
 		SelectedDevice:        0,
 	}

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -181,16 +181,10 @@ func RunSampleInDockerWithArgs(t *testing.T, name sampleName, image dockerImage,
 	var dockerPID int64
 	var dockerContainerID string
 
-	// The docker container might take a bit to start, so we retry until we get the PID
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		dockerPID, err = dockerutils.GetMainPID(containerName)
-		assert.NoError(c, err)
-	}, 1*time.Second, 100*time.Millisecond, "failed to get docker PID")
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		dockerContainerID, err = dockerutils.GetContainerID(containerName)
-		assert.NoError(c, err)
-	}, 1*time.Second, 100*time.Millisecond, "failed to get docker container ID")
+	dockerPID, err = dockerutils.GetMainPID(containerName)
+	assert.NoError(t, err, "failed to get docker PID")
+	dockerContainerID, err = dockerutils.GetContainerID(containerName)
+	assert.NoError(t, err, "failed to get docker container ID")
 
 	log.Debugf("Sample binary %s running in Docker container %s (CID=%s) with PID %d", name, containerName, dockerContainerID, dockerPID)
 

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -40,7 +40,7 @@ const (
 type dockerImage string
 
 var sampleStartedPattern = regexp.MustCompile("Starting CudaSample program")
-var timeoutError = errors.New(fmt.Sprintf("%s execution attempt reached timeout %v ", CudaSample, dockerutils.DefaultTimeout))
+var errTimeout = errors.New(fmt.Sprintf("%s execution attempt reached timeout %v ", CudaSample, dockerutils.DefaultTimeout))
 
 const (
 	// MinimalDockerImage is the minimal docker image, just used for running a binary
@@ -137,7 +137,7 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 			return cmd, nil
 		case <-time.After(dockerutils.DefaultTimeout):
 			//setting the error explicitly to trigger the defer function
-			err = timeoutError
+			err = errTimeout
 			return nil, err
 		}
 	}

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -8,11 +8,12 @@
 package testutil
 
 import (
-	"bufio"
+	"context"
+	"errors"
 	"fmt"
-	"io"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -23,34 +24,32 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	procutil "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	dockerutils "github.com/DataDog/datadog-agent/pkg/util/testutil/docker"
 )
 
-// SampleName represents the name of the sample binary.
-type SampleName string
+// sampleName represents the name of the sample binary.
+type sampleName string
 
 const (
 	// CudaSample is the sample binary that uses CUDA.
-	CudaSample SampleName = "cudasample"
+	CudaSample sampleName = "cudasample"
 )
 
-// DockerImage represents the Docker image to use for running the sample binary.
-type DockerImage string
+// dockerImage represents the Docker image to use for running the sample binary.
+type dockerImage string
+
+var sampleStartedPattern = regexp.MustCompile("Starting CudaSample program")
+var timeoutError = errors.New(fmt.Sprintf("%s execution attempt reached timeout %v ", CudaSample, dockerutils.DefaultTimeout))
 
 const (
 	// MinimalDockerImage is the minimal docker image, just used for running a binary
-	MinimalDockerImage DockerImage = "alpine:3.20.3"
+	MinimalDockerImage dockerImage = "alpine:3.20.3"
 )
 
 type SampleArgs struct { //nolint:revive // TODO
 	// StartWaitTimeSec represents the time in seconds to wait before the binary starting the CUDA calls
 	StartWaitTimeSec int
-
-	// EndWaitTimeSec represents the time in seconds to wait before the binary stops after making the CUDA calls
-	// This is necessary because the mock CUDA calls are instant, which means that the binary will exit before the
-	// eBPF probe has a chance to read the events and inspect the binary. To make the behavior of the sample binary
-	// more predictable and avoid flakiness in the tests, we introduce a delay before the binary exits.
-	EndWaitTimeSec int
 
 	// CudaVisibleDevicesEnv represents the value of the CUDA_VISIBLE_DEVICES environment variable
 	CudaVisibleDevicesEnv string
@@ -69,25 +68,13 @@ func (a *SampleArgs) getEnv() []string {
 
 func (a *SampleArgs) getCLIArgs() []string {
 	return []string{
-		strconv.Itoa(int(a.StartWaitTimeSec)),
-		strconv.Itoa(int(a.EndWaitTimeSec)),
+		strconv.Itoa(a.StartWaitTimeSec),
 		strconv.Itoa(a.SelectedDevice),
 	}
 }
 
-// redirectReaderToLog reads from the reader and logs the output with the given prefix
-func redirectReaderToLog(r io.Reader, prefix string) {
-	go func() {
-		scanner := bufio.NewScanner(r)
-		for scanner.Scan() {
-			log.Debugf("%s: %s", prefix, scanner.Text())
-		}
-		// Automatically exits when the scanner reaches EOF, that is, when the command finishes
-	}()
-}
-
 // RunSampleWithArgs executes the sample binary and returns the command. Cleanup is configured automatically
-func getBuiltSamplePath(t *testing.T, sample SampleName) string {
+func getBuiltSamplePath(t *testing.T, sample sampleName) string {
 	curDir, err := testutil.CurDir()
 	require.NoError(t, err)
 
@@ -100,77 +87,94 @@ func getBuiltSamplePath(t *testing.T, sample SampleName) string {
 	return builtBin
 }
 
-// GetDefaultArgs returns the default arguments for the sample binary
-func GetDefaultArgs() SampleArgs {
+// getDefaultArgs returns the default arguments for the sample binary
+func getDefaultArgs() SampleArgs {
 	return SampleArgs{
 		StartWaitTimeSec:      5,
-		EndWaitTimeSec:        1, // We need the process to stay active a bit so we can inspect its environment variables, if it ends too quickly we get no information
 		CudaVisibleDevicesEnv: "",
 		SelectedDevice:        0,
 	}
 }
 
-func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs, logName string) *exec.Cmd {
+func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (cmd *exec.Cmd, err error) {
 	command = append(command, args.getCLIArgs()...)
 
-	cmd := exec.Command(command[0], command[1:]...)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	cmd = exec.CommandContext(ctx, command[0], command[1:]...)
 	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
 	})
 
+	scanner := procutil.NewScanner(sampleStartedPattern, make(chan struct{}, 1))
+	defer func() {
+		//print the cudasample log in case there was an error
+		if err != nil {
+			scanner.PrintLogs(t)
+		}
+	}()
 	env := args.getEnv()
 	cmd.Env = append(cmd.Env, env...)
-
-	stdout, err := cmd.StdoutPipe()
-	require.NoError(t, err)
-	stderr, err := cmd.StderrPipe()
-	require.NoError(t, err)
-
-	redirectReaderToLog(stdout, fmt.Sprintf("%s stdout", logName))
-	redirectReaderToLog(stderr, fmt.Sprintf("%s stderr", logName))
+	cmd.Stdout = scanner
+	cmd.Stderr = scanner
 
 	log.Debugf("Running command %v, env=%v", command, env)
 	err = cmd.Start()
-	require.NoError(t, err)
+	if err != nil {
+		return nil, err
+	}
 
-	return cmd
+	for {
+		select {
+		case <-ctx.Done():
+			if err = ctx.Err(); err != nil {
+				return nil, fmt.Errorf("failed to start the container %s due to: %w", command[0], err)
+			}
+		case <-scanner.DoneChan:
+			return cmd, nil
+		case <-time.After(dockerutils.DefaultTimeout):
+			//setting the error explicitly to trigger the defer function
+			err = timeoutError
+			return nil, err
+		}
+	}
 }
 
 // RunSample executes the sample binary and returns the command. Cleanup is configured automatically
-func RunSample(t *testing.T, name SampleName) *exec.Cmd {
-	return RunSampleWithArgs(t, name, GetDefaultArgs())
+func RunSample(t *testing.T, name sampleName) (*exec.Cmd, error) {
+	return RunSampleWithArgs(t, name, getDefaultArgs())
 }
 
 // RunSampleWithArgs executes the sample binary with args and returns the command. Cleanup is configured automatically
-func RunSampleWithArgs(t *testing.T, name SampleName, args SampleArgs) *exec.Cmd {
+func RunSampleWithArgs(t *testing.T, name sampleName, args SampleArgs) (*exec.Cmd, error) {
 	builtBin := getBuiltSamplePath(t, name)
-
-	return runCommandAndPipeOutput(t, []string{builtBin}, args, string(name))
+	return runCommandAndPipeOutput(t, []string{builtBin}, args)
 }
 
 // RunSampleInDocker executes the sample binary in a Docker container and returns the PID of the main container process, and the container ID
-func RunSampleInDocker(t *testing.T, name SampleName, image DockerImage) (int, string) {
-	return RunSampleInDockerWithArgs(t, name, image, GetDefaultArgs())
+func RunSampleInDocker(t *testing.T, name sampleName, image dockerImage) (int, string) {
+	return RunSampleInDockerWithArgs(t, name, image, getDefaultArgs())
 }
 
 // RunSampleInDockerWithArgs executes the sample binary in a Docker container and returns the PID of the main container process, and the container ID
-func RunSampleInDockerWithArgs(t *testing.T, name SampleName, image DockerImage, args SampleArgs) (int, string) {
+func RunSampleInDockerWithArgs(t *testing.T, name sampleName, image dockerImage, args SampleArgs) (int, string) {
 	builtBin := getBuiltSamplePath(t, name)
 	containerName := fmt.Sprintf("gpu-testutil-%s", utils.RandString(10))
-	mountArg := fmt.Sprintf("%s:%s", builtBin, builtBin)
 
-	command := []string{"docker", "run", "--rm", "-v", mountArg, "--name", containerName}
+	dockerConfig := dockerutils.NewRunConfig(containerName,
+		dockerutils.DefaultTimeout,
+		dockerutils.DefaultRetries,
+		sampleStartedPattern,
+		args.getEnv(),
+		string(image),
+		builtBin,
+		args.getCLIArgs(),
+		map[string]string{builtBin: builtBin})
 
-	// Pass environment variables to the container as docker args
-	for _, env := range args.getEnv() {
-		command = append(command, "-e", env)
-	}
-
-	command = append(command, string(image), builtBin)
-
-	_ = runCommandAndPipeOutput(t, command, args, string(name))
+	require.NoError(t, dockerutils.Run(t, dockerConfig))
 
 	var dockerPID int64
 	var dockerContainerID string

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -9,7 +9,6 @@ package testutil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -40,7 +39,6 @@ const (
 type dockerImage string
 
 var sampleStartedPattern = regexp.MustCompile("Starting CudaSample program")
-var errTimeout = errors.New(fmt.Sprintf("%s execution attempt reached timeout %v ", CudaSample, dockerutils.DefaultTimeout))
 
 const (
 	// MinimalDockerImage is the minimal docker image, just used for running a binary
@@ -138,7 +136,7 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 			return cmd, nil
 		case <-time.After(dockerutils.DefaultTimeout):
 			//setting the error explicitly to trigger the defer function
-			err = errTimeout
+			err = fmt.Errorf("%s execution attempt reached timeout %v ", CudaSample, dockerutils.DefaultTimeout)
 			return nil, err
 		}
 	}

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -106,6 +106,7 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 	t.Cleanup(func() {
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
 		}
 	})
 

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -120,7 +120,6 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 	cmd.Stdout = scanner
 	cmd.Stderr = scanner
 
-	log.Debugf("Running command %v, env=%v", command, env)
 	err = cmd.Start()
 	if err != nil {
 		return nil, err
@@ -133,6 +132,7 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 				return nil, fmt.Errorf("failed to start the process %s due to: %w", command[0], err)
 			}
 		case <-scanner.DoneChan:
+			t.Logf("%s command succeeded", command)
 			return cmd, nil
 		case <-time.After(dockerutils.DefaultTimeout):
 			//setting the error explicitly to trigger the defer function

--- a/pkg/gpu/testutil/samplebins.go
+++ b/pkg/gpu/testutil/samplebins.go
@@ -58,11 +58,10 @@ type SampleArgs struct { //nolint:revive // TODO
 }
 
 func (a *SampleArgs) getEnv() []string {
-	env := []string{}
 	if a.CudaVisibleDevicesEnv != "" {
-		env = append(env, fmt.Sprintf("CUDA_VISIBLE_DEVICES=%s", a.CudaVisibleDevicesEnv))
+		return []string{fmt.Sprintf("CUDA_VISIBLE_DEVICES=%s", a.CudaVisibleDevicesEnv)}
 	}
-	return env
+	return nil
 }
 
 func (a *SampleArgs) getCLIArgs() []string {
@@ -89,7 +88,7 @@ func getBuiltSamplePath(t *testing.T, sample sampleName) string {
 // getDefaultArgs returns the default arguments for the sample binary
 func getDefaultArgs() SampleArgs {
 	return SampleArgs{
-		StartWaitTimeSec:      5,
+		StartWaitTimeSec:      6,
 		CudaVisibleDevicesEnv: "",
 		SelectedDevice:        0,
 	}
@@ -131,7 +130,7 @@ func runCommandAndPipeOutput(t *testing.T, command []string, args SampleArgs) (c
 		select {
 		case <-ctx.Done():
 			if err = ctx.Err(); err != nil {
-				return nil, fmt.Errorf("failed to start the container %s due to: %w", command[0], err)
+				return nil, fmt.Errorf("failed to start the process %s due to: %w", command[0], err)
 			}
 		case <-scanner.DoneChan:
 			return cmd, nil


### PR DESCRIPTION
### What does this PR do?

Fixes the flaky test (TestDetectsContainer) by switching to use pkg/util/testutil/docker (see this https://github.com/DataDog/datadog-agent/pull/31470) and making the cudasample process to wait until killed explicitly (avoiding potential race conditions when trying to get docker's main process PID)

### Motivation

fix race condition when trying to detect container's main pid. was returning 0, if the container finished its execution following its main process exit

### Describe how to test/QA your changes

all /pkg/gpu pkg tests should pass.
Need to monitor on main that `TestDetectsContainer` is not flaky anymore

### Possible Drawbacks / Trade-offs

### Additional Notes

[Jira ticket](https://datadoghq.atlassian.net/browse/EBPF-620)