### PR TITLE
[chore] ignore otel collector package updates in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -55,6 +55,9 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
       # See https://github.com/DataDog/datadog-agent/pull/10112
       - dependency-name: github.com/mailru/easyjson
+      # OpenTelemetry collector packages need to be updated with inv rather than dependabot
+      - dependency-name: go.opentelemetry.io/collector/*
+      - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
     schedule:
       interval: weekly
     open-pull-requests-limit: 100

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -29,7 +29,7 @@ updates:
       - dependency-name: github.com/DataDog/datadog-agent/*
       # OpenTelemetry collector packages need to be updated with inv rather than dependabot
       - dependency-name: go.opentelemetry.io/collector/*
-      - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib
+      - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
     schedule:
       interval: weekly
     open-pull-requests-limit: 100

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,6 +27,9 @@ updates:
       - dependency-name: github.com/ugorji/go
       # Ignore internal modules
       - dependency-name: github.com/DataDog/datadog-agent/*
+      # OpenTelemetry collector packages need to be updated with inv rather than dependabot
+      - dependency-name: go.opentelemetry.io/collector/*
+      - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib
     schedule:
       interval: weekly
     open-pull-requests-limit: 100


### PR DESCRIPTION
### What does this PR do?
ignore otel collector package updates in dependabot

### Motivation
OpenTelemetry collector packages need to be updated with inv rather than dependabot