### PR TITLE
[CONTP-521] use a hybrid health check for wlm kubeapiserver collector

### DIFF
--- a/comp/core/healthprobe/impl/healthprobe_test.go
+++ b/comp/core/healthprobe/impl/healthprobe_test.go
@@ -13,11 +13,12 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	healthprobeComponent "github.com/DataDog/datadog-agent/comp/core/healthprobe/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestServer(t *testing.T) {

--- a/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
+++ b/comp/core/workloadmeta/collectors/internal/kubeapiserver/kubeapiserver.go
@@ -224,7 +224,7 @@ func runStartupCheck(ctx context.Context, stores []*reflectorStore) {
 	// There is no way to ensure liveness correctly as it would need to be plugged inside the
 	// inner loop of Reflector.
 	// However, we add Startup when we got at least some data.
-	startupHealthCheck := health.RegisterStartup(componentName)
+	startupHealthCheck := health.RegisterReadiness(componentName, health.Once)
 
 	// Checked synced, in its own scope to cleanly un-reference the syncTimer
 	{

--- a/pkg/status/health/global.go
+++ b/pkg/status/health/global.go
@@ -12,21 +12,23 @@ import (
 
 var readinessAndLivenessCatalog = newCatalog()
 var readinessOnlyCatalog = newCatalog()
-var startupOnlyCatalog = newStartupCatalog()
+var startupOnlyCatalog = newCatalog()
 
 // RegisterReadiness registers a component for readiness check with the default 30 seconds timeout, returns a token
-func RegisterReadiness(name string) *Handle {
-	return readinessOnlyCatalog.register(name)
+func RegisterReadiness(name string, options ...Option) *Handle {
+	return readinessOnlyCatalog.register(name, options...)
 }
 
 // RegisterLiveness registers a component for liveness check with the default 30 seconds timeout, returns a token
-func RegisterLiveness(name string) *Handle {
-	return readinessAndLivenessCatalog.register(name)
+func RegisterLiveness(name string, options ...Option) *Handle {
+	return readinessAndLivenessCatalog.register(name, options...)
 }
 
 // RegisterStartup registers a component for startup check, returns a token
-func RegisterStartup(name string) *Handle {
-	return startupOnlyCatalog.register(name)
+func RegisterStartup(name string, options ...Option) *Handle {
+	// Startup health checks are registered with Once option because, by design, they should stop being checked
+	// once they are marked as healthy once
+	return startupOnlyCatalog.register(name, append(options, Once)...)
 }
 
 // Deregister a component from the healthcheck

--- a/pkg/status/health/health_test.go
+++ b/pkg/status/health/health_test.go
@@ -124,9 +124,9 @@ func TestGetHealthy(t *testing.T) {
 	assert.Len(t, status.Unhealthy, 0)
 }
 
-func TestStartupCatalog(t *testing.T) {
-	cat := newStartupCatalog()
-	token := cat.register("test1")
+func TestCatalogWithOnceComponent(t *testing.T) {
+	cat := newCatalog()
+	token := cat.register("test1", Once)
 
 	// Start unhealthy
 	status := cat.getStatus()

--- a/pkg/status/health/options.go
+++ b/pkg/status/health/options.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package health implements the internal healthcheck
+package health
+
+// Option represents the application of an option to a component's health check
+type Option func(*component)
+
+// Once has the effect of not checking the health of a component once it has been marked healthy once
+func Once(c *component) {
+	c.once = true
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replaces Startup health check of workloadmeta's kubeapiserver collector by a hybrid check between readiness and startup:
- if the check didn't pass yet, the DCA pod should be removed from the DCA service
- if the check didn't pass for some time, the DCA should not be killed and restarted.

### Motivation

Reduce CrashLoopbackOff issues faced in the DCA on large clusters due to the time it takes for the kubeapiserver workloadmeta collector to sync kubernetes resources and mark the check as ready.

Full context:

```
The main problem with using the Readiness probe is that it stays active for the entire lifecycle of the pod. This means that it will keep checking the Readiness probe even though the probe on `workloadmeta-kubeapiserver` was intended as a startup one. This could lead to the Cluster Agent being removed from the Kubernetes Service and therefor unreachable.

The Startup probe will pass once and after validation, be disabled by Kubernetes, fitting the use-case that we have for the `workloadmeta-kubeapiserver`.

The problem with this probe is that the impact is not the same. Instead of removing the pod for Kubernetes Services, the startup probe will, like the liveness one, try to restart the pod.

In specific cases like on large cluster, the `workloadmeta-kubeapiserver` can take more than the allocated time to be validated as the synchronization of the reflector is depends on the Kubernetes API Server. If that happens, then the Cluster Agent gets restarted.

Even worse, this could lead to CrashLoopBackOff as the Cluster Agent never has enough time to sync the reflectors before the probe fails.
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests are updated to test the new change.
We also already have E2E tests in place.

As an extra validation, you can deploy the cluster agent on a kubernetes cluster and ensure that you have the correct components healthy in liveness, readiness and startup endpoints:


```
# startup probe:
curl http://localhost:5556/start

{
  "Healthy":
    [
      "healthcheck",
      "tagger-store",
      "clusterchecks-leadership",
      "ad-config-provider-kubernetes-endpoints",
      "ad-config-provider-kubernetes-services",
      "clusterchecks-dispatch",
      "workloadmeta-puller",
      "ad-servicelistening",
      "workloadmeta-store",
      "tagger-workloadmeta",
      "collector-queue-15s",
      "aggregator",
    ],
  "Unhealthy": null,
}


# liveness probe:
curl http://localhost:5556/live

{
  "Healthy":
    [
      "healthcheck",
      "clusterchecks-leadership",
      "ad-config-provider-kubernetes-endpoints",
      "ad-config-provider-kubernetes-services",
      "clusterchecks-dispatch",
      "workloadmeta-puller",
      "tagger-store",
      "workloadmeta-store",
      "tagger-workloadmeta",
      "collector-queue-15s",
      "aggregator",
      "ad-servicelistening",
    ],
  "Unhealthy": null,
}

# readiness probe:
curl http://localhost:5556/ready

{
  "Healthy":
    [
      "healthcheck",
      "collector-queue-15s",
      "aggregator",
      "ad-servicelistening",
      "workloadmeta-store",
      "tagger-workloadmeta",
      "ad-config-provider-kubernetes-services",
      "clusterchecks-dispatch",
      "workloadmeta-puller",
      "tagger-store",
      "clusterchecks-leadership",
      "ad-config-provider-kubernetes-endpoints",
      "healthcheck",
      "workloadmeta-kubeapiserver",
    ],
  "Unhealthy": null,
}
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->