### PR TITLE
(fleet) small optmisation to the installer script

### DIFF
--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -22,10 +22,10 @@ install() {
   $sudo_cmd mkdir -p "${tmp_dir}"
   case "$(uname -m)" in
   x86_64)
-    echo "${downloader_bin_linux_amd64}" | base64 -d | $sudo_cmd tee "${downloader_path}" >/dev/null
+    write_installer_amd64 "$sudo_cmd" "$downloader_path"
     ;;
   aarch64)
-    echo "${downloader_bin_linux_arm64}" | base64 -d | $sudo_cmd tee "${downloader_path}" >/dev/null
+    write_installer_arm64 "$sudo_cmd" "$downloader_path"
     ;;
   esac
   $sudo_cmd chmod +x "${downloader_path}"
@@ -37,16 +37,16 @@ install() {
 # Embedded binaries used to install Datadog.
 # Source: https://github.com/DataDog/datadog-agent/tree/INSTALLER_COMMIT/pkg/fleet/installer
 # DO NOT EDIT THIS SECTION MANUALLY.
-downloader_bin_linux_amd64=$(
-  cat <<EOM
-DOWNLOADER_BIN_LINUX_AMD64
-EOM
-)
-downloader_bin_linux_arm64=$(
-  cat <<EOM
-DOWNLOADER_BIN_LINUX_ARM64
-EOM
-)
+write_installer_amd64() {
+  local sudo_cmd=$1
+  local path=$2
+  base64 -d <<<"DOWNLOADER_BIN_LINUX_AMD64" | $sudo_cmd tee "${path}" >/dev/null
+}
+write_installer_arm64() {
+  local sudo_cmd=$1
+  local path=$2
+  base64 -d <<<"DOWNLOADER_BIN_LINUX_ARM64" | $sudo_cmd tee "${path}" >/dev/null
+}
 
 install "$@"
 exit 0

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -111,7 +111,7 @@ def build_linux_script(
         build_downloader(ctx, flavor=flavor, version=version, os='linux', arch=arch)
         with open(DOWNLOADER_BIN, 'rb') as f:
             encoded_bin = base64.encodebytes(f.read()).decode('utf-8')
-        install_script = install_script.replace(f'DOWNLOADER_BIN_{arch.upper()}', encoded_bin)
+        install_script = install_script.replace(f'DOWNLOADER_BIN_LINUX_{arch.upper()}', encoded_bin)
 
     commit_sha = ctx.run('git rev-parse HEAD', hide=True).stdout.strip()
     install_script = install_script.replace('INSTALLER_COMMIT', commit_sha)


### PR DESCRIPTION
This PR speeds up the decoding of the downloader from base64 (5.5s => 3.5s on my laptop).

- Isolate the base64 decoding to function to avoid processing both architecture strings every time
- Remove some back and forth (cat, here-doc, echo => direct base64)

QA: 
- Not in prod yet, will be covered by e2e
