### PR TITLE
Add apm_config.additional_endpoints to authorized config paths

### DIFF
--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -48,7 +48,7 @@ type AuthorizedSet map[string]struct{}
 // config API.
 var AuthorizedConfigPathsCore = buildAuthorizedSet(
 	"api_key", "site", "dd_url", "logs_config.dd_url",
-	"additional_endpoints", "logs_config.additional_endpoints",
+	"additional_endpoints", "logs_config.additional_endpoints", "apm_config.additional_endpoints",
 )
 
 func buildAuthorizedSet(paths ...string) AuthorizedSet {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds `apm_config.additional_endpoints` to the set of authorized config paths.

### Motivation
As part of #incident-33011 we noticed that configsync in the otel agent wasn't updating the API key from `apm_config.additional_endpoints`.  This change fixes this issue and the otel agent is able to fetch the additional endpoints API key from the core agent to send traces.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Validated locally

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->