### PR TITLE
AMLII-2169 Activate BouncyCastle Java FIPS provider for FIPS images

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -154,7 +154,7 @@ docker_build_fips_agent7_jmx:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-amd64.tar.xz
 
 docker_build_fips_agent7_arm64_jmx:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
@@ -167,7 +167,7 @@ docker_build_fips_agent7_arm64_jmx:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
     TAG_SUFFIX: -7-fips-jmx
-    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
+    BUILD_ARG: --target test --build-arg WITH_JMX=true --build-arg WITH_JMX_FIPS=true --build-arg DD_AGENT_ARTIFACT=datadog-fips-agent-7*-arm64.tar.xz
 
 # build agent7 UA image
 docker_build_ot_agent7:

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -39,6 +39,7 @@ RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sy
 FROM baseimage AS extract
 ARG TARGETARCH
 ARG WITH_JMX
+ARG WITH_JMX_FIPS
 ARG DD_AGENT_ARTIFACT=datadog-agent*-$TARGETARCH.tar.xz
 ARG GENERAL_ARTIFACTS_CACHE_BUCKET_URL
 
@@ -96,6 +97,7 @@ RUN if [ -n "$WITH_JMX" ]; then cd /opt/bouncycastle-fips && mvn dependency:copy
 FROM baseimage AS release
 LABEL maintainer="Datadog <package@datadoghq.com>"
 ARG WITH_JMX
+ARG WITH_JMX_FIPS
 ARG DD_GIT_REPOSITORY_URL
 ARG DD_GIT_COMMIT_SHA
 ENV DOCKER_DD_AGENT=true \
@@ -196,6 +198,9 @@ COPY --from=extract /opt/bouncycastle-fips/target/dependency/*.jar /opt/bouncyca
 COPY --chmod=644 bouncycastle-fips/java.security /opt/bouncycastle-fips/
 COPY --chmod=644 bouncycastle-fips/bc-fips.policy /opt/bouncycastle-fips/
 RUN if [ -z "$WITH_JMX" ]; then rm -rf /opt/bouncycastle-fips; fi
+# Configure Java to use BouncyCastle FIPS provider on JMX FIPS images.
+# Double equals sign for java.security.properties istructs java to replace system defaults with the contents of the new file.
+ENV JAVA_TOOL_OPTIONS="${WITH_JMX_FIPS:+--module-path=/opt/bouncycastle-fips -Djava.security.properties==/opt/bouncycastle-fips/java.security -Dpolicy.url.2=file:/opt/bouncycastle-fips/bc-fips.policy}"
 
 # Update if optional OTel Agent process should not run
 RUN if [ ! -f /opt/datadog-agent/embedded/bin/otel-agent ]; then \


### PR DESCRIPTION
### What does this PR do?

Activate BouncyCastle Java FIPS provider via JAVA_TOOL_OPTIONS. This will have effect on both the java runtime used to run JMXFetch itself, as well as other commands, such as keytool, which is necessary to prepare TLS certificates.

### Motivation

### Describe how you validated your changes

Using `-fips-jmx` image, configure SSL JMX integration, and verify that JMXFetch can connect and collect metrics.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->