### PR TITLE
[tagger] Move entity ID functions to types package

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -505,7 +505,7 @@ func (c *WorkloadMetaCollector) handleECSTask(ev workloadmeta.Event) []*types.Ta
 		low, orch, high, standard := taskTags.Compute()
 		tagInfos = append(tagInfos, &types.TagInfo{
 			Source:               taskSource,
-			EntityID:             common.GetGlobalEntityID(),
+			EntityID:             types.GetGlobalEntityID(),
 			HighCardTags:         high,
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,

--- a/comp/core/tagger/collectors/workloadmeta_main.go
+++ b/comp/core/tagger/collectors/workloadmeta_main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gobwas/glob"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	k8smetadata "github.com/DataDog/datadog-agent/comp/core/tagger/k8s_metadata"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -129,7 +128,7 @@ func (c *WorkloadMetaCollector) collectStaticGlobalTags(ctx context.Context, dat
 	c.tagProcessor.ProcessTagInfo([]*types.TagInfo{
 		{
 			Source:               staticSource,
-			EntityID:             common.GetGlobalEntityID(),
+			EntityID:             types.GetGlobalEntityID(),
 			HighCardTags:         high,
 			OrchestratorCardTags: orch,
 			LowCardTags:          low,

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/taglist"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
@@ -1553,7 +1552,7 @@ func TestHandleECSTask(t *testing.T) {
 				},
 				{
 					Source:       taskSource,
-					EntityID:     common.GetGlobalEntityID(),
+					EntityID:     types.GetGlobalEntityID(),
 					HighCardTags: []string{},
 					OrchestratorCardTags: []string{
 						"task_arn:foobar",
@@ -2425,7 +2424,7 @@ func TestNoGlobalTags(t *testing.T) {
 
 	expectedEmptyEvent := &types.TagInfo{
 		Source:               staticSource,
-		EntityID:             common.GetGlobalEntityID(),
+		EntityID:             types.GetGlobalEntityID(),
 		HighCardTags:         []string{},
 		OrchestratorCardTags: []string{},
 		LowCardTags:          []string{},

--- a/comp/core/tagger/common/entity_id_builder.go
+++ b/comp/core/tagger/common/entity_id_builder.go
@@ -7,9 +7,6 @@
 package common
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -37,21 +34,4 @@ func BuildTaggerEntityID(entityID workloadmeta.EntityID) types.EntityID {
 			entityID.ID, entityID.Kind, entityID.ID, entityID.Kind)
 		return types.NewEntityID(types.EntityIDPrefix(entityID.Kind), entityID.ID)
 	}
-}
-
-var globalEntityID = types.NewEntityID(types.InternalID, "global-entity-id")
-
-// GetGlobalEntityID returns the entity ID that holds global tags
-func GetGlobalEntityID() types.EntityID {
-	return globalEntityID
-}
-
-// ExtractPrefixAndID extracts prefix and id from tagger entity id and returns an error if the received entityID is not valid
-func ExtractPrefixAndID(entityID string) (prefix types.EntityIDPrefix, id string, err error) {
-	extractedPrefix, extractedID, found := strings.Cut(entityID, "://")
-	if !found {
-		return "", "", fmt.Errorf("unsupported tagger entity id format %q, correct format is `{prefix}://{id}`", entityID)
-	}
-
-	return types.EntityIDPrefix(extractedPrefix), extractedID, nil
 }

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -26,7 +26,6 @@ import (
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -242,7 +241,7 @@ func (t *remoteTagger) Tag(entityID types.EntityID, cardinality types.TagCardina
 // This function exists in order not to break backward compatibility with rtloader and python
 // integrations using the tagger
 func (t *remoteTagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	prefix, id, err := taggercommon.ExtractPrefixAndID(entity)
+	prefix, id, err := types.ExtractPrefixAndID(entity)
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +321,7 @@ func (t *remoteTagger) AgentTags(_ types.TagCardinality) ([]string, error) {
 }
 
 func (t *remoteTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
-	return t.Tag(taggercommon.GetGlobalEntityID(), cardinality)
+	return t.Tag(types.GetGlobalEntityID(), cardinality)
 }
 
 func (t *remoteTagger) SetNewCaptureTagger(tagger.Component) {}
@@ -335,7 +334,7 @@ func (t *remoteTagger) ResetCaptureTagger() {}
 // and they always use the local tagger.
 // This function can only add the global tags.
 func (t *remoteTagger) EnrichTags(tb tagset.TagsAccumulator, _ taggertypes.OriginInfo) {
-	if err := t.AccumulateTagsFor(taggercommon.GetGlobalEntityID(), t.dogstatsdCardinality, tb); err != nil {
+	if err := t.AccumulateTagsFor(types.GetGlobalEntityID(), t.dogstatsdCardinality, tb); err != nil {
 		t.log.Error(err.Error())
 	}
 }

--- a/comp/core/tagger/impl/local_tagger.go
+++ b/comp/core/tagger/impl/local_tagger.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/collectors"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tagstore"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
@@ -105,7 +104,7 @@ func (t *localTagger) Tag(entityID types.EntityID, cardinality types.TagCardinal
 // This function exists in order not to break backward compatibility with rtloader and python
 // integrations using the tagger
 func (t *localTagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	prefix, id, err := taggercommon.ExtractPrefixAndID(entity)
+	prefix, id, err := types.ExtractPrefixAndID(entity)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/tagger/impl/replay_tagger.go
+++ b/comp/core/tagger/impl/replay_tagger.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tagstore"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
@@ -69,7 +68,7 @@ func (t *replayTagger) Tag(entityID types.EntityID, cardinality types.TagCardina
 // This function exists in order not to break backward compatibility with rtloader and python
 // integrations using the tagger
 func (t *replayTagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	prefix, id, err := taggercommon.ExtractPrefixAndID(entity)
+	prefix, id, err := types.ExtractPrefixAndID(entity)
 	if err != nil {
 		return nil, err
 	}

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -25,7 +25,6 @@ import (
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
@@ -257,7 +256,7 @@ func (t *TaggerWrapper) Tag(entityID types.EntityID, cardinality types.TagCardin
 // This function exists in order not to break backward compatibility with rtloader and python
 // integrations using the tagger
 func (t *TaggerWrapper) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	prefix, id, err := taggercommon.ExtractPrefixAndID(entity)
+	prefix, id, err := types.ExtractPrefixAndID(entity)
 	if err != nil {
 		return nil, err
 	}
@@ -331,14 +330,14 @@ func (t *TaggerWrapper) AgentTags(cardinality types.TagCardinality) ([]string, e
 func (t *TaggerWrapper) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
 	t.mux.RLock()
 	if t.captureTagger != nil {
-		tags, err := t.captureTagger.Tag(taggercommon.GetGlobalEntityID(), cardinality)
+		tags, err := t.captureTagger.Tag(types.GetGlobalEntityID(), cardinality)
 		if err == nil && len(tags) > 0 {
 			t.mux.RUnlock()
 			return tags, nil
 		}
 	}
 	t.mux.RUnlock()
-	return t.defaultTagger.Tag(taggercommon.GetGlobalEntityID(), cardinality)
+	return t.defaultTagger.Tag(types.GetGlobalEntityID(), cardinality)
 }
 
 // globalTagBuilder queries global tags that should apply to all data coming
@@ -346,7 +345,7 @@ func (t *TaggerWrapper) GlobalTags(cardinality types.TagCardinality) ([]string, 
 func (t *TaggerWrapper) globalTagBuilder(cardinality types.TagCardinality, tb tagset.TagsAccumulator) error {
 	t.mux.RLock()
 	if t.captureTagger != nil {
-		err := t.captureTagger.AccumulateTagsFor(taggercommon.GetGlobalEntityID(), cardinality, tb)
+		err := t.captureTagger.AccumulateTagsFor(types.GetGlobalEntityID(), cardinality, tb)
 
 		if err == nil {
 			t.mux.RUnlock()
@@ -354,7 +353,7 @@ func (t *TaggerWrapper) globalTagBuilder(cardinality types.TagCardinality, tb ta
 		}
 	}
 	t.mux.RUnlock()
-	return t.defaultTagger.AccumulateTagsFor(taggercommon.GetGlobalEntityID(), cardinality, tb)
+	return t.defaultTagger.AccumulateTagsFor(types.GetGlobalEntityID(), cardinality, tb)
 }
 
 // List the content of the defaulTagger

--- a/comp/core/tagger/mock/fake_tagger.go
+++ b/comp/core/tagger/mock/fake_tagger.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"strconv"
 
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tagstore"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
@@ -66,7 +65,7 @@ func (f *FakeTagger) SetTags(entityID types.EntityID, source string, low, orch, 
 
 // SetGlobalTags allows to set tags in store for the global entity
 func (f *FakeTagger) SetGlobalTags(low, orch, high, std []string) {
-	f.SetTags(taggercommon.GetGlobalEntityID(), "static", low, orch, high, std)
+	f.SetTags(types.GetGlobalEntityID(), "static", low, orch, high, std)
 }
 
 // Tagger interface
@@ -110,7 +109,7 @@ func (f *FakeTagger) Tag(entityID types.EntityID, cardinality types.TagCardinali
 // This function exists in order not to break backward compatibility with rtloader and python
 // integrations using the tagger
 func (f *FakeTagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	prefix, id, err := taggercommon.ExtractPrefixAndID(entity)
+	prefix, id, err := types.ExtractPrefixAndID(entity)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +120,7 @@ func (f *FakeTagger) LegacyTag(entity string, cardinality types.TagCardinality) 
 
 // GlobalTags fake implementation
 func (f *FakeTagger) GlobalTags(cardinality types.TagCardinality) ([]string, error) {
-	return f.Tag(taggercommon.GetGlobalEntityID(), cardinality)
+	return f.Tag(types.GetGlobalEntityID(), cardinality)
 }
 
 // AccumulateTagsFor fake implementation

--- a/comp/core/tagger/types/entity_id.go
+++ b/comp/core/tagger/types/entity_id.go
@@ -6,8 +6,15 @@
 // Package types defines types used by the Tagger component.
 package types
 
+import (
+	"fmt"
+	"strings"
+)
+
 const separator = "://"
 const separatorLength = len(separator)
+
+var globalEntityID = NewEntityID(InternalID, "global-entity-id")
 
 // GetSeparatorLengh returns the length of the entityID separator
 func GetSeparatorLengh() int {
@@ -79,4 +86,19 @@ func AllPrefixesSet() map[EntityIDPrefix]struct{} {
 		Process:                {},
 		InternalID:             {},
 	}
+}
+
+// GetGlobalEntityID returns the entity ID that holds global tags
+func GetGlobalEntityID() EntityID {
+	return globalEntityID
+}
+
+// ExtractPrefixAndID extracts prefix and id from tagger entity id and returns an error if the received entityID is not valid
+func ExtractPrefixAndID(entityID string) (prefix EntityIDPrefix, id string, err error) {
+	extractedPrefix, extractedID, found := strings.Cut(entityID, "://")
+	if !found {
+		return "", "", fmt.Errorf("unsupported tagger entity id format %q, correct format is `{prefix}://{id}`", entityID)
+	}
+
+	return EntityIDPrefix(extractedPrefix), extractedID, nil
 }

--- a/comp/dogstatsd/replay/impl/writer.go
+++ b/comp/dogstatsd/replay/impl/writer.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerproto "github.com/DataDog/datadog-agent/comp/core/tagger/proto"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -317,7 +316,7 @@ func (tc *TrafficCaptureWriter) writeState() (int, error) {
 
 	// iterate entities
 	for _, entityIDStr := range tc.taggerState {
-		prefix, id, err := common.ExtractPrefixAndID(entityIDStr)
+		prefix, id, err := types.ExtractPrefixAndID(entityIDStr)
 		if err != nil {
 			log.Warnf("Invalid entity id: %q", id)
 			continue

--- a/comp/otelcol/otlp/collector.go
+++ b/comp/otelcol/otlp/collector.go
@@ -31,7 +31,6 @@ import (
 	otlpmetrics "github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
@@ -71,7 +70,7 @@ func (t *tagEnricher) Enrich(_ context.Context, extraTags []string, dimensions *
 	enrichedTags := make([]string, 0, len(extraTags)+len(dimensions.Tags()))
 	enrichedTags = append(enrichedTags, extraTags...)
 	enrichedTags = append(enrichedTags, dimensions.Tags()...)
-	prefix, id, err := common.ExtractPrefixAndID(dimensions.OriginID())
+	prefix, id, err := types.ExtractPrefixAndID(dimensions.OriginID())
 	if err != nil {
 		entityID := types.NewEntityID(prefix, id)
 		entityTags, err := t.tagger.Tag(entityID, t.cardinality)

--- a/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/cadvisor/provider_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -111,7 +110,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 	fakeTagger := mock.SetupFakeTagger(suite.T())
 
 	for entity, tags := range commontesting.CommonTags {
-		prefix, id, _ := taggercommon.ExtractPrefixAndID(entity)
+		prefix, id, _ := taggertypes.ExtractPrefixAndID(entity)
 		entityID := taggertypes.NewEntityID(prefix, id)
 		fakeTagger.SetTags(entityID, "foo", tags, nil, nil, nil)
 	}

--- a/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/kubelet/provider_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -142,7 +141,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 	fakeTagger := mock.SetupFakeTagger(suite.T())
 
 	for entity, tags := range commontesting.CommonTags {
-		prefix, id, _ := taggercommon.ExtractPrefixAndID(entity)
+		prefix, id, _ := taggertypes.ExtractPrefixAndID(entity)
 		entityID := taggertypes.NewEntityID(prefix, id)
 		fakeTagger.SetTags(entityID, "foo", tags, nil, nil, nil)
 	}

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
@@ -119,7 +118,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 	fakeTagger := mock.SetupFakeTagger(suite.T())
 
 	for entity, tags := range commontesting.CommonTags {
-		prefix, id, _ := taggercommon.ExtractPrefixAndID(entity)
+		prefix, id, _ := taggertypes.ExtractPrefixAndID(entity)
 		entityID := taggertypes.NewEntityID(prefix, id)
 		fakeTagger.SetTags(entityID, "foo", tags, nil, nil, nil)
 	}

--- a/pkg/collector/corechecks/containers/kubelet/provider/probe/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/probe/provider_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/types"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	taggerMock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -276,7 +275,7 @@ func TestProvider_Provide(t *testing.T) {
 			fakeTagger := taggerMock.SetupFakeTagger(t)
 
 			for entity, tags := range probeTags {
-				prefix, id, _ := taggercommon.ExtractPrefixAndID(entity)
+				prefix, id, _ := taggertypes.ExtractPrefixAndID(entity)
 				entityID := taggertypes.NewEntityID(prefix, id)
 				fakeTagger.SetTags(entityID, "foo", tags, nil, nil, nil)
 			}

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider_test.go
@@ -21,7 +21,6 @@ import (
 	configcomp "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
-	taggercommon "github.com/DataDog/datadog-agent/comp/core/tagger/common"
 	taggerMock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -338,7 +337,7 @@ func TestProvider_Provide(t *testing.T) {
 			fakeTagger := taggerMock.SetupFakeTagger(t)
 
 			for entity, tags := range entityTags {
-				prefix, id, _ := taggercommon.ExtractPrefixAndID(entity)
+				prefix, id, _ := taggertypes.ExtractPrefixAndID(entity)
 				entityID := taggertypes.NewEntityID(prefix, id)
 				fakeTagger.SetTags(entityID, "foo", tags, nil, nil, nil)
 			}


### PR DESCRIPTION
### What does this PR do?

This PR is related with the previous ones that were about enabling the opentelemetry team to import the tagger directly.

The remote tagger implementation still requires workloadmeta which is a dependency that we'd like to avoid. This dependency exists because the remote tagger uses a couple of functions in `comp/core/tagger/common/entity_id_builder.go`, but the file depends on workloadmeta because another function not used by the remote tagger.

To solve this, this PR simply moves the functions used to the tagger types module, which also kind of makes sense since these functions are related with tagger entity IDs, and that's the module where it's defined.

Other agents that rely on the remote tagger and don't need workloadmeta also benefit from this. The number of packages that they depend on should be reduced.

### Describe how you validated your changes

It's a refactor. Our tests cover this.