### PR TITLE
Bump otel-agent BYOC flow to use 7.59.0-v1.1.0 agent version

### DIFF
--- a/Dockerfiles/agent-ot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ot/Dockerfile.agent-otel
@@ -1,5 +1,5 @@
-ARG AGENT_VERSION=7.57.0-v1.0-ot-beta-jmx
-ARG AGENT_BRANCH=7.57.x-otel-beta-v1
+ARG AGENT_VERSION=7.59.0-v1.1.0-ot-beta-jmx
+ARG AGENT_BRANCH=7.59.x
 # Use the Ubuntu Slim AMD64 base image
 FROM ubuntu:24.04 AS builder
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates `otel-agent` BYOC Dockerfile to use agent version `7.59.0-v1.1.0-ot-beta-jmx`

### Motivation

A version mismatch error occurs when customers using BYOC Dockerfile with the latest `manifest.yaml` file. Currently, the OCB version included with `7.57.0-v1.0-ot-beta-jmx` agent (`0.104`) does not match the version listed in `main` branch `manifest.yaml` (`0.115`), leading to errors during build stage. By using `AGENT_BRANCH=7.59.x` we're aligning these versions.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Built a custom version of `otel-agent` using v0.104 custom OTel components and deployed it to a test k8s cluster.

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

PR to update docs: https://github.com/DataDog/documentation/pull/26704
