### PR TITLE
Reorder source layers so unknown is before default

### DIFF
--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -60,8 +60,8 @@ const (
 
 // sources list the known sources, following the order of hierarchy between them
 var sources = []Source{
-	SourceDefault,
 	SourceUnknown,
+	SourceDefault,
 	SourceFile,
 	SourceEnvVar,
 	SourceFleetPolicies,
@@ -74,8 +74,8 @@ var sources = []Source{
 // sourcesPriority give each source a priority, the higher the more important a source. This is used when merging
 // configuration tree (a higher priority overwrites a lower one).
 var sourcesPriority = map[Source]int{
-	SourceDefault:            0,
-	SourceUnknown:            1,
+	SourceUnknown:            0,
+	SourceDefault:            1,
 	SourceFile:               2,
 	SourceEnvVar:             3,
 	SourceFleetPolicies:      4,
@@ -91,9 +91,18 @@ type ValueWithSource struct {
 	Value  interface{}
 }
 
-// IsGreaterOrEqualThan returns true if the current source is of higher priority than the one given as a parameter
-func (s Source) IsGreaterOrEqualThan(x Source) bool {
-	return sourcesPriority[s] >= sourcesPriority[x]
+// IsGreaterThan returns true if the current source is of higher priority than the one given as a parameter
+func (s Source) IsGreaterThan(x Source) bool {
+	return sourcesPriority[s] > sourcesPriority[x]
+}
+
+// PreviousSource returns the source before the current one, or Unknown if there isn't one
+func (s Source) PreviousSource() Source {
+	previous := sourcesPriority[s]
+	if previous == 0 {
+		return SourceUnknown
+	}
+	return sources[previous-1]
 }
 
 // String casts Source into a string

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -27,8 +27,8 @@ import (
 
 // sources lists the known sources, following the order of hierarchy between them
 var sources = []model.Source{
-	model.SourceDefault,
 	model.SourceUnknown,
+	model.SourceDefault,
 	model.SourceFile,
 	model.SourceEnvVar,
 	model.SourceFleetPolicies,
@@ -140,10 +140,10 @@ func (c *ntmConfig) setDefault(key string, value interface{}) {
 
 func (c *ntmConfig) getTreeBySource(source model.Source) (InnerNode, error) {
 	switch source {
-	case model.SourceDefault:
-		return c.defaults, nil
 	case model.SourceUnknown:
 		return c.unknown, nil
+	case model.SourceDefault:
+		return c.defaults, nil
 	case model.SourceFile:
 		return c.file, nil
 	case model.SourceEnvVar:
@@ -577,7 +577,7 @@ func (c *ntmConfig) AllSettingsWithoutDefault() map[string]interface{} {
 	defer c.RUnlock()
 
 	// We only want to include leaf with a source higher than SourceDefault
-	return c.root.DumpSettings(func(source model.Source) bool { return source.IsGreaterOrEqualThan(model.SourceUnknown) })
+	return c.root.DumpSettings(func(source model.Source) bool { return source.IsGreaterThan(model.SourceDefault) })
 }
 
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)
@@ -587,8 +587,8 @@ func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 
 	// We don't return include unknown settings
 	return map[model.Source]interface{}{
-		model.SourceDefault:            c.defaults.DumpSettings(func(model.Source) bool { return true }),
 		model.SourceUnknown:            c.unknown.DumpSettings(func(model.Source) bool { return true }),
+		model.SourceDefault:            c.defaults.DumpSettings(func(model.Source) bool { return true }),
 		model.SourceFile:               c.file.DumpSettings(func(model.Source) bool { return true }),
 		model.SourceEnvVar:             c.envs.DumpSettings(func(model.Source) bool { return true }),
 		model.SourceFleetPolicies:      c.fleetPolicies.DumpSettings(func(model.Source) bool { return true }),

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -147,8 +147,8 @@ func TestBasicUsage(t *testing.T) {
 func TestSet(t *testing.T) {
 	cfg := NewConfig("test", "TEST", nil)
 
-	cfg.SetDefault("default", 0)
 	cfg.SetDefault("unknown", 0)
+	cfg.SetDefault("default", 0)
 	cfg.SetDefault("file", 0)
 	cfg.SetDefault("env", 0)
 	cfg.SetDefault("runtime", 0)
@@ -159,8 +159,8 @@ func TestSet(t *testing.T) {
 
 	cfg.BuildSchema()
 
-	assert.Equal(t, 0, cfg.Get("default"))
 	assert.Equal(t, 0, cfg.Get("unknown"))
+	assert.Equal(t, 0, cfg.Get("default"))
 	assert.Equal(t, 0, cfg.Get("file"))
 	assert.Equal(t, 0, cfg.Get("env"))
 	assert.Equal(t, 0, cfg.Get("runtime"))
@@ -169,8 +169,8 @@ func TestSet(t *testing.T) {
 	assert.Equal(t, 0, cfg.Get("fleetPolicies"))
 	assert.Equal(t, 0, cfg.Get("cli"))
 
-	cfg.Set("unknown", 1, model.SourceUnknown)
-	assert.Equal(t, 1, cfg.Get("unknown"))
+	cfg.Set("default", 1, model.SourceDefault)
+	assert.Equal(t, 1, cfg.Get("default"))
 
 	cfg.ReadConfig(strings.NewReader(`
 file: 2
@@ -178,7 +178,7 @@ file: 2
 
 	assert.Equal(t, 2, cfg.Get("file"))
 
-	cfg.Set("unknown", 1, model.SourceUnknown)
+	cfg.Set("default", 1, model.SourceDefault)
 	cfg.Set("env", 3, model.SourceEnvVar)
 	cfg.Set("runtime", 4, model.SourceAgentRuntime)
 	cfg.Set("localConfigProcess", 5, model.SourceLocalConfigProcess)
@@ -186,8 +186,8 @@ file: 2
 	cfg.Set("fleetPolicies", 7, model.SourceFleetPolicies)
 	cfg.Set("cli", 8, model.SourceCLI)
 
-	assert.Equal(t, 0, cfg.Get("default"))
-	assert.Equal(t, 1, cfg.Get("unknown"))
+	assert.Equal(t, 0, cfg.Get("unknown"))
+	assert.Equal(t, 1, cfg.Get("default"))
 	assert.Equal(t, 2, cfg.Get("file"))
 	assert.Equal(t, 3, cfg.Get("env"))
 	assert.Equal(t, 4, cfg.Get("runtime"))
@@ -196,8 +196,8 @@ file: 2
 	assert.Equal(t, 7, cfg.Get("fleetPolicies"))
 	assert.Equal(t, 8, cfg.Get("cli"))
 
+	assert.Equal(t, model.SourceDefault, cfg.GetSource("unknown"))
 	assert.Equal(t, model.SourceDefault, cfg.GetSource("default"))
-	assert.Equal(t, model.SourceUnknown, cfg.GetSource("unknown"))
 	assert.Equal(t, model.SourceFile, cfg.GetSource("file"))
 	assert.Equal(t, model.SourceEnvVar, cfg.GetSource("env"))
 	assert.Equal(t, model.SourceAgentRuntime, cfg.GetSource("runtime"))

--- a/pkg/config/nodetreemodel/getter_test.go
+++ b/pkg/config/nodetreemodel/getter_test.go
@@ -231,10 +231,9 @@ func TestGetFloat64SliceStringFromEnv(t *testing.T) {
 
 func TestGetAllSources(t *testing.T) {
 	cfg := NewConfig("test", "", nil)
-	cfg.SetDefault("a", 0)
+	cfg.SetDefault("a", 1)
 	cfg.BuildSchema()
 
-	cfg.Set("a", 1, model.SourceUnknown)
 	cfg.Set("a", 2, model.SourceFile)
 	cfg.Set("a", 3, model.SourceEnvVar)
 	cfg.Set("a", 4, model.SourceFleetPolicies)
@@ -246,8 +245,8 @@ func TestGetAllSources(t *testing.T) {
 	res := cfg.GetAllSources("a")
 	assert.Equal(t,
 		[]model.ValueWithSource{
-			{Source: model.SourceDefault, Value: 0},
-			{Source: model.SourceUnknown, Value: 1},
+			{Source: model.SourceUnknown, Value: nil},
+			{Source: model.SourceDefault, Value: 1},
 			{Source: model.SourceFile, Value: 2},
 			{Source: model.SourceEnvVar, Value: 3},
 			{Source: model.SourceFleetPolicies, Value: 4},

--- a/pkg/config/nodetreemodel/inner_node.go
+++ b/pkg/config/nodetreemodel/inner_node.go
@@ -88,7 +88,7 @@ func (n *innerNode) Merge(src InnerNode) error {
 			}
 
 			if srcIsLeaf {
-				if srcLeaf.SourceGreaterOrEqual(dstLeaf.Source()) {
+				if srcLeaf.Source() == dstLeaf.Source() || srcLeaf.SourceGreaterThan(dstLeaf.Source()) {
 					n.children[name] = srcLeaf.Clone()
 				}
 			} else {
@@ -132,7 +132,7 @@ func (n *innerNode) SetAt(key []string, value interface{}, source model.Source) 
 		}
 
 		if leaf, ok := node.(LeafNode); ok {
-			if source.IsGreaterOrEqualThan(leaf.Source()) {
+			if source == leaf.Source() || source.IsGreaterThan(leaf.Source()) {
 				n.children[part] = newLeafNode(value, source)
 				return true, nil
 			}

--- a/pkg/config/nodetreemodel/leaf_node.go
+++ b/pkg/config/nodetreemodel/leaf_node.go
@@ -43,10 +43,10 @@ func (n *leafNodeImpl) Clone() Node {
 	return newLeafNode(n.val, n.source)
 }
 
-// SourceGreaterOrEqual returns true if the source of the current node is greater or equal to the one given as a
+// SourceGreaterThan returns true if the source of the current node is greater than the one given as a
 // parameter
-func (n *leafNodeImpl) SourceGreaterOrEqual(source model.Source) bool {
-	return n.source.IsGreaterOrEqualThan(source)
+func (n *leafNodeImpl) SourceGreaterThan(source model.Source) bool {
+	return n.source.IsGreaterThan(source)
 }
 
 // GetChild returns an error because a leaf has no children

--- a/pkg/config/nodetreemodel/missing_node.go
+++ b/pkg/config/nodetreemodel/missing_node.go
@@ -38,6 +38,6 @@ func (m *missingLeafImpl) Clone() Node {
 	return m
 }
 
-func (m *missingLeafImpl) SourceGreaterOrEqual(model.Source) bool {
+func (m *missingLeafImpl) SourceGreaterThan(model.Source) bool {
 	return false
 }

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -105,5 +105,5 @@ type LeafNode interface {
 	Node
 	Get() interface{}
 	Source() model.Source
-	SourceGreaterOrEqual(model.Source) bool
+	SourceGreaterThan(model.Source) bool
 }

--- a/pkg/config/nodetreemodel/struct_node.go
+++ b/pkg/config/nodetreemodel/struct_node.go
@@ -82,9 +82,9 @@ func (n *structNodeImpl) Clone() Node {
 	return &structNodeImpl{val: n.val}
 }
 
-// SourceGreaterOrEqual returns true if the source of the current node is greater or equal to the one given as a
+// SourceGreaterThan returns true if the source of the current node is greater than the one given as a
 // parameter
-func (n *structNodeImpl) SourceGreaterOrEqual(model.Source) bool {
+func (n *structNodeImpl) SourceGreaterThan(model.Source) bool {
 	return false
 }
 


### PR DESCRIPTION

### What does this PR do?

Reorder the unknown and default layers in viper so that unknown is the lowest priority.

### Motivation

Testing to see if this works in the CI. Part of the effort to remove dependency on viper.

### Describe how you validated your changes

Functionality change covered by unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes

This is a single commit from the PR https://github.com/DataDog/datadog-agent/pull/31733, which is failing on CI. I want to see if the CI fails with this change alone.