### PR TITLE
[CI] Don't stop the integration tests at the first failure

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -92,7 +92,7 @@ def integration_tests(ctx, race=False, remote_docker=False, go_mod="readonly", t
     Run integration tests for cluster-agent
     """
     if sys.platform == 'win32':
-        raise Exit(message='cluster-agent integration tests are not supported on Windows', code=0)
+        raise NotImplementedError('Cluster Agent integration tests are not supported on Windows')
 
     # We need docker for the kubeapiserver integration tests
     tags = get_default_build_tags(build="cluster-agent") + ["docker", "test"]

--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -15,6 +15,7 @@ from invoke.exceptions import Exit
 from tasks.build_tags import get_build_tags, get_default_build_tags
 from tasks.cluster_agent_helpers import build_common, clean_common, refresh_assets_common, version_common
 from tasks.cws_instrumentation import BIN_PATH as CWS_INSTRUMENTATION_BIN_PATH
+from tasks.libs.common.utils import TestsNotSupportedError
 from tasks.libs.releasing.version import load_release_versions
 
 # constants
@@ -92,7 +93,7 @@ def integration_tests(ctx, race=False, remote_docker=False, go_mod="readonly", t
     Run integration tests for cluster-agent
     """
     if sys.platform == 'win32':
-        raise NotImplementedError('Cluster Agent integration tests are not supported on Windows')
+        raise TestsNotSupportedError('Cluster Agent integration tests are not supported on Windows')
 
     # We need docker for the kubeapiserver integration tests
     tags = get_default_build_tags(build="cluster-agent") + ["docker", "test"]

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -175,7 +175,7 @@ def integration_tests(ctx, race=False, remote_docker=False, go_mod="readonly", t
     Run integration tests for dogstatsd
     """
     if sys.platform == 'win32':
-        raise Exit(message='dogstatsd integration tests are not supported on Windows', code=0)
+        raise NotImplementedError('DogStatsD integration tests are not supported on Windows')
 
     go_build_tags = " ".join(get_default_build_tags(build="test"))
     race_opt = "-race" if race else ""

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -11,7 +11,7 @@ from invoke.exceptions import Exit
 
 from tasks.build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from tasks.flavor import AgentFlavor
-from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags, get_root
+from tasks.libs.common.utils import REPO_PATH, TestsNotSupportedError, bin_name, get_build_flags, get_root
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
 
 # constants
@@ -175,7 +175,7 @@ def integration_tests(ctx, race=False, remote_docker=False, go_mod="readonly", t
     Run integration tests for dogstatsd
     """
     if sys.platform == 'win32':
-        raise NotImplementedError('DogStatsD integration tests are not supported on Windows')
+        raise TestsNotSupportedError('DogStatsD integration tests are not supported on Windows')
 
     go_build_tags = " ".join(get_default_build_tags(build="test"))
     race_opt = "-race" if race else ""

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -423,6 +423,9 @@ def integration_tests(ctx, race=False, remote_docker=False, timeout=""):
             except NotImplementedError as e:
                 print(f"Skipping {t_name}\n{e}")
             except Exception:
+                # Keep printing the traceback not to have to wait until all tests are done to see what failed
+                traceback.print_exc()
+                # Storing the traceback to print it at the end without directly raising the exception
                 tests_failures[t_name] = traceback.format_exc()
     if tests_failures:
         print("Integration tests failed:")

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -422,7 +422,7 @@ def integration_tests(ctx, race=False, remote_docker=False, timeout=""):
             try:
                 t()
             except TestsNotSupportedError as e:
-                print(f"Skipping {t_name}\n{e}")
+                print(f"Skipping {t_name}: {e}")
             except Exception:
                 # Keep printing the traceback not to have to wait until all tests are done to see what failed
                 traceback.print_exc()

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -36,6 +36,7 @@ from tasks.libs.common.git import get_modified_files
 from tasks.libs.common.gomodules import get_default_modules
 from tasks.libs.common.junit_upload_core import enrich_junitxml, produce_junit_tar
 from tasks.libs.common.utils import (
+    TestsNotSupportedError,
     clean_nested_paths,
     get_build_flags,
     gitlab_section,
@@ -420,7 +421,7 @@ def integration_tests(ctx, race=False, remote_docker=False, timeout=""):
         with gitlab_section(f"Running the {t_name} integration tests", collapsed=True, echo=True):
             try:
                 t()
-            except NotImplementedError as e:
+            except TestsNotSupportedError as e:
                 print(f"Skipping {t_name}\n{e}")
             except Exception:
                 # Keep printing the traceback not to have to wait until all tests are done to see what failed

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -11,6 +11,7 @@ import operator
 import os
 import re
 import sys
+import traceback
 from collections import defaultdict
 from collections.abc import Iterable
 from datetime import datetime
@@ -404,24 +405,30 @@ def test(
 
 
 @task
-def integration_tests(ctx, race=False, remote_docker=False, debug=False, timeout=""):
+def integration_tests(ctx, race=False, remote_docker=False, timeout=""):
     """
     Run all the available integration tests
     """
-    tests = [
-        lambda: agent_integration_tests(ctx, race=race, remote_docker=remote_docker, timeout=timeout),
-        lambda: dsd_integration_tests(ctx, race=race, remote_docker=remote_docker, timeout=timeout),
-        lambda: dca_integration_tests(ctx, race=race, remote_docker=remote_docker, timeout=timeout),
-        lambda: trace_integration_tests(ctx, race=race, timeout=timeout),
-    ]
-    for t in tests:
-        try:
-            t()
-        except Exit as e:
-            if e.code != 0:
-                raise
-            elif debug:
-                print(e.message)
+    tests = {
+        "Agent": lambda: agent_integration_tests(ctx, race=race, remote_docker=remote_docker, timeout=timeout),
+        "DogStatsD": lambda: dsd_integration_tests(ctx, race=race, remote_docker=remote_docker, timeout=timeout),
+        "Cluster Agent": lambda: dca_integration_tests(ctx, race=race, remote_docker=remote_docker, timeout=timeout),
+        "Trace Agent": lambda: trace_integration_tests(ctx, race=race, timeout=timeout),
+    }
+    tests_failures = {}
+    for t_name, t in tests.items():
+        with gitlab_section(f"Running the {t_name} integration tests", collapsed=True, echo=True):
+            try:
+                t()
+            except NotImplementedError as e:
+                print(f"Skipping {t_name}\n{e}")
+            except Exception:
+                tests_failures[t_name] = traceback.format_exc()
+    if tests_failures:
+        print("Integration tests failed:")
+        for t_name, t_failure in tests_failures.items():
+            print(f"{t_name}:\n{t_failure}")
+        raise Exit(code=1)
 
 
 @task

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -61,6 +61,10 @@ class TimedOperationResult:
             return True
 
 
+class TestsNotSupportedError(Exception):
+    pass
+
+
 def get_all_allowed_repo_branches():
     return ALLOWED_REPO_ALL_BRANCHES
 

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from invoke import Exit, task
+from invoke import task
 
 from tasks.build_tags import add_fips_tags, filter_incompatible_tags, get_build_tags, get_default_build_tags
 from tasks.flavor import AgentFlavor
@@ -82,7 +82,7 @@ def integration_tests(ctx, race=False, go_mod="readonly", timeout="10m"):
     Run integration tests for trace agent
     """
     if sys.platform == 'win32':
-        raise Exit(message='trace-agent integration tests are not supported on Windows', code=0)
+        raise NotImplementedError('Trace Agent integration tests are not supported on Windows')
 
     go_build_tags = " ".join(get_default_build_tags(build="test"))
     race_opt = "-race" if race else ""

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -5,7 +5,7 @@ from invoke import task
 
 from tasks.build_tags import add_fips_tags, filter_incompatible_tags, get_build_tags, get_default_build_tags
 from tasks.flavor import AgentFlavor
-from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags
+from tasks.libs.common.utils import REPO_PATH, TestsNotSupportedError, bin_name, get_build_flags
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
 
 BIN_PATH = os.path.join(".", "bin", "trace-agent")
@@ -82,7 +82,7 @@ def integration_tests(ctx, race=False, go_mod="readonly", timeout="10m"):
     Run integration tests for trace agent
     """
     if sys.platform == 'win32':
-        raise NotImplementedError('Trace Agent integration tests are not supported on Windows')
+        raise TestsNotSupportedError('Trace Agent integration tests are not supported on Windows')
 
     go_build_tags = " ".join(get_default_build_tags(build="test"))
     race_opt = "-race" if race else ""


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR make the `integration-tests` invoke tasks run all the integration tests to avoid stopping at the first failure. In details:
- It still prints the exception and traceback in the logs when the error happens so the devs can see it directly when it happens.
- It exits with a code 1, if an error happened, only after running all the integration tests.

This PR also removes the `debug` flag, which was replaced with the use of the `NotImplementedError` exception raising.

### Motivation

Stopping at the first failure can be very annoying for developers that will have to go see and run the tests back and forth to debug one by one their issues. This could even hide some useful logs. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->