### PR TITLE
[EBPF-560] attacher: Fix TestSingleFile flaky test

### DIFF
--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -824,7 +824,7 @@ func createTempTestFile(t *testing.T, name string) (string, utils.PathIdentifier
 
 type SharedLibrarySuite struct {
 	suite.Suite
-	procMonitor ProcessMonitor
+	procMonitor *processMonitorProxy
 }
 
 func TestAttacherSharedLibrary(t *testing.T) {
@@ -839,14 +839,25 @@ func TestAttacherSharedLibrary(t *testing.T) {
 
 		tt.Run("netlink", func(ttt *testing.T) {
 			processMonitor := launchProcessMonitor(ttt, false)
-			suite.Run(ttt, &SharedLibrarySuite{procMonitor: processMonitor})
+
+			// Use a proxy so we can manually trigger events in case of misses
+			procmonObserver := newProcessMonitorProxy(processMonitor)
+			suite.Run(ttt, &SharedLibrarySuite{procMonitor: procmonObserver})
 		})
 
 		tt.Run("event stream", func(ttt *testing.T) {
 			processMonitor := launchProcessMonitor(ttt, true)
-			suite.Run(ttt, &SharedLibrarySuite{procMonitor: processMonitor})
+
+			// Use a proxy so we can manually trigger events in case of misses
+			procmonObserver := newProcessMonitorProxy(processMonitor)
+			suite.Run(ttt, &SharedLibrarySuite{procMonitor: procmonObserver})
 		})
 	})
+}
+
+func (s *SharedLibrarySuite) SetupTest() {
+	// Reset callbacks
+	s.procMonitor.Reset()
 }
 
 func (s *SharedLibrarySuite) TestSingleFile() {
@@ -900,16 +911,31 @@ func (s *SharedLibrarySuite) TestSingleFile() {
 		3, 10*time.Millisecond, 500*time.Millisecond, "did not catch process running, received calls %v", mockRegistry.Calls)
 
 	mockRegistry.AssertCalled(t, "Register", fooPath1, uint32(cmd.Process.Pid), mock.Anything, mock.Anything, mock.Anything)
-
 	mockRegistry.Calls = nil
-	require.NoError(t, cmd.Process.Kill())
 
-	require.Eventually(t, func() bool {
-		// Other processes might have finished and forced the Unregister call to the registry
-		return methodHasBeenCalledWithPredicate(mockRegistry, "Unregister", func(call mock.Call) bool {
-			return call.Arguments[0].(uint32) == uint32(cmd.Process.Pid)
-		})
-	}, time.Second*10, 200*time.Millisecond, "received calls %v", mockRegistry.Calls)
+	// The ideal path would be that the process monitor sends an exit event for
+	// the process as it's killed. However, sometimes these events are missed
+	// and the callbacks aren't called. Unlike the "Process launch" event, we
+	// cannot recreate the process exit, which would be the ideal solution to
+	// ensure we're testing the correct behavior (including any
+	// filters/callbacks on the process monitor). Instead, we manually trigger
+	// the exit event for the process using the processMonitorProxy, which
+	// should replicate the same codepath.
+	waitAndRetryIfFail(t,
+		func() {
+			require.NoError(t, cmd.Process.Kill())
+		},
+		func() bool {
+			return methodHasBeenCalledWithPredicate(mockRegistry, "Unregister", func(call mock.Call) bool {
+				return call.Arguments[0].(uint32) == uint32(cmd.Process.Pid)
+			})
+		},
+		func(testSuccess bool) {
+			if !testSuccess {
+				// If the test failed once, manually trigger the exit event
+				s.procMonitor.triggerExit(uint32(cmd.Process.Pid))
+			}
+		}, 2, 10*time.Millisecond, 500*time.Millisecond, "attacher did not correctly handle exit events received calls %v", mockRegistry.Calls)
 
 	mockRegistry.AssertCalled(t, "Unregister", uint32(cmd.Process.Pid))
 }

--- a/pkg/ebpf/uprobes/testutil.go
+++ b/pkg/ebpf/uprobes/testutil.go
@@ -275,15 +275,6 @@ func (o *processMonitorProxy) SubscribeExit(cb func(uint32)) func() {
 	return o.target.SubscribeExit(cb)
 }
 
-func (o *processMonitorProxy) triggerExec(pid uint32) {
-	o.mutex.Lock()
-	defer o.mutex.Unlock()
-
-	for cb := range o.execCallbacks {
-		(*cb)(pid)
-	}
-}
-
 func (o *processMonitorProxy) triggerExit(pid uint32) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()

--- a/pkg/ebpf/uprobes/testutil.go
+++ b/pkg/ebpf/uprobes/testutil.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-//go:build linux_bpf
+//go:build linux_bpf && test
 
 package uprobes
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR attempts to fix a flaky test in the TestAttacher suite by ensuring that the exit event is notified to the attacher.

### Motivation

### Describe how to test/QA your changes

Automated tests should pass.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->