### PR TITLE
Remade worktree unit tests

### DIFF
--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -63,7 +63,7 @@ def remove_env(ctx):
 def is_worktree():
     """Will return True if the current environment is a worktree environment."""
 
-    return Path.cwd() == WORKTREE_DIRECTORY
+    return Path.cwd().resolve() == WORKTREE_DIRECTORY.resolve()
 
 
 def enter_env(ctx, branch: str | None, skip_checkout=False):

--- a/tasks/unit_tests/libs/common/worktree_tests.py
+++ b/tasks/unit_tests/libs/common/worktree_tests.py
@@ -1,104 +1,147 @@
-# TODO(celian): Reintroduce these tests
+import os
+import re
+import shutil
+import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-"""
-NOTE: These tests are disabled since they use git commands that are not mocked yet.
-This breaks unit tests ran with macos runners.
-"""
+from invoke.context import Context, MockContext, Result
 
-# import os
-# import unittest
+from tasks.libs.common.gomodules import Configuration, get_default_modules
+from tasks.libs.common.worktree import agent_context, init_env, is_worktree
 
-# from invoke import Context
-
-# from tasks.libs.common.git import get_default_branch
-# from tasks.libs.common.gomodules import get_default_modules
-# from tasks.libs.common.worktree import agent_context, init_env, is_worktree
+TEST_WORKTREE_DIR = Path('/tmp/datadog-agent-worktree')
 
 
-# def get_ctx():
-#     return Context()
+def get_ctx():
+    return Context()
 
 
-# class TestWorktree(unittest.TestCase):
-#     def setUp(self):
-#         # Pull only once
-#         init_env(get_ctx(), '6.53.x')
-#         os.environ['AGENT_WORKTREE_NO_PULL'] = '1'
+class WorktreeMockContext(MockContext):
+    """Mock for invoke context to simulate git commands (clone / switch).
 
-#     def test_context_is_worktree_true(self):
-#         with agent_context(get_ctx(), '6.53.x'):
-#             self.assertTrue(is_worktree())
+    Only `modules.yml` will be updated to simulate it.
+    """
 
-#     def test_context_is_worktree_false(self):
-#         self.assertFalse(is_worktree())
+    def __init__(self):
+        super().__init__()
 
-#     def test_context_nested(self):
-#         with agent_context(get_ctx(), '6.53.x'):
-#             with agent_context(get_ctx(), '6.53.x'):
-#                 self.assertTrue(is_worktree())
-#             self.assertTrue(is_worktree())
+        self.branch = None
+        self.modules_main = get_default_modules()
+        # Exclude some modules
+        self.modules_653x = {name: mod for (name, mod) in get_default_modules().items() if not name.startswith('comp/')}
 
-#     def test_context_pwd(self):
-#         ctx = get_ctx()
+        assert self.modules_main.keys() != self.modules_653x.keys()
 
-#         with agent_context(ctx, None, skip_checkout=True):
-#             pwdnone = ctx.run('pwd').stdout
+    def _checkout(self, branch):
+        assert branch in ('main', '6.53.x')
 
-#         with agent_context(ctx, '6.53.x'):
-#             pwd6 = ctx.run('pwd').stdout
+        if self.branch == branch:
+            return
 
-#         with agent_context(ctx, 'main'):
-#             pwdmain = ctx.run('pwd').stdout
+        self.branch = branch
+        modules = self.modules_main if branch == 'main' else self.modules_653x
 
-#         self.assertEqual(pwd6, pwdnone)
-#         self.assertEqual(pwd6, pwdmain)
+        Configuration(TEST_WORKTREE_DIR, modules, set()).to_file()
 
-#     def test_context_modules(self):
-#         ctx = get_ctx()
+    def _clone(self):
+        self.reset()
+        TEST_WORKTREE_DIR.mkdir(parents=True)
+        self._checkout('main')
 
-#         with agent_context(ctx, 'main'):
-#             modules7 = get_default_modules()
+    def reset(self):
+        shutil.rmtree(TEST_WORKTREE_DIR, ignore_errors=True)
+        self.branch = None
 
-#         with agent_context(ctx, '6.53.x'):
-#             modules6 = get_default_modules()
+    def run(self, command, *args, **kwargs):
+        if re.match(r'git.*rev-parse.*', command):
+            return Result(stdout=self.branch)
 
-#         self.assertNotEqual(set(modules6.keys()), set(modules7.keys()))
+        if re.match(r'git.*remote get-url.*', command):
+            return Result(stdout='git@my-amazing-git-server.dev:datadog/datadog-agent.git')
 
-#     def test_context_branch(self):
-#         ctx = get_ctx()
+        if re.match(r'git.*clone.*', command):
+            self._clone()
 
-#         with agent_context(ctx, 'main'):
-#             branch7 = get_default_branch()
+            return Result(stdout='cloned')
 
-#         with agent_context(ctx, '6.53.x'):
-#             branch6 = get_default_branch()
+        if re.match(r'git.*checkout.*', command):
+            on_653x = '6.53.x' in command
 
-#         self.assertNotEqual(branch6, branch7)
+            self._checkout('6.53.x' if on_653x else 'main')
 
-#     def test_context_no_checkout(self):
-#         ctx = get_ctx()
+            return Result(stdout='checked out')
 
-#         with agent_context(ctx, '6.53.x'):
-#             branch6 = get_default_branch()
+        return super().run(command, *args, **kwargs)
 
-#         with agent_context(ctx, 'main'):
-#             branch7 = get_default_branch()
 
-#         with agent_context(ctx, 'main', skip_checkout=True):
-#             branch_no_checkout = get_default_branch()
+class TestWorktree(unittest.TestCase):
+    def setUp(self):
+        # Pull only once
+        self.mock_ctx = WorktreeMockContext()
+        self.mock_ctx.reset()
+        self.patch_workdir = patch('tasks.libs.common.worktree.WORKTREE_DIRECTORY', TEST_WORKTREE_DIR)
+        self.patch_workdir.start()
+        self.patch_agentdir = patch('tasks.libs.common.gomodules.agent_working_directory', lambda: TEST_WORKTREE_DIR)
+        self.patch_agentdir.start()
 
-#         self.assertNotEqual(branch6, branch7)
-#         self.assertEqual(branch7, branch_no_checkout)
+        os.environ['AGENT_WORKTREE_NO_PULL'] = '1'
+        init_env(self.mock_ctx, '6.53.x')
 
-#     def test_context_no_checkout_error(self):
-#         ctx = get_ctx()
+    def tearDown(self):
+        self.patch_workdir.stop()
+        self.patch_agentdir.stop()
+        self.mock_ctx.reset()
 
-#         with agent_context(ctx, '6.53.x'):
-#             pass
+    def test_context_is_worktree_true(self):
+        with agent_context(self.mock_ctx, '6.53.x'):
+            self.assertTrue(is_worktree())
 
-#         def switch_context():
-#             # The current branch is not main
-#             with agent_context(ctx, 'main', skip_checkout=True):
-#                 pass
+    def test_context_is_worktree_false(self):
+        self.assertFalse(is_worktree())
 
-#         self.assertRaises(AssertionError, switch_context)
+    def test_context_nested(self):
+        with agent_context(self.mock_ctx, '6.53.x'):
+            with agent_context(self.mock_ctx, '6.53.x'):
+                self.assertTrue(is_worktree())
+            self.assertTrue(is_worktree())
+
+    def test_context_pwd(self):
+        ctx = get_ctx()
+
+        with agent_context(self.mock_ctx, None, skip_checkout=True):
+            pwdnone = ctx.run('pwd').stdout
+
+        with agent_context(self.mock_ctx, '6.53.x'):
+            pwd6 = ctx.run('pwd').stdout
+
+        with agent_context(self.mock_ctx, 'main'):
+            pwdmain = ctx.run('pwd').stdout
+
+        self.assertEqual(pwd6, pwdnone)
+        self.assertEqual(pwd6, pwdmain)
+
+    def test_context_modules(self):
+        with agent_context(self.mock_ctx, 'main'):
+            modules7 = get_default_modules()
+
+        with agent_context(self.mock_ctx, '6.53.x'):
+            modules6 = get_default_modules()
+
+        self.assertNotEqual(set(modules6.keys()), set(modules7.keys()))
+
+    def test_context_no_checkout(self):
+        with agent_context(self.mock_ctx, 'main'):
+            modules7 = get_default_modules()
+
+        with agent_context(self.mock_ctx, '6.53.x'):
+            modules6 = get_default_modules()
+
+        # Cannot skip checkout if the branch is not the target one (current is 6.53.x)
+        self.assertRaises(AssertionError, lambda: agent_context(self.mock_ctx, 'main', skip_checkout=True).__enter__())
+
+        with agent_context(self.mock_ctx, '6.53.x', skip_checkout=True):
+            modules_no_checkout = get_default_modules()
+
+        self.assertNotEqual(set(modules6.keys()), set(modules7.keys()))
+        self.assertEqual(set(modules6.keys()), set(modules_no_checkout.keys()))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

> [!NOTE]
> Please prefer reviewing [this diff](https://github.com/DataDog/datadog-agent/compare/8ea4e935b5192660c2dca85ed0a39dd6e9624222...celian/worktree-unit-tests-reenable) that doesn't include the un-comment part of the PR.

Worktree unit tests were disabled following this [PR](https://github.com/DataDog/datadog-agent/pull/31641). Enabled again these tests by modifying them:

- Mocked all git commands with a custom invoke context mock
  - The new worktree is a temporary directory that is removed before / after each test
  - Instead of `git clone`, the directory is created and `modules.yml` file is written (only this file is within this directory)
  - Instead of `git checkout`, the `modules.yml` file is changed
  - To test a context change, modules are loaded from `modules.yml` and compared
- Fixed `is_worktree()` to resolve path
- The get current branch test has been removed since it is not useful anymore (was testing only the mock)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->