### PR TITLE
[ASCII-2582] Add certificate generation and retrieval for IPC communications

### DIFF
--- a/comp/api/authtoken/component.go
+++ b/comp/api/authtoken/component.go
@@ -9,9 +9,12 @@
 package authtoken
 
 import (
+	"crypto/tls"
+
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
-	"go.uber.org/fx"
 )
 
 // team: agent-shared-components
@@ -19,6 +22,8 @@ import (
 // Component is the component type.
 type Component interface {
 	Get() string
+	GetTLSClientConfig() *tls.Config
+	GetTLSServerConfig() *tls.Config
 }
 
 // NoneModule return a None optional type for authtoken.Component.

--- a/comp/api/authtoken/createandfetchimpl/authtoken.go
+++ b/comp/api/authtoken/createandfetchimpl/authtoken.go
@@ -8,6 +8,8 @@
 package createandfetchimpl
 
 import (
+	"crypto/tls"
+
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
@@ -48,4 +50,14 @@ func newAuthToken(deps dependencies) (authtoken.Component, error) {
 // Get returns the session token
 func (at *authToken) Get() string {
 	return util.GetAuthToken()
+}
+
+// GetTLSServerConfig return a TLS configuration with the IPC certificate for http.Server
+func (at *authToken) GetTLSClientConfig() *tls.Config {
+	return util.GetTLSClientConfig()
+}
+
+// GetTLSServerConfig return a TLS configuration with the IPC certificate for http.Client
+func (at *authToken) GetTLSServerConfig() *tls.Config {
+	return util.GetTLSServerConfig()
 }

--- a/comp/api/authtoken/createandfetchimpl/authtoken_test.go
+++ b/comp/api/authtoken/createandfetchimpl/authtoken_test.go
@@ -10,11 +10,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -24,8 +25,10 @@ import (
 func TestGet(t *testing.T) {
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth_token")
+	ipcPath := filepath.Join(dir, "ipc_cert")
 	overrides := map[string]any{
 		"auth_token_file_path": authPath,
+		"ipc_cert_file_path":   ipcPath,
 	}
 
 	comp, err := newAuthToken(

--- a/comp/api/authtoken/createandfetchimpl/authtoken_test.go
+++ b/comp/api/authtoken/createandfetchimpl/authtoken_test.go
@@ -14,12 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/pkg/api/util"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 func TestGet(t *testing.T) {

--- a/comp/api/authtoken/fetchonlyimpl/authtoken.go
+++ b/comp/api/authtoken/fetchonlyimpl/authtoken.go
@@ -8,6 +8,9 @@
 package fetchonlyimpl
 
 import (
+	"crypto/tls"
+	"fmt"
+
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
@@ -26,9 +29,8 @@ func Module() fxutil.Module {
 }
 
 type authToken struct {
-	log  log.Component
-	conf config.Component
-
+	log         log.Component
+	conf        config.Component
 	tokenLoaded bool
 }
 
@@ -48,17 +50,44 @@ func newAuthToken(deps dependencies) authtoken.Component {
 	}
 }
 
-// Get returns the session token
-func (at *authToken) Get() string {
+func (at *authToken) setToken() error {
 	if !at.tokenLoaded {
 		// We try to load the auth_token until we succeed since it might be created at some point by another
 		// process.
 		if err := util.SetAuthToken(at.conf); err != nil {
-			at.log.Debugf("could not load auth_token: %s", err)
-			return ""
+			return fmt.Errorf("could not load auth_token: %s", err)
 		}
 		at.tokenLoaded = true
 	}
+	return nil
+}
+
+// Get returns the session token
+func (at *authToken) Get() string {
+	if err := at.setToken(); err != nil {
+		at.log.Debugf(err.Error())
+		return ""
+	}
 
 	return util.GetAuthToken()
+}
+
+// GetTLSClientConfig return a TLS configuration with the IPC certificate for http.Client
+func (at *authToken) GetTLSClientConfig() *tls.Config {
+	if err := at.setToken(); err != nil {
+		at.log.Debugf(err.Error())
+		return nil
+	}
+
+	return util.GetTLSClientConfig()
+}
+
+// GetTLSServerConfig return a TLS configuration with the IPC certificate for http.Server
+func (at *authToken) GetTLSServerConfig() *tls.Config {
+	if err := at.setToken(); err != nil {
+		at.log.Debugf(err.Error())
+		return nil
+	}
+
+	return util.GetTLSServerConfig()
 }

--- a/comp/api/authtoken/fetchonlyimpl/authtoken.go
+++ b/comp/api/authtoken/fetchonlyimpl/authtoken.go
@@ -65,7 +65,7 @@ func (at *authToken) setToken() error {
 // Get returns the session token
 func (at *authToken) Get() string {
 	if err := at.setToken(); err != nil {
-		at.log.Debugf(err.Error())
+		at.log.Debugf("%s", err.Error())
 		return ""
 	}
 
@@ -75,7 +75,7 @@ func (at *authToken) Get() string {
 // GetTLSClientConfig return a TLS configuration with the IPC certificate for http.Client
 func (at *authToken) GetTLSClientConfig() *tls.Config {
 	if err := at.setToken(); err != nil {
-		at.log.Debugf(err.Error())
+		at.log.Debugf("%s", err.Error())
 		return nil
 	}
 
@@ -85,7 +85,7 @@ func (at *authToken) GetTLSClientConfig() *tls.Config {
 // GetTLSServerConfig return a TLS configuration with the IPC certificate for http.Server
 func (at *authToken) GetTLSServerConfig() *tls.Config {
 	if err := at.setToken(); err != nil {
-		at.log.Debugf(err.Error())
+		at.log.Debugf("%s", err.Error())
 		return nil
 	}
 

--- a/comp/api/authtoken/fetchonlyimpl/authtoken_test.go
+++ b/comp/api/authtoken/fetchonlyimpl/authtoken_test.go
@@ -10,10 +10,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/pkg/api/security/cert"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -23,6 +25,7 @@ import (
 func TestGet(t *testing.T) {
 	dir := t.TempDir()
 	authPath := filepath.Join(dir, "auth_token")
+	var cfg config.Component
 	overrides := map[string]any{
 		"auth_token_file_path": authPath,
 	}
@@ -32,6 +35,7 @@ func TestGet(t *testing.T) {
 			t,
 			fx.Provide(func() log.Component { return logmock.New(t) }),
 			config.MockModule(),
+			fx.Populate(&cfg),
 			fx.Replace(config.MockParams{Overrides: overrides}),
 		),
 	).(*authToken)
@@ -40,6 +44,14 @@ func TestGet(t *testing.T) {
 	assert.False(t, comp.tokenLoaded)
 
 	err := os.WriteFile(authPath, []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 0777)
+	require.NoError(t, err)
+
+	// Should be empty because the cert/key weren't generated yet
+	assert.Empty(t, comp.Get())
+	assert.False(t, comp.tokenLoaded)
+
+	// generating IPC cert/key files
+	_, _, err = cert.CreateOrFetchAgentIPCCert(cfg)
 	require.NoError(t, err)
 
 	assert.Equal(t, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", comp.Get())

--- a/comp/api/authtoken/fetchonlyimpl/mock.go
+++ b/comp/api/authtoken/fetchonlyimpl/mock.go
@@ -8,9 +8,12 @@
 package fetchonlyimpl
 
 import (
+	"crypto/tls"
+
+	"go.uber.org/fx"
+
 	authtokeninterface "github.com/DataDog/datadog-agent/comp/api/authtoken"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"go.uber.org/fx"
 )
 
 // MockModule defines the fx options for the mock component.
@@ -26,6 +29,18 @@ type MockFetchOnly struct{}
 // Get is a mock of the fetchonly Get function
 func (fc *MockFetchOnly) Get() string {
 	return "a string"
+}
+
+// GetTLSClientConfig is a mock of the fetchonly GetTLSClientConfig function
+func (fc *MockFetchOnly) GetTLSClientConfig() *tls.Config {
+	return &tls.Config{
+		InsecureSkipVerify: true,
+	}
+}
+
+// GetTLSServerConfig is a mock of the fetchonly GetTLSServerConfig function
+func (fc *MockFetchOnly) GetTLSServerConfig() *tls.Config {
+	return &tls.Config{}
 }
 
 // NewMock returns a new fetch only authtoken mock

--- a/pkg/api/security/cert/cert_generator.go
+++ b/pkg/api/security/cert/cert_generator.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package cert provide useful functions to generate certificates
+package cert
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+func generateKeyPair(bits int) (*rsa.PrivateKey, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, fmt.Errorf("generating random key: %v", err)
+	}
+
+	return privKey, nil
+}
+
+func certTemplate() (*x509.Certificate, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %s", err)
+	}
+
+	notBefore := time.Now()
+	// 50 years duration
+	notAfter := notBefore.Add(50 * 365 * 24 * time.Hour)
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Datadog, Inc."},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IsCA:                  true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+
+	return &template, nil
+}
+
+func generateCertKeyPair(bits int) ([]byte, []byte, error) {
+	rootCertTmpl, err := certTemplate()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rootKey, err := generateKeyPair(bits)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, rootCertTmpl, rootCertTmpl, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rootKey)})
+
+	return certPEM, keyPEM, nil
+}

--- a/pkg/api/security/cert/cert_generator.go
+++ b/pkg/api/security/cert/cert_generator.go
@@ -69,7 +69,7 @@ func generateCertKeyPair() ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("Unable to marshall private key: %v", err)
 	}
 
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: rawKey})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: rawKey})
 
 	return certPEM, keyPEM, nil
 }

--- a/pkg/api/security/cert/cert_generator_test.go
+++ b/pkg/api/security/cert/cert_generator_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cert
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertCommunication(t *testing.T) {
+	bits := 2048
+
+	certPEM, keyPEM, err := generateCertKeyPair(bits)
+	assert.NoError(t, err)
+
+	// Load server certificate
+	serverCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	assert.NoError(t, err)
+
+	// Create a certificate pool with the generated certificate
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(certPEM)
+	assert.True(t, ok)
+
+	// Create a TLS config for the server
+	serverTLSConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+	}
+
+	// Create a TLS config for the client
+	clientTLSConfig := &tls.Config{
+		RootCAs: certPool,
+	}
+
+	expectedResult := []byte("hello word")
+
+	// Create a HTTPS Server
+	s := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(expectedResult)
+	}))
+
+	s.TLS = serverTLSConfig
+	s.StartTLS()
+	t.Cleanup(func() {
+		s.Close()
+	})
+
+	// Create a HTTPS Client
+	client := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: clientTLSConfig,
+		},
+	}
+
+	// Try to communicate together
+	resp, err := client.Get(s.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, expectedResult)
+}

--- a/pkg/api/security/cert/cert_generator_test.go
+++ b/pkg/api/security/cert/cert_generator_test.go
@@ -18,9 +18,7 @@ import (
 )
 
 func TestCertCommunication(t *testing.T) {
-	bits := 2048
-
-	certPEM, keyPEM, err := generateCertKeyPair(bits)
+	certPEM, keyPEM, err := generateCertKeyPair()
 	assert.NoError(t, err)
 
 	// Load server certificate

--- a/pkg/api/security/cert/cert_getter.go
+++ b/pkg/api/security/cert/cert_getter.go
@@ -59,7 +59,7 @@ func fetchAgentIPCCert(config configModel.Reader, certCreationAllowed bool) ([]b
 			log.Infof("[%s:%d] Creating a new IPC certificate", file, line)
 		}
 
-		cert, key, err := generateCertKeyPair(2048)
+		cert, key, err := generateCertKeyPair()
 
 		if err != nil {
 			return nil, nil, err

--- a/pkg/api/security/cert/cert_getter.go
+++ b/pkg/api/security/cert/cert_getter.go
@@ -93,7 +93,7 @@ func fetchAgentIPCCert(config configModel.Reader, certCreationAllowed bool) ([]b
 
 	block, _ = pem.Decode(rest)
 
-	if block == nil || block.Type != "RSA PRIVATE KEY" {
+	if block == nil || block.Type != "EC PRIVATE KEY" {
 		return nil, nil, log.Error("failed to decode PEM block containing key")
 	}
 

--- a/pkg/api/security/cert/cert_getter.go
+++ b/pkg/api/security/cert/cert_getter.go
@@ -118,8 +118,8 @@ func saveIPCCertKey(cert, key []byte, dest string) (err error) {
 		return err
 	}
 
-	if err := perms.RestrictAccessToUser(dest + ".key"); err != nil {
-		log.Errorf("Failed to write IPC key file %s", err)
+	if err := perms.RestrictAccessToUser(dest); err != nil {
+		log.Errorf("Failed to set IPC cert permissions: %s", err)
 		return err
 	}
 

--- a/pkg/api/security/cert/cert_getter.go
+++ b/pkg/api/security/cert/cert_getter.go
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package cert provide useful functions to generate certificates
+package cert
+
+import (
+	"bytes"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	configModel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// defaultCertFileName represent the default IPC certificate root name (without .cert or .key)
+const defaultCertFileName = "ipc_cert.pem"
+
+// GetCertFilepath returns the path to the IPC cert file.
+func GetCertFilepath(config configModel.Reader) string {
+	if configPath := config.GetString("ipc_cert_file_path"); configPath != "" {
+		return configPath
+	}
+	// Since customers who set the "auth_token_file_path" configuration likely prefer to avoid writing it next to the configuration file,
+	// we should follow this behavior for the cert/key generation as well to minimize the risk of disrupting IPC functionality.
+	if config.GetString("auth_token_file_path") != "" {
+		dest := filepath.Join(filepath.Dir(config.GetString("auth_token_file_path")), defaultCertFileName)
+		log.Warnf("IPC cert/key created or retrieved next to auth_token_file_path location: %v", dest)
+		return dest
+	}
+	return filepath.Join(filepath.Dir(config.ConfigFileUsed()), defaultCertFileName)
+}
+
+// FetchAgentIPCCert return the IPC certificate and key from the path set in the configuration
+// Requires that the config has been set up before calling
+func FetchAgentIPCCert(config configModel.Reader) ([]byte, []byte, error) {
+	return fetchAgentIPCCert(config, false)
+}
+
+// CreateOrFetchAgentIPCCert return the IPC certificate and key from the path set in the configuration or create if not present
+// Requires that the config has been set up before calling
+func CreateOrFetchAgentIPCCert(config configModel.Reader) ([]byte, []byte, error) {
+	return fetchAgentIPCCert(config, true)
+}
+
+func fetchAgentIPCCert(config configModel.Reader, certCreationAllowed bool) ([]byte, []byte, error) {
+	certPath := GetCertFilepath(config)
+
+	// Create cert&key if it doesn't exist and if permitted by calling func
+	if _, e := os.Stat(certPath); os.IsNotExist(e) && certCreationAllowed {
+		// print the caller to identify what is calling this function
+		if _, file, line, ok := runtime.Caller(2); ok {
+			log.Infof("[%s:%d] Creating a new IPC certificate", file, line)
+		}
+
+		cert, key, err := generateCertKeyPair(2048)
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		// Write the IPC cert/key in the FS (platform-specific)
+		e = saveIPCCertKey(cert, key, certPath)
+		if e != nil {
+			return nil, nil, fmt.Errorf("error writing IPC cert/key file on fs: %s", e)
+		}
+		log.Infof("Saved a new  IPC certificate/key pair to %s", certPath)
+
+		return cert, key, nil
+	}
+
+	// Read the IPC certAndKey/key
+	certAndKey, e := os.ReadFile(certPath)
+	if e != nil {
+		return nil, nil, fmt.Errorf("unable to read authentication IPC cert/key files: %s", e.Error())
+	}
+
+	// Demultiplexing cert and key from file
+	var block *pem.Block
+
+	block, rest := pem.Decode(certAndKey)
+
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, nil, log.Error("failed to decode PEM block containing certificate")
+	}
+	cert := pem.EncodeToMemory(block)
+
+	block, _ = pem.Decode(rest)
+
+	if block == nil || block.Type != "RSA PRIVATE KEY" {
+		return nil, nil, log.Error("failed to decode PEM block containing key")
+	}
+
+	key := pem.EncodeToMemory(block)
+
+	return cert, key, nil
+}
+
+// writes IPC cert/key files to a file with the same permissions as datadog.yaml
+func saveIPCCertKey(cert, key []byte, dest string) (err error) {
+	log.Infof("Saving a new IPC certificate/key pair in %s", dest)
+
+	perms, err := filesystem.NewPermission()
+	if err != nil {
+		return err
+	}
+
+	// Concatenating cert and key together
+	certAndKey := bytes.Join([][]byte{cert, key}, []byte{})
+
+	if err = os.WriteFile(dest, certAndKey, 0o600); err != nil {
+		return err
+	}
+
+	if err := perms.RestrictAccessToUser(dest + ".key"); err != nil {
+		log.Errorf("Failed to write IPC key file %s", err)
+		return err
+	}
+
+	log.Infof("Wrote IPC certificate/key pair in %s", dest)
+	return nil
+}

--- a/pkg/api/security/cert/cert_getter_test.go
+++ b/pkg/api/security/cert/cert_getter_test.go
@@ -1,0 +1,139 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cert
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+func initMockConf(t *testing.T) (model.Config, string) {
+	testDir := t.TempDir()
+
+	f, err := os.CreateTemp(testDir, "fake-datadog-yaml-")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		f.Close()
+	})
+
+	mockConfig := configmock.New(t)
+	mockConfig.SetConfigFile(f.Name())
+	mockConfig.SetWithoutSource("auth_token", "")
+
+	return mockConfig, filepath.Join(testDir, "auth_token")
+}
+
+func TestCreateOrFetchAuthTokenValidGen(t *testing.T) {
+	config, _ := initMockConf(t)
+	ipccert, ipckey, err := CreateOrFetchAgentIPCCert(config)
+	require.NoError(t, err)
+
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(ipccert)
+	assert.True(t, ok)
+
+	_, err = tls.X509KeyPair(ipccert, ipckey)
+	assert.NoError(t, err)
+}
+
+func TestFetchAuthToken(t *testing.T) {
+	config, _ := initMockConf(t)
+
+	// Trying to fetch before create cert: must fail
+	_, _, err := FetchAgentIPCCert(config)
+	require.Error(t, err)
+
+	// Creating a cert
+	ipcCert, ipcKey, err := CreateOrFetchAgentIPCCert(config)
+	require.NoError(t, err)
+
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(ipcCert)
+	assert.True(t, ok)
+
+	_, err = tls.X509KeyPair(ipcCert, ipcKey)
+	assert.NoError(t, err)
+
+	// Trying to fetch after creating cert: must succeed
+	fetchedCert, fetchedKey, err := FetchAgentIPCCert(config)
+	require.NoError(t, err)
+	require.Equal(t, string(ipcCert), string(fetchedCert))
+	require.Equal(t, string(ipcKey), string(fetchedKey))
+}
+
+func TestFetchAuthTokenWithAuthTokenFilePath(t *testing.T) {
+	config, _ := initMockConf(t)
+
+	// Setting custom auth_token filepath
+	dname, err := os.MkdirTemp("", "auth_token_dir")
+	require.NoError(t, err)
+	config.SetWithoutSource("auth_token_file_path", filepath.Join(dname, "auth_token"))
+
+	// Creating a cert
+	ipcCert, ipcKey, err := CreateOrFetchAgentIPCCert(config)
+	require.NoError(t, err)
+
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(ipcCert)
+	assert.True(t, ok)
+
+	_, err = tls.X509KeyPair(ipcCert, ipcKey)
+	assert.NoError(t, err)
+
+	// Checking that the cert have been created next to the auth_token_file path
+	_, err = os.Stat(filepath.Join(dname, defaultCertFileName))
+	require.NoError(t, err)
+
+	// Trying to fetch after creating cert: must succeed
+	fetchedCert, fetchedKey, err := FetchAgentIPCCert(config)
+	require.NoError(t, err)
+	require.Equal(t, string(ipcCert), string(fetchedCert))
+	require.Equal(t, string(ipcKey), string(fetchedKey))
+}
+
+func TestFetchAuthTokenWithIPCCertFilePath(t *testing.T) {
+	config, _ := initMockConf(t)
+
+	// Setting custom auth_token filepath
+	authTokenDirName, err := os.MkdirTemp("", "auth_token_dir")
+	require.NoError(t, err)
+	config.SetWithoutSource("auth_token_file_path", filepath.Join(authTokenDirName, "custom_auth_token"))
+
+	// Setting custom IPC cert filepath
+	ipcDirName, err := os.MkdirTemp("", "ipc_cert_dir")
+	require.NoError(t, err)
+	config.SetWithoutSource("ipc_cert_file_path", filepath.Join(ipcDirName, "custom_ipc_cert"))
+
+	// Creating a cert
+	ipcCert, ipcKey, err := CreateOrFetchAgentIPCCert(config)
+	require.NoError(t, err)
+
+	certPool := x509.NewCertPool()
+	ok := certPool.AppendCertsFromPEM(ipcCert)
+	assert.True(t, ok)
+
+	_, err = tls.X509KeyPair(ipcCert, ipcKey)
+	assert.NoError(t, err)
+
+	// Checking that the cert have been created at the custom IPC cert filepath
+	_, err = os.Stat(filepath.Join(ipcDirName, "custom_ipc_cert"))
+	require.NoError(t, err)
+
+	// Trying to fetch after creating cert: must succeed
+	fetchedCert, fetchedKey, err := FetchAgentIPCCert(config)
+	require.NoError(t, err)
+	require.Equal(t, string(ipcCert), string(fetchedCert))
+	require.Equal(t, string(ipcKey), string(fetchedKey))
+}

--- a/pkg/api/util/ipc_endpoint_test.go
+++ b/pkg/api/util/ipc_endpoint_test.go
@@ -17,96 +17,108 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-func createConfig(t *testing.T, ts *httptest.Server) pkgconfigmodel.Config {
-	conf := configmock.New(t)
-
-	// create a fake auth token
-	authTokenFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
-	authTokenPath := authTokenFile.Name()
-	os.WriteFile(authTokenPath, []byte("0123456789abcdef0123456789abcdef"), 0640)
-
-	addr, err := url.Parse(ts.URL)
-	assert.NoError(t, err)
-	localHost, localPort, _ := net.SplitHostPort(addr.Host)
-
-	// set minimal configuration that IPCEndpoint needs
-	conf.Set("auth_token_file_path", authTokenPath, pkgconfigmodel.SourceAgentRuntime)
-	conf.Set("cmd_host", localHost, pkgconfigmodel.SourceAgentRuntime)
-	conf.Set("cmd_port", localPort, pkgconfigmodel.SourceAgentRuntime)
-
-	return conf
+type IPCEndpointTestSuite struct {
+	suite.Suite
+	conf pkgconfigmodel.Config
 }
 
-func TestNewIPCEndpoint(t *testing.T) {
-	conf := configmock.New(t)
+func TestIPCEndpointTestSuite(t *testing.T) {
+	// cleaning auth_token and cert globals to be able initialize again the authToken and IPC cert
+	token = ""
+	dcaToken = ""
+	clientTLSConfig = nil
+	serverTLSConfig = nil
+
+	// creating test suite
+	testSuite := new(IPCEndpointTestSuite)
+
+	// simulating a normal startup of Agent with auth_token and cert generation
+	testSuite.conf = configmock.New(t)
 
 	// create a fake auth token
 	authTokenFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	authTokenPath := authTokenFile.Name()
 	os.WriteFile(authTokenPath, []byte("0123456789abcdef0123456789abcdef"), 0640)
+	testSuite.conf.Set("auth_token_file_path", authTokenPath, pkgconfigmodel.SourceAgentRuntime)
+
+	// use the cert in the httptest server
+	CreateAndSetAuthToken(testSuite.conf)
+
+	suite.Run(t, testSuite)
+}
+
+func (suite *IPCEndpointTestSuite) setTestServerAndConfig(t *testing.T, ts *httptest.Server, isHTTPS bool) {
+	if isHTTPS {
+		ts.TLS = GetTLSServerConfig()
+		ts.StartTLS()
+	} else {
+		ts.Start()
+	}
+
+	// use the httptest server as the CMD_API
+	addr, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+	localHost, localPort, _ := net.SplitHostPort(addr.Host)
+	suite.conf.Set("cmd_host", localHost, pkgconfigmodel.SourceAgentRuntime)
+	suite.conf.Set("cmd_port", localPort, pkgconfigmodel.SourceAgentRuntime)
+}
+
+func (suite *IPCEndpointTestSuite) TestNewIPCEndpoint() {
+	t := suite.T()
 
 	// set minimal configuration that IPCEndpoint needs
-	conf.Set("auth_token_file_path", authTokenPath, pkgconfigmodel.SourceAgentRuntime)
-	conf.Set("cmd_host", "localhost", pkgconfigmodel.SourceAgentRuntime)
-	conf.Set("cmd_port", "6789", pkgconfigmodel.SourceAgentRuntime)
+	suite.conf.Set("cmd_host", "localhost", pkgconfigmodel.SourceAgentRuntime)
+	suite.conf.Set("cmd_port", "6789", pkgconfigmodel.SourceAgentRuntime)
 
 	// test the endpoint construction
-	end, err := NewIPCEndpoint(conf, "test/api")
+	end, err := NewIPCEndpoint(suite.conf, "test/api")
 	assert.NoError(t, err)
 	assert.Equal(t, end.target.String(), "https://localhost:6789/test/api")
 }
 
-func TestNewIPCEndpointWithCloseConnection(t *testing.T) {
-	conf := configmock.New(t)
-
-	// create a fake auth token
-	authTokenFile, err := os.CreateTemp("", "")
-	assert.NoError(t, err)
-	authTokenPath := authTokenFile.Name()
-	os.WriteFile(authTokenPath, []byte("0123456789abcdef0123456789abcdef"), 0640)
-
-	// set minimal configuration that IPCEndpoint needs
-	conf.Set("auth_token_file_path", authTokenPath, pkgconfigmodel.SourceAgentRuntime)
-	conf.Set("cmd_host", "localhost", pkgconfigmodel.SourceAgentRuntime)
-	conf.Set("cmd_port", "6789", pkgconfigmodel.SourceAgentRuntime)
+func (suite *IPCEndpointTestSuite) TestNewIPCEndpointWithCloseConnection() {
+	t := suite.T()
 
 	// test constructing with the CloseConnection option
-	end, err := NewIPCEndpoint(conf, "test/api", WithCloseConnection(true))
-	assert.NoError(t, err)
+	end, err := NewIPCEndpoint(suite.conf, "test/api", WithCloseConnection(true))
+	require.NoError(t, err)
 	assert.True(t, end.closeConn)
 }
 
-func TestIPCEndpointDoGet(t *testing.T) {
+func (suite *IPCEndpointTestSuite) TestIPCEndpointDoGet() {
+	t := suite.T()
 	gotURL := ""
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotURL = r.URL.String()
 		_, _ = io.ReadAll(r.Body)
 		w.Write([]byte("ok"))
 	}))
 	defer ts.Close()
 
-	conf := createConfig(t, ts)
-	end, err := NewIPCEndpoint(conf, "test/api")
+	suite.setTestServerAndConfig(t, ts, true)
+	end, err := NewIPCEndpoint(suite.conf, "test/api")
 	assert.NoError(t, err)
 
 	// test that DoGet will hit the endpoint url
 	res, err := end.DoGet()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, res, []byte("ok"))
 	assert.Equal(t, gotURL, "/test/api")
 }
 
-func TestIPCEndpointGetWithHTTPClientAndNonTLS(t *testing.T) {
+func (suite *IPCEndpointTestSuite) TestIPCEndpointGetWithHTTPClientAndNonTLS() {
+	t := suite.T()
 	// non-http server
 	gotURL := ""
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotURL = r.URL.String()
 		_, _ = io.ReadAll(r.Body)
 		w.Write([]byte("ok"))
@@ -114,106 +126,112 @@ func TestIPCEndpointGetWithHTTPClientAndNonTLS(t *testing.T) {
 	defer ts.Close()
 
 	// create non-TLS client and use the "http" protocol
+	suite.setTestServerAndConfig(t, ts, false)
 	client := http.Client{}
-	conf := createConfig(t, ts)
-	end, err := NewIPCEndpoint(conf, "test/api", WithHTTPClient(&client), WithURLScheme("http"))
+	end, err := NewIPCEndpoint(suite.conf, "test/api", WithHTTPClient(&client), WithURLScheme("http"))
 	assert.NoError(t, err)
 
 	// test that DoGet will hit the endpoint url
 	res, err := end.DoGet()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, res, []byte("ok"))
 	assert.Equal(t, gotURL, "/test/api")
 }
 
-func TestIPCEndpointGetWithValues(t *testing.T) {
+func (suite *IPCEndpointTestSuite) TestIPCEndpointGetWithValues() {
+	t := suite.T()
 	gotURL := ""
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotURL = r.URL.String()
 		_, _ = io.ReadAll(r.Body)
 		w.Write([]byte("ok"))
 	}))
 	defer ts.Close()
 
-	conf := createConfig(t, ts)
+	suite.setTestServerAndConfig(t, ts, true)
 	// set url values for GET request
 	v := url.Values{}
 	v.Set("verbose", "true")
 
 	// test construction with option for url.Values
-	end, err := NewIPCEndpoint(conf, "test/api")
+	end, err := NewIPCEndpoint(suite.conf, "test/api")
 	assert.NoError(t, err)
 
 	// test that DoGet will use query parameters from the url.Values
 	res, err := end.DoGet(WithValues(v))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, res, []byte("ok"))
 	assert.Equal(t, gotURL, "/test/api?verbose=true")
 }
 
-func TestIPCEndpointGetWithHostAndPort(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func (suite *IPCEndpointTestSuite) TestIPCEndpointGetWithHostAndPort() {
+	t := suite.T()
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.ReadAll(r.Body)
 		w.Write([]byte("ok"))
 	}))
 	defer ts.Close()
 
-	conf := createConfig(t, ts)
+	suite.setTestServerAndConfig(t, ts, true)
 	// modify the config so that it uses a different setting for the cmd_host
-	conf.Set("process_config.cmd_host", "127.0.0.1", pkgconfigmodel.SourceAgentRuntime)
+	suite.conf.Set("process_config.cmd_host", "127.0.0.1", pkgconfigmodel.SourceAgentRuntime)
 
 	// test construction with alternate values for the host and port
-	end, err := NewIPCEndpoint(conf, "test/api", WithHostAndPort(conf.GetString("process_config.cmd_host"), conf.GetInt("cmd_port")))
+	end, err := NewIPCEndpoint(suite.conf, "test/api", WithHostAndPort(suite.conf.GetString("process_config.cmd_host"), suite.conf.GetInt("cmd_port")))
 	assert.NoError(t, err)
 
 	// test that host provided by WithHostAndPort is used for the endpoint
 	res, err := end.DoGet()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, res, []byte("ok"))
-	assert.Equal(t, end.target.Host, fmt.Sprintf("127.0.0.1:%d", conf.GetInt("cmd_port")))
+	assert.Equal(t, end.target.Host, fmt.Sprintf("127.0.0.1:%d", suite.conf.GetInt("cmd_port")))
 }
 
-func TestIPCEndpointDeprecatedIPCAddress(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func (suite *IPCEndpointTestSuite) TestIPCEndpointDeprecatedIPCAddress() {
+	t := suite.T()
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.ReadAll(r.Body)
 		w.Write([]byte("ok"))
 	}))
 	defer ts.Close()
 
-	conf := createConfig(t, ts)
+	suite.setTestServerAndConfig(t, ts, true)
 	// Use the deprecated (but still supported) option "ipc_address"
-	conf.UnsetForSource("cmd_host", pkgconfigmodel.SourceAgentRuntime)
-	conf.Set("ipc_address", "127.0.0.1", pkgconfigmodel.SourceAgentRuntime)
+	suite.conf.UnsetForSource("cmd_host", pkgconfigmodel.SourceAgentRuntime)
+	suite.conf.Set("ipc_address", "127.0.0.1", pkgconfigmodel.SourceAgentRuntime)
+	defer suite.conf.UnsetForSource("ipc_address", pkgconfigmodel.SourceAgentRuntime)
 
 	// test construction, uses ipc_address instead of cmd_host
-	end, err := NewIPCEndpoint(conf, "test/api")
+	end, err := NewIPCEndpoint(suite.conf, "test/api")
 	assert.NoError(t, err)
 
 	// test that host provided by "ipc_address" is used for the endpoint
 	res, err := end.DoGet()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, res, []byte("ok"))
-	assert.Equal(t, end.target.Host, fmt.Sprintf("127.0.0.1:%d", conf.GetInt("cmd_port")))
+	assert.Equal(t, end.target.Host, fmt.Sprintf("127.0.0.1:%d", suite.conf.GetInt("cmd_port")))
 }
 
-func TestIPCEndpointErrorText(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+func (suite *IPCEndpointTestSuite) TestIPCEndpointErrorText() {
+	t := suite.T()
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(400)
 		w.Write([]byte("bad request"))
 	}))
 	defer ts.Close()
 
-	conf := createConfig(t, ts)
-	end, err := NewIPCEndpoint(conf, "test/api")
-	assert.NoError(t, err)
+	suite.setTestServerAndConfig(t, ts, true)
+	end, err := NewIPCEndpoint(suite.conf, "test/api")
+	require.NoError(t, err)
 
 	// test that error is returned by the endpoint
 	_, err = end.DoGet()
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
-func TestIPCEndpointErrorMap(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+func (suite *IPCEndpointTestSuite) TestIPCEndpointErrorMap() {
+	t := suite.T()
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(400)
 		data, _ := json.Marshal(map[string]string{
 			"error": "something went wrong",
@@ -222,12 +240,12 @@ func TestIPCEndpointErrorMap(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	conf := createConfig(t, ts)
-	end, err := NewIPCEndpoint(conf, "test/api")
-	assert.NoError(t, err)
+	suite.setTestServerAndConfig(t, ts, true)
+	end, err := NewIPCEndpoint(suite.conf, "test/api")
+	require.NoError(t, err)
 
 	// test that error gets unwrapped from the errmap
 	_, err = end.DoGet()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, err.Error(), "something went wrong")
 }

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -40,7 +40,6 @@ var (
 		InsecureSkipVerify: true,
 	}
 	serverTLSConfig *tls.Config
-	initialized     sync.Once
 	initSource      int
 )
 

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -8,52 +8,135 @@ package util
 
 import (
 	"crypto/subtle"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"net"
 	"net/http"
 	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/api/security"
+	pkgtoken "github.com/DataDog/datadog-agent/pkg/api/security"
+	"github.com/DataDog/datadog-agent/pkg/api/security/cert"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
 	tokenLock sync.RWMutex
 	token     string
 	dcaToken  string
+	// The clientTLSConfig is set by default with `InsecureSkipVerify: true`.
+	// This is intentionally done to allow the Agent to local Agent APIs when the clientTLSConfig is not yet initialized.
+	// However, this default value should be removed in the future.
+	// TODO: Monitor and fix the logs printed by GetTLSClientConfig and GetTLSServerConfig.
+	clientTLSConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	serverTLSConfig *tls.Config
+	initialized     sync.Once
+	initializedBy   string
 )
 
-// SetAuthToken sets the session token
+// SetAuthToken sets the session token and IPC certificate
 // Requires that the config has been set up before calling
 func SetAuthToken(config model.Reader) error {
 	tokenLock.Lock()
 	defer tokenLock.Unlock()
 
 	// Noop if token is already set
-	if token != "" {
+	if initializedBy != "" {
+		if initializedBy != "SetAuthToken" {
+			log.Infof("function SetAuthToken was called after CreateAndSetAuthToken was called")
+		}
 		return nil
 	}
 
 	var err error
-	token, err = security.FetchAuthToken(config)
-	return err
+	token, err = pkgtoken.FetchAuthToken(config)
+	if err != nil {
+		return err
+	}
+	ipccert, ipckey, err := cert.FetchAgentIPCCert(config)
+	if err != nil {
+		return err
+	}
+
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(ipccert); !ok {
+		return fmt.Errorf("unable to use cert for creating CertPool")
+	}
+
+	clientTLSConfig = &tls.Config{
+		RootCAs: certPool,
+	}
+
+	tlsCert, err := tls.X509KeyPair(ipccert, ipckey)
+	if err != nil {
+		return err
+	}
+	serverTLSConfig = &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}
+
+	initialized.Do(func() {
+		initializedBy = "SetAuthToken"
+	})
+
+	return nil
 }
 
-// CreateAndSetAuthToken creates and sets the authorization token
+// CreateAndSetAuthToken creates and sets the authorization token and IPC certificate
 // Requires that the config has been set up before calling
 func CreateAndSetAuthToken(config model.Reader) error {
 	tokenLock.Lock()
 	defer tokenLock.Unlock()
 
 	// Noop if token is already set
-	if token != "" {
+	if initializedBy != "" {
+		if initializedBy != "CreateAndSetAuthToken" {
+			log.Warnf("function CreateAndSetAuthToken was called after SetAuthToken was called")
+		}
 		return nil
 	}
 
 	var err error
-	token, err = security.CreateOrFetchToken(config)
-	return err
+	token, err = pkgtoken.CreateOrFetchToken(config)
+	if err != nil {
+		return err
+	}
+	ipccert, ipckey, err := cert.CreateOrFetchAgentIPCCert(config)
+	if err != nil {
+		return err
+	}
+
+	certPool := x509.NewCertPool()
+	if ok := certPool.AppendCertsFromPEM(ipccert); !ok {
+		return fmt.Errorf("Unable to generate certPool from PERM IPC cert")
+	}
+
+	clientTLSConfig = &tls.Config{
+		RootCAs: certPool,
+	}
+
+	tlsCert, err := tls.X509KeyPair(ipccert, ipckey)
+	if err != nil {
+		return fmt.Errorf("Unable to generate x509 cert from PERM IPC cert and key")
+	}
+	serverTLSConfig = &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	}
+
+	initialized.Do(func() {
+		initializedBy = "CreateAndSetAuthToken"
+	})
+
+	return nil
+}
+
+// IsInitialized return true if the auth_token and IPC cert/key pair have been initialized with SetAuthToken or CreateAndSetAuthToken functions
+func IsInitialized() bool {
+	return initializedBy != ""
 }
 
 // GetAuthToken gets the session token
@@ -61,6 +144,26 @@ func GetAuthToken() string {
 	tokenLock.RLock()
 	defer tokenLock.RUnlock()
 	return token
+}
+
+// GetTLSClientConfig gets the certificate and key used for IPC
+func GetTLSClientConfig() *tls.Config {
+	tokenLock.RLock()
+	defer tokenLock.RUnlock()
+	if initializedBy == "" {
+		log.Errorf("GetTLSClientConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function)")
+	}
+	return clientTLSConfig.Clone()
+}
+
+// GetTLSServerConfig gets the certificate and key used for IPC
+func GetTLSServerConfig() *tls.Config {
+	tokenLock.RLock()
+	defer tokenLock.RUnlock()
+	if initializedBy == "" {
+		log.Errorf("GetTLSServerConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function)")
+	}
+	return serverTLSConfig.Clone()
 }
 
 // InitDCAAuthToken initialize the session token for the Cluster Agent based on config options
@@ -75,7 +178,7 @@ func InitDCAAuthToken(config model.Reader) error {
 	}
 
 	var err error
-	dcaToken, err = security.CreateOrGetClusterAgentAuthToken(config)
+	dcaToken, err = pkgtoken.CreateOrGetClusterAgentAuthToken(config)
 	return err
 }
 

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -22,8 +22,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+type source int
+
 const (
-	uninitialized = iota
+	uninitialized source = iota
 	setAuthToken
 	createAndSetAuthToken
 )
@@ -40,7 +42,7 @@ var (
 		InsecureSkipVerify: true,
 	}
 	serverTLSConfig *tls.Config
-	initSource      int
+	initSource      source
 )
 
 // SetAuthToken sets the session token and IPC certificate

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1091,6 +1091,8 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("check_runners", int64(4))
 	config.BindEnvAndSetDefault("check_cancel_timeout", 500*time.Millisecond)
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
+	// used to override the path where the IPC cert/key files are stored/retrieved
+	config.BindEnvAndSetDefault("ipc_cert_file_path", "")
 	config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)


### PR DESCRIPTION
### What does this PR do?
This PR introduce the generation of an IPC dedicated certificate and key pair, used to allow Agent API server to authenticate it. This generation/retrieval process takes places during the initialization of the auth_token.
 
The next steps are using this generated certificate in the different API servers:
- #31843 
- #31845 
- #31844 
- #31847

### Motivation
This PR is part of a plan to improve the security of the Agent's inter-process communication (IPC).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Some unit tests have been added to cover the new generation/retrieval steps. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The `comp/api/authtoken component` has been updated to provide the IPC TLS configurations based on the generated certificate. The component's name should be updated in a subsequent pull request to better reflect its behavior.
