### PR TITLE
Remove importable module setting

### DIFF
--- a/modules.yml
+++ b/modules.yml
@@ -144,8 +144,7 @@ modules:
   pkg/config/utils:
     used_by_otel: true
   pkg/errors: default
-  pkg/gohai:
-    importable: false
+  pkg/gohai: default
   pkg/linters/components/pkgconfigusage:
     independent: false
     should_tag: false

--- a/tasks/libs/common/gomodules.py
+++ b/tasks/libs/common/gomodules.py
@@ -101,7 +101,6 @@ class GoModule:
         test_targets: Directories to unit test.
         should_test_condition: When to execute tests, must be a enumerated field of `GoModule.CONDITIONS`.
         should_tag: Whether this module should be tagged or not.
-        importable: HACK: Workaround for modules that can be tested, but not imported (eg. gohai), because they define a main package A better solution would be to automatically detect if a module contains a main package, at the cost of spending some time parsing the module.
         independent: Specifies whether this modules is supposed to exist independently of the datadog-agent module. If True, a check will run to ensure this is true.
         lint_targets: Directories to lint.
         used_by_otel: Whether the module is an otel dependency or not.
@@ -109,7 +108,6 @@ class GoModule:
     Usage:
         A module is defined within the modules.yml file containing the following fields by default (these can be omitted if the default value is used):
         > should_test_condition: always
-        > importable: true
         > independent: true
         > lint_targets:
         > - .
@@ -140,11 +138,6 @@ class GoModule:
     should_test_condition: str = 'always'
     # Whether this module should be tagged or not
     should_tag: bool = True
-    # HACK: Workaround for modules that can be tested, but not imported (eg. gohai), because
-    # they define a main package
-    # A better solution would be to automatically detect if a module contains a main package,
-    # at the cost of spending some time parsing the module.
-    importable: bool = True
     # Whether this modules is supposed to exist independently of the datadog-agent module. If True, a check will run to ensure this is true.
     independent: bool = True
     # Directories to lint
@@ -164,7 +157,6 @@ class GoModule:
             lint_targets=data.get("lint_targets", default["lint_targets"]),
             should_test_condition=data.get("should_test_condition", default["should_test_condition"]),
             should_tag=data.get("should_tag", default["should_tag"]),
-            importable=data.get("importable", default["importable"]),
             independent=data.get("independent", default["independent"]),
             used_by_otel=data.get("used_by_otel", default["used_by_otel"]),
             legacy_go_mod_version=data.get("legacy_go_mod_version", default["legacy_go_mod_version"]),
@@ -197,7 +189,6 @@ class GoModule:
             "lint_targets": self.lint_targets,
             "should_test_condition": self.should_test_condition,
             "should_tag": self.should_tag,
-            "importable": self.importable,
             "independent": self.independent,
             "used_by_otel": self.used_by_otel,
             "legacy_go_mod_version": self.legacy_go_mod_version,

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -45,7 +45,7 @@ def generate_dummy_package(ctx, folder):
     try:
         import_paths = []
         for mod in get_default_modules().values():
-            if mod.path != "." and mod.should_test() and mod.importable:
+            if mod.path != "." and mod.should_test():
                 import_paths.append(mod.import_path)
 
         os.mkdir(folder)

--- a/tasks/unit_tests/modules_tests.py
+++ b/tasks/unit_tests/modules_tests.py
@@ -133,7 +133,6 @@ class TestGoModuleSerialization(unittest.TestCase):
             lint_targets=['.'],
             should_test_condition='always',
             should_tag=True,
-            importable=True,
             independent=True,
             used_by_otel=True,
         )
@@ -159,7 +158,6 @@ class TestGoModuleSerialization(unittest.TestCase):
             'lint_targets': ['.'],
             'should_test_condition': 'always',
             'should_tag': True,
-            'importable': True,
             'independent': True,
             'used_by_otel': True,
         }
@@ -185,7 +183,6 @@ class TestGoModuleSerialization(unittest.TestCase):
             'lint_targets': ['.'],
             'should_test_condition': 'always',
             'should_tag': True,
-            'importable': True,
             'independent': True,
             'used_by_otel': True,
             'legacy_go_mod_version': None,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove the `importable` setting on modules.

### Motivation
It's been useless for months, it was added for `pkg/gohai` a year and a half ago but gohai doesn't have a `main` anymore so we can get rid of it.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->