### PR TITLE
[CWS] Move tags from cgroup to tags resolver

### DIFF
--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // CacheEntry cgroup resolver cache entry
@@ -23,9 +22,8 @@ type CacheEntry struct {
 	model.CGroupContext
 	model.ContainerContext
 	sync.RWMutex
-	Deleted          *atomic.Bool
-	WorkloadSelector WorkloadSelector
-	PIDs             map[uint32]bool
+	Deleted *atomic.Bool
+	PIDs    map[uint32]bool
 }
 
 // NewCacheEntry returns a new instance of a CacheEntry
@@ -77,28 +75,4 @@ func (cgce *CacheEntry) AddPID(pid uint32) {
 	defer cgce.Unlock()
 
 	cgce.PIDs[pid] = true
-}
-
-// SetTags sets the tags for the provided workload
-func (cgce *CacheEntry) SetTags(tags []string) {
-	cgce.Lock()
-	defer cgce.Unlock()
-
-	cgce.Tags = tags
-	cgce.WorkloadSelector.Image = utils.GetTagValue("image_name", tags)
-	cgce.WorkloadSelector.Tag = utils.GetTagValue("image_tag", tags)
-	if len(cgce.WorkloadSelector.Image) != 0 && len(cgce.WorkloadSelector.Tag) == 0 {
-		cgce.WorkloadSelector.Tag = "latest"
-	}
-}
-
-// GetWorkloadSelectorCopy returns a copy of the workload selector of this cgroup
-func (cgce *CacheEntry) GetWorkloadSelectorCopy() *WorkloadSelector {
-	cgce.Lock()
-	defer cgce.Unlock()
-
-	return &WorkloadSelector{
-		Image: cgce.WorkloadSelector.Image,
-		Tag:   cgce.WorkloadSelector.Tag,
-	}
 }

--- a/pkg/security/resolvers/cgroup/model/types.go
+++ b/pkg/security/resolvers/cgroup/model/types.go
@@ -61,3 +61,11 @@ func (ws WorkloadSelector) ToTags() []string {
 		"image_tag:" + ws.Tag,
 	}
 }
+
+// Copy returns a copy of the selector
+func (ws WorkloadSelector) Copy() *WorkloadSelector {
+	return &WorkloadSelector{
+		Image: ws.Image,
+		Tag:   ws.Tag,
+	}
+}

--- a/pkg/security/resolvers/cgroup/model/types.go
+++ b/pkg/security/resolvers/cgroup/model/types.go
@@ -64,8 +64,5 @@ func (ws WorkloadSelector) ToTags() []string {
 
 // Copy returns a copy of the selector
 func (ws WorkloadSelector) Copy() *WorkloadSelector {
-	return &WorkloadSelector{
-		Image: ws.Image,
-		Tag:   ws.Tag,
-	}
+	return &ws
 }

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -486,15 +487,15 @@ func (r *Resolver) triggerScan(sbom *SBOM) {
 }
 
 // OnWorkloadSelectorResolvedEvent is used to handle the creation of a new cgroup with its resolved tags
-func (r *Resolver) OnWorkloadSelectorResolvedEvent(cgroup *cgroupModel.CacheEntry) {
+func (r *Resolver) OnWorkloadSelectorResolvedEvent(workload *tags.Workload) {
 	r.sbomsLock.Lock()
 	defer r.sbomsLock.Unlock()
 
-	if cgroup == nil {
+	if workload == nil {
 		return
 	}
 
-	id := cgroup.ContainerID
+	id := workload.ContainerID
 	// We don't scan hosts for now
 	if len(id) == 0 {
 		return
@@ -502,8 +503,8 @@ func (r *Resolver) OnWorkloadSelectorResolvedEvent(cgroup *cgroupModel.CacheEntr
 
 	_, ok := r.sboms[id]
 	if !ok {
-		workloadKey := getWorkloadKey(cgroup.GetWorkloadSelectorCopy())
-		sbom, err := r.newWorkloadEntry(id, cgroup, workloadKey)
+		workloadKey := getWorkloadKey(workload.Selector.Copy())
+		sbom, err := r.newWorkloadEntry(id, workload.CacheEntry, workloadKey)
 		if err != nil {
 			seclog.Errorf("couldn't create new SBOM entry for sbom '%s': %v", id, err)
 		}

--- a/pkg/security/resolvers/sbom/resolver_unsupported.go
+++ b/pkg/security/resolvers/sbom/resolver_unsupported.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
@@ -33,7 +34,7 @@ func (r *Resolver) OnCGroupDeletedEvent(_ *cgroupModel.CacheEntry) {
 }
 
 // OnWorkloadSelectorResolvedEvent is used to handle the creation of a new cgroup with its resolved tags
-func (r *Resolver) OnWorkloadSelectorResolvedEvent(_ *cgroupModel.CacheEntry) {
+func (r *Resolver) OnWorkloadSelectorResolvedEvent(_ *tags.Workload) {
 }
 
 // ResolvePackage returns the Package that owns the provided file

--- a/pkg/security/resolvers/tags/resolver.go
+++ b/pkg/security/resolvers/tags/resolver.go
@@ -21,6 +21,8 @@ type Event int
 const (
 	// WorkloadSelectorResolved is used to notify that a new cgroup with a resolved workload selector is ready
 	WorkloadSelectorResolved Event = iota
+	// WorkloadSelectorDeleted is used to notify that a cgroup with a resolved workload selector is deleted
+	WorkloadSelectorDeleted
 )
 
 // Tagger defines a Tagger for the Tags Resolver

--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -13,21 +13,26 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
-type pendingWorkload struct {
+// Workload represents a workload along with its tags
+type Workload struct {
 	*cgroupModel.CacheEntry
-	retries int
+	Tags     []string
+	Selector cgroupModel.WorkloadSelector
+	retries  int
 }
 
 // LinuxResolver represents a default resolver based directly on the underlying tagger
 type LinuxResolver struct {
 	*DefaultResolver
-	*utils.Notifier[Event, *cgroupModel.CacheEntry]
-	workloadsWithoutTags chan *pendingWorkload
+	*utils.Notifier[Event, *Workload]
+	workloadsWithoutTags chan *Workload
 	cgroupResolver       *cgroup.Resolver
+	workloads            map[containerutils.CGroupID]*Workload
 }
 
 // Start the resolver
@@ -37,8 +42,15 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 	}
 
 	if err := t.cgroupResolver.RegisterListener(cgroup.CGroupCreated, func(cgce *cgroupModel.CacheEntry) {
-		workload := &pendingWorkload{CacheEntry: cgce, retries: 3}
+		workload := &Workload{CacheEntry: cgce, retries: 3}
+		t.workloads[cgce.CGroupID] = workload
 		t.checkTags(workload)
+	}); err != nil {
+		return err
+	}
+
+	if err := t.cgroupResolver.RegisterListener(cgroup.CGroupDeleted, func(cgce *cgroupModel.CacheEntry) {
+		delete(t.workloads, cgce.CGroupID)
 	}); err != nil {
 		return err
 	}
@@ -73,17 +85,18 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 	return nil
 }
 
-func needsTagsResolution(cgce *cgroupModel.CacheEntry) bool {
-	return len(cgce.ContainerID) != 0 && !cgce.WorkloadSelector.IsReady()
+func needsTagsResolution(workload *Workload) bool {
+	return len(workload.ContainerID) != 0 && !workload.Selector.IsReady()
 }
 
 // checkTags checks if the tags of a workload were properly set
-func (t *LinuxResolver) checkTags(pendingWorkload *pendingWorkload) {
-	workload := pendingWorkload.CacheEntry
+func (t *LinuxResolver) checkTags(pendingWorkload *Workload) {
+	workload := pendingWorkload
 	// check if the workload tags were found or if it was deleted
 	if !workload.Deleted.Load() && needsTagsResolution(workload) {
 		// this is an alive cgroup, try to resolve its tags now
-		if err := t.fetchTags(workload); err != nil || needsTagsResolution(workload) {
+		err := t.fetchTags(workload)
+		if err != nil || needsTagsResolution(workload) {
 			if pendingWorkload.retries--; pendingWorkload.retries >= 0 {
 				// push to the workloadsWithoutTags chan so that its tags can be resolved later
 				select {
@@ -102,22 +115,29 @@ func (t *LinuxResolver) checkTags(pendingWorkload *pendingWorkload) {
 }
 
 // fetchTags fetches tags for the provided workload
-func (t *LinuxResolver) fetchTags(container *cgroupModel.CacheEntry) error {
-	newTags, err := t.ResolveWithErr(container.ContainerID)
+func (t *LinuxResolver) fetchTags(workload *Workload) error {
+	newTags, err := t.ResolveWithErr(workload.ContainerID)
 	if err != nil {
-		return fmt.Errorf("failed to resolve %s: %w", container.ContainerID, err)
+		return fmt.Errorf("failed to resolve %s: %w", workload.ContainerID, err)
 	}
-	container.SetTags(newTags)
+
+	workload.Selector.Image = utils.GetTagValue("image_name", newTags)
+	workload.Selector.Tag = utils.GetTagValue("image_tag", newTags)
+	if len(workload.Selector.Image) != 0 && len(workload.Selector.Tag) == 0 {
+		workload.Selector.Tag = "latest"
+	}
+
 	return nil
 }
 
 // NewResolver returns a new tags resolver
 func NewResolver(tagger Tagger, cgroupsResolver *cgroup.Resolver) *LinuxResolver {
 	resolver := &LinuxResolver{
-		Notifier:             utils.NewNotifier[Event, *cgroupModel.CacheEntry](),
+		Notifier:             utils.NewNotifier[Event, *Workload](),
 		DefaultResolver:      NewDefaultResolver(tagger),
-		workloadsWithoutTags: make(chan *pendingWorkload, 100),
+		workloadsWithoutTags: make(chan *Workload, 100),
 		cgroupResolver:       cgroupsResolver,
+		workloads:            make(map[containerutils.CGroupID]*Workload),
 	}
 	return resolver
 }

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
@@ -47,7 +48,7 @@ type ActivityDumpHandler interface {
 
 // SecurityProfileManager is a generic interface used to communicate with the Security Profile manager
 type SecurityProfileManager interface {
-	FetchSilentWorkloads() map[cgroupModel.WorkloadSelector][]*cgroupModel.CacheEntry
+	FetchSilentWorkloads() map[cgroupModel.WorkloadSelector][]*tags.Workload
 	OnLocalStorageCleanup(files []string)
 }
 

--- a/pkg/security/security_profile/profile/manager_test.go
+++ b/pkg/security/security_profile/profile/manager_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
@@ -841,14 +842,15 @@ func TestSecurityProfileManager_tryAutolearn(t *testing.T) {
 			if ti.newProfile || profile == nil {
 				profile = NewSecurityProfile(cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"}, []model.EventType{model.ExecEventType, model.DNSEventType}, nil)
 				profile.ActivityTree = activity_tree.NewActivityTree(profile, nil, "security_profile")
-				profile.Instances = append(profile.Instances, &cgroupModel.CacheEntry{
-					ContainerContext: model.ContainerContext{
+				profile.Instances = append(profile.Instances, &tags.Workload{
+					CacheEntry: &cgroupModel.CacheEntry{ContainerContext: model.ContainerContext{
 						ContainerID: containerutils.ContainerID(defaultContainerID),
 					},
-					CGroupContext: model.CGroupContext{
-						CGroupID: containerutils.CGroupID(defaultContainerID),
+						CGroupContext: model.CGroupContext{
+							CGroupID: containerutils.CGroupID(defaultContainerID),
+						},
 					},
-					WorkloadSelector: cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"},
+					Selector: cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"},
 				})
 				profile.loadedNano = uint64(t0.UnixNano())
 			}

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	mtdt "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree/metadata"
@@ -69,7 +70,7 @@ type SecurityProfile struct {
 	pathsReducer        *activity_tree.PathsReducer
 
 	// Instances is the list of workload instances to witch the profile should apply
-	Instances []*cgroupModel.CacheEntry
+	Instances []*tags.Workload
 
 	// Metadata contains metadata for the current profile
 	Metadata mtdt.Metadata

--- a/pkg/security/security_profile/tests/activity_tree_test.go
+++ b/pkg/security/security_profile/tests/activity_tree_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	cgroupModel "github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup/model"
+	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
@@ -692,12 +693,14 @@ func TestActivityTree_CreateProcessNode(t *testing.T) {
 								profile := profile.NewSecurityProfile(cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"}, []model.EventType{model.ExecEventType, model.DNSEventType}, nil)
 								at = activity_tree.NewActivityTree(profile, nil, "profile")
 								profile.ActivityTree = at
-								profile.Instances = append(profile.Instances, &cgroupModel.CacheEntry{
-									ContainerContext: model.ContainerContext{
-										ContainerID: containerutils.ContainerID(contID),
+								profile.Instances = append(profile.Instances, &tags.Workload{
+									CacheEntry: &cgroupModel.CacheEntry{
+										ContainerContext: model.ContainerContext{
+											ContainerID: containerutils.ContainerID(contID),
+										},
+										CGroupContext: model.CGroupContext{CGroupID: containerutils.CGroupID(contID)},
 									},
-									CGroupContext:    model.CGroupContext{CGroupID: containerutils.CGroupID(contID)},
-									WorkloadSelector: cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"},
+									Selector: cgroupModel.WorkloadSelector{Image: "image", Tag: "tag"},
 								})
 							}
 						} else { // retrieve last saved tree state


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Extract tags from cgroup resolver and move it to tags resolver.

### Motivation

This allows not having to deal with low level object (`cgroup.CacheEntry`) in activity dump and security profile managers.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->