### PR TITLE
[CWS] do not enable fentry on kernel < 6.1

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -194,6 +194,12 @@ func (p *EBPFProbe) selectFentryMode() {
 		return
 	}
 
+	if p.kernelVersion.Code < kernel.Kernel6_1 {
+		p.useFentry = false
+		seclog.Warnf("fentry enabled but not fully supported on this kernel version (< 6.1), falling back to kprobe mode")
+		return
+	}
+
 	if !p.kernelVersion.HaveFentrySupport() {
 		p.useFentry = false
 		seclog.Errorf("fentry enabled but not supported, falling back to kprobe mode")


### PR DESCRIPTION
### What does this PR do?

We already have some checks to ensure fentry will work, but as a first step we are going to enforce kernel >= 6.1 to actually turn on fentry. This will allow us to gain more confidence on fentry as a whole before trying to turn it on more globally.

### Motivation

### Describe how you validated your changes

Tested in functional tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->