### PR TITLE
Adding schema to OTLP config

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4515,7 +4515,7 @@ api_key:
     #
     # enabled: true
 
-## @param debug - custom object - optional
+  ## @param debug - custom object - optional
   ## Debug-specific configuration for OTLP ingest in the Datadog Agent.
   ## This template lists the most commonly used settings; see the OpenTelemetry Collector documentation
   ## for a full list of available settings:
@@ -4528,6 +4528,7 @@ api_key:
     ## Valid values are basic, normal, detailed, none.
     #
     # verbosity: normal
+
 {{- if (eq .OS "windows")}}
 #####################################################
 ## Datadog Agent Manager System Tray Configuration ##


### PR DESCRIPTION
### What does this PR do?

As we deprecate SetKnown and move toward building a schema for the config we need to explicitly list what settings the agent support and thei default.

This also fix an indentation error in the config template

### Describe how you validated your changes

Running CI for unit tests and asking the OTLP team to QA this for any edge case (since their might be undocumented settings that are used).