### PR TITLE
[EBPF] gpu: validate e2e environment before running tests

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.10.0 // indirect
-	github.com/pulumi/pulumi-command/sdk v1.0.1 // indirect
+	github.com/pulumi/pulumi-command/sdk v1.0.1
 	github.com/pulumi/pulumi-docker/sdk/v4 v4.5.5 // indirect
 	github.com/pulumi/pulumi-libvirt/sdk v0.4.7 // indirect
 	github.com/pulumi/pulumi-random/sdk/v4 v4.16.7 // indirect

--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -218,7 +218,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
 	github.com/pulumi/esc v0.10.0 // indirect
-	github.com/pulumi/pulumi-command/sdk v1.0.1
+	github.com/pulumi/pulumi-command/sdk v1.0.1 // indirect
 	github.com/pulumi/pulumi-docker/sdk/v4 v4.5.5 // indirect
 	github.com/pulumi/pulumi-libvirt/sdk v0.4.7 // indirect
 	github.com/pulumi/pulumi-random/sdk/v4 v4.16.7 // indirect

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -6,6 +6,7 @@
 package gpu
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -178,7 +179,7 @@ func gpuInstanceProvisioner(params *provisionerParams) e2e.Provisioner {
 // validateGPUDevices checks that there are GPU devices present and accesible
 func validateGPUDevices(e aws.Environment, vm *remote.Host) ([]pulumi.Resource, error) {
 	commands := map[string]string{
-		"pci":    "lspci -d 10de:: | grep NVIDIA",
+		"pci":    fmt.Sprintf("lspci -d %s:: | grep NVIDIA", nvidiaPCIVendorID),
 		"driver": "lsmod | grep nvidia",
 		"nvidia": "nvidia-smi -L | grep GPU",
 	}

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -158,7 +158,7 @@ func gpuInstanceProvisioner(params *provisionerParams) e2e.Provisioner {
 			agentparams.WithPulumiResourceOptions(utils.PulumiDependsOn(dockerManager)), // Depend on Docker to avoid apt lock issues
 		)
 
-		// Set updater to nil as we're not using it, and
+		// Set updater to nil as we're not using it
 		env.Updater = nil
 
 		// Install the agent

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package gpu
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/docker"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/components/remote"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake"
+	goremote "github.com/pulumi/pulumi-command/sdk/go/command/remote"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+)
+
+const gpuEnabledAMI = "ami-0f71e237bb2ba34be" // Ubuntu 22.04 with GPU drivers
+const gpuInstanceType = "g4dn.xlarge"
+const nvidiaPCIVendorID = "10de"
+
+const defaultGpuCheckConfig = `
+init_config:
+  min_collection_interval: 5
+
+instances:
+  - {}
+`
+
+const defaultSysprobeConfig = `
+gpu_monitoring:
+  enabled: true
+`
+
+type provisionerParams struct {
+	agentOptions []agentparams.Option
+	ami          string
+	amiOS        os.Descriptor
+	instanceType string
+}
+
+func getDefaultProvisionerParams() *provisionerParams {
+	return &provisionerParams{
+		agentOptions: []agentparams.Option{
+			agentparams.WithIntegration("gpu.d", defaultGpuCheckConfig),
+			agentparams.WithSystemProbeConfig(defaultSysprobeConfig),
+		},
+		ami:          gpuEnabledAMI,
+		amiOS:        os.Ubuntu2204,
+		instanceType: gpuInstanceType,
+	}
+}
+
+func gpuInstanceProvisioner(params *provisionerParams) e2e.Provisioner {
+	return e2e.NewTypedPulumiProvisioner[environments.Host]("gpu", func(ctx *pulumi.Context, env *environments.Host) error {
+		name := "gpuvm"
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Create the EC2 instance
+		host, err := ec2.NewVM(awsEnv, name,
+			ec2.WithInstanceType(params.instanceType),
+			ec2.WithAMI(params.ami, params.amiOS, os.AMD64Arch),
+		)
+		if err != nil {
+			return err
+		}
+		err = host.Export(ctx, &env.RemoteHost.HostOutput)
+		if err != nil {
+			return err
+		}
+
+		// Create the fakeintake instance
+		fakeIntake, err := fakeintake.NewECSFargateInstance(awsEnv, name)
+		if err != nil {
+			return err
+		}
+		err = fakeIntake.Export(ctx, &env.FakeIntake.FakeintakeOutput)
+		if err != nil {
+			return err
+		}
+
+		// install the ECR credentials helper
+		// required to get pipeline agent images or other internally hosted images
+		installEcrCredsHelperCmd, err := ec2.InstallECRCredentialsHelper(awsEnv, host)
+		if err != nil {
+			return err
+		}
+
+		// Validate GPU devices
+		validateGPUDevicesCmd, err := validateGPUDevices(awsEnv, host)
+		if err != nil {
+			return err
+		}
+
+		// Install Docker (only after GPU devices are validated and the ECR credentials helper is installed)
+		dockerManager, err := docker.NewManager(&awsEnv, host, utils.PulumiDependsOn(installEcrCredsHelperCmd, validateGPUDevicesCmd))
+		if err != nil {
+			return err
+		}
+
+		// Combine agent options from the parameters with the fakeintake and docker dependencies
+		params.agentOptions = append(params.agentOptions,
+			agentparams.WithFakeintake(fakeIntake),
+			agentparams.WithPulumiResourceOptions(utils.PulumiDependsOn(dockerManager)), // Depend on Docker to avoid apt lock issues
+		)
+
+		// Set updater to nil as we're not using it, and
+		env.Updater = nil
+
+		// Install the agent
+		agent, err := agent.NewHostAgent(&awsEnv, host, params.agentOptions...)
+		if err != nil {
+			return err
+		}
+
+		err = agent.Export(ctx, &env.Agent.HostAgentOutput)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, nil)
+}
+
+// validateGPUDevices checks that there are GPU devices present and accesible
+func validateGPUDevices(e aws.Environment, vm *remote.Host) (*goremote.Command, error) {
+	pciValidate, err := vm.OS.Runner().Command(
+		e.CommonNamer().ResourceName("pci-validate"),
+		&command.Args{
+			Create: pulumi.Sprintf("lspci -d %s:: | grep NVIDIA", nvidiaPCIVendorID),
+			Sudo:   false,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	nvidiaValidate, err := vm.OS.Runner().Command(
+		e.CommonNamer().ResourceName("nvidia-validate"),
+		&command.Args{
+			Create: pulumi.Sprintf("nvidia-smi -L | grep GPU"),
+			Sudo:   false,
+		},
+		utils.PulumiDependsOn(pciValidate),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return nvidiaValidate, nil
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a custom provisioner to the GPU e2e tests which adds commands to validate the presence of GPU devices in the system.

### Motivation

Understand the reason behind some flakes where CUDA tools reported no devices being found.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

e2e tests passing.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->