### PR TITLE
chore(fleet): Add datadog-secret-backend to the agent packages

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/secrets_test.go
@@ -78,6 +78,10 @@ func (m *MockSecretResolver) haveAllScenariosNotCalled() bool {
 	return true
 }
 
+func (m *MockSecretResolver) ListSecrets() []string {
+	return nil
+}
+
 var sharedTpl = integration.Config{
 	Name:          "cpu",
 	ADIdentifiers: []string{"redis"},

--- a/comp/core/secrets/component.go
+++ b/comp/core/secrets/component.go
@@ -37,4 +37,6 @@ type Component interface {
 	SubscribeToChanges(callback SecretChangeCallback)
 	// Refresh will resolve secret handles again, notifying any subscribers of changed values
 	Refresh() (string, error)
+	// ListSecrets returns the list of secret keys that are available
+	ListSecrets() []string
 }

--- a/comp/core/secrets/secretsimpl/fetch_secret.go
+++ b/comp/core/secrets/secretsimpl/fetch_secret.go
@@ -32,7 +32,7 @@ func (b *limitBuffer) Write(p []byte) (n int, err error) {
 	return b.buf.Write(p)
 }
 
-func (r *secretResolver) execCommand(inputPayload string) ([]byte, error) {
+func (r *secretResolver) execCommand(inputPayload string, additionalArguments ...string) ([]byte, error) {
 	// hook used only for tests
 	if r.commandHookFunc != nil {
 		return r.commandHookFunc(inputPayload)
@@ -42,7 +42,8 @@ func (r *secretResolver) execCommand(inputPayload string) ([]byte, error) {
 		time.Duration(r.backendTimeout)*time.Second)
 	defer cancel()
 
-	cmd, done, err := commandContext(ctx, r.backendCommand, r.backendArguments...)
+	args := append(r.backendArguments, additionalArguments...)
+	cmd, done, err := commandContext(ctx, r.backendCommand, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/secrets/type.go
+++ b/comp/core/secrets/type.go
@@ -22,3 +22,9 @@ type SecretChangeCallback func(handle, origin string, path []string, oldValue, n
 
 // PayloadVersion defines the current payload version sent to a secret backend
 const PayloadVersion = "1.0"
+
+// SecretKeys defines the structure for secret keys in JSON output
+type SecretKeys struct {
+	Keys     []string `json:"keys"`
+	ErrorMsg string   `json:"error,omitempty"`
+}

--- a/comp/metadata/bundle_test.go
+++ b/comp/metadata/bundle_test.go
@@ -13,6 +13,7 @@ import (
 	authtokenimpl "github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -29,6 +30,7 @@ func TestBundleDependencies(t *testing.T) {
 			return optional.NewNoneOption[agent.Component]()
 		}),
 		authtokenimpl.Module(),
+		secretsimpl.MockModule(),
 	)
 }
 

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
 	sysprobeConfigFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher/sysprobe"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -48,6 +50,8 @@ func getProvides(t *testing.T, confOverrides map[string]any, sysprobeConfOverrid
 			fx.Replace(sysprobeconfigimpl.MockParams{Overrides: sysprobeConfOverrides}),
 			fx.Provide(func() serializer.MetricSerializer { return serializermock.NewMetricSerializer(t) }),
 			authtokenimpl.Module(),
+			secretsimpl.MockModule(),
+			telemetryimpl.MockModule(),
 		),
 	)
 }
@@ -527,6 +531,8 @@ func TestFetchSystemProbeAgent(t *testing.T) {
 			sysprobeconfig.NoneModule(),
 			fx.Provide(func() serializer.MetricSerializer { return serializermock.NewMetricSerializer(t) }),
 			authtokenimpl.Module(),
+			secretsimpl.MockModule(),
+			telemetryimpl.MockModule(),
 		),
 	)
 	ia = p.Comp.(*inventoryagent)

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -198,6 +198,14 @@ build do
     end
   end
 
+  # Secrets backend
+  # TODO: remove this once the secret backend is supported on Windows
+  unless windows_target?
+    command "inv agent.get-datadog-secret-backend", :env => env
+    command "chmod 700 bin/datadog-secret-backend/datadog-secret-backend"
+    copy 'bin/datadog-secret-backend/datadog-secret-backend', "#{install_dir}/embedded/bin"
+  end
+
   if osx_target?
     # Launchd service definition
     erb source: "launchd.plist.example.erb",

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -339,7 +339,12 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("enabled_rfc1123_compliant_cluster_name_tag", true)
 
 	// secrets backend
-	config.BindEnvAndSetDefault("secret_backend_command", "")
+	if runtime.GOOS == "windows" {
+		// TODO: remove this once the secret backend is supported on Windows
+		config.BindEnvAndSetDefault("secret_backend_command", "")
+	} else {
+		config.BindEnvAndSetDefault("secret_backend_command", filepath.Join(InstallPath, "embedded/bin/datadog-secret-backend"))
+	}
 	config.BindEnvAndSetDefault("secret_backend_arguments", []string{})
 	config.BindEnvAndSetDefault("secret_backend_output_max_size", 0)
 	config.BindEnvAndSetDefault("secret_backend_timeout", 0)

--- a/test/new-e2e/tests/agent-subcommands/secret/secret_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/secret/secret_common_test.go
@@ -8,15 +8,8 @@ package secret
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
-	"github.com/stretchr/testify/assert"
 )
 
 type baseSecretSuite struct {
 	e2e.BaseSuite[environments.Host]
-}
-
-func (v *baseSecretSuite) TestAgentSecretNotEnabledByDefault() {
-	secret := v.Env().Agent.Client.Secret()
-
-	assert.Contains(v.T(), secret, "No secret_backend_command set")
 }


### PR DESCRIPTION
### What does this PR do?
- Adds [datadog-secret-backend](https://github.com/DataDog/datadog-secret-backend) to the agent package under `embedded/bin`
- (PR pending in datadog-secret-backend) Supports the `--list` option to list the available secret keys and report them to the backend

### Motivation
Hackathon

### Describe how you validated your changes
Tested manually on a Linux VM

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->