### PR TITLE
[usm] system-probe, http statskeeper, add pool of ddsketch objects

### DIFF
--- a/pkg/network/protocols/http/statkeeper.go
+++ b/pkg/network/protocols/http/statkeeper.go
@@ -93,9 +93,11 @@ func (h *StatKeeper) GetAndResetAllStats() (stats map[Key]*RequestStats) {
 			h.add(tx)
 		}
 
+		// put back 'DDSketch' objects to pool
+		h.releaseSketchPool()
+
 		// Rotate stats
 		stats = h.stats
-		h.releaseSketchPool()
 		h.stats = make(map[Key]*RequestStats)
 
 		// Rotate ConnectionAggregator
@@ -228,7 +230,7 @@ func (h *StatKeeper) clearEphemeralPorts(aggregator *utils.ConnectionAggregator,
 	}
 }
 
-// newSketchPool creates new pool of DDSketch objects.
+// newSketchPool creates new pool of 'DDSketch' objects.
 func newSketchPool() *ddsync.TypedPool[ddsketch.DDSketch] {
 	sketchPool := ddsync.NewTypedPool(func() *ddsketch.DDSketch {
 		sketch, err := ddsketch.NewDefaultDDSketch(RelativeAccuracy)
@@ -240,9 +242,9 @@ func newSketchPool() *ddsync.TypedPool[ddsketch.DDSketch] {
 	return sketchPool
 }
 
-// releaseSketchPool put DDSketch objects to pool.
+// releaseSketchPool puts 'DDSketch' objects back to pool.
 func (h *StatKeeper) releaseSketchPool() {
 	for _, stats := range h.stats {
-		stats.PutSketches()
+		stats.putSketches()
 	}
 }

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -322,3 +322,78 @@ func TestHTTPCorrectness(t *testing.T) {
 		require.Len(t, stats, 0)
 	})
 }
+
+func makeStatkeeper() *StatKeeper {
+	cfg := config.New()
+	cfg.MaxHTTPStatsBuffered = 100000
+	tel := NewTelemetry("http")
+	return NewStatkeeper(cfg, tel, NewIncompleteBuffer(cfg, tel))
+}
+
+// BenchmarkHTTPStatkeeperWithPool benchmark allocations with pool of 'DDSketch' objects
+func BenchmarkHTTPStatkeeperWithPool(b *testing.B) {
+	sk := makeStatkeeper()
+
+	sourceIP := util.AddressFromString("1.1.1.1")
+	sourcePort := 1234
+	destIP := util.AddressFromString("2.2.2.2")
+	destPort := 8080
+
+	const numPaths = 10000
+	const uniqPaths = 50
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sk.GetAndResetAllStats()
+		for p := 0; p < numPaths; p++ {
+			b.StopTimer()
+			//we use subset of unique endpoints, but those will occur over and over again like in regular target application
+			path := "/testpath/blablabla/dsadas/isdaasd/asdasadsadasd" + strconv.Itoa(p%uniqPaths)
+			//we simulate different conn tuples by increasing the port number
+			newSourcePort := sourcePort + (p % 30)
+			statusCode := (i%5 + 1) * 100
+			latency := time.Duration(i%5+1) * time.Millisecond
+			tx := generateIPv4HTTPTransaction(sourceIP, destIP, newSourcePort, destPort, path, statusCode, latency)
+			b.StartTimer()
+			sk.Process(tx)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkHTTPStatkeeperNoPool benchmark allocations without pool of 'DDSketch' objects
+func BenchmarkHTTPStatkeeperNoPool(b *testing.B) {
+	sk := makeStatkeeper()
+	sk.DisableSketchPool()
+
+	sourceIP := util.AddressFromString("1.1.1.1")
+	sourcePort := 1234
+	destIP := util.AddressFromString("2.2.2.2")
+	destPort := 8080
+
+	const numPaths = 10000
+	const uniqPaths = 50
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sk.GetAndResetAllStats()
+		for p := 0; p < numPaths; p++ {
+			b.StopTimer()
+			//we use subset of unique endpoints, but those will occur over and over again like in regular target application
+			path := "/testpath/blablabla/dsadas/isdaasd/asdasadsadasd" + strconv.Itoa(p%uniqPaths)
+			//we simulate different conn tuples by increasing the port number
+			newSourcePort := sourcePort + (p % 30)
+			statusCode := (i%5 + 1) * 100
+			latency := time.Duration(i%5+1) * time.Millisecond
+			tx := generateIPv4HTTPTransaction(sourceIP, destIP, newSourcePort, destPort, path, statusCode, latency)
+			b.StartTimer()
+			sk.Process(tx)
+		}
+	}
+	b.StopTimer()
+}
+
+// DisableSketchPool disable pool of 'DDSketch' objects for testing purpose.
+func (h *StatKeeper) DisableSketchPool() {
+	h.ddsketchPool = nil
+}

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -249,8 +249,8 @@ func (r *RequestStats) HalfAllCounts() {
 	}
 }
 
-// PutSketches adds all obtained sketch objects to the pool.
-func (r *RequestStats) PutSketches() {
+// putSketches returns all obtained 'DDSketch' objects to the pool.
+func (r *RequestStats) putSketches() {
 	if r.SketchPool != nil {
 		for _, stats := range r.Data {
 			r.SketchPool.Put(stats.Latencies)

--- a/pkg/network/protocols/http/stats_test.go
+++ b/pkg/network/protocols/http/stats_test.go
@@ -77,39 +77,3 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	assert.True(t, val >= expectedValue-acceptableError)
 	assert.True(t, val <= expectedValue+acceptableError)
 }
-
-// BenchmarkHttpRequestsNoPool generates stats requests
-func BenchmarkHttpRequestsNoPool(b *testing.B) {
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		stats := NewRequestStats()
-		// run over expected code range from 100 to 600
-		for n := 100; n < 600; n++ {
-			var code = uint16(n)
-			stats.AddRequest(code, 5.0, 1, nil)
-			// call twice to trigger allocation of DDSketch
-			stats.AddRequest(code, 10.0, 1, nil)
-		}
-	}
-	b.StopTimer()
-}
-
-// BenchmarkHttpRequestsWithPool generates stats requests using pool of DDSketch objects
-func BenchmarkHttpRequestsWithPool(b *testing.B) {
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	pool := NewSketchPool()
-	for i := 0; i < b.N; i++ {
-		stats := NewRequestStatsWithPool(pool)
-		for n := 100; n < 600; n++ {
-			var code = uint16(n)
-			stats.AddRequest(code, 5.0, 1, nil)
-			// call twice to trigger allocation of DDSketch
-			stats.AddRequest(code, 10.0, 1, nil)
-		}
-	}
-	b.StopTimer()
-}

--- a/pkg/network/protocols/http/stats_test.go
+++ b/pkg/network/protocols/http/stats_test.go
@@ -10,8 +10,9 @@ package http
 import (
 	"testing"
 
-	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/sketches-go/ddsketch"
 )
 
 func TestAddRequest(t *testing.T) {
@@ -75,4 +76,40 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	acceptableError := expectedValue * sketch.IndexMapping.RelativeAccuracy()
 	assert.True(t, val >= expectedValue-acceptableError)
 	assert.True(t, val <= expectedValue+acceptableError)
+}
+
+// BenchmarkHttpRequestsNoPool generates stats requests
+func BenchmarkHttpRequestsNoPool(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		stats := NewRequestStats()
+		// run over expected code range from 100 to 600
+		for n := 100; n < 600; n++ {
+			var code = uint16(n)
+			stats.AddRequest(code, 5.0, 1, nil)
+			// call twice to trigger allocation of DDSketch
+			stats.AddRequest(code, 10.0, 1, nil)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkHttpRequestsWithPool generates stats requests using pool of DDSketch objects
+func BenchmarkHttpRequestsWithPool(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	pool := NewSketchPool()
+	for i := 0; i < b.N; i++ {
+		stats := NewRequestStatsWithPool(pool)
+		for n := 100; n < 600; n++ {
+			var code = uint16(n)
+			stats.AddRequest(code, 5.0, 1, nil)
+			// call twice to trigger allocation of DDSketch
+			stats.AddRequest(code, 10.0, 1, nil)
+		}
+	}
+	b.StopTimer()
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds pool of `DDSketch` objects to `StatKeeper` struct.

### Motivation
This is part of an effort to improve USM performance and reliability.
Profiling shows frequently allocated objects of 'DDSketch', using pool of these objects should decrease memory utilization.

Benchmarking on local VM shows shows allocation decrease 3.7 times:
```
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
BenchmarkHTTPStatkeeperWithPool-4   	     100	  10853091 ns/op	   86515 B/op	     651 allocs/op
BenchmarkHTTPStatkeeperNoPool-4     	     100	  11162432 ns/op	  338688 B/op	    2414 allocs/op

```
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Covered by unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->