### PR TITLE
Mark TestPodParser test as flaky

### DIFF
--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
@@ -16,9 +16,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 func TestPodParser_Parse(t *testing.T) {
+	flake.Mark(t)
 	filterAnnotations := []string{"ignoreAnnotation"}
 
 	parser, err := NewPodParser(filterAnnotations)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Mark test updated in https://github.com/DataDog/datadog-agent/pull/31465 as flaky.

We should probably not assert for the exact order of `nvidia` and `intel` element. Otherwise we get some flaky like in the following error: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/728496489#L1677

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->