### PR TITLE
fix(podresources): detect API availability client creation

### DIFF
--- a/pkg/config/env/environment_container_features.go
+++ b/pkg/config/env/environment_container_features.go
@@ -31,4 +31,6 @@ const (
 	CloudFoundry Feature = "cloudfoundry"
 	// Podman containers storage path accessible
 	Podman Feature = "podman"
+	// PodResources socket present
+	PodResources Feature = "podresources"
 )

--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -239,7 +239,7 @@ func detectPodResources(features FeatureMap, cfg model.Reader) {
 	} else if exists && !reachable {
 		log.Infof("Agent found PodResources socket at %s but socket not reachable (permissions?)", socketPath)
 	} else {
-		log.Infof("Agent did not find PodResources socket at %s")
+		log.Infof("Agent did not find PodResources socket at %s", socketPath)
 	}
 }
 

--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -46,6 +46,7 @@ func init() {
 	registerFeature(ECSOrchestratorExplorer)
 	registerFeature(CloudFoundry)
 	registerFeature(Podman)
+	registerFeature(PodResources)
 }
 
 // IsAnyContainerFeaturePresent checks if any of known container features is present
@@ -69,6 +70,7 @@ func detectContainerFeatures(features FeatureMap, cfg model.Reader) {
 	detectAWSEnvironments(features, cfg)
 	detectCloudFoundry(features, cfg)
 	detectPodman(features, cfg)
+	detectPodResources(features, cfg)
 }
 
 func detectKubernetes(features FeatureMap, cfg model.Reader) {
@@ -96,7 +98,7 @@ func detectDocker(features FeatureMap) {
 
 				// Even though it does not modify configuration, using the OverrideFunc mechanism for uniformity
 				model.AddOverrideFunc(func(model.Config) {
-					os.Setenv("DOCKER_HOST", getDefaultDockerSocketType()+defaultDockerSocketPath)
+					os.Setenv("DOCKER_HOST", getDefaultSocketPrefix()+defaultDockerSocketPath)
 				})
 				break
 			}
@@ -226,6 +228,21 @@ func detectPodman(features FeatureMap, cfg model.Reader) {
 	}
 }
 
+func detectPodResources(features FeatureMap, cfg model.Reader) {
+	// We only check the path from config. Default socket path is defined in the config
+	socketPath := getDefaultSocketPrefix() + cfg.GetString("kubernetes_kubelet_podresources_socket")
+
+	exists, reachable := socket.IsAvailable(socketPath, socketTimeout)
+	if exists && reachable {
+		log.Infof("Agent found PodResources socket at %s", socketPath)
+		features[PodResources] = struct{}{}
+	} else if exists && !reachable {
+		log.Infof("Agent found PodResources socket at %s but socket not reachable (permissions?)", socketPath)
+	} else {
+		log.Infof("Agent did not find PodResources socket at %s")
+	}
+}
+
 func getHostMountPrefixes() []string {
 	if IsContainerized() {
 		return []string{"", defaultHostMountPrefix}
@@ -233,7 +250,7 @@ func getHostMountPrefixes() []string {
 	return []string{""}
 }
 
-func getDefaultDockerSocketType() string {
+func getDefaultSocketPrefix() string {
 	if runtime.GOOS == "windows" {
 		return winNamedPipePrefix
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -217,8 +217,7 @@ func (ku *KubeUtil) getLocalPodList(ctx context.Context) (*PodList, error) {
 
 	err = ku.addContainerResourcesData(ctx, pods.Items)
 	if err != nil {
-		// TODO: Switch back to error level once the socket issue is fixed.
-		log.Debugf("Error adding container resources data: %s", err)
+		log.Errorf("Error adding container resources data: %s", err)
 	}
 
 	// ensure we dont have nil pods

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -84,9 +85,11 @@ func (ku *KubeUtil) init() error {
 		}
 	}
 
-	ku.podResourcesClient, err = NewPodResourcesClient(pkgconfigsetup.Datadog())
-	if err != nil {
-		log.Warnf("Failed to create pod resources client, resource data will not be available: %s", err)
+	if env.IsFeaturePresent(env.PodResources) {
+		ku.podResourcesClient, err = NewPodResourcesClient(pkgconfigsetup.Datadog())
+		if err != nil {
+			log.Warnf("Failed to create pod resources client, resource data will not be available: %s", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds feature detection for the PodResources API socket.

### Motivation

Avoid log spam.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated by running on a k8s cluster with GPU nodes:

- Check that, with a valid podresources socket, the socket is detected and `agent workload-list` shows correctly assigned resources.
- With an invalid podresources socket, validate that the podresources client is not enabled and there is no error log spam.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->