### PR TITLE
[tagger/remote] Fix "tagger-list" command

### DIFF
--- a/comp/core/tagger/impl-dual/dual.go
+++ b/comp/core/tagger/impl-dual/dual.go
@@ -54,7 +54,8 @@ func NewComponent(req Requires) (Provides, error) {
 
 		return Provides{
 			local.Provides{
-				Comp: provide.Comp,
+				Comp:     provide.Comp,
+				Endpoint: provide.Endpoint,
 			},
 		}, nil
 	}

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -9,8 +9,10 @@ package remotetaggerimpl
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -21,6 +23,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 
+	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
@@ -35,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
 const (
@@ -59,7 +63,8 @@ type Requires struct {
 type Provides struct {
 	compdef.Out
 
-	Comp tagger.Component
+	Comp     tagger.Component
+	Endpoint api.AgentEndpointProvider
 }
 
 type remoteTagger struct {
@@ -112,11 +117,12 @@ func NewComponent(req Requires) (Provides, error) {
 	}})
 
 	return Provides{
-		Comp: remoteTagger,
+		Comp:     remoteTagger,
+		Endpoint: api.NewAgentEndpointProvider(remoteTagger.writeList, "/tagger-list", "GET"),
 	}, nil
 }
 
-func newRemoteTagger(params tagger.RemoteParams, cfg config.Component, log log.Component, telemetryComp coretelemetry.Component) (tagger.Component, error) {
+func newRemoteTagger(params tagger.RemoteParams, cfg config.Component, log log.Component, telemetryComp coretelemetry.Component) (*remoteTagger, error) {
 	telemetryStore := telemetry.NewStore(telemetryComp)
 
 	target, err := params.RemoteTarget(cfg)
@@ -492,6 +498,17 @@ func (t *remoteTagger) startTaggerStream(maxElapsed time.Duration) error {
 
 		return nil
 	}, expBackoff)
+}
+
+func (t *remoteTagger) writeList(w http.ResponseWriter, _ *http.Request) {
+	response := t.List()
+
+	jsonTags, err := json.Marshal(response)
+	if err != nil {
+		httputils.SetJSONError(w, t.log.Errorf("Unable to marshal tagger list response: %s", err), 500)
+		return
+	}
+	w.Write(jsonTags)
 }
 
 func convertEventType(t pb.EventType) (types.EventType, error) {


### PR DESCRIPTION
### What does this PR do?

Fixes the `agent tagger-list` command in the remote tagger.

The “agent tagger-list” command no longer works in the CLC runner when configured to use the remote tagger. I think that the problem was introduced in this PR https://github.com/DataDog/datadog-agent/pull/30584 because the Remote implementation no longer returns an AgentEndpointProvider.


### Describe how you validated your changes
I added a unit test. I also verified that `agent tagger-list` no longer returns a 404 error in the cluster check runners when configured to use the remote tagger (`DD_CLC_RUNNER_REMOTE_TAGGER_ENABLED=true`).


[ASCII-2428]: https://datadoghq.atlassian.net/browse/ASCII-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ