### PR TITLE
[CWS] fix unmarshalling of regular int to `time.Duration`

### DIFF
--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -7,7 +7,7 @@
 package rules
 
 import (
-	"errors"
+	"fmt"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -219,7 +219,7 @@ func (d *HumanReadableDuration) UnmarshalYAML(n *yaml.Node) error {
 		return err
 	}
 	switch value := v.(type) {
-	case float64:
+	case int:
 		d.Duration = time.Duration(value)
 		return nil
 	case string:
@@ -230,7 +230,7 @@ func (d *HumanReadableDuration) UnmarshalYAML(n *yaml.Node) error {
 		}
 		return nil
 	default:
-		return errors.New("invalid duration")
+		return fmt.Errorf("invalid duration: (yaml type: %T)", v)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

As opposed to json that unmarshals numbers to `float64`, yaml will unmarshal them to `int`. This PR fixes this issue in `HumanReadableDuration`.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->