### PR TITLE
[CWS] small optimizations to regex parsing in SECL

### DIFF
--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -135,7 +135,7 @@ func (r *RegexpStringMatcher) Compile(pattern string, caseInsensitive bool) erro
 		}
 	}
 
-	if caseInsensitive {
+	if caseInsensitive && !strings.HasPrefix(pattern, "(?i)") {
 		pattern = "(?i)" + pattern
 	}
 

--- a/pkg/security/secl/compiler/eval/strings.go
+++ b/pkg/security/secl/compiler/eval/strings.go
@@ -123,7 +123,7 @@ type RegexpStringMatcher struct {
 	re *regexp.Regexp
 }
 
-var stringBigOrRe = regexp.MustCompile(`^\.\*\(([a-zA-Z_|]+)\)\.\*$`)
+var stringBigOrRe = regexp.MustCompile(`^(?:\.\*)?\(([a-zA-Z_|]+)\)(?:\.\*)?$`)
 
 // Compile a regular expression based pattern
 func (r *RegexpStringMatcher) Compile(pattern string, caseInsensitive bool) error {

--- a/pkg/security/secl/compiler/eval/strings_test.go
+++ b/pkg/security/secl/compiler/eval/strings_test.go
@@ -260,17 +260,35 @@ func TestRegexp(t *testing.T) {
 }
 
 func BenchmarkRegexpEvaluator(b *testing.B) {
-	pattern := ".*(restore|recovery|readme|instruction|how_to|ransom).*"
+	b.Run("with stars", func(b *testing.B) {
+		pattern := ".*(restore|recovery|readme|instruction|how_to|ransom).*"
 
-	var matcher RegexpStringMatcher
-	if err := matcher.Compile(pattern, false); err != nil {
-		b.Fatal(err)
-	}
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if !matcher.Matches("123ransom456.txt") {
-			b.Fatal("unexpected result")
+		var matcher RegexpStringMatcher
+		if err := matcher.Compile(pattern, false); err != nil {
+			b.Fatal(err)
 		}
-	}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !matcher.Matches("123ransom456.txt") {
+				b.Fatal("unexpected result")
+			}
+		}
+	})
+
+	b.Run("without stars", func(b *testing.B) {
+		pattern := "(restore|recovery|readme|instruction|how_to|ransom)"
+
+		var matcher RegexpStringMatcher
+		if err := matcher.Compile(pattern, false); err != nil {
+			b.Fatal(err)
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !matcher.Matches("123ransom456.txt") {
+				b.Fatal("unexpected result")
+			}
+		}
+	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds 2 small optimizations to the regex matching path:
- do not add `(?i)` if the user provided regex is already case insensitive 
- improve the "big or" optimization to not need `.*` at the beginning and end of the regex (since we already do un-anchored matches)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->