### PR TITLE
[CONTP-535] optimise tagger server chunking function by processing chunks in place

### DIFF
--- a/comp/core/tagger/server/README.md
+++ b/comp/core/tagger/server/README.md
@@ -1,0 +1,77 @@
+## Introduction
+
+This package server implements a gRPC server that streams Tagger entities to remote tagger clients.
+
+## Behaviour
+
+When a client connects to the tagger grpc server, the server creates a subscription to the local tagger in order to stream tags.
+
+Before streaming new tag events, the server sends an initial burst to the client over the stream. This initial burst contains a snapshot of the tagger content. After the initial burst has been processed, the server will stream new tag events to the client based on the filters provided in the streaming request.
+
+### Cutting Events into chunks
+
+Sending very large messages over the grpc stream can cause the message to be dropped or rejected by the client. The limit is 4MB by default.
+
+To avoid such scenarios, especially when sending the initial burst, the server cuts each message into small chunks that can be easily transmitted over the stream.
+
+This logic is implemented in the `util.go` folder.
+
+We provide 2 implementations:
+- `processChunksWithSplit`: splits an event slice into a small chunks where each chunk contains a contiguous slice of events. It then processes the generated chunks sequentially. This will load all chunks into memory (stored in a slice) and then return them.
+- `processChunksInPlace`: this has a similar functionality as `processChunksWithSplit`, but it is more optimized in terms of memory and cpu because it processes chunks in place without any extra memory allocation.
+
+We keep both implementations for at least release candidate to ensure everything works well and be able to quickly revert in case of regressions.
+
+#### Benchmark Testing 
+
+Benchmark tests show that using lazy chunking results in significant memory and cpu improvement:
+
+Go to `util_benchmark_test.go`:
+
+```
+// with processChunksFunc = processChunksWithSplit[int]
+go test -bench BenchmarkProcessChunks    -benchmem -count 6 -benchtime 100x > old.txt
+
+// with processChunksFunc = processChunksInPlace[int]
+go test -bench BenchmarkProcessChunks    -benchmem -count 6  -benchtime 100x > new.txt
+
+// Compare results
+benchstat old.txt new.txt
+
+goos: linux
+goarch: arm64
+pkg: github.com/DataDog/datadog-agent/comp/core/tagger/server
+                               │    old.txt    │               new.txt               │
+                               │    sec/op     │    sec/op     vs base               │
+ProcessChunks/100-items-10       2399.5n ± 47%   239.8n ±  4%  -90.01% (p=0.002 n=6)
+ProcessChunks/1000-items-10      35.072µ ± 13%   2.344µ ± 11%  -93.32% (p=0.002 n=6)
+ProcessChunks/10000-items-10     365.19µ ±  5%   22.56µ ± 18%  -93.82% (p=0.002 n=6)
+ProcessChunks/100000-items-10    3435.1µ ±  7%   222.5µ ± 16%  -93.52% (p=0.002 n=6)
+ProcessChunks/1000000-items-10   29.059m ±  9%   2.219m ± 31%  -92.36% (p=0.002 n=6)
+geomean                           314.3µ         22.87µ        -92.72%
+
+                               │   old.txt    │                 new.txt                  │
+                               │     B/op     │     B/op      vs base                    │
+ProcessChunks/100-items-10       2.969Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/1000-items-10      29.02Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/10000-items-10     370.7Ki ± 0%     0.0Ki ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/100000-items-10    4.165Mi ± 0%   0.000Mi ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/1000000-items-10   44.65Mi ± 0%    0.00Mi ± 0%  -100.00% (p=0.002 n=6)
+geomean                          362.1Ki                      ?                      ¹ ²
+¹ summaries must be >0 to compute geomean
+² ratios must be >0 to compute geomean
+
+                               │   old.txt   │                 new.txt                 │
+                               │  allocs/op  │  allocs/op   vs base                    │
+ProcessChunks/100-items-10        81.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/1000-items-10       759.0 ± 0%      0.0 ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/10000-items-10     7.514k ± 0%   0.000k ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/100000-items-10    75.02k ± 0%    0.00k ± 0%  -100.00% (p=0.002 n=6)
+ProcessChunks/1000000-items-10   750.0k ± 0%     0.0k ± 0%  -100.00% (p=0.002 n=6)
+geomean                          7.638k                     ?                      ¹ ²
+¹ summaries must be >0 to compute geomean
+² ratios must be >0 to compute geomean
+```
+
+
+

--- a/comp/core/tagger/server/util_benchmark_test.go
+++ b/comp/core/tagger/server/util_benchmark_test.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package server
+
+import (
+	"fmt"
+	"testing"
+)
+
+var benchmarkSizes = []int{100, 1000, 10000, 100000, 1000000}
+
+const maxChunkSize = 4
+const mockItemSize = 1
+
+var global []int
+
+func createBaseBenchmarkSlice(size int) []int {
+	var baseBenchmarkSlice = make([]int, size)
+	for i := range size {
+		baseBenchmarkSlice[i] = i
+	}
+	return baseBenchmarkSlice
+}
+
+func mockComputeSize(int) int { return mockItemSize }
+
+func BenchmarkProcessChunks(b *testing.B) {
+	b.ReportAllocs()
+	for _, size := range benchmarkSizes {
+		b.Run(fmt.Sprintf("%d-items", size), func(b *testing.B) {
+
+			// Point this to the implementation you want to benchmark
+			var processChunksFunc = processChunksInPlace[int]
+
+			items := createBaseBenchmarkSlice(size)
+			var local []int
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = processChunksFunc(items, maxChunkSize, mockComputeSize, func(t []int) error { local = t; return nil })
+			}
+			global = local
+		})
+	}
+}

--- a/comp/core/tagger/server/util_test.go
+++ b/comp/core/tagger/server/util_test.go
@@ -6,6 +6,7 @@
 package server
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,18 +17,35 @@ type mockStreamTagsEvent struct {
 	size int
 }
 
-func TestSplitEvents(t *testing.T) {
+var computeSize = func(e mockStreamTagsEvent) int {
+	return e.size
+}
+
+func getConsumeFunc(slice *[][]int) consumeChunkFunc[[]mockStreamTagsEvent] {
+	return func(chunk []mockStreamTagsEvent) error {
+		ids := make([]int, 0, len(chunk))
+		for _, item := range chunk {
+			ids = append(ids, item.id)
+		}
+
+		*slice = append(*slice, ids)
+		return nil
+	}
+}
+
+func Test(t *testing.T) {
+
 	testCases := []struct {
 		name         string
 		events       []mockStreamTagsEvent
 		maxChunkSize int
-		expected     [][]mockStreamTagsEvent // Expecting indices of events in chunks for easier comparison
+		expected     [][]int // Expecting id's of events in chunks for easier comparison
 	}{
 		{
 			name:         "Empty input",
 			events:       []mockStreamTagsEvent{},
 			maxChunkSize: 100,
-			expected:     nil, // No chunks expected
+			expected:     [][]int{},
 		},
 		{
 			name: "Single event within chunk size",
@@ -35,9 +53,9 @@ func TestSplitEvents(t *testing.T) {
 				{id: 1, size: 50}, // Mock event with size 50
 			},
 			maxChunkSize: 100,
-			expected: [][]mockStreamTagsEvent{
+			expected: [][]int{
 				{
-					{id: 1, size: 50}, // One chunk with one event
+					1, // One chunk with one event
 				},
 			},
 		},
@@ -47,9 +65,9 @@ func TestSplitEvents(t *testing.T) {
 				{id: 1, size: 20}, {id: 2, size: 30}, {id: 3, size: 40}, // Total size = 90
 			},
 			maxChunkSize: 100,
-			expected: [][]mockStreamTagsEvent{
+			expected: [][]int{
 				{
-					{id: 1, size: 20}, {id: 2, size: 30}, {id: 3, size: 40}, // All events fit in one chunk
+					1, 2, 3, // All events fit in one chunk
 				},
 			},
 		},
@@ -59,13 +77,12 @@ func TestSplitEvents(t *testing.T) {
 				{id: 1, size: 40}, {id: 2, size: 50}, {id: 3, size: 60}, // Total size = 150
 			},
 			maxChunkSize: 100,
-			expected: [][]mockStreamTagsEvent{
+			expected: [][]int{
 				{
-					{id: 1, size: 40},
-					{id: 2, size: 50},
+					1, 2,
 				},
 				{
-					{id: 3, size: 60},
+					3,
 				}, // Last event in second chunk
 			},
 		},
@@ -75,8 +92,8 @@ func TestSplitEvents(t *testing.T) {
 				{id: 1, size: 50}, {id: 2, size: 50}, // Total size = 100
 			},
 			maxChunkSize: 100,
-			expected: [][]mockStreamTagsEvent{
-				{{id: 1, size: 50}, {id: 2, size: 50}}, // Both events fit exactly in one chunk
+			expected: [][]int{
+				{1, 2}, // Both events fit exactly in one chunk
 			},
 		},
 		{
@@ -85,21 +102,35 @@ func TestSplitEvents(t *testing.T) {
 				{id: 1, size: 100}, {id: 2, size: 101}, // One exactly fits, one exceeds
 			},
 			maxChunkSize: 100,
-			expected: [][]mockStreamTagsEvent{
-				{
-					{id: 1, size: 100},
-				},
-				{
-					{id: 2, size: 101},
-				},
+			expected: [][]int{
+				{1}, {2},
+			},
+		},
+		{
+			name: "Multiple items exceeding max chunk size",
+			events: []mockStreamTagsEvent{
+				{id: 1, size: 100}, {id: 2, size: 101}, {id: 3, size: 101},
+			},
+			maxChunkSize: 100,
+			expected: [][]int{
+				{1}, {2}, {3},
 			},
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			chunks := splitBySize(testCase.events, testCase.maxChunkSize, func(e mockStreamTagsEvent) int { return e.size })
-			assert.Equal(t, testCase.expected, chunks)
+			slice := make([][]int, 0, len(testCase.expected))
+			processChunksInPlace(testCase.events, testCase.maxChunkSize, computeSize, getConsumeFunc(&slice))
+			if len(testCase.expected) > 0 || len(slice) > 0 {
+				assert.Truef(t, reflect.DeepEqual(testCase.expected, slice), "expected %v, found %v", testCase.expected, slice)
+			}
+
+			slice = make([][]int, 0, len(testCase.expected))
+			processChunksWithSplit(testCase.events, testCase.maxChunkSize, computeSize, getConsumeFunc(&slice))
+			if len(testCase.expected) > 0 || len(slice) > 0 {
+				assert.Truef(t, reflect.DeepEqual(testCase.expected, slice), "expected %v, found %v", testCase.expected, slice)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR optimises tagger server chunking logic by processing chunks in place instead of duplicating them in memory.

### Motivation

Memory and CPU optimisation.

Results of benchmarks:
```
goos: linux
goarch: arm64
pkg: github.com/DataDog/datadog-agent/comp/core/tagger/server
                               │    old.txt    │               new.txt               │
                               │    sec/op     │    sec/op     vs base               │
ProcessChunks/100-items-10       2399.5n ± 47%   239.8n ±  4%  -90.01% (p=0.002 n=6)
ProcessChunks/1000-items-10      35.072µ ± 13%   2.344µ ± 11%  -93.32% (p=0.002 n=6)
ProcessChunks/10000-items-10     365.19µ ±  5%   22.56µ ± 18%  -93.82% (p=0.002 n=6)
ProcessChunks/100000-items-10    3435.1µ ±  7%   222.5µ ± 16%  -93.52% (p=0.002 n=6)
ProcessChunks/1000000-items-10   29.059m ±  9%   2.219m ± 31%  -92.36% (p=0.002 n=6)
geomean                           314.3µ         22.87µ        -92.72%

                               │   old.txt    │                 new.txt                  │
                               │     B/op     │     B/op      vs base                    │
ProcessChunks/100-items-10       2.969Ki ± 0%   0.000Ki ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/1000-items-10      29.02Ki ± 0%    0.00Ki ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/10000-items-10     370.7Ki ± 0%     0.0Ki ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/100000-items-10    4.165Mi ± 0%   0.000Mi ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/1000000-items-10   44.65Mi ± 0%    0.00Mi ± 0%  -100.00% (p=0.002 n=6)
geomean                          362.1Ki                      ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                               │   old.txt   │                 new.txt                 │
                               │  allocs/op  │  allocs/op   vs base                    │
ProcessChunks/100-items-10        81.00 ± 0%     0.00 ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/1000-items-10       759.0 ± 0%      0.0 ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/10000-items-10     7.514k ± 0%   0.000k ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/100000-items-10    75.02k ± 0%    0.00k ± 0%  -100.00% (p=0.002 n=6)
ProcessChunks/1000000-items-10   750.0k ± 0%     0.0k ± 0%  -100.00% (p=0.002 n=6)
geomean                          7.638k                     ?                      ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests and E2E are sufficient.

As long as remote tagger still works, then everything is good.

### Possible Drawbacks / Trade-offs
None.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I have added benchmark tests and included all details in the README.md file