### PR TITLE
[NPM-3662] Add sestatus to agent flare

### DIFF
--- a/cmd/system-probe/api/debug/handlers_linux.go
+++ b/cmd/system-probe/api/debug/handlers_linux.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+// Package debug contains handlers for debug information global to all of system-probe
+package debug
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os/exec"
+)
+
+// HandleSelinuxSestatus reports the output of sestatus as an http result
+func HandleSelinuxSestatus(w http.ResponseWriter, _ *http.Request) {
+	cmd := exec.Command("sestatus")
+	output, err := cmd.CombinedOutput()
+	// don't report ExitErrors since we are using the combined output which will already include stderr
+	if err != nil && !errors.Is(err, &exec.ExitError{}) {
+		fmt.Fprintf(w, "sestatus command failed: %s", err)
+		return
+	}
+
+	w.Write(output)
+}

--- a/cmd/system-probe/api/debug/handlers_nolinux.go
+++ b/cmd/system-probe/api/debug/handlers_nolinux.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build !linux
+
+// Package debug contains handlers for debug information global to all of system-probe
+package debug
+
+import (
+	"io"
+	"net/http"
+)
+
+// HandleSelinuxSestatus is not supported
+func HandleSelinuxSestatus(w http.ResponseWriter, _ *http.Request) {
+	io.WriteString(w, "HandleSelinuxSestatus is not supported on this platform")
+	w.WriteHeader(500)
+	return
+}

--- a/cmd/system-probe/api/debug/handlers_nolinux.go
+++ b/cmd/system-probe/api/debug/handlers_nolinux.go
@@ -17,5 +17,4 @@ import (
 func HandleSelinuxSestatus(w http.ResponseWriter, _ *http.Request) {
 	io.WriteString(w, "HandleSelinuxSestatus is not supported on this platform")
 	w.WriteHeader(500)
-	return
 }

--- a/cmd/system-probe/api/debug/handlers_nolinux.go
+++ b/cmd/system-probe/api/debug/handlers_nolinux.go
@@ -15,6 +15,6 @@ import (
 
 // HandleSelinuxSestatus is not supported
 func HandleSelinuxSestatus(w http.ResponseWriter, _ *http.Request) {
-	io.WriteString(w, "HandleSelinuxSestatus is not supported on this platform")
 	w.WriteHeader(500)
+	io.WriteString(w, "HandleSelinuxSestatus is not supported on this platform")
 }

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -15,6 +15,7 @@ import (
 
 	gorilla "github.com/gorilla/mux"
 
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/debug"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/server"
 	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
@@ -58,6 +59,7 @@ func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmet
 
 	if runtime.GOOS == "linux" {
 		mux.HandleFunc("/debug/ebpf_btf_loader_info", ebpf.HandleBTFLoaderInfo)
+		mux.HandleFunc("/debug/selinux_sestatus", debug.HandleSelinuxSestatus)
 	}
 
 	go func() {

--- a/pkg/ebpf/debug_handlers.go
+++ b/pkg/ebpf/debug_handlers.go
@@ -6,10 +6,9 @@
 package ebpf
 
 import (
+	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // HandleBTFLoaderInfo responds with where the system-probe found BTF data (and
@@ -17,7 +16,7 @@ import (
 func HandleBTFLoaderInfo(w http.ResponseWriter, _ *http.Request) {
 	info, err := GetBTFLoaderInfo()
 	if err != nil {
-		log.Errorf("unable to get ebpf_btf_loader info: %s", err)
+		fmt.Fprintf(w, "unable to get ebpf_btf_loader info: %s", err)
 		w.WriteHeader(500)
 		return
 	}

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -38,6 +38,7 @@ func addSystemProbePlatformSpecificEntries(fb flaretypes.FlareBuilder) {
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "conntrack_cached.log"), getSystemProbeConntrackCached)
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "conntrack_host.log"), getSystemProbeConntrackHost)
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "ebpf_btf_loader.log"), getSystemProbeBTFLoaderInfo)
+		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "selinux_sestatus.log"), getSystemProbeSelinuxSestatus)
 	}
 }
 
@@ -146,5 +147,11 @@ func getSystemProbeConntrackHost() ([]byte, error) {
 func getSystemProbeBTFLoaderInfo() ([]byte, error) {
 	sysProbeClient := sysprobeclient.Get(getSystemProbeSocketPath())
 	url := sysprobeclient.DebugURL("/ebpf_btf_loader_info")
+	return getHTTPData(sysProbeClient, url)
+}
+
+func getSystemProbeSelinuxSestatus() ([]byte, error) {
+	sysProbeClient := sysprobeclient.Get(getSystemProbeSocketPath())
+	url := sysprobeclient.DebugURL("/debug/selinux_sestatus")
 	return getHTTPData(sysProbeClient, url)
 }

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -152,6 +152,6 @@ func getSystemProbeBTFLoaderInfo() ([]byte, error) {
 
 func getSystemProbeSelinuxSestatus() ([]byte, error) {
 	sysProbeClient := sysprobeclient.Get(getSystemProbeSocketPath())
-	url := sysprobeclient.DebugURL("/debug/selinux_sestatus")
+	url := sysprobeclient.DebugURL("/selinux_sestatus")
 	return getHTTPData(sysProbeClient, url)
 }

--- a/releasenotes/notes/agent-flare-sestatus-5820cfc79ec91d1f.yaml
+++ b/releasenotes/notes/agent-flare-sestatus-5820cfc79ec91d1f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added the output of ``sestatus`` into the Agent flare. This information will appear in ``system-probe/selinux_sestatus.log``.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This probe writes the output of `sestatus` to `system-probe/selinux_sestatus.log`.

This PR is a rebase of #31088 on top of Bryce's SystemProbeUtil refactors.
### Motivation
Various distros ship selinux by default and this is useful for support on customers deploying selinux.
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run system-probe and check `curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/debug/selinux_sestatus`
Run a flare and check `system-probe/selinux_sestatus.log`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->