### PR TITLE
[CWS] Lower a noisy ptrace info log to debug

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1097,7 +1097,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 				} else {
 					pid, err := utils.TryToResolveTraceePid(event.ProcessContext.Process.Pid, event.PTrace.NSPID)
 					if err != nil {
-						seclog.Infof("PTrace err: %v", err)
+						seclog.Debugf("PTrace err: %v", err)
 						return
 					}
 					pidToResolve = pid


### PR DESCRIPTION
### What does this PR do?

It reduces the log level from Error to Debug, as we know the fallback can be racy and may not succeed.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->