### PR TITLE
Fix build without clusterchecks build tag

### DIFF
--- a/pkg/clusteragent/clusterchecks/handler_api_nocompile.go
+++ b/pkg/clusteragent/clusterchecks/handler_api_nocompile.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 )
 
@@ -31,7 +32,7 @@ func (h *Handler) GetState() (types.StateResponse, error) {
 }
 
 // NewHandler not implemented
-func NewHandler(_ autodiscovery.Component) (*Handler, error) {
+func NewHandler(_ autodiscovery.Component, tagger tagger.Component) (*Handler, error) {
 	return nil, ErrNotCompiled
 }
 

--- a/pkg/clusteragent/clusterchecks/handler_api_nocompile.go
+++ b/pkg/clusteragent/clusterchecks/handler_api_nocompile.go
@@ -32,7 +32,7 @@ func (h *Handler) GetState() (types.StateResponse, error) {
 }
 
 // NewHandler not implemented
-func NewHandler(_ autodiscovery.Component, tagger tagger.Component) (*Handler, error) {
+func NewHandler(_ autodiscovery.Component, _ tagger.Component) (*Handler, error) {
 	return nil, ErrNotCompiled
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the compilation when not using the clusterchecks build tag (to have the same prototype as in the version with the build tag).

### Motivation
Not have compilation errors in vscode.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The function is not used (otherwise it would not compile).
I think I could also remove that file entirely, if the cluster agent is never built without the build tag ?

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The function prototype in `pkg/clusteragent/clusterchecks/handler.go` was changed by https://github.com/DataDog/datadog-agent/issues/31386.
