### PR TITLE
[CWS] fix ttl field `time.Duration` unmarshaller

### DIFF
--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -103,8 +103,8 @@ func (rl *RateLimiter) Apply(ruleSet *rules.RuleSet, customRuleIDs []eval.RuleID
 	for id, rule := range ruleSet.GetRules() {
 		every, burst := defaultEvery, defaultBurst
 
-		if rule.Def.Every != 0 {
-			every, burst = rule.Def.Every, 1
+		if rule.Def.Every.Duration != 0 {
+			every, burst = rule.Def.Every.Duration, 1
 		}
 
 		if len(rule.Def.RateLimiterToken) > 0 {

--- a/pkg/security/generators/schemas/policy/main.go
+++ b/pkg/security/generators/schemas/policy/main.go
@@ -33,7 +33,7 @@ func main() {
 		ExpandedStruct: true,
 		Mapper: func(t reflect.Type) *jsonschema.Schema {
 			switch t {
-			case reflect.TypeOf(time.Duration(0)):
+			case reflect.TypeOf(rules.HumanReadableDuration{}), reflect.TypeOf(time.Duration(0)):
 				return &jsonschema.Schema{
 					OneOf: []*jsonschema.Schema{
 						{

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -425,7 +425,7 @@ func (p *ProcessKiller) getDisarmerParams(kill *rules.KillDefinition) (*disarmer
 	if kill.Disarmer != nil && kill.Disarmer.Container != nil && kill.Disarmer.Container.MaxAllowed > 0 {
 		containerParams.enabled = true
 		containerParams.capacity = uint64(kill.Disarmer.Container.MaxAllowed)
-		containerParams.period = kill.Disarmer.Container.Period
+		containerParams.period = kill.Disarmer.Container.Period.Duration
 	} else if p.cfg.RuntimeSecurity.EnforcementDisarmerContainerEnabled {
 		containerParams.enabled = true
 		containerParams.capacity = uint64(p.cfg.RuntimeSecurity.EnforcementDisarmerContainerMaxAllowed)
@@ -435,7 +435,7 @@ func (p *ProcessKiller) getDisarmerParams(kill *rules.KillDefinition) (*disarmer
 	if kill.Disarmer != nil && kill.Disarmer.Executable != nil && kill.Disarmer.Executable.MaxAllowed > 0 {
 		executableParams.enabled = true
 		executableParams.capacity = uint64(kill.Disarmer.Executable.MaxAllowed)
-		executableParams.period = kill.Disarmer.Executable.Period
+		executableParams.period = kill.Disarmer.Executable.Period.Duration
 	} else if p.cfg.RuntimeSecurity.EnforcementDisarmerExecutableEnabled {
 		executableParams.enabled = true
 		executableParams.capacity = uint64(p.cfg.RuntimeSecurity.EnforcementDisarmerExecutableMaxAllowed)

--- a/pkg/security/probe/selftests/ebpfless.go
+++ b/pkg/security/probe/selftests/ebpfless.go
@@ -30,8 +30,10 @@ func (o *EBPFLessSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
 		Expression: `exec.file.path != "" && process.parent.pid == 0 && process.ppid == 0`,
-		Every:      time.Duration(math.MaxInt64),
-		Silent:     true,
+		Every: rules.HumanReadableDuration{
+			Duration: time.Duration(math.MaxInt64),
+		},
+		Silent: true,
 	}
 }
 

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -63,21 +63,21 @@ type RuleID = string
 
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
-	ID                     RuleID              `yaml:"id,omitempty" json:"id"`
-	Version                string              `yaml:"version,omitempty" json:"version,omitempty"`
-	Expression             string              `yaml:"expression" json:"expression,omitempty"`
-	Description            string              `yaml:"description,omitempty" json:"description,omitempty"`
-	Tags                   map[string]string   `yaml:"tags,omitempty" json:"tags,omitempty"`
-	AgentVersionConstraint string              `yaml:"agent_version,omitempty" json:"agent_version,omitempty"`
-	Filters                []string            `yaml:"filters,omitempty" json:"filters,omitempty"`
-	Disabled               bool                `yaml:"disabled,omitempty" json:"disabled,omitempty"`
-	Combine                CombinePolicy       `yaml:"combine,omitempty" json:"combine,omitempty" jsonschema:"enum=override"`
-	OverrideOptions        OverrideOptions     `yaml:"override_options,omitempty" json:"override_options,omitempty"`
-	Actions                []*ActionDefinition `yaml:"actions,omitempty" json:"actions,omitempty"`
-	Every                  time.Duration       `yaml:"every,omitempty" json:"every,omitempty"`
-	RateLimiterToken       []string            `yaml:"limiter_token,omitempty" json:"limiter_token,omitempty"`
-	Silent                 bool                `yaml:"silent,omitempty" json:"silent,omitempty"`
-	GroupID                string              `yaml:"group_id,omitempty" json:"group_id,omitempty"`
+	ID                     RuleID                `yaml:"id,omitempty" json:"id"`
+	Version                string                `yaml:"version,omitempty" json:"version,omitempty"`
+	Expression             string                `yaml:"expression" json:"expression,omitempty"`
+	Description            string                `yaml:"description,omitempty" json:"description,omitempty"`
+	Tags                   map[string]string     `yaml:"tags,omitempty" json:"tags,omitempty"`
+	AgentVersionConstraint string                `yaml:"agent_version,omitempty" json:"agent_version,omitempty"`
+	Filters                []string              `yaml:"filters,omitempty" json:"filters,omitempty"`
+	Disabled               bool                  `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	Combine                CombinePolicy         `yaml:"combine,omitempty" json:"combine,omitempty" jsonschema:"enum=override"`
+	OverrideOptions        OverrideOptions       `yaml:"override_options,omitempty" json:"override_options,omitempty"`
+	Actions                []*ActionDefinition   `yaml:"actions,omitempty" json:"actions,omitempty"`
+	Every                  HumanReadableDuration `yaml:"every,omitempty" json:"every,omitempty"`
+	RateLimiterToken       []string              `yaml:"limiter_token,omitempty" json:"limiter_token,omitempty"`
+	Silent                 bool                  `yaml:"silent,omitempty" json:"silent,omitempty"`
+	GroupID                string                `yaml:"group_id,omitempty" json:"group_id,omitempty"`
 }
 
 // GetTag returns the tag value associated with a tag key
@@ -144,8 +144,8 @@ type SetDefinition struct {
 
 // KillDisarmerParamsDefinition describes the parameters of a kill action disarmer
 type KillDisarmerParamsDefinition struct {
-	MaxAllowed int           `yaml:"max_allowed" json:"max_allowed,omitempty" jsonschema:"description=The maximum number of allowed kill actions within the period,example=5"`
-	Period     time.Duration `yaml:"period" json:"period,omitempty" jsonschema:"description=The period of time during which the maximum number of allowed kill actions is calculated,example=1m"`
+	MaxAllowed int                   `yaml:"max_allowed" json:"max_allowed,omitempty" jsonschema:"description=The maximum number of allowed kill actions within the period,example=5"`
+	Period     HumanReadableDuration `yaml:"period" json:"period,omitempty" jsonschema:"description=The period of time during which the maximum number of allowed kill actions is calculated,example=1m"`
 }
 
 // KillDisarmerDefinition describes the 'disarmer' section of a kill action

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -199,6 +199,11 @@ type HumanReadableDuration struct {
 	time.Duration
 }
 
+// MarshalYAML marshals a duration to a human readable format
+func (d HumanReadableDuration) MarshalYAML() (interface{}, error) {
+	return d.String(), nil
+}
+
 // UnmarshalYAML unmarshals a duration from a human readable format or from an integer
 func (d *HumanReadableDuration) UnmarshalYAML(n *yaml.Node) error {
 	var v interface{}
@@ -221,4 +226,5 @@ func (d *HumanReadableDuration) UnmarshalYAML(n *yaml.Node) error {
 	}
 }
 
+var _ yaml.Marshaler = (*HumanReadableDuration)(nil)
 var _ yaml.Unmarshaler = (*HumanReadableDuration)(nil)

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -193,10 +193,13 @@ type PolicyDef struct {
 	OnDemandHookPoints []OnDemandHookPoint `yaml:"hooks,omitempty" json:"hooks,omitempty"`
 }
 
+// HumanReadableDuration represents a duration that can unmarshalled from YAML from a human readable format (like `10m`)
+// or from a regular integer
 type HumanReadableDuration struct {
 	time.Duration
 }
 
+// UnmarshalYAML unmarshals a duration from a human readable format or from an integer
 func (d *HumanReadableDuration) UnmarshalYAML(n *yaml.Node) error {
 	var v interface{}
 	if err := n.Decode(&v); err != nil {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -340,7 +340,9 @@ func TestActionSetVariableTTL(t *testing.T) {
 					Name:   "var1",
 					Append: true,
 					Value:  []string{"foo"},
-					TTL:    1 * time.Second,
+					TTL: HumanReadableDuration{
+						Duration: 1 * time.Second,
+					},
 				},
 			}},
 		}},

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -241,7 +241,7 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					variableProvider = &rs.globalVariables
 				}
 
-				opts := eval.VariableOpts{TTL: actionDef.Set.TTL, Size: actionDef.Set.Size}
+				opts := eval.VariableOpts{TTL: actionDef.Set.TTL.Duration, Size: actionDef.Set.Size}
 
 				variable, err := variableProvider.GetVariable(actionDef.Set.Name, variableValue, opts)
 				if err != nil {

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -619,11 +619,15 @@ func TestActionKillDisarmFromRule(t *testing.T) {
 						Disarmer: &rules.KillDisarmerDefinition{
 							Executable: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period:     enforcementDisarmerExecutablePeriod,
+								Period: rules.HumanReadableDuration{
+									Duration: enforcementDisarmerExecutablePeriod,
+								},
 							},
 							Container: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period:     enforcementDisarmerContainerPeriod,
+								Period: rules.HumanReadableDuration{
+									Duration: enforcementDisarmerContainerPeriod,
+								},
 							},
 						},
 					},
@@ -640,11 +644,15 @@ func TestActionKillDisarmFromRule(t *testing.T) {
 						Disarmer: &rules.KillDisarmerDefinition{
 							Executable: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period:     enforcementDisarmerExecutablePeriod,
+								Period: rules.HumanReadableDuration{
+									Duration: enforcementDisarmerExecutablePeriod,
+								},
 							},
 							Container: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period:     enforcementDisarmerContainerPeriod,
+								Period: rules.HumanReadableDuration{
+									Duration: enforcementDisarmerContainerPeriod,
+								},
 							},
 						},
 					},

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -104,15 +104,19 @@ func TestEventRaleLimiters(t *testing.T) {
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
-			ID:               "test_unique_id",
-			Expression:       `open.file.path == "{{.Root}}/test-unique-id"`,
-			Every:            5 * time.Second,
+			ID:         "test_unique_id",
+			Expression: `open.file.path == "{{.Root}}/test-unique-id"`,
+			Every: rules.HumanReadableDuration{
+				Duration: 5 * time.Second,
+			},
 			RateLimiterToken: []string{"process.file.name"},
 		},
 		{
 			ID:         "test_std",
 			Expression: `open.file.path == "{{.Root}}/test-std"`,
-			Every:      5 * time.Second,
+			Every: rules.HumanReadableDuration{
+				Duration: 5 * time.Second,
+			},
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/31718 introduced an issue where you can't unmarshal a simple integer into a `time.Duration` anymore.

This PR fixes the issue by adding a new type that can unmarshal from both a human readable time (like `10s`) and an integer.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->