### PR TITLE
[HA Agent] Add agent_group tag to host tags

### DIFF
--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -133,6 +133,10 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 		hostTags = appendToHostTags(hostTags, clusterNameTags)
 	}
 
+	if conf.GetBool("ha_agent.enabled") {
+		hostTags = appendToHostTags(hostTags, []string{"agent_group:" + conf.GetString("ha_agent.group")})
+	}
+
 	gceTags := []string{}
 	providers := getProvidersDefinitionsFunc(conf)
 	for {

--- a/comp/metadata/host/hostimpl/hosttags/tags_test.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags_test.go
@@ -141,10 +141,14 @@ func TestHostTagsCache(t *testing.T) {
 func TestHaAgentTags(t *testing.T) {
 	mockConfig, ctx := setupTest(t)
 
+	hostTags := Get(ctx, false, mockConfig)
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{}, hostTags.System)
+
 	mockConfig.SetWithoutSource("ha_agent.enabled", true)
 	mockConfig.SetWithoutSource("ha_agent.group", "my-group")
 
-	hostTags := Get(ctx, false, mockConfig)
+	hostTags = Get(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
 	assert.Equal(t, []string{"agent_group:my-group"}, hostTags.System)
 }

--- a/comp/metadata/host/hostimpl/hosttags/tags_test.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags_test.go
@@ -146,5 +146,5 @@ func TestHaAgentTags(t *testing.T) {
 
 	hostTags := Get(ctx, false, mockConfig)
 	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, []string{}, hostTags.System)
+	assert.Equal(t, []string{"agent_group:my-group"}, hostTags.System)
 }

--- a/comp/metadata/host/hostimpl/hosttags/tags_test.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags_test.go
@@ -137,3 +137,14 @@ func TestHostTagsCache(t *testing.T) {
 	assert.Equal(t, []string{"foo1:value1"}, hostTags.System)
 	assert.Equal(t, 2, nbCall)
 }
+
+func TestHaAgentTags(t *testing.T) {
+	mockConfig, ctx := setupTest(t)
+
+	mockConfig.SetWithoutSource("ha_agent.enabled", true)
+	mockConfig.SetWithoutSource("ha_agent.group", "my-group")
+
+	hostTags := Get(ctx, false, mockConfig)
+	assert.NotNil(t, hostTags.System)
+	assert.Equal(t, []string{}, hostTags.System)
+}

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -877,9 +877,6 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 			tags = append(tags, "package_version:"+version.AgentPackageVersion)
 		}
 	}
-	if agg.haAgent.Enabled() {
-		tags = append(tags, "agent_group:"+agg.haAgent.GetGroup())
-	}
 	// nil to empty string
 	// This is expected by other components/tests
 	if tags == nil {

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -294,7 +294,7 @@ func TestDefaultSeries(t *testing.T) {
 		require.Equal(t, 1, len(m))
 		require.Equal(t, "datadog.agent.up", m[0].CheckName)
 		require.Equal(t, servicecheck.ServiceCheckOK, m[0].Status)
-		require.Equal(t, []string{"agent_group:group01"}, m[0].Tags)
+		require.Equal(t, []string{}, m[0].Tags)
 		require.Equal(t, agg.hostname, m[0].Host)
 
 		return true
@@ -304,14 +304,14 @@ func TestDefaultSeries(t *testing.T) {
 	expectedSeries := metrics.Series{&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion, "agent_group:group01"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion}),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 	}, &metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.ha_agent.running", agg.agentName),
 		Points:         []metrics.Point{{Value: float64(1), Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"agent_group:group01", "agent_state:standby"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"agent_state:standby"}),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -319,7 +319,7 @@ func TestDefaultSeries(t *testing.T) {
 		Name:           fmt.Sprintf("n_o_i_n_d_e_x.datadog.%s.payload.dropped", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 0, Ts: float64(start.Unix())}},
 		Host:           agg.hostname,
-		Tags:           tagset.CompositeTagsFromSlice([]string{"agent_group:group01"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{}),
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 		NoIndex:        true,
@@ -642,16 +642,6 @@ func TestTags(t *testing.T) {
 			globalTags:              func(types.TagCardinality) ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
 			withVersion:             true,
 			want:                    []string{"container_name:agent", "version:" + version.AgentVersion, "kube_cluster_name:foo"},
-		},
-		{
-			name:                    "tags disabled, without version, ha agent enabled",
-			hostname:                "hostname",
-			tlmContainerTagsEnabled: false,
-			agentTags:               func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
-			withVersion:             false,
-			haAgentEnabled:          true,
-			want:                    []string{"agent_group:group01"},
 		},
 	}
 	for _, tt := range tests {

--- a/test/new-e2e/tests/ha-agent/haagent_test.go
+++ b/test/new-e2e/tests/ha-agent/haagent_test.go
@@ -45,21 +45,6 @@ func (s *haAgentTestSuite) TestHaAgentRunningMetrics() {
 	fakeClient := s.Env().FakeIntake.Client()
 
 	s.EventuallyWithT(func(c *assert.CollectT) {
-		s.T().Log("try assert datadog.agent.running metric")
-		metrics, err := fakeClient.FilterMetrics("datadog.agent.running")
-		require.NoError(c, err)
-		assert.NotEmpty(c, metrics)
-		for _, metric := range metrics {
-			s.T().Logf("    datadog.agent.running metric tags: %+v", metric.Tags)
-		}
-
-		tags := []string{"agent_group:test-group01"}
-		metrics, err = fakeClient.FilterMetrics("datadog.agent.running", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
-		require.NoError(c, err)
-		assert.NotEmpty(c, metrics)
-	}, 5*time.Minute, 3*time.Second)
-
-	s.EventuallyWithT(func(c *assert.CollectT) {
 		s.T().Log("try assert datadog.agent.ha_agent.running metric")
 		metrics, err := fakeClient.FilterMetrics("datadog.agent.ha_agent.running")
 		require.NoError(c, err)
@@ -68,7 +53,7 @@ func (s *haAgentTestSuite) TestHaAgentRunningMetrics() {
 			s.T().Logf("    datadog.agent.ha_agent.running metric tags: %+v", metric.Tags)
 		}
 
-		tags := []string{"agent_group:test-group01", "agent_state:unknown"}
+		tags := []string{"agent_state:unknown"}
 		metrics, err = fakeClient.FilterMetrics("datadog.agent.ha_agent.running", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
 		require.NoError(c, err)
 		assert.NotEmpty(c, metrics)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[HA Agent] Add agent_group tag to host tags

And remove from `pkg/aggregator/aggregator.go` since it's redundant.

### Motivation

Having `agent_group` tag will improve HA Agent OOTB dashboard, since the `agent_group` tag can be use as template var to filter / group all agent and integrations metrics

Of course, beside the OOTB dashboard, user will be able to use `agent_group` on metrics and any dashboard in general.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->