### PR TITLE
Stop initializing the logger twice in dogstatsd

### DIFF
--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -55,7 +55,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/runner"
 	metadatarunnerimpl "github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/compression/fx"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util"
@@ -235,33 +234,6 @@ func RunDogstatsd(_ context.Context, cliParams *CLIParams, config config.Compone
 			log.Errorf("Error creating dogstatsd stats server on port %d: %s", port, err)
 		}
 	}()
-
-	// Setup logger
-	syslogURI := pkglogsetup.GetSyslogURI(pkgconfigsetup.Datadog())
-	logFile := config.GetString("log_file")
-	if logFile == "" {
-		logFile = params.DefaultLogFile
-	}
-
-	if config.GetBool("disable_file_logging") {
-		// this will prevent any logging on file
-		logFile = ""
-	}
-
-	err = pkglogsetup.SetupLogger(
-		loggerName,
-		config.GetString("log_level"),
-		logFile,
-		syslogURI,
-		config.GetBool("syslog_rfc"),
-		config.GetBool("log_to_console"),
-		config.GetBool("log_format_json"),
-		pkgconfigsetup.Datadog(),
-	)
-	if err != nil {
-		log.Criticalf("Unable to setup logger: %s", err)
-		return
-	}
 
 	if err := util.SetupCoreDump(config); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Stop initializing the logger explicitly in dogstatsd, as it is already initialized when importing the component.

### Motivation
The exact same logic is already in `comp/core/log` and runs when initializing the log component.
There is no need to do the setup again.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ran dogstatsd and checked that it was still able to log as expected.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
