### PR TITLE
[ebpfless] Fix the pre-existing connection tests

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -270,10 +270,10 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, timestampNs uint64
 	return nil
 }
 
-// HasConnEstablished is used to avoid a connection appearing before the three-way handshake is complete.
+// HasConnEverEstablished is used to avoid a connection appearing before the three-way handshake is complete.
 // This is done to mirror the behavior of ebpf tracing accept() and connect(), which both return
 // after the handshake is completed.
-func (t *TCPProcessor) HasConnEstablished(conn *network.ConnectionStats) bool {
+func (t *TCPProcessor) HasConnEverEstablished(conn *network.ConnectionStats) bool {
 	st := t.conns[conn.ConnectionTuple]
 
 	// conn.Monotonic.TCPEstablished can be 0 even though isEstablished is true,

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -9,6 +9,7 @@ package ebpfless
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"syscall"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/google/gopacket/layers"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type connectionState struct {
@@ -51,7 +51,12 @@ type connectionState struct {
 	// remoteFinSeq is the tcp.Seq number for the incoming FIN (including any payload length)
 	remoteFinSeq uint32
 
+	// rttTracker is used to track round trip times
 	rttTracker rttTracker
+}
+
+func (st *connectionState) hasMissedHandshake() bool {
+	return st.localSynState == synStateMissed || st.remoteSynState == synStateMissed
 }
 
 // TCPProcessor encapsulates TCP state tracking for the ebpfless tracer
@@ -125,9 +130,13 @@ func (t *TCPProcessor) updateSynFlag(conn *network.ConnectionStats, st *connecti
 		updateConnStatsForOpen(conn)
 	}
 	// if both synStates are ack'd, move to established
-	if st.tcpState == connStatAttempted && st.localSynState == synStateAcked && st.remoteSynState == synStateAcked {
+	if st.tcpState == connStatAttempted && st.localSynState.isSynAcked() && st.remoteSynState.isSynAcked() {
 		st.tcpState = connStatEstablished
-		conn.Monotonic.TCPEstablished++
+		if st.hasMissedHandshake() {
+			statsTelemetry.missedTCPConnections.Inc()
+		} else {
+			conn.Monotonic.TCPEstablished++
+		}
 	}
 }
 
@@ -155,7 +164,7 @@ func (t *TCPProcessor) updateTCPStats(conn *network.ConnectionStats, st *connect
 		ackOutdated := !st.hasLocalAck || isSeqBefore(st.lastLocalAck, tcp.Ack)
 		if tcp.ACK && ackOutdated {
 			// wait until data comes in via synStateAcked
-			if st.hasLocalAck && st.remoteSynState == synStateAcked {
+			if st.hasLocalAck && st.remoteSynState.isSynAcked() {
 				ackDiff := tcp.Ack - st.lastLocalAck
 				isFinAck := st.hasRemoteFin && tcp.Ack == st.remoteFinSeq
 				if isFinAck {
@@ -259,4 +268,19 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, timestampNs uint64
 
 	t.conns[conn.ConnectionTuple] = st
 	return nil
+}
+
+// HasConnEstablished is used to avoid a connection appearing before the three-way handshake is complete.
+// This is done to mirror the behavior of ebpf tracing accept() and connect(), which both return
+// after the handshake is completed.
+func (t *TCPProcessor) HasConnEstablished(conn *network.ConnectionStats) bool {
+	st := t.conns[conn.ConnectionTuple]
+
+	// conn.Monotonic.TCPEstablished can be 0 even though isEstablished is true,
+	// because pre-existing connections don't increment TCPEstablished.
+	// That's why we use tcpState instead of conn
+	isEstablished := st.tcpState == connStatEstablished
+	// if the connection has closed in any way, report that too
+	hasEverClosed := conn.Monotonic.TCPClosed > 0 || len(conn.TCPFailures) > 0
+	return isEstablished || hasEverClosed
 }

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -185,8 +185,7 @@ func (t *ebpfLessTracer) processConnection(
 		return nil
 	}
 
-	isLoopback := t.scratchConn.Source.IsLoopback() && t.scratchConn.Dest.IsLoopback()
-	t.determineConnectionDirection(t.scratchConn, pktType, isLoopback)
+	t.determineConnectionDirection(t.scratchConn, pktType)
 	flipSourceDest(t.scratchConn, pktType)
 
 	t.m.Lock()
@@ -247,7 +246,7 @@ func flipSourceDest(conn *network.ConnectionStats, pktType uint8) {
 	}
 }
 
-func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionStats, pktType uint8, _isLoopback bool) {
+func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionStats, pktType uint8) {
 	t.m.Lock()
 	defer t.m.Unlock()
 

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -247,7 +247,7 @@ func flipSourceDest(conn *network.ConnectionStats, pktType uint8) {
 	}
 }
 
-func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionStats, pktType uint8, isLoopback bool) {
+func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionStats, pktType uint8, _isLoopback bool) {
 	t.m.Lock()
 	defer t.m.Unlock()
 

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -148,20 +148,23 @@ func (t *ebpfLessTracer) processConnection(
 	tcp *layers.TCP,
 	decoded []gopacket.LayerType,
 ) error {
+
 	t.scratchConn.Source, t.scratchConn.Dest = util.Address{}, util.Address{}
 	t.scratchConn.SPort, t.scratchConn.DPort = 0, 0
 	t.scratchConn.TCPFailures = make(map[uint16]uint32)
-	var udpPresent, tcpPresent bool
+	var ip4Present, ip6Present, udpPresent, tcpPresent bool
 	for _, layerType := range decoded {
 		switch layerType {
 		case layers.LayerTypeIPv4:
 			t.scratchConn.Source = util.AddressFromNetIP(ip4.SrcIP)
 			t.scratchConn.Dest = util.AddressFromNetIP(ip4.DstIP)
 			t.scratchConn.Family = network.AFINET
+			ip4Present = true
 		case layers.LayerTypeIPv6:
 			t.scratchConn.Source = util.AddressFromNetIP(ip6.SrcIP)
 			t.scratchConn.Dest = util.AddressFromNetIP(ip6.DstIP)
 			t.scratchConn.Family = network.AFINET6
+			ip6Present = true
 		case layers.LayerTypeTCP:
 			t.scratchConn.SPort = uint16(tcp.SrcPort)
 			t.scratchConn.DPort = uint16(tcp.DstPort)
@@ -175,15 +178,16 @@ func (t *ebpfLessTracer) processConnection(
 		}
 	}
 
-	// check if have all the basic pieces
+	// check if we have all the basic pieces
 	if !udpPresent && !tcpPresent {
 		log.Debugf("ignoring packet since its not udp or tcp")
 		ebpfLessTracerTelemetry.skippedPackets.Inc("not_tcp_udp")
 		return nil
 	}
 
+	isLoopback := t.scratchConn.Source.IsLoopback() && t.scratchConn.Dest.IsLoopback()
+	t.determineConnectionDirection(t.scratchConn, pktType, isLoopback)
 	flipSourceDest(t.scratchConn, pktType)
-	t.determineConnectionDirection(t.scratchConn, pktType)
 
 	t.m.Lock()
 	defer t.m.Unlock()
@@ -202,17 +206,17 @@ func (t *ebpfLessTracer) processConnection(
 		return fmt.Errorf("error getting last updated timestamp for connection: %w", err)
 	}
 
-	if ip4 == nil && ip6 == nil {
+	if !ip4Present && !ip6Present {
 		return nil
 	}
 	switch conn.Type {
 	case network.UDP:
-		if (ip4 != nil && !t.config.CollectUDPv4Conns) || (ip6 != nil && !t.config.CollectUDPv6Conns) {
+		if (ip4Present && !t.config.CollectUDPv4Conns) || (ip6Present && !t.config.CollectUDPv6Conns) {
 			return nil
 		}
 		err = t.udp.process(conn, pktType, udp)
 	case network.TCP:
-		if (ip4 != nil && !t.config.CollectTCPv4Conns) || (ip6 != nil && !t.config.CollectTCPv6Conns) {
+		if (ip4Present && !t.config.CollectTCPv4Conns) || (ip6Present && !t.config.CollectTCPv6Conns) {
 			return nil
 		}
 		err = t.tcp.Process(conn, uint64(ts), pktType, ip4, ip6, tcp)
@@ -224,8 +228,11 @@ func (t *ebpfLessTracer) processConnection(
 		return fmt.Errorf("error processing connection: %w", err)
 	}
 
-	conn.LastUpdateEpoch = uint64(ts)
-	t.conns[t.scratchConn.ConnectionTuple] = conn
+	// TODO probably remove HasConnEverEstablished once we handle closed connections properly
+	if conn.Type == network.UDP || (conn.Type == network.TCP && t.tcp.HasConnEverEstablished(conn)) {
+		conn.LastUpdateEpoch = uint64(ts)
+		t.conns[t.scratchConn.ConnectionTuple] = conn
+	}
 
 	log.TraceFunc(func() string {
 		return fmt.Sprintf("connection: %s", conn)
@@ -240,29 +247,28 @@ func flipSourceDest(conn *network.ConnectionStats, pktType uint8) {
 	}
 }
 
-func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionStats, pktType uint8) {
-	t.m.Lock()
-	defer t.m.Unlock()
-
-	ok := t.boundPorts.Find(conn.Type, conn.SPort)
-	if ok {
-		// incoming connection
-		conn.Direction = network.INCOMING
+func (t *ebpfLessTracer) determineConnectionDirection(conn *network.ConnectionStats, pktType uint8, isLoopback bool) {
+	// Loopback interfaces show up twice in packet capture (once incoming, once outgoing).
+	// Similarly, in our tracer, a local connection creates two ConnectionStats: one for the server, one for the client.
+	// So we can just take the pktType and pass it through, it will properly get us both sides
+	if isLoopback {
+		switch pktType {
+		case unix.PACKET_HOST:
+			conn.Direction = network.INCOMING
+		case unix.PACKET_OUTGOING:
+			conn.Direction = network.OUTGOING
+		}
 		return
 	}
-	// only used for local connections - "outgoing" local packets
-	if conn.Dest.IsLoopback() {
-		ok := t.boundPorts.Find(conn.Type, conn.DPort)
-		if ok {
-			conn.Direction = network.OUTGOING
-			return
-		}
-	}
 
-	switch pktType {
-	case unix.PACKET_HOST:
+	t.m.Lock()
+	defer t.m.Unlock()
+	// For external traffic, we need to compare against bound ports to determine the correct direction
+	isIncoming := t.boundPorts.Find(conn.Type, conn.SPort)
+	if isIncoming {
+		// incoming connection
 		conn.Direction = network.INCOMING
-	case unix.PACKET_OUTGOING:
+	} else {
 		conn.Direction = network.OUTGOING
 	}
 }
@@ -291,9 +297,6 @@ func (t *ebpfLessTracer) GetConnections(buffer *network.ConnectionBuffer, filter
 	log.Trace(t.conns)
 	conns := make([]network.ConnectionStats, 0, len(t.conns))
 	for _, c := range t.conns {
-		if c.Type == network.TCP && !t.tcp.HasConnEstablished(c) {
-			continue
-		}
 		if filter != nil && !filter(c) {
 			continue
 		}

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1130,6 +1130,7 @@ func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
 	c, err := net.DialTimeout("tcp", server.Address(), 50*time.Millisecond)
 	require.NoError(t, err)
 	laddr, raddr := c.LocalAddr(), c.RemoteAddr()
+	t.Logf("laddr=%s raddr=%s", laddr, raddr)
 
 	// Ensure closed connections are flushed as soon as possible
 	cfg := testConfig()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes `TestPreexistingConnectionDirection`, `TestPreexistingEmptyIncomingConnectionDirection`, and `TestTCPEstablishedPreExistingConn`
### Motivation
Want the whole suite to pass for kernel matrix testing
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run the tracer test suite:
```
DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless
```
Run just the TCP processor unit tests:
```
go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer/connection/ebpfless
```
### Possible Drawbacks / Trade-offs
This PR changes how connections are populated slightly (via `HasConnEstablished`). It adds a filter to `GetConnections` to try to hold onto `ConnectionStats` before the connection is established (for the sake of preexisting connections).
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->