### PR TITLE
fix(kubernetesadmissionevents): add demultiplexer flushing in the unit tests

### DIFF
--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
@@ -249,7 +249,10 @@ func TestKubernetesAdmissionEvents(t *testing.T) {
 			assert.Equal(t, eventType, kubernetesAuditWebhook.name)
 
 			// Emit the event
+			start := time.Now()
 			mockSender.On("Event", mock.AnythingOfType("event.Event")).Return().Once()
+			// Force flush to serializer to ensure the event is emitted and received.
+			demultiplexerMock.ForceFlushToSerializer(start, true)
 			validated, err := kubernetesAuditWebhook.emitEvent(&tt.request, "", nil)
 			assert.NoError(t, err)
 			assert.True(t, validated)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add a flush for the `demultiplexer` during each test to ensure that the events are emitted correctly. This should address potential flakiness when verifying if the sender correctly receives the events.

### Motivation
We noticed flakiness in the `kubernetesadmissionevents` unit tests, where the order of the received tests is incorrect.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Validated by unit tests.

### Possible Drawbacks / Trade-offs
None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
None