### PR TITLE
fix(podresources): switch socket error to debug

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -214,6 +214,7 @@ func (ku *KubeUtil) getLocalPodList(ctx context.Context) (*PodList, error) {
 
 	err = ku.addContainerResourcesData(ctx, pods.Items)
 	if err != nil {
+		// TODO: Switch back to error level once the socket issue is fixed.
 		log.Debugf("Error adding container resources data: %s", err)
 	}
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -214,7 +214,7 @@ func (ku *KubeUtil) getLocalPodList(ctx context.Context) (*PodList, error) {
 
 	err = ku.addContainerResourcesData(ctx, pods.Items)
 	if err != nil {
-		log.Errorf("Error adding container resources data: %s", err)
+		log.Debugf("Error adding container resources data: %s", err)
 	}
 
 	// ensure we dont have nil pods


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Switch the `error getting container resources data` error newly introduced with podresources to `debug` as it is emited constantly when the socket is missing. This is a temporary solution before fixing the problem by using [Container Features](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/env/environment_container_features.go).

### Motivation

To avoid overflowing error logs with `error getting container resources data`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Tested using Minikube. Error logs are now clean but debug logs are overflowed with the error.
Before (after around an hour)
```
➜  klo datadog-agent-6b6p6 | grep /var/lib/kubelet/pod-resources/kubelet.sock | wc -l
1116
```

After
```
➜  klo datadog-agent-4hrnb | grep /var/lib/kubelet/pod-resources/kubelet.sock | wc -l
0
```

With debug logs (after less than a minute)
```
➜  datadog-dev git:(main) ✗ klo datadog-agent-4njt5 | grep /var/lib/kubelet/pod-resources/kubelet.sock |wc -l
8
```

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->