### PR TITLE
Fix require.Eventually gotchas

### DIFF
--- a/pkg/network/dns/snooper_test.go
+++ b/pkg/network/dns/snooper_test.go
@@ -230,7 +230,7 @@ func TestDNSFailedResponseCount(t *testing.T) {
 		"nonexistenent.net.com",
 		"missingdomain.com",
 	}
-	queryIP, queryPort, reps, _ := testdns.SendDNSQueries(t, domains, testdns.GetServerIP(t), "tcp")
+	queryIP, queryPort, reps, _ := testdns.SendDNSQueries(domains, testdns.GetServerIP(t), "tcp")
 	for _, rep := range reps {
 		require.NotNil(t, rep)
 		require.Equal(t, rep.Rcode, mdns.RcodeNameError) // All the queries should have failed
@@ -281,7 +281,7 @@ func TestDNSOverNonPort53(t *testing.T) {
 	shutdown, port := newTestServer(t, localhost, "udp")
 	defer shutdown()
 
-	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort(t, domains, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
+	queryIP, queryPort, reps, err := testdns.SendDNSQueriesOnPort(domains, net.ParseIP(localhost), strconv.Itoa(int(port)), "udp")
 	require.NoError(t, err)
 	require.NotNil(t, reps[0])
 
@@ -334,7 +334,7 @@ func TestDNSOverUDPTimeoutCount(t *testing.T) {
 
 	invalidServerIP := "8.8.8.90"
 	domainQueried := "agafsdfsdasdfsd"
-	queryIP, queryPort, reps, err := testdns.SendDNSQueries(t, []string{domainQueried}, net.ParseIP(invalidServerIP), "udp")
+	queryIP, queryPort, reps, err := testdns.SendDNSQueries([]string{domainQueried}, net.ParseIP(invalidServerIP), "udp")
 	require.ErrorIs(t, err, os.ErrDeadlineExceeded, "error should be i/o timeout")
 	require.Len(t, reps, 1)
 	require.Nil(t, reps[0])
@@ -358,7 +358,7 @@ func TestDNSOverUDPTimeoutCountWithoutDomain(t *testing.T) {
 
 	invalidServerIP := "8.8.8.90"
 	domainQueried := "agafsdfsdasdfsd"
-	queryIP, queryPort, reps, err := testdns.SendDNSQueries(t, []string{domainQueried}, net.ParseIP(invalidServerIP), "udp")
+	queryIP, queryPort, reps, err := testdns.SendDNSQueries([]string{domainQueried}, net.ParseIP(invalidServerIP), "udp")
 	require.ErrorIs(t, err, os.ErrDeadlineExceeded, "error should be i/o timeout")
 	require.Len(t, reps, 1)
 	require.Nil(t, reps[0])

--- a/pkg/network/tracer/testutil/testdns/test_dns_server.go
+++ b/pkg/network/tracer/testutil/testdns/test_dns_server.go
@@ -131,8 +131,7 @@ func respond(req *dns.Msg, writer dns.ResponseWriter, record string) {
 }
 
 // SendDNSQueriesOnPort makes a DNS query for every domain provided, on the given serverIP, port, and protocol.
-func SendDNSQueriesOnPort(t *testing.T, domains []string, serverIP net.IP, port string, protocol string) (string, int, []*dns.Msg, error) {
-	t.Helper()
+func SendDNSQueriesOnPort(domains []string, serverIP net.IP, port string, protocol string) (string, int, []*dns.Msg, error) {
 	dnsClient := dns.Client{Net: protocol, Timeout: 3 * time.Second}
 	dnsHost := net.JoinHostPort(serverIP.String(), port)
 	conn, err := dnsClient.Dial(dnsHost)
@@ -168,24 +167,21 @@ func SendDNSQueriesOnPort(t *testing.T, domains []string, serverIP net.IP, port 
 
 // SendDNSQueriesAndCheckError is a simple helper that requires no errors to be present when calling SendDNSQueries
 func SendDNSQueriesAndCheckError(
-	t *testing.T,
+	t require.TestingT,
 	domains []string,
 	serverIP net.IP,
 	protocol string,
 ) (string, int, []*dns.Msg) {
-	t.Helper()
-	ip, port, resp, err := SendDNSQueries(t, domains, serverIP, protocol)
+	ip, port, resp, err := SendDNSQueries(domains, serverIP, protocol)
 	require.NoError(t, err)
 	return ip, port, resp
 }
 
 // SendDNSQueries is a simple helper that calls SendDNSQueriesOnPort with port 53
 func SendDNSQueries(
-	t *testing.T,
 	domains []string,
 	serverIP net.IP,
 	protocol string,
 ) (string, int, []*dns.Msg, error) {
-	t.Helper()
-	return SendDNSQueriesOnPort(t, domains, serverIP, "53", protocol)
+	return SendDNSQueriesOnPort(domains, serverIP, "53", protocol)
 }

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -726,7 +726,7 @@ func (s *TracerSuite) TestGatewayLookupEnabled() {
 	var clientIP string
 	var clientPort int
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		clientIP, clientPort, _, err = testdns.SendDNSQueries(t, []string{"google.com"}, dnsAddr, "udp")
+		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{"google.com"}, dnsAddr, "udp")
 		assert.NoError(c, err)
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
@@ -783,7 +783,7 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 	var clientIP string
 	var clientPort int
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		clientIP, clientPort, _, err = testdns.SendDNSQueries(t, []string{destDomain}, destAddr, "udp")
+		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{destDomain}, destAddr, "udp")
 		assert.NoError(c, err)
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
@@ -798,7 +798,7 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 	require.Nil(t, c.Via)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		clientIP, clientPort, _, err = testdns.SendDNSQueries(t, []string{destDomain}, destAddr, "udp")
+		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{destDomain}, destAddr, "udp")
 		assert.NoError(c, err)
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
@@ -957,7 +957,7 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 		var clientPort int
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			kernel.WithNS(test2Ns, func() error {
-				clientIP, clientPort, _, err = testdns.SendDNSQueries(t, []string{"google.com"}, dnsAddr, "udp")
+				clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{"google.com"}, dnsAddr, "udp")
 				return nil
 			})
 			assert.NoError(c, err)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -726,9 +726,9 @@ func (s *TracerSuite) TestGatewayLookupEnabled() {
 
 	var clientIP string
 	var clientPort int
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{"google.com"}, dnsAddr, "udp")
-		return err == nil
+		assert.NoError(c, err)
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 	dnsClientAddr := &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}
@@ -783,9 +783,9 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 
 	var clientIP string
 	var clientPort int
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{destDomain}, destAddr, "udp")
-		return err == nil
+		assert.NoError(c, err)
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 	dnsClientAddr := &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}
@@ -798,9 +798,9 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 	}, 3*time.Second, 100*time.Millisecond, "connection not found")
 	require.Nil(t, c.Via)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{destDomain}, destAddr, "udp")
-		return err == nil
+		assert.NoError(c, err)
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 	dnsClientAddr = &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}
@@ -958,12 +958,12 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 		var dnsClientAddr, dnsServerAddr *net.UDPAddr
 		var clientIP string
 		var clientPort int
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			kernel.WithNS(test2Ns, func() error {
 				clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{"google.com"}, dnsAddr, "udp")
 				return nil
 			})
-			return err == nil
+			assert.NoError(c, err)
 		}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 		dnsClientAddr = &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -174,7 +174,7 @@ func (s *TracerSuite) TestTCPRetransmit() {
 	var conn *network.ConnectionStats
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// Iterate through active connections until we find connection created above, and confirm send + recv counts
-		connections := getConnections(t, tr)
+		connections := getConnections(ct, tr)
 
 		ok := false
 		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
@@ -185,7 +185,7 @@ func (s *TracerSuite) TestTCPRetransmit() {
 		assert.Equal(ct, 100*clientMessageSize, int(conn.Monotonic.SentBytes))
 		assert.Equal(ct, serverMessageSize, int(conn.Monotonic.RecvBytes))
 		if !tr.config.EnableEbpfless {
-			assert.Equal(t, os.Getpid(), int(conn.Pid))
+			assert.Equal(ct, os.Getpid(), int(conn.Pid))
 		}
 
 		assert.Equal(ct, addrPort(server.Address()), int(conn.DPort))
@@ -308,7 +308,7 @@ func (s *TracerSuite) TestTCPRTT() {
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// Fetch connection matching source and target address
-		allConnections := getConnections(t, tr)
+		allConnections := getConnections(ct, tr)
 		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), allConnections)
 		if !assert.True(ct, ok) {
 			return
@@ -478,7 +478,7 @@ func (s *TracerSuite) TestConntrackExpiration() {
 			return
 		}
 
-		connections := getConnections(t, tr)
+		connections := getConnections(collect, tr)
 		t.Log(connections) // for debugging failures
 		var ok bool
 		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
@@ -541,10 +541,11 @@ func (s *TracerSuite) TestConntrackDelays() {
 	_, err = c.Write([]byte("ping"))
 	require.NoError(t, err)
 
-	require.Eventually(t, func() bool {
-		connections := getConnections(t, tr)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		connections := getConnections(collect, tr)
 		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		return ok && tr.conntracker.GetTranslationForConn(&conn.ConnectionTuple) != nil
+		require.True(collect, ok)
+		require.NotNil(collect, tr.conntracker.GetTranslationForConn(&conn.ConnectionTuple))
 	}, 3*time.Second, 100*time.Millisecond, "failed to find connection with translation")
 
 	// write newline so server connections will exit
@@ -629,7 +630,7 @@ func (s *TracerSuite) TestUnconnectedUDPSendIPv6() {
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		connections := getConnections(t, tr)
+		connections := getConnections(ct, tr)
 		outgoing := network.FilterConnections(connections, func(cs network.ConnectionStats) bool {
 			if cs.Type != network.UDP {
 				return false
@@ -725,9 +726,9 @@ func (s *TracerSuite) TestGatewayLookupEnabled() {
 
 	var clientIP string
 	var clientPort int
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.Eventually(t, func() bool {
 		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{"google.com"}, dnsAddr, "udp")
-		assert.NoError(c, err)
+		return err == nil
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 	dnsClientAddr := &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}
@@ -782,9 +783,9 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 
 	var clientIP string
 	var clientPort int
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.Eventually(t, func() bool {
 		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{destDomain}, destAddr, "udp")
-		assert.NoError(c, err)
+		return err == nil
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 	dnsClientAddr := &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}
@@ -797,9 +798,9 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 	}, 3*time.Second, 100*time.Millisecond, "connection not found")
 	require.Nil(t, c.Via)
 
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.Eventually(t, func() bool {
 		clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{destDomain}, destAddr, "udp")
-		assert.NoError(c, err)
+		return err == nil
 	}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 	dnsClientAddr = &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}
@@ -906,12 +907,13 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 		_, err = c.Write([]byte("foo"))
 		require.NoError(t, err)
 
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			var ok bool
-			conns := getConnections(t, tr)
+			conns := getConnections(collect, tr)
 			t.Log(conns)
 			conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-			return ok && conn.Direction == network.OUTGOING
+			require.True(collect, ok)
+			require.Equal(collect, network.OUTGOING, conn.Direction)
 		}, 3*time.Second, 100*time.Millisecond)
 
 		// conn.Via should be nil, since traffic is local
@@ -939,12 +941,13 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 		require.NoError(t, err)
 
 		var conn *network.ConnectionStats
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			var ok bool
-			conns := getConnections(t, tr)
+			conns := getConnections(collect, tr)
 			t.Log(conns)
 			conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-			return ok && conn.Direction == network.OUTGOING
+			require.True(collect, ok)
+			require.Equal(collect, network.OUTGOING, conn.Direction)
 		}, 3*time.Second, 100*time.Millisecond)
 
 		// traffic is local, so Via field should not be set
@@ -955,12 +958,12 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 		var dnsClientAddr, dnsServerAddr *net.UDPAddr
 		var clientIP string
 		var clientPort int
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Eventually(t, func() bool {
 			kernel.WithNS(test2Ns, func() error {
 				clientIP, clientPort, _, err = testdns.SendDNSQueries([]string{"google.com"}, dnsAddr, "udp")
 				return nil
 			})
-			assert.NoError(c, err)
+			return err == nil
 		}, 6*time.Second, 100*time.Millisecond, "failed to send dns query")
 
 		dnsClientAddr = &net.UDPAddr{IP: net.ParseIP(clientIP), Port: clientPort}
@@ -969,10 +972,11 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 		iif := ipRouteGet(t, "", dnsClientAddr.IP.String(), nil)
 		ifi := ipRouteGet(t, dnsClientAddr.IP.String(), dnsAddr.String(), iif)
 
-		require.Eventually(t, func() bool {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			var ok bool
-			conn, ok = findConnection(dnsClientAddr, dnsServerAddr, getConnections(t, tr))
-			return ok && conn.Direction == network.OUTGOING
+			conn, ok = findConnection(dnsClientAddr, dnsServerAddr, getConnections(collect, tr))
+			require.True(collect, ok)
+			require.Equal(collect, network.OUTGOING, conn.Direction)
 		}, 3*time.Second, 100*time.Millisecond)
 
 		require.NotNil(t, conn.Via)
@@ -1012,16 +1016,15 @@ func (s *TracerSuite) TestConnectionAssured() {
 		require.NoError(t, err)
 	}
 
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
-		var ok bool
-		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		return ok && conn.Monotonic.SentBytes > 0 && conn.Monotonic.RecvBytes > 0
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
+		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		require.True(collect, ok)
+		require.Positive(collect, conn.Monotonic.SentBytes)
+		require.Positive(collect, conn.Monotonic.RecvBytes)
+		// verify the connection is marked as assured
+		require.True(collect, conn.IsAssured)
 	}, 3*time.Second, 100*time.Millisecond, "could not find udp connection")
-
-	// verify the connection is marked as assured
-	require.True(t, conn.IsAssured)
 }
 
 func (s *TracerSuite) TestConnectionNotAssured() {
@@ -1047,16 +1050,15 @@ func (s *TracerSuite) TestConnectionNotAssured() {
 	_, err = c.Write(genPayload(clientMessageSize))
 	require.NoError(t, err)
 
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
-		var ok bool
-		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		return ok && conn.Monotonic.SentBytes > 0 && conn.Monotonic.RecvBytes == 0
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
+		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		require.True(collect, ok)
+		require.Positive(collect, conn.Monotonic.SentBytes)
+		require.Zero(collect, conn.Monotonic.RecvBytes)
+		// verify the connection is marked as not assured
+		require.False(collect, conn.IsAssured)
 	}, 3*time.Second, 100*time.Millisecond, "could not find udp connection")
-
-	// verify the connection is marked as not assured
-	require.False(t, conn.IsAssured)
 }
 
 func (s *TracerSuite) TestUDPConnExpiryTimeout() {
@@ -1111,19 +1113,15 @@ func (s *TracerSuite) TestDNATIntraHostIntegration() {
 	})
 
 	var incoming, outgoing *network.ConnectionStats
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err = conn.Write([]byte("ping"))
-		if !assert.NoError(t, err, "error writing in client") {
-			return false
-		}
+		require.NoError(collect, err)
 
 		bs := make([]byte, 4)
 		_, err = conn.Read(bs)
-		if !assert.NoError(t, err) {
-			return false
-		}
+		require.NoError(collect, err)
 
-		conns := getConnections(t, tr)
+		conns := getConnections(collect, tr)
 		t.Log(conns)
 
 		outgoing, _ = findConnection(conn.LocalAddr(), conn.RemoteAddr(), conns)
@@ -1131,7 +1129,9 @@ func (s *TracerSuite) TestDNATIntraHostIntegration() {
 
 		t.Logf("incoming: %+v, outgoing: %+v", incoming, outgoing)
 
-		return outgoing != nil && incoming != nil && outgoing.IPTranslation != nil
+		require.NotNil(collect, outgoing)
+		require.NotNil(collect, incoming)
+		require.NotNil(collect, outgoing.IPTranslation)
 	}, 3*time.Second, 100*time.Millisecond, "failed to get both incoming and outgoing connection")
 
 	assert.True(t, outgoing.IntraHost, "did not find outgoing connection classified as local: %v", outgoing)
@@ -1175,13 +1175,13 @@ func (s *TracerSuite) TestSelfConnect() {
 
 	t.Logf("port is %d", port)
 
-	require.Eventually(t, func() bool {
-		conns := network.FilterConnections(getConnections(t, tr), func(cs network.ConnectionStats) bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := network.FilterConnections(getConnections(collect, tr), func(cs network.ConnectionStats) bool {
 			return cs.SPort == uint16(port) && cs.DPort == uint16(port) && cs.Source.IsLoopback() && cs.Dest.IsLoopback()
 		})
 
 		t.Logf("connections: %v", conns)
-		return len(conns) == 2
+		require.Len(collect, conns, 2)
 	}, 5*time.Second, 100*time.Millisecond, "could not find expected number of tcp connections, expected: 2")
 }
 
@@ -1277,8 +1277,8 @@ func testUDPPeekCount(t *testing.T, udpnet, ip string) {
 
 	var incoming *network.ConnectionStats
 	var outgoing *network.ConnectionStats
-	require.Eventuallyf(t, func() bool {
-		conns := getConnections(t, tr)
+	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
 		if outgoing == nil {
 			outgoing, _ = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
 		}
@@ -1286,7 +1286,8 @@ func testUDPPeekCount(t *testing.T, udpnet, ip string) {
 			incoming, _ = findConnection(c.RemoteAddr(), c.LocalAddr(), conns)
 		}
 
-		return outgoing != nil && incoming != nil
+		require.NotNil(collect, outgoing)
+		require.NotNil(collect, incoming)
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find incoming and outgoing connections matching")
 
 	m := outgoing.Monotonic
@@ -1343,8 +1344,8 @@ func testUDPPacketSumming(t *testing.T, udpnet, ip string) {
 
 	var incoming *network.ConnectionStats
 	var outgoing *network.ConnectionStats
-	require.Eventuallyf(t, func() bool {
-		conns := getConnections(t, tr)
+	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
 		if outgoing == nil {
 			outgoing, _ = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
 		}
@@ -1352,7 +1353,8 @@ func testUDPPacketSumming(t *testing.T, udpnet, ip string) {
 			incoming, _ = findConnection(c.RemoteAddr(), c.LocalAddr(), conns)
 		}
 
-		return outgoing != nil && incoming != nil
+		require.NotNil(collect, outgoing)
+		require.NotNil(collect, incoming)
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find incoming and outgoing connections matching")
 
 	m := outgoing.Monotonic
@@ -1407,8 +1409,8 @@ func (s *TracerSuite) TestUDPPythonReusePort() {
 	t.Logf("port is %d", port)
 
 	conns := map[network.ConnectionTuple]network.ConnectionStats{}
-	require.Eventually(t, func() bool {
-		_conns := network.FilterConnections(getConnections(t, tr), func(cs network.ConnectionStats) bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_conns := network.FilterConnections(getConnections(collect, tr), func(cs network.ConnectionStats) bool {
 			return cs.Type == network.UDP &&
 				cs.Source.IsLoopback() &&
 				cs.Dest.IsLoopback() &&
@@ -1421,7 +1423,7 @@ func (s *TracerSuite) TestUDPPythonReusePort() {
 
 		t.Log(conns)
 
-		return len(conns) == 4
+		require.Len(collect, conns, 4)
 	}, 3*time.Second, 100*time.Millisecond, "could not find expected number of udp connections, expected: 4")
 
 	var incoming, outgoing []network.ConnectionStats
@@ -1781,15 +1783,12 @@ func (s *TracerSuite) TestSendfileError() {
 
 	c.Close()
 
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
-		var ok bool
-		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		return ok
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
+		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		require.True(collect, ok)
+		require.Equalf(collect, int64(0), int64(conn.Monotonic.SentBytes), "sendfile data wasn't properly traced")
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection used by sendfile(2)")
-
-	assert.Equalf(t, int64(0), int64(conn.Monotonic.SentBytes), "sendfile data wasn't properly traced")
 }
 
 func sendFile(t *testing.T, c SyscallConn, f *os.File, offset *int64, count int) (int, error) {
@@ -1881,15 +1880,12 @@ func (s *TracerSuite) TestShortWrite() {
 	c, err := net.FileConn(f)
 	require.NoError(t, err)
 
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
-		var ok bool
-		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		return ok
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
+		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		require.True(collect, ok)
+		require.Equal(collect, sent, conn.Monotonic.SentBytes)
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection used by short write")
-
-	assert.Equal(t, sent, conn.Monotonic.SentBytes)
 }
 
 func (s *TracerSuite) TestKprobeAttachWithKprobeEvents() {
@@ -1972,14 +1968,11 @@ func (s *TracerSuite) TestBlockingReadCounts() {
 		assert.Equal(collect, 6, read)
 	}, 10*time.Second, 100*time.Millisecond, "failed to get required bytes")
 
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		var found bool
-		conn, found = findConnection(c.(*net.TCPConn).LocalAddr(), c.(*net.TCPConn).RemoteAddr(), getConnections(t, tr))
-		return found
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conn, found := findConnection(c.(*net.TCPConn).LocalAddr(), c.(*net.TCPConn).RemoteAddr(), getConnections(collect, tr))
+		require.True(collect, found)
+		require.Equal(collect, uint64(read), conn.Monotonic.RecvBytes)
 	}, 3*time.Second, 100*time.Millisecond)
-
-	assert.Equal(t, uint64(read), conn.Monotonic.RecvBytes)
 }
 
 func (s *TracerSuite) TestPreexistingConnectionDirection() {
@@ -2020,15 +2013,16 @@ func (s *TracerSuite) TestPreexistingConnectionDirection() {
 	c.Close()
 
 	var incoming, outgoing *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		connections := getConnections(t, tr)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		connections := getConnections(collect, tr)
 		if outgoing == nil {
 			outgoing, _ = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
 		}
 		if incoming == nil {
 			incoming, _ = findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
 		}
-		return incoming != nil && outgoing != nil
+		require.NotNil(collect, outgoing)
+		require.NotNil(collect, incoming)
 	}, 3*time.Second, 100*time.Millisecond, "could not find connection incoming and outgoing connections")
 
 	m := outgoing.Monotonic
@@ -2136,14 +2130,12 @@ func (s *TracerSuite) TestUDPIncomingDirectionFix() {
 	raddr, err := net.ResolveUDPAddr("udp", server.address)
 	require.NoError(t, err)
 
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
-		conn, _ = findConnection(net.UDPAddrFromAddrPort(ap), raddr, conns)
-		return conn != nil
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
+		conn, _ := findConnection(net.UDPAddrFromAddrPort(ap), raddr, conns)
+		require.NotNil(collect, conn)
+		require.Equal(collect, network.OUTGOING, conn.Direction)
 	}, 3*time.Second, 100*time.Millisecond)
-
-	assert.Equal(t, network.OUTGOING, conn.Direction)
 }
 
 func TestEbpfConntrackerFallback(t *testing.T) {
@@ -2413,31 +2405,24 @@ LOOP:
 	// get connections, the client connection will still
 	// not be in the closed state, so duration will the
 	// timestamp of when it was created
-	var conn *network.ConnectionStats
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		conns := getConnections(t, tr)
-		var found bool
-		conn, found = findConnection(c.LocalAddr(), srv.Addr(), conns)
-		assert.True(collect, found, "could not find connection")
-
+		conns := getConnections(collect, tr)
+		conn, found := findConnection(c.LocalAddr(), srv.Addr(), conns)
+		require.True(collect, found, "could not find connection")
+		// all we can do is verify it is > 0
+		require.Greater(collect, conn.Duration, time.Duration(0))
 	}, 3*time.Second, 100*time.Millisecond, "could not find connection")
-	// all we can do is verify it is > 0
-	assert.Greater(t, conn.Duration, time.Duration(0))
 
 	require.NoError(t, c.Close(), "error closing client connection")
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		var found bool
-		conn, found = findConnection(c.LocalAddr(), srv.Addr(), getConnections(t, tr))
-		if !assert.True(collect, found, "could not find connection") {
-			return
-		}
-		assert.True(collect, conn.IsClosed, "connection should be closed")
+		conn, found := findConnection(c.LocalAddr(), srv.Addr(), getConnections(t, tr))
+		require.True(collect, found, "could not find connection")
+		require.True(collect, conn.IsClosed, "connection should be closed")
+		// after closing the client connection, the duration should be
+		// updated to a value between 1s and 2s
+		require.Greater(collect, conn.Duration, time.Second, "connection duration should be between 1 and 2 seconds")
+		require.Less(collect, conn.Duration, 2*time.Second, "connection duration should be between 1 and 2 seconds")
 	}, 3*time.Second, 100*time.Millisecond, "could not find closed connection")
-
-	// after closing the client connection, the duration should be
-	// updated to a value between 1s and 2s
-	assert.Greater(t, conn.Duration, time.Second, "connection duration should be between 1 and 2 seconds")
-	assert.Less(t, conn.Duration, 2*time.Second, "connection duration should be between 1 and 2 seconds")
 }
 
 var failedConnectionsBuildModes = map[ebpftest.BuildMode]struct{}{
@@ -2503,19 +2488,17 @@ func (s *TracerSuite) TestTCPFailureConnectionTimeout() {
 	localAddr := fmt.Sprintf("127.0.0.1:%d", port)
 
 	// Check if the connection was recorded as failed due to timeout
-	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
 		// 110 is the errno for ETIMEDOUT
-		conn = findFailedConnection(t, localAddr, srvAddr, conns, 110)
-		return conn != nil
+		conn := findFailedConnection(t, localAddr, srvAddr, conns, 110)
+		require.NotNil(collect, conn)
+		assert.Equal(collect, uint32(0), conn.TCPFailures[104], "expected 0 connection reset")
+		assert.Equal(collect, uint32(0), conn.TCPFailures[111], "expected 0 connection refused")
+		assert.Equal(collect, uint32(1), conn.TCPFailures[110], "expected 1 connection timeout")
+		assert.Equal(collect, uint64(0), conn.Monotonic.SentBytes, "expected 0 bytes sent")
+		assert.Equal(collect, uint64(0), conn.Monotonic.RecvBytes, "expected 0 bytes received")
 	}, 3*time.Second, 100*time.Millisecond, "Failed connection not recorded properly")
-
-	assert.Equal(t, uint32(0), conn.TCPFailures[104], "expected 0 connection reset")
-	assert.Equal(t, uint32(0), conn.TCPFailures[111], "expected 0 connection refused")
-	assert.Equal(t, uint32(1), conn.TCPFailures[110], "expected 1 connection timeout")
-	assert.Equal(t, uint64(0), conn.Monotonic.SentBytes, "expected 0 bytes sent")
-	assert.Equal(t, uint64(0), conn.Monotonic.RecvBytes, "expected 0 bytes received")
 }
 
 func (s *TracerSuite) TestTCPFailureConnectionResetWithDNAT() {
@@ -2561,10 +2544,11 @@ func (s *TracerSuite) TestTCPFailureConnectionResetWithDNAT() {
 
 	// Check if the connection was recorded as reset
 	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		// 104 is the errno for ECONNRESET
-		conn = findFailedConnection(t, c.LocalAddr().String(), serverAddr, getConnections(t, tr), 104)
-		return conn != nil
+		// findFailedConnection gets `t` as it needs to log, it does not assert so no conversion is needed.
+		conn = findFailedConnection(t, c.LocalAddr().String(), serverAddr, getConnections(collect, tr), 104)
+		require.NotNil(collect, conn)
 	}, 3*time.Second, 100*time.Millisecond, "Failed connection not recorded properly")
 
 	require.NoError(t, c.Close(), "error closing client connection")

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -198,12 +198,13 @@ func (s *TracerSuite) TestTCPSendAndReceive() {
 	require.NoError(t, err)
 
 	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		// Iterate through active connections until we find connection created above, and confirm send + recv counts
-		connections := getConnections(t, tr)
+		connections := getConnections(collect, tr)
 		var ok bool
 		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		return conn != nil && ok
+		require.True(collect, ok)
+		require.NotNil(collect, conn)
 	}, 3*time.Second, 100*time.Millisecond, "failed to find connection")
 
 	m := conn.Monotonic
@@ -246,10 +247,10 @@ func (s *TracerSuite) TestTCPShortLived() {
 	c.Close()
 
 	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		var ok bool
-		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), getConnections(t, tr))
-		return ok
+		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), getConnections(collect, tr))
+		require.True(collect, ok)
 	}, 3*time.Second, 100*time.Millisecond, "connection not found")
 
 	m := conn.Monotonic
@@ -399,14 +400,15 @@ func (s *TracerSuite) TestTCPConnsReported() {
 	var reverse *network.ConnectionStats
 	var okForward, okReverse bool
 	// for ebpfless, it takes time for the packet capture to arrive, so poll
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		// Test
-		connections := getConnections(t, tr)
+		connections := getConnections(collect, tr)
 		// Server-side
 		forward, okForward = findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		require.True(collect, okForward)
 		// Client-side
 		reverse, okReverse = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		return okForward && okReverse
+		require.True(collect, okReverse)
 	}, 3*time.Second, 100*time.Millisecond, "connection not found")
 
 	assert.Equal(t, network.INCOMING, forward.Direction)
@@ -470,7 +472,7 @@ func testUDPSendAndReceive(t *testing.T, tr *Tracer, addr string) {
 	// Iterate through active connections until we find connection created above, and confirm send + recv counts
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// use t instead of ct because getConnections uses require (not assert), and we get a better error message
-		connections := getConnections(t, tr)
+		connections := getConnections(ct, tr)
 		incoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
 		if assert.True(ct, ok, "unable to find incoming connection") {
 			assert.Equal(ct, network.INCOMING, incoming.Direction)
@@ -482,12 +484,12 @@ func testUDPSendAndReceive(t *testing.T, tr *Tracer, addr string) {
 		}
 
 		outgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		if assert.True(t, ok, "unable to find outgoing connection") {
-			assert.Equal(t, network.OUTGOING, outgoing.Direction)
+		if assert.True(ct, ok, "unable to find outgoing connection") {
+			assert.Equal(ct, network.OUTGOING, outgoing.Direction)
 
-			assert.Equal(t, clientMessageSize, int(outgoing.Monotonic.SentBytes), "outgoing sent")
-			assert.Equal(t, serverMessageSize, int(outgoing.Monotonic.RecvBytes), "outgoing recv")
-			assert.True(t, outgoing.IntraHost, "outgoing intrahost")
+			assert.Equal(ct, clientMessageSize, int(outgoing.Monotonic.SentBytes), "outgoing sent")
+			assert.Equal(ct, serverMessageSize, int(outgoing.Monotonic.RecvBytes), "outgoing recv")
+			assert.True(ct, outgoing.IntraHost, "outgoing intrahost")
 		}
 
 	}, 3*time.Second, 100*time.Millisecond)
@@ -579,14 +581,14 @@ func (s *TracerSuite) TestLocalDNSCollectionEnabled() {
 	assert.NoError(t, err)
 
 	// Iterate through active connections making sure theres at least one connection
-	require.Eventually(t, func() bool {
-		for _, c := range getConnections(t, tr).Conns {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		for _, c := range getConnections(collect, tr).Conns {
 			if isLocalDNS(c) {
-				return true
+				return
 			}
 		}
 
-		return false
+		require.Fail(collect, "could not find connection")
 	}, 3*time.Second, 100*time.Millisecond, "could not find connection")
 }
 
@@ -651,15 +653,15 @@ func (s *TracerSuite) TestShouldExcludeEmptyStatsConnection() {
 	assert.NoError(t, err)
 
 	var zeroConn network.ConnectionStats
-	require.Eventually(t, func() bool {
-		cxs := getConnections(t, tr)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		cxs := getConnections(collect, tr)
 		for _, c := range cxs.Conns {
 			if c.Dest.String() == "127.0.0.1" && c.DPort == 80 {
 				zeroConn = c
-				return true
+				return
 			}
 		}
-		return false
+		require.Fail(collect, "could not find connection")
 	}, 2*time.Second, 100*time.Millisecond)
 
 	// next call should not have the same connection
@@ -1094,9 +1096,9 @@ func (s *TracerSuite) TestTCPEstablished() {
 	var ok bool
 
 	// for ebpfless, wait for the packet capture to appear
-	require.Eventually(t, func() bool {
-		conn, ok = findConnection(laddr, raddr, getConnections(t, tr))
-		return ok
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conn, ok = findConnection(laddr, raddr, getConnections(collect, tr))
+		require.True(collect, ok)
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection")
 
 	require.True(t, ok)
@@ -1106,10 +1108,10 @@ func (s *TracerSuite) TestTCPEstablished() {
 	c.Close()
 
 	// Wait for the connection to be sent from the perf buffer
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		var ok bool
-		conn, ok = findConnection(laddr, raddr, getConnections(t, tr))
-		return ok
+		conn, ok = findConnection(laddr, raddr, getConnections(collect, tr))
+		require.True(collect, ok)
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection")
 
 	require.True(t, ok)
@@ -1140,10 +1142,10 @@ func (s *TracerSuite) TestTCPEstablishedPreExistingConn() {
 
 	// Wait for the connection to be sent from the perf buffer
 	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		var ok bool
-		conn, ok = findConnection(laddr, raddr, getConnections(t, tr))
-		return ok
+		conn, ok = findConnection(laddr, raddr, getConnections(collect, tr))
+		require.True(collect, ok)
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection")
 
 	m := conn.Monotonic
@@ -1167,7 +1169,7 @@ func (s *TracerSuite) TestUnconnectedUDPSendIPv4() {
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		connections := getConnections(t, tr)
+		connections := getConnections(ct, tr)
 		outgoing := network.FilterConnections(connections, func(cs network.ConnectionStats) bool {
 			return cs.DPort == uint16(remotePort)
 		})
@@ -1198,7 +1200,7 @@ func (s *TracerSuite) TestConnectedUDPSendIPv6() {
 
 	var outgoing []network.ConnectionStats
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		connections := getConnections(t, tr)
+		connections := getConnections(ct, tr)
 		outgoing = network.FilterConnections(connections, func(cs network.ConnectionStats) bool {
 			return cs.DPort == uint16(remotePort)
 		})
@@ -1247,8 +1249,8 @@ func (s *TracerSuite) TestTCPDirection() {
 	// Iterate through active connections until we find connection created above
 	var outgoingConns []network.ConnectionStats
 	var incomingConns []network.ConnectionStats
-	require.Eventuallyf(t, func() bool {
-		conns := getConnections(t, tr)
+	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
 		if len(outgoingConns) == 0 {
 			outgoingConns = network.FilterConnections(conns, func(cs network.ConnectionStats) bool {
 				return fmt.Sprintf("%s:%d", cs.Dest, cs.DPort) == serverAddr
@@ -1260,7 +1262,8 @@ func (s *TracerSuite) TestTCPDirection() {
 			})
 		}
 
-		return len(outgoingConns) == 1 && len(incomingConns) == 1
+		require.Len(collect, outgoingConns, 1)
+		require.Len(collect, incomingConns, 1)
 	}, 3*time.Second, 10*time.Millisecond, "couldn't find incoming and outgoing http connections matching: %s", serverAddr)
 
 	// Verify connection directions
@@ -1290,11 +1293,11 @@ func (s *TracerSuite) TestTCPFailureConnectionRefused() {
 
 	// Check if the connection was recorded as refused
 	var foundConn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
 		// Check for the refusal record
 		foundConn = findFailedConnectionByRemoteAddr(srvAddr, conns, 111)
-		return foundConn != nil
+		require.NotNil(collect, foundConn)
 	}, 3*time.Second, 100*time.Millisecond, "Failed connection not recorded properly")
 
 	assert.Equal(t, uint32(1), foundConn.TCPFailures[111], "expected 1 connection refused")
@@ -1342,10 +1345,11 @@ func (s *TracerSuite) TestTCPFailureConnectionResetWithData() {
 
 	// Check if the connection was recorded as reset
 	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		// 104 is the errno for ECONNRESET
-		conn = findFailedConnection(t, c.LocalAddr().String(), serverAddr, getConnections(t, tr), 104)
-		return conn != nil
+		// findFailedConnection needs `t` for logging, hence no need to pass `collect`.
+		conn = findFailedConnection(t, c.LocalAddr().String(), serverAddr, getConnections(collect, tr), 104)
+		require.NotNil(collect, conn)
 	}, 3*time.Second, 100*time.Millisecond, "Failed connection not recorded properly")
 
 	require.NoError(t, c.Close(), "error closing client connection")
@@ -1391,11 +1395,12 @@ func (s *TracerSuite) TestTCPFailureConnectionResetNoData() {
 
 	// Check if the connection was recorded as reset
 	var conn *network.ConnectionStats
-	require.Eventually(t, func() bool {
-		conns := getConnections(t, tr)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		conns := getConnections(collect, tr)
 		// 104 is the errno for ECONNRESET
+		// findFailedConnection needs `t` for logging, hence no need to pass `collect`.
 		conn = findFailedConnection(t, c.LocalAddr().String(), serverAddr, conns, 104)
-		return conn != nil
+		require.NotNil(collect, conn)
 	}, 3*time.Second, 100*time.Millisecond, "Failed connection not recorded properly")
 
 	require.NoError(t, c.Close(), "error closing client connection")

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -521,14 +521,14 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 						require.NoError(t, client.Client.ProduceSync(ctxTimeout, record).FirstErr(), "record had a produce error while synchronously producing")
 
 						var telemetryMap *kafka.RawKernelTelemetry
-						require.Eventually(t, func() bool {
+						require.EventuallyWithT(t, func(collect *assert.CollectT) {
 							telemetryMap, err = kafka.GetKernelTelemetryMap(monitor.ebpfProgram.Manager.Manager)
-							require.NoError(t, err)
+							require.NoError(collect, err)
 
 							// Ensure that the other buckets remain unchanged before verifying the expected bucket.
 							for idx := 0; idx < kafka.TopicNameBuckets; idx++ {
 								if idx != tt.expectedBucketIndex {
-									require.Equal(t, currentRawKernelTelemetry.Topic_name_size_buckets[idx],
+									require.Equal(collect, currentRawKernelTelemetry.Topic_name_size_buckets[idx],
 										telemetryMap.Topic_name_size_buckets[idx],
 										"Expected bucket (%d) to remain unchanged", idx)
 								}
@@ -536,7 +536,7 @@ func (s *KafkaProtocolParsingSuite) testKafkaProtocolParsing(t *testing.T, tls b
 
 							// Verify that the expected bucket contains the correct number of occurrences.
 							expectedNumberOfOccurrences := fixCount(2) // (1 produce request + 1 fetch request)
-							return uint64(expectedNumberOfOccurrences)+currentRawKernelTelemetry.Topic_name_size_buckets[tt.expectedBucketIndex] == telemetryMap.Topic_name_size_buckets[tt.expectedBucketIndex]
+							require.Equal(collect, uint64(expectedNumberOfOccurrences)+currentRawKernelTelemetry.Topic_name_size_buckets[tt.expectedBucketIndex], telemetryMap.Topic_name_size_buckets[tt.expectedBucketIndex])
 						}, time.Second*3, time.Millisecond*100)
 
 						// Update the current raw kernel telemetry for the next iteration

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -429,15 +429,14 @@ func (s *USMSuite) TestIgnoreTLSClassificationIfApplicationProtocolWasDetected()
 
 			// Perform the TLS handshake
 			require.NoError(t, tlsConn.Handshake())
-
-			require.Eventually(t, func() bool {
-				payload := getConnections(t, tr)
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				payload := getConnections(collect, tr)
 				for _, c := range payload.Conns {
 					if c.DPort == srvPortU16 || c.SPort == srvPortU16 {
-						return c.ProtocolStack.Contains(protocols.TLS) == tt.shouldBeTLS
+						require.Equal(collect, c.ProtocolStack.Contains(protocols.TLS), tt.shouldBeTLS)
 					}
 				}
-				return false
+				require.Fail(collect, "")
 			}, 10*time.Second, 100*time.Millisecond)
 		})
 	}
@@ -502,14 +501,14 @@ func (s *USMSuite) TestTLSClassification() {
 			},
 			validation: func(t *testing.T, tr *tracer.Tracer) {
 				// Iterate through active connections until we find connection created above
-				require.Eventuallyf(t, func() bool {
-					payload := getConnections(t, tr)
+				require.EventuallyWithTf(t, func(collect *assert.CollectT) {
+					payload := getConnections(collect, tr)
 					for _, c := range payload.Conns {
 						if c.DPort == port && c.ProtocolStack.Contains(protocols.TLS) {
-							return true
+							return
 						}
 					}
-					return false
+					require.Fail(collect, "")
 				}, 4*time.Second, 100*time.Millisecond, "couldn't find TLS connection matching: dst port %v", portAsString)
 			},
 		})
@@ -574,8 +573,8 @@ func (s *USMSuite) TestTLSClassificationAlreadyRunning() {
 
 	// Iterate through active connections until we find connection created above
 	var foundIncoming, foundOutgoing bool
-	require.Eventuallyf(t, func() bool {
-		payload := getConnections(t, tr)
+	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
+		payload := getConnections(collect, tr)
 
 		for _, c := range payload.Conns {
 			if !foundIncoming && c.DPort == uint16(portAsValue) && c.ProtocolStack.Contains(protocols.TLS) {
@@ -586,7 +585,8 @@ func (s *USMSuite) TestTLSClassificationAlreadyRunning() {
 				foundOutgoing = true
 			}
 		}
-		return foundIncoming && foundOutgoing
+		require.True(collect, foundIncoming)
+		require.True(collect, foundOutgoing)
 	}, 4*time.Second, 100*time.Millisecond, "couldn't find matching TLS connection")
 }
 

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -434,6 +434,7 @@ func (s *USMSuite) TestIgnoreTLSClassificationIfApplicationProtocolWasDetected()
 				for _, c := range payload.Conns {
 					if c.DPort == srvPortU16 || c.SPort == srvPortU16 {
 						require.Equal(collect, c.ProtocolStack.Contains(protocols.TLS), tt.shouldBeTLS)
+						return
 					}
 				}
 				require.Fail(collect, "")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Using `require.*` functions with `t *testing.T` inside `require.Eventually` will lead to early return (and test failure) even if the condition will be fulfilled in the next iteration. To use `require.*` methods inside `require.Eventually` we need to use `require.EventuallyWithT` and passed `collect *assert.CollectT` instead of `t *testing.T`. 

### Motivation

Fix possible test failures due to early abort.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->