### PR TITLE
ci: Fix CODEOWNERS due to team split

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -118,7 +118,7 @@
 /.gitlab/binary_build/system_probe.yml               @DataDog/ebpf-platform @DataDog/agent-delivery
 /.gitlab/binary_build/windows.yml                    @DataDog/agent-delivery @DataDog/windows-agent
 
-/.gitlab/benchmarks/                                 @DataDog/agent-devx-infra @DataDog/apm-reliability-and-performance @DataDog/agent-apm
+/.gitlab/benchmarks/                                 @DataDog/agent-devx-infra @DataDog/apm-ecosystems-performance @DataDog/agent-apm
 
 /.gitlab/deploy_containers/                          @DataDog/container-integrations @DataDog/agent-delivery
 /.gitlab/deploy_dca/                                 @DataDog/container-integrations @DataDog/agent-delivery

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -44,5 +44,5 @@
 '@datadog/agent-devx-infra': '#agent-devx-ops'
 '@datadog/agent-devx-loops': '#agent-devx-ops'
 '@datadog/apm-onboarding': '#apm-onboarding'
-'@datadog/apm-reliability-and-performance': '#apm-ecosystems-reliability'
+'@datadog/apm-ecosystems-performance': '#apm-benchmarking-platform'
 '@DataDog/container-ecosystems': '#container-ecosystems-ops'


### PR DESCRIPTION
### What does this PR do?

The team #apm-reliability-and-performance was split. This PR updates handle and assigns correct codeowners for benchmarking Gitlab CI pipelines, owned by APM Ecosystems Performance.

### Motivation

Fix handle after team split.