### PR TITLE
Performance improvements of External Metrics controller and allow multiple workers

### DIFF
--- a/cmd/secrethelper/secret_helper.go
+++ b/cmd/secrethelper/secret_helper.go
@@ -52,7 +52,7 @@ const (
 )
 
 // NewKubeClient returns a new kubernetes.Interface
-type NewKubeClient func(timeout time.Duration) (kubernetes.Interface, error)
+type NewKubeClient func(timeout time.Duration, qps float32, burst int) (kubernetes.Interface, error)
 
 // cliParams are the command-line arguments for this subcommand
 type cliParams struct {
@@ -175,7 +175,7 @@ func readSecretsUsingPrefixes(secretsList []string, rootPath string, newKubeClie
 		case filePrefix:
 			res[secretID] = providers.ReadSecretFile(id)
 		case k8sSecretPrefix:
-			kubeClient, err := newKubeClientFunc(10 * time.Second)
+			kubeClient, err := newKubeClientFunc(10*time.Second, 0, 0) // Default QPS and burst to Kube client defaults using 0
 			if err != nil {
 				res[secretID] = secrets.SecretVal{Value: "", ErrorMsg: err.Error()}
 			} else {

--- a/cmd/secrethelper/secret_helper_test.go
+++ b/cmd/secrethelper/secret_helper_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestReadSecrets(t *testing.T) {
-	newKubeClientFunc := func(_ time.Duration) (kubernetes.Interface, error) {
+	newKubeClientFunc := func(_ time.Duration, _ float32, _ int) (kubernetes.Interface, error) {
 		return fake.NewSimpleClientset(&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "some_name",

--- a/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller_test.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/datadogmetric_controller_test.go
@@ -87,7 +87,7 @@ func (f *fixture) runControllerSync(leader bool, datadogMetricID string, expecte
 	defer close(stopCh)
 	informer.Start(stopCh)
 
-	err := controller.processDatadogMetric(datadogMetricID)
+	_, err := controller.processDatadogMetric(0, datadogMetricID)
 	assert.Equal(f.t, expectedError, err)
 
 	actions := autoscaling.FilterInformerActions(f.client.Actions(), "datadogmetrics")

--- a/pkg/clusteragent/autoscaling/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/metrics_retriever.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/externalmetrics/model"
 	"github.com/DataDog/datadog-agent/pkg/util/backoff"
+	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -59,7 +60,7 @@ func (mr *MetricsRetriever) Run(stopCh <-chan struct{}) {
 			if mr.isLeader() {
 				startTime := time.Now()
 				mr.retrieveMetricsValues()
-				retrieverElapsed.Observe(time.Since(startTime).Seconds())
+				retrieverElapsed.Observe(time.Since(startTime).Seconds(), le.JoinLeaderValue)
 			}
 		case <-stopCh:
 			log.Infof("Stopping MetricsRetriever")
@@ -196,7 +197,6 @@ func (mr *MetricsRetriever) retrieveMetricsValuesSlice(datadogMetrics []model.Da
 		}
 
 		datadogMetricFromStore.UpdateTime = currentTime
-
 		mr.store.UnlockSet(datadogMetric.ID, *datadogMetricFromStore, metricRetrieverStoreID)
 	}
 }

--- a/pkg/clusteragent/autoscaling/externalmetrics/metrics_retriever_test.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/metrics_retriever_test.go
@@ -62,8 +62,7 @@ type metricsFixture struct {
 	expected     []ddmWithQuery
 }
 
-//nolint:revive // TODO(CINT) Fix revive linter
-func (f *metricsFixture) run(t *testing.T, testTime time.Time) {
+func (f *metricsFixture) run(t *testing.T) {
 	t.Helper()
 
 	// Create and fill store
@@ -174,7 +173,7 @@ func TestRetrieveMetricsBasic(t *testing.T) {
 
 	for i, fixture := range fixtures {
 		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
-			fixture.run(t, defaultTestTime)
+			fixture.run(t)
 		})
 	}
 }
@@ -500,7 +499,7 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 
 	for i, fixture := range fixtures {
 		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
-			fixture.run(t, defaultTestTime)
+			fixture.run(t)
 		})
 	}
 }
@@ -639,7 +638,7 @@ func TestRetrieveMetricsNotActive(t *testing.T) {
 
 	for i, fixture := range fixtures {
 		t.Run(fmt.Sprintf("#%d %s", i, fixture.desc), func(t *testing.T) {
-			fixture.run(t, defaultTestTime)
+			fixture.run(t)
 		})
 	}
 }

--- a/pkg/clusteragent/autoscaling/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/model/datadogmetricinternal.go
@@ -317,7 +317,7 @@ func (d *DatadogMetricInternal) resolveQuery(query string) {
 		return
 	}
 	if resolvedQuery != "" {
-		log.Infof("DatadogMetric query %q was resolved successfully, new query: %q", query, resolvedQuery)
+		log.Debugf("DatadogMetric query %q was resolved successfully, new query: %q", query, resolvedQuery)
 		d.resolvedQuery = &resolvedQuery
 		return
 	}

--- a/pkg/clusteragent/autoscaling/externalmetrics/provider.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/provider.go
@@ -70,6 +70,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 	autogenNamespace := common.GetResourcesNamespace()
 	autogenEnabled := pkgconfigsetup.Datadog().GetBool("external_metrics_provider.enable_datadogmetric_autogen")
 	wpaEnabled := pkgconfigsetup.Datadog().GetBool("external_metrics_provider.wpa_controller")
+	numWorkers := pkgconfigsetup.Datadog().GetInt("external_metrics_provider.num_workers")
 
 	provider := &datadogMetricProvider{
 		apiCl:            apiCl,
@@ -117,7 +118,7 @@ func NewDatadogMetricProvider(ctx context.Context, apiCl *apiserver.APIClient, d
 	apiCl.InformerFactory.Start(ctx.Done())
 
 	go autoscalerWatcher.Run(ctx.Done())
-	go controller.Run(ctx)
+	go controller.Run(ctx, numWorkers)
 
 	return provider, nil
 }
@@ -133,7 +134,7 @@ func (p *datadogMetricProvider) GetExternalMetric(_ context.Context, namespace s
 		}
 	}
 
-	setQueryTelemtry("get", namespace, startTime, err)
+	setQueryTelemtry("get", startTime, err)
 	return res, err
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -257,8 +257,8 @@ func init() {
 	if envvar == "enable" {
 		datadog = nodetreemodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 	} else if envvar == "tee" {
-		var viperConfig = pkgconfigmodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))   // nolint: forbidigo // legit use case
-		var nodetreeConfig = nodetreemodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+		viperConfig := pkgconfigmodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))   // nolint: forbidigo // legit use case
+		nodetreeConfig := nodetreemodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 		datadog = teeconfig.NewTeeConfig(viperConfig, nodetreeConfig)
 	} else {
 		datadog = pkgconfigmodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
@@ -703,6 +703,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("external_metrics_provider.local_copy_refresh_rate", 30)        // value in seconds
 	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                     // Maximum number of queries to batch when querying Datadog.
 	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)  // Splits batches and runs queries with errors individually with an exponential backoff
+	config.BindEnvAndSetDefault("external_metrics_provider.num_workers", 2)                     // Number of workers spawned by controller (only when CRD is used)
 	pkgconfigmodel.AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.support_hybrid_ignore_ad_tags", false) // TODO(CINT)(Agent 7.53+) Remove this flag when hybrid ignore_ad_tags is fully deprecated
@@ -1284,7 +1285,6 @@ func telemetry(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("agent_telemetry.enabled", true)
 	config.SetKnown("agent_telemetry.additional_endpoints.*")
 	bindEnvAndSetLogsConfigKeys(config, "agent_telemetry.")
-
 }
 
 func serializer(config pkgconfigmodel.Setup) {

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -64,6 +64,15 @@ const (
 	tokenTime         = "tokenTimestamp"
 	tokenKey          = "tokenKey"
 	metadataMapExpire = 2 * time.Minute
+
+	// Default QPS and Burst values for the clients
+	informerClientQPSLimit = 5
+	informerClientQPSBurst = 10
+	standardClientQPSLimit = 10
+	standardClientQPSBurst = 20
+	// This is mostly required for built-in controllers in Cluster Agent (ExternalMetrics, Autoscaling that can generate a high nunber of `Update` requests)
+	controllerClientQPSLimit = 150
+	controllerClientQPSBurst = 300
 )
 
 // APIClient provides authenticated access to the
@@ -197,8 +206,7 @@ func WaitForAPIClient(ctx context.Context) (*APIClient, error) {
 	}
 }
 
-// GetClientConfig returns a REST client configuration
-func GetClientConfig(timeout time.Duration) (*rest.Config, error) {
+func getClientConfig(timeout time.Duration, qps float32, burst int) (*rest.Config, error) {
 	var clientConfig *rest.Config
 	var err error
 	cfgPath := pkgconfigsetup.Datadog().GetString("kubernetes_kubeconfig_path")
@@ -231,6 +239,8 @@ func GetClientConfig(timeout time.Duration) (*rest.Config, error) {
 	}
 
 	clientConfig.Timeout = timeout
+	clientConfig.QPS = qps
+	clientConfig.Burst = burst
 	clientConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
 		return NewCustomRoundTripper(rt, timeout)
 	})
@@ -240,10 +250,10 @@ func GetClientConfig(timeout time.Duration) (*rest.Config, error) {
 
 // GetKubeClient returns a kubernetes API server client
 // You should not use this function except if you need to create a *NEW* Client.
-func GetKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
+func GetKubeClient(timeout time.Duration, qps float32, burst int) (kubernetes.Interface, error) {
 	// TODO: Remove custom warning logger when we remove usage of ComponentStatus
 	rest.SetDefaultWarningHandler(CustomWarningLogger{})
-	clientConfig, err := GetClientConfig(timeout)
+	clientConfig, err := getClientConfig(timeout, qps, burst)
 	if err != nil {
 		return nil, err
 	}
@@ -251,8 +261,8 @@ func GetKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
 	return kubernetes.NewForConfig(clientConfig)
 }
 
-func getKubeDynamicClient(timeout time.Duration) (dynamic.Interface, error) {
-	clientConfig, err := GetClientConfig(timeout)
+func getKubeDynamicClient(timeout time.Duration, qps float32, burst int) (dynamic.Interface, error) {
+	clientConfig, err := getClientConfig(timeout, qps, burst)
 	if err != nil {
 		return nil, err
 	}
@@ -260,8 +270,8 @@ func getKubeDynamicClient(timeout time.Duration) (dynamic.Interface, error) {
 	return dynamic.NewForConfig(clientConfig)
 }
 
-func getCRDClient(timeout time.Duration) (*clientset.Clientset, error) {
-	clientConfig, err := GetClientConfig(timeout)
+func getCRDClient(timeout time.Duration, qps float32, burst int) (*clientset.Clientset, error) {
+	clientConfig, err := getClientConfig(timeout, qps, burst)
 	if err != nil {
 		return nil, err
 	}
@@ -269,16 +279,16 @@ func getCRDClient(timeout time.Duration) (*clientset.Clientset, error) {
 	return clientset.NewForConfig(clientConfig)
 }
 
-func getAPISClient(timeout time.Duration) (*apiregistrationclient.ApiregistrationV1Client, error) {
-	clientConfig, err := GetClientConfig(timeout)
+func getAPISClient(timeout time.Duration, qps float32, burst int) (*apiregistrationclient.ApiregistrationV1Client, error) {
+	clientConfig, err := getClientConfig(timeout, qps, burst)
 	if err != nil {
 		return nil, err
 	}
 	return apiregistrationclient.NewForConfig(clientConfig)
 }
 
-func getKubeVPAClient(timeout time.Duration) (vpa.Interface, error) {
-	clientConfig, err := GetClientConfig(timeout)
+func getKubeVPAClient(timeout time.Duration, qps float32, burst int) (vpa.Interface, error) {
+	clientConfig, err := getClientConfig(timeout, qps, burst)
 	if err != nil {
 		return nil, err
 	}
@@ -286,8 +296,8 @@ func getKubeVPAClient(timeout time.Duration) (vpa.Interface, error) {
 	return vpa.NewForConfig(clientConfig)
 }
 
-func getScaleClient(discoveryCl discovery.ServerResourcesInterface, restMapper meta.RESTMapper, timeout time.Duration) (scale.ScalesGetter, error) {
-	clientConfig, err := GetClientConfig(timeout)
+func getScaleClient(discoveryCl discovery.ServerResourcesInterface, restMapper meta.RESTMapper, timeout time.Duration, qps float32, burst int) (scale.ScalesGetter, error) {
+	clientConfig, err := getClientConfig(timeout, qps, burst)
 	if err != nil {
 		return nil, err
 	}
@@ -311,13 +321,13 @@ func (c *APIClient) GetInformerWithOptions(resyncPeriod *time.Duration, options 
 func (c *APIClient) connect() error {
 	var err error
 	// Clients
-	c.Cl, err = GetKubeClient(c.defaultClientTimeout)
+	c.Cl, err = GetKubeClient(c.defaultClientTimeout, standardClientQPSLimit, standardClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver client: %v", err)
 		return err
 	}
 
-	c.DynamicCl, err = getKubeDynamicClient(c.defaultClientTimeout)
+	c.DynamicCl, err = getKubeDynamicClient(c.defaultClientTimeout, controllerClientQPSLimit, controllerClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver dynamic client: %v", err)
 		return err
@@ -328,38 +338,38 @@ func (c *APIClient) connect() error {
 	c.RESTMapper = restmapper.NewDeferredDiscoveryRESTMapper(cachedClient)
 
 	// Scale client  has specific init and dependencies
-	c.ScaleCl, err = getScaleClient(c.Cl.Discovery(), c.RESTMapper, c.defaultClientTimeout)
+	c.ScaleCl, err = getScaleClient(c.Cl.Discovery(), c.RESTMapper, c.defaultClientTimeout, controllerClientQPSLimit, controllerClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get scale client: %v", err)
 		return err
 	}
 
 	// Informer clients
-	c.InformerCl, err = GetKubeClient(c.defaultInformerTimeout)
+	c.InformerCl, err = GetKubeClient(c.defaultInformerTimeout, informerClientQPSLimit, informerClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver client: %v", err)
 		return err
 	}
 
-	c.DynamicInformerCl, err = getKubeDynamicClient(c.defaultInformerTimeout)
+	c.DynamicInformerCl, err = getKubeDynamicClient(c.defaultInformerTimeout, informerClientQPSLimit, informerClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver dynamic client: %v", err)
 		return err
 	}
 
-	c.VPAInformerClient, err = getKubeVPAClient(c.defaultInformerTimeout)
+	c.VPAInformerClient, err = getKubeVPAClient(c.defaultInformerTimeout, informerClientQPSLimit, informerClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver vpa client: %v", err)
 		return err
 	}
 
-	c.CRDInformerClient, err = getCRDClient(c.defaultInformerTimeout)
+	c.CRDInformerClient, err = getCRDClient(c.defaultInformerTimeout, informerClientQPSLimit, informerClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver CRDClient client: %v", err)
 		return err
 	}
 
-	c.APISInformerClient, err = getAPISClient(c.defaultInformerTimeout)
+	c.APISInformerClient, err = getAPISClient(c.defaultInformerTimeout, informerClientQPSLimit, informerClientQPSBurst)
 	if err != nil {
 		log.Infof("Could not get apiserver APISClient client: %v", err)
 		return err
@@ -651,7 +661,7 @@ func (c *APIClient) GetARandomNodeName(ctx context.Context) (string, error) {
 
 // RESTClient returns a new REST client
 func (c *APIClient) RESTClient(apiPath string, groupVersion *schema.GroupVersion, negotiatedSerializer runtime.NegotiatedSerializer) (*rest.RESTClient, error) {
-	clientConfig, err := GetClientConfig(c.defaultClientTimeout)
+	clientConfig, err := getClientConfig(c.defaultClientTimeout, standardClientQPSLimit, standardClientQPSBurst)
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +675,7 @@ func (c *APIClient) RESTClient(apiPath string, groupVersion *schema.GroupVersion
 
 // MetadataClient returns a new kubernetes metadata client
 func (c *APIClient) MetadataClient() (metadata.Interface, error) {
-	clientConfig, err := GetClientConfig(c.defaultInformerTimeout)
+	clientConfig, err := getClientConfig(c.defaultInformerTimeout, standardClientQPSLimit, standardClientQPSBurst)
 	if err != nil {
 		return nil, err
 	}
@@ -676,7 +686,7 @@ func (c *APIClient) MetadataClient() (metadata.Interface, error) {
 
 // NewSPDYExecutor returns a new SPDY executor for the provided method and URL
 func (c *APIClient) NewSPDYExecutor(apiPath string, groupVersion *schema.GroupVersion, negotiatedSerializer runtime.NegotiatedSerializer, method string, url *url.URL) (remotecommand.Executor, error) {
-	clientConfig, err := GetClientConfig(c.defaultClientTimeout)
+	clientConfig, err := getClientConfig(c.defaultClientTimeout, standardClientQPSLimit, standardClientQPSBurst)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -19,11 +19,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-var (
-	// ErrNotCompiled is returned if kubernetes apiserver support is not compiled in.
-	// User classes should handle that case as gracefully as possible.
-	ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
-)
+// ErrNotCompiled is returned if kubernetes apiserver support is not compiled in.
+// User classes should handle that case as gracefully as possible.
+var ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
 
 // APIClient provides authenticated access to the
 type APIClient struct {
@@ -69,6 +67,6 @@ func GetNodeLabels(_ *APIClient, _ string) (map[string]string, error) {
 // GetKubeClient returns a Kubernetes client.
 //
 //nolint:revive // TODO(CINT) Fix revive linter
-func GetKubeClient(_ time.Duration) (kubernetes.Interface, error) {
+func GetKubeClient(_ time.Duration, _ float32, _ int) (kubernetes.Interface, error) {
 	return nil, ErrNotCompiled
 }


### PR DESCRIPTION
### What does this PR do?

Implement several improvements to allow much better scalability on External Metrics controller:
- Allow multiple workers through the `external_metrics_provider.num_workers`. With the new improvements, 2 workers can handle >3k `DatadogMetric`, although more workers could be necessary with a slow APIServer.
- Unlock store before doing APIServer `Update` calls
- Increase the limit of QPS/Burst on Kubernetes APIServer client (shared client) as we ultimately need to push 1 update for each `DatadogMetric` every 30s.
- Reduce the number of unnecessary

### Motivation

Fix delayed/lagging Autoscaling on large deployments.

### Describe how you validated your changes
The performance improvement can only be seen on large clusters with a lot of `DatadogMetric` objects (starting ~600).
Without this PR, a degradation in the frequency and freshness of data visible in the `DatadogMetric` objects can be seen.
With this PR, the updates should be available on time every 30s.

Outside of that, only non-regression

### Possible Drawbacks / Trade-offs

### Additional Notes

If the controller is already in a lagging state, the amount of requests to APIServer is going to increase a lot.