### PR TITLE
Fix TestPodParser_Parse flakiness

### DIFF
--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
@@ -8,9 +8,10 @@
 package kubernetesresourceparsers
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -125,6 +126,11 @@ func TestPodParser_Parse(t *testing.T) {
 		QOSClass:                   "Guaranteed",
 	}
 
-	assert.True(t, reflect.DeepEqual(expected, parsed),
-		"Expected: %v, Actual: %v", expected, parsed)
+	opt := cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	})
+	assert.True(t,
+		cmp.Equal(expected, parsed, opt),
+		cmp.Diff(expected, parsed, opt),
+	)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use `github.com/google/go-cmp/cmp` in `TestPodParser_Parse` unit-test to allow unsorted nested slice in a struct.

### Motivation

Fix flakiness of `TestPodParser_Parse` unit-test. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->