### PR TITLE
discovery: tests: use collect instead of t in EventuallyWithT calls

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -51,9 +51,9 @@ func TestIgnoreComm(t *testing.T) {
 	badPid := badCmd.Process.Pid
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		svcMap := getServicesMap(t, url)
+		svcMap := getServicesMap(collect, url)
 		assert.Contains(collect, svcMap, goodPid)
-		require.NotContains(t, svcMap, badPid)
+		assert.NotContains(collect, svcMap, badPid)
 	}, 30*time.Second, 100*time.Millisecond)
 }
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -100,7 +100,7 @@ func setupDiscoveryModule(t *testing.T) (string, *proccontainersmocks.MockContai
 	return srv.URL, mockContainerProvider
 }
 
-func getServices(t *testing.T, url string) []model.Service {
+func getServices(t require.TestingT, url string) []model.Service {
 	location := url + "/" + string(config.DiscoveryModule) + pathServices
 	req, err := http.NewRequest(http.MethodGet, location, nil)
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func getServices(t *testing.T, url string) []model.Service {
 	return res.Services
 }
 
-func getServicesMap(t *testing.T, url string) map[int]model.Service {
+func getServicesMap(t require.TestingT, url string) map[int]model.Service {
 	services := getServices(t, url)
 	servicesMap := make(map[int]model.Service)
 	for _, service := range services {
@@ -235,7 +235,7 @@ func TestBasic(t *testing.T) {
 
 	// Eventually to give the processes time to start
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		portMap := getServicesMap(t, url)
+		portMap := getServicesMap(collect, url)
 		for _, pid := range expectedPIDs {
 			assert.Contains(collect, portMap, pid)
 		}
@@ -363,15 +363,15 @@ func TestServiceName(t *testing.T) {
 	pid := cmd.Process.Pid
 	// Eventually to give the processes time to start
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		portMap := getServicesMap(t, url)
+		portMap := getServicesMap(collect, url)
 		assert.Contains(collect, portMap, pid)
 		// Non-ASCII character removed due to normalization.
-		assert.Equal(t, "foo_bar", portMap[pid].DDService)
-		assert.Equal(t, portMap[pid].DDService, portMap[pid].Name)
-		assert.Equal(t, "sleep", portMap[pid].GeneratedName)
-		assert.Equal(t, string(usm.CommandLine), portMap[pid].GeneratedNameSource)
-		assert.False(t, portMap[pid].DDServiceInjected)
-		assert.Equal(t, portMap[pid].ContainerID, "")
+		assert.Equal(collect, "foo_bar", portMap[pid].DDService)
+		assert.Equal(collect, portMap[pid].DDService, portMap[pid].Name)
+		assert.Equal(collect, "sleep", portMap[pid].GeneratedName)
+		assert.Equal(collect, string(usm.CommandLine), portMap[pid].GeneratedNameSource)
+		assert.False(collect, portMap[pid].DDServiceInjected)
+		assert.Equal(collect, portMap[pid].ContainerID, "")
 	}, 30*time.Second, 100*time.Millisecond)
 }
 
@@ -505,7 +505,7 @@ func testCaptureWrappedCommands(t *testing.T, script string, commandWrapper []st
 	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
 	pid := int(proc.Pid)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		svcMap := getServicesMap(t, url)
+		svcMap := getServicesMap(collect, url)
 		assert.Contains(collect, svcMap, pid)
 		assert.True(collect, validator(svcMap[pid]))
 	}, 30*time.Second, 100*time.Millisecond)
@@ -559,12 +559,12 @@ func TestAPMInstrumentationProvided(t *testing.T) {
 			pid := cmd.Process.Pid
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				portMap := getServicesMap(t, url)
+				portMap := getServicesMap(collect, url)
 				assert.Contains(collect, portMap, pid)
 				assert.Equal(collect, string(test.language), portMap[pid].Language)
 				assert.Equal(collect, string(apm.Provided), portMap[pid].APMInstrumentation)
-				assertStat(t, portMap[pid])
-				assertCPU(t, url, pid)
+				assertStat(collect, portMap[pid])
+				assertCPU(collect, url, pid)
 			}, 30*time.Second, 100*time.Millisecond)
 		})
 	}
@@ -605,7 +605,7 @@ func assertStat(t assert.TestingT, svc model.Service) {
 	assert.InDelta(t, uint64(createTimeMs), svc.StartTimeMilli, 10000)
 }
 
-func assertCPU(t *testing.T, url string, pid int) {
+func assertCPU(t require.TestingT, url string, pid int) {
 	proc, err := process.NewProcess(int32(pid))
 	require.NoError(t, err, "could not create gopsutil process handle")
 
@@ -642,7 +642,7 @@ func TestCommandLineSanitization(t *testing.T) {
 	pid := cmd.Process.Pid
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		svcMap := getServicesMap(t, url)
+		svcMap := getServicesMap(collect, url)
 		assert.Contains(collect, svcMap, pid)
 		assert.Equal(collect, sanitizedCommandLine, svcMap[pid].CommandLine)
 	}, 30*time.Second, 100*time.Millisecond)
@@ -661,7 +661,7 @@ func TestNodeDocker(t *testing.T) {
 	pid := int(nodeJSPID)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		svcMap := getServicesMap(t, url)
+		svcMap := getServicesMap(collect, url)
 		assert.Contains(collect, svcMap, pid)
 		// test@... changed to test_... due to normalization.
 		assert.Equal(collect, "test_nodejs-https-server", svcMap[pid].GeneratedName)
@@ -669,7 +669,7 @@ func TestNodeDocker(t *testing.T) {
 		assert.Equal(collect, svcMap[pid].GeneratedName, svcMap[pid].Name)
 		assert.Equal(collect, "provided", svcMap[pid].APMInstrumentation)
 		assertStat(collect, svcMap[pid])
-		assertCPU(t, url, pid)
+		assertCPU(collect, url, pid)
 	}, 30*time.Second, 100*time.Millisecond)
 }
 
@@ -720,7 +720,7 @@ func TestAPMInstrumentationProvidedWithMaps(t *testing.T) {
 
 			pid := cmd.Process.Pid
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				portMap := getServicesMap(t, url)
+				portMap := getServicesMap(collect, url)
 				assert.Contains(collect, portMap, pid)
 				assert.Equal(collect, string(test.language), portMap[pid].Language)
 				assert.Equal(collect, string(apm.Provided), portMap[pid].APMInstrumentation)
@@ -779,7 +779,7 @@ func TestNamespaces(t *testing.T) {
 
 	// Eventually to give the processes time to start
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		portMap := getServicesMap(t, url)
+		portMap := getServicesMap(collect, url)
 		for _, pid := range pids {
 			assert.Contains(collect, portMap, pid)
 		}

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -887,7 +887,7 @@ func TestCache(t *testing.T) {
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err = discovery.getServices()
-		require.NoError(t, err)
+		require.NoError(collect, err)
 
 		for _, cmd := range cmds {
 			pid := int32(cmd.Process.Pid)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Some tests of the service discovery test suite use `t` instead of the provided `assert.CollectT` argument, causing flakiness in tests. This PR fixes that.

### Motivation

Reduce test flakiness.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->