### PR TITLE
Fix default syslog URI on Darwin

### DIFF
--- a/comp/core/log/def/params.go
+++ b/comp/core/log/def/params.go
@@ -119,6 +119,9 @@ func ForDaemon(loggerName, logFileConfig, defaultLogFile string) Params {
 		}
 
 		if uri == "" {
+			if runtime.GOOS == "darwin" {
+				return "unixgram:///var/run/syslog"
+			}
 			return "unixgram:///dev/log"
 		}
 

--- a/releasenotes/notes/fix-syslog-default-uri-macos-31cd74143cfe1fcc.yaml
+++ b/releasenotes/notes/fix-syslog-default-uri-macos-31cd74143cfe1fcc.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Use ``/var/run/syslog`` as the default syslog URI on macOS.
+    Use ``/var/run/syslog`` as the default syslog socket path on macOS.

--- a/releasenotes/notes/fix-syslog-default-uri-macos-31cd74143cfe1fcc.yaml
+++ b/releasenotes/notes/fix-syslog-default-uri-macos-31cd74143cfe1fcc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Use ``/var/run/syslog`` as the default syslog URI on macOS.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use `/var/run/syslog` as default socket path for syslog on MacOS when starting the agent.

### Motivation
This is the correct path on MacOS.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
When setting `log_to_syslog: true`, you get the following errors repetitively:
```
Trying to connect to: /dev/log
seelog internal error: Unable to connect to syslog
```
Checked manually that this fix removes the error.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is also set in `pkg/util/log/setup`.
This was most likely broken when the logger was moved to a component.

I didn't import the value from `pkg/util/log/setup` to avoid the dependency from the component interface to that package (and its dependencies). 