### PR TITLE
omnibus cache: simplify the build images handling

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -11,13 +11,6 @@ from tasks.libs.common.utils import get_metric_origin
 from tasks.release import _get_release_json_value
 
 
-def _get_build_images(ctx):
-    # We intentionally include both build images & their test suffixes in the pattern
-    # as a test image and the merged version shouldn't share their cache
-    tags = ctx.run("grep -E 'DATADOG_AGENT_.*BUILDIMAGES' .gitlab-ci.yml | cut -d ':' -f 2", hide='stdout').stdout
-    return (t.strip() for t in tags.splitlines())
-
-
 def _get_omnibus_commits(field):
     if 'RELEASE_VERSION' in os.environ:
         release_version = os.environ['RELEASE_VERSION']
@@ -211,9 +204,7 @@ def omnibus_compute_cache_key(ctx):
     h = hashlib.sha1()
     omnibus_last_changes = _last_omnibus_changes(ctx)
     h.update(str.encode(omnibus_last_changes))
-    buildimages_hash = _get_build_images(ctx)
-    for img_hash in buildimages_hash:
-        h.update(str.encode(img_hash))
+    h.update(str.encode(os.getenv('CI_JOB_IMAGE', 'local_build')))
     omnibus_ruby_commit = _get_omnibus_commits('OMNIBUS_RUBY_VERSION')
     omnibus_software_commit = _get_omnibus_commits('OMNIBUS_SOFTWARE_VERSION')
     print(f'Omnibus ruby commit: {omnibus_ruby_commit}')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

SImplify the build image handling when computing the cache key

### Motivation

The existing approach could cause a cache miss including when the image for the currently running job didn't changed.
This is especially true now that multiple image version can be used independently of the others

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->