### PR TITLE
[fleet] First working set of databricks script e2e 

### DIFF
--- a/pkg/fleet/installer/setup/common/config.go
+++ b/pkg/fleet/installer/setup/common/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/exec"
-	"github.com/DataDog/datadog-agent/pkg/fleet/internal/paths"
 	"gopkg.in/yaml.v2"
 )
 
@@ -220,7 +219,11 @@ func (i *HostInstaller) ConfigureAndInstall(ctx context.Context) error {
 		return fmt.Errorf("failed to write configurations: %w", err)
 	}
 
-	cmd := exec.NewInstallerExec(i.env, paths.StableInstallerPath)
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+	cmd := exec.NewInstallerExec(i.env, exePath)
 
 	if i.injectorVersion != "" {
 		if err := cmd.Install(ctx, oci.PackageURL(i.env, "datadog-apm-inject", i.injectorVersion), nil); err != nil {

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	databricksInjectorVersion = "0.21.0"
-	databricksJavaVersion     = "1.41.1"
-	databricksAgentVersion    = "7.57.2"
+	databricksInjectorVersion = "0.21.0-1"
+	databricksJavaVersion     = "1.41.1-1"
+	databricksAgentVersion    = "7.57.2-1"
 	logsService               = "databricks"
 )
 

--- a/pkg/fleet/installer/setup/setup.go
+++ b/pkg/fleet/installer/setup/setup.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/djm"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/exec"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/paths"
@@ -25,11 +26,11 @@ const (
 func Setup(ctx context.Context, env *env.Env, flavor string) error {
 	switch flavor {
 	case FlavorDatabricks:
-		// temporary until the whole e2e test pipeline is setup
+		if err := packages.SetupInstaller(ctx); err != nil {
+			return fmt.Errorf("failed to setup installer: %w", err)
+		}
 		if err := djm.SetupDatabricks(ctx, env); err != nil {
-			fmt.Printf("Databricks setup failed: %v\n", err)
-		} else {
-			fmt.Println("Databricks setup completed")
+			return fmt.Errorf("failed to setup Databricks: %w", err)
 		}
 		return nil
 	default:

--- a/test/new-e2e/tests/installer/script/databricks_test.go
+++ b/test/new-e2e/tests/installer/script/databricks_test.go
@@ -24,7 +24,7 @@ type vmUpdaterSuite struct {
 
 func (s *vmUpdaterSuite) TestInstallScript() {
 	url := fmt.Sprintf("https://installtesting.datad0g.com/%s/scripts/install-databricks.sh", s.commitHash)
-	s.Env().RemoteHost.MustExecute(fmt.Sprintf("curl -L %s > install_script; export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE=installtesting.datad0g.com; sudo -E bash install_script", url))
+	s.Env().RemoteHost.MustExecute(fmt.Sprintf("curl -L %s > install_script; export DD_API_KEY=test; export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE=installtesting.datad0g.com; sudo -E bash install_script", url))
 }
 
 func TestUpdaterSuite(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Enforce that we don't break the install script for amd/arm and that databricks script install the proper packages!
I didn't cleanly setup the installer yet, just executing its setup on the script start as a temporary hack to make the e2e work

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->