### PR TITLE
[JUnit] Raise error on `datadog-ci` command not found

### DIFF
--- a/tasks/libs/common/junit_upload_core.py
+++ b/tasks/libs/common/junit_upload_core.py
@@ -29,12 +29,15 @@ from tasks.libs.testing.flakes import get_tests_family, is_known_flaky_test
 E2E_INTERNAL_ERROR_STRING = "E2E INTERNAL ERROR"
 CODEOWNERS_ORG_PREFIX = "@DataDog/"
 REPO_NAME_PREFIX = "github.com/DataDog/datadog-agent/"
-if platform.system() == "Windows":
-    DATADOG_CI_COMMAND = [r"c:\devtools\datadog-ci\datadog-ci", "junit", "upload"]
-else:
-    DATADOG_CI_COMMAND = [which("datadog-ci"), "junit", "upload"]
 JOB_ENV_FILE_NAME = "job_env.txt"
 TAGS_FILE_NAME = "tags.txt"
+
+
+def get_datadog_ci_command():
+    path_datadog_ci = which("datadog-ci")
+    if path_datadog_ci is None:
+        raise FileNotFoundError("datadog-ci command not found")
+    return path_datadog_ci
 
 
 def enrich_junitxml(xml_path: str, flavor: AgentFlavor):
@@ -232,6 +235,7 @@ def upload_junitxmls(team_dir: Path):
     """
     Upload all per-team split JUnit XMLs from given directory.
     """
+    datadog_ci_command = [get_datadog_ci_command(), "junit", "upload"]
     additional_tags = read_additional_tags(team_dir.parent)
     process_env = _update_environ(team_dir.parent)
     processes = []
@@ -242,7 +246,7 @@ def upload_junitxmls(team_dir: Path):
     for flags, files in xml_files.items():
         args = set_tags(owner, flavor, flags, additional_tags, files[0])
         args.extend(files)
-        processes.append(Popen(DATADOG_CI_COMMAND + args, bufsize=-1, env=process_env, stdout=PIPE, stderr=PIPE))
+        processes.append(Popen(datadog_ci_command + args, bufsize=-1, env=process_env, stdout=PIPE, stderr=PIPE))
 
     for process in processes:
         stdout, stderr = process.communicate()
@@ -250,7 +254,7 @@ def upload_junitxmls(team_dir: Path):
         print(f" Uploaded {len(tuple(team_dir.iterdir()))} files for {team_dir.name}")
         if stderr:
             print(f"Failed uploading junit:\n{stderr.decode()}", file=sys.stderr)
-            raise CalledProcessError(process.returncode, DATADOG_CI_COMMAND)
+            raise CalledProcessError(process.returncode, datadog_ci_command)
     return ""  # For ThreadPoolExecutor.map. Without this it prints None in the log output.
 
 

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -123,10 +123,12 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
     @patch.dict("os.environ", {"CI_PIPELINE_ID": "1664"})
     @patch.dict("os.environ", {"CI_PIPELINE_SOURCE": "beer"})
     @patch("tasks.libs.common.junit_upload_core.Popen")
-    def test_e2e(self, mock_popen):
+    @patch("tasks.libs.common.junit_upload_core.which")
+    def test_e2e(self, mock_which, mock_popen):
         mock_instance = MagicMock()
         mock_instance.communicate.return_value = (b"stdout", b"")
         mock_popen.return_value = mock_instance
+        mock_which.side_effect = lambda cmd: f"/usr/local/bin/{cmd}"
         junit.junit_upload_from_tgz("tasks/unit_tests/testdata/testjunit-tests_deb-x64-py3.tgz")
         mock_popen.assert_called()
         self.assertEqual(mock_popen.call_count, 31)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

TL;DR: Working version of #29458.
I fixed the unit test #29458 broke.

This PR raises an error when the `datadog-ci` command is not found.

### Motivation

I stumbled upon a pretty cryptic error while trying to upload the JUnit files to the backend, while working on a runner without `datadog-ci` installed. I couldn't find quickly what the problem was, so I made it clearer.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->