### PR TITLE
pkg/languagedetection: extract mock function from privileged detector

### DIFF
--- a/pkg/languagedetection/privileged/privileged_detector.go
+++ b/pkg/languagedetection/privileged/privileged_detector.go
@@ -18,7 +18,6 @@ import (
 	"strconv"
 	"sync"
 	"syscall"
-	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 
@@ -105,13 +104,6 @@ func (l *LanguageDetector) DetectWithPrivileges(procs []languagemodels.Process) 
 		l.mux.Unlock()
 	}
 	return languages
-}
-
-// MockPrivilegedDetectors is used in tests to inject mock tests. It should be called before `DetectWithPrivileges`
-func MockPrivilegedDetectors(t *testing.T, newDetectors []languagemodels.Detector) {
-	oldDetectors := detectorsWithPrivilege
-	t.Cleanup(func() { detectorsWithPrivilege = oldDetectors })
-	detectorsWithPrivilege = newDetectors
 }
 
 func (l *LanguageDetector) getBinID(process languagemodels.Process) (binaryID, error) {

--- a/pkg/languagedetection/privileged/privileged_detector_testutil.go
+++ b/pkg/languagedetection/privileged/privileged_detector_testutil.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && test
+
+// Package privileged implements language detection that relies on elevated permissions.
+//
+// An example of privileged language detection would be binary analysis, where the binary must be
+// inspected to determine the language it was compiled from.
+package privileged
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/languagedetection/languagemodels"
+)
+
+// MockPrivilegedDetectors is used in tests to inject mock tests. It should be called before `DetectWithPrivileges`
+func MockPrivilegedDetectors(t *testing.T, newDetectors []languagemodels.Detector) {
+	oldDetectors := detectorsWithPrivilege
+	t.Cleanup(func() { detectorsWithPrivilege = oldDetectors })
+	detectorsWithPrivilege = newDetectors
+}

--- a/pkg/languagedetection/privileged/privileged_detector_testutil.go
+++ b/pkg/languagedetection/privileged/privileged_detector_testutil.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2024-present Datadog, Inc.
 
 //go:build linux && test
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`MockPrivilegedDetectors` takes a `testing.T` as argument, so it makes the whole package import "testing". This PR moves this function to a separate file, build gated to tests.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->