### PR TITLE
[EBPF] gpu: Add tagger integration

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -165,7 +165,7 @@ func (m *Check) getTagsForKey(key model.StatsKey) []string {
 	entityID := taggertypes.NewEntityID(taggertypes.ContainerID, key.ContainerID)
 	tags, err := m.tagger.Tag(entityID, m.tagger.ChecksCardinality())
 	if err != nil {
-		log.Errorf("Error collecting tags for process %d: %s", key.PID, err)
+		log.Errorf("Error collecting container tags for process %d: %s", key.PID, err)
 	}
 
 	// Container ID tag will be added or not depending on the tagger configuration

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -162,18 +162,18 @@ func (m *Check) emitSysprobeMetrics(snd sender.Sender) error {
 }
 
 func (m *Check) getTagsForKey(key model.StatsKey) []string {
-	// Per-PID metrics are subject to change due to high cardinality
 	entityID := taggertypes.NewEntityID(taggertypes.ContainerID, key.ContainerID)
 	tags, err := m.tagger.Tag(entityID, m.tagger.ChecksCardinality())
 	if err != nil {
 		log.Errorf("Error collecting tags for process %d: %s", key.PID, err)
 	}
 
-	// Add the key fields as tags
+	// Container ID tag will be added or not depending on the tagger configuration
+	// PID and GPU UUID are always added as they're not relying on the tagger yet
 	keyTags := []string{
+		// Per-PID metrics are subject to change due to high cardinality
 		fmt.Sprintf("pid:%d", key.PID),
 		fmt.Sprintf("gpu_uuid:%s", key.DeviceUUID),
-		fmt.Sprintf("container_id:%s", key.ContainerID),
 	}
 
 	return append(tags, keyTags...)

--- a/pkg/collector/corechecks/gpu/gpu_stub.go
+++ b/pkg/collector/corechecks/gpu/gpu_stub.go
@@ -8,11 +8,12 @@
 package gpu
 
 import (
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 // Factory creates a new check factory
-func Factory() optional.Option[func() check.Check] {
+func Factory(_ tagger.Component) optional.Option[func() check.Check] {
 	return optional.NewNoneOption[func() check.Check]()
 }

--- a/pkg/collector/corechecks/gpu/model/model.go
+++ b/pkg/collector/corechecks/gpu/model/model.go
@@ -26,16 +26,14 @@ type StatsKey struct {
 
 	// DeviceUUID is the UUID of the device
 	DeviceUUID string `json:"device_uuid"`
-}
 
-type Metadata struct {
+	// ContainerID is the ID of the container the process is running on
 	ContainerID string `json:"container_id"`
 }
 
 // StatsTuple is a single entry in the GPUStats array, as we cannot use a complex key in the map
 type StatsTuple struct {
 	Key                StatsKey
-	Metadata           Metadata
 	UtilizationMetrics UtilizationMetrics
 }
 

--- a/pkg/collector/corechecks/gpu/model/model.go
+++ b/pkg/collector/corechecks/gpu/model/model.go
@@ -28,9 +28,14 @@ type StatsKey struct {
 	DeviceUUID string `json:"device_uuid"`
 }
 
+type Metadata struct {
+	ContainerID string `json:"container_id"`
+}
+
 // StatsTuple is a single entry in the GPUStats array, as we cannot use a complex key in the map
 type StatsTuple struct {
 	Key                StatsKey
+	Metadata           Metadata
 	UtilizationMetrics UtilizationMetrics
 }
 

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -77,7 +77,7 @@ func RegisterChecks(store workloadmeta.Component, tagger tagger.Component, cfg c
 	corecheckLoader.RegisterCheck(helm.CheckName, helm.Factory())
 	corecheckLoader.RegisterCheck(pod.CheckName, pod.Factory(store, cfg, tagger))
 	corecheckLoader.RegisterCheck(ebpf.CheckName, ebpf.Factory())
-	corecheckLoader.RegisterCheck(gpu.CheckName, gpu.Factory())
+	corecheckLoader.RegisterCheck(gpu.CheckName, gpu.Factory(tagger))
 	corecheckLoader.RegisterCheck(ecs.CheckName, ecs.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(oomkill.CheckName, oomkill.Factory(tagger))
 	corecheckLoader.RegisterCheck(tcpqueuelength.CheckName, tcpqueuelength.Factory(tagger))

--- a/pkg/gpu/aggregator.go
+++ b/pkg/gpu/aggregator.go
@@ -40,9 +40,6 @@ type aggregator struct {
 
 	// sysCtx is the system context with global GPU-system data
 	sysCtx *systemContext
-
-	// metadata is the metadata for the process
-	metadata model.Metadata
 }
 
 func newAggregator(sysCtx *systemContext) *aggregator {

--- a/pkg/gpu/aggregator.go
+++ b/pkg/gpu/aggregator.go
@@ -40,6 +40,9 @@ type aggregator struct {
 
 	// sysCtx is the system context with global GPU-system data
 	sysCtx *systemContext
+
+	// metadata is the metadata for the process
+	metadata model.Metadata
 }
 
 func newAggregator(sysCtx *systemContext) *aggregator {

--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -208,7 +208,7 @@ func (c *cudaEventConsumer) getStreamKey(header *gpuebpf.CudaEventHeader) stream
 	containerID, err := cgroups.ContainerFilter("", cgroup)
 	if err != nil {
 		// We don't want to return an error here, as we can still process the event without the container ID
-		log.Errorf("error getting container ID for cgroup %s: %s", cgroup, err)
+		log.Warnf("error getting container ID for cgroup %s: %s", cgroup, err)
 	}
 
 	key := streamKey{

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -200,7 +200,7 @@ func (s *probeTestSuite) TestDetectsContainer() {
 	}
 
 	stats, err := probe.GetAndFlush()
-	key := model.StatsKey{PID: uint32(pid), DeviceUUID: testutil.DefaultGpuUUID}
+	key := model.StatsKey{PID: uint32(pid), DeviceUUID: testutil.DefaultGpuUUID, ContainerID: cid}
 	require.NoError(t, err)
 	require.NotNil(t, stats)
 	pidStats := getMetricsEntry(key, stats)

--- a/pkg/gpu/stats.go
+++ b/pkg/gpu/stats.go
@@ -40,7 +40,7 @@ func (g *statsGenerator) getStats(nowKtime int64) *model.GPUStats {
 	g.currGenerationKTime = nowKtime
 
 	for key, handler := range g.streamHandlers {
-		aggr := g.getOrCreateAggregator(key)
+		aggr := g.getOrCreateAggregator(key, handler.containerID)
 		currData := handler.getCurrentData(uint64(nowKtime))
 		pastData := handler.getPastData(true)
 
@@ -66,6 +66,7 @@ func (g *statsGenerator) getStats(nowKtime int64) *model.GPUStats {
 	for aggKey, aggr := range g.aggregators {
 		entry := model.StatsTuple{
 			Key:                aggKey,
+			Metadata:           aggr.metadata,
 			UtilizationMetrics: aggr.getStats(normFactor),
 		}
 		stats.Metrics = append(stats.Metrics, entry)
@@ -76,7 +77,7 @@ func (g *statsGenerator) getStats(nowKtime int64) *model.GPUStats {
 	return stats
 }
 
-func (g *statsGenerator) getOrCreateAggregator(sKey streamKey) *aggregator {
+func (g *statsGenerator) getOrCreateAggregator(sKey streamKey, containerID string) *aggregator {
 	aggKey := model.StatsKey{
 		PID:        sKey.pid,
 		DeviceUUID: sKey.gpuUUID,
@@ -84,6 +85,7 @@ func (g *statsGenerator) getOrCreateAggregator(sKey streamKey) *aggregator {
 
 	if _, ok := g.aggregators[aggKey]; !ok {
 		g.aggregators[aggKey] = newAggregator(g.sysCtx)
+		g.aggregators[aggKey].metadata.ContainerID = containerID
 	}
 
 	// Update the last check time and the measured interval, as these change between check runs

--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -44,9 +44,10 @@ type enrichedKernelLaunch struct {
 
 // streamKey is a unique identifier for a CUDA stream
 type streamKey struct {
-	pid     uint32
-	stream  uint64
-	gpuUUID string
+	pid         uint32
+	stream      uint64
+	gpuUUID     string
+	containerID string
 }
 
 // streamData contains kernel spans and allocations for a stream


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the tagger to the core agent GPU module, to add tags based on container ID to the GPU metrics.

### Motivation

Uniform experience with GPU metrics and their tags.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manually validated in the load-test environment, by ensuring the metrics have container-related tags.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The container ID is added as part of the metrics/stream keys. While it's not technically part of the identifier for a stream or a process, in practice it would need to passed along with the key in a lot of cases. This choice facilitates the design and avoids having an extra "metadata" structure.