### PR TITLE
Revert "Revert "When running in CI, scrub e2e tests output to avoid leaking keys""

### DIFF
--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -111,7 +111,14 @@ def run(
         test_run_arg = f"-run {test_run_name}"
 
     cmd = f'gotestsum --format {gotestsum_format} '
-    cmd += '{junit_file_flag} {json_flag} --packages="{packages}" -- -ldflags="-X {REPO_PATH}/test/new-e2e/tests/containers.GitCommit={commit}" {verbose} -mod={go_mod} -vet=off -timeout {timeout} -tags "{go_build_tags}" {nocache} {run} {skip} {test_run_arg} -args {osversion} {platform} {major_version} {arch} {flavor} {cws_supported_osversion} {src_agent_version} {dest_agent_version} {keep_stacks} {extra_flags}'
+    scrubber_raw_command = ""
+    # Scrub the test output to avoid leaking API or APP keys when running in the CI
+    if running_in_ci():
+        scrubber_raw_command = (
+            # Using custom go command piped with scrubber sed instructions https://github.com/gotestyourself/gotestsum#custom-go-test-command
+            f"--raw-command {os.path.join(os.path.dirname(__file__), 'tools', 'gotest-scrubbed.sh')} {{packages}}"
+        )
+    cmd += f'{{junit_file_flag}} {{json_flag}} --packages="{{packages}}" {scrubber_raw_command} -- -ldflags="-X {{REPO_PATH}}/test/new-e2e/tests/containers.GitCommit={{commit}}" {{verbose}} -mod={{go_mod}} -vet=off -timeout {{timeout}} -tags "{{go_build_tags}}" {{nocache}} {{run}} {{skip}} {{test_run_arg}} -args {{osversion}} {{platform}} {{major_version}} {{arch}} {{flavor}} {{cws_supported_osversion}} {{src_agent_version}} {{dest_agent_version}} {{keep_stacks}} {{extra_flags}}'
 
     args = {
         "go_mod": "readonly",

--- a/tasks/tools/gotest-scrubbed.sh
+++ b/tasks/tools/gotest-scrubbed.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ### This script is used to run go test and scrub the output, the command can be used as follow:
 ### ./gotest-scrubbed.sh <packages comma separated> -- <go tests flags>
+set -euo pipefail
 go test -json "$1" "${@:3}" | 
 sed -E 's/\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b/**************************\1/g' | # Scrub API keys
 sed -E 's/\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b/************************************\1/g' # Scrub APP keys

--- a/tasks/tools/gotest-scrubbed.sh
+++ b/tasks/tools/gotest-scrubbed.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+### This script is used to run go test and scrub the output, the command can be used as follow:
+### ./gotest-scrubbed.sh <packages comma separated> -- <go tests flags>
+go test -json "$1" "${@:3}" | 
+sed -E 's/\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b/**************************\1/g' | # Scrub API keys
+sed -E 's/\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b/************************************\1/g' # Scrub APP keys


### PR DESCRIPTION
Reverts DataDog/datadog-agent#32027

Tried to make an e2e test fail: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/735205063