### PR TITLE
[PROCS-4589] Split K8s e2e test

### DIFF
--- a/test/new-e2e/tests/process/k8s_test.go
+++ b/test/new-e2e/tests/process/k8s_test.go
@@ -156,7 +156,11 @@ func (s *K8sSuite) TestProcessDiscoveryCheck() {
 	assertProcessDiscoveryCollected(t, payloads, "stress-ng-cpu [run]")
 }
 
-func (s *K8sSuite) TestProcessCheckInCoreAgent() {
+type K8sCoreAgentSuite struct {
+	e2e.BaseSuite[environments.Kubernetes]
+}
+
+func (s *K8sCoreAgentSuite) TestProcessCheckInCoreAgent() {
 	t := s.T()
 
 	helmValues, err := createHelmValues(helmConfig{
@@ -207,7 +211,7 @@ func (s *K8sSuite) TestProcessCheckInCoreAgent() {
 	assertContainersNotCollected(t, payloads, []string{"process-agent"})
 }
 
-func (s *K8sSuite) TestProcessCheckInCoreAgentWithNPM() {
+func (s *K8sCoreAgentSuite) TestProcessCheckInCoreAgentWithNPM() {
 	t := s.T()
 
 	helmValues, err := createHelmValues(helmConfig{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
 
Splits off the K8s core agent tests into their own suite.

### Motivation

Flakes in the core agent tests due to improper environment (process agent present when it shouldn't be).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated the split
```
--- PASS: TestK8sTestSuite (890.74s)
    --- PASS: TestK8sTestSuite/TestManualContainerCheck (16.97s)
    --- PASS: TestK8sTestSuite/TestManualProcessCheck (17.72s)
    --- PASS: TestK8sTestSuite/TestManualProcessDiscoveryCheck (11.76s)
    --- PASS: TestK8sTestSuite/TestProcessCheck (21.34s)
    --- PASS: TestK8sTestSuite/TestProcessDiscoveryCheck (68.18s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	893.787s

DONE 6 tests in 917.562s
All tests passed

--- PASS: TestK8sCoreAgentTestSuite (946.24s)
    --- PASS: TestK8sCoreAgentTestSuite/TestProcessCheckInCoreAgent (31.48s)
    --- PASS: TestK8sCoreAgentTestSuite/TestProcessCheckInCoreAgentWithNPM (85.65s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	949.421s

DONE 3 tests in 974.248s
All tests passed
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->