### PR TITLE
feat(installer): Publish install scripts on installtesting.datad0g.com on success on main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -282,6 +282,9 @@ variables:
 .if_main_branch: &if_main_branch
   if: $CI_COMMIT_BRANCH == "main"
 
+.if_not_main_branch: &if_not_main_branch
+  if: $CI_COMMIT_BRANCH != "main"
+
 .if_release_branch: &if_release_branch
   if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
 
@@ -627,6 +630,10 @@ workflow:
       compare_to: main
     variables:
       FAST_TESTS: "true"
+
+.only_main:
+  - <<: *if_not_main_branch
+    when: never
 
 .except_main_or_release_branch:
   - <<: *if_main_branch

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -114,9 +114,9 @@ deploy_packages*                       @DataDog/agent-delivery
 deploy_staging*                        @DataDog/agent-delivery
 publish_winget*                        @DataDog/windows-agent
 powershell_script_deploy               @DataDog/windows-agent
-windows_bootstrapper_deploy             @DataDog/windows-agent
+windows_bootstrapper_deploy            @DataDog/windows-agent
 qa_*_oci                               @DataDog/agent-delivery
-qa_installer_script                    @DataDog/agent-delivery
+qa_installer_script*                   @DataDog/agent-delivery
 
 # Deploy containers
 deploy_containers*                     @Datadog/agent-delivery

--- a/.gitlab/e2e_install_packages/include.yml
+++ b/.gitlab/e2e_install_packages/include.yml
@@ -9,3 +9,4 @@ include:
   - .gitlab/e2e_install_packages/centos.yml
   - .gitlab/e2e_install_packages/suse.yml
   - .gitlab/e2e_install_packages/windows.yml
+  - .gitlab/e2e_install_packages/installer.yml

--- a/.gitlab/e2e_install_packages/installer.yml
+++ b/.gitlab/e2e_install_packages/installer.yml
@@ -1,0 +1,15 @@
+qa_installer_script_main:
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  stage: e2e_install_packages
+  tags: ["arch:amd64"]
+  rules:
+    - !reference [.only_main] # Disable non-main branch. Must be first.
+    - !reference [.on_installer_or_e2e_changes]
+    - !reference [.manual]
+  needs:
+    - new-e2e-installer-script
+    - installer-install-scripts
+  before_script:
+    - ls $OMNIBUS_PACKAGE_DIR
+  script:
+    - $S3_CP_CMD --recursive --exclude "*" --include "install-*.sh" "$OMNIBUS_PACKAGE_DIR" "s3://${INSTALLER_TESTING_S3_BUCKET}/scripts/"


### PR DESCRIPTION
### What does this PR do?
Adds a new job to "promote" the installer install scripts on `main` if they pass E2E tests. That way internal customers of script flavors will be able to test them on their infrastructure before merging.

Deployed url: https://installtesting.datad0g.com/scripts/install-databricks.sh

### Describe how you validated your changes
Changed the trigger to use this branch and checked on the target bucket

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->