### PR TITLE
Add profile metadata to JSON schema

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -831,15 +831,9 @@ func Test_snmpConfig_setProfile(t *testing.T) {
 			{Tag: "location", Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.6.0", Name: "sysLocation"}},
 		},
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"description": {
-						Symbol: profiledefinition.SymbolConfig{
-							OID:  "1.3.6.1.2.1.1.99.3.0",
-							Name: "sysDescr",
-						},
-					},
-					"name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbols: []profiledefinition.SymbolConfig{
 							{
 								OID:  "1.3.6.1.2.1.1.99.1.0",
@@ -851,11 +845,17 @@ func Test_snmpConfig_setProfile(t *testing.T) {
 							},
 						},
 					},
+					Description: profiledefinition.MetadataField{
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "1.3.6.1.2.1.1.99.3.0",
+							Name: "sysDescr",
+						},
+					},
 				},
 			},
-			"interface": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"oper_status": {
+			Interface: profiledefinition.InterfaceMetadata{
+				Fields: profiledefinition.InterfaceMetadataFields{
+					OperStatus: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.2.2.1.99",
 							Name: "someIfSymbol",
@@ -882,15 +882,9 @@ func Test_snmpConfig_setProfile(t *testing.T) {
 			{Tag: "btag", Symbol: profiledefinition.SymbolConfigCompat{OID: "2.3.4.5.6.2", Name: "b-tag-name"}},
 		},
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"b-description": {
-						Symbol: profiledefinition.SymbolConfig{
-							OID:  "2.3.4.5.6.3",
-							Name: "sysDescr",
-						},
-					},
-					"b-name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbols: []profiledefinition.SymbolConfig{
 							{
 								OID:  "2.3.4.5.6.4",
@@ -902,11 +896,17 @@ func Test_snmpConfig_setProfile(t *testing.T) {
 							},
 						},
 					},
+					Description: profiledefinition.MetadataField{
+						Symbol: profiledefinition.SymbolConfig{
+							OID:  "2.3.4.5.6.3",
+							Name: "sysDescr",
+						},
+					},
 				},
 			},
-			"interface": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"oper_status": {
+			Interface: profiledefinition.InterfaceMetadata{
+				Fields: profiledefinition.InterfaceMetadataFields{
+					OperStatus: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "2.3.4.5.6.6",
 							Name: "b-someIfSymbol",

--- a/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich_test.go
+++ b/pkg/collector/corechecks/snmp/internal/configvalidation/config_validate_enrich_test.go
@@ -671,14 +671,14 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		name             string
 		metadata         profiledefinition.MetadataConfig
 		expectedErrors   []string
-		expectedMetadata profiledefinition.MetadataConfig
+		expectedMetadata *profiledefinition.MetadataConfig
 	}{
 		{
 			name: "both field symbol and value can be provided",
 			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
+				Device: profiledefinition.DeviceMetadata{
+					Fields: profiledefinition.DeviceMetadataFields{
+						Name: profiledefinition.MetadataField{
 							Value: "hey",
 							Symbol: profiledefinition.SymbolConfig{
 								OID:  "1.2.3",
@@ -688,10 +688,10 @@ func Test_validateEnrichMetadata(t *testing.T) {
 					},
 				},
 			},
-			expectedMetadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
+			expectedMetadata: &profiledefinition.MetadataConfig{
+				Device: profiledefinition.DeviceMetadata{
+					Fields: profiledefinition.DeviceMetadataFields{
+						Name: profiledefinition.MetadataField{
 							Value: "hey",
 							Symbol: profiledefinition.SymbolConfig{
 								OID:  "1.2.3",
@@ -705,9 +705,9 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		{
 			name: "invalid regex pattern for symbol",
 			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
+				Device: profiledefinition.DeviceMetadata{
+					Fields: profiledefinition.DeviceMetadataFields{
+						Name: profiledefinition.MetadataField{
 							Symbol: profiledefinition.SymbolConfig{
 								OID:          "1.2.3",
 								Name:         "someSymbol",
@@ -724,15 +724,13 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		{
 			name: "invalid regex pattern for multiple symbols",
 			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
-							Symbols: []profiledefinition.SymbolConfig{
-								{
-									OID:          "1.2.3",
-									Name:         "someSymbol",
-									ExtractValue: "(\\w[)",
-								},
+				Device: profiledefinition.DeviceMetadata{
+					Fields: profiledefinition.DeviceMetadataFields{
+						Name: profiledefinition.MetadataField{
+							Symbol: profiledefinition.SymbolConfig{
+								OID:          "1.2.3",
+								Name:         "someSymbol",
+								ExtractValue: "(\\w[)",
 							},
 						},
 					},
@@ -745,9 +743,9 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		{
 			name: "field regex pattern is compiled",
 			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
+				Device: profiledefinition.DeviceMetadata{
+					Fields: profiledefinition.DeviceMetadataFields{
+						Name: profiledefinition.MetadataField{
 							Symbol: profiledefinition.SymbolConfig{
 								OID:          "1.2.3",
 								Name:         "someSymbol",
@@ -758,10 +756,10 @@ func Test_validateEnrichMetadata(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{},
-			expectedMetadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
+			expectedMetadata: &profiledefinition.MetadataConfig{
+				Device: profiledefinition.DeviceMetadata{
+					Fields: profiledefinition.DeviceMetadataFields{
+						Name: profiledefinition.MetadataField{
 							Symbol: profiledefinition.SymbolConfig{
 								OID:                  "1.2.3",
 								Name:                 "someSymbol",
@@ -774,44 +772,9 @@ func Test_validateEnrichMetadata(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid resource",
-			metadata: profiledefinition.MetadataConfig{
-				"invalid-res": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
-							Value: "hey",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"invalid resource: invalid-res",
-			},
-		},
-		{
-			name: "invalid field",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"invalid-field": {
-							Value: "hey",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"invalid resource (device) field: invalid-field",
-			},
-		},
-		{
 			name: "invalid idtags",
 			metadata: profiledefinition.MetadataConfig{
-				"interface": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"invalid-field": {
-							Value: "hey",
-						},
-					},
+				Interface: profiledefinition.InterfaceMetadata{
 					IDTags: profiledefinition.MetricTagConfigList{
 						profiledefinition.MetricTagConfig{
 							Symbol: profiledefinition.SymbolConfigCompat{
@@ -827,32 +790,7 @@ func Test_validateEnrichMetadata(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{
-				"invalid resource (interface) field: invalid-field",
 				"cannot compile `match` (`([a-z)`)",
-			},
-		},
-		{
-			name: "device resource does not support id_tags",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
-						"name": {
-							Value: "hey",
-						},
-					},
-					IDTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
-								OID:  "1.2.3",
-								Name: "abc",
-							},
-							Tag: "abc",
-						},
-					},
-				},
-			},
-			expectedErrors: []string{
-				"device resource does not support custom id_tags",
 			},
 		},
 	}

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver_test.go
@@ -174,11 +174,9 @@ func Test_resolveProfiles(t *testing.T) {
 					for _, metric := range profile.Definition.Metrics {
 						metricsNames = append(metricsNames, fmt.Sprintf("%s:%s", name, metric.Symbol.Name))
 					}
-					ifMeta, ok := profile.Definition.Metadata["interface"]
-					if ok {
-						for _, metricTag := range ifMeta.IDTags {
-							ifIDTags = append(ifIDTags, fmt.Sprintf("%s:%s", name, metricTag.Tag))
-						}
+					ifMeta := profile.Definition.Metadata.Interface
+					for _, metricTag := range ifMeta.IDTags {
+						ifIDTags = append(ifIDTags, fmt.Sprintf("%s:%s", name, metricTag.Tag))
 					}
 				}
 				assert.ElementsMatch(t, tt.expectedProfileMetrics, metricsNames)
@@ -202,12 +200,12 @@ func Test_mergeProfileDefinition(t *testing.T) {
 			},
 		},
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"vendor": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Vendor: profiledefinition.MetadataField{
 						Value: "f5",
 					},
-					"description": {
+					Description: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.1.1.0",
 							Name: "sysDescr",
@@ -215,11 +213,10 @@ func Test_mergeProfileDefinition(t *testing.T) {
 					},
 				},
 			},
-			"interface": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"admin_status": {
+			Interface: profiledefinition.InterfaceMetadata{
+				Fields: profiledefinition.InterfaceMetadataFields{
+					AdminStatus: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
-
 							OID:  "1.3.6.1.2.1.2.2.1.7",
 							Name: "ifAdminStatus",
 						},
@@ -249,9 +246,9 @@ func Test_mergeProfileDefinition(t *testing.T) {
 			},
 		},
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.1.5.0",
 							Name: "sysName",
@@ -259,9 +256,9 @@ func Test_mergeProfileDefinition(t *testing.T) {
 					},
 				},
 			},
-			"interface": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"oper_status": {
+			Interface: profiledefinition.InterfaceMetadata{
+				Fields: profiledefinition.InterfaceMetadataFields{
+					OperStatus: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.2.2.1.8",
 							Name: "ifOperStatus",
@@ -306,54 +303,53 @@ func Test_mergeProfileDefinition(t *testing.T) {
 					},
 				},
 				Metadata: profiledefinition.MetadataConfig{
-					"device": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"vendor": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Vendor: profiledefinition.MetadataField{
 								Value: "f5",
 							},
-							"name": {
-								Symbol: profiledefinition.SymbolConfig{
-									OID:  "1.3.6.1.2.1.1.5.0",
-									Name: "sysName",
-								},
-							},
-							"description": {
+							Description: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.1.1.0",
 									Name: "sysDescr",
 								},
 							},
+							Name: profiledefinition.MetadataField{
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.2.1.1.5.0",
+									Name: "sysName",
+								},
+							},
 						},
 					},
-					"interface": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"oper_status": {
+					Interface: profiledefinition.InterfaceMetadata{
+						Fields: profiledefinition.InterfaceMetadataFields{
+							AdminStatus: profiledefinition.MetadataField{
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.2.1.2.2.1.7",
+									Name: "ifAdminStatus",
+								},
+							},
+							OperStatus: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.2.2.1.8",
 									Name: "ifOperStatus",
 								},
 							},
-							"admin_status": {
-								Symbol: profiledefinition.SymbolConfig{
-
-									OID:  "1.3.6.1.2.1.2.2.1.7",
-									Name: "ifAdminStatus",
-								},
-							},
 						},
 						IDTags: profiledefinition.MetricTagConfigList{
-							{
-								Tag: "interface",
-								Symbol: profiledefinition.SymbolConfigCompat{
-									OID:  "1.3.6.1.2.1.31.1.1.1.1",
-									Name: "ifName",
-								},
-							},
 							{
 								Tag: "alias",
 								Symbol: profiledefinition.SymbolConfigCompat{
 									OID:  "1.3.6.1.2.1.31.1.1.1.1",
 									Name: "ifAlias",
+								},
+							},
+							{
+								Tag: "interface",
+								Symbol: profiledefinition.SymbolConfigCompat{
+									OID:  "1.3.6.1.2.1.31.1.1.1.1",
+									Name: "ifName",
 								},
 							},
 						},
@@ -376,9 +372,9 @@ func Test_mergeProfileDefinition(t *testing.T) {
 					},
 				},
 				Metadata: profiledefinition.MetadataConfig{
-					"device": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"name": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Name: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.1.5.0",
 									Name: "sysName",
@@ -386,9 +382,9 @@ func Test_mergeProfileDefinition(t *testing.T) {
 							},
 						},
 					},
-					"interface": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"oper_status": {
+					Interface: profiledefinition.InterfaceMetadata{
+						Fields: profiledefinition.InterfaceMetadataFields{
+							OperStatus: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.2.2.1.8",
 									Name: "ifOperStatus",
@@ -423,12 +419,12 @@ func Test_mergeProfileDefinition(t *testing.T) {
 					},
 				},
 				Metadata: profiledefinition.MetadataConfig{
-					"device": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"vendor": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Vendor: profiledefinition.MetadataField{
 								Value: "f5",
 							},
-							"description": {
+							Description: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.1.1.0",
 									Name: "sysDescr",
@@ -436,11 +432,10 @@ func Test_mergeProfileDefinition(t *testing.T) {
 							},
 						},
 					},
-					"interface": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"admin_status": {
+					Interface: profiledefinition.InterfaceMetadata{
+						Fields: profiledefinition.InterfaceMetadataFields{
+							AdminStatus: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
-
 									OID:  "1.3.6.1.2.1.2.2.1.7",
 									Name: "ifAdminStatus",
 								},

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -83,56 +83,55 @@ func FixtureProfileDefinitionMap() ProfileConfigMap {
 					{Tag: "snmp_host", Index: 0x0, Symbol: profiledefinition.SymbolConfigCompat{OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"}},
 				},
 				Metadata: profiledefinition.MetadataConfig{
-					"device": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"vendor": {
-								Value: "f5",
-							},
-							"description": {
-								Symbol: profiledefinition.SymbolConfig{
-									OID:  "1.3.6.1.2.1.1.1.0",
-									Name: "sysDescr",
-								},
-							},
-							"name": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Name: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.1.5.0",
 									Name: "sysName",
 								},
 							},
-							"serial_number": {
+							Description: profiledefinition.MetadataField{
+								Symbol: profiledefinition.SymbolConfig{
+									OID:  "1.3.6.1.2.1.1.1.0",
+									Name: "sysDescr",
+								},
+							},
+							Vendor: profiledefinition.MetadataField{
+								Value: "f5",
+							},
+							SerialNumber: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.4.1.3375.2.1.3.3.3.0",
 									Name: "sysGeneralChassisSerialNum",
 								},
 							},
-							"sys_object_id": {
+							Type: profiledefinition.MetadataField{
+								Value: "load_balancer",
+							},
+							SysObjectId: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.1.2.0",
 									Name: "sysObjectID",
 								},
 							},
-							"type": {
-								Value: "load_balancer",
-							},
 						},
 					},
-					"interface": {
-						Fields: map[string]profiledefinition.MetadataField{
-							"admin_status": {
+					Interface: profiledefinition.InterfaceMetadata{
+						Fields: profiledefinition.InterfaceMetadataFields{
+							Name: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
-
-									OID:  "1.3.6.1.2.1.2.2.1.7",
-									Name: "ifAdminStatus",
+									OID:  "1.3.6.1.2.1.31.1.1.1.1",
+									Name: "ifName",
 								},
 							},
-							"alias": {
+							Alias: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.31.1.1.1.18",
 									Name: "ifAlias",
 								},
 							},
-							"description": {
+							Description: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:                  "1.3.6.1.2.1.31.1.1.1.1",
 									Name:                 "ifName",
@@ -140,20 +139,20 @@ func FixtureProfileDefinitionMap() ProfileConfigMap {
 									ExtractValueCompiled: regexp.MustCompile(`(Row\d)`),
 								},
 							},
-							"mac_address": {
+							MacAddress: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:    "1.3.6.1.2.1.2.2.1.6",
 									Name:   "ifPhysAddress",
 									Format: "mac_address",
 								},
 							},
-							"name": {
+							AdminStatus: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
-									OID:  "1.3.6.1.2.1.31.1.1.1.1",
-									Name: "ifName",
+									OID:  "1.3.6.1.2.1.2.2.1.7",
+									Name: "ifAdminStatus",
 								},
 							},
-							"oper_status": {
+							OperStatus: profiledefinition.MetadataField{
 								Symbol: profiledefinition.SymbolConfig{
 									OID:  "1.3.6.1.2.1.2.2.1.8",
 									Name: "ifOperStatus",

--- a/pkg/collector/corechecks/snmp/internal/profile/utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils.go
@@ -7,6 +7,7 @@ package profile
 
 import (
 	"os"
+	"reflect"
 
 	"github.com/mohae/deepcopy"
 )
@@ -28,4 +29,36 @@ func mergeProfiles(profilesA ProfileConfigMap, profilesB ProfileConfigMap) Profi
 func pathExists(path string) bool {
 	_, err := os.Stat(path)
 	return !os.IsNotExist(err)
+}
+
+// isStructEmpty returns true if the given struct is empty
+func isStructEmpty(s interface{}) bool {
+	v := reflect.ValueOf(s)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if !reflect.DeepEqual(v.Field(i).Interface(), reflect.Zero(v.Field(i).Type()).Interface()) {
+			return false
+		}
+	}
+	return true
+}
+
+// isEmpty returns true if the given field is empty
+func isEmpty(field reflect.Value) bool {
+	switch field.Kind() {
+	case reflect.String:
+		return field.String() == ""
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return field.Int() == 0
+	case reflect.Bool:
+		return !field.Bool()
+	// Add other types as needed
+	default:
+		return false
+	}
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
@@ -23,9 +23,9 @@ func Test_mergeProfiles(t *testing.T) {
 		"profile-p2": ProfileConfig{
 			Definition: profiledefinition.ProfileDefinition{
 				Metadata: profiledefinition.MetadataConfig{
-					"device": profiledefinition.MetadataResourceConfig{
-						Fields: map[string]profiledefinition.MetadataField{
-							"name": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Name: profiledefinition.MetadataField{
 								Value: "foo",
 							},
 						},
@@ -45,9 +45,9 @@ func Test_mergeProfiles(t *testing.T) {
 		"profile-p3": ProfileConfig{
 			Definition: profiledefinition.ProfileDefinition{
 				Metadata: profiledefinition.MetadataConfig{
-					"device": profiledefinition.MetadataResourceConfig{
-						Fields: map[string]profiledefinition.MetadataField{
-							"name": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Name: profiledefinition.MetadataField{
 								Value: "bar",
 							},
 						},
@@ -62,10 +62,12 @@ func Test_mergeProfiles(t *testing.T) {
 
 	p2 := actualMergedProfiles["profile-p2"]
 	p2.Definition.Description = "abc"
-	p2.Definition.Metadata["device"] = profiledefinition.MetadataResourceConfig{
-		Fields: map[string]profiledefinition.MetadataField{
-			"name": {
-				Value: "foo2",
+	p2.Definition.Metadata = profiledefinition.MetadataConfig{
+		Device: profiledefinition.DeviceMetadata{
+			Fields: profiledefinition.DeviceMetadataFields{
+				Name: profiledefinition.MetadataField{
+					Value: "foo2",
+				},
 			},
 		},
 	}
@@ -73,10 +75,12 @@ func Test_mergeProfiles(t *testing.T) {
 
 	p3 := actualMergedProfiles["profile-p3"]
 	p3.Definition.Description = "abc"
-	p3.Definition.Metadata["device"] = profiledefinition.MetadataResourceConfig{
-		Fields: map[string]profiledefinition.MetadataField{
-			"name": {
-				Value: "bar2",
+	p3.Definition.Metadata = profiledefinition.MetadataConfig{
+		Device: profiledefinition.DeviceMetadata{
+			Fields: profiledefinition.DeviceMetadataFields{
+				Name: profiledefinition.MetadataField{
+					Value: "bar2",
+				},
 			},
 		},
 	}
@@ -93,9 +97,9 @@ func Test_mergeProfiles(t *testing.T) {
 			Definition: profiledefinition.ProfileDefinition{
 				Description: "abc",
 				Metadata: profiledefinition.MetadataConfig{
-					"device": profiledefinition.MetadataResourceConfig{
-						Fields: map[string]profiledefinition.MetadataField{
-							"name": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Name: profiledefinition.MetadataField{
 								Value: "foo2",
 							},
 						},
@@ -107,9 +111,9 @@ func Test_mergeProfiles(t *testing.T) {
 			Definition: profiledefinition.ProfileDefinition{
 				Description: "abc",
 				Metadata: profiledefinition.MetadataConfig{
-					"device": profiledefinition.MetadataResourceConfig{
-						Fields: map[string]profiledefinition.MetadataField{
-							"name": {
+					Device: profiledefinition.DeviceMetadata{
+						Fields: profiledefinition.DeviceMetadataFields{
+							Name: profiledefinition.MetadataField{
 								Value: "bar2",
 							},
 						},

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -67,9 +67,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 			Version: 10,
 		},
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						// Should use value from Symbol `1.3.6.1.2.1.1.5.0`
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.1.5.0",
@@ -82,7 +82,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 							},
 						},
 					},
-					"description": {
+					Description: profiledefinition.MetadataField{
 						// Should use value from first element in Symbols `1.3.6.1.2.1.1.1.0`
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.9999",
@@ -95,7 +95,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 							},
 						},
 					},
-					"location": {
+					Location: profiledefinition.MetadataField{
 						// Should use value from first element in Symbols `1.3.6.1.2.1.1.1.0`
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.9999",
@@ -116,7 +116,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 							},
 						},
 					},
-					"type": {
+					DeviceType: profiledefinition.MetadataField{
 						Value: "router",
 					},
 				},
@@ -444,16 +444,16 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
 		ResolvedSubnetName: "127.0.0.0/29",
 		Namespace:          "my-ns",
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.999",
 							Name: "doesNotExist",
 						},
 						Value: "my-fallback-value",
 					},
-					"type": {
+					DeviceType: profiledefinition.MetadataField{
 						Value: "firewall",
 					},
 				},
@@ -519,9 +519,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_Nil(t *testing
 		ResolvedSubnetName: "127.0.0.0/29",
 		Namespace:          "my-ns",
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.999",
 							Name: "doesNotExist",
@@ -590,9 +590,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_True(t *testin
 		ResolvedSubnetName: "127.0.0.0/29",
 		Namespace:          "my-ns",
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.999",
 							Name: "doesNotExist",
@@ -662,9 +662,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_False(t *testi
 		ResolvedSubnetName: "127.0.0.0/29",
 		Namespace:          "my-ns",
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"name": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.999",
 							Name: "doesNotExist",

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -116,7 +116,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 							},
 						},
 					},
-					DeviceType: profiledefinition.MetadataField{
+					Type: profiledefinition.MetadataField{
 						Value: "router",
 					},
 				},
@@ -293,34 +293,34 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 		ResolvedSubnetName: "127.0.0.0/29",
 		Namespace:          "my-ns",
 		Metadata: profiledefinition.MetadataConfig{
-			"device": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"type": {
+			Device: profiledefinition.DeviceMetadata{
+				Fields: profiledefinition.DeviceMetadataFields{
+					Type: profiledefinition.MetadataField{
 						Value: "switch",
 					},
 				},
 			},
-			"interface": {
-				Fields: map[string]profiledefinition.MetadataField{
-					"name": {
+			Interface: profiledefinition.InterfaceMetadata{
+				Fields: profiledefinition.InterfaceMetadataFields{
+					Name: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.31.1.1.1.1",
 							Name: "ifName",
 						},
 					},
-					"alias": {
+					Alias: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.31.1.1.1.18",
 							Name: "ifAlias",
 						},
 					},
-					"admin_status": {
+					AdminStatus: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.2.2.1.7",
 							Name: "ifAdminStatus",
 						},
 					},
-					"oper_status": {
+					OperStatus: profiledefinition.MetadataField{
 						Symbol: profiledefinition.SymbolConfig{
 							OID:  "1.3.6.1.2.1.2.2.1.8",
 							Name: "ifOperStatus",
@@ -453,7 +453,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
 						},
 						Value: "my-fallback-value",
 					},
-					DeviceType: profiledefinition.MetadataField{
+					Type: profiledefinition.MetadataField{
 						Value: "firewall",
 					},
 				},

--- a/pkg/networkdevice/profile/profiledefinition/metadata.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata.go
@@ -23,22 +23,23 @@ type DeviceMetadata struct {
 type DeviceMetadataFields struct {
 	Name         MetadataField `yaml:"name,omitempty" json:"name,omitempty"`
 	Description  MetadataField `yaml:"description,omitempty" json:"description,omitempty"`
+	SysObjectId  MetadataField `yaml:"sys_object_id,omitempty" json:"sys_object_id,omitempty"`
 	Location     MetadataField `yaml:"location,omitempty" json:"location,omitempty"`
-	Vendor       MetadataField `yaml:"vendor,omitempty" json:"vendor,omitempty"`
 	SerialNumber MetadataField `yaml:"serial_number,omitempty" json:"serial_number,omitempty"`
+	Vendor       MetadataField `yaml:"vendor,omitempty" json:"vendor,omitempty"`
 	Version      MetadataField `yaml:"version,omitempty" json:"version,omitempty"`
 	ProductName  MetadataField `yaml:"product_name,omitempty" json:"product_name,omitempty"`
 	Model        MetadataField `yaml:"model,omitempty" json:"model,omitempty"`
 	OsName       MetadataField `yaml:"os_name,omitempty" json:"os_name,omitempty"`
 	OsVersion    MetadataField `yaml:"os_version,omitempty" json:"os_version,omitempty"`
 	OsHostname   MetadataField `yaml:"os_hostname,omitempty" json:"os_hostname,omitempty"`
-	DeviceType   MetadataField `yaml:"type,omitempty" json:"type,omitempty"`
+	Type         MetadataField `yaml:"type,omitempty" json:"type,omitempty"`
 }
 
 // InterfaceMetadata holds interface metadata
 type InterfaceMetadata struct {
-	Fields string              `yaml:"fields,omitempty" json:"fields,omitempty"`
-	IDTags MetricTagConfigList `yaml:"id_tags,omitempty" json:"id_tags,omitempty"`
+	Fields InterfaceMetadataFields `yaml:"fields,omitempty" json:"fields,omitempty"`
+	IDTags MetricTagConfigList     `yaml:"id_tags,omitempty" json:"id_tags,omitempty"`
 }
 
 // InterfaceMetadataFields holds interface metadata fields

--- a/pkg/networkdevice/profile/profiledefinition/metadata.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata.go
@@ -8,8 +8,48 @@ package profiledefinition
 // MetadataDeviceResource is the device resource name
 const MetadataDeviceResource = "device"
 
-// MetadataConfig holds configs per resource type
-type MetadataConfig map[string]MetadataResourceConfig
+// MetadataConfig holds metadata config per resource type
+type MetadataConfig struct {
+	Device    DeviceMetadata    `yaml:"device,omitempty" json:"device,omitempty"`
+	Interface InterfaceMetadata `yaml:"interface,omitempty" json:"interface,omitempty"`
+}
+
+// DeviceMetadata holds device metadata
+type DeviceMetadata struct {
+	Fields DeviceMetadataFields `yaml:"fields,omitempty" json:"fields,omitempty"`
+}
+
+// DeviceMetadataFields holds device metadata fields
+type DeviceMetadataFields struct {
+	Name         MetadataField `yaml:"name,omitempty" json:"name,omitempty"`
+	Description  MetadataField `yaml:"description,omitempty" json:"description,omitempty"`
+	Location     MetadataField `yaml:"location,omitempty" json:"location,omitempty"`
+	Vendor       MetadataField `yaml:"vendor,omitempty" json:"vendor,omitempty"`
+	SerialNumber MetadataField `yaml:"serial_number,omitempty" json:"serial_number,omitempty"`
+	Version      MetadataField `yaml:"version,omitempty" json:"version,omitempty"`
+	ProductName  MetadataField `yaml:"product_name,omitempty" json:"product_name,omitempty"`
+	Model        MetadataField `yaml:"model,omitempty" json:"model,omitempty"`
+	OsName       MetadataField `yaml:"os_name,omitempty" json:"os_name,omitempty"`
+	OsVersion    MetadataField `yaml:"os_version,omitempty" json:"os_version,omitempty"`
+	OsHostname   MetadataField `yaml:"os_hostname,omitempty" json:"os_hostname,omitempty"`
+	DeviceType   MetadataField `yaml:"type,omitempty" json:"type,omitempty"`
+}
+
+// InterfaceMetadata holds interface metadata
+type InterfaceMetadata struct {
+	Fields string              `yaml:"fields,omitempty" json:"fields,omitempty"`
+	IDTags MetricTagConfigList `yaml:"id_tags,omitempty" json:"id_tags,omitempty"`
+}
+
+// InterfaceMetadataFields holds interface metadata fields
+type InterfaceMetadataFields struct {
+	Name        MetadataField `yaml:"name,omitempty" json:"name,omitempty"`
+	Alias       MetadataField `yaml:"alias,omitempty" json:"alias,omitempty"`
+	Description MetadataField `yaml:"description,omitempty" json:"description,omitempty"`
+	MacAddress  MetadataField `yaml:"mac_address,omitempty" json:"mac_address,omitempty"` // add mac_Address format
+	AdminStatus MetadataField `yaml:"admin_status,omitempty" json:"admin_status,omitempty"`
+	OperStatus  MetadataField `yaml:"oper_status,omitempty" json:"oper_status,omitempty"`
+}
 
 // MetadataResourceConfig holds configs for a metadata resource
 type MetadataResourceConfig struct {

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -82,12 +82,15 @@ type MetricTagConfig struct {
 	// Table config
 	Index uint `yaml:"index,omitempty" json:"index,omitempty"`
 
-	// DEPRECATED: Column field is deprecated in favour Symbol field
+	// DEPRECATED: Use .Symbol instead
 	Column SymbolConfig `yaml:"column,omitempty" json:"-"`
 
-	// Symbol config
-	OID string `yaml:"OID,omitempty" json:"-"  jsonschema:"-"` // DEPRECATED replaced by Symbol field
-	// Using Symbol field below as string is deprecated
+	// DEPRECATED: use .Symbol instead
+	OID string `yaml:"OID,omitempty" json:"-"  jsonschema:"-"`
+	// Symbol records the OID to be parsed. Note that .Symbol.Name is ignored:
+	// set .Tag to specify the tag name. If a serialized Symbol is a string
+	// instead of an object, it will be treated like {name: <value>}; this use
+	// pattern is deprecated
 	Symbol SymbolConfigCompat `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 
 	IndexTransform []MetricIndexTransform `yaml:"index_transform,omitempty" json:"index_transform,omitempty"`
@@ -129,8 +132,9 @@ type MetricsConfig struct {
 	// Symbol configs
 	Symbol SymbolConfig `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 
-	// Legacy Symbol configs syntax
-	OID  string `yaml:"OID,omitempty" json:"OID,omitempty" jsonschema:"-"`
+	// DEPRECATED: Use .Symbol instead
+	OID string `yaml:"OID,omitempty" json:"OID,omitempty" jsonschema:"-"`
+	// DEPRECATED: Use .Symbol instead
 	Name string `yaml:"name,omitempty" json:"name,omitempty" jsonschema:"-"`
 
 	// Table configs
@@ -140,11 +144,11 @@ type MetricsConfig struct {
 	StaticTags []string            `yaml:"static_tags,omitempty" json:"-"`
 	MetricTags MetricTagConfigList `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
 
-	ForcedType ProfileMetricType `yaml:"forced_type,omitempty" json:"forced_type,omitempty" jsonschema:"-"` // deprecated in favour of metric_type
+	// DEPRECATED: use MetricType instead.
+	ForcedType ProfileMetricType `yaml:"forced_type,omitempty" json:"forced_type,omitempty" jsonschema:"-"`
 	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty"`
 
-	// `options` is not exposed as json at the moment since we need to evaluate if we want to expose it via UI
-	Options MetricsConfigOption `yaml:"options,omitempty" json:"-"`
+	Options MetricsConfigOption `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
 // GetSymbolTags returns symbol tags

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -22,7 +22,7 @@ type ProfileDefinition struct {
 	Description  string            `yaml:"description,omitempty" json:"description,omitempty"`
 	SysObjectIDs StringArray       `yaml:"sysobjectid,omitempty" json:"sysobjectid,omitempty"`
 	Extends      []string          `yaml:"extends,omitempty" json:"extends,omitempty"`
-	Metadata     MetadataConfig    `yaml:"metadata,omitempty" json:"metadata,omitempty" jsonschema:"-"`
+	Metadata     MetadataConfig    `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 	MetricTags   []MetricTagConfig `yaml:"metric_tags,omitempty" json:"metric_tags,omitempty"`
 	StaticTags   []string          `yaml:"static_tags,omitempty" json:"static_tags,omitempty"`
 	Metrics      []MetricsConfig   `yaml:"metrics,omitempty" json:"metrics,omitempty"`

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -27,9 +27,8 @@ type ProfileDefinition struct {
 	StaticTags   []string          `yaml:"static_tags,omitempty" json:"static_tags,omitempty"`
 	Metrics      []MetricsConfig   `yaml:"metrics,omitempty" json:"metrics,omitempty"`
 
-	// Used previously to pass device vendor field (has been replaced by Metadata).
-	// Used in RC for passing device vendor field.
-	Device DeviceMeta `yaml:"device,omitempty" json:"device,omitempty" jsonschema:"device,omitempty"` // DEPRECATED
+	// DEPRECATED: Use metadata directly
+	Device DeviceMeta `yaml:"device,omitempty" json:"device,omitempty" jsonschema:"device,omitempty"`
 
 	// Version is the profile version.
 	// It is currently used only with downloaded/RC profiles.

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -43,6 +43,6 @@ type DeviceProfileRcConfig struct {
 // NewProfileDefinition creates a new ProfileDefinition
 func NewProfileDefinition() *ProfileDefinition {
 	p := &ProfileDefinition{}
-	p.Metadata = make(MetadataConfig)
+	p.Metadata = MetadataConfig{}
 	return p
 }

--- a/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
@@ -156,6 +156,21 @@
         },
         "metric_type": {
           "type": "string"
+        },
+        "options": {
+          "$ref": "#/$defs/MetricsConfigOption"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetricsConfigOption": {
+      "properties": {
+        "placement": {
+          "type": "integer"
+        },
+        "metric_suffix": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
@@ -43,6 +43,48 @@
       },
       "type": "array"
     },
+    "MetadataConfig": {
+      "additionalProperties": {
+        "$ref": "#/$defs/MetadataResourceConfig"
+      },
+      "type": "object"
+    },
+    "MetadataField": {
+      "properties": {
+        "symbol": {
+          "$ref": "#/$defs/SymbolConfig"
+        },
+        "symbols": {
+          "items": {
+            "$ref": "#/$defs/SymbolConfig"
+          },
+          "type": "array"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MetadataResourceConfig": {
+      "properties": {
+        "fields": {
+          "additionalProperties": {
+            "$ref": "#/$defs/MetadataField"
+          },
+          "type": "object"
+        },
+        "id_tags": {
+          "$ref": "#/$defs/MetricTagConfigList"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "fields"
+      ]
+    },
     "MetricIndexTransform": {
       "properties": {
         "start": {
@@ -135,6 +177,9 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/MetadataConfig"
         },
         "metric_tags": {
           "items": {

--- a/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
+++ b/pkg/networkdevice/profile/profiledefinition/schema/profile_rc_schema.json
@@ -12,6 +12,57 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "DeviceMetadata": {
+      "properties": {
+        "fields": {
+          "$ref": "#/$defs/DeviceMetadataFields"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "DeviceMetadataFields": {
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "description": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "location": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "vendor": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "serial_number": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "version": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "product_name": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "model": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "os_name": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "os_version": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "os_hostname": {
+          "$ref": "#/$defs/MetadataField"
+        },
+        "type": {
+          "$ref": "#/$defs/MetadataField"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "DeviceProfileRcConfig": {
       "properties": {
         "profile_definition": {
@@ -23,6 +74,18 @@
       "required": [
         "profile_definition"
       ]
+    },
+    "InterfaceMetadata": {
+      "properties": {
+        "fields": {
+          "type": "string"
+        },
+        "id_tags": {
+          "$ref": "#/$defs/MetricTagConfigList"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
     },
     "ListMap[string]": {
       "items": {
@@ -44,9 +107,15 @@
       "type": "array"
     },
     "MetadataConfig": {
-      "additionalProperties": {
-        "$ref": "#/$defs/MetadataResourceConfig"
+      "properties": {
+        "device": {
+          "$ref": "#/$defs/DeviceMetadata"
+        },
+        "interface": {
+          "$ref": "#/$defs/InterfaceMetadata"
+        }
       },
+      "additionalProperties": false,
       "type": "object"
     },
     "MetadataField": {
@@ -66,24 +135,6 @@
       },
       "additionalProperties": false,
       "type": "object"
-    },
-    "MetadataResourceConfig": {
-      "properties": {
-        "fields": {
-          "additionalProperties": {
-            "$ref": "#/$defs/MetadataField"
-          },
-          "type": "object"
-        },
-        "id_tags": {
-          "$ref": "#/$defs/MetricTagConfigList"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "fields"
-      ]
     },
     "MetricIndexTransform": {
       "properties": {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add profile metadata to JSON schema

### Motivation
We are adding support for the metadata

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This structure is used on the backend side by RC, changes were validated by sending requests with the new fields to the rc-api and making sure they succeeded.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->