### PR TITLE
[Backport 7.61.x] [tagger/remote] Fix "tagger-list" command

### DIFF
--- a/comp/core/tagger/impl-dual/dual.go
+++ b/comp/core/tagger/impl-dual/dual.go
@@ -54,7 +54,8 @@ func NewComponent(req Requires) (Provides, error) {
 
 		return Provides{
 			local.Provides{
-				Comp: provide.Comp,
+				Comp:     provide.Comp,
+				Endpoint: provide.Endpoint,
 			},
 		}, nil
 	}

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -9,8 +9,10 @@ package remotetaggerimpl
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -21,6 +23,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 
+	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
@@ -35,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
 const (
@@ -59,7 +63,8 @@ type Requires struct {
 type Provides struct {
 	compdef.Out
 
-	Comp tagger.Component
+	Comp     tagger.Component
+	Endpoint api.AgentEndpointProvider
 }
 
 type remoteTagger struct {
@@ -97,7 +102,7 @@ type Options struct {
 
 // NewComponent returns a remote tagger
 func NewComponent(req Requires) (Provides, error) {
-	remoteTagger, err := NewRemoteTagger(req.Params, req.Config, req.Log, req.Telemetry)
+	remoteTagger, err := newRemoteTagger(req.Params, req.Config, req.Log, req.Telemetry)
 
 	if err != nil {
 		return Provides{}, err
@@ -112,13 +117,12 @@ func NewComponent(req Requires) (Provides, error) {
 	}})
 
 	return Provides{
-		Comp: remoteTagger,
+		Comp:     remoteTagger,
+		Endpoint: api.NewAgentEndpointProvider(remoteTagger.writeList, "/tagger-list", "GET"),
 	}, nil
 }
 
-// NewRemoteTagger creates a new remote tagger.
-// TODO: (components) remove once we pass the remote tagger instance to pkg/security/resolvers/tags/resolver.go
-func NewRemoteTagger(params tagger.RemoteParams, cfg config.Component, log log.Component, telemetryComp coretelemetry.Component) (tagger.Component, error) {
+func newRemoteTagger(params tagger.RemoteParams, cfg config.Component, log log.Component, telemetryComp coretelemetry.Component) (*remoteTagger, error) {
 	telemetryStore := telemetry.NewStore(telemetryComp)
 
 	target, err := params.RemoteTarget(cfg)
@@ -494,6 +498,17 @@ func (t *remoteTagger) startTaggerStream(maxElapsed time.Duration) error {
 
 		return nil
 	}, expBackoff)
+}
+
+func (t *remoteTagger) writeList(w http.ResponseWriter, _ *http.Request) {
+	response := t.List()
+
+	jsonTags, err := json.Marshal(response)
+	if err != nil {
+		httputils.SetJSONError(w, t.log.Errorf("Unable to marshal tagger list response: %s", err), 500)
+		return
+	}
+	w.Write(jsonTags)
 }
 
 func convertEventType(t pb.EventType) (types.EventType, error) {

--- a/comp/core/tagger/impl-remote/remote_test.go
+++ b/comp/core/tagger/impl-remote/remote_test.go
@@ -7,8 +7,12 @@ package remotetaggerimpl
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
@@ -16,6 +20,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 )
@@ -39,7 +44,7 @@ func TestStart(t *testing.T) {
 	log := logmock.New(t)
 	telemetry := nooptelemetry.GetCompatComponent()
 
-	remoteTagger, err := NewRemoteTagger(params, cfg, log, telemetry)
+	remoteTagger, err := newRemoteTagger(params, cfg, log, telemetry)
 	require.NoError(t, err)
 	err = remoteTagger.Start(context.TODO())
 	require.NoError(t, err)
@@ -61,9 +66,48 @@ func TestStartDoNotBlockIfServerIsNotAvailable(t *testing.T) {
 	log := logmock.New(t)
 	telemetry := nooptelemetry.GetCompatComponent()
 
-	remoteTagger, err := NewRemoteTagger(params, cfg, log, telemetry)
+	remoteTagger, err := newRemoteTagger(params, cfg, log, telemetry)
 	require.NoError(t, err)
 	err = remoteTagger.Start(context.TODO())
 	require.NoError(t, err)
 	remoteTagger.Stop()
+}
+
+func TestNewComponentSetsTaggerListEndpoint(t *testing.T) {
+	req := Requires{
+		Lc:     compdef.NewTestLifecycle(t),
+		Config: configmock.New(t),
+		Log:    logmock.New(t),
+		Params: tagger.RemoteParams{
+			RemoteTarget: func(config.Component) (string, error) { return ":5001", nil },
+			RemoteTokenFetcher: func(config.Component) func() (string, error) {
+				return func() (string, error) {
+					return "something", nil
+				}
+			},
+		},
+		Telemetry: nooptelemetry.GetCompatComponent(),
+	}
+	provides, err := NewComponent(req)
+	require.NoError(t, err)
+
+	endpointProvider := provides.Endpoint.Provider
+
+	assert.Equal(t, []string{"GET"}, endpointProvider.Methods())
+	assert.Equal(t, "/tagger-list", endpointProvider.Route())
+
+	// Create a test server with the endpoint handler
+	server := httptest.NewServer(endpointProvider.HandlerFunc())
+	defer server.Close()
+
+	// Make a request to the endpoint
+	resp, err := http.Get(server.URL + "/tagger-list")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var response types.TaggerListResponse
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	require.NoError(t, err)
+	assert.NotNil(t, response.Entities)
 }


### PR DESCRIPTION
### What does this PR do?

Backports https://github.com/DataDog/datadog-agent/pull/31647 to the 7.61.x branch.
The automatic backport failed and I needed to fix some conflicts: https://github.com/DataDog/datadog-agent/pull/31647#issuecomment-2511523237

### Describe how you validated your changes
Done. Same as described in #31647 