### PR TITLE
[CONTP-350] unify inclusion/exclusion logic for container images 

### DIFF
--- a/pkg/collector/corechecks/containers/generic/filters.go
+++ b/pkg/collector/corechecks/containers/generic/filters.go
@@ -56,7 +56,7 @@ func (f LegacyContainerFilter) IsExcluded(container *workloadmeta.Container) boo
 		annotations = pod.Annotations
 	}
 
-	return f.OldFilter.IsExcluded(annotations, container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel])
+	return f.OldFilter.IsExcluded(annotations, container.Name, container.Image.RawName, container.Labels[kubernetes.CriContainerNamespaceLabel])
 }
 
 // RuntimeContainerFilter filters containers by runtime

--- a/pkg/collector/corechecks/containers/kubelet/common/pod.go
+++ b/pkg/collector/corechecks/containers/kubelet/common/pod.go
@@ -190,7 +190,7 @@ func GetContainerID(store workloadmeta.Component, metric model.Metric, filter *c
 		return "", ErrContainerNotFound
 	}
 
-	if filter.IsExcluded(pod.EntityMeta.Annotations, container.Name, container.Image.Name, pod.Namespace) {
+	if filter.IsExcluded(pod.EntityMeta.Annotations, container.Name, container.Image.RawName, pod.Namespace) {
 		return "", ErrContainerExcluded
 	}
 

--- a/pkg/process/util/containers/containers.go
+++ b/pkg/process/util/containers/containers.go
@@ -120,7 +120,7 @@ func (p *containerProvider) GetContainers(cacheValidity time.Duration, previousC
 			annotations = pod.Annotations
 		}
 
-		if p.filter != nil && p.filter.IsExcluded(annotations, container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
+		if p.filter != nil && p.filter.IsExcluded(annotations, container.Name, container.Image.RawName, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
 			continue
 		}
 
@@ -209,7 +209,7 @@ func (p *containerProvider) GetPidToCid(cacheValidity time.Duration) map[int]str
 			annotations = pod.Annotations
 		}
 
-		if p.filter != nil && p.filter.IsExcluded(annotations, container.Name, container.Image.Name, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
+		if p.filter != nil && p.filter.IsExcluded(annotations, container.Name, container.Image.RawName, container.Labels[kubernetes.CriContainerNamespaceLabel]) {
 			continue
 		}
 

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -112,6 +112,7 @@ func parseFilters(filters []string) (imageFilters, nameFilters, namespaceFilters
 	for _, filter := range filters {
 		switch {
 		case strings.HasPrefix(filter, imageFilterPrefix):
+			filter = preprocessImageFilter(filter)
 			r, err := filterToRegex(filter, imageFilterPrefix)
 			if err != nil {
 				filterErrs = append(filterErrs, err.Error())
@@ -143,6 +144,19 @@ func parseFilters(filters []string) (imageFilters, nameFilters, namespaceFilters
 		return nil, nil, nil, append(filterErrs, filterWarnings...), errors.New(filterErrs[0])
 	}
 	return imageFilters, nameFilters, namespaceFilters, filterWarnings, nil
+}
+
+// preprocessImageFilter modifies image filters having the format `name$`, where {name} doesn't include a colon (e.g. nginx$, ^nginx$), to
+// `name:.*`.
+// This is done so that image filters can still match even if the matched image contains the tag or digest.
+func preprocessImageFilter(imageFilter string) string {
+	regexVal := strings.TrimPrefix(imageFilter, imageFilterPrefix)
+	if strings.HasSuffix(regexVal, "$") && !strings.Contains(regexVal, ":") {
+		mutatedRegexVal := regexVal[:len(regexVal)-1] + "(@sha256)?:.*"
+		return imageFilterPrefix + mutatedRegexVal
+	}
+
+	return imageFilter
 }
 
 // filterToRegex checks a filter's regex
@@ -327,7 +341,16 @@ func NewAutodiscoveryFilter(ft FilterType) (*Filter, error) {
 // based on the filters in the containerFilter instance. Consider also using
 // Note: exclude filters are not applied to empty container names, empty
 // images and empty namespaces.
+//
+// containerImage may or may not contain the image tag or image digest. (e.g. nginx:latest and nginx are both valid)
 func (cf Filter) IsExcluded(annotations map[string]string, containerName, containerImage, podNamespace string) bool {
+
+	// If containerImage doesn't include the tag or digest, add a colon so that it
+	// can match image filters
+	if len(containerImage) > 0 && strings.Index(containerImage, ":") < 0 {
+		containerImage += ":"
+	}
+
 	if cf.isExcludedByAnnotation(annotations, containerName) {
 		return true
 	}

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -347,7 +347,7 @@ func (cf Filter) IsExcluded(annotations map[string]string, containerName, contai
 
 	// If containerImage doesn't include the tag or digest, add a colon so that it
 	// can match image filters
-	if len(containerImage) > 0 && strings.Index(containerImage, ":") < 0 {
+	if len(containerImage) > 0 && !strings.Contains(containerImage, ":") {
 		containerImage += ":"
 	}
 

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -30,6 +30,14 @@ func TestFilter(t *testing.T) {
 	}{
 		{
 			c: ctnDef{
+				ID:    "0",
+				Name:  "container-with-sha",
+				Image: "docker-dd-agent@sha256:1892862abcdef61516516",
+			},
+			ns: "default",
+		},
+		{
+			c: ctnDef{
 				ID:    "1",
 				Name:  "secret-container-dd",
 				Image: "docker-dd-agent",
@@ -268,25 +276,33 @@ func TestFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+			expectedIDs: []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
-			excludeList: []string{"name:secret"},
+			excludeList: []string{"image:^docker-dd-agent$"},
 			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
+			excludeList: []string{"image:^apache$"},
+			expectedIDs: []string{"0", "1", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+		},
+		{
+			excludeList: []string{"name:secret"},
+			expectedIDs: []string{"0", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+		},
+		{
 			excludeList: []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+			expectedIDs: []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			includeList: []string{},
 			excludeList: []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+			expectedIDs: []string{"0", "1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			includeList: []string{"name:mysql"},
 			excludeList: []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+			expectedIDs: []string{"0", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			excludeList: []string{"kube_namespace:.*"},
@@ -295,7 +311,7 @@ func TestFilter(t *testing.T) {
 		},
 		{
 			excludeList: []string{"kube_namespace:bar"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+			expectedIDs: []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			excludeList: []string{"name:.*"},
@@ -305,7 +321,17 @@ func TestFilter(t *testing.T) {
 		{
 			excludeList: []string{"image:.*"},
 			includeList: []string{"image:docker-dd-agent"},
-			expectedIDs: []string{"1", "30"},
+			expectedIDs: []string{"0", "1", "30"},
+		},
+		{
+			excludeList: []string{"image:.*"},
+			includeList: []string{"image:^docker-dd-agent$"},
+			expectedIDs: []string{"0", "1", "30"},
+		},
+		{
+			excludeList: []string{"image:.*"},
+			includeList: []string{"image:^docker-dd-agent$"},
+			expectedIDs: []string{"0", "1", "30"},
 		},
 		// Test kubernetes defaults
 		{
@@ -326,7 +352,7 @@ func TestFilter(t *testing.T) {
 				pauseContainerUpstream,
 				pauseContainerCDK,
 			},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "14", "15", "29", "30", "31"},
+			expectedIDs: []string{"0", "1", "2", "3", "4", "5", "14", "15", "29", "30", "31"},
 		},
 	} {
 		t.Run("", func(t *testing.T) {
@@ -619,6 +645,15 @@ func TestParseFilters(t *testing.T) {
 			desc:             "valid filters",
 			filters:          []string{"image:nginx.*", "name:xyz-.*", "kube_namespace:sandbox.*", "name:abc"},
 			imageFilters:     []*regexp.Regexp{regexp.MustCompile("nginx.*")},
+			nameFilters:      []*regexp.Regexp{regexp.MustCompile("xyz-.*"), regexp.MustCompile("abc")},
+			namespaceFilters: []*regexp.Regexp{regexp.MustCompile("sandbox.*")},
+			expectedErrMsg:   nil,
+			filterErrors:     nil,
+		},
+		{
+			desc:             "valid filters, image filter strict match without tag or digest",
+			filters:          []string{"image:^nginx$", "name:xyz-.*", "kube_namespace:sandbox.*", "name:abc"},
+			imageFilters:     []*regexp.Regexp{regexp.MustCompile("^nginx(@sha256)?:.*")},
 			nameFilters:      []*regexp.Regexp{regexp.MustCompile("xyz-.*"), regexp.MustCompile("abc")},
 			namespaceFilters: []*regexp.Regexp{regexp.MustCompile("sandbox.*")},
 			expectedErrMsg:   nil,

--- a/releasenotes/notes/make_image_filters_consistent-14fd44a352723e50.yaml
+++ b/releasenotes/notes/make_image_filters_consistent-14fd44a352723e50.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes consistency issue with container image filters.
+    Depending on the agent configuration, filters were sometimes behaving differently
+    for metrics and logs. For example, an image filter that worked for excluding logs
+    didn't work when used to exclude metrics, and vice versa. 
+    The exclusion logic is now guaranteed to be consistent between metrics and logs.
+

--- a/releasenotes/notes/make_image_filters_consistent-14fd44a352723e50.yaml
+++ b/releasenotes/notes/make_image_filters_consistent-14fd44a352723e50.yaml
@@ -9,7 +9,7 @@
 fixes:
   - |
     Fixes consistency issue with container image filters.
-    Depending on the agent configuration, filters were sometimes behaving differently
+    Depending on the Agent configuration, filters were sometimes behaving differently
     for metrics and logs. For example, an image filter that worked for excluding logs
     didn't work when used to exclude metrics, and vice versa. 
     The exclusion logic is now guaranteed to be consistent between metrics and logs.

--- a/releasenotes/notes/make_image_filters_consistent-14fd44a352723e50.yaml
+++ b/releasenotes/notes/make_image_filters_consistent-14fd44a352723e50.yaml
@@ -12,5 +12,5 @@ fixes:
     Depending on the Agent configuration, filters were sometimes behaving differently
     for metrics and logs. For example, an image filter that worked for excluding logs
     didn't work when used to exclude metrics, and vice versa. 
-    The exclusion logic is now guaranteed to be consistent between metrics and logs.
+    The exclusion logic is now consistent between metrics and logs.
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

This PR unifies the inclusion/exclusion filtering logic for container images.

Documentation will be updated in [this](https://github.com/DataDog/documentation/pull/26733) PR.

### Motivation

There are several parts that should be explained here:
- What the documentation says is supported/not supported
- What is actually supported in practice
- How users are using the feature

These 3 parts are interconnected, and any change that is done needs to be handled with care in order not to break any user setup. 

#### Current Documentation:

Currently, [the documentation](https://docs.datadoghq.com/containers/guide/container-discovery-management/?tab=datadogoperator#environment-variables) indicates that container metrics and logs can be filtered for inclusion/exclusion by specifying regex for container name, namespace, and image name. 

The documentation doesn't clarify if image name can include the image tag (or image digest), or if it should strictly include the image name without the tag nor the digest.

But then, the documentation gives some examples:
- `image:^dockercloud/network-daemon$`
- `image:ubuntu`

None of the examples given in the documentation includes the image tag or image digest.

#### What is supported in practice:

In practice, we make no check on whether the regex for image name contains a tag or digest, so such filters are accepted during configuration of the agent.

We basically use filtering by image for 2 main purposes:
- filtering metrics 
- filtering logs

When checking if a log should be filtered out, we use `Image.RawName` field of the container entity in workloadmeta. 
The `Image.RawName` contains the full image name, including the tag or digest. ([example](https://github.com/DataDog/datadog-agent/blob/def18e3815c6cc67d8669408032961804821687a/comp/core/autodiscovery/listeners/kubelet.go#L122))

When checking if a metric should be filtered out, we use `Image.Name` field of the container entity in workloadmeta.
The `Image.Name` contains the image name excluding its tag or digest. ([example](https://github.com/DataDog/datadog-agent/blob/def18e3815c6cc67d8669408032961804821687a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go#L217-L222))

We also have other use cases, but in general we don't impose any requirement on whether the image name that we match against the image filter regex includes should include (or may) the tag/digest or not.

Due to this discrepancy, users can configure filters that result in inconsistent filtering behaviour. Here is an example:

Suppose that a user configures `DD_CONTAINER_EXCLUDE: "image:^bar$"`

Based on the documentation, the user would expect exclusion of logs and metrics emitted by containers having the image `bar`, regardless of the image tag or digest.

However, since metric exclusion is matching `Image.Name` against the regex, and log exclusion is matching `Image.RawName` against the regex, only the metric exclusion will result in a match (`bar` matches `^bar$`, but `bar:latest` doesn't match ^bar$`).

A similar issue occurs if a user configures `DD_CONTAINER_EXCLUDE: "image:^bar:latest"`. In this case, logs will be excluded, but metrics won't.

Given this, we already have an inconsistency problem.

We had (at least one) support ticket regarding this problem (CONS-6500).

#### How users are configuring filters

Checking how users are configuring image filters, we notice that they actually use almost all possible ways of configuring image name regex filter.

Here are some examples:
- `image:********@sha256:e2feace0e0f852ffa3a3b9031[REDACTED]$`
- `image:906394416424.dkr.ecr.us-west-2.amazonaws.com/aws-for-fluent-bit:latest`
- `image:^gcr.io/datadoghq/agent:latest$`
- `image:mysql:8`

This means that some users might already have inconsistent filtering behaviour without them knowing about it.

A lot of users are including image tag in the image filter regex, and the documentation says nothing about it. It doesn't say if this is supported or not. In practice, it is supported for logs exclusion, but not for metrics exclusion.


### Summary

Based on what was explained above, it is difficult to drop support for including image tags and/or image digest for 2 main reasons:
1. It will break the filtering behaviour for most customers who already include image tag in their filters
2. Based statistics, customers seem to be interested in filtering by image and tag, so, supporting this provides value to the user.
3. In theory, it is more flexible to give the user the ability to filter by whatever they want.

In order to achieve consistent filtering support without breaking any user setup, we are doing the following:
- When building container filters, preprocess image filter regex string as follows:
   - If the regex string doesn't contain any tag or digest, and is of the form `name$` (e.g. `^nginx$` or `nginx$` ), convert the regex to `name(@sha256)?:.*`
   - Else, keep the regex as was set by the user.
- Update the `IsExcluded` method of container filter:
   - Currently, the method receives an argument named `containerImage`.
   - If the containerImage is non empty, and doesn't contain a colon (i.e. no tag, no digest), append a `:`.
- All components calling `IsExcluded` are expected to pass the maximum information that they have. For instance, if a component has the image name with the tag, it should include the tag when calling `IsExcluded`. (Specifically, the metric collectors should use `Image.RawName` instead of `Image.Name`).  

With this, no existing user setup will be broken, and the filtering logic will be consistent and uniform everywhere.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

We need to validate filtering is working as expected.

For this we need to test several cases on a sample deployment.

We will use the following deployment as an example:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dummy-test-app
  labels:
    run: my-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: dummy-test-app
      run: my-test
  template:
    metadata:
      labels:
        app: dummy-test-app
        run: my-test
    spec:
      containers:
        - name: ubuntu
          image: ubuntu@sha256:98706f0f213dbd440021993a82d2f70451a73698315370ae8615cc468ac06624
          command: ["/bin/bash", "-c", "--"]
          args: ["while true; do sleep 30; echo hello-ubuntu; done;"]
        - name: nginx
          image: nginx:1.19.0
          command: ["/bin/bash", "-c", "--"]
          args: ["while true; do sleep 30; echo hello-nginx; done;"]
```

It contains 2 containers, the first one having an image with a digest, the second one having an image with a tag.

#### Case 1: Default Behaviour: No filtering at all

Deploy the agent with the following:

```
datadog:
  kubelet:
    tlsVerify: false
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  logs:
    enabled: true
    containerCollectAll: true
```

Navigate to the metrics and logs explorers and verify that metrics and logs are reported for both containers:

![image](https://github.com/user-attachments/assets/178ddb66-bb02-461b-998b-ea427be2e695)

![image](https://github.com/user-attachments/assets/e238f5af-d122-466f-a05d-5ff5a0db8e67)

![image](https://github.com/user-attachments/assets/6d0380be-62ef-44f9-9009-e426b7a27c3d)

This is to ensure the default behaviour is still conserved.

#### Case 2: Filtering Out

Deploy the agent as follows:

```
datadog:
  kubelet:
    tlsVerify: false
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  logs:
    enabled: true
    containerCollectAll: true
  containerExclude: "image:^docker.io/library/ubuntu$ image:nginx:1.19.0$"
```

With this, metrics and logs should be excluded for both containers:

![image](https://github.com/user-attachments/assets/83e1c3df-2bf5-4f46-8118-227b58a4aa00)

However, logs and metrics should still be visible for other containers:

![image](https://github.com/user-attachments/assets/620a975e-5d56-4cd5-b259-1a54742061ef)



### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->