### PR TITLE
Add rocky 9.4 to KMT platforms

### DIFF
--- a/test/new-e2e/system-probe/config/platforms.json
+++ b/test/new-e2e/system-probe/config/platforms.json
@@ -257,6 +257,14 @@
       "alt_version_names": [
         "oracular"
       ]
+    },
+    "rocky_9.4": {
+      "os_name": "Rocky Linux",
+      "os_id": "rocky",
+      "kernel": "5.14.0-503.15.1.el9_5",
+      "os_version": "9.4",
+      "image": "rocky-9.4-x86_64.qcow2.xz",
+      "image_version": "20241209_f6a14db0"
     }
   },
   "arm64": {
@@ -486,6 +494,14 @@
       "alt_version_names": [
         "oracular"
       ]
+    },
+    "rocky_9.4": {
+      "os_name": "Rocky Linux",
+      "os_id": "rocky",
+      "kernel": "5.14.0-503.15.1.el9_5",
+      "os_version": "9.4",
+      "image": "rocky-9.4-arm64.qcow2.xz",
+      "image_version": "20241209_f6a14db0"
     }
   }
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add rocky 9.4 to KMT platforms
Rocky 9.4 image initially added by this PR: https://github.com/DataDog/ami-builder/pull/209
Rocky 9.4 boot issues for amd64 fixed by this PR: https://github.com/DataDog/ami-builder/pull/214

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->