### PR TITLE
Fix Get() method not being able to return an inner node

### DIFF
--- a/pkg/config/model/viper.go
+++ b/pkg/config/model/viper.go
@@ -32,6 +32,8 @@ type Source string
 
 // Declare every known Source
 const (
+	// SourceSchema are settings define in the schema for the configuration but without any default.
+	SourceSchema Source = "schema"
 	// SourceDefault are the values from defaults.
 	SourceDefault Source = "default"
 	// SourceUnknown are the values from unknown source. This should only be used in tests when calling
@@ -74,6 +76,7 @@ var sources = []Source{
 // sourcesPriority give each source a priority, the higher the more important a source. This is used when merging
 // configuration tree (a higher priority overwrites a lower one).
 var sourcesPriority = map[Source]int{
+	SourceSchema:             -1,
 	SourceDefault:            0,
 	SourceUnknown:            1,
 	SourceFile:               2,

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -256,6 +256,7 @@ func TestAllSettings(t *testing.T) {
 	cfg.SetDefault("a", 0)
 	cfg.SetDefault("b.c", 0)
 	cfg.SetDefault("b.d", 0)
+	cfg.SetKnown("b.e")
 	cfg.BuildSchema()
 
 	cfg.ReadConfig(strings.NewReader("a: 987"))

--- a/pkg/config/nodetreemodel/getter.go
+++ b/pkg/config/nodetreemodel/getter.go
@@ -112,14 +112,44 @@ func (c *ntmConfig) inferTypeFromDefault(key string, value interface{}) (interfa
 	return deepcopy.Copy(value), nil
 }
 
+func (c *ntmConfig) getNodeValue(key string) interface{} {
+	if !c.isReady() {
+		log.Errorf("attempt to read key before config is constructed: %s", key)
+		return missingLeaf
+	}
+
+	node := c.nodeAtPathFromNode(key, c.root)
+
+	if leaf, ok := node.(LeafNode); ok {
+		return leaf.Get()
+	}
+
+	// When querying an InnerNode we convert it as a map[string]interface{} to mimic Viper's logic
+	var converter func(node InnerNode) map[string]interface{}
+	converter = func(node InnerNode) map[string]interface{} {
+		res := map[string]interface{}{}
+		for _, name := range node.ChildrenKeys() {
+			child, _ := node.GetChild(name)
+
+			if leaf, ok := child.(LeafNode); ok {
+				res[name] = leaf.Get()
+			} else {
+				res[name] = converter(child.(InnerNode))
+			}
+		}
+		return res
+	}
+
+	return converter(node.(InnerNode))
+}
+
 // Get returns a copy of the value for the given key
 func (c *ntmConfig) Get(key string) interface{} {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val := c.leafAtPath(key).Get()
 
-	val, err := c.inferTypeFromDefault(key, val)
+	val, err := c.inferTypeFromDefault(key, c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -149,7 +179,7 @@ func (c *ntmConfig) GetString(key string) string {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	str, err := cast.ToStringE(c.leafAtPath(key).Get())
+	str, err := cast.ToStringE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -161,7 +191,7 @@ func (c *ntmConfig) GetBool(key string) bool {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	b, err := cast.ToBoolE(c.leafAtPath(key).Get())
+	b, err := cast.ToBoolE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -173,7 +203,7 @@ func (c *ntmConfig) GetInt(key string) int {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToIntE(c.leafAtPath(key).Get())
+	val, err := cast.ToIntE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -185,7 +215,7 @@ func (c *ntmConfig) GetInt32(key string) int32 {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToInt32E(c.leafAtPath(key).Get())
+	val, err := cast.ToInt32E(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -197,7 +227,7 @@ func (c *ntmConfig) GetInt64(key string) int64 {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToInt64E(c.leafAtPath(key).Get())
+	val, err := cast.ToInt64E(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -209,7 +239,7 @@ func (c *ntmConfig) GetFloat64(key string) float64 {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToFloat64E(c.leafAtPath(key).Get())
+	val, err := cast.ToFloat64E(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -222,7 +252,7 @@ func (c *ntmConfig) GetFloat64Slice(key string) []float64 {
 	defer c.RUnlock()
 	c.checkKnownKey(key)
 
-	list, err := cast.ToStringSliceE(c.leafAtPath(key).Get())
+	list, err := cast.ToStringSliceE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -244,7 +274,7 @@ func (c *ntmConfig) GetDuration(key string) time.Duration {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToDurationE(c.leafAtPath(key).Get())
+	val, err := cast.ToDurationE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -256,7 +286,7 @@ func (c *ntmConfig) GetStringSlice(key string) []string {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToStringSliceE(c.leafAtPath(key).Get())
+	val, err := cast.ToStringSliceE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -268,7 +298,7 @@ func (c *ntmConfig) GetStringMap(key string) map[string]interface{} {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToStringMapE(c.leafAtPath(key).Get())
+	val, err := cast.ToStringMapE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -280,7 +310,7 @@ func (c *ntmConfig) GetStringMapString(key string) map[string]string {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToStringMapStringE(c.leafAtPath(key).Get())
+	val, err := cast.ToStringMapStringE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}
@@ -292,7 +322,7 @@ func (c *ntmConfig) GetStringMapStringSlice(key string) map[string][]string {
 	c.RLock()
 	defer c.RUnlock()
 	c.checkKnownKey(key)
-	val, err := cast.ToStringMapStringSliceE(c.leafAtPath(key).Get())
+	val, err := cast.ToStringMapStringSliceE(c.getNodeValue(key))
 	if err != nil {
 		log.Warnf("failed to get configuration value for key %q: %s", key, err)
 	}

--- a/pkg/config/nodetreemodel/getter_test.go
+++ b/pkg/config/nodetreemodel/getter_test.go
@@ -44,6 +44,28 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, 9876, cfg.Get("a"))
 
 	assert.Equal(t, nil, cfg.Get("does_not_exists"))
+
+	// test implicit conversion
+	cfg.Set("a", "1111", model.SourceAgentRuntime)
+	assert.Equal(t, 1111, cfg.Get("a"))
+}
+
+func TestGetInnerNode(t *testing.T) {
+	cfg := NewConfig("test", "", nil)
+	cfg.SetDefault("a.b.c", 1234)
+	cfg.SetDefault("a.e", 1234)
+	cfg.BuildSchema()
+
+	assert.Equal(t, 1234, cfg.Get("a.b.c"))
+	assert.Equal(t, 1234, cfg.Get("a.e"))
+	assert.Equal(t, map[string]interface{}{"c": 1234}, cfg.Get("a.b"))
+	assert.Equal(t, map[string]interface{}{"b": map[string]interface{}{"c": 1234}, "e": 1234}, cfg.Get("a"))
+
+	cfg.Set("a.b.c", 9876, model.SourceAgentRuntime)
+	assert.Equal(t, 9876, cfg.Get("a.b.c"))
+	assert.Equal(t, 1234, cfg.Get("a.e"))
+	assert.Equal(t, map[string]interface{}{"c": 9876}, cfg.Get("a.b"))
+	assert.Equal(t, map[string]interface{}{"b": map[string]interface{}{"c": 9876}, "e": 1234}, cfg.Get("a"))
 }
 
 func TestGetCastToDefault(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The `Get()` method for the nodetreemodel was not capable of returning an inner node.

### Describe how you validated your changes

Unit tests where added.