### PR TITLE
usm: sowatcher: Extend paths support up to 220 characters

### DIFF
--- a/pkg/network/ebpf/c/shared-libraries/types.h
+++ b/pkg/network/ebpf/c/shared-libraries/types.h
@@ -4,7 +4,7 @@
 #include "ktypes.h"
 
 #define LIB_SO_SUFFIX_SIZE 9
-#define LIB_PATH_MAX_SIZE 120
+#define LIB_PATH_MAX_SIZE 220
 
 typedef struct {
     __u32 pid;

--- a/pkg/network/usm/sharedlibraries/types_linux.go
+++ b/pkg/network/usm/sharedlibraries/types_linux.go
@@ -6,9 +6,9 @@ package sharedlibraries
 type LibPath struct {
 	Pid uint32
 	Len uint32
-	Buf [120]byte
+	Buf [220]byte
 }
 
 const (
-	LibPathMaxSize = 0x78
+	LibPathMaxSize = 0xdc
 )

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -104,6 +104,53 @@ func (s *SharedLibrarySuite) TestSharedLibraryDetection() {
 	}, time.Second*10, 100*time.Millisecond)
 }
 
+func (s *SharedLibrarySuite) TestLongPath() {
+	t := s.T()
+
+	const (
+		fileName             = "foo-libssl.so"
+		nullTerminatorLength = len("\x00")
+	)
+	padLength := LibPathMaxSize - len(fileName) - len(t.TempDir()) - len("_") - len(string(filepath.Separator)) - nullTerminatorLength
+	fooPath1, fooPathID1 := createTempTestFile(t, strings.Repeat("a", padLength)+"_"+fileName)
+	// fooPath2 is longer than the limit we have, thus it will be ignored.
+	fooPath2, fooPathID2 := createTempTestFile(t, strings.Repeat("a", padLength+1)+"_"+fileName)
+
+	registerRecorder := new(utils.CallbackRecorder)
+	unregisterRecorder := new(utils.CallbackRecorder)
+
+	watcher, err := NewWatcher(utils.NewUSMEmptyConfig(), LibsetCrypto,
+		Rule{
+			Re:           regexp.MustCompile(`foo-libssl.so`),
+			RegisterCB:   registerRecorder.Callback(),
+			UnregisterCB: unregisterRecorder.Callback(),
+		},
+	)
+	require.NoError(t, err)
+	watcher.Start()
+	t.Cleanup(watcher.Stop)
+
+	// create files
+	command1, err := fileopener.OpenFromAnotherProcess(t, fooPath1)
+	require.NoError(t, err)
+
+	command2, err := fileopener.OpenFromAnotherProcess(t, fooPath2)
+	require.NoError(t, err)
+
+	require.Eventuallyf(t, func() bool {
+		return registerRecorder.CallsForPathID(fooPathID1) == 1 &&
+			registerRecorder.CallsForPathID(fooPathID2) == 0
+	}, time.Second*10, 100*time.Millisecond, "")
+
+	require.NoError(t, command1.Process.Kill())
+	require.NoError(t, command2.Process.Kill())
+
+	require.Eventually(t, func() bool {
+		return unregisterRecorder.CallsForPathID(fooPathID1) == 1 &&
+			unregisterRecorder.CallsForPathID(fooPathID2) == 0
+	}, time.Second*10, 100*time.Millisecond)
+}
+
 func (s *SharedLibrarySuite) TestSharedLibraryDetectionWithPIDAndRootNamespace() {
 	t := s.T()
 	_, err := os.Stat("/usr/bin/busybox")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

A followup to PR #31947, now we have more room to increase the buffer size and support longer paths than we used to

### Motivation

Support longer paths in sowatcher

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->