### PR TITLE
usm: Remove telemetry from load in big endian helper

### DIFF
--- a/pkg/network/ebpf/c/protocols/helpers/big_endian.h
+++ b/pkg/network/ebpf/c/protocols/helpers/big_endian.h
@@ -16,7 +16,7 @@
         }                                                                                                   \
         type val;                                                                                           \
         bpf_memset(&val, 0, sizeof(type));                                                                  \
-        bpf_skb_load_bytes_with_telemetry(skb, offset, &val, sizeof(type));                                 \
+        bpf_skb_load_bytes(skb, offset, &val, sizeof(type));                                 \
         *out = transformer(val);                                                                            \
         return true;                                                                                        \
     }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove telemetry from load in big endian helper. This helper is only used from Kafka. The telemetry in this helper does not serve much purpose since there are length checks before it (although they should be changed to use data_end) and other protocols don't have telemetry in every read like this.

### Motivation

Reduce instruction count ahead of changes for kprobes.

### Describe how you validated your changes

The code is covered by automated tests.

I also ran it on one host in a staging cluster and there the errors from the `datadog.system_probe.ebpf.helpers.errors{helper:bpf_skb_load_bytes,probe_name:socket_kafka_filter}` metric [were not affected](https://ddstaging.datadoghq.com/metric/explorer?fromUser=true&state=H4sIAAAAAAAAA12R0WrDMAxF_0WPI5SkXVeaXxnFmFhJBU6cSXIhDfn3oSTtYG_S4frqSp7hgSyUBqjhWB4_XVW5soICOvbjXaD-niFgSwPpKppBSSNCDVBspRN6Wl99vYmP1JlhxFYNTqMJlHoUZEKBAhh_MopuAxhlTIOgaxP3Xv9rf_JWmXTwvXkZmixm8OqdpMyN4R6VqXm9maAG_-hqmUSxPzRjPmRBnj8WWG4F2LAc_ea7N3_Wy225LSaTMZK6QD0OdieTv2mThpa61SBSTwp1VRYgidUulTggQw0BpYHVy9ZqeV1hBlFvuupyOl2P1-u5LI_nAnAIOztVl50xtoxyd30KtuXos2CA4lXUyhmXAlqKirwHfAd2D3q61xekMZIoLL93UmEN9wEAAA&start=1733929950025&end=1733931750025&paused=true#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVCCc21XkyXkNkHYdOMy0zqxkQPlt7R0wfM20sACZAimDPMOQQX0iAZkCAXSoUvRc3EQx1cL8A-gwEDAB9DXxtAGMlJPUEXTrLbIiaJI08VWQocowoHBgAOg0sDQQ4VUr5bRwAIzhRuEX5QVG2NEVtDVXtBb3gbd3kdcFqgGtFyrQcIcrFrGmNAAIKK7xlyrq0PCmOkqBXUyDY5W0GBEH3mSzgwMKcGQNTqV0QlSuGEEmMqwjQ020FDejBwU2QEAAtAAGAAsqQArABOADsVOZjLgZCgZEEgjgUR4b2ebxOpIQPFGGA0v3wIgQAAoAJSxUAgxrJToxMoVaq1BrKZqtdoavzKHp9PBiABuOg0GDQo0x2Iwoz+ejlW3EGmAXx+fwBBIRoPBLShRJJZMptIZLLZHK5PL5AqFWBFvvh-sB2iDcAlUplloVyqCIDVxTSBhAAx1NTw9XVhogbUrKS6IHNyHT2hEiE0rqkFVEttG2ktYhEMB93wzA4wQ+zauQGHgco+EYQ5OpdKZrPZnO5vP5guFwAgqmX8IqMAlYHYnGmUCVmUMmnkUi0uJC5WUak0OlylZTFgaCNKA8j2og0zKMMMC-M4GhNpWaBDpUciKGaODIVASEofQTDKCIX5oLEVYQBo8iYFgqEKOqiwYHsmQ8Hw7YUeIADCUjCDAKAiE4aA8EAA) by disabling this telemetry (the actual fix for that is in https://github.com/DataDog/datadog-agent/pull/32028)

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->