### PR TITLE
[CWS] split host workloads and container workloads in cgroup resolver

### DIFF
--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -47,8 +47,9 @@ type ResolverInterface interface {
 // Resolver defines a cgroup monitor
 type Resolver struct {
 	*utils.Notifier[Event, *cgroupModel.CacheEntry]
-	sync.RWMutex
-	workloads *simplelru.LRU[containerutils.CGroupID, *cgroupModel.CacheEntry]
+	sync.Mutex
+	hostWorkloads      *simplelru.LRU[containerutils.CGroupID, *cgroupModel.CacheEntry]
+	containerWorkloads *simplelru.LRU[containerutils.ContainerID, *cgroupModel.CacheEntry]
 }
 
 // NewResolver returns a new cgroups monitor
@@ -56,16 +57,29 @@ func NewResolver() (*Resolver, error) {
 	cr := &Resolver{
 		Notifier: utils.NewNotifier[Event, *cgroupModel.CacheEntry](),
 	}
-	workloads, err := simplelru.NewLRU(1024, func(_ containerutils.CGroupID, value *cgroupModel.CacheEntry) {
+
+	cleanup := func(value *cgroupModel.CacheEntry) {
 		value.CallReleaseCallback()
 		value.Deleted.Store(true)
 
 		cr.NotifyListeners(CGroupDeleted, value)
+	}
+
+	var err error
+	cr.hostWorkloads, err = simplelru.NewLRU(1024, func(_ containerutils.CGroupID, value *cgroupModel.CacheEntry) {
+		cleanup(value)
 	})
 	if err != nil {
 		return nil, err
 	}
-	cr.workloads = workloads
+
+	cr.containerWorkloads, err = simplelru.NewLRU(1024, func(_ containerutils.ContainerID, value *cgroupModel.CacheEntry) {
+		cleanup(value)
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return cr, nil
 }
 
@@ -78,7 +92,15 @@ func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 	cr.Lock()
 	defer cr.Unlock()
 
-	entry, exists := cr.workloads.Get(process.CGroup.CGroupID)
+	if process.ContainerID != "" {
+		entry, exists := cr.containerWorkloads.Get(process.ContainerID)
+		if exists {
+			entry.AddPID(process.Pid)
+			return
+		}
+	}
+
+	entry, exists := cr.hostWorkloads.Get(process.CGroup.CGroupID)
 	if exists {
 		entry.AddPID(process.Pid)
 		return
@@ -94,33 +116,25 @@ func (cr *Resolver) AddPID(process *model.ProcessCacheEntry) {
 	newCGroup.CreatedAt = uint64(process.ProcessContext.ExecTime.UnixNano())
 
 	// add the new CGroup to the cache
-	cr.workloads.Add(process.CGroup.CGroupID, newCGroup)
+	if process.ContainerID != "" {
+		cr.containerWorkloads.Add(process.ContainerID, newCGroup)
+	} else {
+		cr.hostWorkloads.Add(process.CGroup.CGroupID, newCGroup)
+	}
 
 	cr.NotifyListeners(CGroupCreated, newCGroup)
 }
 
-// Get returns the workload referenced by the provided ID
-func (cr *Resolver) Get(id containerutils.CGroupID) (*cgroupModel.CacheEntry, bool) {
-	cr.RLock()
-	defer cr.RUnlock()
-
-	return cr.workloads.Get(id)
-}
-
 // GetWorkload returns the workload referenced by the provided ID
 func (cr *Resolver) GetWorkload(id containerutils.ContainerID) (*cgroupModel.CacheEntry, bool) {
-	cr.RLock()
-	defer cr.RUnlock()
-
-	if id != "" {
-		for _, workload := range cr.workloads.Values() {
-			if workload.ContainerID == id {
-				return workload, true
-			}
-		}
+	if id == "" {
+		return nil, false
 	}
 
-	return nil, false
+	cr.Lock()
+	defer cr.Unlock()
+
+	return cr.containerWorkloads.Get(id)
 }
 
 // DelPID removes a PID from the cgroup resolver
@@ -128,7 +142,11 @@ func (cr *Resolver) DelPID(pid uint32) {
 	cr.Lock()
 	defer cr.Unlock()
 
-	for _, workload := range cr.workloads.Values() {
+	for _, workload := range cr.containerWorkloads.Values() {
+		cr.deleteWorkloadPID(pid, workload)
+	}
+
+	for _, workload := range cr.hostWorkloads.Values() {
 		cr.deleteWorkloadPID(pid, workload)
 	}
 }
@@ -138,11 +156,9 @@ func (cr *Resolver) DelPIDWithID(id containerutils.ContainerID, pid uint32) {
 	cr.Lock()
 	defer cr.Unlock()
 
-	for _, workload := range cr.workloads.Values() {
-		if workload.ContainerID == id {
-			cr.deleteWorkloadPID(pid, workload)
-			return
-		}
+	entry, exists := cr.containerWorkloads.Get(id)
+	if exists {
+		cr.deleteWorkloadPID(pid, entry)
 	}
 }
 
@@ -155,14 +171,17 @@ func (cr *Resolver) deleteWorkloadPID(pid uint32, workload *cgroupModel.CacheEnt
 
 	// check if the workload should be deleted
 	if len(workload.PIDs) <= 0 {
-		cr.workloads.Remove(workload.CGroupID)
+		cr.hostWorkloads.Remove(workload.CGroupID)
+		if workload.ContainerID != "" {
+			cr.containerWorkloads.Remove(workload.ContainerID)
+		}
 	}
 }
 
 // Len return the number of entries
 func (cr *Resolver) Len() int {
-	cr.RLock()
-	defer cr.RUnlock()
+	cr.Lock()
+	defer cr.Unlock()
 
-	return cr.workloads.Len()
+	return cr.hostWorkloads.Len() + cr.containerWorkloads.Len()
 }


### PR DESCRIPTION
### What does this PR do?

`GetWorkload` is called a lot, and every call iterate on the whole map and allocates a new "values" slice. This PR splits the workload into host workloads (that have a cgroupID but no containerID) and container workloads (that have both).

This PR also switches the RWMutex to a regular Mutex since an LRU needs to write even in the Get path (to update the LRU info)

Fixes: https://github.com/DataDog/datadog-agent/pull/31702

[Example profile showing the issue](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astripe&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZO1wSZNZmJfHgAAABhBWk8xd1NsTUFBQ0NnWm5vc1JkZzl3QUEAAAAkMDE5M2I1YzUtMTFjMi00NjgwLWE3YmYtZmE5YTIwNDYzYTRiAACedw&my_code=disabled&profile_type=alloc-size&profileId=AZO1wSlMAACCgZnosRdg9wAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1733920479941&to_ts=1733924079941&live=false)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->