### PR TITLE
[CWS][hackathon24Q4] eBPF ransomware detector

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1344,6 +1344,43 @@ CSM Threats event for Linux systems have the following JSON schema:
             ],
             "description": "ProcessCredentialsSerializer serializes the process credentials to JSON"
         },
+        "RansomwareScore": {
+            "properties": {
+                "time_to_trigger": {
+                    "type": "integer"
+                },
+                "new_file": {
+                    "type": "integer"
+                },
+                "unlink": {
+                    "type": "integer"
+                },
+                "rename": {
+                    "type": "integer"
+                },
+                "urandom": {
+                    "type": "integer"
+                },
+                "kill": {
+                    "type": "integer"
+                },
+                "score": {
+                    "type": "integer"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "time_to_trigger",
+                "new_file",
+                "unlink",
+                "rename",
+                "urandom",
+                "kill",
+                "score"
+            ],
+            "description": "RansomwareScoreSerializer defines a ransomware socre serializer"
+        },
         "RawPacket": {
             "properties": {
                 "device": {
@@ -1780,6 +1817,9 @@ CSM Threats event for Linux systems have the following JSON schema:
         },
         "packet": {
             "$ref": "#/$defs/RawPacket"
+        },
+        "ransomware_score": {
+            "$ref": "#/$defs/RansomwareScore"
         }
     },
     "additionalProperties": false,
@@ -1823,6 +1863,7 @@ CSM Threats event for Linux systems have the following JSON schema:
 | `usr` | $ref | Please see [UserContext](#usercontext) |
 | `syscall` | $ref | Please see [SyscallContext](#syscallcontext) |
 | `packet` | $ref | Please see [RawPacket](#rawpacket) |
+| `ransomware_score` | $ref | Please see [RansomwareScore](#ransomwarescore) |
 
 ## `AWSIMDSEvent`
 
@@ -3767,6 +3808,52 @@ CSM Threats event for Linux systems have the following JSON schema:
 | `cap_effective` | Effective Capability set |
 | `cap_permitted` | Permitted Capability set |
 | `destination` | Credentials after the operation |
+
+
+## `RansomwareScore`
+
+
+{{< code-block lang="json" collapsible="true" >}}
+{
+    "properties": {
+        "time_to_trigger": {
+            "type": "integer"
+        },
+        "new_file": {
+            "type": "integer"
+        },
+        "unlink": {
+            "type": "integer"
+        },
+        "rename": {
+            "type": "integer"
+        },
+        "urandom": {
+            "type": "integer"
+        },
+        "kill": {
+            "type": "integer"
+        },
+        "score": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false,
+    "type": "object",
+    "required": [
+        "time_to_trigger",
+        "new_file",
+        "unlink",
+        "rename",
+        "urandom",
+        "kill",
+        "score"
+    ],
+    "description": "RansomwareScoreSerializer defines a ransomware socre serializer"
+}
+
+{{< /code-block >}}
+
 
 
 ## `RawPacket`

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1333,6 +1333,43 @@
       ],
       "description": "ProcessCredentialsSerializer serializes the process credentials to JSON"
     },
+    "RansomwareScore": {
+      "properties": {
+        "time_to_trigger": {
+          "type": "integer"
+        },
+        "new_file": {
+          "type": "integer"
+        },
+        "unlink": {
+          "type": "integer"
+        },
+        "rename": {
+          "type": "integer"
+        },
+        "urandom": {
+          "type": "integer"
+        },
+        "kill": {
+          "type": "integer"
+        },
+        "score": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "time_to_trigger",
+        "new_file",
+        "unlink",
+        "rename",
+        "urandom",
+        "kill",
+        "score"
+      ],
+      "description": "RansomwareScoreSerializer defines a ransomware socre serializer"
+    },
     "RawPacket": {
       "properties": {
         "device": {
@@ -1769,6 +1806,9 @@
     },
     "packet": {
       "$ref": "#/$defs/RawPacket"
+    },
+    "ransomware_score": {
+      "$ref": "#/$defs/RansomwareScore"
     }
   },
   "additionalProperties": false,

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -49,6 +49,7 @@ Triggers are events that correspond to types of activity seen by the system. The
 | `open` | File | A file was opened | 7.27 |
 | `packet` | Network | A raw network packet captured | 7.60 |
 | `ptrace` | Kernel | A ptrace command was executed | 7.35 |
+| `ransomware_score` | Kernel | [Experimental] A ransomware has reach the score threshold | 7.62 |
 | `removexattr` | File | Remove extended attributes | 7.27 |
 | `rename` | File | A file/directory was renamed | 7.27 |
 | `rmdir` | File | A directory was removed | 7.27 |
@@ -1229,6 +1230,22 @@ A ptrace command was executed
 | [`ptrace.tracee.user_session.k8s_groups`](#common-usersessioncontext-k8s_groups-doc) | Kubernetes groups of the user that executed the process |
 | [`ptrace.tracee.user_session.k8s_uid`](#common-usersessioncontext-k8s_uid-doc) | Kubernetes UID of the user that executed the process |
 | [`ptrace.tracee.user_session.k8s_username`](#common-usersessioncontext-k8s_username-doc) | Kubernetes username of the user that executed the process |
+
+### Event `ransomware_score`
+
+_This event type is experimental and may change in the future._
+
+A ransomware has reach the score threshold
+
+| Property | Definition |
+| -------- | ------------- |
+| [`ransomware_score.kill`](#ransomware_score-kill-doc) | Number of kills |
+| [`ransomware_score.new_file`](#ransomware_score-new_file-doc) | Number of new files |
+| [`ransomware_score.rename`](#ransomware_score-rename-doc) | Number of renames |
+| [`ransomware_score.score`](#ransomware_score-score-doc) | Final score |
+| [`ransomware_score.time_to_trigger`](#ransomware_score-time_to_trigger-doc) | Time to reach the score |
+| [`ransomware_score.unlink`](#ransomware_score-unlink-doc) | Number of unlinks |
+| [`ransomware_score.urandom`](#ransomware_score-urandom-doc) | Number of urandom |
 
 ### Event `removexattr`
 
@@ -3099,6 +3116,55 @@ Definition: ptrace request
 
 
 Constants: [Ptrace constants](#ptrace-constants)
+
+
+
+### `ransomware_score.kill` {#ransomware_score-kill-doc}
+Type: int
+
+Definition: Number of kills
+
+
+
+### `ransomware_score.new_file` {#ransomware_score-new_file-doc}
+Type: int
+
+Definition: Number of new files
+
+
+
+### `ransomware_score.rename` {#ransomware_score-rename-doc}
+Type: int
+
+Definition: Number of renames
+
+
+
+### `ransomware_score.score` {#ransomware_score-score-doc}
+Type: int
+
+Definition: Final score
+
+
+
+### `ransomware_score.time_to_trigger` {#ransomware_score-time_to_trigger-doc}
+Type: int
+
+Definition: Time to reach the score
+
+
+
+### `ransomware_score.unlink` {#ransomware_score-unlink-doc}
+Type: int
+
+Definition: Number of unlinks
+
+
+
+### `ransomware_score.urandom` {#ransomware_score-urandom-doc}
+Type: int
+
+Definition: Number of urandom
 
 
 

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -5020,6 +5020,50 @@
       ]
     },
     {
+      "name": "ransomware_score",
+      "definition": "A ransomware has reach the score threshold",
+      "type": "Kernel",
+      "from_agent_version": "7.62",
+      "experimental": true,
+      "properties": [
+        {
+          "name": "ransomware_score.kill",
+          "definition": "Number of kills",
+          "property_doc_link": "ransomware_score-kill-doc"
+        },
+        {
+          "name": "ransomware_score.new_file",
+          "definition": "Number of new files",
+          "property_doc_link": "ransomware_score-new_file-doc"
+        },
+        {
+          "name": "ransomware_score.rename",
+          "definition": "Number of renames",
+          "property_doc_link": "ransomware_score-rename-doc"
+        },
+        {
+          "name": "ransomware_score.score",
+          "definition": "Final score",
+          "property_doc_link": "ransomware_score-score-doc"
+        },
+        {
+          "name": "ransomware_score.time_to_trigger",
+          "definition": "Time to reach the score",
+          "property_doc_link": "ransomware_score-time_to_trigger-doc"
+        },
+        {
+          "name": "ransomware_score.unlink",
+          "definition": "Number of unlinks",
+          "property_doc_link": "ransomware_score-unlink-doc"
+        },
+        {
+          "name": "ransomware_score.urandom",
+          "definition": "Number of urandom",
+          "property_doc_link": "ransomware_score-urandom-doc"
+        }
+      ]
+    },
+    {
       "name": "removexattr",
       "definition": "Remove extended attributes",
       "type": "File",
@@ -10407,6 +10451,90 @@
       ],
       "constants": "Ptrace constants",
       "constants_link": "ptrace-constants",
+      "examples": []
+    },
+    {
+      "name": "ransomware_score.kill",
+      "link": "ransomware_score-kill-doc",
+      "type": "int",
+      "definition": "Number of kills",
+      "prefixes": [
+        "ransomware_score"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "ransomware_score.new_file",
+      "link": "ransomware_score-new_file-doc",
+      "type": "int",
+      "definition": "Number of new files",
+      "prefixes": [
+        "ransomware_score"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "ransomware_score.rename",
+      "link": "ransomware_score-rename-doc",
+      "type": "int",
+      "definition": "Number of renames",
+      "prefixes": [
+        "ransomware_score"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "ransomware_score.score",
+      "link": "ransomware_score-score-doc",
+      "type": "int",
+      "definition": "Final score",
+      "prefixes": [
+        "ransomware_score"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "ransomware_score.time_to_trigger",
+      "link": "ransomware_score-time_to_trigger-doc",
+      "type": "int",
+      "definition": "Time to reach the score",
+      "prefixes": [
+        "ransomware_score"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "ransomware_score.unlink",
+      "link": "ransomware_score-unlink-doc",
+      "type": "int",
+      "definition": "Number of unlinks",
+      "prefixes": [
+        "ransomware_score"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "ransomware_score.urandom",
+      "link": "ransomware_score-urandom-doc",
+      "type": "int",
+      "definition": "Number of urandom",
+      "prefixes": [
+        "ransomware_score"
+      ],
+      "constants": "",
+      "constants_link": "",
       "examples": []
     },
     {

--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -52,6 +52,7 @@ enum event_type
     EVENT_LOGIN_UID_WRITE,
     EVENT_CGROUP_WRITE,
     EVENT_RAW_PACKET,
+    EVENT_RANSOMWARE,
     EVENT_MAX, // has to be the last one
 
     EVENT_ALL = 0xffffffff // used as a mask for all the events

--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -11,6 +11,21 @@ struct invalidate_dentry_event_t {
     u32 padding;
 };
 
+struct ransomware_event_t {
+    struct kevent_t event;
+    struct process_context_t process;
+    struct span_context_t span;
+    struct container_context_t container;
+
+    u64 time_to_trigger_ns;
+    u32 new_file;
+    u32 unlink;
+    u32 rename;
+    u32 urandom;
+    u32 kill;
+    u32 score;
+};
+
 struct bind_event_t {
     struct kevent_t event;
     struct process_context_t process;

--- a/pkg/security/ebpf/c/include/helpers/ransomware.h
+++ b/pkg/security/ebpf/c/include/helpers/ransomware.h
@@ -7,8 +7,8 @@
 #include "constants/macros.h"
 
 #define RANSOMWARE_SCORE_NEW_FILE 1
-#define RANSOMWARE_SCORE_UNLINK 10
-#define RANSOMWARE_SCORE_RENAME 10
+#define RANSOMWARE_SCORE_UNLINK 5
+#define RANSOMWARE_SCORE_RENAME 5
 #define RANSOMWARE_SCORE_URANDOM 100
 #define RANSOMWARE_SCORE_KILL 100
 
@@ -16,15 +16,16 @@
 #define RANSOMWARE_THRESHOLD_SCORE 500
 
 __attribute__((always_inline)) void ransomware_cleanup(u32 pid) {
-    bpf_map_lookup_elem(&ransomware_score, &pid);
+    bpf_map_delete_elem(&ransomware_score, &pid);
     return;
 }
 
-__attribute__((always_inline)) void reset_score(struct ransomware_score_t *rs) {
+__attribute__((always_inline)) void reset_score(struct ransomware_score_t *rs, u64 ts) {
     if (!rs) {
         return; // should not happen
     }
     __builtin_memset(rs, 0, sizeof(*rs));
+    rs->first_syscall = ts;
     return;
 }
 
@@ -38,11 +39,16 @@ __attribute__((always_inline)) void compute_score(ctx_t *ctx, struct ransomware_
     score += rs->kill * RANSOMWARE_SCORE_KILL;
 
     if (score < RANSOMWARE_THRESHOLD_SCORE) {
-        /* bpf_printk("-- new score: %u", score); */
         return;
     }
 
     u64 diff_time = rs->last_syscall - rs->first_syscall;
+    if (diff_time > RANSOMWARE_WATCH_PERIOD_NS) {
+        // if it took more than 1sec to reach the threshold, reset and continue
+        reset_score(rs, rs->last_syscall);
+        return;
+    }
+
     bpf_printk("== THRESHOLD REACHED with score: %u in %u.%u seconds", score, NS_TO_SEC(diff_time), diff_time%1000000000);
     bpf_printk("  new_files: %u", rs->new_file);
     bpf_printk("  unlinks:   %u", rs->unlink);
@@ -59,11 +65,8 @@ __attribute__((always_inline)) void compute_score(ctx_t *ctx, struct ransomware_
         .kill = rs->kill,
         .score = score,
     };
-
     /* rs->already_notified = 1; */
-    u64 last = rs->last_syscall; //DEBUG, TODO: REDO ^
-    reset_score(rs); //DEBUG, TODO: REDO ^
-    rs->first_syscall = last; //DEBUG, TODO: REDO ^
+    reset_score(rs, rs->last_syscall); //DEBUG, TODO: REDO ^?
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);
@@ -74,11 +77,12 @@ __attribute__((always_inline)) void compute_score(ctx_t *ctx, struct ransomware_
 
 __attribute__((always_inline)) struct ransomware_score_t* ransomware_get_score() {
     u32 pid = bpf_get_current_pid_tgid() >> 32;
+    u64 now = bpf_ktime_get_ns();
 
     struct ransomware_score_t *score = bpf_map_lookup_elem(&ransomware_score, &pid);
     if (!score) {
         struct ransomware_score_t s;
-        reset_score(&s);
+        reset_score(&s, now);
         if (bpf_map_update_elem(&ransomware_score, &pid, &s, BPF_ANY) < 0) {
             bpf_printk("ransomware_get_score failed to update elem");
             return NULL;
@@ -88,10 +92,8 @@ __attribute__((always_inline)) struct ransomware_score_t* ransomware_get_score()
         return NULL;
     }
 
-    u64 now = bpf_ktime_get_ns();
     if (score->last_syscall + RANSOMWARE_WATCH_PERIOD_NS < now) {
-        reset_score(score);
-        score->first_syscall = now;
+        reset_score(score, now);
     }
     score->last_syscall = now;
     return score;
@@ -103,7 +105,6 @@ __attribute__((always_inline)) void ransomware_score_unlink(ctx_t *ctx) {
     if (!score) {
         return;
     }
-    /* bpf_printk("++ unlink"); */
     score->unlink++;
     compute_score(ctx, score);
     return;
@@ -114,7 +115,6 @@ __attribute__((always_inline)) void ransomware_score_rename(ctx_t *ctx) {
     if (!score) {
         return;
     }
-    /* bpf_printk("++ rename"); */
     score->rename++;
     compute_score(ctx, score);
     return;
@@ -129,7 +129,6 @@ __attribute__((always_inline)) void ransomware_score_open(ctx_t *ctx, int flags)
     if (!score) {
         return;
     }
-    /* bpf_printk("++ open new file"); */
     score->new_file++;
     compute_score(ctx, score);
     return;
@@ -144,7 +143,6 @@ __attribute__((always_inline)) void ransomware_score_kill(ctx_t *ctx, int sig) {
     if (!score) {
         return;
     }
-    /* bpf_printk("++ kill"); */
     score->kill++;
     compute_score(ctx, score);
     return;

--- a/pkg/security/ebpf/c/include/helpers/ransomware.h
+++ b/pkg/security/ebpf/c/include/helpers/ransomware.h
@@ -1,0 +1,153 @@
+#ifndef __RANSOMWARE_H__
+#define __RANSOMWARE_H__
+
+#include "maps.h"
+#include "perf_ring.h"
+#include "events.h"
+#include "constants/macros.h"
+
+#define RANSOMWARE_SCORE_NEW_FILE 1
+#define RANSOMWARE_SCORE_UNLINK 10
+#define RANSOMWARE_SCORE_RENAME 10
+#define RANSOMWARE_SCORE_URANDOM 100
+#define RANSOMWARE_SCORE_KILL 100
+
+#define RANSOMWARE_WATCH_PERIOD_NS SEC_TO_NS(1)
+#define RANSOMWARE_THRESHOLD_SCORE 500
+
+__attribute__((always_inline)) void ransomware_cleanup(u32 pid) {
+    bpf_map_lookup_elem(&ransomware_score, &pid);
+    return;
+}
+
+__attribute__((always_inline)) void reset_score(struct ransomware_score_t *rs) {
+    if (!rs) {
+        return; // should not happen
+    }
+    __builtin_memset(rs, 0, sizeof(*rs));
+    return;
+}
+
+
+__attribute__((always_inline)) void compute_score(ctx_t *ctx, struct ransomware_score_t *rs) {
+    u32 score = 0;
+    score += rs->new_file * RANSOMWARE_SCORE_NEW_FILE;
+    score += rs->unlink * RANSOMWARE_SCORE_UNLINK;
+    score += rs->rename * RANSOMWARE_SCORE_RENAME;
+    score += rs->urandom * RANSOMWARE_SCORE_URANDOM;
+    score += rs->kill * RANSOMWARE_SCORE_KILL;
+
+    if (score < RANSOMWARE_THRESHOLD_SCORE) {
+        /* bpf_printk("-- new score: %u", score); */
+        return;
+    }
+
+    u64 diff_time = rs->last_syscall - rs->first_syscall;
+    bpf_printk("== THRESHOLD REACHED with score: %u in %u.%u seconds", score, NS_TO_SEC(diff_time), diff_time%1000000000);
+    bpf_printk("  new_files: %u", rs->new_file);
+    bpf_printk("  unlinks:   %u", rs->unlink);
+    bpf_printk("  renames:   %u", rs->rename);
+    bpf_printk("  urandoms:  %u", rs->urandom);
+    bpf_printk("  kills:     %u\n", rs->kill);
+
+    struct ransomware_event_t event = {
+        .time_to_trigger_ns = diff_time,
+        .new_file = rs->new_file,
+        .unlink = rs->unlink,
+        .rename = rs->rename,
+        .urandom = rs->urandom,
+        .kill = rs->kill,
+        .score = score,
+    };
+
+    /* rs->already_notified = 1; */
+    u64 last = rs->last_syscall; //DEBUG, TODO: REDO ^
+    reset_score(rs); //DEBUG, TODO: REDO ^
+    rs->first_syscall = last; //DEBUG, TODO: REDO ^
+
+    struct proc_cache_t *entry = fill_process_context(&event.process);
+    fill_container_context(entry, &event.container);
+    fill_span_context(&event.span);
+    send_event(ctx, EVENT_RANSOMWARE, event);
+    return;
+}
+
+__attribute__((always_inline)) struct ransomware_score_t* ransomware_get_score() {
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+
+    struct ransomware_score_t *score = bpf_map_lookup_elem(&ransomware_score, &pid);
+    if (!score) {
+        struct ransomware_score_t s;
+        reset_score(&s);
+        if (bpf_map_update_elem(&ransomware_score, &pid, &s, BPF_ANY) < 0) {
+            bpf_printk("ransomware_get_score failed to update elem");
+            return NULL;
+        }
+        score = &s;
+    } else if (score->already_notified) {
+        return NULL;
+    }
+
+    u64 now = bpf_ktime_get_ns();
+    if (score->last_syscall + RANSOMWARE_WATCH_PERIOD_NS < now) {
+        reset_score(score);
+        score->first_syscall = now;
+    }
+    score->last_syscall = now;
+    return score;
+}
+
+
+__attribute__((always_inline)) void ransomware_score_unlink(ctx_t *ctx) {
+    struct ransomware_score_t *score = ransomware_get_score();
+    if (!score) {
+        return;
+    }
+    /* bpf_printk("++ unlink"); */
+    score->unlink++;
+    compute_score(ctx, score);
+    return;
+}
+
+__attribute__((always_inline)) void ransomware_score_rename(ctx_t *ctx) {
+    struct ransomware_score_t *score = ransomware_get_score();
+    if (!score) {
+        return;
+    }
+    /* bpf_printk("++ rename"); */
+    score->rename++;
+    compute_score(ctx, score);
+    return;
+}
+
+__attribute__((always_inline)) void ransomware_score_open(ctx_t *ctx, int flags) {
+    if ((flags & (O_TRUNC|O_CREAT)) == 0) {
+        return; // only interested on file creation
+    }
+
+    struct ransomware_score_t *score = ransomware_get_score();
+    if (!score) {
+        return;
+    }
+    /* bpf_printk("++ open new file"); */
+    score->new_file++;
+    compute_score(ctx, score);
+    return;
+}
+
+__attribute__((always_inline)) void ransomware_score_kill(ctx_t *ctx, int sig) {
+    if (sig != SIGKILL && sig != SIGTERM) {
+        return;
+    }
+
+    struct ransomware_score_t *score = ransomware_get_score();
+    if (!score) {
+        return;
+    }
+    /* bpf_printk("++ kill"); */
+    score->kill++;
+    compute_score(ctx, score);
+    return;
+}
+
+#endif // __RANSOMWARE_H__

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -5,6 +5,7 @@
 #include "constants/offsets/filesystem.h"
 #include "helpers/filesystem.h"
 #include "helpers/syscalls.h"
+#include "helpers/ransomware.h"
 #include "constants/fentry_macro.h"
 
 int __attribute__((always_inline)) trace__sys_execveat(ctx_t *ctx, const char *path, const char **argv, const char **env) {
@@ -283,6 +284,9 @@ int hook_do_exit(ctx_t *ctx) {
         bpf_map_delete_elem(&pid_ignored, &pid);
         return 0;
     }
+
+    // cleanup ransomware cache
+    ransomware_cleanup(tgid);
 
     // delete netns entry
     bpf_map_delete_elem(&netns_cache, &pid);

--- a/pkg/security/ebpf/c/include/hooks/signal.h
+++ b/pkg/security/ebpf/c/include/hooks/signal.h
@@ -4,8 +4,11 @@
 #include "constants/syscall_macro.h"
 #include "helpers/discarders.h"
 #include "helpers/syscalls.h"
+#include "helpers/ransomware.h"
 
 HOOK_SYSCALL_ENTRY2(kill, int, pid, int, type) {
+    ransomware_score_kill(ctx, type);
+
     if (is_discarded_by_pid()) {
         return 0;
     }

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -49,6 +49,7 @@ BPF_LRU_MAP(tgid_fd_map_id, struct bpf_tgid_fd_t, u32, 4096)
 BPF_LRU_MAP(tgid_fd_prog_id, struct bpf_tgid_fd_t, u32, 4096)
 BPF_LRU_MAP(proc_cache, u64, struct proc_cache_t, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_cache, u32, struct pid_cache_t, 1) // max entries will be overridden at runtime
+BPF_LRU_MAP(ransomware_score, u32, struct ransomware_score_t, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(pid_ignored, u32, u32, 16738)
 BPF_LRU_MAP(exec_pid_transfer, u32, u64, 512)
 BPF_LRU_MAP(netns_cache, u32, u32, 40960)

--- a/pkg/security/ebpf/c/include/structs/all.h
+++ b/pkg/security/ebpf/c/include/structs/all.h
@@ -16,5 +16,6 @@
 #include "syscalls.h"
 #include "tracepoints.h"
 #include "user_sessions.h"
+#include "ransomware.h"
 
 #endif

--- a/pkg/security/ebpf/c/include/structs/ransomware.h
+++ b/pkg/security/ebpf/c/include/structs/ransomware.h
@@ -1,0 +1,17 @@
+#ifndef __STRUCTS_RANSOMWARE_H__
+#define __STRUCTS_RANSOMWARE_H__
+
+struct ransomware_score_t {
+    u64 first_syscall;
+    u64 last_syscall;
+
+    u32 new_file;
+    u32 unlink;
+    u32 rename;
+    u32 urandom;
+    u32 kill;
+
+    u32 already_notified;
+};
+
+#endif // __STRUCTS_RANSOMWARE_H__

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -177,6 +177,10 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.Ma
 			MaxEntries: procPidCacheMaxEntries,
 			EditorFlag: manager.EditMaxEntries,
 		},
+		"ransomware_score": {
+			MaxEntries: procPidCacheMaxEntries,
+			EditorFlag: manager.EditMaxEntries,
+		},
 
 		"activity_dumps_config": {
 			MaxEntries: model.MaxTracedCgroupsCount,

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1246,6 +1246,11 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode on-demand event for syscall event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
+	case model.RansomwareScoreEventType:
+		if _, err = event.RansomwareScore.UnmarshalBinary(data[offset:]); err != nil {
+			seclog.Errorf("failed to decode ransomware score event: %s (offset %d, len %d)", err, offset, len(data))
+			return
+		}
 	}
 
 	// resolve the container context

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -42,6 +42,7 @@ func (m *Model) GetEventTypes() []eval.EventType {
 		eval.EventType("open"),
 		eval.EventType("packet"),
 		eval.EventType("ptrace"),
+		eval.EventType("ransomware_score"),
 		eval.EventType("removexattr"),
 		eval.EventType("rename"),
 		eval.EventType("rmdir"),
@@ -14222,6 +14223,76 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Field:  field,
 			Weight: eval.HandlerWeight,
 		}, nil
+	case "ransomware_score.kill":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.RansomwareScore.Kill)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "ransomware_score.new_file":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.RansomwareScore.NewFile)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "ransomware_score.rename":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.RansomwareScore.Rename)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "ransomware_score.score":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.RansomwareScore.Score)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "ransomware_score.time_to_trigger":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.RansomwareScore.TimeToTrigger)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "ransomware_score.unlink":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.RansomwareScore.Unlink)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+	case "ransomware_score.urandom":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return int(ev.RansomwareScore.Urandom)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
 	case "removexattr.file.change_time":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -21781,6 +21852,13 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.user_session.k8s_groups",
 		"ptrace.tracee.user_session.k8s_uid",
 		"ptrace.tracee.user_session.k8s_username",
+		"ransomware_score.kill",
+		"ransomware_score.new_file",
+		"ransomware_score.rename",
+		"ransomware_score.score",
+		"ransomware_score.time_to_trigger",
+		"ransomware_score.unlink",
+		"ransomware_score.urandom",
 		"removexattr.file.change_time",
 		"removexattr.file.destination.name",
 		"removexattr.file.destination.namespace",
@@ -26818,6 +26896,20 @@ func (ev *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 		return ev.FieldHandlers.ResolveK8SUID(ev, &ev.PTrace.Tracee.Process.UserSession), nil
 	case "ptrace.tracee.user_session.k8s_username":
 		return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Process.UserSession), nil
+	case "ransomware_score.kill":
+		return int(ev.RansomwareScore.Kill), nil
+	case "ransomware_score.new_file":
+		return int(ev.RansomwareScore.NewFile), nil
+	case "ransomware_score.rename":
+		return int(ev.RansomwareScore.Rename), nil
+	case "ransomware_score.score":
+		return int(ev.RansomwareScore.Score), nil
+	case "ransomware_score.time_to_trigger":
+		return int(ev.RansomwareScore.TimeToTrigger), nil
+	case "ransomware_score.unlink":
+		return int(ev.RansomwareScore.Unlink), nil
+	case "ransomware_score.urandom":
+		return int(ev.RansomwareScore.Urandom), nil
 	case "removexattr.file.change_time":
 		return int(ev.RemoveXAttr.File.FileFields.CTime), nil
 	case "removexattr.file.destination.name":
@@ -30862,6 +30954,20 @@ func (ev *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "ptrace", nil
 	case "ptrace.tracee.user_session.k8s_username":
 		return "ptrace", nil
+	case "ransomware_score.kill":
+		return "ransomware_score", nil
+	case "ransomware_score.new_file":
+		return "ransomware_score", nil
+	case "ransomware_score.rename":
+		return "ransomware_score", nil
+	case "ransomware_score.score":
+		return "ransomware_score", nil
+	case "ransomware_score.time_to_trigger":
+		return "ransomware_score", nil
+	case "ransomware_score.unlink":
+		return "ransomware_score", nil
+	case "ransomware_score.urandom":
+		return "ransomware_score", nil
 	case "removexattr.file.change_time":
 		return "removexattr", nil
 	case "removexattr.file.destination.name":
@@ -33687,6 +33793,20 @@ func (ev *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 	case "ptrace.tracee.user_session.k8s_username":
 		return reflect.String, nil
+	case "ransomware_score.kill":
+		return reflect.Int, nil
+	case "ransomware_score.new_file":
+		return reflect.Int, nil
+	case "ransomware_score.rename":
+		return reflect.Int, nil
+	case "ransomware_score.score":
+		return reflect.Int, nil
+	case "ransomware_score.time_to_trigger":
+		return reflect.Int, nil
+	case "ransomware_score.unlink":
+		return reflect.Int, nil
+	case "ransomware_score.urandom":
+		return reflect.Int, nil
 	case "removexattr.file.change_time":
 		return reflect.Int, nil
 	case "removexattr.file.destination.name":
@@ -44451,6 +44571,55 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "PTrace.Tracee.Process.UserSession.K8SUsername"}
 		}
 		ev.PTrace.Tracee.Process.UserSession.K8SUsername = rv
+		return nil
+	case "ransomware_score.kill":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RansomwareScore.Kill"}
+		}
+		ev.RansomwareScore.Kill = uint32(rv)
+		return nil
+	case "ransomware_score.new_file":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RansomwareScore.NewFile"}
+		}
+		ev.RansomwareScore.NewFile = uint32(rv)
+		return nil
+	case "ransomware_score.rename":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RansomwareScore.Rename"}
+		}
+		ev.RansomwareScore.Rename = uint32(rv)
+		return nil
+	case "ransomware_score.score":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RansomwareScore.Score"}
+		}
+		ev.RansomwareScore.Score = uint32(rv)
+		return nil
+	case "ransomware_score.time_to_trigger":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RansomwareScore.TimeToTrigger"}
+		}
+		ev.RansomwareScore.TimeToTrigger = uint64(rv)
+		return nil
+	case "ransomware_score.unlink":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RansomwareScore.Unlink"}
+		}
+		ev.RansomwareScore.Unlink = uint32(rv)
+		return nil
+	case "ransomware_score.urandom":
+		rv, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RansomwareScore.Urandom"}
+		}
+		ev.RansomwareScore.Urandom = uint32(rv)
 		return nil
 	case "removexattr.file.change_time":
 		rv, ok := value.(int)

--- a/pkg/security/secl/model/category.go
+++ b/pkg/security/secl/model/category.go
@@ -58,7 +58,8 @@ func GetEventTypeCategory(eventType eval.EventType) EventCategory {
 		PTraceEventType.String(),
 		UnloadModuleEventType.String(),
 		BindEventType.String(),
-		ConnectEventType.String():
+		ConnectEventType.String(),
+		RansomwareScoreEventType.String():
 		return KernelCategory
 
 	// Network

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -101,6 +101,8 @@ const (
 	CgroupWriteEventType
 	// RawPacketEventType raw packet event
 	RawPacketEventType
+	// RansomwareScoreEventType raw packet event
+	RansomwareScoreEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -231,6 +233,8 @@ func (t EventType) String() string {
 		return "ondemand"
 	case RawPacketEventType:
 		return "packet"
+	case RansomwareScoreEventType:
+		return "ransomware_score"
 	case CustomEventType:
 		return "custom_event"
 	case CreateNewFileEventType:

--- a/pkg/security/secl/model/field_accessors_unix.go
+++ b/pkg/security/secl/model/field_accessors_unix.go
@@ -13414,6 +13414,62 @@ func (ev *Event) GetPtraceTraceeUserSessionK8sUsername() string {
 	return ev.FieldHandlers.ResolveK8SUsername(ev, &ev.PTrace.Tracee.Process.UserSession)
 }
 
+// GetRansomwareScoreKill returns the value of the field, resolving if necessary
+func (ev *Event) GetRansomwareScoreKill() uint32 {
+	if ev.GetEventType().String() != "ransomware_score" {
+		return uint32(0)
+	}
+	return ev.RansomwareScore.Kill
+}
+
+// GetRansomwareScoreNewFile returns the value of the field, resolving if necessary
+func (ev *Event) GetRansomwareScoreNewFile() uint32 {
+	if ev.GetEventType().String() != "ransomware_score" {
+		return uint32(0)
+	}
+	return ev.RansomwareScore.NewFile
+}
+
+// GetRansomwareScoreRename returns the value of the field, resolving if necessary
+func (ev *Event) GetRansomwareScoreRename() uint32 {
+	if ev.GetEventType().String() != "ransomware_score" {
+		return uint32(0)
+	}
+	return ev.RansomwareScore.Rename
+}
+
+// GetRansomwareScoreScore returns the value of the field, resolving if necessary
+func (ev *Event) GetRansomwareScoreScore() uint32 {
+	if ev.GetEventType().String() != "ransomware_score" {
+		return uint32(0)
+	}
+	return ev.RansomwareScore.Score
+}
+
+// GetRansomwareScoreTimeToTrigger returns the value of the field, resolving if necessary
+func (ev *Event) GetRansomwareScoreTimeToTrigger() uint64 {
+	if ev.GetEventType().String() != "ransomware_score" {
+		return uint64(0)
+	}
+	return ev.RansomwareScore.TimeToTrigger
+}
+
+// GetRansomwareScoreUnlink returns the value of the field, resolving if necessary
+func (ev *Event) GetRansomwareScoreUnlink() uint32 {
+	if ev.GetEventType().String() != "ransomware_score" {
+		return uint32(0)
+	}
+	return ev.RansomwareScore.Unlink
+}
+
+// GetRansomwareScoreUrandom returns the value of the field, resolving if necessary
+func (ev *Event) GetRansomwareScoreUrandom() uint32 {
+	if ev.GetEventType().String() != "ransomware_score" {
+		return uint32(0)
+	}
+	return ev.RansomwareScore.Urandom
+}
+
 // GetRemovexattrFileChangeTime returns the value of the field, resolving if necessary
 func (ev *Event) GetRemovexattrFileChangeTime() uint64 {
 	if ev.GetEventType().String() != "removexattr" {

--- a/pkg/security/secl/model/field_handlers_unix.go
+++ b/pkg/security/secl/model/field_handlers_unix.go
@@ -783,6 +783,7 @@ func (ev *Event) resolveFields(forADs bool) {
 		if ev.PTrace.Tracee.HasParent() {
 			_ = ev.FieldHandlers.ResolveProcessIsThread(ev, ev.PTrace.Tracee.Parent)
 		}
+	case "ransomware_score":
 	case "removexattr":
 		_ = ev.FieldHandlers.ResolveFileFieldsUser(ev, &ev.RemoveXAttr.File.FileFields)
 		_ = ev.FieldHandlers.ResolveFileFieldsGroup(ev, &ev.RemoveXAttr.File.FileFields)

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -78,6 +78,9 @@ type Event struct {
 	IMDS      IMDSEvent      `field:"imds" event:"imds"`     // [7.55] [Network] An IMDS event was captured
 	RawPacket RawPacketEvent `field:"packet" event:"packet"` // [7.60] [Network] A raw network packet captured
 
+	// malware scoring events
+	RansomwareScore RansomwareScoreEvent `field:"ransomware_score" event:"ransomware_score"` // [7.62] [Kernel] [Experimental] A ransomware has reach the score threshold
+
 	// on-demand events
 	OnDemand OnDemandEvent `field:"ondemand" event:"ondemand"`
 
@@ -717,4 +720,15 @@ type RawPacketEvent struct {
 	Filter      string               `field:"filter" op_override:"PacketFilterMatching"` // SECLDoc[filter] Definition:`pcap filter expression`
 	CaptureInfo gopacket.CaptureInfo `field:"-"`
 	Data        []byte               `field:"-"`
+}
+
+// RansomwareScoreEvent represents a ransomware scoring event
+type RansomwareScoreEvent struct {
+	TimeToTrigger uint64 `field:"time_to_trigger"` // SECLDoc[time_to_trigger] Definition:`Time to reach the score`
+	NewFile       uint32 `field:"new_file"`        // SECLDoc[new_file] Definition:`Number of new files`
+	Unlink        uint32 `field:"unlink"`          // SECLDoc[unlink] Definition:`Number of unlinks`
+	Rename        uint32 `field:"rename"`          // SECLDoc[rename] Definition:`Number of renames`
+	Urandom       uint32 `field:"urandom"`         // SECLDoc[urandom] Definition:`Number of urandom`
+	Kill          uint32 `field:"kill"`            // SECLDoc[kill] Definition:`Number of kills`
+	Score         uint32 `field:"score"`           // SECLDoc[score] Definition:`Final score`
 }

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1393,3 +1393,18 @@ func (e *RawPacketEvent) UnmarshalBinary(data []byte) (int, error) {
 
 	return len(data), nil
 }
+
+// UnmarshalBinary unmarshalls a binary representation of itself
+func (e *RansomwareScoreEvent) UnmarshalBinary(data []byte) (int, error) {
+	if len(data) < 32 {
+		return 0, ErrNotEnoughData
+	}
+	e.TimeToTrigger = binary.NativeEndian.Uint64(data[0:8])
+	e.NewFile = binary.NativeEndian.Uint32(data[8:12])
+	e.Unlink = binary.NativeEndian.Uint32(data[12:16])
+	e.Rename = binary.NativeEndian.Uint32(data[16:20])
+	e.Urandom = binary.NativeEndian.Uint32(data[20:24])
+	e.Kill = binary.NativeEndian.Uint32(data[24:28])
+	e.Score = binary.NativeEndian.Uint32(data[28:32])
+	return 32, nil
+}

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -101,6 +101,8 @@ const (
 	CgroupWriteEventType
 	// RawPacketEventType raw packet event
 	RawPacketEventType
+	// RansomwareScoreEventType raw packet event
+	RansomwareScoreEventType
 	// MaxKernelEventType is used internally to get the maximum number of kernel events.
 	MaxKernelEventType
 
@@ -231,6 +233,8 @@ func (t EventType) String() string {
 		return "ondemand"
 	case RawPacketEventType:
 		return "packet"
+	case RansomwareScoreEventType:
+		return "ransomware_score"
 	case CustomEventType:
 		return "custom_event"
 	case CreateNewFileEventType:

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -519,6 +519,18 @@ type SyscallArgsSerializer struct {
 	FSType *string `json:"fs_type,omitempty"`
 }
 
+// RansomwareScoreSerializer defines a ransomware socre serializer
+// easyjson:json
+type RansomwareScoreSerializer struct {
+	TimeToTrigger uint64 `json:"time_to_trigger"`
+	NewFile       uint32 `json:"new_file"`
+	Unlink        uint32 `json:"unlink"`
+	Rename        uint32 `json:"rename"`
+	Urandom       uint32 `json:"urandom"`
+	Kill          uint32 `json:"kill"`
+	Score         uint32 `json:"score"`
+}
+
 func newSyscallArgsSerializer(sc *model.SyscallContext, e *model.Event) *SyscallArgsSerializer {
 
 	switch e.GetEventType() {
@@ -623,23 +635,24 @@ type EventSerializer struct {
 	*DDContextSerializer              `json:"dd,omitempty"`
 	*SecurityProfileContextSerializer `json:"security_profile,omitempty"`
 
-	*SELinuxEventSerializer   `json:"selinux,omitempty"`
-	*BPFEventSerializer       `json:"bpf,omitempty"`
-	*MMapEventSerializer      `json:"mmap,omitempty"`
-	*MProtectEventSerializer  `json:"mprotect,omitempty"`
-	*PTraceEventSerializer    `json:"ptrace,omitempty"`
-	*ModuleEventSerializer    `json:"module,omitempty"`
-	*SignalEventSerializer    `json:"signal,omitempty"`
-	*SpliceEventSerializer    `json:"splice,omitempty"`
-	*DNSEventSerializer       `json:"dns,omitempty"`
-	*IMDSEventSerializer      `json:"imds,omitempty"`
-	*BindEventSerializer      `json:"bind,omitempty"`
-	*ConnectEventSerializer   `json:"connect,omitempty"`
-	*MountEventSerializer     `json:"mount,omitempty"`
-	*SyscallsEventSerializer  `json:"syscalls,omitempty"`
-	*UserContextSerializer    `json:"usr,omitempty"`
-	*SyscallContextSerializer `json:"syscall,omitempty"`
-	*RawPacketSerializer      `json:"packet,omitempty"`
+	*SELinuxEventSerializer    `json:"selinux,omitempty"`
+	*BPFEventSerializer        `json:"bpf,omitempty"`
+	*MMapEventSerializer       `json:"mmap,omitempty"`
+	*MProtectEventSerializer   `json:"mprotect,omitempty"`
+	*PTraceEventSerializer     `json:"ptrace,omitempty"`
+	*ModuleEventSerializer     `json:"module,omitempty"`
+	*SignalEventSerializer     `json:"signal,omitempty"`
+	*SpliceEventSerializer     `json:"splice,omitempty"`
+	*DNSEventSerializer        `json:"dns,omitempty"`
+	*IMDSEventSerializer       `json:"imds,omitempty"`
+	*BindEventSerializer       `json:"bind,omitempty"`
+	*ConnectEventSerializer    `json:"connect,omitempty"`
+	*MountEventSerializer      `json:"mount,omitempty"`
+	*SyscallsEventSerializer   `json:"syscalls,omitempty"`
+	*UserContextSerializer     `json:"usr,omitempty"`
+	*SyscallContextSerializer  `json:"syscall,omitempty"`
+	*RawPacketSerializer       `json:"packet,omitempty"`
+	*RansomwareScoreSerializer `json:"ransomware_score,omitempty"`
 }
 
 func newSyscallsEventSerializer(e *model.SyscallsEvent) *SyscallsEventSerializer {
@@ -1021,6 +1034,18 @@ func newRawPacketEventSerializer(rp *model.RawPacketEvent, e *model.Event) *RawP
 		TLSContext: &TLSContextSerializer{
 			Version: model.TLSVersion(rp.TLSContext.Version).String(),
 		},
+	}
+}
+
+func newRansomwareScoreEventSerializer(rs *model.RansomwareScoreEvent, e *model.Event) *RansomwareScoreSerializer {
+	return &RansomwareScoreSerializer{
+		TimeToTrigger: rs.TimeToTrigger,
+		NewFile:       rs.NewFile,
+		Unlink:        rs.Unlink,
+		Rename:        rs.Rename,
+		Urandom:       rs.Urandom,
+		Kill:          rs.Kill,
+		Score:         rs.Score,
 	}
 }
 
@@ -1439,6 +1464,8 @@ func NewEventSerializer(event *model.Event, opts *eval.Opts) *EventSerializer {
 		})
 	case model.RawPacketEventType:
 		s.RawPacketSerializer = newRawPacketEventSerializer(&event.RawPacket, event)
+	case model.RansomwareScoreEventType:
+		s.RansomwareScoreSerializer = newRansomwareScoreEventSerializer(&event.RansomwareScore, event)
 	}
 
 	return s

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -1426,7 +1426,101 @@ func (v SELinuxBoolChangeSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *SELinuxBoolChangeSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(in *jlexer.Lexer, out *ProcessSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(in *jlexer.Lexer, out *RansomwareScoreSerializer) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		if in.IsNull() {
+			in.Skip()
+			in.WantComma()
+			continue
+		}
+		switch key {
+		case "time_to_trigger":
+			out.TimeToTrigger = uint64(in.Uint64())
+		case "new_file":
+			out.NewFile = uint32(in.Uint32())
+		case "unlink":
+			out.Unlink = uint32(in.Uint32())
+		case "rename":
+			out.Rename = uint32(in.Uint32())
+		case "urandom":
+			out.Urandom = uint32(in.Uint32())
+		case "kill":
+			out.Kill = uint32(in.Uint32())
+		case "score":
+			out.Score = uint32(in.Uint32())
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(out *jwriter.Writer, in RansomwareScoreSerializer) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"time_to_trigger\":"
+		out.RawString(prefix[1:])
+		out.Uint64(uint64(in.TimeToTrigger))
+	}
+	{
+		const prefix string = ",\"new_file\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.NewFile))
+	}
+	{
+		const prefix string = ",\"unlink\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.Unlink))
+	}
+	{
+		const prefix string = ",\"rename\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.Rename))
+	}
+	{
+		const prefix string = ",\"urandom\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.Urandom))
+	}
+	{
+		const prefix string = ",\"kill\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.Kill))
+	}
+	{
+		const prefix string = ",\"score\":"
+		out.RawString(prefix)
+		out.Uint32(uint32(in.Score))
+	}
+	out.RawByte('}')
+}
+
+// MarshalEasyJSON supports easyjson.Marshaler interface
+func (v RansomwareScoreSerializer) MarshalEasyJSON(w *jwriter.Writer) {
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(w, v)
+}
+
+// UnmarshalEasyJSON supports easyjson.Unmarshaler interface
+func (v *RansomwareScoreSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(l, v)
+}
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in *jlexer.Lexer, out *ProcessSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1643,7 +1737,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 					}
 					for !in.IsDelim(']') {
 						var v14 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in, &v14)
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in, &v14)
 						*out.Syscalls = append(*out.Syscalls, v14)
 						in.WantComma()
 					}
@@ -1691,7 +1785,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(out *jwriter.Writer, in ProcessSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out *jwriter.Writer, in ProcessSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1875,7 +1969,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 				if v20 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out, v21)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out, v21)
 			}
 			out.RawByte(']')
 		}
@@ -1903,14 +1997,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers13(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in *jlexer.Lexer, out *SyscallSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in *jlexer.Lexer, out *SyscallSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -1943,7 +2037,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out *jwriter.Writer, in SyscallSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out *jwriter.Writer, in SyscallSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -1959,7 +2053,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(
 	}
 	out.RawByte('}')
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in *jlexer.Lexer, out *ProcessCredentialsSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2069,7 +2163,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out *jwriter.Writer, in ProcessCredentialsSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out *jwriter.Writer, in ProcessCredentialsSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2192,14 +2286,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessCredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessCredentialsSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(in *jlexer.Lexer, out *PTraceEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *PTraceEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2242,7 +2336,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(out *jwriter.Writer, in PTraceEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out *jwriter.Writer, in PTraceEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2266,14 +2360,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PTraceEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *PTraceEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(in *jlexer.Lexer, out *NetworkDeviceSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2308,7 +2402,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out *jwriter.Writer, in NetworkDeviceSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(out *jwriter.Writer, in NetworkDeviceSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2332,14 +2426,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NetworkDeviceSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *NetworkDeviceSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(in *jlexer.Lexer, out *MountEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(in *jlexer.Lexer, out *MountEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2406,7 +2500,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(out *jwriter.Writer, in MountEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(out *jwriter.Writer, in MountEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2481,14 +2575,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MountEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MountEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(in *jlexer.Lexer, out *ModuleEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in *jlexer.Lexer, out *ModuleEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2562,7 +2656,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(out *jwriter.Writer, in ModuleEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out *jwriter.Writer, in ModuleEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2600,14 +2694,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ModuleEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ModuleEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers19(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(in *jlexer.Lexer, out *MProtectEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in *jlexer.Lexer, out *MProtectEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2644,7 +2738,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(out *jwriter.Writer, in MProtectEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out *jwriter.Writer, in MProtectEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2673,14 +2767,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MProtectEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MProtectEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers20(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(in *jlexer.Lexer, out *MMapEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(in *jlexer.Lexer, out *MMapEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2719,7 +2813,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(out *jwriter.Writer, in MMapEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(out *jwriter.Writer, in MMapEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -2753,14 +2847,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v MMapEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *MMapEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers21(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(in *jlexer.Lexer, out *FileSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(in *jlexer.Lexer, out *FileSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -2943,7 +3037,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(out *jwriter.Writer, in FileSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(out *jwriter.Writer, in FileSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3136,14 +3230,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers22(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(in *jlexer.Lexer, out *FileEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(in *jlexer.Lexer, out *FileEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3342,7 +3436,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(out *jwriter.Writer, in FileEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(out *jwriter.Writer, in FileEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -3575,14 +3669,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *FileEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(in *jlexer.Lexer, out *EventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *EventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -3612,6 +3706,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 	out.UserContextSerializer = new(UserContextSerializer)
 	out.SyscallContextSerializer = new(SyscallContextSerializer)
 	out.RawPacketSerializer = new(RawPacketSerializer)
+	out.RansomwareScoreSerializer = new(RansomwareScoreSerializer)
 	in.Delim('{')
 	for !in.IsDelim('}') {
 		key := in.UnsafeFieldName(false)
@@ -3806,7 +3901,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 					}
 					for !in.IsDelim(']') {
 						var v45 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(in, &v45)
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(in, &v45)
 						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v45)
 						in.WantComma()
 					}
@@ -3842,6 +3937,16 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 					out.RawPacketSerializer = new(RawPacketSerializer)
 				}
 				(*out.RawPacketSerializer).UnmarshalEasyJSON(in)
+			}
+		case "ransomware_score":
+			if in.IsNull() {
+				in.Skip()
+				out.RansomwareScoreSerializer = nil
+			} else {
+				if out.RansomwareScoreSerializer == nil {
+					out.RansomwareScoreSerializer = new(RansomwareScoreSerializer)
+				}
+				(*out.RansomwareScoreSerializer).UnmarshalEasyJSON(in)
 			}
 		case "evt":
 			(out.EventContextSerializer).UnmarshalEasyJSON(in)
@@ -3909,7 +4014,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(out *jwriter.Writer, in EventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in EventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4085,7 +4190,7 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 				if v46 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers14(out, v47)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers15(out, v47)
 			}
 			out.RawByte(']')
 		}
@@ -4119,6 +4224,16 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 			out.RawString(prefix)
 		}
 		(*in.RawPacketSerializer).MarshalEasyJSON(out)
+	}
+	if in.RansomwareScoreSerializer != nil {
+		const prefix string = ",\"ransomware_score\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		(*in.RansomwareScoreSerializer).MarshalEasyJSON(out)
 	}
 	if true {
 		const prefix string = ",\"evt\":"
@@ -4195,14 +4310,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *EventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers24(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(in *jlexer.Lexer, out *DDContextSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *DDContextSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4235,7 +4350,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(out *jwriter.Writer, in DDContextSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in DDContextSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4260,14 +4375,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DDContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *DDContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers25(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(in *jlexer.Lexer, out *CredentialsSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *CredentialsSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4368,7 +4483,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(out *jwriter.Writer, in CredentialsSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in CredentialsSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4474,14 +4589,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CredentialsSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(in *jlexer.Lexer, out *ConnectEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *ConnectEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4514,7 +4629,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(out *jwriter.Writer, in ConnectEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in ConnectEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4533,14 +4648,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ConnectEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ConnectEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(in *jlexer.Lexer, out *CapsetSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *CapsetSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4615,7 +4730,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(out *jwriter.Writer, in CapsetSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in CapsetSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4656,14 +4771,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CapsetSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *CapsetSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers28(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(in *jlexer.Lexer, out *BindEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *BindEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4696,7 +4811,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(out *jwriter.Writer, in BindEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in BindEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4715,14 +4830,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BindEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BindEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(in *jlexer.Lexer, out *BPFProgramSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *BPFProgramSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4782,7 +4897,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(out *jwriter.Writer, in BPFProgramSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in BPFProgramSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4846,14 +4961,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFProgramSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFProgramSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(in *jlexer.Lexer, out *BPFMapSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *BPFMapSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4886,7 +5001,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(out *jwriter.Writer, in BPFMapSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in BPFMapSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4911,14 +5026,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFMapSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFMapSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers31(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(in *jlexer.Lexer, out *BPFEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *BPFEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -4969,7 +5084,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(out *jwriter.Writer, in BPFEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in BPFEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -4993,14 +5108,14 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v BPFEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *BPFEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
 }
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(in *jlexer.Lexer, out *AnomalyDetectionSyscallEventSerializer) {
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(in *jlexer.Lexer, out *AnomalyDetectionSyscallEventSerializer) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -5031,7 +5146,7 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 		in.Consumed()
 	}
 }
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(out *jwriter.Writer, in AnomalyDetectionSyscallEventSerializer) {
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(out *jwriter.Writer, in AnomalyDetectionSyscallEventSerializer) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -5045,10 +5160,10 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AnomalyDetectionSyscallEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(w, v)
+	easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(w, v)
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AnomalyDetectionSyscallEventSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(l, v)
+	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(l, v)
 }


### PR DESCRIPTION
### What does this PR do?

The idea is to add an eBPF ransomware detector, looking at processes which behaves as a ransomware.

The PR adds a new `ransomware score` event type. To be raised by the kernel, a process should reach a dedicated score threshold in a given period of time (as today, a score of "500" in a 1sec period). Each time a process create a new file, make a rename, a kill or a rename the process score is incremented.

TODO: compute the random score when getrandom() is called, or when /dev/urandom file is opened.


### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->