### PR TITLE
[ASCII-2585] Migrating ProcessAgent to use IPC cert

### DIFF
--- a/cmd/process-agent/subcommands/status/status.go
+++ b/cmd/process-agent/subcommands/status/status.go
@@ -28,8 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-var httpClient = apiutil.GetClient(false)
-
 const (
 	notRunning = `
 =============
@@ -111,6 +109,7 @@ func writeError(log log.Component, w io.Writer, e error) {
 }
 
 func fetchStatus(statusURL string) ([]byte, error) {
+	httpClient := apiutil.GetClient(false)
 	body, err := apiutil.DoGet(httpClient, statusURL, apiutil.LeaveConnectionOpen)
 	if err != nil {
 		return nil, status.NewConnectionError(err)

--- a/comp/process/apiserver/apiserver.go
+++ b/comp/process/apiserver/apiserver.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
+	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
@@ -31,6 +32,8 @@ type dependencies struct {
 	Lc fx.Lifecycle
 
 	Log log.Component
+
+	At authtoken.Component
 
 	APIServerDeps api.APIServerDeps
 }
@@ -54,6 +57,7 @@ func newApiServer(deps dependencies) Component {
 			ReadTimeout:  timeout,
 			WriteTimeout: timeout,
 			IdleTimeout:  timeout,
+			TLSConfig:    deps.At.GetTLSServerConfig(),
 		},
 	}
 

--- a/comp/process/apiserver/apiserver_test.go
+++ b/comp/process/apiserver/apiserver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/settings/settingsimpl"
 	"github.com/DataDog/datadog-agent/comp/core/status"
@@ -39,6 +40,7 @@ func TestLifecycle(t *testing.T) {
 		}),
 		statusimpl.Module(),
 		settingsimpl.MockModule(),
+		fetchonlyimpl.MockModule(),
 	))
 
 	assert.Eventually(t, func() bool {

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	configComp "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -60,6 +61,7 @@ func TestBundleDependencies(t *testing.T) {
 		rdnsquerier.MockModule(),
 		npcollectorimpl.MockModule(),
 		statsd.MockModule(),
+		fetchonlyimpl.MockModule(),
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?
This PR replaces the self-signed certificate used in the Process Agent with the new Agent-wide IPC certificate. This change will allow Agents to identify this API as legitimate when they act as a client.

The certificate generation/retrieval implementation have been made in the following PR:
- #31838

### Motivation
This PR takes place in a plan of Agent security IPC improvement.   

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Process Agent API is extensively used in Process Agent e2e tests. They should fail if the current PR introduce bugs.



### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->