### PR TITLE
discovery: fix "too many open files" issue

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/comm.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm.go
@@ -13,8 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/v3/process"
-
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
 )
@@ -41,11 +39,11 @@ var (
 )
 
 // shouldIgnoreComm returns true if process should be ignored
-func (s *discovery) shouldIgnoreComm(proc *process.Process) bool {
+func (s *discovery) shouldIgnoreComm(pid int32) bool {
 	if s.config.ignoreComms == nil {
 		return false
 	}
-	commPath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "comm")
+	commPath := kernel.HostProc(strconv.Itoa(int(pid)), "comm")
 	file, err := os.Open(commPath)
 	if err != nil {
 		return true

--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -137,16 +137,10 @@ func TestShouldIgnoreComm(t *testing.T) {
 				_ = cmd.Process.Kill()
 			})
 
-			var proc *process.Process
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				proc, err = customNewProcess(int32(cmd.Process.Pid))
-				assert.NoError(collect, err)
-			}, 2*time.Second, 100*time.Millisecond)
-
-			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				ignore := discovery.shouldIgnoreComm(proc)
+				ignore := discovery.shouldIgnoreComm(int32(cmd.Process.Pid))
 				assert.Equal(collect, test.ignore, ignore)
-			}, 500*time.Millisecond, 100*time.Millisecond)
+			}, 2*time.Second, 100*time.Millisecond)
 		})
 	}
 }
@@ -193,9 +187,8 @@ func BenchmarkProcName(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// create a new process on each iteration to eliminate name caching from the calculation
-		proc, err := customNewProcess(int32(cmd.Process.Pid))
-		if err != nil {
-			b.Fatal(err)
+		proc := &process.Process{
+			Pid: int32(cmd.Process.Pid),
 		}
 		comm, err := proc.Name()
 		if err != nil {
@@ -216,11 +209,7 @@ func BenchmarkShouldIgnoreComm(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		proc, err := customNewProcess(int32(cmd.Process.Pid))
-		if err != nil {
-			b.Fatal(err)
-		}
-		ok := discovery.shouldIgnoreComm(proc)
+		ok := discovery.shouldIgnoreComm(int32(cmd.Process.Pid))
 		if ok {
 			b.Fatalf("process should not have been ignored")
 		}

--- a/pkg/collector/corechecks/servicediscovery/module/envs_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/envs_test.go
@@ -151,15 +151,12 @@ func TestTargetEnvs(t *testing.T) {
 
 // BenchmarkGetEnvs benchmarks reading of all environment variables from /proc/<pid>/environ.
 func BenchmarkGetEnvs(b *testing.B) {
-	proc, err := customNewProcess(int32(os.Getpid()))
-	if err != nil {
-		return
-	}
+	proc := &process.Process{Pid: int32(os.Getpid())}
+
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, err = getEnvs(proc)
-		if err != nil {
+		if _, err := getEnvs(proc); err != nil {
 			return
 		}
 	}
@@ -167,16 +164,12 @@ func BenchmarkGetEnvs(b *testing.B) {
 
 // BenchmarkGetEnvsTarget benchmarks reading of target environment variables only from /proc/<pid>/environ.
 func BenchmarkGetEnvsTarget(b *testing.B) {
-	proc, err := customNewProcess(int32(os.Getpid()))
-	if err != nil {
-		return
-	}
+	proc := &process.Process{Pid: int32(os.Getpid())}
 
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		_, err = getTargetEnvs(proc)
-		if err != nil {
+		if _, err := getTargetEnvs(proc); err != nil {
 			return
 		}
 	}

--- a/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
@@ -69,12 +69,9 @@ func TestShouldIgnorePid(t *testing.T) {
 			discovery := newDiscovery(nil)
 			require.NotEmpty(t, discovery)
 
-			proc, err := customNewProcess(int32(cmd.Process.Pid))
-			require.NoError(t, err)
-
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				// wait until the service name becomes available
-				info, err := discovery.getServiceInfo(proc)
+				info, err := discovery.getServiceInfo(int32(cmd.Process.Pid))
 				assert.NoError(collect, err)
 				assert.Equal(collect, test.service, info.ddServiceName)
 			}, 3*time.Second, 100*time.Millisecond)
@@ -92,7 +89,7 @@ func TestShouldIgnorePid(t *testing.T) {
 			}
 
 			// check saved pid to ignore
-			ignore := discovery.shouldIgnorePid(proc.Pid)
+			ignore := discovery.shouldIgnorePid(int32(cmd.Process.Pid))
 			require.Equal(t, test.ignore, ignore)
 		})
 	}

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -1025,22 +1025,6 @@ func TestTagsPriority(t *testing.T) {
 	}
 }
 
-func BenchmarkOldProcess(b *testing.B) {
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		process.NewProcess(int32(os.Getpid()))
-	}
-}
-
-func BenchmarkNewProcess(b *testing.B) {
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		customNewProcess(int32(os.Getpid()))
-	}
-}
-
 func getSocketsOld(p *process.Process) ([]uint64, error) {
 	FDs, err := p.OpenFiles()
 	if err != nil {

--- a/pkg/collector/corechecks/servicediscovery/module/stat.go
+++ b/pkg/collector/corechecks/servicediscovery/module/stat.go
@@ -16,8 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/shirou/gopsutil/v3/process"
-
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -28,8 +26,8 @@ var pageSize = uint64(os.Getpagesize())
 // getRSS returns the RSS for the process, in bytes. Compare MemoryInfo() in
 // gopsutil which does the same thing but which parses several other fields
 // which we're not interested in.
-func getRSS(proc *process.Process) (uint64, error) {
-	statmPath := kernel.HostProc(strconv.Itoa(int(proc.Pid)), "statm")
+func getRSS(pid int32) (uint64, error) {
+	statmPath := kernel.HostProc(strconv.Itoa(int(pid)), "statm")
 
 	// This file is very small so just read it fully.
 	contents, err := os.ReadFile(statmPath)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the "Too many open files" issue that has been observed in CI runs. The issue could also be manually triggered by polling multiple times in a row the service discovery endpoints:

```
sudo lsof -c system-probe|wc -l & sudo curl -s --unix /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/services
```
Running this multiple times in a row will show the number of file descriptors grow at each request to the endpoint. The maximum observed value from lsof was in 2000s. After the fix, it remains stable at around 22 file descriptors.

The issue was due to use of gopsutil's `PidExists` function, which calls the `pidfd_open` syscall, but does not release manually the FD returned by it, leaving to the GC to handle it.

This PR removes the call to `PidExists`, since, given the `pidfd_open` will be released by the GC at an unknown time, did not bring us any extra guarantee for the rest of the `getService` call. The PR also removes unneeded references to the gopsutil `Process` struct, as it was, in many places, used to get the pid of the process, which is already available from a variable on the stack. The `Process` struct was also created well in advance of its actual use, before checks that would make us leave the function early. The struct is now only created close to where it is used.

### Motivation

Reduce test flakiness.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

The change fixes test flakiness + has been verified manually (see above).

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->