### PR TITLE
fix(build_rc): Enable compatibility with agent6

### DIFF
--- a/tasks/libs/common/gomodules.py
+++ b/tasks/libs/common/gomodules.py
@@ -261,8 +261,13 @@ class GoModule:
         >>> [mod.tag("7.27.0") for mod in mods]
         [["7.27.0"], ["pkg/util/log/v0.27.0"]]
         """
+        from invoke import Context
+
+        from tasks.libs.common.git import is_agent6
+
+        major = "6" if is_agent6(Context()) else "7"
         if self.path == ".":
-            return ["7" + agent_version[1:]]
+            return [major + agent_version[1:]]
 
         return [f"{self.path}/{self.__version(agent_version)}"]
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -45,9 +45,7 @@ BOT_NAME = "github-actions[bot]"
 
 def check_deploy_pipeline(repo_branch):
     """
-    Run checks to verify a deploy pipeline is valid:
-    - it targets a valid repo branch
-    - it has matching Agent 6 and Agent 7 tags (depending on release_version_* values)
+    Run checks to verify a deploy pipeline is valid (it targets a valid repo branch)
     """
 
     # Check that the target repo branch is valid

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -43,7 +43,7 @@ BOT_NAME = "github-actions[bot]"
 # Tasks to trigger pipelines
 
 
-def check_deploy_pipeline(repo: Project, git_ref: str, release_version_6, release_version_7, repo_branch):
+def check_deploy_pipeline(repo_branch):
     """
     Run checks to verify a deploy pipeline is valid:
     - it targets a valid repo branch
@@ -56,41 +56,6 @@ def check_deploy_pipeline(repo: Project, git_ref: str, release_version_6, releas
             f"--repo-branch argument '{repo_branch}' is not in the list of allowed repository branches: {get_all_allowed_repo_branches()}"
         )
         raise Exit(code=1)
-
-    #
-    # If git_ref matches v7 pattern and release_version_6 is not empty, make sure Gitlab has v6 tag.
-    # If git_ref matches v6 pattern and release_version_7 is not empty, make sure Gitlab has v7 tag.
-    # v7 version pattern should be able to match 7.12.24-rc2 and 7.12.34
-    #
-    v7_pattern = r'^7\.(\d+\.\d+)(-.+|)$'
-    v6_pattern = r'^6\.(\d+\.\d+)(-.+|)$'
-
-    match = re.match(v7_pattern, git_ref)
-
-    # TODO(@spencergilbert): remove cross reference check when all references to a6 are removed
-    if release_version_6 and match:
-        # release_version_6 is not empty and git_ref matches v7 pattern, construct v6 tag and check.
-        tag_name = "6." + "".join(match.groups())
-        try:
-            repo.tags.get(tag_name)
-        except GitlabError:
-            print(f"Cannot find GitLab v6 tag {tag_name} while trying to build git ref {git_ref}")
-            print("v6 tags are no longer created, this check will be removed in a later commit")
-
-        print(f"Successfully cross checked v6 tag {tag_name} and git ref {git_ref}")
-    else:
-        match = re.match(v6_pattern, git_ref)
-
-        if release_version_7 and match:
-            # release_version_7 is not empty and git_ref matches v6 pattern, construct v7 tag and check.
-            tag_name = "7." + "".join(match.groups())
-            try:
-                repo.tags.get(tag_name)
-            except GitlabError as e:
-                print(f"Cannot find GitLab v7 tag {tag_name} while trying to build git ref {git_ref}")
-                raise Exit(code=1) from e
-
-            print(f"Successfully cross checked v7 tag {tag_name} and git ref {git_ref}")
 
 
 @task
@@ -292,7 +257,7 @@ def run(
 
     if deploy or deploy_installer:
         # Check the validity of the deploy pipeline
-        check_deploy_pipeline(repo, git_ref, release_version_6, release_version_7, repo_branch)
+        check_deploy_pipeline(repo_branch)
         # Force all builds and e2e tests to be run
         if not all_builds:
             print(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Get the correct module tag when generating a build pipeline
- Do not have 6 & 7 cross checks anymore (as they are 2 independent pipelines now)

### Motivation
I wanted to validate I could trigger an `agent6` pipeline from the main branch of `datadog-agent` using the `inv release.build-rc -r 6.53.x` command

### Describe how you validated your changes
Launched the command from a brand new clone of `datadog-agent`. If finally generated [this pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/50959212)
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->