### PR TITLE
Fix "no snapshot data found" when ` agent check --profile-memory`

### DIFF
--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -508,11 +508,7 @@ func run(
 			}
 			instancesData = append(instancesData, instanceData)
 		} else if cliParams.profileMemory {
-			// Every instance will create its own directory
-			instanceID := strings.SplitN(string(c.ID()), ":", 2)[1]
-			// Colons can't be part of Windows file paths
-			instanceID = strings.Replace(instanceID, ":", "_", -1)
-			profileDataDir := filepath.Join(cliParams.profileMemoryDir, cliParams.checkName, instanceID)
+			profileDataDir := filepath.Join(cliParams.profileMemoryDir, "profile_memory")
 
 			snapshotDir := filepath.Join(profileDataDir, "snapshots")
 			if _, err := os.Stat(snapshotDir); !os.IsNotExist(err) {

--- a/releasenotes/notes/fix-agent-check-profile-memory-1f616117e8d5cc45.yaml
+++ b/releasenotes/notes/fix-agent-check-profile-memory-1f616117e8d5cc45.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix errror, "no snapshot data found in ...." when running
+    ``agent check <check> --profile-memory``.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix the path to `profileDataDir`.

### Motivation

`agent check <check> --profile-memory` causes error like "no snapshot data found ...".

```bash
docker run --name datadog-agent -d --cgroupns host --pid host \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-e DD_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
datadog/agent:7.59.0

docker exec -it datadog-agent agent check network -m -t 3
Error: no snapshot data found in /tmp/datadog-agent-memory-profiler208359086/network/70057a643880f49f
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

We can see memory profiles.

```bash
docker run --name datadog-agent -d --cgroupns host --pid host \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-e DD_API_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \
datadog/agent-dev:keisku-profile-memory-flare-py3-first-commit

docker exec -it datadog-agent-test agent check network -m -t 3
Top 30 lines

#1: network/check_linux.py:320: 1.62 KiB
    with open(file_location, 'r') as f:
...skip....

docker exec -it datadog-agent-test agent check network -m -t 3 --m-dir /var/log/datadog
Top 30 lines

#1: network/check_linux.py:320: 1.62 KiB
    with open(file_location, 'r') as f:
...skip....
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->