### PR TITLE
[CWS] cleanup hacky check for security-agent flavor in system-probe SBOM code path

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -80,6 +80,9 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("sbom.cache.clean_interval", "30m")        // used by custom cache.
 	cfg.BindEnvAndSetDefault("sbom.scan_queue.base_backoff", "5m")
 	cfg.BindEnvAndSetDefault("sbom.scan_queue.max_backoff", "1h")
+	// those configs are used by the core agent path, but are not used by the system probe
+	cfg.SetKnown("sbom.container_image.enabled")
+	cfg.SetKnown("sbom.container_image.overlayfs_direct_scan")
 
 	// Auto exit configuration
 	cfg.BindEnvAndSetDefault("auto_exit.validation_period", 60)

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -16,7 +16,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
@@ -43,11 +42,7 @@ func (c *Collector) Init(cfg config.Component, wmeta optional.Option[workloadmet
 		return err
 	}
 	c.trivyCollector = trivyCollector
-	if flavor.GetFlavor() == flavor.SecurityAgent {
-		c.opts = sbom.ScanOptions{Analyzers: []string{trivy.OSAnalyzers}, Fast: false, CollectFiles: true}
-	} else {
-		c.opts = sbom.ScanOptionsFromConfig(cfg, false)
-	}
+	c.opts = sbom.ScanOptionsFromConfig(cfg, false)
 	return nil
 }
 

--- a/pkg/sbom/types/types.go
+++ b/pkg/sbom/types/types.go
@@ -23,7 +23,6 @@ type ScanOptions struct {
 	Timeout          time.Duration
 	WaitAfter        time.Duration
 	Fast             bool
-	CollectFiles     bool
 	UseMount         bool
 	OverlayFsScan    bool
 }

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -10,7 +10,6 @@ package tests
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"testing"
 
@@ -28,8 +27,6 @@ func TestSBOM(t *testing.T) {
 	if testEnvironment == DockerEnvironment {
 		t.Skip("Skip test spawning docker containers on docker")
 	}
-
-	os.Chdir("/")
 
 	ruleDefs := []*rules.RuleDefinition{
 		{

--- a/pkg/security/tests/sbom_test.go
+++ b/pkg/security/tests/sbom_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 
 	"github.com/avast/retry-go/v4"
 )
@@ -30,11 +29,6 @@ func TestSBOM(t *testing.T) {
 		t.Skip("Skip test spawning docker containers on docker")
 	}
 
-	originalFlavor := flavor.GetFlavor()
-	flavor.SetFlavor(flavor.SecurityAgent)
-	defer func() {
-		flavor.SetFlavor(originalFlavor)
-	}()
 	os.Chdir("/")
 
 	ruleDefs := []*rules.RuleDefinition{


### PR DESCRIPTION
### What does this PR do?

The system-probe is a different flavor than the security agent, and the security agent does not run any SBOM collector. This was seemingly done only for testing purposes ?

This PR cleans up all this code path, removing the ugly flavor check and the test-side flavor set as well. It adds a few "known" config to prevent some warnings.

This PR also removes the `CollectFiles` field in the scan options that was unused.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->