### PR TITLE
Query Aurora instances per cluster

### DIFF
--- a/pkg/databasemonitoring/aws/aurora.go
+++ b/pkg/databasemonitoring/aws/aurora.go
@@ -45,45 +45,50 @@ func (c *Client) GetAuroraClusterEndpoints(ctx context.Context, dbClusterIdentif
 	if len(dbClusterIdentifiers) == 0 {
 		return nil, fmt.Errorf("at least one database cluster identifier is required")
 	}
-	clusterInstances, err := c.client.DescribeDBInstances(ctx,
-		&rds.DescribeDBInstancesInput{
-			Filters: []types.Filter{
-				{
-					Name:   aws.String("db-cluster-id"),
-					Values: dbClusterIdentifiers,
-				},
-			},
-		})
-	if err != nil {
-		return nil, fmt.Errorf("error running GetAuroraClusterEndpoints %v", err)
-	}
 	clusters := make(map[string]*AuroraCluster, 0)
-	for _, db := range clusterInstances.DBInstances {
-		if db.Endpoint != nil && db.DBClusterIdentifier != nil {
-			if db.Endpoint.Address == nil || db.DBInstanceStatus == nil || strings.ToLower(*db.DBInstanceStatus) != "available" {
-				continue
-			}
-			// Add to list of instances for the cluster
-			instance := &Instance{
-				Endpoint: *db.Endpoint.Address,
-			}
-			// Set if IAM is configured for the endpoint
-			if db.IAMDatabaseAuthenticationEnabled != nil {
-				instance.IamEnabled = *db.IAMDatabaseAuthenticationEnabled
-			}
-			// Set the port, if it is known
-			if db.Endpoint.Port != nil {
-				instance.Port = *db.Endpoint.Port
-			}
-			if db.Engine != nil {
-				instance.Engine = *db.Engine
-			}
-			if _, ok := clusters[*db.DBClusterIdentifier]; !ok {
-				clusters[*db.DBClusterIdentifier] = &AuroraCluster{
-					Instances: make([]*Instance, 0),
+
+	for _, clusterId := range dbClusterIdentifiers {
+		// TODO: Seth Samuel: This method is not paginated, so if there are more than 100 instances in a cluster, we will only get the first 100
+		// We should add pagination support to this method at some point
+		clusterInstances, err := c.client.DescribeDBInstances(ctx,
+			&rds.DescribeDBInstancesInput{
+				Filters: []types.Filter{
+					{
+						Name:   aws.String("db-cluster-id"),
+						Values: []string{clusterId},
+					},
+				},
+			})
+		if err != nil {
+			return nil, fmt.Errorf("error running GetAuroraClusterEndpoints %v", err)
+		}
+		for _, db := range clusterInstances.DBInstances {
+			if db.Endpoint != nil && db.DBClusterIdentifier != nil {
+				if db.Endpoint.Address == nil || db.DBInstanceStatus == nil || strings.ToLower(*db.DBInstanceStatus) != "available" {
+					continue
 				}
+				// Add to list of instances for the cluster
+				instance := &Instance{
+					Endpoint: *db.Endpoint.Address,
+				}
+				// Set if IAM is configured for the endpoint
+				if db.IAMDatabaseAuthenticationEnabled != nil {
+					instance.IamEnabled = *db.IAMDatabaseAuthenticationEnabled
+				}
+				// Set the port, if it is known
+				if db.Endpoint.Port != nil {
+					instance.Port = *db.Endpoint.Port
+				}
+				if db.Engine != nil {
+					instance.Engine = *db.Engine
+				}
+				if _, ok := clusters[*db.DBClusterIdentifier]; !ok {
+					clusters[*db.DBClusterIdentifier] = &AuroraCluster{
+						Instances: make([]*Instance, 0),
+					}
+				}
+				clusters[*db.DBClusterIdentifier].Instances = append(clusters[*db.DBClusterIdentifier].Instances, instance)
 			}
-			clusters[*db.DBClusterIdentifier].Instances = append(clusters[*db.DBClusterIdentifier].Instances, instance)
 		}
 	}
 	if len(clusters) == 0 {

--- a/pkg/databasemonitoring/aws/aurora.go
+++ b/pkg/databasemonitoring/aws/aurora.go
@@ -47,7 +47,7 @@ func (c *Client) GetAuroraClusterEndpoints(ctx context.Context, dbClusterIdentif
 	}
 	clusters := make(map[string]*AuroraCluster, 0)
 
-	for _, clusterId := range dbClusterIdentifiers {
+	for _, clusterID := range dbClusterIdentifiers {
 		// TODO: Seth Samuel: This method is not paginated, so if there are more than 100 instances in a cluster, we will only get the first 100
 		// We should add pagination support to this method at some point
 		clusterInstances, err := c.client.DescribeDBInstances(ctx,
@@ -55,7 +55,7 @@ func (c *Client) GetAuroraClusterEndpoints(ctx context.Context, dbClusterIdentif
 				Filters: []types.Filter{
 					{
 						Name:   aws.String("db-cluster-id"),
-						Values: []string{clusterId},
+						Values: []string{clusterID},
 					},
 				},
 			})

--- a/pkg/databasemonitoring/aws/aurora_test.go
+++ b/pkg/databasemonitoring/aws/aurora_test.go
@@ -211,7 +211,7 @@ func TestGetAuroraClusterEndpoints(t *testing.T) {
 		{
 			name: "multiple cluster ids returns single endpoint from API",
 			configureClient: func(k *MockrdsService) {
-				k.EXPECT().DescribeDBInstances(gomock.Any(), createDescribeDBInstancesRequest([]string{"test-cluster", "test-cluster-2"})).Return(&rds.DescribeDBInstancesOutput{
+				k.EXPECT().DescribeDBInstances(gomock.Any(), createDescribeDBInstancesRequest([]string{"test-cluster"})).Return(&rds.DescribeDBInstancesOutput{
 					DBInstances: []types.DBInstance{
 						{
 							Endpoint: &types.Endpoint{
@@ -225,6 +225,9 @@ func TestGetAuroraClusterEndpoints(t *testing.T) {
 							Engine:                           aws.String("aurora-postgresql"),
 						},
 					},
+				}, nil).Times(1)
+				k.EXPECT().DescribeDBInstances(gomock.Any(), createDescribeDBInstancesRequest([]string{"test-cluster-2"})).Return(&rds.DescribeDBInstancesOutput{
+					DBInstances: []types.DBInstance{},
 				}, nil).Times(1)
 			},
 			clusterIDs: []string{"test-cluster", "test-cluster-2"},
@@ -244,7 +247,7 @@ func TestGetAuroraClusterEndpoints(t *testing.T) {
 		{
 			name: "multiple cluster ids returns many endpoints from API",
 			configureClient: func(k *MockrdsService) {
-				k.EXPECT().DescribeDBInstances(gomock.Any(), createDescribeDBInstancesRequest([]string{"test-cluster", "test-cluster-2"})).Return(&rds.DescribeDBInstancesOutput{
+				k.EXPECT().DescribeDBInstances(gomock.Any(), createDescribeDBInstancesRequest([]string{"test-cluster"})).Return(&rds.DescribeDBInstancesOutput{
 					DBInstances: []types.DBInstance{
 						{
 							Endpoint: &types.Endpoint{
@@ -268,6 +271,11 @@ func TestGetAuroraClusterEndpoints(t *testing.T) {
 							DBInstanceStatus:                 aws.String("available"),
 							Engine:                           aws.String("aurora-postgresql"),
 						},
+					},
+				}, nil).Times(1)
+
+				k.EXPECT().DescribeDBInstances(gomock.Any(), createDescribeDBInstancesRequest([]string{"test-cluster-2"})).Return(&rds.DescribeDBInstancesOutput{
+					DBInstances: []types.DBInstance{
 						{
 							Endpoint: &types.Endpoint{
 								Address: aws.String("test-endpoint-3"),

--- a/releasenotes/notes/query-aurora-instances-per-cluster-8481d23d9e432e1a.yaml
+++ b/releasenotes/notes/query-aurora-instances-per-cluster-8481d23d9e432e1a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Query Aurora instances per cluster to allow up to 100 instances per cluster
+    rather than 100 instances total.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Updates Aurora autodiscovery to query database instances per cluster.

### Motivation
`DescribeDBInstances` has a limit of 100 instances per call. As a first pass at handling large AWS RDS installations this will allow the agent to autodiscover up to 100 instances per cluster, rather than 100 instances total.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Mocked tests have been updated but full confirmation can only be done in a deployment to a customer with a large number of Aurora instances being autodiscovered.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->