### PR TITLE
[PROCS-4568] Split ECS Fargate e2e test

### DIFF
--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -79,7 +79,7 @@ type ECSFargateCoreAgentSuite struct {
 
 func TestECSFargateCoreAgentTestSuite(t *testing.T) {
 	t.Parallel()
-	s := ECSFargateSuite{}
+	s := ECSFargateCoreAgentSuite{}
 
 	extraConfig := runner.ConfigMap{
 		"ddagent:extraEnvVars": auto.ConfigValue{Value: "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED=true"},

--- a/test/new-e2e/tests/process/fargate_test.go
+++ b/test/new-e2e/tests/process/fargate_test.go
@@ -73,14 +73,27 @@ func (s *ECSFargateSuite) TestProcessCheck() {
 	assertContainersCollected(t, payloads, []string{"stress-ng"})
 }
 
-func (s *ECSFargateSuite) TestProcessCheckInCoreAgent() {
-	t := s.T()
+type ECSFargateCoreAgentSuite struct {
+	e2e.BaseSuite[environments.ECS]
+}
+
+func TestECSFargateCoreAgentTestSuite(t *testing.T) {
+	t.Parallel()
+	s := ECSFargateSuite{}
 
 	extraConfig := runner.ConfigMap{
 		"ddagent:extraEnvVars": auto.ConfigValue{Value: "DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED=true"},
 	}
+	e2eParams := []e2e.SuiteOption{e2e.WithProvisioner(
+		getFargateProvisioner(extraConfig),
+	),
+	}
 
-	s.UpdateEnv(getFargateProvisioner(extraConfig))
+	e2e.Run(t, &s, e2eParams...)
+}
+
+func (s *ECSFargateCoreAgentSuite) TestProcessCheckInCoreAgent() {
+	t := s.T()
 
 	// Flush fake intake to remove any payloads which may have
 	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Splits off the ECS Fargate core agent tests into their own suite.

### Motivation

Flakes in the core agent tests due to improper environment (process agent present when it shouldn't be).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Ran the tests
```
=== RUN   TestECSFargateCoreAgentTestSuite/TestProcessCheck
    suite.go:280: No change in provisioners, skipping environment update
--- PASS: TestECSFargateCoreAgentTestSuite (684.46s)
    --- PASS: TestECSFargateCoreAgentTestSuite/TestProcessCheck (120.39s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	687.560s

DONE 2 tests in 710.956s
All tests passed

=== RUN   TestECSFargateTestSuite/TestProcessCheck
    suite.go:280: No change in provisioners, skipping environment update
--- PASS: TestECSFargateTestSuite (551.49s)
    --- PASS: TestECSFargateTestSuite/TestProcessCheck (20.30s)
PASS
ok  	github.com/DataDog/datadog-agent/test/new-e2e/tests/process	554.558s

DONE 2 tests in 575.430s
All tests passed
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->