### PR TITLE
Set codeowners for go.work file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,7 +47,6 @@
 /modules.yml                            @DataDog/agent-shared-components
 # if go.work changes then either .go-version or modules.yml changed too, so ASC might as well own it
 /go.work                                @DataDog/agent-shared-components
-/go.work.sum                            @DataDog/agent-shared-components
 
 /.circleci/                             @DataDog/agent-devx-infra
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,9 @@
 /static-analysis.datadog.yml            @DataDog/software-integrity-and-trust @DataDog/agent-devx-infra
 
 /modules.yml                            @DataDog/agent-shared-components
+# if go.work changes then either .go-version or modules.yml changed too, so ASC might as well own it
+/go.work                                @DataDog/agent-shared-components
+/go.work.sum                            @DataDog/agent-shared-components
 
 /.circleci/                             @DataDog/agent-devx-infra
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set agent-shared-components as codeowner for `go.work` file.

### Motivation
The file is currently un-owned, but it should definitely have an owner.
Agent Shared Components already owns the `.go-version` and `modules.yml`, if `go.work` changes then one of those files changed, so we might as well own `go.work`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->