### PR TITLE
add agent 6 schedule to create rc pr workflow

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -96,9 +96,9 @@ jobs:
                 WARNING: ${{ needs.find_release_branches.outputs.warning }}
               run: |
                 if [ -n "${{ needs.find_release_branches.outputs.warning }}" ]; then
-                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" "$WARNING" | tail -n 1)" >> $GITHUB_OUTPUT
+                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" "$WARNING")" >> $GITHUB_OUTPUT
                 else
-                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" | tail -n 1)" >> $GITHUB_OUTPUT
+                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX")" >> $GITHUB_OUTPUT
                 fi
 
             - name: Create RC PR
@@ -107,7 +107,7 @@ jobs:
                 MATRIX: ${{ matrix.value }}
               run: |
                 if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then
-                  inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }} --github-action --patch-version
+                  inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }} --patch-version
                 else
-                  inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }} --github-action
+                  inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }}
                 fi

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -5,10 +5,12 @@ on:
   schedule:
     - cron: '0 14 * * 1,3,5' # Run on Monday, Wednesday, and Friday at 14:00 UTC
     - cron: '0 8 * * 1,3,5' # Same as above but at 08:00 UTC, to warn agent-integrations team about releasing
+    - cron: '0 9 * * 1' # Run Agent 6 workflow on Monday at 09:00 UTC
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+  AGENT6_RELEASE_BRANCH: '6.53.x'
+  IS_AGENT6_RELEASE: ${{ github.event.schedule == '0 9 * * 1' }}
 permissions: {}
 
 jobs:
@@ -19,18 +21,21 @@ jobs:
           warning: ${{ steps.warning.outputs.value }}
         steps:
             - name: Checkout repository
+              if: ${{ env.IS_AGENT6_RELEASE == 'false' }}
               uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
               with:
                 sparse-checkout: 'tasks'
                 persist-credentials: false
 
             - name: Install python
+              if: ${{ env.IS_AGENT6_RELEASE == 'false' }}
               uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
               with:
                 python-version: 3.11
                 cache: "pip"
 
             - name: Install Python dependencies
+              if: ${{ env.IS_AGENT6_RELEASE == 'false' }}
               run: |
                 python -m pip install --upgrade pip
                 pip install -r requirements.txt
@@ -40,7 +45,11 @@ jobs:
             - name: Determine the release active branches
               id: branches
               run: |
-                echo "value=$(inv release.get-unreleased-release-branches)" >> $GITHUB_OUTPUT
+                if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then
+                  echo "value=[\"$AGENT6_RELEASE_BRANCH\"]" >> $GITHUB_OUTPUT
+                else
+                  echo "value=$(inv release.get-unreleased-release-branches)" >> $GITHUB_OUTPUT
+                fi
 
             - name: Set the warning option
               id: warning
@@ -87,17 +96,18 @@ jobs:
                 WARNING: ${{ needs.find_release_branches.outputs.warning }}
               run: |
                 if [ -n "${{ needs.find_release_branches.outputs.warning }}" ]; then
-                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" "$WARNING")" >> $GITHUB_OUTPUT
+                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" "$WARNING" | tail -n 1)" >> $GITHUB_OUTPUT
                 else
-                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX")" >> $GITHUB_OUTPUT
+                  echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX" | tail -n 1)" >> $GITHUB_OUTPUT
                 fi
 
             - name: Create RC PR
-              if: ${{ steps.check_for_changes.outputs.CHANGES == 'true'}}
+              if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || env.IS_AGENT6_RELEASE == 'true' }}
               env:
                 MATRIX: ${{ matrix.value }}
               run: |
-                git config user.name "github-actions[bot]"
-                git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                git fetch
-                inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }}
+                if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then
+                  inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }} --github-action --patch-version
+                else
+                  inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }} --github-action
+                fi

--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -14,7 +14,7 @@ from invoke.tasks import task
 from tasks.go import tidy
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.common.color import Color, color_message
-from tasks.libs.common.git import check_uncommitted_changes
+from tasks.libs.common.git import check_uncommitted_changes, get_git_config, revert_git_config, set_git_config
 
 LICENSE_HEADER = """// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
@@ -500,23 +500,6 @@ def update(ctx):
     updater = CollectorVersionUpdater()
     updater.update()
     print("Update complete.")
-
-
-def get_git_config(key):
-    result = subprocess.run(['git', 'config', '--get', key], capture_output=True, text=True)
-    return result.stdout.strip() if result.returncode == 0 else None
-
-
-def set_git_config(key, value):
-    subprocess.run(['git', 'config', key, value])
-
-
-def revert_git_config(original_config):
-    for key, value in original_config.items():
-        if value is None:
-            subprocess.run(['git', 'config', '--unset', key])
-        else:
-            subprocess.run(['git', 'config', key, value])
 
 
 @task()

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-import sys
 import subprocess
+import sys
 import tempfile
 from contextlib import contextmanager
 from time import sleep

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import sys
+import subprocess
 import tempfile
 from contextlib import contextmanager
 from time import sleep
@@ -292,3 +293,20 @@ def get_last_release_tag(ctx, repo, pattern):
             last_tag_name = last_tag_name_with_suffix.removesuffix("^{}")
     last_tag_name = last_tag_name.removeprefix("refs/tags/")
     return last_tag_commit, last_tag_name
+
+
+def get_git_config(key):
+    result = subprocess.run(['git', 'config', '--get', key], capture_output=True, text=True)
+    return result.stdout.strip() if result.returncode == 0 else None
+
+
+def set_git_config(key, value):
+    subprocess.run(['git', 'config', key, value])
+
+
+def revert_git_config(original_config):
+    for key, value in original_config.items():
+        if value is None:
+            subprocess.run(['git', 'config', '--unset', key])
+        else:
+            subprocess.run(['git', 'config', key, value])

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -397,7 +397,7 @@ def finish(ctx, release_branch, upstream="origin"):
 
 
 @task(help={'upstream': "Remote repository name (default 'origin')"})
-def create_rc(ctx, release_branch, patch_version=False, upstream="origin", slack_webhook=None, github_action=False):
+def create_rc(ctx, release_branch, patch_version=False, upstream="origin", slack_webhook=None):
     """Updates the release entries in release.json to prepare the next RC build.
 
     If the previous version of the Agent (determined as the latest tag on the
@@ -437,6 +437,7 @@ def create_rc(ctx, release_branch, patch_version=False, upstream="origin", slack
 
     with agent_context(ctx, release_branch):
         github = GithubAPI(repository=GITHUB_REPO_NAME)
+        github_action = os.environ.get("GITHUB_ACTIONS")
 
         if github_action:
             set_git_config('user.name', 'github-actions[bot]')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add a weekly schedule to the create rc pr workflow for agent 6 release candidates. [ACIX-454](https://datadoghq.atlassian.net/browse/ACIX-454)
- change `find_release_branches` job to return `[6.53.x]` when it is for a6
- use `--patch-version` for `inv release.create-rc` to bump to the right version after a final version (`6.53.x-rc-1`)
- skip `yes_no_question` user interaction because it is a github workflow
- reuse the `set_git_config` function from this [OTel PR](https://github.com/DataDog/datadog-agent/pull/31545/files#diff-909ceda28445b406c806e55409c5e4853ba7f58c2bb4e1b4ef43c3f781a7606dR509)

### Motivation
We want to ensure that agent 6 can be released at any point. So a weekly rc will be run to test that the agent 6 pipeline works. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
created a [test branch](https://github.com/DataDog/datadog-agent/compare/sabrina/a6-workflow...sabrina/a6-workflow-test) to simulate when:
 - it is a weekly agent 6 rc cron job: [PR](https://github.com/DataDog/datadog-agent/pull/32078) that was created from [successful workflow](https://github.com/DataDog/datadog-agent/actions/runs/12290204973)
 - it is a agent 7 rc cron job: [PR](https://github.com/DataDog/datadog-agent/pull/32077) that was created from [successful workflow](https://github.com/DataDog/datadog-agent/actions/runs/12290082901)


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[ACIX-454]: https://datadoghq.atlassian.net/browse/ACIX-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ