### PR TITLE
Enter repo root

### DIFF
--- a/tasks/winbuildscripts/common.ps1
+++ b/tasks/winbuildscripts/common.ps1
@@ -44,6 +44,23 @@ function Exit-BuildRoot() {
 
 <#
 .SYNOPSIS
+Sets the current directory to the root of the repository.
+#>
+function Enter-RepoRoot() {
+    # Expected PSScriptRoot: datadog-agent\tasks\winbuildscripts\
+    Push-Location "$PSScriptRoot\..\.." -ErrorAction Stop -StackName AgentRepoRoot | Out-Null
+}
+
+<#
+.SYNOPSIS
+Leaves the repository root directory and returns to the original working directory.
+#>
+function Exit-RepoRoot() {
+    Pop-Location -StackName AgentRepoRoot
+}
+
+<#
+.SYNOPSIS
 Expands the Go module cache from an archive file.
 
 .DESCRIPTION
@@ -209,6 +226,8 @@ function Invoke-BuildScript {
 
         if ($BuildOutOfSource) {
             Enter-BuildRoot
+        } else {
+            Enter-RepoRoot
         }
 
         Expand-ModCache -modcache modcache
@@ -234,9 +253,11 @@ function Invoke-BuildScript {
         # This finally block is executed regardless of whether the try block completes successfully, throws an exception,
         # or uses `exit` to terminate the script.
 
+        # Restore the original working directory
         if ($BuildOutOfSource) {
-            # Restore the original working directory
             Exit-BuildRoot
+        } else {
+            Exit-RepoRoot
         }
     }
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
`Invoke-BuildScript -BuildOutOfSource 0` sets CWD to the root of the datadog-agent repository

### Motivation
Allow script to be called without requiring CWD to be the root of the repo, as the [.bat files](https://github.com/DataDog/datadog-agent/blob/2fcc87ad9b3774a112905beda211d6e2984dce47/tasks/winbuildscripts/dobuild.bat#L35-L37) did


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
script should work when run like
```powershell
docker exec -it agentbuild powershell -c "cd C:\Windows; C:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1"
```
(or by a container with a different CWD)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->