### PR TITLE
[OTEL-2304] export obfuscateStatsGroup function

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -536,7 +536,7 @@ func (a *Agent) processStats(in *pb.ClientStatsPayload, lang, tracerVersion, con
 				continue
 			}
 			obfuscator := a.lazyInitObfuscator()
-			obfuscateStatsGroup(obfuscator, b)
+			ObfuscateStatsGroup(obfuscator, b)
 			a.Replacer.ReplaceStatsGroup(b)
 			group.Stats[n] = b
 			n++

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -535,7 +535,8 @@ func (a *Agent) processStats(in *pb.ClientStatsPayload, lang, tracerVersion, con
 			if !a.Blacklister.AllowsStat(b) {
 				continue
 			}
-			a.obfuscateStatsGroup(b)
+			obfuscator := a.lazyInitObfuscator()
+			obfuscateStatsGroup(obfuscator, b)
 			a.Replacer.ReplaceStatsGroup(b)
 			group.Stats[n] = b
 			n++

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -110,9 +110,7 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 	}
 }
 
-func (a *Agent) obfuscateStatsGroup(b *pb.ClientGroupedStats) {
-	o := a.lazyInitObfuscator()
-
+func obfuscateStatsGroup(o *obfuscate.Obfuscator, b *pb.ClientGroupedStats) {
 	switch b.Type {
 	case "sql", "cassandra":
 		oq, err := o.ObfuscateSQLString(b.Resource)

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -110,7 +110,8 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 	}
 }
 
-func obfuscateStatsGroup(o *obfuscate.Obfuscator, b *pb.ClientGroupedStats) {
+// ObfuscateStatsGroup obfuscates sensitive data to enable APM Trace Metrics calculation
+func ObfuscateStatsGroup(o *obfuscate.Obfuscator, b *pb.ClientGroupedStats) {
 	switch b.Type {
 	case "sql", "cassandra":
 		oq, err := o.ObfuscateSQLString(b.Resource)

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -110,7 +110,7 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 	}
 }
 
-// ObfuscateStatsGroup obfuscates sensitive data to enable APM Trace Metrics calculation
+// ObfuscateStatsGroup obfuscates sensitive data in APM stats payloads
 func ObfuscateStatsGroup(o *obfuscate.Obfuscator, b *pb.ClientGroupedStats) {
 	switch b.Type {
 	case "sql", "cassandra":

--- a/pkg/trace/agent/obfuscate_test.go
+++ b/pkg/trace/agent/obfuscate_test.go
@@ -48,7 +48,8 @@ func TestObfuscateStatsGroup(t *testing.T) {
 	} {
 		agnt, stop := agentWithDefaults()
 		defer stop()
-		agnt.obfuscateStatsGroup(tt.in)
+		obfuscator := agnt.lazyInitObfuscator()
+		obfuscateStatsGroup(obfuscator, tt.in)
 		assert.Equal(t, tt.in.Resource, tt.out)
 	}
 }

--- a/pkg/trace/agent/obfuscate_test.go
+++ b/pkg/trace/agent/obfuscate_test.go
@@ -49,7 +49,7 @@ func TestObfuscateStatsGroup(t *testing.T) {
 		agnt, stop := agentWithDefaults()
 		defer stop()
 		obfuscator := agnt.lazyInitObfuscator()
-		obfuscateStatsGroup(obfuscator, tt.in)
+		ObfuscateStatsGroup(obfuscator, tt.in)
 		assert.Equal(t, tt.in.Resource, tt.out)
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
removes `*Agent` type receiver from obfuscateStatsGroup function and exports for use in other Datadog components

### Motivation
enable obfuscation for APM trace metrics for OTel Collector customers inside datadogconnector: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35401

We don't want to have to duplicate this function or duplicate instantiating an entire Agent inside datadogconnector component; if this is accepted and merged I can just import this function and pass in the obfuscator we instantiate there.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
made change to existing unit test

### Possible Drawbacks / Trade-offs
need to pass obfuscator pointer to the function instead of just calling on Agent struct pointer; any downstream dependencies that import this function

### Additional Notes
If we know that any other datadog or downstream dependencies are using this function currently; I'd be happy to break out a helper function that takes obfuscator as a pointer and keep the existing signature as a shell for compatibility. Let me know if this is the case
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->