### PR TITLE
omnibus: build python, openssl & FIPS provider on Windows

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -47,9 +47,8 @@
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
   artifacts:
     expire_in: 2 weeks
-    when: always
     paths:
-      - omnibus/dbg
+      - omnibus/pkg
 
 .windows_main_agent_base:
   extends: .windows_msi_base

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -47,8 +47,9 @@
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
   artifacts:
     expire_in: 2 weeks
+    when: always
     paths:
-      - omnibus/pkg
+      - omnibus/dbg
 
 .windows_main_agent_base:
   extends: .windows_msi_base

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -339,6 +339,23 @@ if windows_target?
       "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll"
     ]
 
+    # Sign additional binaries from here.
+    # We can't request signing from the respective components/software definitions
+    # for now since the binaries may be restored from cache, which would
+    # shortcut the associated build directives, which would not schedule the files
+    # for signing.
+    BINARIES_TO_SIGN += [
+      "#{windows_safe_path(python_3_embedded)}\\python.exe",
+      "#{windows_safe_path(python_3_embedded)}\\python3.dll",
+      "#{windows_safe_path(python_3_embedded)}\\python312.dll",
+      "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3-x64.dll",
+      "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3-x64.dll",
+      "#{windows_safe_path(python_3_embedded)}\\bin\\openssl.exe",
+    ]
+    if fips_mode?
+      BINARIES_TO_SIGN += "#{windows_safe_path(python_3_embedded)}\\lib\\ossl-modules\\fips.dll"
+    end
+
     BINARIES_TO_SIGN.each do |bin|
       sign_file bin
     end

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -334,27 +334,27 @@ if windows_target?
   end
 
   if windows_signing_enabled?
-    BINARIES_TO_SIGN = GO_BINARIES + [
-      "#{install_dir}\\bin\\agent\\ddtray.exe",
-      "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll"
-    ]
-
     # Sign additional binaries from here.
     # We can't request signing from the respective components/software definitions
     # for now since the binaries may be restored from cache, which would
     # shortcut the associated build directives, which would not schedule the files
     # for signing.
-    BINARIES_TO_SIGN += [
+    PYTHON_BINARIES = [
       "#{python_3_embedded}\\python.exe",
       "#{python_3_embedded}\\python3.dll",
       "#{python_3_embedded}\\python312.dll",
+    ]
+    OPENSSL_BINARIES = [
       "#{python_3_embedded}\\DLLs\\libcrypto-3-x64.dll",
       "#{python_3_embedded}\\DLLs\\libssl-3-x64.dll",
       "#{python_3_embedded}\\bin\\openssl.exe",
+      fips_mode? ? "#{python_3_embedded}\\lib\\ossl-modules\\fips.dll" : nil,
+    ].compact
+
+    BINARIES_TO_SIGN = GO_BINARIES + PYTHON_BINARIES + OPENSSL_BINARIES + [
+      "#{install_dir}\\bin\\agent\\ddtray.exe",
+      "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll"
     ]
-    if fips_mode?
-      BINARIES_TO_SIGN += "#{python_3_embedded}\\lib\\ossl-modules\\fips.dll"
-    end
 
     BINARIES_TO_SIGN.each do |bin|
       sign_file bin

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -333,7 +333,7 @@ if windows_target?
     windows_symbol_stripping_file bin
   end
 
-  if ENV['SIGN_WINDOWS_DD_WCS']
+  if windows_signing_enabled?
     BINARIES_TO_SIGN = GO_BINARIES + [
       "#{install_dir}\\bin\\agent\\ddtray.exe",
       "#{install_dir}\\bin\\agent\\libdatadog-agent-three.dll"

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -341,6 +341,7 @@ if windows_target?
     # for signing.
     PYTHON_BINARIES = [
       "#{python_3_embedded}\\python.exe",
+      "#{python_3_embedded}\\pythonw.exe",
       "#{python_3_embedded}\\python3.dll",
       "#{python_3_embedded}\\python312.dll",
     ]

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -345,15 +345,15 @@ if windows_target?
     # shortcut the associated build directives, which would not schedule the files
     # for signing.
     BINARIES_TO_SIGN += [
-      "#{windows_safe_path(python_3_embedded)}\\python.exe",
-      "#{windows_safe_path(python_3_embedded)}\\python3.dll",
-      "#{windows_safe_path(python_3_embedded)}\\python312.dll",
-      "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3-x64.dll",
-      "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3-x64.dll",
-      "#{windows_safe_path(python_3_embedded)}\\bin\\openssl.exe",
+      "#{python_3_embedded}\\python.exe",
+      "#{python_3_embedded}\\python3.dll",
+      "#{python_3_embedded}\\python312.dll",
+      "#{python_3_embedded}\\DLLs\\libcrypto-3-x64.dll",
+      "#{python_3_embedded}\\DLLs\\libssl-3-x64.dll",
+      "#{python_3_embedded}\\bin\\openssl.exe",
     ]
     if fips_mode?
-      BINARIES_TO_SIGN += "#{windows_safe_path(python_3_embedded)}\\lib\\ossl-modules\\fips.dll"
+      BINARIES_TO_SIGN += "#{python_3_embedded}\\lib\\ossl-modules\\fips.dll"
     end
 
     BINARIES_TO_SIGN.each do |bin|

--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -6,9 +6,9 @@ description "Enforce building dependencies as soon as possible so they can be ca
 if linux_target?
   dependency 'procps-ng'
   dependency 'curl'
-  if fips_mode?
-    dependency 'openssl-fips-provider'
-  end
+end
+if fips_mode?
+  dependency 'openssl-fips-provider'
 end
 
 # Bundled cacerts file (is this a good idea?)

--- a/omnibus/config/software/openssl-fips-provider.rb
+++ b/omnibus/config/software/openssl-fips-provider.rb
@@ -56,9 +56,6 @@ build do
       copy "/usr/local/lib*/ossl-modules/fips.so", "#{dest}/lib/ossl-modules/fips.so"
     elsif windows_target?
       copy "providers/fips.dll", "#{dest}/lib/ossl-modules/fips.dll"
-      if windows_signing_enabled?
-        project.sign_file "#{dest}/lib/ossl-modules/fips.dll"
-      end
     end
 
     erb source: "openssl.cnf.erb",

--- a/omnibus/config/software/openssl-fips-provider.rb
+++ b/omnibus/config/software/openssl-fips-provider.rb
@@ -62,8 +62,10 @@ build do
         dest: "#{dest}/ssl/openssl.cnf.tmp",
         mode: 0644,
         vars: { install_dir: install_dir }
-    erb source: "fipsinstall.sh.erb",
-        dest: "#{dest}/bin/fipsinstall.sh",
-        mode: 0755,
-        vars: { install_dir: install_dir }
+    if windows_target?
+      erb source: "fipsinstall.sh.erb",
+          dest: "#{dest}/bin/fipsinstall.sh",
+          mode: 0755,
+          vars: { install_dir: install_dir }
+    end
 end

--- a/omnibus/config/software/openssl-fips-provider.rb
+++ b/omnibus/config/software/openssl-fips-provider.rb
@@ -62,7 +62,7 @@ build do
         dest: "#{dest}/ssl/openssl.cnf.tmp",
         mode: 0644,
         vars: { install_dir: install_dir }
-    if windows_target?
+    unless windows_target?
       erb source: "fipsinstall.sh.erb",
           dest: "#{dest}/bin/fipsinstall.sh",
           mode: 0755,

--- a/omnibus/config/software/openssl-fips-provider.rb
+++ b/omnibus/config/software/openssl-fips-provider.rb
@@ -57,7 +57,7 @@ build do
     elsif windows_target?
       copy "providers/fips.dll", "#{dest}/lib/ossl-modules/fips.dll"
       if windows_signing_enabled?
-        sign_file "#{dest}/lib/ossl-modules/fips.dll"
+        project.sign_file "#{dest}/lib/ossl-modules/fips.dll"
       end
     end
 

--- a/omnibus/config/software/openssl-fips-provider.rb
+++ b/omnibus/config/software/openssl-fips-provider.rb
@@ -56,6 +56,9 @@ build do
       copy "/usr/local/lib*/ossl-modules/fips.so", "#{dest}/lib/ossl-modules/fips.so"
     elsif windows_target?
       copy "providers/fips.dll", "#{dest}/lib/ossl-modules/fips.dll"
+      if windows_signing_enabled?
+        sign_file "#{dest}/lib/ossl-modules/fips.dll"
+      end
     end
 
     erb source: "openssl.cnf.erb",

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -107,12 +107,17 @@ build do
     # -e to enable external libraries. They won't be fetched if already
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
-    command "dir PCbuild/#{python_arch}/"
-    # Install the build artifact to their expected locations
+    command "ls -lR PCbuild/#{python_arch}/"
+    # Install the built artifacts to their expected locations
     copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"
     copy "PCbuild/#{python_arch}/*.dll", "#{windows_safe_path(python_3_embedded)}/"
+
     mkdir "#{windows_safe_path(python_3_embedded)}/DLLs"
     copy "PCbuild/#{python_arch}/*.pyd", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    copy "PCbuild/#{python_arch}/*.ico", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    copy "PCbuild/#{python_arch}/*.cat", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    copy "PCbuild/#{python_arch}/*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+
     mkdir "#{windows_safe_path(python_3_embedded)}/libs"
     copy "PCbuild/#{python_arch}/*.lib", "#{windows_safe_path(python_3_embedded)}/libs"
     copy "Lib", "#{windows_safe_path(python_3_embedded)}/"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -111,12 +111,13 @@ build do
     command "ls -lR PCbuild/#{python_arch}/"
     # Install the built artifacts to their expected locations
     copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"
+    move "PCbuild/#{python_arch}/sqlite*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
     copy "PCbuild/#{python_arch}/*.dll", "#{windows_safe_path(python_3_embedded)}/"
 
     mkdir "#{windows_safe_path(python_3_embedded)}/DLLs"
     copy "PCbuild/#{python_arch}/*.pyd", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    copy "PCbuild/#{python_arch}/*.ico", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    copy "PCbuild/#{python_arch}/*.cat", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    # copy "PCbuild/#{python_arch}/*.ico", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    # copy "PCbuild/#{python_arch}/*.cat", "#{windows_safe_path(python_3_embedded)}/DLLs/"
     copy "PCbuild/#{python_arch}/*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
 
     mkdir "#{windows_safe_path(python_3_embedded)}/libs"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -122,8 +122,8 @@ build do
     # the OpenSSL build, so we need to copy those files to the install directory.
     # The ones we copied for the build are now irrelevant
     openssl_arch = "x64"
-    move "#{install_dir}\\embedded3\\bin\\libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
-    move "#{install_dir}\\embedded3\\bin\\libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
+    copy "#{install_dir}\\embedded3\\bin\\libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
+    copy "#{install_dir}\\embedded3\\bin\\libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
     # Generate libpython3XY.a for MinGW tools
     # https://docs.python.org/3/whatsnew/3.8.html
     command "gendef #{windows_safe_path(python_3_embedded)}\\python312.dll"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -141,6 +141,17 @@ build do
 
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"
+
+    # Sign the binaries
+    if windows_signing_enabled?
+      sign_file python
+      sign_file "#{windows_safe_path(python_3_embedded)}\\python3.dll"
+      sign_file "#{windows_safe_path(python_3_embedded)}\\python312.dll"
+      sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3.dll"
+      sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3.dll"
+      sign_file "#{windows_safe_path(python_3_embedded)}\\bin\\openssl.exe"
+
+    end
   end
 end
 

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -145,13 +145,12 @@ build do
 
     # Sign the binaries
     if windows_signing_enabled?
-      sign_file python
-      sign_file "#{windows_safe_path(python_3_embedded)}\\python3.dll"
-      sign_file "#{windows_safe_path(python_3_embedded)}\\python312.dll"
-      sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3.dll"
-      sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3.dll"
-      sign_file "#{windows_safe_path(python_3_embedded)}\\bin\\openssl.exe"
-
+      project.sign_file python
+      project.sign_file "#{windows_safe_path(python_3_embedded)}\\python3.dll"
+      project.sign_file "#{windows_safe_path(python_3_embedded)}\\python312.dll"
+      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3.dll"
+      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3.dll"
+      project.sign_file "#{windows_safe_path(python_3_embedded)}\\bin\\openssl.exe"
     end
   end
 end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -126,6 +126,11 @@ build do
     copy "PCbuild\\#{python_arch}\\*.lib", "#{windows_safe_path(python_3_embedded)}\\libs"
     copy "Lib", "#{windows_safe_path(python_3_embedded)}\\"
 
+    # Copy the same icon files that we used to ship from the python installer
+    copy "PC\\icons\\py.ico", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
+    copy "PC\\icons\\pyc.ico", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
+    copy "PC\\icons\\pyd.ico", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
+
     ###############################
     # Install build artifacts...  #
     ###############################

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -111,8 +111,10 @@ build do
     mkdir "#{windows_safe_path(python_3_embedded)}/DLLs"
     copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"
     move "PCbuild/#{python_arch}\\sqlite*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    move "PCbuild/#{python_arch}\\libssl-3.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    move "PCbuild/#{python_arch}\\libcrypto-3.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    # We can also remove the DLLs that were put there by the python build before copying all other DLLs
+    # since they won't be loaded anyway
+    delete "#{windows_safe_path(python_3_embedded)}/libcrypto-3.dll"
+    delete "#{windows_safe_path(python_3_embedded)}/libssl-3.dll"
     move "PCbuild/#{python_arch}\\libffi*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
     copy "PCbuild/#{python_arch}\\*.dll", "#{windows_safe_path(python_3_embedded)}/"
 
@@ -133,11 +135,8 @@ build do
     # the OpenSSL build, so we need to copy those files to the install directory.
     # The ones we copied for the build are now irrelevant
     openssl_arch = "x64"
-    copy "#{install_dir}/embedded3/bin/libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
-    copy "#{install_dir}/embedded3/bin/libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
-    # We can also remove the DLLs that were put there by the python build since they won't be loaded anyway
-    delete "#{windows_safe_path(python_3_embedded)}/libcrypto-3.dll"
-    delete "#{windows_safe_path(python_3_embedded)}/libssl-3.dll"
+    move "#{install_dir}/embedded3/bin/libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
+    move "#{install_dir}/embedded3/bin/libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
 
     copy "Include", "#{windows_safe_path(python_3_embedded)}\\include"
     copy "PC/pyconfig.h", "#{windows_safe_path(python_3_embedded)}\\include\\"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -75,6 +75,10 @@ build do
     # Setup openssl dependency... #
     ###############################
 
+    # We must provide python with the same file hierarchy as
+    # https://github.com/python/cpython-bin-deps/tree/openssl-bin-3.0/amd64
+    # but with our OpenSSL build instead.
+
     # This is not necessarily the version we built, but the version
     # the Python build system expects.
     openssl_version = "3.0.15"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -107,8 +107,6 @@ build do
     # -e to enable external libraries. They won't be fetched if already
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
-    copy "PCBuild/", "C:\\mnt\\omnibus\\dbg"
-    command "ls -lR PCbuild/#{python_arch}/"
     # Install the built artifacts to their expected locations
     mkdir "#{windows_safe_path(python_3_embedded)}/DLLs"
     copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -109,27 +109,7 @@ build do
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
     # Install the built artifacts to their expected locations
-    mkdir "#{windows_safe_path(python_3_embedded)}\\DLLs"
-    copy "PCbuild\\#{python_arch}\\*.exe", "#{windows_safe_path(python_3_embedded)}\\"
-    move "PCbuild\\#{python_arch}\\sqlite*.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
-    # We can also remove the DLLs that were put there by the python build before copying all other DLLs
-    # since they won't be loaded anyway
-    delete "#{windows_safe_path(python_3_embedded)}\\libcrypto-3.dll"
-    delete "#{windows_safe_path(python_3_embedded)}\\libssl-3.dll"
-    move "PCbuild\\#{python_arch}\\libffi*.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
-    copy "PCbuild\\#{python_arch}\\*.dll", "#{windows_safe_path(python_3_embedded)}\\"
-
-    copy "PCbuild\\#{python_arch}\\*.pyd", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
-    copy "PCbuild\\#{python_arch}\\*.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
-
-    mkdir "#{windows_safe_path(python_3_embedded)}\\libs"
-    copy "PCbuild\\#{python_arch}\\*.lib", "#{windows_safe_path(python_3_embedded)}\\libs"
-    copy "Lib", "#{windows_safe_path(python_3_embedded)}\\"
-
-    # Copy the same icon files that we used to ship from the python installer
-    copy "PC\\icons\\py.ico", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
-    copy "PC\\icons\\pyc.ico", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
-    copy "PC\\icons\\pyd.ico", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
+    command "PCbuild\\#{python_arch}\\python.exe PC\\layout\\main.py --build PCbuild\\#{python_arch} --include-cat --precompile --copy #{windows_safe_path(python_3_embedded)} -vv"
 
     ###############################
     # Install build artifacts...  #

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -124,6 +124,10 @@ build do
     openssl_arch = "x64"
     move "#{install_dir}\\embedded3\\bin\\libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
     move "#{install_dir}\\embedded3\\bin\\libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
+    # Generate libpython3XY.a for MinGW tools
+    # https://docs.python.org/3/whatsnew/3.8.html
+    command "gendef #{windows_safe_path(python_3_embedded)}\\python312.dll"
+    command "dlltool --dllname python312.dll --def python312.def --output-lib #{windows_safe_path(python_3_embedded)}\\libs\\libpython312.a"
 
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -84,21 +84,21 @@ build do
     openssl_version = "3.0.15"
     python_arch = "amd64"
 
-    mkdir "externals/openssl-bin-#{openssl_version}/#{python_arch}/include"
+    mkdir "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\include"
     # Copy the import library to have them point at our own built versions, regardless of
     # their names in usual python builds
-    copy "#{install_dir}/embedded3/lib/libcrypto.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto.lib"
-    copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
-    copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
+    copy "#{install_dir}\\embedded3\\lib\\libcrypto.dll.a", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto.lib"
+    copy "#{install_dir}\\embedded3\\lib\\libssl.dll.a", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl.lib"
+    copy "#{install_dir}\\embedded3\\lib\\libssl.dll.a", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl.lib"
     # Copy the actual DLLs, be sure to keep the same name since that's what the IMPLIBs expect
     copy "#{install_dir}\\embedded3\\bin\\libssl-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl-3.dll"
-    command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl-3.pdb"
+    command "touch externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl-3.pdb"
     copy "#{install_dir}\\embedded3\\bin\\libcrypto-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto-3.dll"
-    command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto-3.pdb"
+    command "touch externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto-3.pdb"
     # The applink "header"
-    copy "#{install_dir}/embedded3/include/openssl/applink.c", "externals/openssl-bin-#{openssl_version}/#{python_arch}/include/"
+    copy "#{install_dir}\\embedded3\\include\\openssl\\applink.c", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\include\\"
     # And finally the headers:
-    copy "#{install_dir}/embedded3/include/openssl", "externals/openssl-bin-#{openssl_version}/#{python_arch}/include/"
+    copy "#{install_dir}\\embedded3\\include\\openssl", "externals\\openssl-bin-#{openssl_version}\#{python_arch}\\include\\"
     # Now build python itself...
 
     ###############################
@@ -108,24 +108,22 @@ build do
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
     # Install the built artifacts to their expected locations
-    mkdir "#{windows_safe_path(python_3_embedded)}/DLLs"
-    copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"
-    move "PCbuild/#{python_arch}\\sqlite*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    mkdir "#{windows_safe_path(python_3_embedded)}\\DLLs"
+    copy "PCbuild\\#{python_arch}\\*.exe", "#{windows_safe_path(python_3_embedded)}\\"
+    move "PCbuild\\#{python_arch}\\sqlite*.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
     # We can also remove the DLLs that were put there by the python build before copying all other DLLs
     # since they won't be loaded anyway
-    delete "#{windows_safe_path(python_3_embedded)}/libcrypto-3.dll"
-    delete "#{windows_safe_path(python_3_embedded)}/libssl-3.dll"
-    move "PCbuild/#{python_arch}\\libffi*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    copy "PCbuild/#{python_arch}\\*.dll", "#{windows_safe_path(python_3_embedded)}/"
+    delete "#{windows_safe_path(python_3_embedded)}\\libcrypto-3.dll"
+    delete "#{windows_safe_path(python_3_embedded)}\\libssl-3.dll"
+    move "PCbuild\\#{python_arch}\\libffi*.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
+    copy "PCbuild\\#{python_arch}\\*.dll", "#{windows_safe_path(python_3_embedded)}\\"
 
-    copy "PCbuild/#{python_arch}/*.pyd", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    # copy "PCbuild/#{python_arch}/*.ico", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    # copy "PCbuild/#{python_arch}/*.cat", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    copy "PCbuild/#{python_arch}/*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    copy "PCbuild\\#{python_arch}\\*.pyd", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
+    copy "PCbuild\\#{python_arch}\\*.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs\\"
 
-    mkdir "#{windows_safe_path(python_3_embedded)}/libs"
-    copy "PCbuild/#{python_arch}/*.lib", "#{windows_safe_path(python_3_embedded)}/libs"
-    copy "Lib", "#{windows_safe_path(python_3_embedded)}/"
+    mkdir "#{windows_safe_path(python_3_embedded)}\\libs"
+    copy "PCbuild\\#{python_arch}\\*.lib", "#{windows_safe_path(python_3_embedded)}\\libs"
+    copy "Lib", "#{windows_safe_path(python_3_embedded)}\\"
 
     ###############################
     # Install build artifacts...  #
@@ -135,11 +133,11 @@ build do
     # the OpenSSL build, so we need to copy those files to the install directory.
     # The ones we copied for the build are now irrelevant
     openssl_arch = "x64"
-    move "#{install_dir}/embedded3/bin/libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
-    move "#{install_dir}/embedded3/bin/libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
+    move "#{install_dir}\\embedded3\\bin\\libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
+    move "#{install_dir}\\embedded3\\bin\\libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
 
     copy "Include", "#{windows_safe_path(python_3_embedded)}\\include"
-    copy "PC/pyconfig.h", "#{windows_safe_path(python_3_embedded)}\\include\\"
+    copy "PC\\pyconfig.h", "#{windows_safe_path(python_3_embedded)}\\include\\"
 
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -141,8 +141,8 @@ build do
       project.sign_file python
       project.sign_file "#{windows_safe_path(python_3_embedded)}\\python3.dll"
       project.sign_file "#{windows_safe_path(python_3_embedded)}\\python312.dll"
-      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3.dll"
-      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3.dll"
+      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3-x64.dll"
+      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3-x64.dll"
       project.sign_file "#{windows_safe_path(python_3_embedded)}\\bin\\openssl.exe"
     end
   end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -91,9 +91,9 @@ build do
     copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
     copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
     # Copy the actual DLLs, be sure to keep the same name since that's what the IMPLIBs expect
-    copy "#{install_dir}\\embedded3\\bin\\libssl-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\DLLs\\libssl-3.dll"
+    copy "#{install_dir}\\embedded3\\bin\\libssl-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl-3.dll"
     command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl-3.pdb"
-    copy "#{install_dir}\\embedded3\\bin\\libcrypto-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\DLLs\\libcrypto-3.dll"
+    copy "#{install_dir}\\embedded3\\bin\\libcrypto-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto-3.dll"
     command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto-3.pdb"
     # The applink "header"
     copy "#{install_dir}/embedded3/include/openssl/applink.c", "externals/openssl-bin-#{openssl_version}/#{python_arch}/include/"
@@ -110,11 +110,14 @@ build do
     copy "PCBuild/", "C:\\mnt\\omnibus\\dbg"
     command "ls -lR PCbuild/#{python_arch}/"
     # Install the built artifacts to their expected locations
-    copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"
-    move "PCbuild/#{python_arch}/sqlite*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
-    copy "PCbuild/#{python_arch}/*.dll", "#{windows_safe_path(python_3_embedded)}/"
-
     mkdir "#{windows_safe_path(python_3_embedded)}/DLLs"
+    copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"
+    move "PCbuild/#{python_arch}\\sqlite*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    move "PCbuild/#{python_arch}\\libssl-3.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    move "PCbuild/#{python_arch}\\libcrypto-3.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    move "PCbuild/#{python_arch}\\libffi*.dll", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    copy "PCbuild/#{python_arch}\\*.dll", "#{windows_safe_path(python_3_embedded)}/"
+
     copy "PCbuild/#{python_arch}/*.pyd", "#{windows_safe_path(python_3_embedded)}/DLLs/"
     # copy "PCbuild/#{python_arch}/*.ico", "#{windows_safe_path(python_3_embedded)}/DLLs/"
     # copy "PCbuild/#{python_arch}/*.cat", "#{windows_safe_path(python_3_embedded)}/DLLs/"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -2,46 +2,47 @@ name "python3"
 
 default_version "3.12.6"
 
-if ohai["platform"] != "windows"
-
+unless windows?
   dependency "libxcrypt"
   dependency "libffi"
   dependency "ncurses"
   dependency "zlib"
-  dependency "openssl3"
   dependency "bzip2"
   dependency "libsqlite3"
   dependency "liblzma"
   dependency "libyaml"
+end
+dependency "openssl3"
 
-  source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "85a4c1be906d20e5c5a69f2466b00da769c221d6a684acfd3a514dbf5bf10a66"
+source :url => "https://python.org/ftp/python/#{version}/Python-#{version}.tgz",
+       :sha256 => "85a4c1be906d20e5c5a69f2466b00da769c221d6a684acfd3a514dbf5bf10a66"
 
-  relative_path "Python-#{version}"
+relative_path "Python-#{version}"
 
-  python_configure_options = [
-    "--without-readline",  # Disables readline support
-    "--with-ensurepip=yes" # We upgrade pip later, in the pip3 software definition
-  ]
+build do
+  # 2.0 is the license version here, not the python version
+  license "Python-2.0"
 
-  if mac_os_x?
-    python_configure_options.push("--enable-ipv6",
-                          "--with-universal-archs=intel",
-                          "--enable-shared")
-  elsif linux_target?
-    python_configure_options.push("--enable-shared",
-                          "--enable-ipv6")
-  elsif aix?
-    # something here...
-  end
-
-  python_configure_options.push("--with-dbmliborder=")
-
-  build do
-    # 2.0 is the license version here, not the python version
-    license "Python-2.0"
-
+  unless windows_target?
     env = with_standard_compiler_flags(with_embedded_path)
+    python_configure_options = [
+      "--without-readline",  # Disables readline support
+      "--with-ensurepip=yes" # We upgrade pip later, in the pip3 software definition
+    ]
+
+    if mac_os_x?
+      python_configure_options.push("--enable-ipv6",
+                            "--with-universal-archs=intel",
+                            "--enable-shared")
+    elsif linux_target?
+      python_configure_options.push("--enable-shared",
+                            "--enable-ipv6")
+    elsif aix?
+      # something here...
+    end
+
+    python_configure_options.push("--with-dbmliborder=")
+
     # Force different defaults for the "optimization settings"
     # This removes the debug symbol generation and doesn't enable all warnings
     env["OPT"] = "-DNDEBUG -fwrapv"
@@ -66,24 +67,71 @@ if ohai["platform"] != "windows"
     block do
       FileUtils.rm_f(Dir.glob("#{install_dir}/embedded/lib/python#{major}.#{minor}/distutils/command/wininst-*.exe"))
     end
-  end
+  else
+    dependency "vc_redist_14"
 
-else
-  dependency "vc_redist_14"
+    vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"
+    ###############################
+    # Setup openssl dependency... #
+    ###############################
 
-  # note that starting with 3.7.3 on Windows, the zip should be created without the built-in pip
-  source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
-         :sha256 => "045d20a659fe80041b6fd508b77f250b03330347d64f128b392b88e68897f5a0".downcase
+    # This is not necessarily the version we built, but the version
+    # the Python build system expects.
+    openssl_version = "3.0.15"
+    python_arch = "amd64"
 
-  vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"
-  build do
-    # 2.0 is the license version here, not the python version
-    license "Python-2.0"
+    mkdir "externals/openssl-bin-#{openssl_version}/#{python_arch}/include"
+    # Copy the import library to have them point at our own built versions, regardless of
+    # their names in usual python builds
+    copy "#{install_dir}/embedded3/lib/libcrypto.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto.lib"
+    copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
+    copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
+    # Copy the actual DLLs, be sure to keep the same name since that's what the IMPLIBs expect
+    copy "#{install_dir}/embedded3/bin/libssl-3-x64.dll", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl-3.dll"
+    command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl-3.pdb"
+    copy "#{install_dir}/embedded3/bin/libcrypto-3-x64.dll", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto-3.dll"
+    command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto-3.pdb"
+    # The applink "header"
+    copy "#{install_dir}/embedded3/include/openssl/applink.c", "externals/openssl-bin-#{openssl_version}/#{python_arch}/include/"
+    # And finally the headers:
+    copy "#{install_dir}/embedded3/include/openssl", "externals/openssl-bin-#{openssl_version}/#{python_arch}/include/"
+    # Now build python itself...
 
-    command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_3_embedded)}\""
+    ###############################
+    # Build Python...             #
+    ###############################
+    # -e to enable external libraries. They won't be fetched if already
+    # present, but the modules will be built nonetheless.
+    command "PCbuild\\build.bat -e --pgo"
+    command "dir PCbuild/#{python_arch}/"
+    # Install the build artifact to their expected locations
+    copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"
+    copy "PCbuild/#{python_arch}/*.dll", "#{windows_safe_path(python_3_embedded)}/"
+    mkdir "#{windows_safe_path(python_3_embedded)}/DLLs"
+    copy "PCbuild/#{python_arch}/*.pyd", "#{windows_safe_path(python_3_embedded)}/DLLs/"
+    mkdir "#{windows_safe_path(python_3_embedded)}/libs"
+    copy "PCbuild/#{python_arch}/*.lib", "#{windows_safe_path(python_3_embedded)}/libs"
+    copy "Lib", "#{windows_safe_path(python_3_embedded)}/"
 
-    # Install pip
+    ###############################
+    # Install build artifacts...  #
+    ###############################
+    # We copied the OpenSSL libraries with the name python expects to keep the build happy
+    # but at runtime, it will attempt to load the DLLs pointed at by the .dll.a generated by
+    # the OpenSSL build, so we need to copy those files to the install directory.
+    # The ones we copied for the build are now irrelevant
+    openssl_arch = "x64"
+    copy "#{install_dir}/embedded3/bin/libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
+    copy "#{install_dir}/embedded3/bin/libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}/DLLs"
+    # We can also remove the DLLs that were put there by the python build since they won't be loaded anyway
+    delete "#{windows_safe_path(python_3_embedded)}/libcrypto-3.dll"
+    delete "#{windows_safe_path(python_3_embedded)}/libssl-3.dll"
+
+    copy "Include", "#{windows_safe_path(python_3_embedded)}\\include"
+    copy "PC/pyconfig.h", "#{windows_safe_path(python_3_embedded)}\\include\\"
+
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"
   end
 end
+

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -124,6 +124,9 @@ build do
     openssl_arch = "x64"
     copy "#{install_dir}\\embedded3\\bin\\libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
     copy "#{install_dir}\\embedded3\\bin\\libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
+    # We can also remove the DLLs that were put there by the python build since they won't be loaded anyway
+    delete "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3.dll"
+    delete "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3.dll"
     # Generate libpython3XY.a for MinGW tools
     # https://docs.python.org/3/whatsnew/3.8.html
     command "gendef #{windows_safe_path(python_3_embedded)}\\python312.dll"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -135,16 +135,6 @@ build do
 
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"
-
-    # Sign the binaries
-    if windows_signing_enabled?
-      project.sign_file python
-      project.sign_file "#{windows_safe_path(python_3_embedded)}\\python3.dll"
-      project.sign_file "#{windows_safe_path(python_3_embedded)}\\python312.dll"
-      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libcrypto-3-x64.dll"
-      project.sign_file "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3-x64.dll"
-      project.sign_file "#{windows_safe_path(python_3_embedded)}\\bin\\openssl.exe"
-    end
   end
 end
 

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -92,6 +92,7 @@ build do
     copy "#{install_dir}\\embedded3\\lib\\libssl.dll.a", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl.lib"
     # Copy the actual DLLs, be sure to keep the same name since that's what the IMPLIBs expect
     copy "#{install_dir}\\embedded3\\bin\\libssl-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl-3.dll"
+    # Create empty PDBs since python's build system require those to be present
     command "touch externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libssl-3.pdb"
     copy "#{install_dir}\\embedded3\\bin\\libcrypto-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto-3.dll"
     command "touch externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\libcrypto-3.pdb"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -109,7 +109,10 @@ build do
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
     # Install the built artifacts to their expected locations
-    command "PCbuild\\#{python_arch}\\python.exe PC\\layout\\main.py --build PCbuild\\#{python_arch} --precompile --copy #{windows_safe_path(python_3_embedded)} -vv"
+    # --include-dev - include include/ and libs/ directories
+    # --include-venv - necessary for ensurepip to work
+    # --include-stable - adds python3.dll
+    command "PCbuild\\#{python_arch}\\python.exe PC\\layout\\main.py --build PCbuild\\#{python_arch} --precompile --copy #{windows_safe_path(python_3_embedded)} --include-dev --include-venv --include-stable -vv"
 
     ###############################
     # Install build artifacts...  #
@@ -121,9 +124,6 @@ build do
     openssl_arch = "x64"
     move "#{install_dir}\\embedded3\\bin\\libcrypto-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
     move "#{install_dir}\\embedded3\\bin\\libssl-3-#{openssl_arch}.dll", "#{windows_safe_path(python_3_embedded)}\\DLLs"
-
-    copy "Include", "#{windows_safe_path(python_3_embedded)}\\include"
-    copy "PC\\pyconfig.h", "#{windows_safe_path(python_3_embedded)}\\include\\"
 
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -99,7 +99,7 @@ build do
     # The applink "header"
     copy "#{install_dir}\\embedded3\\include\\openssl\\applink.c", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\include\\"
     # And finally the headers:
-    copy "#{install_dir}\\embedded3\\include\\openssl", "externals\\openssl-bin-#{openssl_version}\#{python_arch}\\include\\"
+    copy "#{install_dir}\\embedded3\\include\\openssl", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\include\\"
     # Now build python itself...
 
     ###############################

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -107,7 +107,7 @@ build do
     # -e to enable external libraries. They won't be fetched if already
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
-    copy "PCBuild/#{python_arch}", "C:\\mnt\\omnibus\\dbg"
+    copy "PCBuild/", "C:\\mnt\\omnibus\\dbg"
     command "ls -lR PCbuild/#{python_arch}/"
     # Install the built artifacts to their expected locations
     copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -107,7 +107,7 @@ build do
     # -e to enable external libraries. They won't be fetched if already
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
-    copy "PCBuild/#{python_arch}" "C:\\mnt\\omnibus\\dbg"
+    copy "PCBuild/#{python_arch}", "C:\\mnt\\omnibus\\dbg"
     command "ls -lR PCbuild/#{python_arch}/"
     # Install the built artifacts to their expected locations
     copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -109,7 +109,7 @@ build do
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
     # Install the built artifacts to their expected locations
-    command "PCbuild\\#{python_arch}\\python.exe PC\\layout\\main.py --build PCbuild\\#{python_arch} --include-cat --precompile --copy #{windows_safe_path(python_3_embedded)} -vv"
+    command "PCbuild\\#{python_arch}\\python.exe PC\\layout\\main.py --build PCbuild\\#{python_arch} --precompile --copy #{windows_safe_path(python_3_embedded)} -vv"
 
     ###############################
     # Install build artifacts...  #

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -91,9 +91,9 @@ build do
     copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
     copy "#{install_dir}/embedded3/lib/libssl.dll.a", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl.lib"
     # Copy the actual DLLs, be sure to keep the same name since that's what the IMPLIBs expect
-    copy "#{install_dir}/embedded3/bin/libssl-3-x64.dll", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl-3.dll"
+    copy "#{install_dir}\\embedded3\\bin\\libssl-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\DLLs\\libssl-3.dll"
     command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libssl-3.pdb"
-    copy "#{install_dir}/embedded3/bin/libcrypto-3-x64.dll", "externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto-3.dll"
+    copy "#{install_dir}\\embedded3\\bin\\libcrypto-3-x64.dll", "externals\\openssl-bin-#{openssl_version}\\#{python_arch}\\DLLs\\libcrypto-3.dll"
     command "touch externals/openssl-bin-#{openssl_version}/#{python_arch}/libcrypto-3.pdb"
     # The applink "header"
     copy "#{install_dir}/embedded3/include/openssl/applink.c", "externals/openssl-bin-#{openssl_version}/#{python_arch}/include/"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -129,8 +129,9 @@ build do
     delete "#{windows_safe_path(python_3_embedded)}\\DLLs\\libssl-3.dll"
     # Generate libpython3XY.a for MinGW tools
     # https://docs.python.org/3/whatsnew/3.8.html
-    command "gendef #{windows_safe_path(python_3_embedded)}\\python312.dll"
-    command "dlltool --dllname python312.dll --def python312.def --output-lib #{windows_safe_path(python_3_embedded)}\\libs\\libpython312.a"
+    major, minor, _ = version.split(".")
+    command "gendef #{windows_safe_path(python_3_embedded)}\\python#{major}#{minor}.dll"
+    command "dlltool --dllname python#{major}#{minor}.dll --def python#{major}#{minor}.def --output-lib #{windows_safe_path(python_3_embedded)}\\libs\\libpython#{major}#{minor}.a"
 
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"
     command "#{python} -m ensurepip"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -107,6 +107,7 @@ build do
     # -e to enable external libraries. They won't be fetched if already
     # present, but the modules will be built nonetheless.
     command "PCbuild\\build.bat -e --pgo"
+    copy "PCBuild/#{python_arch}" "C:\\mnt\\omnibus\\dbg"
     command "ls -lR PCbuild/#{python_arch}/"
     # Install the built artifacts to their expected locations
     copy "PCbuild/#{python_arch}/*.exe", "#{windows_safe_path(python_3_embedded)}/"

--- a/omnibus/lib/project_helpers.rb
+++ b/omnibus/lib/project_helpers.rb
@@ -10,3 +10,6 @@ def sysprobe_enabled?()
   !heroku_target? && linux_target? && !ENV.fetch('SYSTEM_PROBE_BIN', '').empty?
 end
 
+def windows_signing_enabled?()
+  return ENV['SIGN_WINDOWS_DD_WCS']
+end

--- a/test/new-e2e/tests/windows/fips-test/fips_test.go
+++ b/test/new-e2e/tests/windows/fips-test/fips_test.go
@@ -103,7 +103,7 @@ func (s *fipsAgentSuite) TestFIPSProviderPresent() {
 func (s *fipsAgentSuite) TestFIPSInstall() {
 	host := s.Env().RemoteHost
 	openssl := path.Join(s.installPath, "embedded3/bin/openssl.exe")
-	cmd := fmt.Sprintf(`"%s" fipsinstall`, openssl)
+	cmd := fmt.Sprintf(`& "%s" fipsinstall`, openssl)
 	_, err := host.Execute(cmd)
 	require.NoError(s.T(), err)
 }

--- a/test/new-e2e/tests/windows/fips-test/fips_test.go
+++ b/test/new-e2e/tests/windows/fips-test/fips_test.go
@@ -100,6 +100,14 @@ func (s *fipsAgentSuite) TestFIPSProviderPresent() {
 	require.True(s.T(), exists, "Agent install path should contain the FIPS provider but doesn't")
 }
 
+func (s *fipsAgentSuite) TestFIPSInstall() {
+	host := s.Env().RemoteHost
+	openssl := path.Join(s.installPath, "embedded3/bin/openssl.exe")
+	cmd := fmt.Sprintf("%s fipsinstall", openssl)
+	_, err := host.Execute(cmd)
+	require.NoError(s.T(), err)
+}
+
 func (s *fipsAgentSuite) execAgentCommand(command string, options ...client.ExecuteOption) (string, error) {
 	host := s.Env().RemoteHost
 

--- a/test/new-e2e/tests/windows/fips-test/fips_test.go
+++ b/test/new-e2e/tests/windows/fips-test/fips_test.go
@@ -103,7 +103,8 @@ func (s *fipsAgentSuite) TestFIPSProviderPresent() {
 func (s *fipsAgentSuite) TestFIPSInstall() {
 	host := s.Env().RemoteHost
 	openssl := path.Join(s.installPath, "embedded3/bin/openssl.exe")
-	cmd := fmt.Sprintf(`& "%s" fipsinstall`, openssl)
+	fipsModule := path.Join(s.installPath, "embedded3/lib/ossl-modules/fips.dll")
+	cmd := fmt.Sprintf(`& "%s" fipsinstall -module "%s"`, openssl, fipsModule)
 	_, err := host.Execute(cmd)
 	require.NoError(s.T(), err)
 }

--- a/test/new-e2e/tests/windows/fips-test/fips_test.go
+++ b/test/new-e2e/tests/windows/fips-test/fips_test.go
@@ -9,6 +9,7 @@ package fipstest
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -91,6 +92,12 @@ func (s *fipsAgentSuite) TestWithSystemFIPSEnabled() {
 			require.NoError(s.T(), err)
 		})
 	})
+}
+
+func (s *fipsAgentSuite) TestFIPSProviderPresent() {
+	host := s.Env().RemoteHost
+	exists, _ := host.FileExists(path.Join(s.installPath, "embedded3/lib/ossl-modules/fips.dll"))
+	require.True(s.T(), exists, "Agent install path should contain the FIPS provider but doesn't")
 }
 
 func (s *fipsAgentSuite) execAgentCommand(command string, options ...client.ExecuteOption) (string, error) {

--- a/test/new-e2e/tests/windows/fips-test/fips_test.go
+++ b/test/new-e2e/tests/windows/fips-test/fips_test.go
@@ -103,7 +103,7 @@ func (s *fipsAgentSuite) TestFIPSProviderPresent() {
 func (s *fipsAgentSuite) TestFIPSInstall() {
 	host := s.Env().RemoteHost
 	openssl := path.Join(s.installPath, "embedded3/bin/openssl.exe")
-	cmd := fmt.Sprintf("%s fipsinstall", openssl)
+	cmd := fmt.Sprintf(`"%s" fipsinstall`, openssl)
 	_, err := host.Execute(cmd)
 	require.NoError(s.T(), err)
 }

--- a/test/new-e2e/tests/windows/install-test/assert.go
+++ b/test/new-e2e/tests/windows/install-test/assert.go
@@ -175,6 +175,8 @@ func getExpectedBinFilesForAgentMajorVersion(majorVersion string) []string {
 		`embedded3\python.exe`,
 		`embedded3\pythonw.exe`,
 		fmt.Sprintf(`embedded3\python%s.dll`, py3),
+		`embedded3\DLLs\libcrypto-3-x64.dll`,
+		`embedded3\DLLs\libssl-3-x64.dll`,
 	}
 	if ExpectPython2Installed(majorVersion) {
 		py2 := shortPythonVersion(common.ExpectedPythonVersion2)

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -86,13 +86,8 @@ func (s *testInstallSuite) testCodeSignatures(t *Tester, remoteMSIPath string) {
 	ddSigned := []string{}
 	otherSigned := []string{}
 	for _, path := range paths {
-		if strings.Contains(path, "embedded3") {
-			// As of 7.5?, the embedded Python3 should be signed by Python, not Datadog
-			// We still build our own Python2, so we need to check that still
-			otherSigned = append(otherSigned, path)
-		} else {
-			ddSigned = append(ddSigned, path)
-		}
+		ddSigned = append(ddSigned, path)
+		// If we have other sigs to check, add them to `otherSigned` instead and check below
 	}
 	// MSI is signed by Datadog
 	if remoteMSIPath != "" {
@@ -106,13 +101,15 @@ func (s *testInstallSuite) testCodeSignatures(t *Tester, remoteMSIPath string) {
 		if !verify {
 			s.T().Skip("skipping code signature verification")
 		}
+		s.Assert().Empty(otherSigned, "no other signed files to check")
 		for _, path := range otherSigned {
 			subject := ""
-			if strings.Contains(path, "embedded3") {
-				subject = "CN=Python Software Foundation, O=Python Software Foundation, L=Beaverton, S=Oregon, C=US"
-			} else {
-				s.Assert().Failf("unexpected signed executable", "unexpected signed executable %s", path)
-			}
+			// As of 7.63, the embedded Python3 is back to being signed by Datadog, so it's checked above
+			// If we need to check it or other files again, we can add it back here
+			// 	subject = "CN=Python Software Foundation, O=Python Software Foundation, L=Beaverton, S=Oregon, C=US"
+			// } else {
+			// 	s.Assert().Failf("unexpected signed executable", "unexpected signed executable %s", path)
+			// }
 			sig, err := windowsCommon.GetAuthenticodeSignature(t.host, path)
 			if !s.Assert().NoError(err, "should get authenticode signature for %s", path) {
 				continue

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -85,10 +85,7 @@ func (s *testInstallSuite) testCodeSignatures(t *Tester, remoteMSIPath string) {
 	}
 	ddSigned := []string{}
 	otherSigned := []string{}
-	for _, path := range paths {
-		ddSigned = append(ddSigned, path)
-		// If we have other sigs to check, add them to `otherSigned` instead and check below
-	}
+	ddSigned = append(ddSigned, paths...)
 	// MSI is signed by Datadog
 	if remoteMSIPath != "" {
 		ddSigned = append(ddSigned, remoteMSIPath)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Start building OpenSSL, Python and the FIPS provider on Windows

### Motivation

This allows us to have better control over our OpenSSL versions, since we will now control it on Windows.
Buliding the FIPS provider is required for FedRAMP High

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

~The FIPS provider recipe is not technically FIPS compliant since we switched from `make install` to `make install_fips`
This is a shortcut to have something working on windows, as we need to have `pod2man` available.
This tool is usually bundled with perl, but we need a very specific version of perl to be available for OpenSSL to build on Windows (a version that uses the native `\` as path separators) and so far I haven't found an msys package that provides both the correct path separator and `pod2man`~
The doc mentions that `make install_fips` is acceptable so this should be FIPS compliant.
The remaining unknown is whether we can use `make` instead of `nmake`

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->