### PR TITLE
Turn tag/mapping conflict into an actual error.

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
 
@@ -174,6 +172,7 @@ func validateEnrichSymbol(symbol *profiledefinition.SymbolConfig, symbolContext 
 	}
 	return errors
 }
+
 func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []string {
 	var errors []string
 	if (metricTag.Column.OID != "" || metricTag.Column.Name != "") && (metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "") {
@@ -217,7 +216,7 @@ func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []str
 		}
 	}
 	if len(metricTag.Mapping) > 0 && metricTag.Tag == "" {
-		log.Warnf("``tag` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping)
+		errors = append(errors, fmt.Sprintf("``tag` must be provided if `mapping` (`%s`) is defined", metricTag.Mapping))
 	}
 	for _, transform := range metricTag.IndexTransform {
 		if transform.Start > transform.End {

--- a/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich_test.go
@@ -6,33 +6,21 @@
 package configvalidation
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 
-	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
 
 func Test_ValidateEnrichMetrics(t *testing.T) {
-	type logCount struct {
-		log   string
-		count int
-	}
-
 	tests := []struct {
 		name            string
 		metrics         []profiledefinition.MetricsConfig
 		expectedErrors  []string
 		expectedMetrics []profiledefinition.MetricsConfig
-		expectedLogs    []logCount
 	}{
 		{
 			name: "either table symbol or scalar symbol must be provided",
@@ -551,7 +539,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "mapping used without tag should raise a warning",
+			name: "mapping used without tag",
 			metrics: []profiledefinition.MetricsConfig{
 				{
 					Symbols: []profiledefinition.SymbolConfig{
@@ -574,23 +562,11 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []string{},
-			expectedLogs: []logCount{
-				{
-					"[WARN] validateEnrichMetricTag: ``tag` must be provided if `mapping` (`map[1:abc 2:def]`) is defined",
-					1,
-				},
-			},
+			expectedErrors: []string{"``tag` must be provided if `mapping` (`map[1:abc 2:def]`) is defined"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var b bytes.Buffer
-			w := bufio.NewWriter(&b)
-			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-			assert.Nil(t, err)
-			log.SetupLogger(l, "debug")
-
 			errors := ValidateEnrichMetrics(tt.metrics)
 			assert.Equal(t, len(tt.expectedErrors), len(errors), fmt.Sprintf("ERRORS: %v", errors))
 			for i := range errors {
@@ -599,29 +575,16 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			if tt.expectedMetrics != nil {
 				assert.Equal(t, tt.expectedMetrics, tt.metrics)
 			}
-
-			w.Flush()
-			logs := b.String()
-
-			for _, aLogCount := range tt.expectedLogs {
-				assert.Equal(t, aLogCount.count, strings.Count(logs, aLogCount.log), logs)
-			}
 		})
 	}
 }
 
 func Test_ValidateEnrichMetricTags(t *testing.T) {
-	type logCount struct {
-		log   string
-		count int
-	}
-
 	tests := []struct {
 		name            string
 		metrics         []profiledefinition.MetricTagConfig
 		expectedErrors  []string
 		expectedMetrics []profiledefinition.MetricTagConfig
-		expectedLogs    []logCount
 	}{
 		{
 			name: "Move OID to Symbol",
@@ -691,12 +654,6 @@ func Test_ValidateEnrichMetricTags(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var b bytes.Buffer
-			w := bufio.NewWriter(&b)
-			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.DebugLvl, "[%LEVEL] %FuncShort: %Msg")
-			assert.Nil(t, err)
-			log.SetupLogger(l, "debug")
-
 			errors := ValidateEnrichMetricTags(tt.metrics)
 			assert.Equal(t, len(tt.expectedErrors), len(errors), fmt.Sprintf("ERRORS: %v", errors))
 			for i := range errors {
@@ -704,13 +661,6 @@ func Test_ValidateEnrichMetricTags(t *testing.T) {
 			}
 			if tt.expectedMetrics != nil {
 				assert.Equal(t, tt.expectedMetrics, tt.metrics)
-			}
-
-			w.Flush()
-			logs := b.String()
-
-			for _, aLogCount := range tt.expectedLogs {
-				assert.Equal(t, aLogCount.count, strings.Count(logs, aLogCount.log), logs)
 			}
 		})
 	}

--- a/releasenotes/notes/make-missing-tags-errors-c4cd44a12d22e7bc.yaml
+++ b/releasenotes/notes/make-missing-tags-errors-c4cd44a12d22e7bc.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    SNMP profiles containing metric_tags without a `tag` field
+    specified will now show an error and be ignored, as with any
+    other profile syntax error.

--- a/releasenotes/notes/make-missing-tags-errors-c4cd44a12d22e7bc.yaml
+++ b/releasenotes/notes/make-missing-tags-errors-c4cd44a12d22e7bc.yaml
@@ -8,6 +8,5 @@
 ---
 deprecations:
   - |
-    SNMP profiles containing metric_tags without a `tag` field
-    specified will now show an error and be ignored, as with any
-    other profile syntax error.
+    SNMP profiles containing metric_tags without a specified `tag` field
+    will now show an error and be ignored, similar to other profile syntax errors.


### PR DESCRIPTION
### What does this PR do?

In the case where a metric tag in a profile provides a `mapping` but not a `tag`, this now returns a validation error instead of simply logging a warning.

### Motivation

Every other validation issue returns an error; this is the only case where we log a warning. Converting it to an error simplifies the handling logic and the tests, and makes it easier to sync profile logic with validation in #31054. Part of NDMII-3168.

### Describe how you validated your changes

I ran the agent locally with a deliberately malformed profile and confirm that other profiles were loaded normally, and the malformed one was logged correctly. The malformed profile looked like:
```yaml
sysobjectid:
  - 1.3.6.1.4.1.8072.3.2.10 # OID of snmpsim
metric_tags:
  - mapping:
      "1": "foo"
    oid: 1.3.6.1.4.1.8072.3.2.10 # OID doesn't matter, just needs to be present
```

### Possible Drawbacks / Trade-offs

If any customers have profiles where they have defined tags without setting the tag name, the agent will now log an error and ignore that profile instead of logging a warning and ignoring the malformed tags.
