### PR TITLE
[NETPATH-366] Enrich dynamic network path with NPM domain cache

### DIFF
--- a/comp/networkpath/npcollector/component.go
+++ b/comp/networkpath/npcollector/component.go
@@ -12,5 +12,5 @@ import model "github.com/DataDog/agent-payload/v5/process"
 
 // Component is the component type.
 type Component interface {
-	ScheduleConns(conns []*model.Connection)
+	ScheduleConns(conns []*model.Connection, dns map[string]*model.DNSEntry)
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/common/pathtest.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/common/pathtest.go
@@ -12,12 +12,21 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 )
 
+// PathtestMetadata contains metadata used to annotate the result of a traceroute.
+// This data is not used by the traceroute itself.
+type PathtestMetadata struct {
+	// ReverseDNSHostname is an optional hostname which will be used in place of rDNS querying for
+	// the destination address.
+	ReverseDNSHostname string
+}
+
 // Pathtest details of information necessary to run a traceroute (pathtrace)
 type Pathtest struct {
 	Hostname          string
 	Port              uint16
 	Protocol          payload.Protocol
 	SourceContainerID string
+	Metadata          PathtestMetadata
 }
 
 // GetHash returns the hash of the Pathtest

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -132,7 +132,7 @@ func makePathtest(conn *model.Connection, dns map[string]*model.DNSEntry) common
 	protocol := convertProtocol(conn.GetType())
 
 	rDNSEntry := dns[conn.Raddr.GetIp()]
-	reverseDNSHostname := ""
+	var reverseDNSHostname string
 	if rDNSEntry != nil && len(rDNSEntry.Names) > 0 {
 		reverseDNSHostname = rDNSEntry.Names[0]
 	}

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -127,26 +127,49 @@ func newNpCollectorImpl(epForwarder eventplatform.Forwarder, collectorConfigs *c
 	}
 }
 
-func (s *npCollectorImpl) ScheduleConns(conns []*model.Connection) {
+// makePathtest extracts pathtest information using a single connection and the connection check's reverse dns map
+func makePathtest(conn *model.Connection, dns map[string]*model.DNSEntry) common.Pathtest {
+	protocol := convertProtocol(conn.GetType())
+
+	rDNSEntry := dns[conn.Raddr.GetIp()]
+	reverseDNSHostname := ""
+	if rDNSEntry != nil && len(rDNSEntry.Names) > 0 {
+		reverseDNSHostname = rDNSEntry.Names[0]
+	}
+
+	var remotePort uint16
+	// UDP traces should not be done to the active port
+	if protocol != payload.ProtocolUDP {
+		remotePort = uint16(conn.Raddr.GetPort())
+	}
+
+	sourceContainer := conn.Laddr.GetContainerId()
+
+	return common.Pathtest{
+		Hostname:          conn.Raddr.GetIp(),
+		Port:              remotePort,
+		Protocol:          protocol,
+		SourceContainerID: sourceContainer,
+		Metadata: common.PathtestMetadata{
+			ReverseDNSHostname: reverseDNSHostname,
+		},
+	}
+}
+
+func (s *npCollectorImpl) ScheduleConns(conns []*model.Connection, dns map[string]*model.DNSEntry) {
 	if !s.collectorConfigs.connectionsMonitoringEnabled {
 		return
 	}
 	startTime := s.TimeNowFn()
 	for _, conn := range conns {
-		remoteAddr := conn.Raddr
-		protocol := convertProtocol(conn.GetType())
-		var remotePort uint16
-		// UDP traces should not be done to the active
-		// port
-		if protocol != payload.ProtocolUDP {
-			remotePort = uint16(conn.Raddr.GetPort())
-		}
 		if !shouldScheduleNetworkPathForConn(conn) {
-			s.logger.Tracef("Skipped connection: addr=%s, port=%d, protocol=%s", remoteAddr, remotePort, protocol)
+			protocol := convertProtocol(conn.GetType())
+			s.logger.Tracef("Skipped connection: addr=%s, protocol=%s", conn.Raddr, protocol)
 			continue
 		}
-		sourceContainer := conn.Laddr.GetContainerId()
-		err := s.scheduleOne(remoteAddr.GetIp(), remotePort, protocol, sourceContainer)
+		pathtest := makePathtest(conn, dns)
+
+		err := s.scheduleOne(&pathtest)
 		if err != nil {
 			s.logger.Errorf("Error scheduling pathtests: %s", err)
 		}
@@ -158,20 +181,14 @@ func (s *npCollectorImpl) ScheduleConns(conns []*model.Connection) {
 
 // scheduleOne schedules pathtests.
 // It shouldn't block, if the input channel is full, an error is returned.
-func (s *npCollectorImpl) scheduleOne(hostname string, port uint16, protocol payload.Protocol, sourceContainerID string) error {
+func (s *npCollectorImpl) scheduleOne(pathtest *common.Pathtest) error {
 	if s.pathtestInputChan == nil {
 		return errors.New("no input channel, please check that network path is enabled")
 	}
-	s.logger.Debugf("Schedule traceroute for: hostname=%s port=%d", hostname, port)
+	s.logger.Debugf("Schedule traceroute for: hostname=%s port=%d", pathtest.Hostname, pathtest.Port)
 
-	ptest := &common.Pathtest{
-		Hostname:          hostname,
-		Port:              port,
-		Protocol:          protocol,
-		SourceContainerID: sourceContainerID,
-	}
 	select {
-	case s.pathtestInputChan <- ptest:
+	case s.pathtestInputChan <- pathtest:
 		return nil
 	default:
 		return fmt.Errorf("collector input channel is full (channel capacity is %d)", cap(s.pathtestInputChan))
@@ -246,7 +263,7 @@ func (s *npCollectorImpl) runTracerouteForPath(ptest *pathteststore.PathtestCont
 	path.Origin = payload.PathOriginNetworkTraffic
 
 	// Perform reverse DNS lookup on destination and hop IPs
-	s.enrichPathWithRDNS(&path)
+	s.enrichPathWithRDNS(&path, ptest.Pathtest.Metadata.ReverseDNSHostname)
 
 	s.sendTelemetry(path, startTime, ptest)
 
@@ -326,14 +343,19 @@ func (s *npCollectorImpl) flush() {
 	}
 }
 
-func (s *npCollectorImpl) enrichPathWithRDNS(path *payload.NetworkPath) {
+// enrichPathWithRDNS populates a NetworkPath with reverse-DNS queried hostnames.
+func (s *npCollectorImpl) enrichPathWithRDNS(path *payload.NetworkPath, knownDestHostname string) {
 	if !s.collectorConfigs.reverseDNSEnabled {
 		return
 	}
 
 	// collect unique IP addresses from destination and hops
 	ipSet := make(map[string]struct{}, len(path.Hops)+1) // +1 for destination
-	ipSet[path.Destination.IPAddress] = struct{}{}
+
+	// only look up the destination hostname if we need to
+	if knownDestHostname == "" {
+		ipSet[path.Destination.IPAddress] = struct{}{}
+	}
 	for _, hop := range path.Hops {
 		if !hop.Reachable {
 			continue
@@ -356,13 +378,17 @@ func (s *npCollectorImpl) enrichPathWithRDNS(path *payload.NetworkPath) {
 	}
 
 	// assign resolved hostnames to destination and hops
-	hostname := s.getReverseDNSResult(path.Destination.IPAddress, results)
-	// if hostname is blank, use what's given by traceroute
-	// TODO: would it be better to move the logic up from the traceroute command?
-	// benefit to the current approach is having consistent behavior for all paths
-	// both static and dynamic
-	if hostname != "" {
-		path.Destination.ReverseDNSHostname = hostname
+	if knownDestHostname != "" {
+		path.Destination.ReverseDNSHostname = knownDestHostname
+	} else {
+		hostname := s.getReverseDNSResult(path.Destination.IPAddress, results)
+		// if hostname is blank, use what's given by traceroute
+		// TODO: would it be better to move the logic up from the traceroute command?
+		// benefit to the current approach is having consistent behavior for all paths
+		// both static and dynamic
+		if hostname != "" {
+			path.Destination.ReverseDNSHostname = hostname
+		}
 	}
 
 	for i, hop := range path.Hops {

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector_mock.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector_mock.go
@@ -23,7 +23,7 @@ func MockModule() fxutil.Module {
 
 type npCollectorMock struct{}
 
-func (s *npCollectorMock) ScheduleConns(_ []*model.Connection) {
+func (s *npCollectorMock) ScheduleConns(_ []*model.Connection, _ map[string]*model.DNSEntry) {
 	panic("implement me")
 }
 

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -193,7 +193,7 @@ func (c *ConnectionsCheck) Run(nextGroupID func() int32, _ *RunOptions) (RunResu
 
 	log.Debugf("collected connections in %s", time.Since(start))
 
-	c.npCollector.ScheduleConns(conns.Conns)
+	c.npCollector.ScheduleConns(conns.Conns, conns.Dns)
 
 	groupID := nextGroupID()
 	messages := batchConnections(c.hostInfo, c.maxConnsPerMessage, groupID, conns.Conns, conns.Dns, c.networkID, conns.ConnTelemetryMap, conns.CompilationTelemetryByAsset, conns.KernelHeaderFetchResult, conns.CORETelemetryByAsset, conns.PrebuiltEBPFAssets, conns.Domains, conns.Routes, conns.Tags, conns.AgentConfiguration, c.serviceExtractor)

--- a/releasenotes/notes/network-path-local-dns-41303d691d58a2b4.yaml
+++ b/releasenotes/notes/network-path-local-dns-41303d691d58a2b4.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - Network Path will use recent DNS lookups to infer the destination hostname, if they are available. If a DNS lookup is not found, it will query reverse DNS the same way as before.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR uses the DNS snooper as the first source of truth for network path tests.

Since the 1 minute TTL of the DNS snooper is shorter than the 5 minute query interval of a path test, the reverse DNS query is added as metadata to the test to avoid expiration issues.

### Motivation
Data from the DNS snooper is preferable to reverse DNS, (if it is available) because it represents the actual DNS query the client made to get that IP.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Run netpath collector test suite:
`go test ./comp/networkpath/npcollector/npcollectorimpl`

I also set up dynamic paths locally by setting `network_path.connections_monitoring.enabled: true` in datadog.yaml, but there seems to be an issue in `main` with the system-probe remote interface so the actual traceroute doesn't work. However, I checked that `Metadata.ReverseDNSHostname` is being set properly.
### Possible Drawbacks / Trade-offs

Worth noting that the DNS snooper uses packet capture as opposed to eBPF, so these data sources could theoretically race (albeit unlikely because it runs within the 30s connection check). Would like someone to review the usage of `ScheduleConns(conns.Conns, conns.Dns)`

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->