### PR TITLE
add a new remote workloadmeta only catalog

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -47,7 +47,7 @@ import (
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	compstatsd "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"

--- a/comp/core/workloadmeta/collectors/catalog-remote/catalog.go
+++ b/comp/core/workloadmeta/collectors/catalog-remote/catalog.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package catalog is a wrapper that loads the available workloadmeta
+// collectors. It exists as a shorthand for importing all packages manually in
+// all of the agents.
+package catalog
+
+import (
+	"go.uber.org/fx"
+)
+
+// GetCatalog returns the set of FX options to populate the catalog
+func GetCatalog() fx.Option {
+	options := getCollectorOptions()
+
+	// remove nil options
+	opts := make([]fx.Option, 0, len(options))
+	for _, item := range options {
+		if item != nil {
+			opts = append(opts, item)
+		}
+	}
+	return fx.Options(opts...)
+}

--- a/comp/core/workloadmeta/collectors/catalog-remote/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-remote/options.go
@@ -12,8 +12,6 @@ import (
 	"go.uber.org/fx"
 
 	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 func getCollectorOptions() []fx.Option {
@@ -24,18 +22,7 @@ func getCollectorOptions() []fx.Option {
 }
 
 func remoteWorkloadmetaParams() fx.Option {
-	var filter *workloadmeta.Filter // Nil filter accepts everything
-
-	// Security Agent is only interested in containers
-	// TODO: (components) create a Catalog component, the implementation used by
-	// security-agent can use this filter, instead of needing to chekc agent.flavor
-	if flavor.GetFlavor() == flavor.SecurityAgent {
-		filter = workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindContainer).Build()
-	}
-
 	return fx.Provide(func() remoteworkloadmeta.Params {
-		return remoteworkloadmeta.Params{
-			Filter: filter,
-		}
+		return remoteworkloadmeta.Params{}
 	})
 }

--- a/comp/core/workloadmeta/collectors/catalog-remote/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-remote/options.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package collectors is a wrapper that loads the available workloadmeta
+// Package catalog is a wrapper that loads the available workloadmeta
 // collectors. It exists as a shorthand for importing all packages manually in
 // all of the agents.
 package catalog

--- a/comp/core/workloadmeta/collectors/catalog-remote/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-remote/options.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build remotewmonly
-
 // Package collectors is a wrapper that loads the available workloadmeta
 // collectors. It exists as a shorthand for importing all packages manually in
 // all of the agents.
@@ -14,14 +12,30 @@ import (
 	"go.uber.org/fx"
 
 	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
-
-// TODO: (components) Move remote-only to its own catalog, similar to how catalog-less works
-// Depend on this catalog-remote using fx, instead of build tags
 
 func getCollectorOptions() []fx.Option {
 	return []fx.Option{
 		remoteworkloadmeta.GetFxOptions(),
 		remoteWorkloadmetaParams(),
 	}
+}
+
+func remoteWorkloadmetaParams() fx.Option {
+	var filter *workloadmeta.Filter // Nil filter accepts everything
+
+	// Security Agent is only interested in containers
+	// TODO: (components) create a Catalog component, the implementation used by
+	// security-agent can use this filter, instead of needing to chekc agent.flavor
+	if flavor.GetFlavor() == flavor.SecurityAgent {
+		filter = workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindContainer).Build()
+	}
+
+	return fx.Provide(func() remoteworkloadmeta.Params {
+		return remoteworkloadmeta.Params{
+			Filter: filter,
+		}
+	})
 }

--- a/comp/core/workloadmeta/collectors/catalog/catalog.go
+++ b/comp/core/workloadmeta/collectors/catalog/catalog.go
@@ -12,8 +12,6 @@ import (
 	"go.uber.org/fx"
 
 	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 // GetCatalog returns the set of FX options to populate the catalog
@@ -30,22 +28,8 @@ func GetCatalog() fx.Option {
 	return fx.Options(opts...)
 }
 
-// TODO: (components) Move remote-only to its own catalog, similar to how catalog-less works
-// Depend on this catalog-remote using fx, instead of build tags
-
 func remoteWorkloadmetaParams() fx.Option {
-	var filter *workloadmeta.Filter // Nil filter accepts everything
-
-	// Security Agent is only interested in containers
-	// TODO: (components) create a Catalog component, the implementation used by
-	// security-agent can use this filter, instead of needing to chekc agent.flavor
-	if flavor.GetFlavor() == flavor.SecurityAgent {
-		filter = workloadmeta.NewFilterBuilder().AddKind(workloadmeta.KindContainer).Build()
-	}
-
 	return fx.Provide(func() remoteworkloadmeta.Params {
-		return remoteworkloadmeta.Params{
-			Filter: filter,
-		}
+		return remoteworkloadmeta.Params{}
 	})
 }

--- a/comp/core/workloadmeta/collectors/catalog/options.go
+++ b/comp/core/workloadmeta/collectors/catalog/options.go
@@ -3,11 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// TODO: (components) Move remote-only to its own catalog, similar to how catalog-less works
-// Depend on this catalog-remote using fx, instead of build tags
-
-//go:build !remotewmonly
-
 // Package catalog is a wrapper that loads the available workloadmeta
 // collectors. It exists as a shorthand for importing all packages manually in
 // all of the agents.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -43,7 +43,6 @@ ALL_TAGS = {
     "podman",
     "process",
     "python",
-    "remotewmonly",  # used when you want to use only the remote workloadmeta store without importing all dependencies of local collectors
     "sds",
     "serverless",
     "systemd",
@@ -162,7 +161,7 @@ SECURITY_AGENT_TAGS = {
 SERVERLESS_TAGS = {"serverless", "otlp"}
 
 # SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
-SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "pcap", "remotewmonly"}).difference({"python", "systemd"})
+SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"linux_bpf", "npm", "pcap"}).difference({"python", "systemd"})
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
 TRACE_AGENT_TAGS = {"docker", "containerd", "datadog.no_waf", "kubeapiserver", "kubelet", "otlp", "netcgo", "podman"}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR creates a workloadmeta catalog that only contains the remote options. This allows user of this catalog to not include all the dependencies that would be needed to run a local workloadmeta. This also allows to drop the `remotewm` build tag.

The flavor check that used to filter the object received to only containers in the case of the security agent is also removed since most of the CWS logic has been moved to the system-probe anyway.

As a side note, the go deps check uses the build tags defined in the new branch for both the before and after sides, so the diff is not correct here. Most of those dependencies were already not included because of the `remotewm` tag

### Motivation

### Describe how you validated your changes

Code covered by tests. Plus dependency check in CI should be enough

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->