### PR TITLE
Stop creating go.work.backup when go.work already exists

### DIFF
--- a/go.work
+++ b/go.work
@@ -126,4 +126,5 @@ use (
 	test/fakeintake
 	test/new-e2e
 	test/otel
+	tools/retry_file_dump
 )

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -81,19 +81,14 @@ def generate_dummy_package(ctx, folder):
 @task
 def go_work(_: Context):
     """
-    Create a go.work file using the module list contained in get_default_modules()
+    Re-create the go.work file using the module list contained in get_default_modules()
     and the go version contained in the file .go-version.
-    If there is already a go.work file, it is renamed go.work.backup and a warning is printed.
     """
 
     # read go version from the .go-version file, removing the bugfix part of the version
 
     with open(".go-version") as f:
         go_version = f.read().strip()
-
-    if os.path.exists("go.work"):
-        print("go.work already exists. Renaming to go.work.backup")
-        os.rename("go.work", "go.work.backup")
 
     with open("go.work", "w") as f:
         f.write(f"go {go_version}\n\nuse (\n")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Do not move existing `go.work` file to `go.work.backup` when running `inv modules.go-work` and file already exists.

### Motivation
Now that the file is tracked in git it's not useful anymore.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->