### PR TITLE
Update SMP CLI version to `0.19.3`.

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -22,7 +22,7 @@ single-machine-performance-regression_detector:
       - outputs/decision_record.md # for posterity, this is appended to final PR comment
     when: always
   variables:
-    SMP_VERSION: 0.18.2
+    SMP_VERSION: 0.19.3
   # See 'decision_record.md' for the determination of whether this job passes or fails.
   allow_failure: false
   script:


### PR DESCRIPTION
### What does this PR do?

Update SMP CLI along with today's SMP infrastructure deploy.