### PR TITLE
omnibus: snmp-traps: drop dependency on datadog-agent

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -221,9 +221,6 @@ end
 # ------------------------------------
 
 if do_build
-  # Include traps db file in snmp.d/traps_db/
-  dependency 'snmp-traps'
-
   # Datadog agent
   dependency 'datadog-agent'
 

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -33,6 +33,9 @@ dependency "systemd" if linux_target?
 
 dependency 'libpcap' if linux_target? and !heroku_target? # system-probe dependency
 
+# Include traps db file in snmp.d/traps_db/
+dependency 'snmp-traps'
+
 # Additional software
 if windows_target?
   if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -120,7 +120,7 @@ build do
 
   # move around bin and config files
   move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"
-  FileUtils.cp_r 'bin/agent/dist/conf.d/.', "#{conf_dir}"
+  copy 'bin/agent/dist/conf.d/.', "#{conf_dir}"
   delete 'bin/agent/dist/conf.d'
 
   unless windows_target?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -120,7 +120,7 @@ build do
 
   # move around bin and config files
   move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"
-  move 'bin/agent/dist/conf.d', "#{conf_dir}/"
+  move 'bin/agent/dist/conf.d/*', "#{conf_dir}/"
 
   unless windows_target?
     copy 'bin/agent', "#{install_dir}/bin/"

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -120,7 +120,7 @@ build do
 
   # move around bin and config files
   move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"
-  move 'bin/agent/dist/conf.d/*', "#{conf_dir}/"
+  FileUtils.cp_r 'bin/agent/dist/conf.d/.', "#{conf_dir}"
   delete 'bin/agent/dist/conf.d'
 
   unless windows_target?

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -121,6 +121,7 @@ build do
   # move around bin and config files
   move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"
   move 'bin/agent/dist/conf.d/*', "#{conf_dir}/"
+  delete 'bin/agent/dist/conf.d'
 
   unless windows_target?
     copy 'bin/agent', "#{install_dir}/bin/"

--- a/omnibus/config/software/snmp-traps.rb
+++ b/omnibus/config/software/snmp-traps.rb
@@ -1,9 +1,6 @@
 name "snmp-traps"
 default_version "0.4.0"
 
-# Needs the configuration folder as created in datadog-agent
-dependency 'datadog-agent'
-
 source :url => "https://s3.amazonaws.com/dd-agent-omnibus/snmp_traps_db/dd_traps_db-#{version}.json.gz",
        :sha256 => "04fb9d43754c2656edf35f08fbad11ba8dc20d52654962933f3dd8f4d463b42c",
        :target_filename => "dd_traps_db.json.gz"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove `snmp-traps` dependency on `datadog-agent`

### Motivation

We already ensure the target directory is created, which is the only reason for depending on datadog-agent
This will ensure snmp-traps gets cached correctly 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->