### PR TITLE
sharedlibraries: tests: Fix bugs in the test

### DIFF
--- a/pkg/network/usm/sharedlibraries/ebpf_test.go
+++ b/pkg/network/usm/sharedlibraries/ebpf_test.go
@@ -43,16 +43,20 @@ func (s *EbpfProgramSuite) TestCanInstantiateMultipleTimes() {
 
 	prog := GetEBPFProgram(cfg)
 	require.NotNil(t, prog)
-	t.Cleanup(prog.Stop)
+	t.Cleanup(func() {
+		if prog != nil {
+			prog.Stop()
+		}
+	})
 
 	require.NoError(t, prog.InitWithLibsets(LibsetCrypto))
 	prog.Stop()
+	prog = nil
 
 	prog2 := GetEBPFProgram(cfg)
 	require.NotNil(t, prog2)
-
-	require.NoError(t, prog.InitWithLibsets(LibsetCrypto))
 	t.Cleanup(prog2.Stop)
+	require.NoError(t, prog2.InitWithLibsets(LibsetCrypto))
 }
 
 func (s *EbpfProgramSuite) TestProgramReceivesEventsWithSingleLibset() {


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Calling prog.Stop only once instead of twice.
Instead of calling twice for prog.InitWithLibsets, we call it once for prog and the second time we call prog2.InitWithLibsets

### Motivation

Fixing incorrect logic in the test

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->