### PR TITLE
[usm] reliability, http, use DDSketch pool in StatKeeper.

### DIFF
--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -225,6 +225,11 @@ func (p *protocol) GetStats() *protocols.ProtocolStats {
 	}
 }
 
+// ReleaseStats release objects back to pool.
+func (p *protocol) ReleaseStats() {
+	p.statkeeper.ReleaseSketches()
+}
+
 // IsBuildModeSupported returns always true, as http module is supported by all modes.
 func (*protocol) IsBuildModeSupported(buildmode.Type) bool {
 	return true

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -26,7 +26,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 	tel := NewTelemetry("http")
 	sk := NewStatkeeper(cfg, tel, NewIncompleteBuffer(cfg, tel))
 	t.Cleanup(func() {
-		sk.releaseAllSketches()
+		sk.ReleaseSketches()
 	})
 
 	srcString := "1.1.1.1"
@@ -68,6 +68,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 			assert.True(t, p50 >= expectedLatency-acceptableError)
 			assert.True(t, p50 <= expectedLatency+acceptableError)
 		}
+		sk.ReleaseSketches()
 	}
 }
 
@@ -358,6 +359,7 @@ func benchmarkHTTPStatkeeper(b *testing.B, sk *StatKeeper) {
 			b.StartTimer()
 			sk.Process(tx)
 		}
+		sk.ReleaseSketches()
 	}
 	b.StopTimer()
 }

--- a/pkg/network/protocols/http/statkeeper_test.go
+++ b/pkg/network/protocols/http/statkeeper_test.go
@@ -25,6 +25,9 @@ func TestProcessHTTPTransactions(t *testing.T) {
 	cfg.MaxHTTPStatsBuffered = 1000
 	tel := NewTelemetry("http")
 	sk := NewStatkeeper(cfg, tel, NewIncompleteBuffer(cfg, tel))
+	t.Cleanup(func() {
+		sk.releaseAllSketches()
+	})
 
 	srcString := "1.1.1.1"
 	dstString := "2.2.2.2"
@@ -53,6 +56,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 		for i := 0; i < 5; i++ {
 			s := stats.Data[uint16((i+1)*100)]
 			require.NotNil(t, s)
+			require.NotNil(t, s.Latencies)
 			assert.Equal(t, 2, s.Count)
 			assert.Equal(t, 2.0, s.Latencies.GetCount())
 
@@ -321,4 +325,55 @@ func TestHTTPCorrectness(t *testing.T) {
 		stats := sk.GetAndResetAllStats()
 		require.Len(t, stats, 0)
 	})
+}
+
+func makeStatkeeper() *StatKeeper {
+	cfg := config.New()
+	cfg.MaxHTTPStatsBuffered = 100000
+	tel := NewTelemetry("http")
+	return NewStatkeeper(cfg, tel, NewIncompleteBuffer(cfg, tel))
+}
+
+func benchmarkHTTPStatkeeper(b *testing.B, sk *StatKeeper) {
+	sourceIP := util.AddressFromString("1.1.1.1")
+	sourcePort := 1234
+	destIP := util.AddressFromString("2.2.2.2")
+	destPort := 8080
+
+	const numPaths = 10000
+	const uniqPaths = 50
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sk.GetAndResetAllStats()
+		for p := 0; p < numPaths; p++ {
+			b.StopTimer()
+			//we use subset of unique endpoints, but those will occur over and over again like in regular target application
+			path := "/testpath/blablabla/dsadas/isdaasd/asdasadsadasd" + strconv.Itoa(p%uniqPaths)
+			//we simulate different conn tuples by increasing the port number
+			newSourcePort := sourcePort + (p % 30)
+			statusCode := (i%5 + 1) * 100
+			latency := time.Duration(i%5+1) * time.Millisecond
+			tx := generateIPv4HTTPTransaction(sourceIP, destIP, newSourcePort, destPort, path, statusCode, latency)
+			b.StartTimer()
+			sk.Process(tx)
+		}
+	}
+	b.StopTimer()
+}
+
+// BenchmarkHTTPStatkeeperWithPool benchmark allocations with pool of 'DDSketch' objects
+func BenchmarkHTTPStatkeeperWithPool(b *testing.B) {
+	sk := makeStatkeeper()
+
+	benchmarkHTTPStatkeeper(b, sk)
+}
+
+// BenchmarkHTTPStatkeeperNoPool benchmark allocations without pool of 'DDSketch' objects
+func BenchmarkHTTPStatkeeperNoPool(b *testing.B) {
+	sk := makeStatkeeper()
+	// disable pool of 'DDSketch' objects
+	sk.sketches = nil
+
+	benchmarkHTTPStatkeeper(b, sk)
 }

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -6,13 +6,12 @@
 package http
 
 import (
-	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
-	"github.com/DataDog/sketches-go/ddsketch"
-
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
+	"github.com/DataDog/sketches-go/ddsketch"
 )
 
 // Interner is used to intern strings to save memory allocations.

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -431,6 +431,11 @@ func (p *Protocol) GetStats() *protocols.ProtocolStats {
 	}
 }
 
+// ReleaseStats release objects back to pool, not implemented yet, to satisfy protocol.
+func (p *Protocol) ReleaseStats() {
+	return
+}
+
 // IsBuildModeSupported returns always true, as http2 module is supported by all modes.
 func (*Protocol) IsBuildModeSupported(buildmode.Type) bool {
 	return true

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -361,6 +361,11 @@ func (p *protocol) GetStats() *protocols.ProtocolStats {
 	}
 }
 
+// ReleaseStats release objects back to pool, not implemented yet, to satisfy protocol.
+func (p *protocol) ReleaseStats() {
+	return
+}
+
 // IsBuildModeSupported returns always true, as kafka module is supported by all modes.
 func (*protocol) IsBuildModeSupported(buildmode.Type) bool {
 	return true

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -239,6 +239,11 @@ func (p *protocol) GetStats() *protocols.ProtocolStats {
 	}
 }
 
+// ReleaseStats release objects back to pool, not implemented yet, to satisfy protocol.
+func (p *protocol) ReleaseStats() {
+	return
+}
+
 // IsBuildModeSupported returns always true, as postgres module is supported by all modes.
 func (*protocol) IsBuildModeSupported(buildmode.Type) bool {
 	return true

--- a/pkg/network/protocols/protocols.go
+++ b/pkg/network/protocols/protocols.go
@@ -61,6 +61,9 @@ type Protocol interface {
 	// implementation.
 	GetStats() *ProtocolStats
 
+	// ReleaseStats puts back stats related objects to pool.
+	ReleaseStats()
+
 	// IsBuildModeSupported return true is the given build mode is supported by this protocol.
 	IsBuildModeSupported(buildmode.Type) bool
 }

--- a/pkg/network/protocols/redis/protocol.go
+++ b/pkg/network/protocols/redis/protocol.go
@@ -155,6 +155,11 @@ func (p *protocol) GetStats() *protocols.ProtocolStats {
 	}
 }
 
+// ReleaseStats release objects back to pool, not implemented yet, to satisfy protocol.
+func (p *protocol) ReleaseStats() {
+	return
+}
+
 // IsBuildModeSupported returns always true, as Redis module is supported by all modes.
 func (*protocol) IsBuildModeSupported(buildmode.Type) bool {
 	return true

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -426,6 +426,9 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 
 	delta := t.state.GetDelta(clientID, latestTime, active, t.reverseDNS.GetDNSStats(), t.usmMonitor.GetProtocolStats())
 
+	// release stats objects back to pool
+	t.usmMonitor.ReleaseStats()
+
 	ips := make(map[util.Address]struct{}, len(delta.Conns)/2)
 	var udpConns, tcpConns int
 	for i := range delta.Conns {

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -290,6 +290,11 @@ func (p *goTLSProgram) GetStats() *protocols.ProtocolStats {
 	return nil
 }
 
+// ReleaseStats is a no-op.
+func (p *goTLSProgram) ReleaseStats() {
+	return
+}
+
 // Stop terminates goTLS main goroutine.
 func (p *goTLSProgram) Stop(*manager.Manager) {
 	close(p.done)

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -544,6 +544,12 @@ func (e *ebpfProgram) getProtocolStats() map[protocols.ProtocolType]interface{} 
 	return ret
 }
 
+func (e *ebpfProgram) releaseStats() {
+	for _, protocol := range e.enabledProtocols {
+		protocol.Instance.ReleaseStats()
+	}
+}
+
 // executePerProtocol runs the given callback (`cb`) for every protocol in the given list (`protocolList`).
 // If the callback failed, then we call the error callback (`errorCb`). Eventually returning a list of protocols which
 // successfully executed the callback.

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -564,6 +564,11 @@ func (o *sslProgram) GetStats() *protocols.ProtocolStats {
 	return nil
 }
 
+// ReleaseStats is a no-op.
+func (p *sslProgram) ReleaseStats() {
+	return
+}
+
 const (
 	// Defined in https://man7.org/linux/man-pages/man5/proc.5.html.
 	taskCommLen = 16

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -196,6 +196,11 @@ func (m *Monitor) GetProtocolStats() map[protocols.ProtocolType]interface{} {
 	return m.ebpfProgram.getProtocolStats()
 }
 
+// ReleaseStats puts back stats related objects to pool.
+func (m *Monitor) ReleaseStats() {
+	m.ebpfProgram.releaseStats()
+}
+
 // Stop HTTP monitoring
 func (m *Monitor) Stop() {
 	if m == nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds pool of `DDSketch` objects to `StatKeeper` struct.

### Motivation
This is part of an effort to improve USM performance and reliability.
Profiling shows frequently allocated objects of 'DDSketch', using pool of these objects should decrease memory utilization.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Covered by unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Benchmarking on local VM shows shows allocation decrease 3.7 times:

```
pkg: github.com/DataDog/datadog-agent/pkg/network/protocols/http
BenchmarkHTTPStatkeeperWithPool-4   	     100	  10148724 ns/op	   90249 B/op	     674 allocs/op
BenchmarkHTTPStatkeeperNoPool-4     	     100	  10633942 ns/op	  338650 B/op	    2414 allocs/op
PASS
```