### PR TITLE
[CWS] always use HumanReadableDuration through a pointer so that unmarshalling works

### DIFF
--- a/pkg/security/probe/selftests/ebpfless.go
+++ b/pkg/security/probe/selftests/ebpfless.go
@@ -30,7 +30,7 @@ func (o *EBPFLessSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 	return &rules.RuleDefinition{
 		ID:         o.ruleID,
 		Expression: `exec.file.path != "" && process.parent.pid == 0 && process.ppid == 0`,
-		Every: rules.HumanReadableDuration{
+		Every: &rules.HumanReadableDuration{
 			Duration: time.Duration(math.MaxInt64),
 		},
 		Silent: true,

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -63,21 +63,21 @@ type RuleID = string
 
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
-	ID                     RuleID                `yaml:"id,omitempty" json:"id"`
-	Version                string                `yaml:"version,omitempty" json:"version,omitempty"`
-	Expression             string                `yaml:"expression" json:"expression,omitempty"`
-	Description            string                `yaml:"description,omitempty" json:"description,omitempty"`
-	Tags                   map[string]string     `yaml:"tags,omitempty" json:"tags,omitempty"`
-	AgentVersionConstraint string                `yaml:"agent_version,omitempty" json:"agent_version,omitempty"`
-	Filters                []string              `yaml:"filters,omitempty" json:"filters,omitempty"`
-	Disabled               bool                  `yaml:"disabled,omitempty" json:"disabled,omitempty"`
-	Combine                CombinePolicy         `yaml:"combine,omitempty" json:"combine,omitempty" jsonschema:"enum=override"`
-	OverrideOptions        OverrideOptions       `yaml:"override_options,omitempty" json:"override_options,omitempty"`
-	Actions                []*ActionDefinition   `yaml:"actions,omitempty" json:"actions,omitempty"`
-	Every                  HumanReadableDuration `yaml:"every,omitempty" json:"every,omitempty"`
-	RateLimiterToken       []string              `yaml:"limiter_token,omitempty" json:"limiter_token,omitempty"`
-	Silent                 bool                  `yaml:"silent,omitempty" json:"silent,omitempty"`
-	GroupID                string                `yaml:"group_id,omitempty" json:"group_id,omitempty"`
+	ID                     RuleID                 `yaml:"id,omitempty" json:"id"`
+	Version                string                 `yaml:"version,omitempty" json:"version,omitempty"`
+	Expression             string                 `yaml:"expression" json:"expression,omitempty"`
+	Description            string                 `yaml:"description,omitempty" json:"description,omitempty"`
+	Tags                   map[string]string      `yaml:"tags,omitempty" json:"tags,omitempty"`
+	AgentVersionConstraint string                 `yaml:"agent_version,omitempty" json:"agent_version,omitempty"`
+	Filters                []string               `yaml:"filters,omitempty" json:"filters,omitempty"`
+	Disabled               bool                   `yaml:"disabled,omitempty" json:"disabled,omitempty"`
+	Combine                CombinePolicy          `yaml:"combine,omitempty" json:"combine,omitempty" jsonschema:"enum=override"`
+	OverrideOptions        OverrideOptions        `yaml:"override_options,omitempty" json:"override_options,omitempty"`
+	Actions                []*ActionDefinition    `yaml:"actions,omitempty" json:"actions,omitempty"`
+	Every                  *HumanReadableDuration `yaml:"every,omitempty" json:"every,omitempty"`
+	RateLimiterToken       []string               `yaml:"limiter_token,omitempty" json:"limiter_token,omitempty"`
+	Silent                 bool                   `yaml:"silent,omitempty" json:"silent,omitempty"`
+	GroupID                string                 `yaml:"group_id,omitempty" json:"group_id,omitempty"`
 }
 
 // GetTag returns the tag value associated with a tag key
@@ -133,19 +133,19 @@ type Scope string
 
 // SetDefinition describes the 'set' section of a rule action
 type SetDefinition struct {
-	Name   string                `yaml:"name" json:"name"`
-	Value  interface{}           `yaml:"value" json:"value,omitempty" jsonschema:"oneof_required=SetWithValue,oneof_type=string;integer;boolean;array"`
-	Field  string                `yaml:"field" json:"field,omitempty" jsonschema:"oneof_required=SetWithField"`
-	Append bool                  `yaml:"append" json:"append,omitempty"`
-	Scope  Scope                 `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=container"`
-	Size   int                   `yaml:"size" json:"size,omitempty"`
-	TTL    HumanReadableDuration `yaml:"ttl" json:"ttl,omitempty"`
+	Name   string                 `yaml:"name" json:"name"`
+	Value  interface{}            `yaml:"value" json:"value,omitempty" jsonschema:"oneof_required=SetWithValue,oneof_type=string;integer;boolean;array"`
+	Field  string                 `yaml:"field" json:"field,omitempty" jsonschema:"oneof_required=SetWithField"`
+	Append bool                   `yaml:"append" json:"append,omitempty"`
+	Scope  Scope                  `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=container"`
+	Size   int                    `yaml:"size" json:"size,omitempty"`
+	TTL    *HumanReadableDuration `yaml:"ttl" json:"ttl,omitempty"`
 }
 
 // KillDisarmerParamsDefinition describes the parameters of a kill action disarmer
 type KillDisarmerParamsDefinition struct {
-	MaxAllowed int                   `yaml:"max_allowed" json:"max_allowed,omitempty" jsonschema:"description=The maximum number of allowed kill actions within the period,example=5"`
-	Period     HumanReadableDuration `yaml:"period" json:"period,omitempty" jsonschema:"description=The period of time during which the maximum number of allowed kill actions is calculated,example=1m"`
+	MaxAllowed int                    `yaml:"max_allowed" json:"max_allowed,omitempty" jsonschema:"description=The maximum number of allowed kill actions within the period,example=5"`
+	Period     *HumanReadableDuration `yaml:"period" json:"period,omitempty" jsonschema:"description=The period of time during which the maximum number of allowed kill actions is calculated,example=1m"`
 }
 
 // KillDisarmerDefinition describes the 'disarmer' section of a kill action
@@ -200,7 +200,7 @@ type HumanReadableDuration struct {
 }
 
 // MarshalYAML marshals a duration to a human readable format
-func (d HumanReadableDuration) MarshalYAML() (interface{}, error) {
+func (d *HumanReadableDuration) MarshalYAML() (interface{}, error) {
 	return d.String(), nil
 }
 

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -340,7 +340,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 					Name:   "var1",
 					Append: true,
 					Value:  []string{"foo"},
-					TTL: HumanReadableDuration{
+					TTL: &HumanReadableDuration{
 						Duration: 1 * time.Second,
 					},
 				},

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -241,7 +241,10 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					variableProvider = &rs.globalVariables
 				}
 
-				opts := eval.VariableOpts{TTL: actionDef.Set.TTL.Duration, Size: actionDef.Set.Size}
+				opts := eval.VariableOpts{Size: actionDef.Set.Size}
+				if actionDef.Set.TTL != nil {
+					opts.TTL = actionDef.Set.TTL.Duration
+				}
 
 				variable, err := variableProvider.GetVariable(actionDef.Set.Name, variableValue, opts)
 				if err != nil {

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -619,13 +619,13 @@ func TestActionKillDisarmFromRule(t *testing.T) {
 						Disarmer: &rules.KillDisarmerDefinition{
 							Executable: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period: rules.HumanReadableDuration{
+								Period: &rules.HumanReadableDuration{
 									Duration: enforcementDisarmerExecutablePeriod,
 								},
 							},
 							Container: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period: rules.HumanReadableDuration{
+								Period: &rules.HumanReadableDuration{
 									Duration: enforcementDisarmerContainerPeriod,
 								},
 							},
@@ -644,13 +644,13 @@ func TestActionKillDisarmFromRule(t *testing.T) {
 						Disarmer: &rules.KillDisarmerDefinition{
 							Executable: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period: rules.HumanReadableDuration{
+								Period: &rules.HumanReadableDuration{
 									Duration: enforcementDisarmerExecutablePeriod,
 								},
 							},
 							Container: &rules.KillDisarmerParamsDefinition{
 								MaxAllowed: 1,
-								Period: rules.HumanReadableDuration{
+								Period: &rules.HumanReadableDuration{
 									Duration: enforcementDisarmerContainerPeriod,
 								},
 							},

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -106,7 +106,7 @@ func TestEventRaleLimiters(t *testing.T) {
 		{
 			ID:         "test_unique_id",
 			Expression: `open.file.path == "{{.Root}}/test-unique-id"`,
-			Every: rules.HumanReadableDuration{
+			Every: &rules.HumanReadableDuration{
 				Duration: 5 * time.Second,
 			},
 			RateLimiterToken: []string{"process.file.name"},
@@ -114,7 +114,7 @@ func TestEventRaleLimiters(t *testing.T) {
 		{
 			ID:         "test_std",
 			Expression: `open.file.path == "{{.Root}}/test-std"`,
-			Every: rules.HumanReadableDuration{
+			Every: &rules.HumanReadableDuration{
 				Duration: 5 * time.Second,
 			},
 		},


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes another small bug with yaml unmarshalling of time.Duration, since the field was not a pointer the unmarshalling function was never called.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->