### PR TITLE
[CWS] remove watch dir option from directory provider

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -472,7 +472,7 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 		},
 	}
 
-	provider, err := rules.NewPoliciesDirProvider(args.dir, false)
+	provider, err := rules.NewPoliciesDirProvider(args.dir)
 	if err != nil {
 		return err
 	}
@@ -611,7 +611,7 @@ func evalRule(_ log.Component, _ config.Component, _ secrets.Component, evalArgs
 		},
 	}
 
-	provider, err := rules.NewPoliciesDirProvider(policiesDir, false)
+	provider, err := rules.NewPoliciesDirProvider(policiesDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -466,7 +466,7 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 		},
 	}
 
-	provider, err := rules.NewPoliciesDirProvider(args.dir, false)
+	provider, err := rules.NewPoliciesDirProvider(args.dir)
 	if err != nil {
 		return err
 	}
@@ -583,7 +583,7 @@ func evalRule(_ log.Component, _ config.Component, _ secrets.Component, evalArgs
 		},
 	}
 
-	provider, err := rules.NewPoliciesDirProvider(policiesDir, false)
+	provider, err := rules.NewPoliciesDirProvider(policiesDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -20,7 +20,6 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// CWS - general config
 	cfg.BindEnvAndSetDefault("runtime_security_config.enabled", false)
 	cfg.BindEnv("runtime_security_config.fim_enabled")
-	cfg.BindEnvAndSetDefault("runtime_security_config.policies.watch_dir", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.per_rule_enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.report_internal_policies", false)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -45,8 +45,6 @@ type RuntimeSecurityConfig struct {
 	RuntimeEnabled bool
 	// PoliciesDir defines the folder in which the policy files are located
 	PoliciesDir string
-	// WatchPoliciesDir activate policy dir inotify
-	WatchPoliciesDir bool
 	// PolicyMonitorEnabled enable policy monitoring
 	PolicyMonitorEnabled bool
 	// PolicyMonitorPerRuleEnabled enabled per-rule policy monitoring
@@ -353,7 +351,6 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 
 		// policy & ruleset
 		PoliciesDir:                         pkgconfigsetup.SystemProbe().GetString("runtime_security_config.policies.dir"),
-		WatchPoliciesDir:                    pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.watch_dir"),
 		PolicyMonitorEnabled:                pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.monitor.enabled"),
 		PolicyMonitorPerRuleEnabled:         pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.monitor.per_rule_enabled"),
 		PolicyMonitorReportInternalPolicies: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.policies.monitor.report_internal_policies"),

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -377,7 +377,7 @@ func (e *RuleEngine) gatherDefaultPolicyProviders() []rules.PolicyProvider {
 	}
 
 	// directory policy provider
-	if provider, err := rules.NewPoliciesDirProvider(e.config.PoliciesDir, e.config.WatchPoliciesDir); err != nil {
+	if provider, err := rules.NewPoliciesDirProvider(e.config.PoliciesDir); err != nil {
 		seclog.Errorf("failed to load local policies: %s", err)
 	} else {
 		policyProviders = append(policyProviders, provider)

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/alecthomas/participle v0.7.1
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/fatih/structtag v1.2.0
-	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gopacket v1.1.19
 	github.com/hashicorp/go-multierror v1.1.1

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -17,8 +17,6 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
-github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
-github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -7,12 +7,10 @@
 package rules
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"sort"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/hashicorp/go-multierror"
 )
 
@@ -25,17 +23,10 @@ var _ PolicyProvider = (*PoliciesDirProvider)(nil)
 // PoliciesDirProvider defines a new policy dir provider
 type PoliciesDirProvider struct {
 	PoliciesDir string
-
-	onNewPoliciesReadyCb func()
-	cancelFnc            func()
-	watcher              *fsnotify.Watcher
-	watchedFiles         []string
 }
 
 // SetOnNewPoliciesReadyCb implements the policy provider interface
-func (p *PoliciesDirProvider) SetOnNewPoliciesReadyCb(cb func()) {
-	p.onNewPoliciesReadyCb = cb
-}
+func (p *PoliciesDirProvider) SetOnNewPoliciesReadyCb(_ func()) {}
 
 // Start starts the policy dir provider
 func (p *PoliciesDirProvider) Start() {}
@@ -92,14 +83,6 @@ func (p *PoliciesDirProvider) LoadPolicies(macroFilters []MacroFilter, ruleFilte
 		errs = multierror.Append(errs, err)
 	}
 
-	// remove oldest watched files
-	if p.watcher != nil {
-		for _, watched := range p.watchedFiles {
-			_ = p.watcher.Remove(watched)
-		}
-		p.watchedFiles = p.watchedFiles[0:0]
-	}
-
 	// Load and parse policies
 	for _, filename := range policyFiles {
 		policy, err := p.loadPolicy(filename, macroFilters, ruleFilters)
@@ -112,14 +95,6 @@ func (p *PoliciesDirProvider) LoadPolicies(macroFilters []MacroFilter, ruleFilte
 		}
 
 		policies = append(policies, policy)
-
-		if p.watcher != nil {
-			if err := p.watcher.Add(filename); err != nil {
-				errs = multierror.Append(errs, err)
-			} else {
-				p.watchedFiles = append(p.watchedFiles, filename)
-			}
-		}
 	}
 
 	return policies, errs
@@ -127,13 +102,6 @@ func (p *PoliciesDirProvider) LoadPolicies(macroFilters []MacroFilter, ruleFilte
 
 // Close stops policy provider interface
 func (p *PoliciesDirProvider) Close() error {
-	if p.cancelFnc != nil {
-		p.cancelFnc()
-	}
-
-	if p.watcher != nil {
-		p.watcher.Close()
-	}
 	return nil
 }
 
@@ -149,57 +117,11 @@ func filesEqual(a []string, b []string) bool {
 	return true
 }
 
-func (p *PoliciesDirProvider) watch(ctx context.Context) {
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event, ok := <-p.watcher.Events:
-				if !ok {
-					return
-				}
-
-				if event.Op&(fsnotify.Create|fsnotify.Remove) > 0 {
-					files, _ := p.getPolicyFiles()
-					if !filesEqual(files, p.watchedFiles) {
-						p.onNewPoliciesReadyCb()
-					}
-				} else if event.Op&fsnotify.Write > 0 && filepath.Ext(event.Name) == policyExtension {
-					p.onNewPoliciesReadyCb()
-				}
-			case _, ok := <-p.watcher.Errors:
-				if !ok {
-					return
-				}
-			}
-		}
-	}()
-}
-
 // NewPoliciesDirProvider returns providers for the given policies dir
-func NewPoliciesDirProvider(policiesDir string, watch bool) (*PoliciesDirProvider, error) {
-	p := &PoliciesDirProvider{
+func NewPoliciesDirProvider(policiesDir string) (*PoliciesDirProvider, error) {
+	return &PoliciesDirProvider{
 		PoliciesDir: policiesDir,
-	}
-
-	if watch {
-		var err error
-		if p.watcher, err = fsnotify.NewWatcher(); err != nil {
-			return nil, err
-		}
-
-		if err := p.watcher.Add(policiesDir); err != nil {
-			p.watcher.Close()
-			return nil, err
-		}
-
-		var ctx context.Context
-		ctx, p.cancelFnc = context.WithCancel(context.Background())
-		go p.watch(ctx)
-	}
-
-	return p, nil
+	}, nil
 }
 
 // Type returns the type of policy dir provider

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -105,18 +105,6 @@ func (p *PoliciesDirProvider) Close() error {
 	return nil
 }
 
-func filesEqual(a []string, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i, v := range a {
-		if v != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // NewPoliciesDirProvider returns providers for the given policies dir
 func NewPoliciesDirProvider(policiesDir string) (*PoliciesDirProvider, error) {
 	return &PoliciesDirProvider{

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -75,7 +75,7 @@ func TestMacroMerge(t *testing.T) {
 	event.SetFieldValue("open.file.path", "/tmp/test")
 	event.SetFieldValue("process.comm", "/usr/bin/vi")
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ func TestRuleMerge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,7 +284,7 @@ func TestActionSetVariable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +354,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +420,7 @@ func TestActionSetVariableConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -441,7 +441,7 @@ func loadPolicy(t *testing.T, testPolicy *PolicyDef, policyOpts PolicyLoaderOpts
 		t.Fatal(err)
 	}
 
-	provider, err := NewPoliciesDirProvider(tmpDir, false)
+	provider, err := NewPoliciesDirProvider(tmpDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -118,7 +118,7 @@ func (tm *testModule) reloadPolicies() error {
 	log.Debugf("reload policies with cfgDir: %s", commonCfgDir)
 
 	bundledPolicyProvider := bundled.NewPolicyProvider(tm.eventMonitor.Probe.Config.RuntimeSecurity)
-	policyDirProvider, err := rules.NewPoliciesDirProvider(commonCfgDir, false)
+	policyDirProvider, err := rules.NewPoliciesDirProvider(commonCfgDir)
 	if err != nil {
 		return err
 	}

--- a/releasenotes/notes/cws-remove-watch-dir-option-f8faee4937353316.yaml
+++ b/releasenotes/notes/cws-remove-watch-dir-option-f8faee4937353316.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    CWS: the `runtime_security_config.policies.watch_dir` option has been removed.
+    Please use remote configuration for dynamically updating policies, or simply send
+    the SIGHUP signal to the system-probe process to reload the policies.

--- a/releasenotes/notes/cws-remove-watch-dir-option-f8faee4937353316.yaml
+++ b/releasenotes/notes/cws-remove-watch-dir-option-f8faee4937353316.yaml
@@ -9,5 +9,5 @@
 deprecations:
   - |
     CWS: the `runtime_security_config.policies.watch_dir` option has been removed.
-    Please use remote configuration for dynamically updating policies, or simply send
-    the SIGHUP signal to the system-probe process to reload the policies.
+    Use remote configuration for dynamically updating policies, or send
+    the `SIGHUP` signal to the `system-probe` process to reload the policies.


### PR DESCRIPTION
### What does this PR do?

With remote config this option has lost its utility. It was also disabled by default (and has been for ever), and can be replicate with a SIGHUP on system-probe if needed.

Removing it allows to clean up this code, but also to remove the fsnotify dependency on pkg/security/secl.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->