### PR TITLE
[CWS] improve handling of nil `HumanReadableDuration`

### DIFF
--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -103,8 +103,8 @@ func (rl *RateLimiter) Apply(ruleSet *rules.RuleSet, customRuleIDs []eval.RuleID
 	for id, rule := range ruleSet.GetRules() {
 		every, burst := defaultEvery, defaultBurst
 
-		if rule.Def.Every.Duration != 0 {
-			every, burst = rule.Def.Every.Duration, 1
+		if duration := rule.Def.Every.GetDuration(); duration != 0 {
+			every, burst = duration, 1
 		}
 
 		if len(rule.Def.RateLimiterToken) > 0 {

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -425,7 +425,7 @@ func (p *ProcessKiller) getDisarmerParams(kill *rules.KillDefinition) (*disarmer
 	if kill.Disarmer != nil && kill.Disarmer.Container != nil && kill.Disarmer.Container.MaxAllowed > 0 {
 		containerParams.enabled = true
 		containerParams.capacity = uint64(kill.Disarmer.Container.MaxAllowed)
-		containerParams.period = kill.Disarmer.Container.Period.Duration
+		containerParams.period = kill.Disarmer.Container.Period.GetDuration()
 	} else if p.cfg.RuntimeSecurity.EnforcementDisarmerContainerEnabled {
 		containerParams.enabled = true
 		containerParams.capacity = uint64(p.cfg.RuntimeSecurity.EnforcementDisarmerContainerMaxAllowed)
@@ -435,7 +435,7 @@ func (p *ProcessKiller) getDisarmerParams(kill *rules.KillDefinition) (*disarmer
 	if kill.Disarmer != nil && kill.Disarmer.Executable != nil && kill.Disarmer.Executable.MaxAllowed > 0 {
 		executableParams.enabled = true
 		executableParams.capacity = uint64(kill.Disarmer.Executable.MaxAllowed)
-		executableParams.period = kill.Disarmer.Executable.Period.Duration
+		executableParams.period = kill.Disarmer.Executable.Period.GetDuration()
 	} else if p.cfg.RuntimeSecurity.EnforcementDisarmerExecutableEnabled {
 		executableParams.enabled = true
 		executableParams.capacity = uint64(p.cfg.RuntimeSecurity.EnforcementDisarmerExecutableMaxAllowed)

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -199,6 +199,14 @@ type HumanReadableDuration struct {
 	time.Duration
 }
 
+// GetDuration returns the duration embedded in the HumanReadableDuration, or 0 if nil
+func (d *HumanReadableDuration) GetDuration() time.Duration {
+	if d == nil {
+		return 0
+	}
+	return d.Duration
+}
+
 // MarshalYAML marshals a duration to a human readable format
 func (d *HumanReadableDuration) MarshalYAML() (interface{}, error) {
 	return d.String(), nil

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -241,10 +241,7 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					variableProvider = &rs.globalVariables
 				}
 
-				opts := eval.VariableOpts{Size: actionDef.Set.Size}
-				if actionDef.Set.TTL != nil {
-					opts.TTL = actionDef.Set.TTL.Duration
-				}
+				opts := eval.VariableOpts{TTL: actionDef.Set.TTL.GetDuration(), Size: actionDef.Set.Size}
 
 				variable, err := variableProvider.GetVariable(actionDef.Set.Name, variableValue, opts)
 				if err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Another fix for some edge case where `HumanReadableDuration` was nil and this case was not handled correctly.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->