### PR TITLE
[netpath] Add initial e2e tests for Network Path Integration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -606,6 +606,7 @@
 /test/new-e2e/tests/language-detection        @DataDog/processes
 /test/new-e2e/tests/ndm                       @DataDog/ndm-core
 /test/new-e2e/tests/ndm/netflow               @DataDog/ndm-integrations
+/test/new-e2e/tests/netpath                   @DataDog/Networks @DataDog/network-device-monitoring
 /test/new-e2e/tests/npm                       @DataDog/Networks
 /test/new-e2e/tests/npm/ec2_1host_wkit_test.go @DataDog/Networks @DataDog/windows-kernel-integrations
 /test/new-e2e/tests/orchestrator              @DataDog/container-app

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -980,6 +980,16 @@ workflow:
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
 
+.on_netpath_or_e2e_changes:
+  - !reference [.on_e2e_main_release_or_rc]
+  - changes:
+      paths:
+        - pkg/collector/corechecks/network_path/**/*
+        - test/new-e2e/tests/netpath/**/*
+        - test/new-e2e/go.mod
+      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+    when: on_success
+
 .on_otel_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -984,7 +984,7 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
-        - pkg/collector/corechecks/network_path/**/*
+        - pkg/collector/corechecks/networkpath/**/*
         - test/new-e2e/tests/netpath/**/*
         - test/new-e2e/go.mod
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -480,6 +480,15 @@ new-e2e-ha-agent:
     TARGETS: ./tests/ha-agent
     TEAM: ndm-core
 
+new-e2e-netpath:
+  extends: .new_e2e_template_needs_deb_x64
+  rules:
+    - !reference [.on_netpath_or_e2e_changes]
+    - !reference [.manual]
+  variables:
+    TARGETS: ./tests/netpath
+    TEAM: network-performance-monitoring
+
 new-e2e-windows-systemprobe:
   extends: .new_e2e_template
   rules:

--- a/test/new-e2e/tests/netpath/network_path_integration_test.go
+++ b/test/new-e2e/tests/netpath/network_path_integration_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package netpath contains e2e tests for Network Path Integration feature
+package netpath
+
+import (
+	_ "embed"
+	"testing"
+	"time"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+)
+
+type networkPathIntegrationTestSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestNetworkPathIntegrationSuite runs the Network Path Integration e2e suite
+func TestNetworkPathIntegrationSuite(t *testing.T) {
+	// language=yaml
+	networkPathIntegration := `
+instances:
+- hostname: api.datadoghq.eu
+  protocol: TCP
+  port: 443
+- hostname: 8.8.8.8
+  protocol: UDP
+`
+
+	e2e.Run(t, &networkPathIntegrationTestSuite{}, e2e.WithProvisioner(awshost.Provisioner(
+		awshost.WithAgentOptions(
+			agentparams.WithIntegration("network_path.d", networkPathIntegration),
+		)),
+	))
+}
+
+func (s *networkPathIntegrationTestSuite) TestHaAgentRunningMetrics() {
+	//fakeClient := s.Env().FakeIntake.Client()
+
+	s.EventuallyWithT(func(c *assert.CollectT) {
+		s.T().Log("try assert datadog.agent.running metric")
+		//metrics, err := fakeClient.FilterMetrics("datadog.agent.running")
+		//require.NoError(c, err)
+		//assert.NotEmpty(c, metrics)
+		//for _, metric := range metrics {
+		//	s.T().Logf("    datadog.agent.running metric tags: %+v", metric.Tags)
+		//}
+		//
+		//tags := []string{"agent_group:test-group01"}
+		//metrics, err = fakeClient.FilterMetrics("datadog.agent.running", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
+		//require.NoError(c, err)
+		//assert.NotEmpty(c, metrics)
+	}, 5*time.Minute, 3*time.Second)
+}

--- a/test/new-e2e/tests/netpath/network_path_integration_test.go
+++ b/test/new-e2e/tests/netpath/network_path_integration_test.go
@@ -53,7 +53,7 @@ instances:
 	))
 }
 
-func (s *networkPathIntegrationTestSuite) TestMetrics() {
+func (s *networkPathIntegrationTestSuite) TestNetworkPathIntegrationMetrics() {
 	fakeClient := s.Env().FakeIntake.Client()
 
 	s.EventuallyWithT(func(c *assert.CollectT) {

--- a/test/new-e2e/tests/netpath/network_path_integration_test.go
+++ b/test/new-e2e/tests/netpath/network_path_integration_test.go
@@ -26,6 +26,12 @@ type networkPathIntegrationTestSuite struct {
 // TestNetworkPathIntegrationSuite runs the Network Path Integration e2e suite
 func TestNetworkPathIntegrationSuite(t *testing.T) {
 	// language=yaml
+	sysProbeConfig := `
+traceroute:
+  enabled: true
+`
+
+	// language=yaml
 	networkPathIntegration := `
 instances:
 - hostname: api.datadoghq.eu
@@ -37,6 +43,7 @@ instances:
 
 	e2e.Run(t, &networkPathIntegrationTestSuite{}, e2e.WithProvisioner(awshost.Provisioner(
 		awshost.WithAgentOptions(
+			agentparams.WithSystemProbeConfig(sysProbeConfig),
 			agentparams.WithIntegration("network_path.d", networkPathIntegration),
 		)),
 	))

--- a/test/new-e2e/tests/netpath/network_path_integration_test.go
+++ b/test/new-e2e/tests/netpath/network_path_integration_test.go
@@ -70,9 +70,19 @@ func (s *networkPathIntegrationTestSuite) TestMetrics() {
 			{"destination_hostname:8.8.8.8", "protocol:UDP"},
 		}
 		for _, tags := range destinationsTagsToAssert {
+			// assert destination is monitored
 			metrics, err = fakeClient.FilterMetrics("datadog.network_path.path.monitored", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
-			require.NoError(c, err)
+			assert.NoError(c, err)
 			assert.NotEmpty(c, metrics, fmt.Sprintf("metric with tags `%v` not found", tags))
+
+			// assert hops
+			metrics, err = fakeClient.FilterMetrics("datadog.network_path.path.hops",
+				fakeintakeclient.WithTags[*aggregator.MetricSeries](tags),
+				fakeintakeclient.WithMetricValueHigherThan(0),
+			)
+			assert.NoError(c, err)
+			assert.NotEmpty(c, metrics, fmt.Sprintf("metric with tags `%v` not found", tags))
+
 		}
 	}, 5*time.Minute, 3*time.Second)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[netpath] Add initial e2e tests for Network Path Integration

Future TODO:
- Test network path payload, see example from NetFlow: https://github.com/DataDog/datadog-agent/pull/24125

### Motivation

e2e coverage

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->