### PR TITLE
(fleet) remove ECR login

### DIFF
--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -20,7 +20,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	oci "github.com/google/go-containerregistry/pkg/v1"
@@ -44,8 +43,6 @@ const (
 	RegistryAuthDefault string = "docker"
 	// RegistryAuthGCR is the Google Container Registry authentication method.
 	RegistryAuthGCR string = "gcr"
-	// RegistryAuthECR is the Amazon Elastic Container Registry authentication method.
-	RegistryAuthECR string = "ecr"
 	// RegistryAuthPassword is the password registry authentication method.
 	RegistryAuthPassword string = "password"
 )
@@ -154,8 +151,6 @@ func getKeychain(auth string, username string, password string) authn.Keychain {
 	switch auth {
 	case RegistryAuthGCR:
 		return google.Keychain
-	case RegistryAuthECR:
-		return authn.NewKeychainFromHelper(ecr.NewECRHelper())
 	case RegistryAuthPassword:
 		return usernamePasswordKeychain{
 			username: username,

--- a/test/new-e2e/tests/installer/unix/package_definitions.go
+++ b/test/new-e2e/tests/installer/unix/package_definitions.go
@@ -67,8 +67,8 @@ func WithAlias(alias string) PackageOption {
 
 // PackagesConfig is the list of known packages configuration for testing
 var PackagesConfig = []TestPackageConfig{
-	{Name: "datadog-installer", Version: fmt.Sprintf("pipeline-%v", os.Getenv("E2E_PIPELINE_ID")), Registry: "669783387624.dkr.ecr.us-east-1.amazonaws.com", Auth: "ecr"},
-	{Name: "datadog-agent", Alias: "agent-package", Version: fmt.Sprintf("pipeline-%v", os.Getenv("E2E_PIPELINE_ID")), Registry: "669783387624.dkr.ecr.us-east-1.amazonaws.com", Auth: "ecr"},
+	{Name: "datadog-installer", Version: fmt.Sprintf("pipeline-%v", os.Getenv("E2E_PIPELINE_ID")), Registry: "installtesting.datad0g.com"},
+	{Name: "datadog-agent", Alias: "agent-package", Version: fmt.Sprintf("pipeline-%v", os.Getenv("E2E_PIPELINE_ID")), Registry: "installtesting.datad0g.com"},
 	{Name: "datadog-apm-inject", Version: "latest"},
 	{Name: "datadog-apm-library-java", Version: "latest"},
 	{Name: "datadog-apm-library-ruby", Version: "latest"},


### PR DESCRIPTION
This PR removes ECR login to avoid a sizeable dependency that has very little purpose.

Before / after for the downloader:
```
-rwxr-xr-x 1 arthur.bellal 67368354 Dec 11 21:47 bin/installer/install-databricks.sh
-rwxr-xr-x 1 arthur.bellal 54038960 Dec 13 14:21 bin/installer/install-databricks.sh
```
