### PR TITLE
[CONTP-535] optimise tagger server chunking function using iter package

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -135,7 +135,7 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 	// event size should be small enough to fit within the grpc max message size
 	maxEventSize := maxMessageSize / 2
 	pb.RegisterAgentSecureServer(grpcSrv, &serverSecure{
-		taggerServer: taggerserver.NewServer(taggerComp, maxEventSize),
+		taggerServer: taggerserver.NewServer(taggerComp, maxEventSize, cfg.GetBool("tagger_server.lazy_event_chunking.enabled")),
 	})
 
 	timeout := pkgconfigsetup.Datadog().GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -68,7 +68,7 @@ func (server *apiServer) startCMDServer(
 	pb.RegisterAgentSecureServer(s, &serverSecure{
 		configService:    server.rcService,
 		configServiceMRF: server.rcServiceMRF,
-		taggerServer:     taggerserver.NewServer(server.taggerComp, maxEventSize),
+		taggerServer:     taggerserver.NewServer(server.taggerComp, maxEventSize, cfg.GetBool("tagger_server.lazy_event_chunking.enabled")),
 		taggerComp:       server.taggerComp,
 		// TODO(components): decide if workloadmetaServer should be componentized itself
 		workloadmetaServer:  workloadmetaServer.NewServer(server.wmeta),

--- a/comp/core/tagger/server/README.md
+++ b/comp/core/tagger/server/README.md
@@ -1,0 +1,41 @@
+## Introduction
+
+This package server implements a gRPC server that streams Tagger entities to remote tagger clients.
+
+## Behaviour
+
+When a client connects to the tagger grpc server, the server creates a subscription to the local tagger in order to stream tags.
+
+Before streaming new tag events, the server sends an initial burst to the client over the stream. This initial burst contains a snapshot of the tagger content. After the initial burst has been processed, the server will stream new tag events to the client based on the filters provided in the streaming request.
+
+### Cutting Events into chunks
+
+Sending very large messages over the grpc stream can cause the message to be dropped or rejected by the client. The limit is 4MB by default.
+
+To avoid such scenarios, especially when sending the initial burst, the server cuts each message into small chunks that can be easily transmitted over the stream.
+
+This logic is implemented in the `util.go` folder.
+
+We provide 2 implementations:
+- `splitBySize`: splits an event slice into a small chunks where each chunk contains a contiguous slice of events. This returns a two dimensional slice. This will load all chunks into memory (stored in a slice) and then return them.
+- `splitBySizeLazy`: this has the same effect as `splitBySize`, but it returns a sequence iterator instead of a two-dimensional slice. This allows loading chunks lazily into memory, and thus results in reducing memory usage compared to the previous implementation.
+
+We keep both implementations for at least release candidate to ensure everything works well and be able to quickly revert in case of regressions.
+
+#### Benchmark Testing 
+
+Benchmark tests show that using lazy chunking results in significant memory and cpu improvement:
+
+```
+go test -bench . -benchmem 
+goos: linux
+goarch: arm64
+pkg: github.com/DataDog/datadog-agent/comp/core/tagger/server
+BenchmarkChunkLazyChunking-10                  6         189819611 ns/op        80000906 B/op   10000001 allocs/op
+BenchmarkChunkSliceChunking-10                 3         480011264 ns/op        1281662296 B/op 10000051 allocs/op
+PASS
+ok      github.com/DataDog/datadog-agent/comp/core/tagger/server        4.351s
+```
+
+
+

--- a/comp/core/tagger/server/util_benchmark_test.go
+++ b/comp/core/tagger/server/util_benchmark_test.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package server
+
+import (
+	"testing"
+)
+
+const baseSliceLength = 10000000
+
+var baseBenchmarkSlice = make([]int, baseSliceLength, baseSliceLength)
+
+func init() {
+	for i := range baseSliceLength {
+		baseBenchmarkSlice[i] = i
+	}
+}
+
+func BenchmarkChunkLazyChunking(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for chunk := range splitBySizeLazy(baseBenchmarkSlice, 1, func(x int) int { return x }) {
+			_ = chunk // Use chunk to avoid compiler optimizations
+		}
+	}
+}
+
+func BenchmarkChunkSliceChunking(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		chunks := splitBySize(baseBenchmarkSlice, 1, func(x int) int { return x })
+		for _, chunk := range chunks {
+			_ = chunk // Use chunks to avoid compiler optimizations
+		}
+	}
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -729,6 +729,13 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("clc_runner_server_readheader_timeout", 10)
 	config.BindEnvAndSetDefault("clc_runner_remote_tagger_enabled", false)
 
+	// Tagger Server
+
+	// if set to true, the server loads one chunk at a time into memory, sends it on the stream, and then loads another chunk
+	// if set to false, the server loads all chunks to memory at once (slice of chunks), and then sends them sequentially over the stream
+	// for internal use only
+	config.BindEnvAndSetDefault("tagger_server.lazy_event_chunking.enabled", true)
+
 	// Admission controller
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.validation.enabled", true)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR leverages the `iter` golang package introduced in golang 1.23.0 in order to optimise the chunk function used in the tagger server. 

### Motivation

Optimise memory consumption of the chunking function used to split the tagger stream events into a sequence of chunks, each having a bounded size (in bytes).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Unit tests are implemented.
E2E should be enough since they validated the remote tagger is still working.

Benchmark Tests Results:
```
go test -bench . -benchmem 
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/comp/core/tagger/server
BenchmarkChunkLazyChunking-10                  6         189819611 ns/op        80000906 B/op   10000001 allocs/op
BenchmarkChunkSliceChunking-10                 3         480011264 ns/op        1281662296 B/op 10000051 allocs/op
PASS
ok      github.com/DataDog/datadog-agent/comp/core/tagger/server        4.351s
```

### Possible Drawbacks / Trade-offs
None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Lazy chunking is enabled by default with the config flag `tagger_server.use_lazy_chunking.enabled`. 
This can be useful to disable the new implementation in case of regressions.
This can be removed later when we no longer need to keep the old implementation.