### PR TITLE
usm: sowatcher: Cut instruction cout by 90%

### DIFF
--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -23,10 +23,9 @@ static __always_inline void do_sys_open_helper_enter(const char *filename) {
 // Find the null character and clean up the garbage following it
 #pragma unroll
         for (int i = 0; i < LIB_PATH_MAX_SIZE; i++) {
-            if (path.len) {
-                path.buf[i] = 0;
-            } else if (path.buf[i] == 0) {
+            if (path.buf[i] == 0) {
                 path.len = i;
+                break;
             }
         }
     } else {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes redundant zeroing operations running in a loop. We don't need to zero the buffer as we set the length of the buffer.

### Motivation

Cut instruction count by 90%. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Diff compared to `main`

```bash
| Filename/Program                                         |   Stack Usage |   Instructions Processed |   Instructions Processed limit |   Max States per Instruction |   Peak States |   Total States |
|----------------------------------------------------------|---------------|--------------------------|--------------------------------|------------------------------|---------------|----------------|
| shared_libraries/tracepoint__syscalls__sys_enter_open    |             0 |                   -17222 |                              0 |                           -4 |           -87 |           -312 |
| shared_libraries/tracepoint__syscalls__sys_enter_openat  |             0 |                   -17222 |                              0 |                           -4 |           -87 |           -312 |
| shared_libraries/tracepoint__syscalls__sys_enter_openat2 |             0 |                   -17222 |                              0 |                           -4 |           -87 |           -312 |
| shared_libraries/tracepoint__syscalls__sys_exit_open     |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| shared_libraries/tracepoint__syscalls__sys_exit_openat   |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| shared_libraries/tracepoint__syscalls__sys_exit_openat2  |             0 |                        0 |                              0 |                            0 |             0 |              0 |
```