### PR TITLE
Implement MergeFleetPolicy for nodetreemodel 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,6 @@ issues:
   exclude:
     - "Error return value of `io.WriteString` is not checked" # 'errcheck' errors in tools/dep_tree_resolver/go_deps.go
     - "Error return value of `pem.Encode` is not checked" # 'errcheck' errors in test/integration/utils/certificates.go
-    - "Error return value of `c.logErrorNotImplemented` is not checked" # 'errcheck' errors in pkg/config/nodetreemodel/config.go
-    - "Error return value of `n.logErrorNotImplemented` is not checked" # 'errcheck' errors in pkg/config/nodetreemodel/config.go
     - "exported: exported const Exec should have comment \\(or a comment on this block\\) or be unexported" # 'revive' errors in pkg/process/events/model/model_common.go
     - "exported: exported const APIName should have comment \\(or a comment on this block\\) or be unexported" # 'revive' errors in pkg/serverless/trace/inferredspan/constants.go
     - "unnecessary conversion" # 'unconvert' errors in test/integration/utils/certificates_test.go

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -634,7 +634,7 @@ func (c *ntmConfig) MergeConfig(in io.Reader) error {
 	}
 
 	other := newInnerNode(nil)
-	if err = c.readConfigurationContent(other, content); err != nil {
+	if err = c.readConfigurationContent(other, model.SourceFile, content); err != nil {
 		return err
 	}
 
@@ -663,8 +663,17 @@ func (c *ntmConfig) MergeFleetPolicy(configPath string) error {
 	}
 	defer in.Close()
 
-	// TODO: Implement merging, merge in the policy that was read
-	return c.logErrorNotImplemented("MergeFleetPolicy")
+	content, err := io.ReadAll(in)
+	if err != nil {
+		return err
+	}
+
+	other := newInnerNode(nil)
+	if err = c.readConfigurationContent(other, model.SourceFleetPolicies, content); err != nil {
+		return err
+	}
+
+	return c.root.Merge(other)
 }
 
 // AllSettings returns all settings from the config

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -128,12 +128,6 @@ type NodeTreeConfig interface {
 	GetNode(string) (Node, error)
 }
 
-func (c *ntmConfig) logErrorNotImplemented(method string) error {
-	err := fmt.Errorf("not implemented: %s", method)
-	log.Error(err)
-	return err
-}
-
 // OnUpdate adds a callback to the list of receivers to be called each time a value is changed in the configuration
 // by a call to the 'Set' method.
 // Callbacks are only called if the value is effectively changed.

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -575,3 +575,18 @@ func TestUnsetForSource(t *testing.T) {
       val:4, source:default`
 	assert.Equal(t, expect, txt)
 }
+
+func TestMergeFleetPolicy(t *testing.T) {
+	config := NewConfig("test", "TEST", strings.NewReplacer(".", "_")) // nolint: forbidigo
+	config.SetConfigType("yaml")
+	config.Set("foo", "bar", model.SourceFile)
+
+	file, err := os.CreateTemp("", "datadog.yaml")
+	assert.NoError(t, err, "failed to create temporary file: %w", err)
+	file.Write([]byte("foo: baz"))
+	err = config.MergeFleetPolicy(file.Name())
+	assert.NoError(t, err)
+
+	assert.Equal(t, "baz", config.Get("foo"))
+	assert.Equal(t, model.SourceFleetPolicies, config.GetSource("foo"))
+}

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -579,6 +579,8 @@ func TestUnsetForSource(t *testing.T) {
 func TestMergeFleetPolicy(t *testing.T) {
 	config := NewConfig("test", "TEST", strings.NewReplacer(".", "_")) // nolint: forbidigo
 	config.SetConfigType("yaml")
+	config.SetDefault("foo", "")
+	config.BuildSchema()
 	config.Set("foo", "bar", model.SourceFile)
 
 	file, err := os.CreateTemp("", "datadog.yaml")

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -67,7 +67,7 @@ func (c *ntmConfig) ReadConfig(in io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if err := c.readConfigurationContent(c.file, content); err != nil {
+	if err := c.readConfigurationContent(c.file, model.SourceFile, content); err != nil {
 		return err
 	}
 	return c.mergeAllLayers()
@@ -78,10 +78,10 @@ func (c *ntmConfig) readInConfig(filePath string) error {
 	if err != nil {
 		return err
 	}
-	return c.readConfigurationContent(c.file, content)
+	return c.readConfigurationContent(c.file, model.SourceFile, content)
 }
 
-func (c *ntmConfig) readConfigurationContent(target InnerNode, content []byte) error {
+func (c *ntmConfig) readConfigurationContent(target InnerNode, source model.Source, content []byte) error {
 	var inData map[string]interface{}
 
 	if strictErr := yaml.UnmarshalStrict(content, &inData); strictErr != nil {
@@ -90,7 +90,7 @@ func (c *ntmConfig) readConfigurationContent(target InnerNode, content []byte) e
 			return err
 		}
 	}
-	c.warnings = append(c.warnings, loadYamlInto(target, model.SourceFile, inData, "", c.schema)...)
+	c.warnings = append(c.warnings, loadYamlInto(target, source, inData, "", c.schema)...)
 	return nil
 }
 
@@ -142,7 +142,7 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 				// Both default and dest have a child but they conflict in type. This should never happen.
 				warnings = append(warnings, "invalid tree: default and dest tree don't have the same layout")
 			} else {
-				dest.InsertChildNode(key, newLeafNode(value, model.SourceFile))
+				dest.InsertChildNode(key, newLeafNode(value, source))
 			}
 			continue
 		}


### PR DESCRIPTION
### What does this PR do?

Implement the MergeFleetPolicy method. It reuses the readConfigurationFile method, but with its own source layer, and then merges the result into the config tree.

### Motivation

Remove our dependency on viper.

### Describe how you validated your changes

Functionality covered by a unit test, which matches the test for the previous viper method.

### Possible Drawbacks / Trade-offs

### Additional Notes
