### PR TITLE
(fleet) build the bootstrapper as a shell script on linux

### DIFF
--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -51,7 +51,6 @@ needs-rules:
 job-owners:
   allowed-jobs:
     - benchmark
-    - bootstrapper_build
     - build_dogstatsd-binary_arm64
     - build_dogstatsd-binary_x64
     - build_dogstatsd_static-binary_arm64
@@ -79,6 +78,7 @@ job-owners:
     - installer-amd64-oci
     - installer-arm64
     - installer-arm64-oci
+    - installer-install-scripts
     - integration_tests_otel
     - invoke_unit_tests
     - kitchen_cleanup_azure-a7

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -111,14 +111,14 @@
     ARTIFACTS_PREFIX: suse_
     OMNIBUS_PACKAGE_DIR: $OMNIBUS_PACKAGE_DIR_SUSE
 
-deploy_installer_boostrapper:
+deploy_installer_install_scripts:
   rules:
     !reference [.on_deploy_installer]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: deploy_packages
-  needs: ["bootstrapper_build"]
+  needs: ["installer-install-scripts"]
   tags: ["arch:amd64"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "bootstrapper-*" "$OMNIBUS_PACKAGE_DIR" "${S3_RELEASE_INSTALLER_ARTIFACTS_URI}/bootstrapper/"
+    - $S3_CP_CMD --recursive --exclude "*" --include "install-*.sh" "$OMNIBUS_PACKAGE_DIR" "${S3_RELEASE_INSTALLER_ARTIFACTS_URI}/scripts/"

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -102,7 +102,7 @@ installer-install-scripts:
   script:
     - !reference [.retrieve_linux_go_deps]
     - echo "About to build for $RELEASE_VERSION"
-    - inv -e installer.build-linux-script --output-bin=$OMNIBUS_PACKAGE_DIR/install-djm.sh
+    - inv -e installer.build-linux-script && mv bin/installer/setup.sh $OMNIBUS_PACKAGE_DIR/install-djm.sh
     - ls -la $OMNIBUS_PACKAGE_DIR
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -102,7 +102,8 @@ installer-install-scripts:
   script:
     - !reference [.retrieve_linux_go_deps]
     - echo "About to build for $RELEASE_VERSION"
-    - inv -e installer.build-linux-script && mv bin/installer/setup.sh $OMNIBUS_PACKAGE_DIR/install-djm.sh
+    - mkdir -p $OMNIBUS_PACKAGE_DIR
+    - inv -e installer.build-linux-script && mv ./bin/installer/setup.sh $OMNIBUS_PACKAGE_DIR/install-djm.sh
     - ls -la $OMNIBUS_PACKAGE_DIR
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -84,9 +84,9 @@ datadog-agent-oci-arm64-a7:
     - export RELEASE_VERSION=$RELEASE_VERSION_7
 
 #
-# The bootstrapper program
+# The installer install scripts (install-djm.sh, ...)
 #
-bootstrapper_build:
+installer-install-scripts:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -102,8 +102,7 @@ bootstrapper_build:
   script:
     - !reference [.retrieve_linux_go_deps]
     - echo "About to build for $RELEASE_VERSION"
-    - inv -e installer.build-linux-script --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-linux.sh
-    - GOOS=windows GOARCH=amd64 inv -e installer.build --bootstrapper --rebuild --no-cgo --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-windows-amd64.exe
+    - inv -e installer.build-linux-script --output-bin=$OMNIBUS_PACKAGE_DIR/install-djm.sh
     - ls -la $OMNIBUS_PACKAGE_DIR
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -102,11 +102,8 @@ bootstrapper_build:
   script:
     - !reference [.retrieve_linux_go_deps]
     - echo "About to build for $RELEASE_VERSION"
-    - GOOS=linux GOARCH=amd64 inv -e installer.build --bootstrapper --rebuild --no-cgo --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-linux-amd64
-    - GOOS=linux GOARCH=arm64 inv -e installer.build --bootstrapper --rebuild --no-cgo --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-linux-arm64
+    - inv -e installer.build-linux-script --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-linux.sh
     - GOOS=windows GOARCH=amd64 inv -e installer.build --bootstrapper --rebuild --no-cgo --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-windows-amd64.exe
-    - GOOS=darwin GOARCH=amd64 inv -e installer.build --bootstrapper --rebuild --no-cgo --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-darwin-amd64
-    - GOOS=darwin GOARCH=arm64 inv -e installer.build --bootstrapper --rebuild --no-cgo --output-bin=$OMNIBUS_PACKAGE_DIR/bootstrapper-darwin-arm64
     - ls -la $OMNIBUS_PACKAGE_DIR
   artifacts:
     expire_in: 2 weeks

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -79,7 +79,6 @@ def build(
 @task
 def build_linux_script(
     ctx,
-    output_bin=None,
     signing_key_id=None,
 ):
     '''
@@ -89,11 +88,6 @@ def build_linux_script(
     signed_script_path = os.path.join(BIN_PATH, "setup.sh.asc")
     amd64_path = os.path.join(BIN_PATH, "bootstrapper-linux-amd64")
     arm64_path = os.path.join(BIN_PATH, "bootstrapper-linux-arm64")
-    if output_bin:
-        script_path = output_bin
-        signed_script_path = output_bin + ".asc"
-        amd64_path = output_bin + "-bootstrapper-linux-amd64"
-        arm64_path = output_bin + "-bootstrapper-linux-arm64"
 
     ctx.run(
         f'inv -e installer.build --bootstrapper --no-no-strip-binary --output-bin {amd64_path} --no-cgo',

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -96,11 +96,11 @@ def build_linux_script(
         arm64_path = output_bin + "-bootstrapper-linux-arm64"
 
     ctx.run(
-        f'inv -e installer.build --bootstrapper --rebuild --no-no-strip-binary --output-bin {amd64_path} --no-cgo',
+        f'inv -e installer.build --bootstrapper --no-no-strip-binary --output-bin {amd64_path} --no-cgo',
         env={'GOOS': 'linux', 'GOARCH': 'amd64'},
     )
     ctx.run(
-        f'inv -e installer.build --bootstrapper --rebuild --no-no-strip-binary --output-bin {arm64_path} --no-cgo',
+        f'inv -e installer.build --bootstrapper --no-no-strip-binary --output-bin {arm64_path} --no-cgo',
         env={'GOOS': 'linux', 'GOARCH': 'arm64'},
     )
     with open(amd64_path, 'rb') as f:


### PR DESCRIPTION
This PR replaces the bootstrapper binary build by the embedded shell script.

The first script flavor we'll build is DJM/Data Job Monitorig so I'm hardcoding their name in this first pass to get the piping working.