### PR TITLE
[Windows] Fix typo in crash detection checks

### DIFF
--- a/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
@@ -196,7 +196,7 @@ func newAgentCrashComponent(deps dependencies) agentcrashdetect.Component {
 func formatText(c *probe.WinCrashStatus) string {
 	baseString := `A system crash was detected.
 	The crash occurred at %s.
-	The offending moudule is %s.
+	The offending module is %s.
 	The bugcheck code is %s`
 	return fmt.Sprintf(baseString, c.DateString, c.Offender, c.BugCheck)
 }

--- a/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
+++ b/pkg/collector/corechecks/system/wincrashdetect/wincrashdetect.go
@@ -121,7 +121,7 @@ func formatTitle(_ *probe.WinCrashStatus) string {
 func formatText(c *probe.WinCrashStatus) string {
 	baseString := `A system crash was detected.
 	The crash occurred at %s.
-	The offending moudule is %s.
+	The offending module is %s.
 	The bugcheck code is %s`
 	return fmt.Sprintf(baseString, c.DateString, c.Offender, c.BugCheck)
 }

--- a/releasenotes/notes/crashchecktypo-32bdd0050636334f.yaml
+++ b/releasenotes/notes/crashchecktypo-32bdd0050636334f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    For the Windows crash detection integrations, fix the misspelling in the generated event.


### PR DESCRIPTION
### What does this PR do?

Title says it all. Fix two identical typos

### Motivation

### Describe how you validated your changes
N/A

### Possible Drawbacks / Trade-offs

### Additional Notes
