### PR TITLE
Suffix the branch name with a timestamp when creating a new branch to build a release candidate

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -378,7 +378,7 @@ def create_rc(ctx, major_versions="6,7", patch_version=False, upstream="origin",
 
     # Check that the current and update branches are valid
     current_branch = get_current_branch(ctx)
-    update_branch = f"release/{new_highest_version}"
+    update_branch = f"release/{new_highest_version}-{int(time.time())}"
 
     check_clean_branch_state(ctx, github, update_branch)
     if not check_base_branch(current_branch, new_highest_version):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Suffix the branch name with a timestamp when creating a new branch to build a release candidate

### Motivation

https://github.com/DataDog/datadog-agent/actions/runs/12120971441/job/33790921441

Sometimes the job fails and leaves the branch behind. It's not a big deal since it does not happen a lot and we already have a job to clean stale branches after a while. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->