### PR TITLE
Fixing logic for when to enable APM

### DIFF
--- a/pkg/config/utils/miscellaneous.go
+++ b/pkg/config/utils/miscellaneous.go
@@ -54,6 +54,6 @@ func IsCoreAgentEnabled(cfg pkgconfigmodel.Reader) bool {
 // Error Tracking standalone only via the apm_config.error_tracking_standalone.enabled option instead of requiring
 // to enable also apm_config.enabled.
 func IsAPMEnabled(cfg pkgconfigmodel.Reader) bool {
-	return (cfg.GetBool("apm_config.enabled") && IsCoreAgentEnabled(cfg)) ||
+	return cfg.GetBool("apm_config.enabled") ||
 		cfg.GetBool("apm_config.error_tracking_standalone.enabled")
 }

--- a/pkg/config/utils/miscellaneous_test.go
+++ b/pkg/config/utils/miscellaneous_test.go
@@ -6,11 +6,12 @@
 package utils
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsCoreAgentEnabled(t *testing.T) {
@@ -61,6 +62,49 @@ func TestIsCoreAgentEnabled(t *testing.T) {
 			assert.Equal(t,
 				test.expected, IsCoreAgentEnabled(mockConfig),
 				"Was expecting IsCoreAgentEnabled to return", test.expected)
+		})
+	}
+}
+
+func TestIsAPMEnabled(t *testing.T) {
+	tests := []struct {
+		name                                      string
+		apmEnabled, errorTrackingEnable, expected bool
+	}{
+		{
+			name:                "APM enabled and Error Tracking standalone disabled",
+			apmEnabled:          false,
+			errorTrackingEnable: false,
+			expected:            false,
+		},
+		{
+			name:                "APM enabled and Error Tracking standalone disabled",
+			apmEnabled:          true,
+			errorTrackingEnable: false,
+			expected:            true,
+		},
+		{
+			name:                "APM disabled and Error Tracking standalone enabled",
+			apmEnabled:          false,
+			errorTrackingEnable: true,
+			expected:            true,
+		},
+		{
+			name:                "APM enabled and Error Tracking standalone enabled",
+			apmEnabled:          true,
+			errorTrackingEnable: true,
+			expected:            true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("apm_config.enabled", test.apmEnabled)
+			mockConfig.SetWithoutSource("apm_config.error_tracking_standalone.enabled", test.errorTrackingEnable)
+			assert.Equal(t,
+				test.expected, IsAPMEnabled(mockConfig),
+				"Was expecting IsAPMEnabled to return", test.expected)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

It fixes the logic that would ether enable or disable the Trace Agent incorrectly.

### Motivation

Making sure the logic to enable Trace Agent is correct.

### Describe how you validated your changes

- Set `apm_config.enabled` to `true` and check that you can still send traces.
- Set `apm_config.enabled` to `false` and `apm_config.error_tracking_standalone.enabled` and check error tracking still works

