### PR TITLE
usm: telemetry: tests: Move Clear method to test only file

### DIFF
--- a/pkg/network/protocols/telemetry/registry.go
+++ b/pkg/network/protocols/telemetry/registry.go
@@ -60,18 +60,6 @@ func (r *registry) GetMetrics(params ...string) []metric {
 	return result
 }
 
-// Clear metrics
-// WARNING: Only intended for tests
-func Clear() {
-	globalRegistry.Lock()
-	globalRegistry.metrics = nil
-	globalRegistry.Unlock()
-
-	telemetryDelta.mux.Lock()
-	telemetryDelta.stateByClientID = make(map[string]*clientState)
-	telemetryDelta.mux.Unlock()
-}
-
 func init() {
 	globalRegistry = new(registry)
 }

--- a/pkg/network/protocols/telemetry/registry_testutil.go
+++ b/pkg/network/protocols/telemetry/registry_testutil.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+package telemetry
+
+// Clear metrics
+func Clear() {
+	globalRegistry.Lock()
+	globalRegistry.metrics = nil
+	globalRegistry.Unlock()
+
+	telemetryDelta.mux.Lock()
+	telemetryDelta.stateByClientID = make(map[string]*clientState)
+	telemetryDelta.mux.Unlock()
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The Clear method is used only in tests, therefore moving it to a testutil file to ensure no inappropriate usage is being done with it

### Motivation

Ensuring no usage of test utils in production code

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->