### PR TITLE
fix(step-by-step): [agent6] Update centos repo files

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -1086,7 +1086,7 @@ def version(
     url_safe=False,
     omnibus_format=False,
     git_sha_length=7,
-    major_version='7',
+    major_version='6',
     version_cached=False,
     pipeline_id=None,
     include_git=True,

--- a/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
+++ b/test/new-e2e/tests/agent-platform/step-by-step/step_by_step_test.go
@@ -214,7 +214,7 @@ func (is *stepByStepSuite) StepByStepRhelTest(VMclient *common.TestClient) {
 		arch = *architecture
 	}
 	yumrepo := fmt.Sprintf("http://yumtesting.datad0g.com/testing/pipeline-%s-a%s/%s/%s/",
-		os.Getenv("CI_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
+		os.Getenv("E2E_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
 	fileManager := VMclient.FileManager
 	var err error
 
@@ -264,7 +264,7 @@ func (is *stepByStepSuite) StepByStepSuseTest(VMclient *common.TestClient) {
 	}
 
 	suseRepo := fmt.Sprintf("http://yumtesting.datad0g.com/suse/testing/pipeline-%s-a%s/%s/%s/",
-		os.Getenv("CI_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
+		os.Getenv("E2E_PIPELINE_ID"), *majorVersion, *majorVersion, arch)
 	fileManager := VMclient.FileManager
 	var err error
 
@@ -292,7 +292,11 @@ func (is *stepByStepSuite) StepByStepSuseTest(VMclient *common.TestClient) {
 		ExecuteWithoutError(t, VMclient, "sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public")
 		ExecuteWithoutError(t, VMclient, "sudo rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public")
 		ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive --no-gpg-checks refresh datadog")
-		ExecuteWithoutError(t, VMclient, "sudo registercloudguest --force-new")
-		ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive install %s", *flavorName)
+		_, err = VMclient.Host.Execute(fmt.Sprintf("sudo zypper --non-interactive install %s", *flavorName))
+		if err != nil {
+			t.Logf("Failed to install %s, trying to register the cloud guest and install the package again", *flavorName)
+			ExecuteWithoutError(t, VMclient, "sudo registercloudguest --force-new")
+			ExecuteWithoutError(t, VMclient, "sudo zypper --non-interactive install %s", *flavorName)
+		}
 	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update centos repo files. Centos 7 EOLed on July 1st, 2024. We need to switch to vault.centos.org to get the packages. See https://github.com/DataDog/datadog-agent-buildimages/pull/618


### Motivation
https://datadoghq.atlassian.net/browse/ACIX-455 and [failure](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/728300444) on release pipeline

### Describe how you validated your changes
Validation pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/50443562

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->