### PR TITLE
[EBPF] Ignore unchanged programs when calculating complexity changes

### DIFF
--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -724,6 +724,7 @@ def generate_complexity_summary_for_pr(
 
     current_branch_artifacts_path = Path(current_branch_artifacts_path)
     complexity_files = list(current_branch_artifacts_path.glob("verifier-complexity-*.tar.gz"))
+    print(complexity_files)
     if len(complexity_files) == 0:
         _try_delete_github_comment(
             f"No complexity data found for the current branch at {current_branch_artifacts_path}"
@@ -804,6 +805,7 @@ def generate_complexity_summary_for_pr(
     max_complexity_abs_change = -9e9
     threshold_for_max_limit = 0.85
     programs_now_below_limit, programs_now_above_limit = 0, 0
+    has_programs_with_changes = False
     for program, entries in sorted(program_complexity.items(), key=lambda x: max(e[2] for e in x[1])):
         avg_new_complexity, avg_old_complexity = 0, 0
         highest_new_complexity, highest_old_complexity = 0, 0
@@ -833,8 +835,11 @@ def generate_complexity_summary_for_pr(
                 programs_now_above_limit += 1
 
             abs_change = new_complexity - old_complexity
-            max_complexity_rel_change = max(max_complexity_rel_change, abs_change / old_complexity)
-            max_complexity_abs_change = max(max_complexity_abs_change, abs_change)
+
+            if abs_change != 0:
+                max_complexity_rel_change = max(max_complexity_rel_change, abs_change / old_complexity)
+                max_complexity_abs_change = max(max_complexity_abs_change, abs_change)
+                has_programs_with_changes = True
 
         avg_new_complexity /= len(entries)
         avg_old_complexity /= len(entries)
@@ -853,6 +858,12 @@ def generate_complexity_summary_for_pr(
             has_changes,
         ]
         summarized_complexity_changes.append(row)
+
+    # Reset the max values if we have no programs with changes, as we don't want the -9e9 values
+    # which are used as the initial values
+    if not has_programs_with_changes:
+        max_complexity_abs_change = 0
+        max_complexity_rel_change = 0
 
     headers = ["Program", "Avg. complexity", "Distro with highest complexity", "Distro with lowest complexity"]
     summarized_complexity_changes = sorted(summarized_complexity_changes, key=lambda x: x[0])

--- a/tasks/ebpf.py
+++ b/tasks/ebpf.py
@@ -724,7 +724,6 @@ def generate_complexity_summary_for_pr(
 
     current_branch_artifacts_path = Path(current_branch_artifacts_path)
     complexity_files = list(current_branch_artifacts_path.glob("verifier-complexity-*.tar.gz"))
-    print(complexity_files)
     if len(complexity_files) == 0:
         _try_delete_github_comment(
             f"No complexity data found for the current branch at {current_branch_artifacts_path}"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the `ebpf.generate-complexity-summary-for-pr` task, which reports that the "highest complexity change" is 0 when complexity is reduced in some programs and others are unchanged. Now only programs that have complexity changes are taken into account for that summary, which is more in-line with how the task ignores unchanged object files, for example.


### Motivation

See https://github.com/DataDog/datadog-agent/pull/31947#issuecomment-2530760113 for an example of a PR with an erroneous comment.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Tested locally.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->