### PR TITLE
feat(notify): Add conductor scheduled pipelines to the notification rules

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -28,23 +28,8 @@ notify:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt
-    - |
-      # Do not send notifications if this is a child pipeline of another repo
-      # The triggering repo should already have its own notification system
-      if [ "$CI_PIPELINE_SOURCE" != "pipeline" ]; then
-        if [ "$DEPLOY_AGENT" = "true" ]; then
-          invoke -e notify.send-message --notification-type "deploy"
-        elif [ "$CI_PIPELINE_SOURCE" != "push" ]; then
-          invoke -e notify.send-message --notification-type "trigger"
-        else
-          invoke -e notify.send-message --notification-type "merge"
-        fi
-        if [ "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH" ]; then
-          invoke notify.check-consistent-failures
-        fi
-      else
-        echo "This pipeline was triggered by another repository, skipping notification."
-      fi
+    - invoke -e notify.send-message
+    - invoke -e notify.check-consistent-failures
 
 send_pipeline_stats:
   stage: notify

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from typing import Any
 from urllib.parse import quote
@@ -43,3 +44,28 @@ def get_ci_visibility_job_url(
         extra_args = ''.join([f'&{key}={value}' for key, value in extra_args.items()])
 
     return CI_VISIBILITY_JOB_URL.format(name=name, extra_flags=extra_flags, extra_args=extra_args)
+
+
+def should_notify():
+    from tasks.libs.ciproviders.gitlab_api import get_pipeline
+
+    CONDUCTOR_ID = 8278
+    # agent = get_gitlab_repo()
+    # pipeline = agent.pipelines.get(os.environ['CI_PIPELINE_ID'])
+    pipeline = get_pipeline(PROJECT_NAME, os.environ['CI_PIPELINE_ID'])
+    if (
+        os.environ['CI_PIPELINE_SOURCE'] != 'pipeline'
+        or os.environ['CI_PIPELINE_SOURCE'] == 'pipeline'
+        and pipeline.user['id'] == CONDUCTOR_ID
+    ):
+        return True
+    return False
+
+
+def notification_type():
+    if os.environ['DEPLOY_AGENT'] == 'true':
+        return 'deploy'
+    elif os.environ['CI_PIPELINE_SOURCE'] != 'push':
+        return 'trigger'
+    else:
+        return 'merge'

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -47,22 +47,24 @@ def get_ci_visibility_job_url(
 
 
 def should_notify():
+    """
+    Check if the pipeline should notify the channel: only for non-downstream pipelines, unless conductor triggered it
+    """
     from tasks.libs.ciproviders.gitlab_api import get_pipeline
 
     CONDUCTOR_ID = 8278
-    # agent = get_gitlab_repo()
-    # pipeline = agent.pipelines.get(os.environ['CI_PIPELINE_ID'])
     pipeline = get_pipeline(PROJECT_NAME, os.environ['CI_PIPELINE_ID'])
-    if (
+    return (
         os.environ['CI_PIPELINE_SOURCE'] != 'pipeline'
         or os.environ['CI_PIPELINE_SOURCE'] == 'pipeline'
         and pipeline.user['id'] == CONDUCTOR_ID
-    ):
-        return True
-    return False
+    )
 
 
 def notification_type():
+    """
+    Return the type of notification to send (related to the type of pipeline, amongst 'deploy', 'trigger' and 'merge')
+    """
     if os.environ['DEPLOY_AGENT'] == 'true':
         return 'deploy'
     elif os.environ['CI_PIPELINE_SOURCE'] != 'push':

--- a/tasks/unit_tests/libs/notify/alerts_tests.py
+++ b/tasks/unit_tests/libs/notify/alerts_tests.py
@@ -30,10 +30,17 @@ def test_job_executions(path="tasks/unit_tests/testdata/job_executions.json"):
 
 
 class TestCheckConsistentFailures(unittest.TestCase):
+    @patch.dict(
+        'os.environ',
+        {
+            'CI_PIPELINE_ID': '456',
+            'CI_PIPELINE_SOURCE': 'push',
+            'CI_COMMIT_BRANCH': 'taylor-swift',
+            'CI_DEFAULT_BRANCH': 'taylor-swift',
+        },
+    )
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     def test_nominal(self, api_mock):
-        os.environ["CI_PIPELINE_ID"] = "456"
-
         repo_mock = api_mock.return_value.projects.get.return_value
         trace_mock = repo_mock.jobs.get.return_value.trace
         list_mock = repo_mock.pipelines.get.return_value.jobs.list
@@ -47,8 +54,28 @@ class TestCheckConsistentFailures(unittest.TestCase):
                 path,
             )
 
+        repo_mock.jobs.get.assert_called()
         trace_mock.assert_called()
         list_mock.assert_called()
+
+    @patch.dict(
+        'os.environ',
+        {
+            'CI_PIPELINE_ID': '456',
+            'CI_PIPELINE_SOURCE': 'push',
+            'CI_COMMIT_BRANCH': 'taylor',
+            'CI_DEFAULT_BRANCH': 'swift',
+        },
+    )
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_dismiss(self, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        with test_job_executions() as path:
+            notify.check_consistent_failures(
+                MockContext(run=Result("test")),
+                path,
+            )
+        repo_mock.jobs.get.assert_not_called()
 
 
 class TestAlertsRetrieveJobExecutionsCreated(unittest.TestCase):

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -31,22 +31,29 @@ def get_github_slack_map():
 
 
 class TestSendMessage(unittest.TestCase):
-    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'false', 'CI_PIPELINE_SOURCE': 'push', 'CI_PIPELINE_ID': '42'})
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
-    def test_merge(self, api_mock):
+    @patch('builtins.print')
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_merge(self, api_mock, print_mock):
         repo_mock = api_mock.return_value.projects.get.return_value
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.jobs.get.return_value.trace.return_value = b"Log trace"
         repo_mock.pipelines.get.return_value.ref = "test"
         list_mock = repo_mock.pipelines.get.return_value.jobs.list
         list_mock.side_effect = [get_fake_jobs(), []]
-        notify.send_message(MockContext(), notification_type="merge", dry_run=True)
+        notify.send_message(MockContext(), dry_run=True)
         list_mock.assert_called()
+        repo_mock.pipelines.get.assert_called_with('42')
+        self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
+        repo_mock.jobs.get.assert_called()
 
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'false', 'CI_PIPELINE_SOURCE': 'push', 'CI_PIPELINE_ID': '42'})
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('tasks.libs.notify.pipeline_status.get_failed_jobs')
+    @patch('builtins.print')
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
-    def test_merge_without_get_failed_call(self, get_failed_jobs_mock, api_mock):
+    def test_merge_without_get_failed_call(self, print_mock, get_failed_jobs_mock, api_mock):
         repo_mock = api_mock.return_value.projects.get.return_value
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.jobs.get.return_value.trace.return_value = b"Log trace"
@@ -114,9 +121,10 @@ class TestSendMessage(unittest.TestCase):
             )
         )
         get_failed_jobs_mock.return_value = failed
-        notify.send_message(MockContext(), notification_type="merge", dry_run=True)
-
+        notify.send_message(MockContext(), dry_run=True)
+        self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
         get_failed_jobs_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
 
     @patch("tasks.libs.owners.parsing.read_owners")
     def test_route_e2e_internal_error(self, read_owners_mock):
@@ -191,9 +199,11 @@ class TestSendMessage(unittest.TestCase):
         self.assertNotIn("@DataDog/agent-devx-loops", owners)
         self.assertNotIn("@DataDog/agent-delivery", owners)
 
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'false', 'CI_PIPELINE_SOURCE': 'push', 'CI_PIPELINE_ID': '42'})
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
-    def test_merge_with_get_failed_call(self, api_mock):
+    def test_merge_with_get_failed_call(self, print_mock, api_mock):
         repo_mock = api_mock.return_value.projects.get.return_value
         trace_mock = repo_mock.jobs.get.return_value.trace
         list_mock = repo_mock.pipelines.get.return_value.jobs.list
@@ -203,10 +213,80 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.pipelines.get.return_value.ref = "test"
 
-        notify.send_message(MockContext(), notification_type="merge", dry_run=True)
-
+        notify.send_message(MockContext(), dry_run=True)
+        self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
         trace_mock.assert_called()
         list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'true', 'CI_PIPELINE_SOURCE': 'push', 'CI_PIPELINE_ID': '42'})
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
+    @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    def test_deploy_with_get_failed_call(self, print_mock, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        trace_mock = repo_mock.jobs.get.return_value.trace
+        list_mock = repo_mock.pipelines.get.return_value.jobs.list
+
+        trace_mock.return_value = b"no basic auth credentials"
+        list_mock.return_value = get_fake_jobs()
+        repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
+        repo_mock.pipelines.get.return_value.ref = "test"
+
+        notify.send_message(MockContext(), dry_run=True)
+        self.assertTrue("rocket" in print_mock.mock_calls[0].args[0])
+        trace_mock.assert_called()
+        list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'false', 'CI_PIPELINE_SOURCE': 'api', 'CI_PIPELINE_ID': '42'})
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
+    @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    def test_trigger_with_get_failed_call(self, print_mock, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        trace_mock = repo_mock.jobs.get.return_value.trace
+        list_mock = repo_mock.pipelines.get.return_value.jobs.list
+
+        trace_mock.return_value = b"no basic auth credentials"
+        list_mock.return_value = get_fake_jobs()
+        repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
+        repo_mock.pipelines.get.return_value.ref = "test"
+
+        notify.send_message(MockContext(), dry_run=True)
+        self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
+        trace_mock.assert_called()
+        list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'false', 'CI_PIPELINE_SOURCE': 'pipeline', 'CI_PIPELINE_ID': '42'})
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
+    @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    def test_trigger_with_get_failed_call_conductor(self, print_mock, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        trace_mock = repo_mock.jobs.get.return_value.trace
+        list_mock = repo_mock.pipelines.get.return_value.jobs.list
+
+        trace_mock.return_value = b"no basic auth credentials"
+        list_mock.return_value = get_fake_jobs()
+        repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
+        repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.user.__getitem__.return_value = 8278
+
+        notify.send_message(MockContext(), dry_run=True)
+        self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
+        trace_mock.assert_called()
+        list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch.dict('os.environ', {'CI_PIPELINE_SOURCE': 'pipeline', 'CI_PIPELINE_ID': '42'})
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_dismiss_notification(self, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+
+        notify.send_message(MockContext(), dry_run=True)
+        repo_mock.jobs.get.assert_not_called()
 
     def test_post_to_channel1(self):
         self.assertFalse(pipeline_status.should_send_message_to_author("main", default_branch="main"))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add a rule to the notification system so that pipelines scheduled by conductor are reported to the agent-ci channels.
I took the opportunity to move the `notification decision` logic from the shell script to the python invoke task

### Motivation
Conductor nightly pipelines are important to monitor, but were dismissed so far because they are `downstream` pipelines. We can filter them in using the pipeline user id (this information is not available on the gitlab [predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)

https://datadoghq.atlassian.net/browse/ACIX-507


### Describe how you validated your changes
I added some unit/integrated tests on this topic
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->