### PR TITLE
Remove unused function GetSyslogURIFromConfig

### DIFF
--- a/pkg/util/log/setup/log_nix.go
+++ b/pkg/util/log/setup/log_nix.go
@@ -14,11 +14,6 @@ import (
 // GetSyslogURI returns the configured/default syslog uri.
 // Returns an empty string when syslog is disabled.
 func GetSyslogURI(cfg pkgconfigmodel.Reader) string {
-	return GetSyslogURIFromConfig(cfg)
-}
-
-// GetSyslogURIFromConfig is like GetSyslogURI but reads from the provided config
-func GetSyslogURIFromConfig(cfg pkgconfigmodel.Reader) string {
 	enabled := cfg.GetBool("log_to_syslog")
 	uri := cfg.GetString("syslog_uri")
 

--- a/pkg/util/log/setup/log_windows.go
+++ b/pkg/util/log/setup/log_windows.go
@@ -12,11 +12,6 @@ import (
 
 // GetSyslogURI returns the configured/default syslog uri
 func GetSyslogURI(cfg pkgconfigmodel.Reader) string {
-	return GetSyslogURIFromConfig(cfg)
-}
-
-// GetSyslogURIFromConfig is like GetSyslogURI but reads from the provided config
-func GetSyslogURIFromConfig(cfg pkgconfigmodel.Reader) string {
 	enabled := cfg.GetBool("log_to_syslog")
 
 	if enabled {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove some unused functions from `pkg/util/log/setup`

### Motivation
The function is not used, and has a 100% equivalent alias, we might as well remove it.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Function is unused, if everything compiles then it's ok.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->