### PR TITLE
[EBPF] gpu: compute utilization based on active GPU

### DIFF
--- a/pkg/gpu/aggregator.go
+++ b/pkg/gpu/aggregator.go
@@ -38,13 +38,13 @@ type aggregator struct {
 	// processTerminated is true if the process has ended and this aggregator should be deleted
 	processTerminated bool
 
-	// sysCtx is the system context with global GPU-system data
-	sysCtx *systemContext
+	// deviceMaxThreads is the maximum number of threads the GPU can run in parallel, for utilization calculations
+	deviceMaxThreads uint64
 }
 
-func newAggregator(sysCtx *systemContext) *aggregator {
+func newAggregator(deviceMaxThreads uint64) *aggregator {
 	return &aggregator{
-		sysCtx: sysCtx,
+		deviceMaxThreads: deviceMaxThreads,
 	}
 }
 
@@ -60,8 +60,7 @@ func (agg *aggregator) processKernelSpan(span *kernelSpan) {
 	}
 
 	durationSec := float64(tsEnd-tsStart) / float64(time.Second.Nanoseconds())
-	maxThreads := uint64(agg.sysCtx.maxGpuThreadsPerDevice[0])                                // TODO: MultiGPU support not enabled yet
-	agg.totalThreadSecondsUsed += durationSec * float64(min(span.avgThreadCount, maxThreads)) // we can't use more threads than the GPU has
+	agg.totalThreadSecondsUsed += durationSec * float64(min(span.avgThreadCount, agg.deviceMaxThreads)) // we can't use more threads than the GPU has
 }
 
 // processPastData takes spans/allocations that have already been closed
@@ -86,8 +85,7 @@ func (agg *aggregator) processCurrentData(data *streamData) {
 func (agg *aggregator) getGPUUtilization() float64 {
 	intervalSecs := float64(agg.measuredIntervalNs) / float64(time.Second.Nanoseconds())
 	if intervalSecs > 0 {
-		// TODO: MultiGPU support not enabled yet
-		availableThreadSeconds := float64(agg.sysCtx.maxGpuThreadsPerDevice[0]) * intervalSecs
+		availableThreadSeconds := float64(agg.deviceMaxThreads) * intervalSecs
 		return agg.totalThreadSecondsUsed / availableThreadSeconds
 	}
 

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -248,3 +248,17 @@ func (ctx *systemContext) setDeviceSelection(pid int, tid int, deviceIndex int32
 
 	ctx.selectedDeviceByPIDAndTID[pid][tid] = deviceIndex
 }
+
+// getDeviceByUUID returns the device with the given UUID.
+func (ctx *systemContext) getDeviceByUUID(uuid string) (nvml.Device, error) {
+	for _, dev := range ctx.gpuDevices {
+		devUUID, ret := dev.GetUUID()
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("error getting device UUID: %s", nvml.ErrorString(ret))
+		}
+		if devUUID == uuid {
+			return dev, nil
+		}
+	}
+	return nil, fmt.Errorf("device with UUID %s not found", uuid)
+}

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -233,3 +233,58 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 	expectedUtil := expectedUtilKern1 + expectedUtilKern2
 	require.InDelta(t, expectedUtil, metrics.UtilizationPercentage, 0.001)
 }
+
+func TestGetStatsMultiGPU(t *testing.T) {
+	statsGen, streamHandlers, ktime := getStatsGeneratorForTest(t)
+
+	startKtime := ktime + int64(1*time.Second)
+	endKtime := startKtime + int64(1*time.Second)
+
+	pid := uint32(1)
+	pidTgid := uint64(pid)<<32 + uint64(pid)
+	numThreads := uint64(5)
+	shmemSize := uint64(10)
+
+	// Add kernels for all devices
+	for i, uuid := range testutil.GPUUUIDs {
+		streamID := uint64(i)
+		streamKey := streamKey{pid: pid, stream: streamID, gpuUUID: uuid}
+		streamHandlers[streamKey] = &StreamHandler{
+			processEnded: false,
+			kernelLaunches: []enrichedKernelLaunch{
+				{
+					CudaKernelLaunch: gpuebpf.CudaKernelLaunch{
+						Header: gpuebpf.CudaEventHeader{
+							Ktime_ns:  uint64(startKtime),
+							Pid_tgid:  pidTgid,
+							Stream_id: streamID,
+						},
+						Kernel_addr:     0,
+						Shared_mem_size: shmemSize,
+						Grid_size:       gpuebpf.Dim3{X: 1, Y: 1, Z: 1},
+						Block_size:      gpuebpf.Dim3{X: 1, Y: 1, Z: 1},
+					},
+				},
+			},
+		}
+	}
+
+	checkDuration := 10 * time.Second
+	checkKtime := ktime + int64(checkDuration)
+	stats := statsGen.getStats(checkKtime)
+	require.NotNil(t, stats)
+
+	// Check the metrics for each device
+	for i, uuid := range testutil.GPUUUIDs {
+		metricsKey := model.StatsKey{PID: pid, DeviceUUID: uuid}
+		metrics := getMetricsEntry(metricsKey, stats)
+		require.NotNil(t, metrics, "cannot find metrics for key %+v", metricsKey)
+
+		gpuCores := float64(testutil.GPUCores[i])
+		threadSecondsUsed := float64(numThreads) * float64(endKtime-startKtime) / 1e9
+		threadSecondsAvailable := gpuCores * checkDuration.Seconds()
+		expectedUtil := threadSecondsUsed / threadSecondsAvailable
+
+		require.InDelta(t, expectedUtil, metrics.UtilizationPercentage, 0.001, "invalid utilization for device %d (uuid=%s)", i, uuid)
+	}
+}

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -241,9 +241,7 @@ func TestGetStatsMultiGPU(t *testing.T) {
 	endKtime := startKtime + int64(1*time.Second)
 
 	pid := uint32(1)
-	pidTgid := uint64(pid)<<32 + uint64(pid)
 	numThreads := uint64(5)
-	shmemSize := uint64(10)
 
 	// Add kernels for all devices
 	for i, uuid := range testutil.GPUUUIDs {
@@ -251,19 +249,12 @@ func TestGetStatsMultiGPU(t *testing.T) {
 		streamKey := streamKey{pid: pid, stream: streamID, gpuUUID: uuid}
 		streamHandlers[streamKey] = &StreamHandler{
 			processEnded: false,
-			kernelLaunches: []enrichedKernelLaunch{
+			kernelSpans: []*kernelSpan{
 				{
-					CudaKernelLaunch: gpuebpf.CudaKernelLaunch{
-						Header: gpuebpf.CudaEventHeader{
-							Ktime_ns:  uint64(startKtime),
-							Pid_tgid:  pidTgid,
-							Stream_id: streamID,
-						},
-						Kernel_addr:     0,
-						Shared_mem_size: shmemSize,
-						Grid_size:       gpuebpf.Dim3{X: 1, Y: 1, Z: 1},
-						Block_size:      gpuebpf.Dim3{X: 1, Y: 1, Z: 1},
-					},
+					startKtime:     uint64(startKtime),
+					endKtime:       uint64(endKtime),
+					avgThreadCount: numThreads,
+					numKernels:     10,
 				},
 			},
 		}

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -23,20 +23,22 @@ var GPUUUIDs = []string{
 	"GPU-00000000-1234-1234-1234-123456789014",
 }
 
+var GPUCores = []int{DefaultGpuCores, 20, 30}
+
 // DefaultGpuUUID is the UUID for the default device returned by the mock
 var DefaultGpuUUID = GPUUUIDs[0]
 
 // GetDeviceMock returns a mock of the nvml.Device with the given UUID.
-func GetDeviceMock(uuid string) *nvmlmock.Device {
+func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 	return &nvmlmock.Device{
 		GetNumGpuCoresFunc: func() (int, nvml.Return) {
-			return DefaultGpuCores, nvml.SUCCESS
+			return GPUCores[deviceIdx], nvml.SUCCESS
 		},
 		GetCudaComputeCapabilityFunc: func() (int, int, nvml.Return) {
 			return 7, 5, nvml.SUCCESS
 		},
 		GetUUIDFunc: func() (string, nvml.Return) {
-			return uuid, nvml.SUCCESS
+			return GPUUUIDs[deviceIdx], nvml.SUCCESS
 		},
 	}
 }
@@ -49,7 +51,7 @@ func GetBasicNvmlMock() *nvmlmock.Interface {
 			return len(GPUUUIDs), nvml.SUCCESS
 		},
 		DeviceGetHandleByIndexFunc: func(index int) (nvml.Device, nvml.Return) {
-			return GetDeviceMock(GPUUUIDs[index]), nvml.SUCCESS
+			return GetDeviceMock(index), nvml.SUCCESS
 		},
 		DeviceGetCudaComputeCapabilityFunc: func(nvml.Device) (int, int, nvml.Return) {
 			return 7, 5, nvml.SUCCESS

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -23,6 +23,7 @@ var GPUUUIDs = []string{
 	"GPU-00000000-1234-1234-1234-123456789014",
 }
 
+// GPUCores is a list of number of cores for the devices returned by the mock, should be the same length as GPUUUIDs
 var GPUCores = []int{DefaultGpuCores, 20, 30}
 
 // DefaultGpuUUID is the UUID for the default device returned by the mock


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR enables multi-gpu support in the utilization calculations.

### Motivation

Up until now, the calculation defaulted to the first GPU device found. After multi-GPU support has been added, we can rely on the actual device.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit test included.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->