### PR TITLE
[PROCS-4577] Remove `ECSEC2Suite` embed from `ECSEC2CoreAgentSuite` struct

### DIFF
--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -91,7 +91,7 @@ func (s *ECSEC2Suite) TestProcessCheck() {
 // This is duplicated as the tests have been flaky. This may be due to how pulumi is handling the provisioning of
 // ecs tasks.
 type ECSEC2CoreAgentSuite struct {
-	ECSEC2Suite
+	e2e.BaseSuite[ecsCPUStressEnv]
 }
 
 func TestECSEC2CoreAgentSuite(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the `ECSEC2Suite` embed in the `ECSEC2CoreAgentSuite` as it resulted in the process agent tests being run. Example from failed job:
```
--- FAIL: TestECSEC2CoreAgentSuite (690.69s)
    --- PASS: TestECSEC2CoreAgentSuite/TestProcessCheck (40.00s)
    --- FAIL: TestECSEC2CoreAgentSuite/TestProcessCheckInCoreAgent (10.00s)
```

### Motivation
[Flakes](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fprocess.TestECSEC2CoreAgentSuite%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1732809799958&end=1733414599958&paused=false)

### Describe how you validated your changes
Ran the test to see that only the Core Agent test was run
```
=== RUN   TestECSEC2CoreAgentSuite/TestProcessCheckInCoreAgent
    suite.go:280: No change in provisioners, skipping environment update
--- PASS: TestECSEC2CoreAgentSuite (649.72s)
    --- PASS: TestECSEC2CoreAgentSuite/TestProcessCheckInCoreAgent (10.15s)
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->