### PR TITLE
AMLII-2207 - alter dogstatsd packet buffers to automatically flush when stream sockets disconnect

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -204,6 +204,7 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 	l.telemetryStore.tlmUDSConnections.Inc(tlmListenerID, l.transport)
 	defer func() {
 		_ = closeFunc(conn)
+		packetsBuffer.Flush()
 		packetsBuffer.Close()
 		if telemetryWithFullListenerID {
 			l.clearTelemetry(tlmListenerID)

--- a/comp/dogstatsd/packets/buffer.go
+++ b/comp/dogstatsd/packets/buffer.go
@@ -70,6 +70,13 @@ func (pb *Buffer) Append(packet *Packet) {
 	}
 }
 
+// Flush offers a thread-safe method to force a flush of the appended packets
+func (pb *Buffer) Flush() {
+	pb.m.Lock()
+	pb.flush()
+	pb.m.Unlock()
+}
+
 func (pb *Buffer) flush() {
 	if len(pb.packets) > 0 {
 		t1 := time.Now()

--- a/comp/dogstatsd/packets/buffer_test.go
+++ b/comp/dogstatsd/packets/buffer_test.go
@@ -24,7 +24,7 @@ func TestBufferTelemetry(t *testing.T) {
 	// We need a high enough duration to avoid the buffer to flush
 	// And cause the program to deadlock on the packetChannel
 	duration := 10 * time.Second
-	packetChannel := make(chan Packets)
+	packetChannel := make(chan Packets, 1)
 	buffer := NewBuffer(3, duration, packetChannel, "test_buffer", telemetryStore)
 	defer buffer.Close()
 
@@ -126,4 +126,23 @@ func TestBufferTelemetryFull(t *testing.T) {
 	assert.Equal(t, float64(123), channelPacketsBytesMetrics[0].Value())
 
 	assert.Equal(t, float64(1), channelSizeMetrics[0].Value())
+}
+
+func TestBufferFlush(t *testing.T) {
+	telemetryComponent := fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
+	telemetryStore := NewTelemetryStore(nil, telemetryComponent)
+	duration := 10 * time.Hour
+	packetChannel := make(chan Packets, 1)
+	buffer := NewBuffer(0, duration, packetChannel, "test_buffer", telemetryStore)
+	packet := &Packet{
+		Contents:   []byte("test"),
+		Buffer:     []byte("test read"),
+		Origin:     "test origin",
+		ListenerID: "1",
+		Source:     0,
+	}
+
+	buffer.Append(packet)
+	buffer.Flush()
+	assert.Equal(t, 1, len(packetChannel))
 }

--- a/releasenotes/notes/stream-socket-race-fix-255b6e7a10f7fde0.yaml
+++ b/releasenotes/notes/stream-socket-race-fix-255b6e7a10f7fde0.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed race condition in stream UDS clients of Dogstatsd that
+    allowed for the loss of received data.
+


### PR DESCRIPTION
### What does this PR do?
Force the dogstatsd packet buffer to flush while a stream socket is being closed

### Motivation
Due to the requirements of the streaming UDS setup, socket connections are regularly created and closed. This is in contrast to the dgram UDS setup, which persists a single server-side socket throughout its entire life. The current packet buffer logic expects this latter setup, and isn't aggressive about persisting its data to the server workers on a socket closure. This causes a stream UDS client that connects, sends data, and disconnects to easily see that sent data lost.

### Describe how you validated your changes
Utilize a dogstatsd client in a small program that generates a metric and then exits - on the current production code this metric is almost always lost, and on the modified code this metric is always persisted. 

### Possible Drawbacks / Trade-offs

### Additional Notes