### PR TITLE
[bug] flake pod parse testing

### DIFF
--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
@@ -8,6 +8,7 @@
 package kubernetesresourceparsers
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,11 +17,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
 
 func TestPodParser_Parse(t *testing.T) {
-	flake.Mark(t)
 	filterAnnotations := []string{"ignoreAnnotation"}
 
 	parser, err := NewPodParser(filterAnnotations)
@@ -126,5 +125,6 @@ func TestPodParser_Parse(t *testing.T) {
 		QOSClass:                   "Guaranteed",
 	}
 
-	assert.Equal(t, expected, parsed)
+	assert.True(t, reflect.DeepEqual(expected, parsed),
+		"Expected: %v, Actual: %v", expected, parsed)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes pod comparison. `assert.Equal` causes issues when comparing structs that contain lists. Addresses [Mark TestPodParser test as flaky](https://github.com/DataDog/datadog-agent/pull/31811/files).

### Motivation

When you have test cases with metadata such as `GPUVendor = {"nvidia", "intel"}`, the order isn't guaranteed for the elements and hence causes `assert.Equal` to flake in some cases.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

N/A

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A