### PR TITLE
Only start telemetryForwarder when we start the receiver (APMSP-1633)

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -235,6 +235,8 @@ func getConfiguredEVPRequestTimeoutDuration(conf *config.AgentConfig) time.Durat
 
 // Start starts doing the HTTP server and is ready to receive traces
 func (r *HTTPReceiver) Start() {
+	r.telemetryForwarder.start()
+
 	if !r.conf.ReceiverEnabled {
 		log.Debug("HTTP Server is off: HTTPReceiver is disabled.")
 		return

--- a/pkg/trace/api/telemetry.go
+++ b/pkg/trace/api/telemetry.go
@@ -123,7 +123,6 @@ func NewTelemetryForwarder(conf *config.AgentConfig, containerIDProvider IDProvi
 		statsd:              statsd,
 		logger:              log.NewThrottled(5, 10*time.Second),
 	}
-	forwarder.start()
 	return forwarder
 }
 

--- a/pkg/trace/api/telemetry_test.go
+++ b/pkg/trace/api/telemetry_test.go
@@ -99,6 +99,7 @@ func TestTelemetryBasicProxyRequest(t *testing.T) {
 		return []string{"key:test\nvalue"}, nil
 	}
 	recv := newTestReceiverFromConfig(cfg)
+	recv.telemetryForwarder.start()
 	recv.telemetryForwarder.containerIDProvider = getTestContainerIDProvider()
 
 	assertSendRequest(t, recv, endpointCalled)
@@ -121,6 +122,7 @@ func TestGoogleCloudRun(t *testing.T) {
 	cfg.GlobalTags["service_name"] = "test_service"
 	cfg.GlobalTags["origin"] = "cloudrun"
 	recv := newTestReceiverFromConfig(cfg)
+	recv.telemetryForwarder.start()
 
 	assertSendRequest(t, recv, endpointCalled)
 }
@@ -145,6 +147,7 @@ func TestAzureAppService(t *testing.T) {
 	cfg.GlobalTags["app_name"] = "test_app"
 	cfg.GlobalTags["origin"] = "appservice"
 	recv := newTestReceiverFromConfig(cfg)
+	recv.telemetryForwarder.start()
 
 	assertSendRequest(t, recv, endpointCalled)
 }
@@ -169,6 +172,7 @@ func TestAzureContainerApp(t *testing.T) {
 	cfg.GlobalTags["app_name"] = "test_app"
 	cfg.GlobalTags["origin"] = "containerapp"
 	recv := newTestReceiverFromConfig(cfg)
+	recv.telemetryForwarder.start()
 
 	assertSendRequest(t, recv, endpointCalled)
 }
@@ -202,6 +206,7 @@ func TestAWSFargate(t *testing.T) {
 		return []string{"task_arn:test_ARN"}, nil
 	}
 	recv := newTestReceiverFromConfig(cfg)
+	recv.telemetryForwarder.start()
 	recv.telemetryForwarder.containerIDProvider = getTestContainerIDProvider()
 
 	assertSendRequest(t, recv, endpointCalled)
@@ -256,6 +261,7 @@ func TestTelemetryProxyMultipleEndpoints(t *testing.T) {
 	cfg.GlobalTags[functionARNKeyTag] = "test_ARN"
 
 	recv := newTestReceiverFromConfig(cfg)
+	recv.telemetryForwarder.start()
 
 	req, rec := newRequestRecorder(t)
 	recv.buildMux().ServeHTTP(rec, req)
@@ -315,6 +321,7 @@ func TestMaxInflightBytes(t *testing.T) {
 
 			cfg := getTestConfig(srv.URL)
 			recv := newTestReceiverFromConfig(cfg)
+			recv.telemetryForwarder.start()
 			recv.telemetryForwarder.maxInflightBytes = 100
 			mux := recv.buildMux()
 
@@ -359,6 +366,7 @@ func TestInflightBytesReset(t *testing.T) {
 
 	cfg := getTestConfig(srv.URL)
 	recv := newTestReceiverFromConfig(cfg)
+	recv.telemetryForwarder.start()
 	recv.telemetryForwarder.maxInflightBytes = 100
 	mux := recv.buildMux()
 
@@ -417,6 +425,7 @@ func TestActualServer(t *testing.T) {
 
 	cfg := getTestConfig(intakeMockServer.URL)
 	r := newTestReceiverFromConfig(cfg)
+	r.telemetryForwarder.start() // We call this manually here to avoid starting the entire test receiver
 	logs := bytes.Buffer{}
 	prevLogger := log.SetLogger(log.NewBufferLogger(&logs))
 	defer log.SetLogger(prevLogger)
@@ -445,6 +454,7 @@ func TestTelemetryConfig(t *testing.T) {
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "api_key"
 		recv := newTestReceiverFromConfig(cfg)
+		recv.telemetryForwarder.start()
 
 		req, rec := newRequestRecorder(t)
 		recv.buildMux().ServeHTTP(rec, req)
@@ -463,6 +473,7 @@ func TestTelemetryConfig(t *testing.T) {
 			Host:   "111://malformed.dd_url.com",
 		}}
 		recv := newTestReceiverFromConfig(cfg)
+		recv.telemetryForwarder.start()
 
 		req, rec := newRequestRecorder(t)
 		recv.buildMux().ServeHTTP(rec, req)
@@ -486,6 +497,7 @@ func TestTelemetryConfig(t *testing.T) {
 			Host:   srv.URL,
 		}}
 		recv := newTestReceiverFromConfig(cfg)
+		recv.telemetryForwarder.start()
 
 		req, rec := newRequestRecorder(t)
 		recv.buildMux().ServeHTTP(rec, req)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Move the start of the TelemetryForwarder to when the HTTPReceiver is created. This defers the creation of 20 go routines until we actually want to start the http receiver. This should be a transparent refactor as no data can be sent to the forwarder until the receiver is started anyways.

### Motivation
Recently in investigating a test timeout in this package the goroutine stack dump was incredibly difficult to sort through as 1400 goroutines out of 1534 were just idle telemetry forwarder go routines. This indicates there's a large number of tests in this package that do not stop these goroutines as it's a bit unexpected. This will significantly reduce the number of goroutines being created during these tests - good for reduced resource consumption and my hope is it prevents the rare timeout flake we've seen recently.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This is all well covered with existing tests which were updated here as well.

### Possible Drawbacks / Trade-offs
Maybe there's some use-case I'm missing here that requires these to be started even when the receiver isn't started but I wouldn't expect it 🤔 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->