### PR TITLE
[ebpfless] Separate pending connection map, handle closed connections

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/map_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/map_utils.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package ebpfless
+
+// WriteMapWithSizeLimit updates a map via m[key] = val.
+// However, if the map would overflow sizeLimit, it returns false instead.
+func WriteMapWithSizeLimit[Key comparable, Val any](m map[Key]Val, key Key, val Val, sizeLimit int) bool {
+	_, exists := m[key]
+	if !exists && len(m) >= sizeLimit {
+		return false
+	}
+	m[key] = val
+	return true
+}

--- a/pkg/network/tracer/connection/ebpfless/map_utils_test.go
+++ b/pkg/network/tracer/connection/ebpfless/map_utils_test.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package ebpfless
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestWriteMapWithSizeLimit(t *testing.T) {
+	m := map[string]int{}
+
+	// not full: any write should work
+	ok := WriteMapWithSizeLimit(m, "foo", 123, 1)
+	require.True(t, ok)
+
+	expectedFoo := map[string]int{
+		"foo": 123,
+	}
+	require.Equal(t, expectedFoo, m)
+
+	// full: shouldn't write a new key
+	ok = WriteMapWithSizeLimit(m, "bar", 456, 1)
+	require.False(t, ok)
+	require.Equal(t, expectedFoo, m)
+
+	// full: replacing key should still work
+	ok = WriteMapWithSizeLimit(m, "foo", 789, 1)
+	require.True(t, ok)
+	require.Equal(t, map[string]int{
+		"foo": 789,
+	}, m)
+}

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -70,7 +70,7 @@ type TCPProcessor struct {
 }
 
 // TODO make this into a config value
-const maxPendingConns = 1024
+const maxPendingConns = 4096
 
 // NewTCPProcessor constructs an empty TCPProcessor
 func NewTCPProcessor(cfg *config.Config) *TCPProcessor {

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor_test.go
@@ -8,6 +8,7 @@
 package ebpfless
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"net"
 	"syscall"
 	"testing"
@@ -166,9 +167,10 @@ func (pb packetBuilder) outgoing(payloadLen uint16, relSeq, relAck uint32, flags
 }
 
 func newTCPTestFixture(t *testing.T) *tcpTestFixture {
+	cfg := config.New()
 	return &tcpTestFixture{
 		t:    t,
-		tcp:  NewTCPProcessor(),
+		tcp:  NewTCPProcessor(cfg),
 		conn: nil,
 	}
 }
@@ -256,6 +258,9 @@ func testBasicHandshake(t *testing.T, pb packetBuilder) {
 	}
 
 	require.Equal(t, expectedStats, f.conn.Monotonic)
+
+	require.Empty(t, f.tcp.pendingConns)
+	require.Empty(t, f.tcp.establishedConns)
 }
 
 var lowerSeq uint32 = 2134452051
@@ -323,6 +328,9 @@ func testReversedBasicHandshake(t *testing.T, pb packetBuilder) {
 		TCPClosed:      1,
 	}
 	require.Equal(t, expectedStats, f.conn.Monotonic)
+
+	require.Empty(t, f.tcp.pendingConns)
+	require.Empty(t, f.tcp.establishedConns)
 }
 
 func TestReversedBasicHandshake(t *testing.T) {

--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -34,20 +34,27 @@ const (
 	// ProcessResultCloseConn - this connection is done and its ConnectionStats should be passed
 	// to the ebpfless tracer's closed connection handler.
 	ProcessResultCloseConn
+	// ProcessResultMapFull - this connection can't be tracked because the TCPProcessor's connection
+	// map is full. This connection should be removed from the tracer as well.
+	ProcessResultMapFull
 )
 
 var statsTelemetry = struct {
-	missedTCPConnections telemetry.Counter
-	missingTCPFlags      telemetry.Counter
-	tcpSynAndFin         telemetry.Counter
-	tcpRstAndSyn         telemetry.Counter
-	tcpRstAndFin         telemetry.Counter
+	droppedPendingConns     telemetry.Counter
+	droppedEstablishedConns telemetry.Counter
+	missedTCPHandshakes     telemetry.Counter
+	missingTCPFlags         telemetry.Counter
+	tcpSynAndFin            telemetry.Counter
+	tcpRstAndSyn            telemetry.Counter
+	tcpRstAndFin            telemetry.Counter
 }{
-	telemetry.NewCounter(ebpflessModuleName, "missed_tcp_connections", []string{}, "Counter measuring the number of TCP connections where we missed the SYN handshake"),
-	telemetry.NewCounter(ebpflessModuleName, "missing_tcp_flags", []string{}, "Counter measuring packets encountered with none of SYN, FIN, ACK, RST set"),
-	telemetry.NewCounter(ebpflessModuleName, "tcp_syn_and_fin", []string{}, "Counter measuring packets encountered with SYN+FIN together"),
-	telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_syn", []string{}, "Counter measuring packets encountered with RST+SYN together"),
-	telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_fin", []string{}, "Counter measuring packets encountered with RST+FIN together"),
+	droppedPendingConns:     telemetry.NewCounter(ebpflessModuleName, "dropped_pending_conns", nil, "Counter measuring the number of TCP connections which were dropped during the handshake (because the map was full)"),
+	droppedEstablishedConns: telemetry.NewCounter(ebpflessModuleName, "dropped_established_conns", nil, "Counter measuring the number of TCP connections which were dropped while established (because the map was full)"),
+	missedTCPHandshakes:     telemetry.NewCounter(ebpflessModuleName, "missed_tcp_handshakes", nil, "Counter measuring the number of TCP connections where we missed the SYN handshake"),
+	missingTCPFlags:         telemetry.NewCounter(ebpflessModuleName, "missing_tcp_flags", nil, "Counter measuring packets encountered with none of SYN, FIN, ACK, RST set"),
+	tcpSynAndFin:            telemetry.NewCounter(ebpflessModuleName, "tcp_syn_and_fin", nil, "Counter measuring packets encountered with SYN+FIN together"),
+	tcpRstAndSyn:            telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_syn", nil, "Counter measuring packets encountered with RST+SYN together"),
+	tcpRstAndFin:            telemetry.NewCounter(ebpflessModuleName, "tcp_rst_and_fin", nil, "Counter measuring packets encountered with RST+FIN together"),
 }
 
 const tcpSeqMidpoint = 0x80000000

--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -21,6 +21,21 @@ import (
 
 const ebpflessModuleName = "ebpfless_network_tracer"
 
+// ProcessResult represents what the ebpfless tracer should do with ConnectionStats after processing a packet
+type ProcessResult uint8
+
+const (
+	// ProcessResultNone - the updated ConnectionStats should NOT be stored in the connection map.
+	// Usually, this is because the connection is not established yet.
+	ProcessResultNone ProcessResult = iota
+	// ProcessResultStoreConn - the updated ConnectionStats should be stored in the connection map.
+	// This happens when the connection is established.
+	ProcessResultStoreConn
+	// ProcessResultCloseConn - this connection is done and its ConnectionStats should be passed
+	// to the ebpfless tracer's closed connection handler.
+	ProcessResultCloseConn
+)
+
 var statsTelemetry = struct {
 	missedTCPConnections telemetry.Counter
 	missingTCPFlags      telemetry.Counter

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -96,7 +96,7 @@ func newEbpfLessTracer(cfg *config.Config) (*ebpfLessTracer, error) {
 }
 
 // Start begins collecting network connection data.
-func (t *ebpfLessTracer) Start(_ func(*network.ConnectionStats)) error {
+func (t *ebpfLessTracer) Start(closeCallback func(*network.ConnectionStats)) error {
 	if err := t.boundPorts.Start(); err != nil {
 		return fmt.Errorf("could not update bound ports: %w", err)
 	}
@@ -123,7 +123,7 @@ func (t *ebpfLessTracer) Start(_ func(*network.ConnectionStats)) error {
 					return nil
 				}
 
-				if err := t.processConnection(pktType, &ip4, &ip6, &udp, &tcp, decoded); err != nil {
+				if err := t.processConnection(pktType, &ip4, &ip6, &udp, &tcp, decoded, closeCallback); err != nil {
 					log.Warnf("could not process packet: %s", err)
 				}
 
@@ -147,8 +147,8 @@ func (t *ebpfLessTracer) processConnection(
 	udp *layers.UDP,
 	tcp *layers.TCP,
 	decoded []gopacket.LayerType,
+	closeCallback func(*network.ConnectionStats),
 ) error {
-
 	t.scratchConn.Source, t.scratchConn.Dest = util.Address{}, util.Address{}
 	t.scratchConn.SPort, t.scratchConn.DPort = 0, 0
 	t.scratchConn.TCPFailures = make(map[uint16]uint32)
@@ -204,21 +204,25 @@ func (t *ebpfLessTracer) processConnection(
 	if ts, err = ddebpf.NowNanoseconds(); err != nil {
 		return fmt.Errorf("error getting last updated timestamp for connection: %w", err)
 	}
+	conn.LastUpdateEpoch = uint64(ts)
 
 	if !ip4Present && !ip6Present {
 		return nil
 	}
+
+	var result ebpfless.ProcessResult
 	switch conn.Type {
 	case network.UDP:
 		if (ip4Present && !t.config.CollectUDPv4Conns) || (ip6Present && !t.config.CollectUDPv6Conns) {
 			return nil
 		}
+		result = ebpfless.ProcessResultStoreConn
 		err = t.udp.process(conn, pktType, udp)
 	case network.TCP:
 		if (ip4Present && !t.config.CollectTCPv4Conns) || (ip6Present && !t.config.CollectTCPv6Conns) {
 			return nil
 		}
-		err = t.tcp.Process(conn, uint64(ts), pktType, ip4, ip6, tcp)
+		result, err = t.tcp.Process(conn, uint64(ts), pktType, ip4, ip6, tcp)
 	default:
 		err = fmt.Errorf("unsupported connection type %d", conn.Type)
 	}
@@ -227,15 +231,19 @@ func (t *ebpfLessTracer) processConnection(
 		return fmt.Errorf("error processing connection: %w", err)
 	}
 
-	// TODO probably remove HasConnEverEstablished once we handle closed connections properly
-	if conn.Type == network.UDP || (conn.Type == network.TCP && t.tcp.HasConnEverEstablished(conn)) {
-		conn.LastUpdateEpoch = uint64(ts)
-		t.conns[t.scratchConn.ConnectionTuple] = conn
-	}
-
 	log.TraceFunc(func() string {
 		return fmt.Sprintf("connection: %s", conn)
 	})
+
+	switch result {
+	case ebpfless.ProcessResultNone:
+	case ebpfless.ProcessResultStoreConn:
+		t.conns[t.scratchConn.ConnectionTuple] = conn
+	case ebpfless.ProcessResultCloseConn:
+		delete(t.conns, conn.ConnectionTuple)
+		closeCallback(conn)
+	}
+
 	return nil
 }
 
@@ -310,6 +318,9 @@ func (t *ebpfLessTracer) Remove(conn *network.ConnectionStats) error {
 	defer t.m.Unlock()
 
 	delete(t.conns, conn.ConnectionTuple)
+	if conn.Type == network.TCP {
+		t.tcp.RemoveConn(conn.ConnectionTuple)
+	}
 	return nil
 }
 

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -242,9 +242,11 @@ func (t *ebpfLessTracer) processConnection(
 	case ebpfless.ProcessResultStoreConn:
 		maxTrackedConns := int(t.config.MaxTrackedConnections)
 		ok := ebpfless.WriteMapWithSizeLimit(t.conns, conn.ConnectionTuple, conn, maxTrackedConns)
-		// we don't have enough space to add this connection, remove its TCP state tracking
-		if !ok && conn.Type == network.TCP {
-			t.tcp.RemoveConn(conn.ConnectionTuple)
+		if !ok {
+			// we don't have enough space to add this connection, remove its TCP state tracking
+			if conn.Type == network.TCP {
+				t.tcp.RemoveConn(conn.ConnectionTuple)
+			}
 			ebpfLessTracerTelemetry.droppedConnections.Inc()
 		}
 	case ebpfless.ProcessResultCloseConn:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR separates the `conns` map in TCPProcessor into `pendingConns` and `establishedConns`. There is no `closedConns` because these are passed directly into the tracer's `closeCallback`.

This PR is stacked on [[ebpfless] Fix the pre-existing connection tests](https://github.com/DataDog/datadog-agent/pull/31858).

### Motivation
In the future, we will limit the size of these maps and having a separate limit for `pendingConns` is important.
Using `closeCallback` is important for correctness purposes also.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run TCPProcessor test suite: (all should pass)
```
go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer/connection/ebpfless
```
Run the ebpfless tracer test suite: (same should pass as before)
```
DD_LOG_LEVEL=info DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless -run TestTracerSuite/eBPFless
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->