### PR TITLE
[CWS] store dump in `localDumps` only if persist was successful

### DIFF
--- a/pkg/security/security_profile/dump/local_storage.go
+++ b/pkg/security/security_profile/dump/local_storage.go
@@ -182,16 +182,6 @@ func (storage *ActivityDumpLocalStorage) Persist(request config.StorageRequest, 
 	// set activity dump size for current encoding
 	ad.Metadata.Size = uint64(len(raw.Bytes()))
 
-	// add the file to the list of local dumps (thus removing one or more files if we reached the limit)
-	if storage.localDumps != nil {
-		filePaths, ok := storage.localDumps.Get(ad.Metadata.Name)
-		if !ok {
-			storage.localDumps.Add(ad.Metadata.Name, &[]string{outputPath})
-		} else {
-			*filePaths = append(*filePaths, outputPath)
-		}
-	}
-
 	// create output file
 	_ = os.MkdirAll(request.OutputDirectory, 0400)
 	tmpOutputPath := outputPath + ".tmp"
@@ -221,6 +211,17 @@ func (storage *ActivityDumpLocalStorage) Persist(request config.StorageRequest, 
 	}
 
 	seclog.Infof("[%s] file for [%s] written at: [%s]", request.Format, ad.GetSelectorStr(), outputPath)
+
+	// add the file to the list of local dumps (thus removing one or more files if we reached the limit)
+	if storage.localDumps != nil {
+		filePaths, ok := storage.localDumps.Get(ad.Metadata.Name)
+		if !ok {
+			storage.localDumps.Add(ad.Metadata.Name, &[]string{outputPath})
+		} else {
+			*filePaths = append(*filePaths, outputPath)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

If the "writing to disk" failed, for example because there is no space left on disk, we shouldn't store it in the `localDumps` maps since it would store a path that does not exist. To fix this we only store in localDumps after writing.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->