### PR TITLE
[Fleet Automation] Remove timeouts in bootstrap command

### DIFF
--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -9,12 +9,6 @@ package installer
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"os"
-	"runtime"
-	"strings"
-	"time"
-
 	"github.com/DataDog/datadog-agent/cmd/installer/command"
 	"github.com/DataDog/datadog-agent/pkg/fleet/bootstrapper"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
@@ -25,6 +19,10 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/yaml.v2"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
 )
 
 const (
@@ -273,7 +271,6 @@ func defaultPackagesCommand() *cobra.Command {
 }
 
 func bootstrapCommand() *cobra.Command {
-	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:     "bootstrap",
 		Short:   "Bootstraps the package with the first version.",
@@ -281,17 +278,13 @@ func bootstrapCommand() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
 			b := newBootstrapperCmd("bootstrap")
 			defer func() { b.Stop(err) }()
-			ctx, cancel := context.WithTimeout(b.ctx, timeout)
-			defer cancel()
-			return bootstrapper.Bootstrap(ctx, b.env)
+			return bootstrapper.Bootstrap(b.ctx, b.env)
 		},
 	}
-	cmd.Flags().DurationVarP(&timeout, "timeout", "T", 10*time.Minute, "timeout to bootstrap with")
 	return cmd
 }
 
 func setupCommand() *cobra.Command {
-	var timeout time.Duration
 	cmd := &cobra.Command{
 		Use:     "setup",
 		Hidden:  true,
@@ -299,12 +292,9 @@ func setupCommand() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
 			cmd := newCmd("setup")
 			defer func() { cmd.Stop(err) }()
-			ctx, cancel := context.WithTimeout(cmd.ctx, timeout)
-			defer cancel()
-			return installer.Setup(ctx, cmd.env)
+			return installer.Setup(cmd.ctx, cmd.env)
 		},
 	}
-	cmd.Flags().DurationVarP(&timeout, "timeout", "T", 10*time.Minute, "timeout to install with")
 	return cmd
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR removes the two timeouts in the bootstrap and setup commands.

### Motivation
The timeouts were ineffectual on Windows, where the bootstrap command actually continued for way past the deadline. It's at best misleading. For instance if a customer had other MSI installation going on during the bootstrap, we could run over the 10m deadline waiting for the other process to finish, and that doesn't warrant timing out the bootstrap command.
On Linux we have not seen anyone getting near the timeout limit so that wouldn't affect Linux customers either.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run the bootstrap command and a separate MSI installation at the same time. The separate MSI installation will block the bootstrap process. Verify that after 10m the bootstrap command is still running. Terminate the separate MSI installation, the bootstrap process should resume.

### Possible Drawbacks / Trade-offs

### Additional Notes
Related to (but does not remediate) https://datadoghq.atlassian.net/browse/WINA-1149
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->