### PR TITLE
usm: process monitor: Increase number of runners

### DIFF
--- a/pkg/process/monitor/process_monitor.go
+++ b/pkg/process/monitor/process_monitor.go
@@ -221,7 +221,10 @@ func (pm *ProcessMonitor) initNetlinkProcessEventMonitor() error {
 
 // initCallbackRunner runs multiple workers that run tasks sent over a queue.
 func (pm *ProcessMonitor) initCallbackRunner() {
-	cpuNum := runtime.NumVCPU()
+	cpuNum, err := kernel.PossibleCPUs()
+	if err != nil {
+		cpuNum = runtime.NumVCPU()
+	}
 	pm.callbackRunner = make(chan func(), pendingCallbacksQueueSize)
 	pm.callbackRunnerStopChannel = make(chan struct{})
 	pm.callbackRunnersWG.Add(cpuNum)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Runs X workers for the process monitor of USM, where X is equivalent to the number of CPUs on the host.

### Motivation

We used to run X workers, where X is defined as the value returned from runtime.NumVCPU(). However, if GOMAXPROCS is defined, we rely on it. For our helm/k8s environments it is set to 1 as we're limited to less than a single core. We use the correct number of cpus over this setting to process faster the events

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->