### PR TITLE
chore(installer): Add boilerplate for install script E2Es

### DIFF
--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -1,0 +1,160 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installscript
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
+	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/stretchr/testify/require"
+)
+
+type installerScriptTests func(os e2eos.Descriptor, arch e2eos.Architecture) installerScriptSuite
+
+type installerScriptTestsWithSkipedFlavors struct {
+	t              installerScriptTests
+	skippedFlavors []e2eos.Descriptor
+}
+
+var (
+	amd64Flavors = []e2eos.Descriptor{
+		e2eos.Ubuntu2204,
+		e2eos.AmazonLinux2,
+		e2eos.Debian12,
+		e2eos.RedHat9,
+		e2eos.FedoraDefault,
+		e2eos.CentOS7,
+		e2eos.Suse15,
+	}
+	arm64Flavors = []e2eos.Descriptor{
+		e2eos.Ubuntu2204,
+		e2eos.AmazonLinux2,
+		e2eos.Suse15,
+	}
+	scriptTestsWithSkippedFlavors = []installerScriptTestsWithSkipedFlavors{
+		{t: testDatabricksScript},
+	}
+)
+
+func shouldSkipFlavor(flavors []e2eos.Descriptor, flavor e2eos.Descriptor) bool {
+	for _, f := range flavors {
+		if f.Flavor == flavor.Flavor && f.Version == flavor.Version {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScripts(t *testing.T) {
+	if _, ok := os.LookupEnv("CI_COMMIT_SHA"); !ok {
+		t.Log("CI_COMMIT_SHA env var is not set, this test requires this variable to be set to work")
+		t.FailNow()
+	}
+
+	var flavors []e2eos.Descriptor
+	for _, flavor := range amd64Flavors {
+		flavor.Architecture = e2eos.AMD64Arch
+		flavors = append(flavors, flavor)
+	}
+	for _, flavor := range arm64Flavors {
+		flavor.Architecture = e2eos.ARM64Arch
+		flavors = append(flavors, flavor)
+	}
+	for _, f := range flavors {
+		for _, test := range scriptTestsWithSkippedFlavors {
+			flavor := f // capture range variable for parallel tests closure
+			if shouldSkipFlavor(test.skippedFlavors, flavor) {
+				continue
+			}
+
+			suite := test.t(flavor, flavor.Architecture)
+			t.Run(suite.Name(), func(t *testing.T) {
+				t.Parallel()
+				// FIXME: Fedora currently has DNS issues
+				if flavor.Flavor == e2eos.Fedora {
+					flake.Mark(t)
+				}
+
+				opts := []awshost.ProvisionerOption{
+					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
+					awshost.WithoutAgent(),
+				}
+				opts = append(opts, suite.ProvisionerOptions()...)
+				e2e.Run(t, suite,
+					e2e.WithProvisioner(awshost.Provisioner(opts...)),
+					e2e.WithStackName(suite.Name()),
+				)
+			})
+		}
+	}
+}
+
+type installerScriptSuite interface {
+	e2e.Suite[environments.Host]
+
+	Name() string
+	ProvisionerOptions() []awshost.ProvisionerOption
+}
+
+func newInstallerScriptSuite(pkg string, e2eos e2eos.Descriptor, arch e2eos.Architecture, opts ...awshost.ProvisionerOption) installerScriptBaseSuite {
+	return installerScriptBaseSuite{
+		commitHash: os.Getenv("CI_COMMIT_SHA"),
+		os:         e2eos,
+		arch:       arch,
+		pkg:        pkg,
+		opts:       opts,
+	}
+}
+
+func (s *installerScriptBaseSuite) Name() string {
+	return regexp.MustCompile("[^a-zA-Z0-9]+").ReplaceAllString(fmt.Sprintf("%s/%s", s.pkg, s.os), "_")
+}
+
+func (s *installerScriptBaseSuite) ProvisionerOptions() []awshost.ProvisionerOption {
+	return s.opts
+}
+
+func (s *installerScriptBaseSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	s.host = host.New(s.T(), s.Env().RemoteHost, s.os, s.arch)
+}
+
+type installerScriptBaseSuite struct {
+	commitHash string
+	e2e.BaseSuite[environments.Host]
+
+	host *host.Host
+	opts []awshost.ProvisionerOption
+	pkg  string
+	arch e2eos.Architecture
+	os   e2eos.Descriptor
+}
+
+func (s *installerScriptBaseSuite) RunInstallScript(url string, params ...string) {
+	err := s.RunInstallScriptWithError(url, params...)
+	require.NoErrorf(s.T(), err, "install script failed")
+}
+
+func (s *installerScriptBaseSuite) RunInstallScriptWithError(url string, params ...string) error {
+	scriptParams := append(params, "DD_API_KEY=test", "DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE=installtesting.datad0g.com")
+	_, err := s.Env().RemoteHost.Execute(fmt.Sprintf("curl -L %s > install_script; sudo -E %s bash install_script", url, strings.Join(scriptParams, " ")))
+	return err
+}
+
+func (s *installerScriptBaseSuite) Purge() {
+	s.Env().RemoteHost.MustExecute("sudo rm -rf install_script")
+	s.Env().RemoteHost.Execute("sudo datadog-installer purge")
+}

--- a/test/new-e2e/tests/installer/script/databricks_test.go
+++ b/test/new-e2e/tests/installer/script/databricks_test.go
@@ -7,39 +7,39 @@ package installscript
 
 import (
 	"fmt"
-	"os"
-	"testing"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/aws/host"
-	osdesc "github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 )
 
-type vmUpdaterSuite struct {
-	commitHash string
-	e2e.BaseSuite[environments.Host]
+type installScriptDatabricksSuite struct {
+	installerScriptBaseSuite
+	url string
 }
 
-func (s *vmUpdaterSuite) TestInstallScript() {
-	url := fmt.Sprintf("https://installtesting.datad0g.com/%s/scripts/install-databricks.sh", s.commitHash)
-
-	// worker
-	s.Env().RemoteHost.MustExecute(fmt.Sprintf("curl -L %s > install_script; export DD_API_KEY=test; export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE=installtesting.datad0g.com; sudo -E bash install_script", url))
-	s.Env().RemoteHost.MustExecute("sudo test -d /opt/datadog-packages/datadog-agent/7.57.2-1")
-
-	// driver
-	s.Env().RemoteHost.MustExecute(fmt.Sprintf("curl -L %s > install_script; export DB_IS_DRIVER=true; export DD_API_KEY=test; export DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE=installtesting.datad0g.com; sudo -E bash install_script", url))
-	s.Env().RemoteHost.MustExecute("sudo test -d /opt/datadog-packages/datadog-agent/7.57.2-1")
-	s.Env().RemoteHost.MustExecute("sudo test -d /opt/datadog-packages/datadog-apm-inject/0.21.0")
-	s.Env().RemoteHost.MustExecute("sudo test -d /opt/datadog-packages/datadog-apm-library-java/1.41.1")
-}
-
-func TestUpdaterSuite(t *testing.T) {
-	for _, arch := range []osdesc.Architecture{osdesc.AMD64Arch, osdesc.ARM64Arch} {
-		e2e.Run(t, &vmUpdaterSuite{commitHash: os.Getenv("CI_COMMIT_SHA")}, e2e.WithProvisioner(awshost.ProvisionerNoFakeIntake(
-			awshost.WithEC2InstanceOptions(ec2.WithOSArch(osdesc.UbuntuDefault, arch)),
-		)))
+func testDatabricksScript(os e2eos.Descriptor, arch e2eos.Architecture) installerScriptSuite {
+	s := &installScriptDatabricksSuite{
+		installerScriptBaseSuite: newInstallerScriptSuite("installer", os, arch, awshost.WithoutFakeIntake()),
 	}
+	s.url = fmt.Sprintf("https://installtesting.datad0g.com/%s/scripts/install-databricks.sh", s.commitHash)
+
+	return s
+}
+
+func (s *installScriptDatabricksSuite) TestDatabricksWorkerInstallScript() {
+	s.RunInstallScript(s.url)
+	state := s.host.State()
+	state.AssertDirExists("/opt/datadog-packages/datadog-agent/7.57.2-1", 0755, "dd-agent", "dd-agent")
+	state.AssertSymlinkExists("/opt/datadog-packages/datadog-agent/stable", "/opt/datadog-packages/datadog-agent/7.57.2-1", "root", "root")
+}
+
+func (s *installScriptDatabricksSuite) TestDatabricksDriverInstallScript() {
+	s.RunInstallScript(s.url, "DB_IS_DRIVER=true")
+	state := s.host.State()
+	state.AssertDirExists("/opt/datadog-packages/datadog-agent/7.57.2-1", 0755, "dd-agent", "dd-agent")
+	state.AssertSymlinkExists("/opt/datadog-packages/datadog-agent/stable", "/opt/datadog-packages/datadog-agent/7.57.2-1", "root", "root")
+	state.AssertDirExists("/opt/datadog-packages/datadog-apm-inject/0.21.0", 0755, "root", "root")
+	state.AssertSymlinkExists("/opt/datadog-packages/datadog-apm-inject/stable", "/opt/datadog-packages/datadog-apm-inject/0.21.0", "root", "root")
+	state.AssertDirExists("/opt/datadog-packages/datadog-apm-library-java/1.41.1", 0755, "root", "root")
+	state.AssertSymlinkExists("/opt/datadog-packages/datadog-apm-library-java/stable", "/opt/datadog-packages/datadog-apm-library-java/1.41.1", "root", "root")
 }


### PR DESCRIPTION
### What does this PR do?
Adds boilerplate to be able to test multiple install scripts on multiple machines

### Motivation

### Describe how you validated your changes
E2E tests only

### Possible Drawbacks / Trade-offs

### Additional Notes
