### PR TITLE
Add IsConfigured to the config interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,6 +59,8 @@ issues:
     # We are using it and it's not clear how to replace it.
     - text: "Temporary has been deprecated since Go 1.18"
       linters: [staticcheck]
+    - text: ".IsSet is deprecated: this method will be removed once all settings have a default, use 'IsConfigured' instead"
+      linters: [staticcheck]
     # Treat this list as a TODO for fixing issues with pkgconfigusage custom linter
     # DO NOT ADD NEW ENTRIES
     - path: comp/api/api/apiimpl/internal/config/endpoint.go
@@ -565,6 +567,7 @@ issues:
     - path: comp/dogstatsd/packets/packet_manager_windows.go
       linters:
         - pkgconfigusage
+
 linters:
   disable-all: true
   enable:

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -56,7 +56,16 @@ type Reader interface {
 	// Note that it returns the keys lowercased.
 	AllKeysLowercased() []string
 
+	// IsSet return true if a non nil values is found in the configuration, including defaults. This is legacy
+	// behavior from viper and don't answer the need to know if something was set by the user (see IsConfigured for
+	// this).
+	//
+	// Deprecated: this method will be removed once all settings have a default, use 'IsConfigured' instead.
 	IsSet(key string) bool
+	// IsConfigured returns true if a settings exists and has a value and doesn't come from default (ie: was
+	// configured by the user). If a setting is configured by the user with the same value that the default this
+	// method will return true as it tests where the settings comes from not its value.
+	IsConfigured(key string) bool
 
 	// UnmarshalKey Unmarshal a configuration key into a struct
 	UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error

--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -343,6 +343,13 @@ func (c *safeConfig) IsSet(key string) bool {
 	return c.Viper.IsSet(key)
 }
 
+// IsConfigured returns true if a settings was configured by the user (ie: the value doesn't come from defaults)
+func (c *safeConfig) IsConfigured(key string) bool {
+	c.RLock()
+	defer c.RUnlock()
+	return c.Viper.IsConfigured(key)
+}
+
 func (c *safeConfig) AllKeysLowercased() []string {
 	c.Lock()
 	defer c.Unlock()

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -519,6 +519,50 @@ func (c *ntmConfig) IsSet(key string) bool {
 	return true
 }
 
+func hasNoneDefaultsLeaf(node InnerNode) bool {
+	// We're on an InnerNode, we need to check if any child leaf are not defaults
+	for _, name := range node.ChildrenKeys() {
+		child, _ := node.GetChild(name)
+		if leaf, ok := child.(LeafNode); ok {
+			if leaf.Source().IsGreaterThan(model.SourceDefault) {
+				return true
+			}
+		}
+		if hasNoneDefaultsLeaf(child.(InnerNode)) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsConfigured checks if a key is set in the config but not from the defaults
+func (c *ntmConfig) IsConfigured(key string) bool {
+	c.RLock()
+	defer c.RUnlock()
+
+	if !c.isReady() {
+		log.Errorf("attempt to read key before config is constructed: %s", key)
+		return false
+	}
+
+	pathParts := splitKey(key)
+	var curr Node = c.root
+	for _, part := range pathParts {
+		next, err := curr.GetChild(part)
+		if err != nil {
+			return false
+		}
+		curr = next
+	}
+	// if key is a leaf, we just check the source
+	if leaf, ok := curr.(LeafNode); ok {
+		return leaf.Source().IsGreaterThan(model.SourceDefault)
+	}
+
+	// if the key was an InnerNode we need to check all the inner leaf node to check if one was set by the user
+	return hasNoneDefaultsLeaf(curr.(InnerNode))
+}
+
 // AllKeysLowercased returns all keys lower-cased from the default tree, but not keys that are merely marked as known
 func (c *ntmConfig) AllKeysLowercased() []string {
 	c.RLock()

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -347,6 +347,27 @@ func TestIsSet(t *testing.T) {
 	assert.False(t, cfg.IsKnown("unknown"))
 }
 
+func TestIsConfigured(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b", 0)
+	cfg.SetKnown("c")
+	cfg.BindEnv("d")
+
+	t.Setenv("TEST_D", "123")
+
+	cfg.BuildSchema()
+
+	cfg.Set("b", 123, model.SourceAgentRuntime)
+
+	assert.False(t, cfg.IsConfigured("a"))
+	assert.True(t, cfg.IsConfigured("b"))
+	assert.False(t, cfg.IsConfigured("c"))
+	assert.True(t, cfg.IsConfigured("d"))
+
+	assert.False(t, cfg.IsConfigured("unknown"))
+}
+
 func TestAllKeysLowercased(t *testing.T) {
 	cfg := NewConfig("test", "TEST", nil)
 	cfg.SetDefault("a", 0)

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -138,6 +138,14 @@ func (t *teeConfig) IsSet(key string) bool {
 	return base
 }
 
+// IsConfigured returns true if a settings is configured by the user (ie: the value doesn't comes from the defaults)
+func (t *teeConfig) IsConfigured(key string) bool {
+	base := t.baseline.IsConfigured(key)
+	compare := t.compare.IsConfigured(key)
+	t.compareResult(key, "IsConfigured", base, compare)
+	return base
+}
+
 func (t *teeConfig) AllKeysLowercased() []string {
 	base := t.baseline.AllKeysLowercased()
 	compare := t.compare.AllKeysLowercased()


### PR DESCRIPTION
### What does this PR do?

Exposing new method `IsConfigured` for the configuration and deprecating `IsSet`.

### Describe how you validated your changes

Unit test where added for the method and it not used anywhere yet.