### PR TITLE
[Network Path] Remove extra trailing slash from URL

### DIFF
--- a/pkg/process/net/common_linux.go
+++ b/pkg/process/net/common_linux.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	pingURL        = "http://unix/" + string(sysconfig.PingModule) + "/ping/"
-	tracerouteURL  = "http://unix/" + string(sysconfig.TracerouteModule) + "/traceroute/"
+	tracerouteURL  = "http://unix/" + string(sysconfig.TracerouteModule) + "/traceroute"
 	connectionsURL = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/connections"
 	networkIDURL   = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/network_id"
 	procStatsURL   = "http://unix/" + string(sysconfig.ProcessModule) + "/stats"

--- a/pkg/process/net/common_windows.go
+++ b/pkg/process/net/common_windows.go
@@ -21,7 +21,7 @@ const (
 	networkIDURL   = "http://unix/" + string(sysconfig.NetworkTracerModule) + "/network_id"
 	registerURL    = "http://localhost:3333/" + string(sysconfig.NetworkTracerModule) + "/register"
 	statsURL       = "http://localhost:3333/debug/stats"
-	tracerouteURL  = "http://localhost:3333/" + string(sysconfig.TracerouteModule) + "/traceroute/"
+	tracerouteURL  = "http://localhost:3333/" + string(sysconfig.TracerouteModule) + "/traceroute"
 
 	// procStatsURL is not used in windows, the value is added to avoid compilation error in windows
 	procStatsURL = "http://localhost:3333/" + string(sysconfig.ProcessModule) + "stats"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Removes an extra trailing slash from the traceroute URL. The code works with it, but it's best to remove it.

### Motivation
Noticed and raised by @pimlu as he was doing some testing of Network Path.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->