### PR TITLE
disable ddflare ocb integration test

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -82,12 +82,4 @@ ddflare_extension_ocb_build:
     - grep -q 'extensions:\\n  - ddflare\\n' flare-info.log || (echo "ddflare extension should be enabled" && kill $OTELCOL_PID && exit 1)
     - kill $OTELCOL_PID  # Kill the process
   rules:
-    - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
-      when: never
-    - if: $CI_COMMIT_TAG
-      when: never
-    - if: $CI_COMMIT_MESSAGE =~ /.*\[skip cancel\].*/
-      when: never
-    - if: $CI_COMMIT_REF_NAME =~ /.*-skip-cancel$/
-      when: never
-    - when: always
+    - when: never


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
disables DDFlare OCB test until `go.work` is implemented
### Motivation
https://github.com/DataDog/datadog-agent/pull/31595 failed due to modules not being published yet
### Describe how you validated your changes
disabled test, none needed
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
need to re-enable test once go.work is enabled to see if it works
https://datadoghq.atlassian.net/browse/OTEL-2287
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->