### PR TITLE
event monitor: tests: Allow setting cached hostname

### DIFF
--- a/pkg/ebpf/uprobes/attacher_test.go
+++ b/pkg/ebpf/uprobes/attacher_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	procmontestutil "github.com/DataDog/datadog-agent/pkg/process/monitor/testutil"
+	secutils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -799,6 +800,7 @@ func launchProcessMonitor(t *testing.T, useEventStream bool) *monitor.ProcessMon
 	t.Cleanup(pm.Stop)
 	require.NoError(t, pm.Initialize(useEventStream))
 	if useEventStream {
+		secutils.SetCachedHostname("test-hostname")
 		eventmonitortestutil.StartEventMonitor(t, procmontestutil.RegisterProcessMonitorEventConsumer)
 	}
 

--- a/pkg/eventmonitor/consumers/testutil/testutil.go
+++ b/pkg/eventmonitor/consumers/testutil/testutil.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/consumers"
-
 	eventtestutil "github.com/DataDog/datadog-agent/pkg/eventmonitor/testutil"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 const defaultChanSize = 100
@@ -25,6 +25,8 @@ const defaultChanSize = 100
 // created for testing. This function should be called in tests that require a ProcessConsumer.
 func NewTestProcessConsumer(t *testing.T) *consumers.ProcessConsumer {
 	var pc *consumers.ProcessConsumer
+	// Set fake hostname to avoid fetching it from the core agent.
+	utils.SetCachedHostname("test-hostname")
 	eventtestutil.StartEventMonitor(t, func(t *testing.T, evm *eventmonitor.EventMonitor) {
 		var err error
 		eventTypes := []consumers.ProcessConsumerEventTypes{consumers.ExecEventType, consumers.ExitEventType}

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -45,6 +45,7 @@ import (
 	usmtestutil "github.com/DataDog/datadog-agent/pkg/network/usm/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	procmontestutil "github.com/DataDog/datadog-agent/pkg/process/monitor/testutil"
+	secutils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	dockerutils "github.com/DataDog/datadog-agent/pkg/util/testutil/docker"
 )
@@ -869,6 +870,7 @@ func setupUSMTLSMonitor(t *testing.T, cfg *config.Config) *Monitor {
 	require.NoError(t, err)
 	require.NoError(t, usmMonitor.Start())
 	if cfg.EnableUSMEventStream && usmconfig.NeedProcessMonitor(cfg) {
+		secutils.SetCachedHostname("test-hostname")
 		eventmonitortestutil.StartEventMonitor(t, procmontestutil.RegisterProcessMonitorEventConsumer)
 	}
 	t.Cleanup(usmMonitor.Stop)

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -21,9 +21,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
@@ -33,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	procmontestutil "github.com/DataDog/datadog-agent/pkg/process/monitor/testutil"
+	secutils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -42,6 +42,7 @@ func launchProcessMonitor(t *testing.T, useEventStream bool) {
 	t.Cleanup(pm.Stop)
 	require.NoError(t, pm.Initialize(useEventStream))
 	if useEventStream {
+		secutils.SetCachedHostname("test-hostname")
 		eventmonitortestutil.StartEventMonitor(t, procmontestutil.RegisterProcessMonitorEventConsumer)
 	}
 }

--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	eventmonitortestutil "github.com/DataDog/datadog-agent/pkg/eventmonitor/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -55,6 +56,7 @@ func waitForProcessMonitor(t *testing.T, pm *ProcessMonitor) {
 func initializePM(t *testing.T, pm *ProcessMonitor, useEventStream bool) {
 	require.NoError(t, pm.Initialize(useEventStream))
 	if useEventStream {
+		utils.SetCachedHostname("test-hostname")
 		eventmonitortestutil.StartEventMonitor(t, func(t *testing.T, evm *eventmonitor.EventMonitor) {
 			// Can't use the implementation in procmontestutil due to import cycles
 			procmonconsumer, err := NewProcessMonitorEventConsumer(evm)

--- a/pkg/security/utils/hostname_testutil.go
+++ b/pkg/security/utils/hostname_testutil.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+package utils
+
+// SetCachedHostname test utility to set the cached hostname, to avoid fetching it from the core agent.
+func SetCachedHostname(name string) {
+	hostnameLock.Lock()
+	cachedHostname = name
+	hostnameLock.Unlock()
+}


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When creating spinning the event monitoring, we spend about 5s in each time for trying to fetch the hostname. Since we're in a test context we don't really care about the host name. We allow setting the cached hostname to spare the fetching process.

The PR modifies the NewTestProcessConsumer utility to make it automatic

### Motivation

Allow cutting 5s from every test that uses event monitor.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->