### PR TITLE
Increase default kube_cache_sync_timeout_seconds from 5 to 10 seconds

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -11,3 +11,5 @@ test/new-e2e/tests/containers:
   - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
+  - TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
+  - TestKindSuite

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -490,7 +490,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("leader_election_default_resource", "configmap")
 	config.BindEnvAndSetDefault("leader_election_release_on_shutdown", true)
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
-	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 5)
+	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 10)
 
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)

--- a/test/new-e2e/tests/containers/dump_cluster_state.go
+++ b/test/new-e2e/tests/containers/dump_cluster_state.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	awsec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
 	awsec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -34,6 +33,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	kubectlget "k8s.io/kubectl/pkg/cmd/get"
 	kubectlutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func dumpEKSClusterState(ctx context.Context, name string) (ret string) {
@@ -287,7 +288,7 @@ func dumpK8sClusterState(ctx context.Context, kubeconfig *clientcmdapi.Config, o
 	getCmd.SetErr(out)
 	getCmd.SetContext(ctx)
 	getCmd.SetArgs([]string{
-		"nodes,all",
+		"nodes,mutatingwebhookconfiguration,validatingwebhookconfiguration,all",
 		"--all-namespaces",
 		"-o",
 		"wide",

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -198,19 +198,15 @@ func (suite *k8sSuite) TestAdmissionControllerWebhooksExist() {
 	expectedWebhookName := "datadog-webhook"
 
 	suite.Run("agent registered mutating webhook configuration", func() {
-		suite.EventuallyWithT(func(c *assert.CollectT) {
-			mutatingConfig, err := suite.K8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
-			assert.NoError(c, err, "Unexpected error while getting mutating webhook configuration")
-			assert.NotNilf(c, mutatingConfig, "None of the mutating webhook configurations have the name '%s'", expectedWebhookName)
-		}, 2*time.Minute, 10*time.Second)
+		mutatingConfig, err := suite.K8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
+		suite.Require().NoError(err)
+		suite.NotNilf(mutatingConfig, "None of the mutating webhook configurations have the name '%s'", expectedWebhookName)
 	})
 
 	suite.Run("agent registered validating webhook configuration", func() {
-		suite.EventuallyWithT(func(c *assert.CollectT) {
-			validatingConfig, err := suite.K8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
-			assert.NoError(c, err, "Unexpected error while getting validating webhook configuration")
-			assert.NotNilf(c, validatingConfig, "None of the validating webhook configurations have the name '%s'", expectedWebhookName)
-		}, 2*time.Minute, 10*time.Second)
+		validatingConfig, err := suite.K8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
+		suite.Require().NoError(err)
+		suite.NotNilf(validatingConfig, "None of the validating webhook configurations have the name '%s'", expectedWebhookName)
 	})
 }
 

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -199,15 +199,19 @@ func (suite *k8sSuite) TestAdmissionControllerWebhooksExist() {
 	expectedWebhookName := "datadog-webhook"
 
 	suite.Run("agent registered mutating webhook configuration", func() {
-		mutatingConfig, err := suite.K8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
-		suite.Require().NoError(err)
-		suite.NotNilf(mutatingConfig, "None of the mutating webhook configurations have the name '%s'", expectedWebhookName)
+		suite.EventuallyWithT(func(c *assert.CollectT) {
+			mutatingConfig, err := suite.K8sClient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
+			assert.NoError(c, err, "Unexpected error while getting mutating webhook configuration")
+			assert.NotNilf(c, mutatingConfig, "None of the mutating webhook configurations have the name '%s'", expectedWebhookName)
+		}, 2*time.Minute, 10*time.Second)
 	})
 
 	suite.Run("agent registered validating webhook configuration", func() {
-		validatingConfig, err := suite.K8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
-		suite.Require().NoError(err)
-		suite.NotNilf(validatingConfig, "None of the validating webhook configurations have the name '%s'", expectedWebhookName)
+		suite.EventuallyWithT(func(c *assert.CollectT) {
+			validatingConfig, err := suite.K8sClient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, expectedWebhookName, metav1.GetOptions{})
+			assert.NoError(c, err, "Unexpected error while getting validating webhook configuration")
+			assert.NotNilf(c, validatingConfig, "None of the validating webhook configurations have the name '%s'", expectedWebhookName)
+		}, 2*time.Minute, 10*time.Second)
 	})
 }
 

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -19,7 +19,6 @@ import (
 	"gopkg.in/zorkian/go-datadog-api.v2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
@@ -997,8 +996,6 @@ func (suite *k8sSuite) TestAdmissionControllerWithLibraryAnnotation() {
 }
 
 func (suite *k8sSuite) TestAdmissionControllerWithAutoDetectedLanguage() {
-	// CONTINT-4009
-	flake.Mark(suite.T())
 	suite.testAdmissionControllerPod("workload-mutated-lib-injection", "mutated-with-auto-detected-language", "python", true)
 }
 

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -10,8 +10,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
-
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/kindvm"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
@@ -28,7 +26,6 @@ type kindSuite struct {
 }
 
 func TestKindSuite(t *testing.T) {
-	flake.Mark(t)
 	suite.Run(t, &kindSuite{})
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR bumps the default value for kube_cache_sync_timeout_seconds from 5 to 10 seconds.

It also adds mutating and validating webhooks to the cluster dump

### Motivation

Multiple tests related to the admission controller seem to be failing. While investigating, we noticed that in some cases some of the k8s informers were hitting the 5 second timeout, and in the case of the failed tests, it was the `admissionregistration.k8s.io/v1/mutatingwebhookconfigurations` informer. The thought is that 5 seconds is a little bit aggressive for small clusters, so we are bumping it in the hopes that that fixes the failing tests (which represent the pressure seen on small clusters)

[Failures over the last week](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.name%3A%28TestKindSuite%2A%20-TestKindSuite%20-TestKindSuite%2FTestCPU%2A%29%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A300%2C%40test.name%3A300%2C%40duration%2C%40test.service%2C%40ci.job.name%2C%40git.branch%2C%40git.commit.message&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1733135910770&end=1733740710770&paused=false), all either directly testing the admission controller or, in the case of dogstatsd, failing because of the admission controller

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->