### PR TITLE
Remove flaky test marker on kind e2e test suite

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -11,5 +11,3 @@ test/new-e2e/tests/containers:
   - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
-  - TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
-  - TestKindSuite


### PR DESCRIPTION
### What does this PR do?

Removes flaky test marker from kind e2e tests

### Motivation

Tests appear to be fixed after merging [this PR](https://github.com/DataDog/datadog-agent/pull/31877)

[No new failures in the last 24 hours](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.name%3A%28TestKindSuite%2A%20-TestKindSuite%20-TestKindSuite%2FTestCPU%2A%29%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=timestamp%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%3A300%2C%40test.name%3A300%2C%40duration%2C%40test.service%2C%40ci.job.name%2C%40git.branch%2C%40git.commit.message&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&testId=&trace=&start=1733302693463&end=1733907493463&paused=false)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->