### PR TITLE
usm: Move helper function to its only usage

### DIFF
--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -487,32 +487,6 @@ func (pm *ProcessMonitor) Stop() {
 	pm.processExitCallbacksMutex.Unlock()
 }
 
-// FindDeletedProcesses returns the terminated PIDs from the given map.
-func FindDeletedProcesses[V any](pids map[uint32]V) map[uint32]struct{} {
-	existingPids := make(map[uint32]struct{}, len(pids))
-
-	procIter := func(pid int) error {
-		if _, exists := pids[uint32(pid)]; exists {
-			existingPids[uint32(pid)] = struct{}{}
-		}
-		return nil
-	}
-	// Scanning already running processes
-	if err := kernel.WithAllProcs(kernel.ProcFSRoot(), procIter); err != nil {
-		return nil
-	}
-
-	res := make(map[uint32]struct{}, len(pids)-len(existingPids))
-	for pid := range pids {
-		if _, exists := existingPids[pid]; exists {
-			continue
-		}
-		res[pid] = struct{}{}
-	}
-
-	return res
-}
-
 // Event defines the event used by the process monitor
 type Event struct {
 	Type model.EventType


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Move findDeletedProcesses from pkg/process/monitor to pkg/network/usm/sharelibraries to be near its only usage in watcher.go

### Motivation

There's an one usage, move implementation near usage.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->