### PR TITLE
Profile cloning

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_metric.go
@@ -28,17 +28,13 @@ func BuildMetricTagsFromValue(metricTag *profiledefinition.MetricTagConfig, valu
 		} else {
 			tags = append(tags, metricTag.Tag+":"+value)
 		}
-	} else if metricTag.Match != "" {
-		if metricTag.Pattern == nil {
-			log.Warnf("match Pattern must be present: match=%s", metricTag.Match)
-			return tags
-		}
-		if metricTag.Pattern.MatchString(value) {
+	} else if metricTag.Match != nil {
+		if metricTag.Match.MatchString(value) {
 			for key, val := range metricTag.Tags {
 				normalizedTemplate := normalizeRegexReplaceValue(val)
-				replacedVal := RegexReplaceValue(value, metricTag.Pattern, normalizedTemplate)
+				replacedVal := RegexReplaceValue(value, metricTag.Match, normalizedTemplate)
 				if replacedVal == "" {
-					log.Debugf("Pattern `%v` failed to match `%v` with template `%v`", metricTag.Pattern, value, normalizedTemplate)
+					log.Debugf("Pattern `%v` failed to match `%v` with template `%v`", metricTag.Match, value, normalizedTemplate)
 					continue
 				}
 				tags = append(tags, key+":"+replacedVal)

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -209,8 +209,7 @@ bulk_max_repetitions: 20
 						Name: "cpiPduName",
 						OID:  "1.2.3.4.8.1.2",
 					},
-					Match:   "(\\w)(\\w+)",
-					Pattern: regexp.MustCompile(`(\w)(\w+)`),
+					Match: regexp.MustCompile(`(\w)(\w+)`),
 					Tags: map[string]string{
 						"prefix": "\\1",
 						"suffix": "\\2",
@@ -226,18 +225,16 @@ bulk_max_repetitions: 20
 		{Tag: "my_symbol", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}},
 		{Tag: "my_symbol_mapped", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}, Mapping: map[string]string{"1": "one", "2": "two"}},
 		{
-			Symbol:  profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"},
-			Match:   "(\\w)(\\w+)",
-			Pattern: regexp.MustCompile(`(\w)(\w+)`),
+			Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"},
+			Match:  regexp.MustCompile(`(\w)(\w+)`),
 			Tags: map[string]string{
 				"prefix": "\\1",
 				"suffix": "\\2",
 			},
 		},
 		{
-			Symbol:  profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
-			Match:   "(\\w)(\\w+)",
-			Pattern: regexp.MustCompile(`(\w)(\w+)`),
+			Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+			Match:  regexp.MustCompile(`(\w)(\w+)`),
 			Tags: map[string]string{
 				"some_tag": "some_tag_value",
 				"prefix":   "\\1",

--- a/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich.go
+++ b/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich.go
@@ -8,8 +8,6 @@ package configvalidation
 
 import (
 	"fmt"
-	"regexp"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
@@ -150,22 +148,6 @@ func validateEnrichSymbol(symbol *profiledefinition.SymbolConfig, symbolContext 
 			errors = append(errors, fmt.Sprintf("symbol oid missing: name=`%s` oid=`%s`", symbol.Name, symbol.OID))
 		}
 	}
-	if symbol.ExtractValue != "" {
-		pattern, err := regexp.Compile(symbol.ExtractValue)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("cannot compile `extract_value` (%s): %s", symbol.ExtractValue, err.Error()))
-		} else {
-			symbol.ExtractValueCompiled = pattern
-		}
-	}
-	if symbol.MatchPattern != "" {
-		pattern, err := regexp.Compile(symbol.MatchPattern)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("cannot compile `extract_value` (%s): %s", symbol.ExtractValue, err.Error()))
-		} else {
-			symbol.MatchPatternCompiled = pattern
-		}
-	}
 	if symbolContext != ColumnSymbol && symbol.ConstantValueOne {
 		errors = append(errors, "`constant_value_one` cannot be used outside of tables")
 	}
@@ -205,13 +187,7 @@ func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []str
 		errors = append(errors, validateEnrichSymbol(&symbol, MetricTagSymbol)...)
 		metricTag.Symbol = profiledefinition.SymbolConfigCompat(symbol)
 	}
-	if metricTag.Match != "" {
-		pattern, err := regexp.Compile(metricTag.Match)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("cannot compile `match` (`%s`): %s", metricTag.Match, err.Error()))
-		} else {
-			metricTag.Pattern = pattern
-		}
+	if metricTag.Match != nil {
 		if len(metricTag.Tags) == 0 {
 			errors = append(errors, fmt.Sprintf("`tags` mapping must be provided if `match` (`%s`) is defined", metricTag.Match))
 		}

--- a/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich_test.go
@@ -220,7 +220,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 								OID:  "1.2.3",
 								Name: "abc",
 							},
-							Match: "([a-z])",
+							Match: regexp.MustCompile("([a-z])"),
 						},
 					},
 				},
@@ -230,35 +230,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			},
 		},
 		{
-			name: "match cannot compile regex",
-			metrics: []profiledefinition.MetricsConfig{
-				{
-					Symbols: []profiledefinition.SymbolConfig{
-						{
-							OID:  "1.2",
-							Name: "abc",
-						},
-					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
-								OID:  "1.2.3",
-								Name: "abc",
-							},
-							Match: "([a-z)",
-							Tags: map[string]string{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"cannot compile `match` (`([a-z)`)",
-			},
-		},
-		{
-			name: "match cannot compile regex",
+			name: "match has invalid transform",
 			metrics: []profiledefinition.MetricsConfig{
 				{
 					Symbols: []profiledefinition.SymbolConfig{
@@ -286,84 +258,6 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 			},
 			expectedErrors: []string{
 				"transform rule end should be greater than start. Invalid rule",
-			},
-		},
-		{
-			name: "compiling extract_value",
-			metrics: []profiledefinition.MetricsConfig{
-				{
-					Symbol: profiledefinition.SymbolConfig{
-						OID:          "1.2.3",
-						Name:         "myMetric",
-						ExtractValue: `(\d+)C`,
-					},
-				},
-				{
-					Symbols: []profiledefinition.SymbolConfig{
-						{
-							OID:          "1.2",
-							Name:         "hey",
-							ExtractValue: `(\d+)C`,
-						},
-					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
-								OID:          "1.2.3",
-								Name:         "abc",
-								ExtractValue: `(\d+)C`,
-							},
-							Tag: "hello",
-						},
-					},
-				},
-			},
-			expectedMetrics: []profiledefinition.MetricsConfig{
-				{
-					Symbol: profiledefinition.SymbolConfig{
-						OID:                  "1.2.3",
-						Name:                 "myMetric",
-						ExtractValue:         `(\d+)C`,
-						ExtractValueCompiled: regexp.MustCompile(`(\d+)C`),
-					},
-				},
-				{
-					Symbols: []profiledefinition.SymbolConfig{
-						{
-							OID:                  "1.2",
-							Name:                 "hey",
-							ExtractValue:         `(\d+)C`,
-							ExtractValueCompiled: regexp.MustCompile(`(\d+)C`),
-						},
-					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
-								OID:                  "1.2.3",
-								Name:                 "abc",
-								ExtractValue:         `(\d+)C`,
-								ExtractValueCompiled: regexp.MustCompile(`(\d+)C`),
-							},
-							Tag: "hello",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{},
-		},
-		{
-			name: "error compiling extract_value",
-			metrics: []profiledefinition.MetricsConfig{
-				{
-					Symbol: profiledefinition.SymbolConfig{
-						OID:          "1.2.3",
-						Name:         "myMetric",
-						ExtractValue: "[{",
-					},
-				},
-			},
-			expectedErrors: []string{
-				"cannot compile `extract_value`",
 			},
 		},
 		{
@@ -753,77 +647,6 @@ func Test_validateEnrichMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid regex pattern for symbol",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
-							Symbol: profiledefinition.SymbolConfig{
-								OID:          "1.2.3",
-								Name:         "someSymbol",
-								ExtractValue: "(\\w[)",
-							},
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"cannot compile `extract_value`",
-			},
-		},
-		{
-			name: "invalid regex pattern for multiple symbols",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
-							Symbols: []profiledefinition.SymbolConfig{
-								{
-									OID:          "1.2.3",
-									Name:         "someSymbol",
-									ExtractValue: "(\\w[)",
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"cannot compile `extract_value`",
-			},
-		},
-		{
-			name: "field regex pattern is compiled",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
-							Symbol: profiledefinition.SymbolConfig{
-								OID:          "1.2.3",
-								Name:         "someSymbol",
-								ExtractValue: "(\\w)",
-							},
-						},
-					},
-				},
-			},
-			expectedErrors: []string{},
-			expectedMetadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
-							Symbol: profiledefinition.SymbolConfig{
-								OID:                  "1.2.3",
-								Name:                 "someSymbol",
-								ExtractValue:         "(\\w)",
-								ExtractValueCompiled: regexp.MustCompile(`(\w)`),
-							},
-						},
-					},
-				},
-			},
-		},
-		{
 			name: "invalid resource",
 			metadata: profiledefinition.MetadataConfig{
 				"invalid-res": profiledefinition.MetadataResourceConfig{
@@ -868,7 +691,6 @@ func Test_validateEnrichMetadata(t *testing.T) {
 								OID:  "1.2.3",
 								Name: "abc",
 							},
-							Match: "([a-z)",
 							Tags: map[string]string{
 								"foo": "bar",
 							},
@@ -878,7 +700,6 @@ func Test_validateEnrichMetadata(t *testing.T) {
 			},
 			expectedErrors: []string{
 				"invalid resource (interface) field: invalid-field",
-				"cannot compile `match` (`([a-z)`)",
 			},
 		},
 		{

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -354,7 +355,7 @@ collect_topology: false
 		{Tag: "snmp_host2", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 		{
 			Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
-			Match:  "(\\w)(\\w+)",
+			Match:  regexp.MustCompile(`(\w)(\w+)`),
 			Tags: map[string]string{
 				"prefix":   "\\1",
 				"suffix":   "\\2",
@@ -963,7 +964,7 @@ community_string: public
 	expectedMetricsTagConfigs := []profiledefinition.MetricTagConfig{
 		{
 			Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
-			Match:  "(\\w)(\\w+)",
+			Match:  regexp.MustCompile(`(\w)(\w+)`),
 			Tags: map[string]string{
 				"some_tag": "some_tag_value",
 				"prefix":   "\\1",

--- a/pkg/collector/corechecks/snmp/internal/profile/config_profile.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/config_profile.go
@@ -12,10 +12,22 @@ import (
 // ProfileConfigMap represent a map of ProfileConfig
 type ProfileConfigMap map[string]ProfileConfig
 
+func (m ProfileConfigMap) Clone() ProfileConfigMap {
+	return profiledefinition.CloneMap(m)
+}
+
 // ProfileConfig represent a profile configuration
 type ProfileConfig struct {
 	DefinitionFile string                              `yaml:"definition_file"`
 	Definition     profiledefinition.ProfileDefinition `yaml:"definition"`
 
 	IsUserProfile bool `yaml:"-"`
+}
+
+func (p ProfileConfig) Clone() ProfileConfig {
+	return ProfileConfig{
+		DefinitionFile: p.DefinitionFile,
+		Definition:     *p.Definition.Clone(),
+		IsUserProfile:  p.IsUserProfile,
+	}
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/mohae/deepcopy"
-
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/configvalidation"
 )
@@ -41,7 +39,7 @@ func loadResolveProfiles(pConfig ProfileConfigMap, defaultProfiles ProfileConfig
 			continue
 		}
 
-		newProfileConfig := deepcopy.Copy(pConfig[name]).(ProfileConfig)
+		newProfileConfig := pConfig[name].Clone()
 		err := recursivelyExpandBaseProfiles(name, &newProfileConfig.Definition, newProfileConfig.Definition.Extends, []string{}, pConfig, defaultProfiles)
 		if err != nil {
 			log.Warnf("failed to expand profile %q: %v", name, err)

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
@@ -7,6 +7,7 @@ package profile
 
 import (
 	"path/filepath"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -66,7 +67,7 @@ func Test_getProfiles(t *testing.T) {
 						Name: "my-init-config-profile",
 						MetricTags: profiledefinition.MetricTagConfigList{
 							{
-								Match: "invalidRegex({[",
+								Match: regexp.MustCompile("foo"), // invalid bcs tags must be provided
 							},
 						},
 					},

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/mohae/deepcopy"
-
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
@@ -20,7 +18,7 @@ import (
 
 // CopyProfileDefinition copies a profile, it's used for testing
 func CopyProfileDefinition(profileDef profiledefinition.ProfileDefinition) profiledefinition.ProfileDefinition {
-	return deepcopy.Copy(profileDef).(profiledefinition.ProfileDefinition)
+	return *profileDef.Clone()
 }
 
 // SetConfdPathAndCleanProfiles is used for testing only

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -71,9 +71,8 @@ func FixtureProfileDefinitionMap() ProfileConfigMap {
 				StaticTags:   []string{"static_tag:from_profile_root", "static_tag:from_base_profile"},
 				MetricTags: []profiledefinition.MetricTagConfig{
 					{
-						Symbol:  profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
-						Match:   "(\\w)(\\w+)",
-						Pattern: regexp.MustCompile(`(\w)(\w+)`),
+						Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
+						Match:  regexp.MustCompile(`(\w)(\w+)`),
 						Tags: map[string]string{
 							"some_tag": "some_tag_value",
 							"prefix":   "\\1",
@@ -134,10 +133,9 @@ func FixtureProfileDefinitionMap() ProfileConfigMap {
 							},
 							"description": {
 								Symbol: profiledefinition.SymbolConfig{
-									OID:                  "1.3.6.1.2.1.31.1.1.1.1",
-									Name:                 "ifName",
-									ExtractValue:         "(Row\\d)",
-									ExtractValueCompiled: regexp.MustCompile(`(Row\d)`),
+									OID:          "1.3.6.1.2.1.31.1.1.1.1",
+									Name:         "ifName",
+									ExtractValue: regexp.MustCompile(`(Row\d)`),
 								},
 							},
 							"mac_address": {

--- a/pkg/collector/corechecks/snmp/internal/profile/utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils.go
@@ -7,19 +7,17 @@ package profile
 
 import (
 	"os"
-
-	"github.com/mohae/deepcopy"
 )
 
-// mergeProfiles merges two profiles config map
-// we use deepcopy to lower risk of modifying original profiles
+// mergeProfiles merges two ProfileConfigMaps
+// we clone the profiles to lower the risk of modifying original profiles
 func mergeProfiles(profilesA ProfileConfigMap, profilesB ProfileConfigMap) ProfileConfigMap {
 	profiles := make(ProfileConfigMap)
 	for k, v := range profilesA {
-		profiles[k] = deepcopy.Copy(v).(ProfileConfig)
+		profiles[k] = v.Clone()
 	}
 	for k, v := range profilesB {
-		profiles[k] = deepcopy.Copy(v).(ProfileConfig)
+		profiles[k] = v.Clone()
 	}
 	return profiles
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
@@ -7,7 +7,6 @@ package profile
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
-	"github.com/mohae/deepcopy"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -34,7 +33,7 @@ func Test_mergeProfiles(t *testing.T) {
 			},
 		},
 	}
-	profilesACopy := deepcopy.Copy(profilesA).(ProfileConfigMap)
+	profilesACopy := profilesA.Clone()
 	profilesB := ProfileConfigMap{
 		"profile-p1": ProfileConfig{
 			Definition: profiledefinition.ProfileDefinition{
@@ -56,7 +55,7 @@ func Test_mergeProfiles(t *testing.T) {
 			},
 		},
 	}
-	profilesBCopy := deepcopy.Copy(profilesB).(ProfileConfigMap)
+	profilesBCopy := profilesB.Clone()
 
 	actualMergedProfiles := mergeProfiles(profilesA, profilesB)
 
@@ -119,6 +118,6 @@ func Test_mergeProfiles(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedMergedProfiles, actualMergedProfiles)
-	assert.Equal(t, profilesACopy, profilesA)
-	assert.Equal(t, profilesBCopy, profilesB)
+	assert.Equal(t, profilesA, profilesACopy)
+	assert.Equal(t, profilesB, profilesBCopy)
 }

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -8,6 +8,7 @@ package report
 import (
 	"bufio"
 	"bytes"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -504,10 +505,13 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		{
 			name: "report scalar tags with regex",
 			metricsTags: []profiledefinition.MetricTagConfig{
-				{Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"}, Match: "^([a-zA-Z]+)([0-9]+)$", Tags: map[string]string{
-					"word":   "\\1",
-					"number": "\\2",
-				}},
+				{
+					Symbol: profiledefinition.SymbolConfigCompat{OID: "1.2.3", Name: "mySymbol"},
+					Match:  regexp.MustCompile("^([a-zA-Z]+)([0-9]+)$"),
+					Tags: map[string]string{
+						"word":   "\\1",
+						"number": "\\2",
+					}},
 			},
 			values: &valuestore.ResultValueStore{
 				ScalarValues: valuestore.ScalarResultValuesType{
@@ -527,7 +531,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 					Symbol: profiledefinition.SymbolConfigCompat{
 						OID:          "1.2.3",
 						Name:         "mySymbol",
-						ExtractValue: "\\w+-(\\w+)-.*",
+						ExtractValue: regexp.MustCompile("\\w+-(\\w+)-.*"),
 					},
 				},
 			},
@@ -549,7 +553,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 					Symbol: profiledefinition.SymbolConfigCompat{
 						OID:          "1.2.3",
 						Name:         "mySymbol",
-						ExtractValue: "\\w+-(\\w+)-.*",
+						ExtractValue: regexp.MustCompile("\\w+-(\\w+)-.*"),
 					},
 				},
 				{
@@ -557,7 +561,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 					Symbol: profiledefinition.SymbolConfigCompat{
 						OID:          "1.2.3",
 						Name:         "mySymbol",
-						ExtractValue: ".*", // invalid regex without match group
+						ExtractValue: regexp.MustCompile(".*"), // invalid regex without match group
 					},
 				},
 			},

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils.go
@@ -50,23 +50,23 @@ func getColumnValueFromSymbol(values *valuestore.ResultValueStore, symbol profil
 }
 
 func processValueUsingSymbolConfig(value valuestore.ResultValue, symbol profiledefinition.SymbolConfig) (valuestore.ResultValue, error) {
-	if symbol.ExtractValueCompiled != nil {
-		extractedValue, err := value.ExtractStringValue(symbol.ExtractValueCompiled)
+	if symbol.ExtractValue != nil {
+		extractedValue, err := value.ExtractStringValue(symbol.ExtractValue)
 		if err != nil {
-			log.Debugf("error extracting value from `%v` with pattern `%v`: %v", value, symbol.ExtractValueCompiled, err)
+			log.Debugf("error extracting value from `%v` with pattern `%v`: %v", value, symbol.ExtractValue, err)
 			return valuestore.ResultValue{}, err
 		}
 		value = extractedValue
 	}
-	if symbol.MatchPatternCompiled != nil {
+	if symbol.MatchPattern != nil {
 		strValue, err := value.ToString()
 		if err != nil {
 			log.Debugf("error converting value to string (value=%v): %v", value, err)
 			return valuestore.ResultValue{}, err
 		}
 
-		if symbol.MatchPatternCompiled.MatchString(strValue) {
-			replacedVal := checkconfig.RegexReplaceValue(strValue, symbol.MatchPatternCompiled, symbol.MatchValue)
+		if symbol.MatchPattern.MatchString(strValue) {
+			replacedVal := checkconfig.RegexReplaceValue(strValue, symbol.MatchPattern, symbol.MatchValue)
 			if replacedVal == "" {
 				return valuestore.ResultValue{}, fmt.Errorf("the pattern `%v` matched value `%v`, but template `%s` is not compatible", symbol.MatchPattern, strValue, symbol.MatchValue)
 			}

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
@@ -59,10 +59,9 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			name:   "extract value pattern error",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				ExtractValue:         "abc",
-				ExtractValueCompiled: regexp.MustCompile("abc"),
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				ExtractValue: regexp.MustCompile("abc"),
 			},
 			expectedValue: valuestore.ResultValue{},
 			expectedError: "extract value extractValuePattern does not match (extractValuePattern=abc, srcValue=value1)",
@@ -71,10 +70,10 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			name:   "OK match pattern without replace",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				MatchPatternCompiled: regexp.MustCompile(`value\d`),
-				MatchValue:           "matched-value-with-digit",
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				MatchPattern: regexp.MustCompile(`value\d`),
+				MatchValue:   "matched-value-with-digit",
 			},
 			expectedValue: valuestore.ResultValue{
 				Value: "matched-value-with-digit",
@@ -85,11 +84,10 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			name:   "Error match pattern does not match",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				MatchPattern:         "doesNotMatch",
-				MatchPatternCompiled: regexp.MustCompile("doesNotMatch"),
-				MatchValue:           "noMatch",
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				MatchPattern: regexp.MustCompile("doesNotMatch"),
+				MatchValue:   "noMatch",
 			},
 			expectedValue: valuestore.ResultValue{},
 			expectedError: "match pattern `doesNotMatch` does not match string `value1`",
@@ -98,11 +96,10 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			name:   "Error match pattern template does not match",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				MatchPattern:         "value(\\d)",
-				MatchPatternCompiled: regexp.MustCompile(`value(\d)`),
-				MatchValue:           "$2",
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				MatchPattern: regexp.MustCompile(`value(\d)`),
+				MatchValue:   "$2",
 			},
 			expectedValue: valuestore.ResultValue{},
 			expectedError: "the pattern `value(\\d)` matched value `value1`, but template `$2` is not compatible",
@@ -111,10 +108,9 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			name:   "OK Extract value case",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				ExtractValue:         "[a-z]+(\\d)",
-				ExtractValueCompiled: regexp.MustCompile(`[a-z]+(\d)`),
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				ExtractValue: regexp.MustCompile(`[a-z]+(\d)`),
 			},
 			expectedValue: valuestore.ResultValue{
 				Value: "1",
@@ -125,10 +121,9 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			name:   "Error extract value pattern des not contain any matching group",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				ExtractValue:         "[a-z]+\\d",
-				ExtractValueCompiled: regexp.MustCompile(`[a-z]+\d`),
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				ExtractValue: regexp.MustCompile(`[a-z]+\d`),
 			},
 			expectedValue: valuestore.ResultValue{},
 			expectedError: "extract value pattern des not contain any matching group (extractValuePattern=[a-z]+\\d, srcValue=value1)",
@@ -137,10 +132,9 @@ func Test_getScalarValueFromSymbol(t *testing.T) {
 			name:   "Error extract value extractValuePattern does not match",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				ExtractValue:         "[a-z]+(\\d)",
-				ExtractValueCompiled: regexp.MustCompile("doesNotMatch"),
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				ExtractValue: regexp.MustCompile("doesNotMatch"),
 			},
 			expectedValue: valuestore.ResultValue{},
 			expectedError: "extract value extractValuePattern does not match (extractValuePattern=doesNotMatch, srcValue=value1)",
@@ -230,10 +224,9 @@ func Test_getColumnValueFromSymbol(t *testing.T) {
 			name:   "invalid extract value pattern",
 			values: mockValues,
 			symbol: profiledefinition.SymbolConfig{
-				OID:                  "1.2.3.4",
-				Name:                 "mySymbol",
-				ExtractValue:         "abc",
-				ExtractValueCompiled: regexp.MustCompile("abc"),
+				OID:          "1.2.3.4",
+				Name:         "mySymbol",
+				ExtractValue: regexp.MustCompile("abc"),
 			},
 			expectedValues: make(map[string]valuestore.ResultValue),
 			expectedError:  "",
@@ -777,14 +770,14 @@ metric_tags:
 			log.SetupLogger(l, "debug")
 
 			m := profiledefinition.MetricsConfig{}
-			yaml.Unmarshal(tt.rawMetricConfig, &m)
+			assert.NoError(t, yaml.Unmarshal(tt.rawMetricConfig, &m))
 
 			configvalidation.ValidateEnrichMetrics([]profiledefinition.MetricsConfig{m})
 			tags := getTagsFromMetricTagConfigList(m.MetricTags, tt.fullIndex, tt.values)
 
 			assert.ElementsMatch(t, tt.expectedTags, tags)
 
-			w.Flush()
+			assert.NoError(t, w.Flush())
 			logs := b.String()
 
 			for _, aLogCount := range tt.expectedLogs {

--- a/pkg/networkdevice/profile/profiledefinition/clone.go
+++ b/pkg/networkdevice/profile/profiledefinition/clone.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+// CopySlice makes a shallow copy of a slice
+func CopySlice[T any](s []T) []T {
+	if s == nil {
+		return nil
+	}
+	s2 := make([]T, len(s))
+	copy(s2, s)
+	return s2
+}
+
+// CopyMap makes a shallow copy of a map
+func CopyMap[K comparable, V any](m map[K]V) map[K]V {
+	if m == nil {
+		return nil
+	}
+	m2 := make(map[K]V, len(m))
+	for k, v := range m {
+		m2[k] = v
+	}
+	return m2
+}
+
+// Cloneable is a generic type for objects that can duplicate themselves.
+// It is exclusively used in the form [T Cloneable[T]], i.e. a type that
+// has a .Clone() that returns a new instance of itself.
+type Cloneable[T any] interface {
+	Clone() T
+}
+
+// CloneSlice clones all the objects in a slice into a new slice.
+func CloneSlice[T Cloneable[T]](t []T) []T {
+	if t == nil {
+		return nil
+	}
+	result := make([]T, 0, len(t))
+	for _, v := range t {
+		result = append(result, v.Clone())
+	}
+	return result
+}
+
+// CloneMap clones a map[K]T for any cloneable type T.
+// The map keys are shallow-copied; values are cloned.
+func CloneMap[K comparable, T Cloneable[T]](m map[K]T) map[K]T {
+	if m == nil {
+		return nil
+	}
+	result := make(map[K]T, len(m))
+	for k, v := range m {
+		result[k] = v.Clone()
+	}
+	return result
+}

--- a/pkg/networkdevice/profile/profiledefinition/clone_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/clone_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCopySlice(t *testing.T) {
+	intSlice := []int{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	intSliceCopy := CopySlice(intSlice)
+	intSliceCopy[0] = 100
+	assert.Equal(t, []int{1, 2, 3, 4, 5, 6, 7, 8, 9}, intSlice)
+	assert.Equal(t, []int{100, 2, 3, 4, 5, 6, 7, 8, 9}, intSliceCopy)
+
+	strSlice := []string{"a", "b", "c", "d", "e", "f", "g"}
+	strSliceCopy := CopySlice(strSlice)
+	strSliceCopy[0] = "aaa"
+	assert.Equal(t, []string{"a", "b", "c", "d", "e", "f", "g"}, strSlice)
+	assert.Equal(t, []string{"aaa", "b", "c", "d", "e", "f", "g"}, strSliceCopy)
+}
+
+func TestCopyMap(t *testing.T) {
+	intMap := map[string]int{
+		"a": 1,
+		"b": 2,
+		"c": 3,
+	}
+	intMapCopy := CopyMap(intMap)
+	intMapCopy["a"] = 100
+	assert.Equal(t, map[string]int{
+		"a": 1, "b": 2, "c": 3,
+	}, intMap)
+	assert.Equal(t, map[string]int{
+		"a": 100, "b": 2, "c": 3,
+	}, intMapCopy)
+}
+
+type cloneMe struct {
+	X int
+	Y string
+}
+
+func (c *cloneMe) Clone() *cloneMe {
+	return &cloneMe{X: c.X, Y: c.Y}
+}
+
+func TestCloneSlice(t *testing.T) {
+	items := []*cloneMe{
+		{1, "a"},
+		{2, "b"},
+		{3, "c"},
+	}
+	itemsCopy := CloneSlice(items)
+	itemsCopy[0].X = 100
+	itemsCopy[1] = &cloneMe{200, "bbb"}
+	assert.Equal(t, []*cloneMe{
+		{1, "a"},
+		{2, "b"},
+		{3, "c"},
+	}, items)
+	assert.Equal(t, []*cloneMe{
+		{100, "a"},
+		{200, "bbb"},
+		{3, "c"},
+	}, itemsCopy)
+}
+
+func TestCloneMap(t *testing.T) {
+	m := map[string]*cloneMe{
+		"Item A": {1, "a"},
+		"Item B": {2, "b"},
+	}
+	mCopy := CloneMap(m)
+	mCopy["Item A"].X = 100
+	mCopy["Item B"] = &cloneMe{200, "bbb"}
+	mCopy["Item C"] = &cloneMe{300, "ccc"}
+	assert.Equal(t, map[string]*cloneMe{
+		"Item A": {1, "a"},
+		"Item B": {2, "b"},
+	}, m)
+	assert.Equal(t, map[string]*cloneMe{
+		"Item A": {100, "a"},
+		"Item B": {200, "bbb"},
+		"Item C": {300, "ccc"},
+	}, mCopy)
+}

--- a/pkg/networkdevice/profile/profiledefinition/metadata.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata.go
@@ -11,10 +11,23 @@ const MetadataDeviceResource = "device"
 // MetadataConfig holds configs per resource type
 type MetadataConfig map[string]MetadataResourceConfig
 
+// Clone duplicates this MetadataConfig
+func (m MetadataConfig) Clone() MetadataConfig {
+	return CloneMap(m)
+}
+
 // MetadataResourceConfig holds configs for a metadata resource
 type MetadataResourceConfig struct {
 	Fields map[string]MetadataField `yaml:"fields" json:"fields"`
 	IDTags MetricTagConfigList      `yaml:"id_tags,omitempty" json:"id_tags,omitempty"`
+}
+
+// Clone duplicates this MetadataResourceConfig
+func (c MetadataResourceConfig) Clone() MetadataResourceConfig {
+	return MetadataResourceConfig{
+		Fields: CloneMap(c.Fields),
+		IDTags: CloneSlice(c.IDTags),
+	}
 }
 
 // MetadataField holds configs for a metadata field
@@ -22,6 +35,15 @@ type MetadataField struct {
 	Symbol  SymbolConfig   `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 	Symbols []SymbolConfig `yaml:"symbols,omitempty" json:"symbols,omitempty"`
 	Value   string         `yaml:"value,omitempty" json:"value,omitempty"`
+}
+
+// Clone duplicates this MetadataField
+func (c MetadataField) Clone() MetadataField {
+	return MetadataField{
+		Symbol:  c.Symbol.Clone(),
+		Symbols: CloneSlice(c.Symbols),
+		Value:   c.Value,
+	}
 }
 
 // NewMetadataResourceConfig returns a new metadata resource config

--- a/pkg/networkdevice/profile/profiledefinition/metadata_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata_test.go
@@ -1,0 +1,140 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func TestCloneMetadata(t *testing.T) {
+	// This is not actually a valid config, since e.g. it has ExtractValue and
+	// MatchPattern both set; this is just to check that every field gets copied
+	// properly.
+	metadata := MetadataConfig{
+		"device": MetadataResourceConfig{
+			Fields: map[string]MetadataField{
+				"name": {
+					Value: "hey",
+					Symbol: SymbolConfig{
+						OID:              "1.2.3",
+						Name:             "someSymbol",
+						ExtractValue:     regexp.MustCompile(".*"),
+						MatchPattern:     regexp.MustCompile(".*"),
+						MatchValue:       "$1",
+						ScaleFactor:      100,
+						Format:           "mac_address",
+						ConstantValueOne: true,
+						MetricType:       "gauge",
+					},
+				},
+			},
+			IDTags: []MetricTagConfig{
+				{
+					Tag:   "foo",
+					Index: 1,
+					Column: SymbolConfig{
+						Name:         "bar",
+						OID:          "1.2.3",
+						ExtractValue: regexp.MustCompile(".*"),
+					},
+					OID: "2.3.4",
+					Symbol: SymbolConfigCompat{
+						OID:          "1.2.3",
+						Name:         "someSymbol",
+						ExtractValue: regexp.MustCompile(".*"),
+					},
+					IndexTransform: []MetricIndexTransform{
+						{
+							Start: 1,
+							End:   5,
+						},
+					},
+					Mapping: map[string]string{
+						"1": "on",
+						"2": "off",
+					},
+					Match: regexp.MustCompile(".*"),
+					Tags: map[string]string{
+						"foo": "bar",
+					},
+					SymbolTag: "ok",
+				},
+			},
+		},
+	}
+
+	// identical regexp, except with longest=true
+	re2 := regexp.MustCompile(".*")
+	re2.Longest()
+	expected := MetadataConfig{
+		"interface": MetadataResourceConfig{},
+		"device": MetadataResourceConfig{
+			Fields: map[string]MetadataField{
+				"name": {
+					Value: "hey",
+					Symbol: SymbolConfig{
+						OID:              "1.2.3",
+						Name:             "someSymbol",
+						ExtractValue:     re2,
+						MatchPattern:     re2,
+						MatchValue:       "$1",
+						ScaleFactor:      100,
+						Format:           "mac_address",
+						ConstantValueOne: true,
+						MetricType:       "gauge",
+					},
+				},
+			},
+			IDTags: []MetricTagConfig{
+				{
+					Tag:   "foo",
+					Index: 1,
+					Column: SymbolConfig{
+						Name:         "bar",
+						OID:          "1.2.3",
+						ExtractValue: re2,
+					},
+					OID: "2.3.4",
+					Symbol: SymbolConfigCompat{
+						OID:          "1.2.3",
+						Name:         "someSymbol",
+						ExtractValue: re2,
+					},
+					IndexTransform: []MetricIndexTransform{
+						{
+							Start: 1,
+							End:   5,
+						},
+					},
+					Mapping: map[string]string{
+						"1": "on",
+						"2": "off",
+					},
+					Match: re2,
+					Tags: map[string]string{
+						"foo": "bar",
+					},
+					SymbolTag: "ok",
+				},
+			},
+		},
+	}
+
+	metaCopy := metadata.Clone()
+	assert.Equal(t, metadata, metaCopy)
+	// Modify the copy in place
+	metaCopy["interface"] = MetadataResourceConfig{}
+	metaCopy["device"].Fields["name"].Symbol.ExtractValue.Longest()
+	metaCopy["device"].Fields["name"].Symbol.MatchPattern.Longest()
+	metaCopy["device"].IDTags[0].Column.ExtractValue.Longest()
+	metaCopy["device"].IDTags[0].Symbol.ExtractValue.Longest()
+	metaCopy["device"].IDTags[0].Match.Longest()
+	// metaCopy should now match expected, and metadata should not have been affected.
+	assert.Equal(t, expected, metaCopy)
+	assert.NotEqual(t, metadata, metaCopy)
+}

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -56,13 +56,10 @@ type SymbolConfig struct {
 	OID  string `yaml:"OID,omitempty" json:"OID,omitempty"`
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
 
-	ExtractValue         string         `yaml:"extract_value,omitempty" json:"extract_value,omitempty"`
-	ExtractValueCompiled *regexp.Regexp `yaml:"-" json:"-"`
+	ExtractValue *regexp.Regexp `yaml:"extract_value,omitempty" json:"extract_value,omitempty"`
 
-	// MatchPattern/MatchValue are not exposed as json (UI) since ExtractValue can be used instead
-	MatchPattern         string         `yaml:"match_pattern,omitempty" json:"-"`
-	MatchValue           string         `yaml:"match_value,omitempty" json:"-"`
-	MatchPatternCompiled *regexp.Regexp `yaml:"-" json:"-"`
+	MatchPattern *regexp.Regexp `yaml:"match_pattern,omitempty" json:"match_pattern,omitempty"`
+	MatchValue   string         `yaml:"match_value,omitempty" json:"match_value,omitempty"`
 
 	ScaleFactor      float64 `yaml:"scale_factor,omitempty" json:"scale_factor,omitempty"`
 	Format           string  `yaml:"format,omitempty" json:"format,omitempty"`
@@ -94,11 +91,10 @@ type MetricTagConfig struct {
 
 	Mapping ListMap[string] `yaml:"mapping,omitempty" json:"mapping,omitempty"`
 
-	// Regex
-	// Match/Tags are not exposed as json (UI) since ExtractValue can be used instead
-	Match   string            `yaml:"match,omitempty" json:"-"`
-	Tags    map[string]string `yaml:"tags,omitempty" json:"-"`
-	Pattern *regexp.Regexp    `yaml:"-" json:"-"`
+	// DEPRECATED: Use MatchPattern/MatchValue on the Symbol instead
+	Match *regexp.Regexp `yaml:"match,omitempty" json:"-"`
+	// DEPRECATED: Use MatchPattern/MatchValue on the Symbol instead
+	Tags map[string]string `yaml:"tags,omitempty" json:"-"`
 
 	SymbolTag string `yaml:"-" json:"-"`
 }

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -79,12 +79,15 @@ type MetricTagConfig struct {
 	// Table config
 	Index uint `yaml:"index,omitempty" json:"index,omitempty"`
 
-	// DEPRECATED: Column field is deprecated in favour Symbol field
+	// DEPRECATED: Use .Symbol instead
 	Column SymbolConfig `yaml:"column,omitempty" json:"-"`
 
-	// Symbol config
-	OID string `yaml:"OID,omitempty" json:"-"  jsonschema:"-"` // DEPRECATED replaced by Symbol field
-	// Using Symbol field below as string is deprecated
+	// DEPRECATED: use .Symbol instead
+	OID string `yaml:"OID,omitempty" json:"-"  jsonschema:"-"`
+	// Symbol records the OID to be parsed. Note that .Symbol.Name is ignored:
+	// set .Tag to specify the tag name. If a serialized Symbol is a string
+	// instead of an object, it will be treated like {name: <value>}; this use
+	// pattern is deprecated
 	Symbol SymbolConfigCompat `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 
 	IndexTransform []MetricIndexTransform `yaml:"index_transform,omitempty" json:"index_transform,omitempty"`
@@ -125,8 +128,9 @@ type MetricsConfig struct {
 	// Symbol configs
 	Symbol SymbolConfig `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 
-	// Legacy Symbol configs syntax
-	OID  string `yaml:"OID,omitempty" json:"OID,omitempty" jsonschema:"-"`
+	// DEPRECATED: Use .Symbol instead
+	OID string `yaml:"OID,omitempty" json:"OID,omitempty" jsonschema:"-"`
+	// DEPRECATED: Use .Symbol instead
 	Name string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"-"`
 
 	// Table configs
@@ -136,11 +140,11 @@ type MetricsConfig struct {
 	StaticTags []string            `yaml:"static_tags,omitempty" json:"-"`
 	MetricTags MetricTagConfigList `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
 
-	ForcedType ProfileMetricType `yaml:"forced_type,omitempty" json:"forced_type,omitempty" jsonschema:"-"` // deprecated in favour of metric_type
+	// DEPRECATED: use MetricType instead.
+	ForcedType ProfileMetricType `yaml:"forced_type,omitempty" json:"forced_type,omitempty" jsonschema:"-"`
 	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty"`
 
-	// `options` is not exposed as json at the moment since we need to evaluate if we want to expose it via UI
-	Options MetricsConfigOption `yaml:"options,omitempty" json:"-"`
+	Options MetricsConfigOption `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
 // GetSymbolTags returns symbol tags

--- a/pkg/networkdevice/profile/profiledefinition/metrics_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics_test.go
@@ -1,0 +1,233 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func TestCloneSymbolConfig(t *testing.T) {
+	s := SymbolConfig{
+		OID:              "1.2.3.4",
+		Name:             "foo",
+		ExtractValue:     regexp.MustCompile(".*"),
+		MatchPattern:     regexp.MustCompile(".*"),
+		MatchValue:       "$1",
+		ScaleFactor:      100,
+		Format:           "mac_address",
+		ConstantValueOne: true,
+		MetricType:       ProfileMetricTypeCounter,
+	}
+	s2 := s.Clone()
+	assert.Equal(t, s, s2)
+	// confirm they aren't the same object
+	s2.ExtractValue.Longest()
+	assert.NotEqual(t, s, s2)
+}
+
+func TestCloneSymbolConfigCompat(t *testing.T) {
+	s := SymbolConfigCompat{
+		OID:              "1.2.3.4",
+		Name:             "foo",
+		ExtractValue:     regexp.MustCompile(".*"),
+		MatchPattern:     regexp.MustCompile(".*"),
+		MatchValue:       "$1",
+		ScaleFactor:      100,
+		Format:           "mac_address",
+		ConstantValueOne: true,
+		MetricType:       ProfileMetricTypeCounter,
+	}
+	s2 := s.Clone()
+	assert.Equal(t, s, s2)
+	// confirm they aren't the same object
+	s2.ExtractValue.Longest()
+	assert.NotEqual(t, s, s2)
+
+}
+
+func TestCloneMetricTagConfig(t *testing.T) {
+	c := MetricTagConfig{
+		Tag:   "foo",
+		Index: 10,
+		Column: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: regexp.MustCompile(".*"),
+		},
+		OID:    "2.4",
+		Symbol: SymbolConfigCompat{},
+		IndexTransform: []MetricIndexTransform{
+			{
+				Start: 0,
+				End:   1,
+			},
+		},
+		Mapping: map[string]string{
+			"1": "bar",
+			"2": "baz",
+		},
+		Match: regexp.MustCompile(".*"),
+		Tags: map[string]string{
+			"foo": "$1",
+		},
+		SymbolTag: "baz",
+	}
+	c2 := c.Clone()
+	assert.Equal(t, c, c2)
+	c2.Tags["bar"] = "$2"
+	c2.IndexTransform = append(c2.IndexTransform, MetricIndexTransform{1, 3})
+	c2.Mapping["3"] = "foo"
+	c2.Tag = "bar"
+	assert.NotEqual(t, c, c2)
+	// Validate that c has not changed
+	assert.Equal(t, c, MetricTagConfig{
+		Tag:   "foo",
+		Index: 10,
+		Column: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: regexp.MustCompile(".*"),
+		},
+		OID:    "2.4",
+		Symbol: SymbolConfigCompat{},
+		IndexTransform: []MetricIndexTransform{
+			{
+				Start: 0,
+				End:   1,
+			},
+		},
+		Mapping: map[string]string{
+			"1": "bar",
+			"2": "baz",
+		},
+		Match: regexp.MustCompile(".*"),
+		Tags: map[string]string{
+			"foo": "$1",
+		},
+		SymbolTag: "baz",
+	})
+}
+
+func TestCloneMetricsConfig(t *testing.T) {
+	conf := &MetricsConfig{
+		MIB: "FOO-MIB",
+		Table: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: regexp.MustCompile(".*"),
+		},
+		Symbol: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: regexp.MustCompile(".*"),
+		},
+		OID:  "1.2.3.4",
+		Name: "foo",
+		Symbols: []SymbolConfig{
+			{
+				OID:          "1.2.3.4",
+				ExtractValue: regexp.MustCompile(".*"),
+			},
+		},
+		StaticTags: []string{
+			"foo",
+			"bar",
+		},
+		MetricTags: []MetricTagConfig{
+			{
+				IndexTransform: make([]MetricIndexTransform, 0),
+			},
+		},
+		ForcedType: ProfileMetricTypeCounter,
+		MetricType: ProfileMetricTypeGauge,
+		Options: MetricsConfigOption{
+			Placement:    1,
+			MetricSuffix: ".foo",
+		},
+	}
+	unchanged := &MetricsConfig{
+		MIB: "FOO-MIB",
+		Table: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: regexp.MustCompile(".*"),
+		},
+		Symbol: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: regexp.MustCompile(".*"),
+		},
+		OID:  "1.2.3.4",
+		Name: "foo",
+		Symbols: []SymbolConfig{
+			{
+				OID:          "1.2.3.4",
+				ExtractValue: regexp.MustCompile(".*"),
+			},
+		},
+		StaticTags: []string{
+			"foo",
+			"bar",
+		},
+		MetricTags: []MetricTagConfig{
+			{
+				IndexTransform: make([]MetricIndexTransform, 0),
+			},
+		},
+		ForcedType: ProfileMetricTypeCounter,
+		MetricType: ProfileMetricTypeGauge,
+		Options: MetricsConfigOption{
+			Placement:    1,
+			MetricSuffix: ".foo",
+		},
+	}
+	re2 := regexp.MustCompile(".*")
+	re2.Longest()
+	expected := &MetricsConfig{
+		MIB: "FOO-MIB",
+		Table: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: re2,
+		},
+		Symbol: SymbolConfig{
+			OID:          "1.2.3.4",
+			ExtractValue: re2,
+		},
+		OID:  "1.2.3.4",
+		Name: "foo",
+		Symbols: []SymbolConfig{
+			{
+				OID:          "1.2.3.4",
+				ExtractValue: re2,
+			},
+		},
+		StaticTags: []string{
+			"baz",
+			"bar",
+		},
+		MetricTags: []MetricTagConfig{
+			{
+				IndexTransform: []MetricIndexTransform{{
+					Start: 5,
+					End:   7,
+				}},
+			},
+		},
+		ForcedType: ProfileMetricTypeCounter,
+		MetricType: ProfileMetricTypeGauge,
+		Options: MetricsConfigOption{
+			Placement:    2,
+			MetricSuffix: ".bar",
+		},
+	}
+	conf2 := conf.Clone()
+	assert.Equal(t, conf, conf2)
+	conf2.Table.ExtractValue.Longest()
+	conf2.Symbol.ExtractValue.Longest()
+	conf2.Symbols[0].ExtractValue.Longest()
+	conf2.StaticTags[0] = "baz"
+	conf2.MetricTags[0].IndexTransform = []MetricIndexTransform{{5, 7}}
+	conf2.Options.Placement = 2
+	conf2.Options.MetricSuffix = ".bar"
+	assert.Equal(t, unchanged, conf)
+	assert.Equal(t, expected, conf2)
+}

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -27,9 +27,8 @@ type ProfileDefinition struct {
 	StaticTags   []string          `yaml:"static_tags,omitempty" json:"static_tags,omitempty"`
 	Metrics      []MetricsConfig   `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 
-	// Used previously to pass device vendor field (has been replaced by Metadata).
-	// Used in RC for passing device vendor field.
-	Device DeviceMeta `yaml:"device,omitempty" json:"device,omitempty" jsonschema:"device,omitempty"` // DEPRECATED
+	// DEPRECATED: Use metadata directly
+	Device DeviceMeta `yaml:"device,omitempty" json:"device,omitempty" jsonschema:"device,omitempty"`
 
 	// Version is the profile version.
 	// It is currently used only with downloaded/RC profiles.

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -46,3 +46,23 @@ func NewProfileDefinition() *ProfileDefinition {
 	p.Metadata = make(MetadataConfig)
 	return p
 }
+
+func (p *ProfileDefinition) Clone() *ProfileDefinition {
+	if p == nil {
+		return nil
+	}
+	return &ProfileDefinition{
+		Name:         p.Name,
+		Description:  p.Description,
+		SysObjectIDs: CopySlice(p.SysObjectIDs),
+		Extends:      CopySlice(p.Extends),
+		Metadata:     CloneMap(p.Metadata),
+		MetricTags:   CloneSlice(p.MetricTags),
+		StaticTags:   CopySlice(p.StaticTags),
+		Metrics:      CopySlice(p.Metrics),
+		Device: DeviceMeta{
+			Vendor: p.Device.Vendor,
+		},
+		Version: p.Version,
+	}
+}

--- a/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
@@ -168,6 +168,11 @@
         "version"
       ]
     },
+    "Regexp": {
+      "properties": {},
+      "additionalProperties": false,
+      "type": "object"
+    },
     "StringArray": {
       "items": {
         "type": "string"
@@ -183,6 +188,12 @@
           "type": "string"
         },
         "extract_value": {
+          "$ref": "#/$defs/Regexp"
+        },
+        "match_pattern": {
+          "$ref": "#/$defs/Regexp"
+        },
+        "match_value": {
           "type": "string"
         },
         "scale_factor": {
@@ -210,6 +221,12 @@
           "type": "string"
         },
         "extract_value": {
+          "$ref": "#/$defs/Regexp"
+        },
+        "match_pattern": {
+          "$ref": "#/$defs/Regexp"
+        },
+        "match_value": {
           "type": "string"
         },
         "scale_factor": {

--- a/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
@@ -114,6 +114,21 @@
         },
         "metric_type": {
           "type": "string"
+        },
+        "options": {
+          "$ref": "#/$defs/MetricsConfigOption"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetricsConfigOption": {
+      "properties": {
+        "placement": {
+          "type": "integer"
+        },
+        "metric_suffix": {
+          "type": "string"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
### What does this PR do?

This PR does three things:
1. Fix several  deprecated/not deprecated fields to align with what we're doing elsewhere (e.g. `MetricTagConfig.Options` was annotated `json:"-"` even though we're using it in the UI).
2. Simplify regex parsing by making regex fields be regexes (e.g. making `Symbol.ExtractValue` a regex instead of having it be a string with a separate `.ExtractValueCompiled`)
3. Add a `.Clone` method to various profile structures so that we don't need to rely on `deepcopy`, since deepcopy fails on anything with private attributes (e.g. if you deepcopy a regex, you get a new regex that panics when you use it).

### Motivation

The JSON annotations are necessary to work with the frontend properly - several fields were being silently omitted in JSON even though we're still using them. The regex parsing was moved forwards so that it can happen when profiles are parsed instead of as part of a normalization pass. The `Clone()` method is necessary so that we can cleanly duplicate profiles when they've already been parsed and have regexes in them.

### Describe how you validated your changes

Tests pass and local runs produce expected results. The behavior of the agent itself shouldn't change, this is purely an internal improvement.
