### PR TITLE
[CWS] downgrade the "Failed to remove dump" to debug if no exist

### DIFF
--- a/pkg/security/security_profile/dump/local_storage.go
+++ b/pkg/security/security_profile/dump/local_storage.go
@@ -10,6 +10,7 @@ package dump
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -87,7 +88,11 @@ func NewActivityDumpLocalStorage(cfg *config.Config, m *ActivityDumpManager) (Ac
 		// remove everything
 		for _, filePath := range *filePaths {
 			if err := os.Remove(filePath); err != nil {
-				seclog.Warnf("Failed to remove dump %s (limit of dumps reach): %v", filePath, err)
+				logFn := seclog.Warnf
+				if errors.Is(err, os.ErrNotExist) {
+					logFn = seclog.Debugf
+				}
+				logFn("Failed to remove dump %s (limit of dumps reach): %v", filePath, err)
 			}
 		}
 


### PR DESCRIPTION
### What does this PR do?

It's possible the profile has already been deleted by the directory provider. As such, let's not `log.Warn` if we can't remove the profile but just `log.Debug` if this is the case.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->