### PR TITLE
[CWS] Do not infer cgroup from container ID

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -516,7 +516,7 @@ func (fh *EBPFFieldHandlers) ResolveCGroupID(ev *model.Event, e *model.CGroupCon
 				return string(entry.CGroup.CGroupID)
 			}
 
-			if err := fh.resolvers.ResolveCGroup(entry, ev.BaseEvent.PIDContext.Pid, e.CGroupFile, e.CGroupFlags, nil); err != nil {
+			if err := fh.resolvers.ResolveCGroup(entry, e.CGroupFile, e.CGroupFlags); err != nil {
 				seclog.Debugf("Failed to resolve cgroup: %s", err)
 			}
 

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -525,11 +525,10 @@ func (fh *EBPFFieldHandlers) ResolveCGroupID(ev *model.Event, e *model.CGroupCon
 
 				entry.Process.CGroup.CGroupID = containerutils.CGroupID(cgroup)
 				entry.CGroup.CGroupID = containerutils.CGroupID(cgroup)
+				entry.CGroup.CGroupFile = e.CGroupFile
 				containerID, _ := containerutils.GetContainerFromCgroup(entry.CGroup.CGroupID)
 				entry.Process.ContainerID = containerutils.ContainerID(containerID)
 				entry.ContainerID = containerutils.ContainerID(containerID)
-			} else {
-				entry.CGroup.CGroupID = containerutils.GetCgroupFromContainer(entry.ContainerID, entry.CGroup.CGroupFlags)
 			}
 
 			e.CGroupID = entry.CGroup.CGroupID

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -673,7 +673,11 @@ func (p *EBPFProbe) unmarshalProcessCacheEntry(ev *model.Event, data []byte) (in
 	}
 
 	entry.Process.ContainerID = ev.ContainerContext.ContainerID
-	entry.Process.CGroup = ev.CGroupContext
+	entry.ContainerID = ev.ContainerContext.ContainerID
+
+	entry.Process.CGroup.Merge(&ev.CGroupContext)
+	entry.CGroup.Merge(&ev.CGroupContext)
+
 	entry.Source = model.ProcessCacheEntryFromEvent
 
 	return n, nil
@@ -824,7 +828,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 
 		pce := p.Resolvers.ProcessResolver.Resolve(event.CgroupWrite.Pid, event.CgroupWrite.Pid, 0, false, newEntryCb)
 		if pce != nil {
-			if err := p.Resolvers.ResolveCGroup(pce, event.CgroupWrite.Pid, event.CgroupWrite.File.PathKey, containerutils.CGroupFlags(event.CgroupWrite.CGroupFlags), newEntryCb); err != nil {
+			if err := p.Resolvers.ResolveCGroup(pce, event.CgroupWrite.File.PathKey, containerutils.CGroupFlags(event.CgroupWrite.CGroupFlags)); err != nil {
 				seclog.Debugf("Failed to resolve cgroup: %s", err)
 			}
 		}

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -81,7 +81,7 @@ func getContainerIDFromProcFS(cgroupPath string) (containerutils.ContainerID, er
 	}
 
 	for _, cgroup := range cgroups {
-		if cid, _ := containerutils.FindContainerID(cgroup.path); cid != "" {
+		if cid, _ := containerutils.FindContainerID(containerutils.CGroupID(cgroup.path)); cid != "" {
 			return cid, nil
 		}
 	}

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -33,7 +33,6 @@ func NewCacheEntry(containerID containerutils.ContainerID, cgroupFlags uint64, p
 	newCGroup := CacheEntry{
 		Deleted: atomic.NewBool(false),
 		CGroupContext: model.CGroupContext{
-			CGroupID:    containerutils.GetCgroupFromContainer(containerID, containerutils.CGroupFlags(cgroupFlags)),
 			CGroupFlags: containerutils.CGroupFlags(cgroupFlags),
 		},
 		ContainerContext: model.ContainerContext{

--- a/pkg/security/resolvers/container/resolver.go
+++ b/pkg/security/resolvers/container/resolver.go
@@ -10,6 +10,7 @@ package container
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -17,7 +18,7 @@ import (
 type Resolver struct{}
 
 // GetContainerContext returns the container id of the given pid along with its flags
-func (cr *Resolver) GetContainerContext(pid uint32) (containerutils.ContainerID, containerutils.CGroupFlags, error) {
+func (cr *Resolver) GetContainerContext(pid uint32) (containerutils.ContainerID, model.CGroupContext, error) {
 	// Parse /proc/[pid]/task/[pid]/cgroup
 	return utils.GetProcContainerContext(pid, pid)
 }

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -28,7 +28,6 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/shirou/gopsutil/v3/process"
 	"go.uber.org/atomic"
-	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
@@ -40,7 +39,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/mount"
 	spath "github.com/DataDog/datadog-agent/pkg/security/resolvers/path"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usergroup"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -340,12 +338,15 @@ func (p *EBPFResolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc 
 	}
 
 	// Retrieve the container ID of the process from /proc
-	containerID, containerFlags, err := p.containerResolver.GetContainerContext(pid)
+	containerID, cgroup, err := p.containerResolver.GetContainerContext(pid)
 	if err != nil {
 		return fmt.Errorf("snapshot failed for %d: couldn't parse container ID: %w", proc.Pid, err)
 	}
 
 	entry.ContainerID = containerID
+
+	entry.CGroup = cgroup
+	entry.Process.CGroup = cgroup
 
 	entry.FileEvent.FileFields = *info
 	setPathname(&entry.FileEvent, pathnameStr)
@@ -354,35 +355,14 @@ func (p *EBPFResolver) enrichEventFromProc(entry *model.ProcessCacheEntry, proc 
 	entry.FileEvent.MountOrigin = model.MountOriginProcfs
 	entry.FileEvent.MountSource = model.MountSourceSnapshot
 
-	entry.Process.CGroup.CGroupFlags = containerFlags
-	var fileStats unix.Statx_t
-
-	taskPath := utils.CgroupTaskPath(pid, pid)
-	if err := unix.Statx(unix.AT_FDCWD, taskPath, 0, unix.STATX_ALL, &fileStats); err == nil {
-		entry.Process.CGroup.CGroupFile.MountID = uint32(fileStats.Mnt_id)
-		entry.Process.CGroup.CGroupFile.Inode = fileStats.Ino
-	} else {
+	if entry.Process.CGroup.CGroupFile.MountID == 0 {
 		// Get the file fields of the cgroup file
+		taskPath := utils.CgroupTaskPath(pid, pid)
 		info, err := p.retrieveExecFileFields(taskPath)
 		if err != nil {
 			seclog.Debugf("snapshot failed for %d: couldn't retrieve inode info: %s", proc.Pid, err)
 		} else {
 			entry.Process.CGroup.CGroupFile.MountID = info.MountID
-		}
-	}
-
-	if cgroupFileContent, err := os.ReadFile(taskPath); err == nil {
-		lines := strings.Split(string(cgroupFileContent), "\n")
-		for _, line := range lines {
-			parts := strings.SplitN(line, ":", 3)
-
-			// Skip potentially malformed lines
-			if len(parts) != 3 {
-				continue
-			}
-
-			entry.Process.CGroup.CGroupID = containerutils.CGroupID(parts[2])
-			break
 		}
 	}
 
@@ -873,10 +853,11 @@ func (p *EBPFResolver) resolveFromKernelMaps(pid, tid uint32, inode uint64, newE
 	// is no insurance that the parent of this process is still running, we can't use our user space cache to check if
 	// the parent is in a container. In other words, we have to fall back to /proc to query the container ID of the
 	// process.
-	if entry.ContainerID == "" {
-		_, containerFlags, err := p.containerResolver.GetContainerContext(pid)
+	if entry.CGroup.CGroupID == "" || entry.ContainerID == "" {
+		containerID, cgroup, err := p.containerResolver.GetContainerContext(pid)
 		if err == nil {
-			entry.CGroup.CGroupFlags = containerFlags
+			entry.CGroup = cgroup
+			entry.ContainerID = containerID
 		}
 	}
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -829,8 +829,7 @@ func (p *EBPFResolver) resolveFromKernelMaps(pid, tid uint32, inode uint64, newE
 		return nil
 	}
 
-	var cgroupCtx model.CGroupContext
-	cgroupRead, err := cgroupCtx.UnmarshalBinary(procCache)
+	cgroupRead, err := entry.CGroup.UnmarshalBinary(procCache)
 	if err != nil {
 		return nil
 	}

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -852,10 +852,9 @@ func (p *EBPFResolver) resolveFromKernelMaps(pid, tid uint32, inode uint64, newE
 	// is no insurance that the parent of this process is still running, we can't use our user space cache to check if
 	// the parent is in a container. In other words, we have to fall back to /proc to query the container ID of the
 	// process.
-	if entry.CGroup.CGroupID == "" || entry.ContainerID == "" {
-		containerID, cgroup, err := p.containerResolver.GetContainerContext(pid)
-		if err == nil {
-			entry.CGroup = cgroup
+	if entry.ContainerID == "" || entry.CGroup.CGroupFile.Inode == 0 {
+		if containerID, cgroup, err := p.containerResolver.GetContainerContext(pid); err == nil {
+			entry.CGroup.Merge(&cgroup)
 			entry.ContainerID = containerID
 		}
 	}

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -874,10 +874,9 @@ func (p *EBPFResolver) resolveFromKernelMaps(pid, tid uint32, inode uint64, newE
 	// the parent is in a container. In other words, we have to fall back to /proc to query the container ID of the
 	// process.
 	if entry.ContainerID == "" {
-		containerID, containerFlags, err := p.containerResolver.GetContainerContext(pid)
+		_, containerFlags, err := p.containerResolver.GetContainerContext(pid)
 		if err == nil {
 			entry.CGroup.CGroupFlags = containerFlags
-			entry.CGroup.CGroupID = containerutils.GetCgroupFromContainer(containerID, containerFlags)
 		}
 	}
 

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -218,7 +218,7 @@ func (r *EBPFResolvers) Start(ctx context.Context) error {
 }
 
 // ResolveCGroup resolves the path of cgroup for a process cache entry
-func (r *EBPFResolvers) ResolveCGroup(pce *model.ProcessCacheEntry, pid uint32, pathKey model.PathKey, cgroupFlags containerutils.CGroupFlags, newEntryCb func(entry *model.ProcessCacheEntry, err error)) error {
+func (r *EBPFResolvers) ResolveCGroup(pce *model.ProcessCacheEntry, pathKey model.PathKey, cgroupFlags containerutils.CGroupFlags) error {
 	path, err := r.DentryResolver.Resolve(pathKey, true)
 	if err == nil && path != "" {
 		cgroup := filepath.Dir(string(path))

--- a/pkg/security/secl/containerutils/cgroup.go
+++ b/pkg/security/secl/containerutils/cgroup.go
@@ -65,13 +65,3 @@ func GetContainerFromCgroup(cgroup CGroupID) (ContainerID, CGroupFlags) {
 	}
 	return "", 0
 }
-
-// GetCgroupFromContainer infers the container runtime from a cgroup name
-func GetCgroupFromContainer(id ContainerID, flags CGroupFlags) CGroupID {
-	for runtimePrefix, runtimeFlag := range RuntimePrefixes {
-		if flags&CGroupManagerMask == CGroupFlags(runtimeFlag) {
-			return CGroupID(runtimePrefix + string(id))
-		}
-	}
-	return CGroupID("")
-}

--- a/pkg/security/secl/containerutils/cgroup.go
+++ b/pkg/security/secl/containerutils/cgroup.go
@@ -36,31 +36,23 @@ const (
 )
 
 // RuntimePrefixes holds the cgroup prefixed used by the different runtimes
-var RuntimePrefixes = map[string]CGroupManager{
-	"docker/":         CGroupManagerDocker, // On Amazon Linux 2 with Docker, 'docker' is the folder name and not a prefix
-	"docker-":         CGroupManagerDocker,
-	"cri-containerd-": CGroupManagerCRI,
-	"crio-":           CGroupManagerCRIO,
-	"libpod-":         CGroupManagerPodman,
+var RuntimePrefixes = []struct {
+	prefix string
+	flags  CGroupManager
+}{
+	{"docker/", CGroupManagerDocker}, // On Amazon Linux 2 with Docker, 'docker' is the folder name and not a prefix
+	{"docker-", CGroupManagerDocker},
+	{"cri-containerd-", CGroupManagerCRI},
+	{"crio-", CGroupManagerCRIO},
+	{"libpod-", CGroupManagerPodman},
 }
 
-// GetCGroupManager extracts the cgroup manager from a cgroup name
-func GetCGroupManager(cgroup string) (string, CGroupFlags) {
-	cgroup = strings.TrimLeft(cgroup, "/")
-	for runtimePrefix, runtimeFlag := range RuntimePrefixes {
-		if strings.HasPrefix(cgroup, runtimePrefix) {
-			return cgroup[:len(runtimePrefix)], CGroupFlags(runtimeFlag)
-		}
-	}
-	return cgroup, 0
-}
-
-// GetContainerFromCgroup extracts the container ID from a cgroup name
-func GetContainerFromCgroup(cgroup CGroupID) (ContainerID, CGroupFlags) {
+// getContainerFromCgroup extracts the container ID from a cgroup name
+func getContainerFromCgroup(cgroup CGroupID) (ContainerID, CGroupFlags) {
 	cgroupID := strings.TrimLeft(string(cgroup), "/")
-	for runtimePrefix, runtimeFlag := range RuntimePrefixes {
-		if strings.HasPrefix(cgroupID, runtimePrefix) {
-			return ContainerID(cgroupID[len(runtimePrefix):]), CGroupFlags(runtimeFlag)
+	for _, runtimePrefix := range RuntimePrefixes {
+		if strings.HasPrefix(cgroupID, runtimePrefix.prefix) {
+			return ContainerID(cgroupID[len(runtimePrefix.prefix):]), CGroupFlags(runtimePrefix.flags)
 		}
 	}
 	return "", 0

--- a/pkg/security/secl/containerutils/helpers.go
+++ b/pkg/security/secl/containerutils/helpers.go
@@ -76,12 +76,3 @@ func FindContainerID(s string) (ContainerID, uint64) {
 
 	return containerID, uint64(flags)
 }
-
-// GetCGroupContext returns the cgroup ID and the sanitized container ID from a container id/flags tuple
-func GetCGroupContext(containerID ContainerID, cgroupFlags CGroupFlags) (CGroupID, ContainerID) {
-	cgroupID := GetCgroupFromContainer(containerID, cgroupFlags)
-	if !cgroupFlags.IsContainer() {
-		containerID = ""
-	}
-	return CGroupID(cgroupID), ContainerID(containerID)
-}

--- a/pkg/security/secl/containerutils/helpers.go
+++ b/pkg/security/secl/containerutils/helpers.go
@@ -22,19 +22,19 @@ var containerIDCoreChars = "0123456789abcdefABCDEF"
 
 func init() {
 	var prefixes []string
-	for prefix := range RuntimePrefixes {
-		prefixes = append(prefixes, prefix)
+	for _, runtimePrefix := range RuntimePrefixes {
+		prefixes = append(prefixes, runtimePrefix.prefix)
 	}
 	ContainerIDPatternStr = "(?:" + strings.Join(prefixes[:], "|") + ")?([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-\\d+)|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4})"
 	containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
 }
 
-func isSystemdCgroup(cgroup string) bool {
-	return strings.HasSuffix(cgroup, ".service") || strings.HasSuffix(cgroup, ".scope")
+func isSystemdCgroup(cgroup CGroupID) bool {
+	return strings.HasSuffix(string(cgroup), ".service") || strings.HasSuffix(string(cgroup), ".scope")
 }
 
 // FindContainerID extracts the first sub string that matches the pattern of a container ID along with the container flags induced from the container runtime prefix
-func FindContainerID(s string) (ContainerID, uint64) {
+func FindContainerID(s CGroupID) (ContainerID, uint64) {
 	match := containerIDPattern.FindIndex([]byte(s))
 	if match == nil {
 		if isSystemdCgroup(s) {
@@ -69,7 +69,7 @@ func FindContainerID(s string) (ContainerID, uint64) {
 	// it starts or/and ends the initial string
 
 	cgroupID := s[match[0]:match[1]]
-	containerID, flags := GetContainerFromCgroup(CGroupID(cgroupID))
+	containerID, flags := getContainerFromCgroup(CGroupID(cgroupID))
 	if containerID == "" {
 		return ContainerID(cgroupID), uint64(flags)
 	}

--- a/pkg/security/secl/containerutils/helpers_test.go
+++ b/pkg/security/secl/containerutils/helpers_test.go
@@ -92,7 +92,7 @@ func TestFindContainerID(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		containerID, containerFlags := FindContainerID(test.input)
+		containerID, containerFlags := FindContainerID(CGroupID(test.input))
 		assert.Equal(t, test.output, string(containerID))
 		assert.Equal(t, uint64(test.flags), containerFlags, "wrong flags for container %s", containerID)
 	}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -101,6 +101,22 @@ type CGroupContext struct {
 	CGroupFile    PathKey                    `field:"file"`
 }
 
+// Merge two cgroup context
+func (cg *CGroupContext) Merge(cg2 *CGroupContext) {
+	if cg.CGroupID == "" {
+		cg.CGroupID = cg2.CGroupID
+	}
+	if cg.CGroupFlags == 0 {
+		cg.CGroupFlags = cg2.CGroupFlags
+	}
+	if cg.CGroupFile.Inode == 0 {
+		cg.CGroupFile.Inode = cg2.CGroupFile.Inode
+	}
+	if cg.CGroupFile.MountID == 0 {
+		cg.CGroupFile.MountID = cg2.CGroupFile.MountID
+	}
+}
+
 // SyscallEvent contains common fields for all the event
 type SyscallEvent struct {
 	Retval int64 `field:"retval"` // SECLDoc[retval] Definition:`Return value of the syscall` Constants:`Error constants`

--- a/pkg/security/secl/model/process_cache_entry_unix.go
+++ b/pkg/security/secl/model/process_cache_entry_unix.go
@@ -80,8 +80,11 @@ func copyProcessContext(parent, child *ProcessCacheEntry) {
 	// WARNING: this is why the user space cache should not be used to detect container breakouts. Dedicated
 	// in-kernel probes will need to be added.
 	if len(parent.ContainerID) > 0 && len(child.ContainerID) == 0 {
-		child.CGroup = parent.CGroup
 		child.ContainerID = parent.ContainerID
+	}
+
+	if len(parent.CGroup.CGroupID) > 0 && len(child.CGroup.CGroupID) == 0 {
+		child.CGroup = parent.CGroup
 	}
 
 	// AUIDs should be inherited just like container IDs

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -37,13 +37,13 @@ type ControlGroup struct {
 
 // GetContainerContext returns both the container ID and its flags
 func (cg ControlGroup) GetContainerContext() (containerutils.ContainerID, containerutils.CGroupFlags) {
-	id, flags := containerutils.FindContainerID(cg.Path)
+	id, flags := containerutils.FindContainerID(containerutils.CGroupID(cg.Path))
 	return containerutils.ContainerID(id), containerutils.CGroupFlags(flags)
 }
 
 // GetContainerID returns the container id extracted from the path of the control group
 func (cg ControlGroup) GetContainerID() containerutils.ContainerID {
-	id, _ := containerutils.FindContainerID(cg.Path)
+	id, _ := containerutils.FindContainerID(containerutils.CGroupID(cg.Path))
 	return containerutils.ContainerID(id)
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove wrong helpers that infer cgroup path simply from the container ID and
the container runtime.

### Motivation

Cgroup path depends from the cgroup version, the distribution and configuration
so it's very hard to guess the cgroup path from the container ID and runtime.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->