### PR TITLE
[ASCII-2590] Retry network timeout errors on fakeintake

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -775,9 +775,6 @@ func (c *Client) get(route string) ([]byte, error) {
 	var body []byte
 	err := backoff.Retry(func() error {
 		tmpResp, err := http.Get(fmt.Sprintf("%s/%s", c.fakeIntakeURL, route))
-		if err, ok := err.(net.Error); ok && err.Timeout() {
-			panic(fmt.Sprintf("fakeintake call timed out: %v", err))
-		}
 		if err != nil {
 			return err
 		}
@@ -812,6 +809,9 @@ func (c *Client) get(route string) ([]byte, error) {
 		body, err = io.ReadAll(tmpResp.Body)
 		return err
 	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 4))
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		panic(fmt.Sprintf("fakeintake call timed out: %v", err))
+	}
 	return body, err
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Retry network timeout errors in fakeintake rather than panic'ing directly. 

### Motivation
We've hit network timeouts a couple times in tests, the logic is in a retry loop except when it's a network timeout.
This PR moves the panic outside the retry loop to give a chance to retrying.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The http client we use (the default one) doesn't have a timeout so in theory it shouldn't even timeout, we could not find out why it does, so this is hopefully an easy workaround to minimize the impact.  