### PR TITLE
[ASCII-2461] Fix flaky TestRunProviders

### DIFF
--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -6,6 +6,7 @@
 package flare
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -75,6 +76,7 @@ func TestFlareCreation(t *testing.T) {
 
 func TestRunProviders(t *testing.T) {
 	firstStarted := make(chan struct{}, 1)
+	var secondDone atomic.Bool
 
 	fakeTagger := mockTagger.SetupFakeTagger(t)
 
@@ -112,6 +114,7 @@ func TestRunProviders(t *testing.T) {
 			func() *types.FlareFiller {
 				return types.NewFiller(func(_ types.FlareBuilder) error {
 					time.Sleep(10 * time.Second)
+					secondDone.Store(true)
 					return nil
 				})
 			},
@@ -131,4 +134,5 @@ func TestRunProviders(t *testing.T) {
 	elapsed := time.Since(start)
 
 	assert.Less(t, elapsed, 5*time.Second)
+	assert.False(t, secondDone.Load())
 }

--- a/comp/core/flare/flare_test.go
+++ b/comp/core/flare/flare_test.go
@@ -130,9 +130,11 @@ func TestRunProviders(t *testing.T) {
 
 	start := time.Now()
 	f.Comp.(*flare).runProviders(fb, cliProviderTimeout)
+	// ensure that providers are actually started
 	<-firstStarted
 	elapsed := time.Since(start)
 
+	// ensure that we're not blocking for the slow provider
 	assert.Less(t, elapsed, 5*time.Second)
 	assert.False(t, secondDone.Load())
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update `TestRunProviders` to fix a race condition. 
Still check that providers are started, and that we don't wait for them forever.

### Motivation
Not have a race.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->