### PR TITLE
fix(installer): Skip LD_PRELOAD check if echo not in path

### DIFF
--- a/pkg/fleet/installer/packages/apm_inject.go
+++ b/pkg/fleet/installer/packages/apm_inject.go
@@ -281,7 +281,10 @@ func (a *apmInjectorInstaller) verifySharedLib(ctx context.Context, libPath stri
 	defer func() { span.Finish(tracer.WithError(err)) }()
 	echoPath, err := exec.LookPath("echo")
 	if err != nil {
-		return fmt.Errorf("failed to find echo: %w", err)
+		// If echo is not found, to not block install,
+		// we skip the test and add it to the span.
+		span.SetTag("skipped", true)
+		return nil
 	}
 	cmd := exec.Command(echoPath, "1")
 	cmd.Env = append(os.Environ(), "LD_PRELOAD="+libPath)


### PR DESCRIPTION
### What does this PR do?
When `echo`  is not in path, skip the LD_PRELOAD test to avoid blocking the installation.

### Motivation

### Describe how you validated your changes
Tested manually on a VM by removing `echo` from path

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->