### PR TITLE
User@domain.com Test

### DIFF
--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -7,21 +7,24 @@ package domain
 
 import (
 	"fmt"
-	awsHostWindows "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
-	"github.com/DataDog/test-infra-definitions/components/activedirectory"
 	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/DataDog/test-infra-definitions/components/activedirectory"
+
+	awsHostWindows "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host/windows"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	platformCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test"
-	"github.com/stretchr/testify/assert"
+	installtest "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test"
 )
 
 const (
@@ -32,8 +35,9 @@ const (
 
 func TestInstallsOnDomainController(t *testing.T) {
 	suites := []e2e.Suite[environments.WindowsHost]{
-		&testInstallSuite{},
+		&testBasicInstallSuite{},
 		&testUpgradeSuite{},
+		&testInstallUserSyntaxSuite{},
 	}
 
 	for _, suite := range suites {
@@ -53,12 +57,12 @@ type testInstallSuite struct {
 	windows.BaseAgentInstallerSuite[environments.WindowsHost]
 }
 
-func (suite *testInstallSuite) TestGivenDomainUserCanInstallAgent() {
+func (suite *testInstallSuite) testGivenDomainUserCanInstallAgent(username string) {
 	host := suite.Env().RemoteHost
 
 	_, err := suite.InstallAgent(host,
 		windowsAgent.WithPackage(suite.AgentPackage),
-		windowsAgent.WithAgentUser(fmt.Sprintf("%s\\%s", TestDomain, TestUser)),
+		windowsAgent.WithAgentUser(username),
 		windowsAgent.WithAgentUserPassword(fmt.Sprintf("\"%s\"", TestPassword)),
 		windowsAgent.WithValidAPIKey(),
 		windowsAgent.WithFakeIntake(suite.Env().FakeIntake),
@@ -79,6 +83,22 @@ func (suite *testInstallSuite) TestGivenDomainUserCanInstallAgent() {
 		assert.NoError(c, err)
 		assert.NotEmpty(c, stats)
 	}, 5*time.Minute, 10*time.Second)
+}
+
+type testBasicInstallSuite struct {
+	testInstallSuite
+}
+
+func (suite *testBasicInstallSuite) TestGivenDomainUserCanInstallAgent() {
+	suite.testGivenDomainUserCanInstallAgent(fmt.Sprintf("%s\\%s", TestDomain, TestUser))
+}
+
+type testInstallUserSyntaxSuite struct {
+	testInstallSuite
+}
+
+func (suite *testInstallUserSyntaxSuite) TestGivenDomainUserCanInstallAgent() {
+	suite.testGivenDomainUserCanInstallAgent(fmt.Sprintf("%s@%s", TestUser, TestDomain))
 }
 
 type testUpgradeSuite struct {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds a test on domains to test `user@domain.com` syntax

### Motivation
https://datadoghq.atlassian.net/browse/WINA-454

Test that there is support for the `user@domain`

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This PR just adds a test.

### Possible Drawbacks / Trade-offs
N/A. Just an additional test.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
By default Microsoft supports [user principal names](https://learn.microsoft.com/en-us/windows/desktop/SecGloss/u-gly) (UPN) (for example, [someone@example.com](mailto:someone@example.com)). If we want to add support for user@computername this PR will need to be merged in also (https://github.com/DataDog/datadog-agent/pull/26185).  