### PR TITLE
[Fleet] Migrate ddtrace references to telem package

### DIFF
--- a/cmd/installer-downloader/main.go
+++ b/cmd/installer-downloader/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
 	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -49,7 +48,7 @@ func main() {
 	defer func() { _ = t.Stop(ctx) }()
 	var err error
 	span, ctx := telemetry.StartSpanFromEnv(ctx, fmt.Sprintf("downloader-%s", Flavor))
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	defer func() { span.Finish(err) }()
 	err = runDownloader(ctx, env, Version, Flavor)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Installation failed: %v\n", err)

--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -22,8 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/spf13/cobra"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/yaml.v2"
 )
 
@@ -89,7 +87,7 @@ func UnprivilegedCommands(_ *command.GlobalParams) []*cobra.Command {
 type cmd struct {
 	t    *telemetry.Telemetry
 	ctx  context.Context
-	span ddtrace.Span
+	span telemetry.Span
 	env  *env.Env
 }
 
@@ -107,7 +105,7 @@ func newCmd(operation string) *cmd {
 }
 
 func (c *cmd) Stop(err error) {
-	c.span.Finish(tracer.WithError(err))
+	c.span.Finish(err)
 	if c.t != nil {
 		err := c.t.Stop(context.Background())
 		if err != nil {

--- a/cmd/installer/subcommands/installer/umask_nix.go
+++ b/cmd/installer/subcommands/installer/umask_nix.go
@@ -10,11 +10,11 @@ package installer
 import (
 	"syscall"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 )
 
 // setInstallerUmask sets umask 0 to override any inherited umask
-func setInstallerUmask(span ddtrace.Span) {
+func setInstallerUmask(span telemetry.Span) {
 	oldmask := syscall.Umask(0)
 	span.SetTag("inherited_umask", oldmask)
 }

--- a/cmd/installer/subcommands/installer/umask_windows.go
+++ b/cmd/installer/subcommands/installer/umask_windows.go
@@ -7,9 +7,7 @@
 
 package installer
 
-import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-)
+import "github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 
 // setInstallerUmask no-op on Windows
-func setInstallerUmask(_ ddtrace.Span) {}
+func setInstallerUmask(_ telemetry.Span) {}

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -20,9 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -34,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/cdn"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/exec"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/paths"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -271,8 +269,8 @@ func (d *daemonImpl) Install(ctx context.Context, url string, args []string) err
 }
 
 func (d *daemonImpl) install(ctx context.Context, url string, args []string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "install")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "install")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -293,8 +291,8 @@ func (d *daemonImpl) StartExperiment(ctx context.Context, url string) error {
 }
 
 func (d *daemonImpl) startExperiment(ctx context.Context, url string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "start_experiment")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "start_experiment")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -308,8 +306,8 @@ func (d *daemonImpl) startExperiment(ctx context.Context, url string) (err error
 }
 
 func (d *daemonImpl) startInstallerExperiment(ctx context.Context, url string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "start_installer_experiment")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "start_installer_experiment")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -334,8 +332,8 @@ func (d *daemonImpl) PromoteExperiment(ctx context.Context, pkg string) error {
 }
 
 func (d *daemonImpl) promoteExperiment(ctx context.Context, pkg string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "promote_experiment")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "promote_experiment")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -356,8 +354,8 @@ func (d *daemonImpl) StopExperiment(ctx context.Context, pkg string) error {
 }
 
 func (d *daemonImpl) stopExperiment(ctx context.Context, pkg string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "stop_experiment")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "stop_experiment")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -378,8 +376,8 @@ func (d *daemonImpl) StartConfigExperiment(ctx context.Context, url string, vers
 }
 
 func (d *daemonImpl) startConfigExperiment(ctx context.Context, url string, version string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "start_config_experiment")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "start_config_experiment")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -400,8 +398,8 @@ func (d *daemonImpl) PromoteConfigExperiment(ctx context.Context, pkg string) er
 }
 
 func (d *daemonImpl) promoteConfigExperiment(ctx context.Context, pkg string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "promote_config_experiment")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "promote_config_experiment")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -422,8 +420,8 @@ func (d *daemonImpl) StopConfigExperiment(ctx context.Context, pkg string) error
 }
 
 func (d *daemonImpl) stopConfigExperiment(ctx context.Context, pkg string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "stop_config_experiment")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "stop_config_experiment")
+	defer func() { span.Finish(err) }()
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -455,7 +453,7 @@ func (d *daemonImpl) handleRemoteAPIRequest(request remoteAPIRequest) (err error
 	defer d.m.Unlock()
 	defer d.requestsWG.Done()
 	parentSpan, ctx := newRequestContext(request)
-	defer parentSpan.Finish(tracer.WithError(err))
+	defer parentSpan.Finish(err)
 	d.refreshState(ctx)
 	defer d.refreshState(ctx)
 
@@ -545,25 +543,13 @@ type requestState struct {
 	ErrorCode installerErrors.InstallerErrorCode
 }
 
-func newRequestContext(request remoteAPIRequest) (ddtrace.Span, context.Context) {
+func newRequestContext(request remoteAPIRequest) (telemetry.Span, context.Context) {
 	ctx := context.WithValue(context.Background(), requestStateKey, &requestState{
 		Package: request.Package,
 		ID:      request.ID,
 		State:   pbgo.TaskState_RUNNING,
 	})
-
-	ctxCarrier := tracer.TextMapCarrier{
-		tracer.DefaultTraceIDHeader:  request.TraceID,
-		tracer.DefaultParentIDHeader: request.ParentSpanID,
-		tracer.DefaultPriorityHeader: "2",
-	}
-	spanCtx, err := tracer.Extract(ctxCarrier)
-	if err != nil {
-		log.Debugf("failed to extract span context from install script params: %v", err)
-		return tracer.StartSpan("remote_request"), ctx
-	}
-
-	return tracer.StartSpanFromContext(ctx, "remote_request", tracer.ChildOf(spanCtx))
+	return telemetry.StartSpanFromIDs(ctx, "remote_request", request.TraceID, request.ParentSpanID)
 }
 
 func setRequestInvalid(ctx context.Context) {

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/cdn"
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/paths"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
@@ -28,8 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/db"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -164,9 +163,9 @@ func (i *installerImpl) Install(ctx context.Context, url string, args []string) 
 	if err != nil {
 		return fmt.Errorf("could not download package: %w", err)
 	}
-	span, ok := tracer.SpanFromContext(ctx)
+	span, ok := telemetry.SpanFromContext(ctx)
 	if ok {
-		span.SetTag(ext.ResourceName, pkg.Name)
+		span.SetResourceName(pkg.Name)
 		span.SetTag("package_version", pkg.Version)
 	}
 	err = i.preparePackage(ctx, pkg.Name, args) // Preinst
@@ -471,9 +470,9 @@ func (i *installerImpl) Purge(ctx context.Context) {
 	}
 
 	// remove all from disk
-	span, _ := tracer.StartSpanFromContext(ctx, "remove_all")
+	span, _ := telemetry.StartSpanFromContext(ctx, "remove_all")
 	err = os.RemoveAll(i.packagesDir)
-	defer span.Finish(tracer.WithError(err))
+	defer span.Finish(err)
 	if err != nil {
 		log.Warnf("could not delete packages dir: %v", err)
 	}
@@ -659,8 +658,8 @@ func (i *installerImpl) configurePackage(ctx context.Context, pkg string) (err e
 		return nil
 	}
 
-	span, _ := tracer.StartSpanFromContext(ctx, "configure_package")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "configure_package")
+	defer func() { span.Finish(err) }()
 
 	switch pkg {
 	case packageDatadogAgent, packageAPMInjector:

--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -31,11 +31,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"go.uber.org/multierr"
 	"golang.org/x/net/http2"
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/tar"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -241,7 +241,7 @@ func getRefAndKeychain(env *env.Env, url string) urlWithKeychain {
 // If they are specified, the registry and authentication overrides are applied first.
 // Then we try each registry in the list of default registries in order and return the first successful download.
 func (d *Downloader) downloadRegistry(ctx context.Context, url string) (oci.Image, error) {
-	transport := httptrace.WrapRoundTripper(d.client.Transport)
+	transport := telemetry.WrapRoundTripper(d.client.Transport)
 	var err error
 	if d.env.Mirror != "" {
 		transport, err = newMirrorTransport(transport, d.env.Mirror)

--- a/pkg/fleet/installer/packages/apm_sockets.go
+++ b/pkg/fleet/installer/packages/apm_sockets.go
@@ -15,8 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/yaml.v2"
 )
 
@@ -119,9 +119,9 @@ func (a *apmInjectorInstaller) configureSocketsEnv(ctx context.Context) (retErr 
 }
 
 // setSocketEnvs sets the socket environment variables
-func setSocketEnvs(ctx context.Context, envFile []byte) ([]byte, error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "set_socket_envs")
-	defer span.Finish()
+func setSocketEnvs(ctx context.Context, envFile []byte) (res []byte, err error) {
+	span, _ := telemetry.StartSpanFromContext(ctx, "set_socket_envs")
+	defer span.Finish(err)
 
 	apmSocket, statsdSocket, err := getSocketsPath()
 	if err != nil {
@@ -169,8 +169,8 @@ func addEnvsIfNotSet(envs map[string]string, envFile []byte) ([]byte, error) {
 //
 // Reloading systemd & restarting the unit has to be done separately by the caller
 func addSystemDEnvOverrides(ctx context.Context, unit string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "add_systemd_env_overrides")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "add_systemd_env_overrides")
+	defer func() { span.Finish(err) }()
 	span.SetTag("unit", unit)
 
 	// The - is important as it lets the unit start even if the file is missing.

--- a/pkg/fleet/installer/packages/app_armor.go
+++ b/pkg/fleet/installer/packages/app_armor.go
@@ -15,8 +15,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -33,8 +33,8 @@ func setupAppArmor(ctx context.Context) (err error) {
 		// no-op if apparmor is not installed
 		return nil
 	}
-	span, _ := tracer.StartSpanFromContext(ctx, "setup_app_armor")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "setup_app_armor")
+	defer func() { span.Finish(err) }()
 	if err = os.MkdirAll(appArmorConfigPath, 0755); err != nil {
 		return fmt.Errorf("failed to create %s: %w", appArmorConfigPath, err)
 	}
@@ -61,8 +61,8 @@ func removeAppArmor(ctx context.Context) (err error) {
 		}
 		return err
 	}
-	span, _ := tracer.StartSpanFromContext(ctx, "remove_app_armor")
-	defer span.Finish(tracer.WithError(err))
+	span, _ := telemetry.StartSpanFromContext(ctx, "remove_app_armor")
+	defer span.Finish(err)
 	if err = os.Remove(datadogProfilePath); err != nil {
 		return err
 	}

--- a/pkg/fleet/installer/packages/datadog_agent.go
+++ b/pkg/fleet/installer/packages/datadog_agent.go
@@ -16,9 +16,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -72,8 +72,8 @@ var (
 
 // PrepareAgent prepares the machine to install the agent
 func PrepareAgent(ctx context.Context) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "prepare_agent")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "prepare_agent")
+	defer func() { span.Finish(err) }()
 
 	// Check if the agent has been installed by a package manager, if yes remove it
 	if !oldAgentInstalled() {
@@ -88,13 +88,13 @@ func PrepareAgent(ctx context.Context) (err error) {
 
 // SetupAgent installs and starts the agent
 func SetupAgent(ctx context.Context, _ []string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "setup_agent")
+	span, ctx := telemetry.StartSpanFromContext(ctx, "setup_agent")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to setup agent, reverting: %s", err)
 			err = errors.Join(err, RemoveAgent(ctx))
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 
 	for _, unit := range stableUnits {
@@ -159,38 +159,45 @@ func SetupAgent(ctx context.Context, _ []string) (err error) {
 
 // RemoveAgent stops and removes the agent
 func RemoveAgent(ctx context.Context) error {
-	span, ctx := tracer.StartSpanFromContext(ctx, "remove_agent_units")
-	defer span.Finish()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "remove_agent_units")
+	var spanErr error
+	defer func() { span.Finish(spanErr) }()
 	// stop experiments, they can restart stable agent
 	for _, unit := range experimentalUnits {
 		if err := stopUnit(ctx, unit); err != nil {
 			log.Warnf("Failed to stop %s: %s", unit, err)
+			spanErr = err
 		}
 	}
 	// stop stable agents
 	for _, unit := range stableUnits {
 		if err := stopUnit(ctx, unit); err != nil {
 			log.Warnf("Failed to stop %s: %s", unit, err)
+			spanErr = err
 		}
 	}
 
 	if err := disableUnit(ctx, agentUnit); err != nil {
 		log.Warnf("Failed to disable %s: %s", agentUnit, err)
+		spanErr = err
 	}
 
 	// remove units from disk
 	for _, unit := range experimentalUnits {
 		if err := removeUnit(ctx, unit); err != nil {
 			log.Warnf("Failed to remove %s: %s", unit, err)
+			spanErr = err
 		}
 	}
 	for _, unit := range stableUnits {
 		if err := removeUnit(ctx, unit); err != nil {
 			log.Warnf("Failed to remove %s: %s", unit, err)
+			spanErr = err
 		}
 	}
 	if err := os.Remove(agentSymlink); err != nil {
 		log.Warnf("Failed to remove agent symlink: %s", err)
+		spanErr = err
 	}
 	installinfo.RmInstallInfo()
 	// TODO: Return error to caller?
@@ -202,12 +209,12 @@ func oldAgentInstalled() bool {
 	return err == nil
 }
 
-func stopOldAgentUnits(ctx context.Context) error {
+func stopOldAgentUnits(ctx context.Context) (err error) {
 	if !oldAgentInstalled() {
 		return nil
 	}
-	span, ctx := tracer.StartSpanFromContext(ctx, "remove_old_agent_units")
-	defer span.Finish()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "remove_old_agent_units")
+	defer span.Finish(err)
 	for _, unit := range stableUnits {
 		if err := stopUnit(ctx, unit); err != nil {
 			return fmt.Errorf("failed to stop %s: %v", unit, err)

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -12,9 +12,8 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/internal/winregistry"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -28,12 +27,12 @@ func PrepareAgent(_ context.Context) error {
 
 // SetupAgent installs and starts the agent
 func SetupAgent(ctx context.Context, args []string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "setup_agent")
+	span, _ := telemetry.StartSpanFromContext(ctx, "setup_agent")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to setup agent: %s", err)
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 	// Make sure there are no Agent already installed
 	_ = removeAgentIfInstalled(ctx)
@@ -43,12 +42,12 @@ func SetupAgent(ctx context.Context, args []string) (err error) {
 
 // StartAgentExperiment starts the agent experiment
 func StartAgentExperiment(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "start_experiment")
+	span, _ := telemetry.StartSpanFromContext(ctx, "start_experiment")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to start agent experiment: %s", err)
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 
 	err = removeAgentIfInstalled(ctx)
@@ -66,12 +65,12 @@ func StartAgentExperiment(ctx context.Context) (err error) {
 
 // StopAgentExperiment stops the agent experiment, i.e. removes/uninstalls it.
 func StopAgentExperiment(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "stop_experiment")
+	span, _ := telemetry.StartSpanFromContext(ctx, "stop_experiment")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to stop agent experiment: %s", err)
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 
 	err = removeAgentIfInstalled(ctx)
@@ -123,14 +122,14 @@ func installAgentPackage(target string, args []string) error {
 
 func removeAgentIfInstalled(ctx context.Context) (err error) {
 	if isProductInstalled("Datadog Agent") {
-		span, _ := tracer.StartSpanFromContext(ctx, "remove_agent")
+		span, _ := telemetry.StartSpanFromContext(ctx, "remove_agent")
 		defer func() {
 			if err != nil {
 				// removal failed, this should rarely happen.
 				// Rollback might have restored the Agent, but we can't be sure.
 				log.Errorf("Failed to remove agent: %s", err)
 			}
-			span.Finish(tracer.WithError(err))
+			span.Finish(err)
 		}()
 		err := removeProduct("Datadog Agent")
 		if err != nil {

--- a/pkg/fleet/installer/packages/datadog_installer_windows.go
+++ b/pkg/fleet/installer/packages/datadog_installer_windows.go
@@ -11,8 +11,8 @@ package packages
 import (
 	"context"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -21,12 +21,12 @@ const (
 
 // SetupInstaller installs and starts the installer
 func SetupInstaller(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "setup_installer")
+	span, _ := telemetry.StartSpanFromContext(ctx, "setup_installer")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to setup installer: %s", err)
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 	cmd, err := msiexec("stable", datadogInstaller, "/i", nil)
 	if err == nil {
@@ -39,12 +39,12 @@ func SetupInstaller(ctx context.Context) (err error) {
 
 // RemoveInstaller removes the installer
 func RemoveInstaller(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "remove_installer")
+	span, _ := telemetry.StartSpanFromContext(ctx, "remove_installer")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to remove installer: %s", err)
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 	err = removeProduct("Datadog Installer")
 	return err
@@ -52,12 +52,12 @@ func RemoveInstaller(ctx context.Context) (err error) {
 
 // StartInstallerExperiment starts the installer experiment
 func StartInstallerExperiment(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "start_installer_experiment")
+	span, _ := telemetry.StartSpanFromContext(ctx, "start_installer_experiment")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to start installer experiment: %s", err)
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 	cmd, err := msiexec("experiment", datadogInstaller, "/i", nil)
 	if err == nil {
@@ -69,12 +69,12 @@ func StartInstallerExperiment(ctx context.Context) (err error) {
 
 // StopInstallerExperiment stops the installer experiment
 func StopInstallerExperiment(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "stop_installer_experiment")
+	span, _ := telemetry.StartSpanFromContext(ctx, "stop_installer_experiment")
 	defer func() {
 		if err != nil {
 			log.Errorf("Failed to stop installer experiment: %s", err)
 		}
-		span.Finish(tracer.WithError(err))
+		span.Finish(err)
 	}()
 	cmd, err := msiexec("stable", datadogInstaller, "/i", nil)
 	if err == nil {

--- a/pkg/fleet/installer/packages/docker.go
+++ b/pkg/fleet/installer/packages/docker.go
@@ -20,9 +20,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/shirou/gopsutil/v4/process"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 type dockerDaemonConfig map[string]interface{}
@@ -73,14 +73,14 @@ func (a *apmInjectorInstaller) uninstrumentDocker(ctx context.Context) error {
 }
 
 // setDockerConfigContent sets the content of the docker daemon configuration
-func (a *apmInjectorInstaller) setDockerConfigContent(ctx context.Context, previousContent []byte) ([]byte, error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "set_docker_config_content")
-	defer span.Finish()
+func (a *apmInjectorInstaller) setDockerConfigContent(ctx context.Context, previousContent []byte) (res []byte, err error) {
+	span, _ := telemetry.StartSpanFromContext(ctx, "set_docker_config_content")
+	defer span.Finish(err)
 
 	dockerConfig := dockerDaemonConfig{}
 
 	if len(previousContent) > 0 {
-		err := json.Unmarshal(previousContent, &dockerConfig)
+		err = json.Unmarshal(previousContent, &dockerConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -140,8 +140,8 @@ func (a *apmInjectorInstaller) deleteDockerConfigContent(_ context.Context, prev
 //
 // This method is valid since at least Docker 17.03 (last update 2018-08-30)
 func (a *apmInjectorInstaller) verifyDockerRuntime(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "verify_docker_runtime")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "verify_docker_runtime")
+	defer func() { span.Finish(err) }()
 
 	if !isDockerActive(ctx) {
 		log.Warn("docker is inactive, skipping docker runtime verification")
@@ -172,8 +172,8 @@ func (a *apmInjectorInstaller) verifyDockerRuntime(ctx context.Context) (err err
 }
 
 func reloadDockerConfig(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "reload_docker")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "reload_docker")
+	defer func() { span.Finish(err) }()
 	if !isDockerActive(ctx) {
 		log.Warn("docker is inactive, skipping docker reload")
 		return nil
@@ -205,8 +205,8 @@ func reloadDockerConfig(ctx context.Context) (err error) {
 
 // isDockerInstalled checks if docker is installed on the system
 func isDockerInstalled(ctx context.Context) bool {
-	span, _ := tracer.StartSpanFromContext(ctx, "is_docker_installed")
-	defer span.Finish()
+	span, _ := telemetry.StartSpanFromContext(ctx, "is_docker_installed")
+	defer span.Finish(nil)
 
 	// Docker is installed if the docker binary is in the PATH
 	_, err := exec.LookPath("docker")

--- a/pkg/fleet/installer/packages/file.go
+++ b/pkg/fleet/installer/packages/file.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 var rollbackNoop = func() error { return nil }
@@ -46,8 +46,8 @@ func newFileMutator(path string, transform func(ctx context.Context, existing []
 }
 
 func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err error) {
-	span, ctx := tracer.StartSpanFromContext(ctx, "mutate_file")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(ctx, "mutate_file")
+	defer func() { span.Finish(err) }()
 	span.SetTag("file", ft.path)
 
 	defer os.Remove(ft.pathTmp)

--- a/pkg/fleet/installer/packages/pkg_manager.go
+++ b/pkg/fleet/installer/packages/pkg_manager.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"os/exec"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 )
 
 // removeDebRPMPackage removes a package installed via deb/rpm package manager
@@ -21,8 +21,8 @@ import (
 // and reinstall the package using the installer.
 // Note: we don't run the pre/post remove scripts as we want to avoid surprises for older agent versions (like removing config)
 func removeDebRPMPackage(ctx context.Context, pkg string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "remove_deb_rpm_package")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "remove_deb_rpm_package")
+	defer func() { span.Finish(err) }()
 	// Compute the right command depending on the package manager
 	var cmd *exec.Cmd
 	if _, pathErr := exec.LookPath("dpkg"); pathErr == nil {

--- a/pkg/fleet/installer/packages/systemd.go
+++ b/pkg/fleet/installer/packages/systemd.go
@@ -17,15 +17,15 @@ import (
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/embedded"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const systemdPath = "/etc/systemd/system"
 
 func stopUnit(ctx context.Context, unit string, args ...string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "stop_unit")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "stop_unit")
+	defer func() { span.Finish(err) }()
 	span.SetTag("unit", unit)
 	args = append([]string{"stop", unit}, args...)
 	err = exec.CommandContext(ctx, "systemctl", args...).Run()
@@ -42,8 +42,8 @@ func stopUnit(ctx context.Context, unit string, args ...string) (err error) {
 }
 
 func startUnit(ctx context.Context, unit string, args ...string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "start_unit")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "start_unit")
+	defer func() { span.Finish(err) }()
 	span.SetTag("unit", unit)
 	args = append([]string{"start", unit}, args...)
 	err = exec.CommandContext(ctx, "systemctl", args...).Run()
@@ -56,8 +56,8 @@ func startUnit(ctx context.Context, unit string, args ...string) (err error) {
 }
 
 func enableUnit(ctx context.Context, unit string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "enable_unit")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "enable_unit")
+	defer func() { span.Finish(err) }()
 	span.SetTag("unit", unit)
 	err = exec.CommandContext(ctx, "systemctl", "enable", unit).Run()
 	exitErr := &exec.ExitError{}
@@ -69,8 +69,8 @@ func enableUnit(ctx context.Context, unit string) (err error) {
 }
 
 func disableUnit(ctx context.Context, unit string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "disable_unit")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "disable_unit")
+	defer func() { span.Finish(err) }()
 	span.SetTag("unit", unit)
 
 	enabledErr := exec.CommandContext(ctx, "systemctl", "is-enabled", "--quiet", unit).Run()
@@ -93,8 +93,8 @@ func disableUnit(ctx context.Context, unit string) (err error) {
 }
 
 func loadUnit(ctx context.Context, unit string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "load_unit")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "load_unit")
+	defer func() { span.Finish(err) }()
 	span.SetTag("unit", unit)
 	content, err := embedded.FS.ReadFile(unit)
 	if err != nil {
@@ -105,8 +105,8 @@ func loadUnit(ctx context.Context, unit string) (err error) {
 }
 
 func removeUnit(ctx context.Context, unit string) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "remove_unit")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "remove_unit")
+	defer func() { span.Finish(err) }()
 	span.SetTag("unit", unit)
 	err = os.Remove(path.Join(systemdPath, unit))
 	if err != nil && !os.IsNotExist(err) {
@@ -116,8 +116,8 @@ func removeUnit(ctx context.Context, unit string) (err error) {
 }
 
 func systemdReload(ctx context.Context) (err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "systemd_reload")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, _ := telemetry.StartSpanFromContext(ctx, "systemd_reload")
+	defer func() { span.Finish(err) }()
 	err = exec.CommandContext(ctx, "systemctl", "daemon-reload").Run()
 	exitErr := &exec.ExitError{}
 	if !errors.As(err, &exitErr) {

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -17,9 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/version"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (
@@ -41,7 +40,7 @@ type Setup struct {
 	Out      *Output
 	Env      *env.Env
 	Ctx      context.Context
-	Span     ddtrace.Span
+	Span     telemetry.Span
 	Packages Packages
 	Config   Config
 }
@@ -61,7 +60,7 @@ Running the %s installation script (https://github.com/DataDog/datadog-agent/tre
 	if err != nil {
 		return nil, fmt.Errorf("failed to create installer: %w", err)
 	}
-	span, ctx := tracer.StartSpanFromContext(ctx, fmt.Sprintf("setup.%s", flavor))
+	span, ctx := telemetry.StartSpanFromContext(ctx, fmt.Sprintf("setup.%s", flavor))
 	s := &Setup{
 		configDir: configDir,
 		installer: installer,
@@ -89,7 +88,7 @@ Running the %s installation script (https://github.com/DataDog/datadog-agent/tre
 
 // Run installs the packages and writes the configurations
 func (s *Setup) Run() (err error) {
-	defer func() { s.Span.Finish(tracer.WithError(err)) }()
+	defer func() { s.Span.Finish(err) }()
 	s.Out.WriteString("Applying configurations...\n")
 	err = writeConfigs(s.Config, s.configDir)
 	if err != nil {
@@ -118,8 +117,8 @@ func (s *Setup) Run() (err error) {
 
 // installPackage mimicks the telemetry of calling the install package command
 func (s *Setup) installPackage(name string, url string) (err error) {
-	span, ctx := tracer.StartSpanFromContext(s.Ctx, "install")
-	defer func() { span.Finish(tracer.WithError(err)) }()
+	span, ctx := telemetry.StartSpanFromContext(s.Ctx, "install")
+	defer func() { span.Finish(err) }()
 	span.SetTag("url", url)
 	span.SetTag("_top_level", 1)
 

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -13,9 +13,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 )
 
 func TestSetupCommonHostTags(t *testing.T) {
@@ -70,7 +70,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 			for k, v := range tt.env {
 				require.NoError(t, os.Setenv(k, v))
 			}
-			span, _ := tracer.StartSpanFromContext(context.Background(), "test")
+			span, _ := telemetry.StartSpanFromContext(context.Background(), "test")
 			s := &common.Setup{Span: span}
 
 			setupCommonHostTags(s)

--- a/pkg/fleet/internal/cdn/cdn.go
+++ b/pkg/fleet/internal/cdn/cdn.go
@@ -16,8 +16,8 @@ import (
 	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const policyMetadataFilename = "policy.metadata"
@@ -110,13 +110,13 @@ func New(env *env.Env, configDBPath string) (*CDN, error) {
 
 // Get fetches the configuration for the given package.
 func (c *CDN) Get(ctx context.Context, pkg string) (cfg Config, err error) {
-	span, _ := tracer.StartSpanFromContext(ctx, "cdn.Get")
+	span, _ := telemetry.StartSpanFromContext(ctx, "cdn.Get")
 	defer func() {
 		spanErr := err
 		if spanErr == ErrProductNotSupported {
 			spanErr = nil
 		}
-		span.Finish(tracer.WithError(spanErr))
+		span.Finish(spanErr)
 	}()
 
 	switch pkg {

--- a/pkg/fleet/internal/exec/installer_exec.go
+++ b/pkg/fleet/internal/exec/installer_exec.go
@@ -22,7 +22,6 @@ import (
 	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // InstallerExec is an implementation of the Installer interface that uses the installer binary.
@@ -41,13 +40,13 @@ func NewInstallerExec(env *env.Env, installerBinPath string) *InstallerExec {
 
 type installerCmd struct {
 	*exec.Cmd
-	span tracer.Span
+	span telemetry.Span
 	ctx  context.Context
 }
 
 func (i *InstallerExec) newInstallerCmd(ctx context.Context, command string, args ...string) *installerCmd {
 	env := i.env.ToEnv()
-	span, ctx := tracer.StartSpanFromContext(ctx, fmt.Sprintf("installer.%s", command))
+	span, ctx := telemetry.StartSpanFromContext(ctx, fmt.Sprintf("installer.%s", command))
 	span.SetTag("args", args)
 	cmd := exec.CommandContext(ctx, i.installerBinPath, append([]string{command}, args...)...)
 	env = append(os.Environ(), env...)
@@ -72,14 +71,14 @@ func (i *InstallerExec) newInstallerCmd(ctx context.Context, command string, arg
 // Install installs a package.
 func (i *InstallerExec) Install(ctx context.Context, url string, _ []string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "install", url)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // Remove removes a package.
 func (i *InstallerExec) Remove(ctx context.Context, pkg string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "remove", pkg)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
@@ -91,70 +90,70 @@ func (i *InstallerExec) Purge(_ context.Context) {
 // InstallExperiment installs an experiment.
 func (i *InstallerExec) InstallExperiment(ctx context.Context, url string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "install-experiment", url)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // RemoveExperiment removes an experiment.
 func (i *InstallerExec) RemoveExperiment(ctx context.Context, pkg string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "remove-experiment", pkg)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // PromoteExperiment promotes an experiment to stable.
 func (i *InstallerExec) PromoteExperiment(ctx context.Context, pkg string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "promote-experiment", pkg)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // InstallConfigExperiment installs an experiment.
 func (i *InstallerExec) InstallConfigExperiment(ctx context.Context, url string, version string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "install-config-experiment", url, version)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // RemoveConfigExperiment removes an experiment.
 func (i *InstallerExec) RemoveConfigExperiment(ctx context.Context, pkg string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "remove-config-experiment", pkg)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // PromoteConfigExperiment promotes an experiment to stable.
 func (i *InstallerExec) PromoteConfigExperiment(ctx context.Context, pkg string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "promote-config-experiment", pkg)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // GarbageCollect runs the garbage collector.
 func (i *InstallerExec) GarbageCollect(ctx context.Context) (err error) {
 	cmd := i.newInstallerCmd(ctx, "garbage-collect")
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // InstrumentAPMInjector instruments the APM auto-injector.
 func (i *InstallerExec) InstrumentAPMInjector(ctx context.Context, method string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "apm instrument", method)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // UninstrumentAPMInjector uninstruments the APM auto-injector.
 func (i *InstallerExec) UninstrumentAPMInjector(ctx context.Context, method string) (err error) {
 	cmd := i.newInstallerCmd(ctx, "apm uninstrument", method)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	return cmd.Run()
 }
 
 // IsInstalled checks if a package is installed.
 func (i *InstallerExec) IsInstalled(ctx context.Context, pkg string) (_ bool, err error) {
 	cmd := i.newInstallerCmd(ctx, "is-installed", pkg)
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	err = cmd.Run()
 	if err != nil && cmd.ProcessState.ExitCode() == 10 {
 		return false, nil
@@ -168,7 +167,7 @@ func (i *InstallerExec) IsInstalled(ctx context.Context, pkg string) (_ bool, er
 // DefaultPackages returns the default packages to install.
 func (i *InstallerExec) DefaultPackages(ctx context.Context) (_ []string, err error) {
 	cmd := i.newInstallerCmd(ctx, "default-packages")
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -190,7 +189,7 @@ func (i *InstallerExec) DefaultPackages(ctx context.Context) (_ []string, err er
 // Setup runs the setup command.
 func (i *InstallerExec) Setup(ctx context.Context) (err error) {
 	cmd := i.newInstallerCmd(ctx, "setup")
-	defer func() { cmd.span.Finish(tracer.WithError(err)) }()
+	defer func() { cmd.span.Finish(err) }()
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	err = cmd.Run()

--- a/pkg/fleet/telemetry/span.go
+++ b/pkg/fleet/telemetry/span.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package telemetry provides the telemetry for fleet components.
+package telemetry
+
+import (
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+// Span is an alias for ddtrace.Span until we phase ddtrace out.
+type Span struct{ ddtrace.Span }
+
+// Finish finishes the span with an error.
+func (s *Span) Finish(err error) {
+	s.Span.Finish(tracer.WithError(err))
+}
+
+// SetResourceName sets the resource name of the span.
+func (s *Span) SetResourceName(name string) {
+	s.Span.SetTag(ext.ResourceName, name)
+}

--- a/pkg/fleet/telemetry/telemetry.go
+++ b/pkg/fleet/telemetry/telemetry.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 
+	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
@@ -207,25 +208,9 @@ func (addr) String() string {
 	return "local"
 }
 
-// StartSpanFromEnv starts a span using the environment variables to find the parent span.
-func StartSpanFromEnv(ctx context.Context, operationName string, spanOptions ...ddtrace.StartSpanOption) (ddtrace.Span, context.Context) {
-	spanContext, ok := spanContextFromEnv()
-	if ok {
-		spanOptions = append([]ddtrace.StartSpanOption{tracer.ChildOf(spanContext)}, spanOptions...)
-	}
-	return tracer.StartSpanFromContext(ctx, operationName, spanOptions...)
-}
-
-// spanContextFromEnv injects the traceID and parentID from the environment into the context if available.
-func spanContextFromEnv() (ddtrace.SpanContext, bool) {
-	traceID, ok := os.LookupEnv(EnvTraceID)
-	if !ok {
-		traceID = strconv.FormatUint(rand.Uint64(), 10)
-	}
-	parentID, ok := os.LookupEnv(EnvParentID)
-	if !ok {
-		parentID = "0"
-	}
+// StartSpanFromIDs starts a span using the trace and parent
+// IDs provided.
+func StartSpanFromIDs(ctx context.Context, operationName, traceID, parentID string, spanOptions ...ddtrace.StartSpanOption) (Span, context.Context) {
 	ctxCarrier := tracer.TextMapCarrier{
 		tracer.DefaultTraceIDHeader:  traceID,
 		tracer.DefaultParentIDHeader: parentID,
@@ -234,9 +219,39 @@ func spanContextFromEnv() (ddtrace.SpanContext, bool) {
 	spanCtx, err := tracer.Extract(ctxCarrier)
 	if err != nil {
 		log.Debugf("failed to extract span context from install script params: %v", err)
-		return nil, false
+		return Span{tracer.StartSpan("remote_request")}, ctx
 	}
-	return spanCtx, true
+	spanOptions = append([]ddtrace.StartSpanOption{tracer.ChildOf(spanCtx)}, spanOptions...)
+
+	return StartSpanFromContext(ctx, operationName, spanOptions...)
+}
+
+// SpanFromContext returns the span from the context if available.
+func SpanFromContext(ctx context.Context) (Span, bool) {
+	span, ok := tracer.SpanFromContext(ctx)
+	if !ok {
+		return Span{}, false
+	}
+	return Span{span}, true
+}
+
+// StartSpanFromContext starts a span using the context to find the parent span.
+func StartSpanFromContext(ctx context.Context, operationName string, spanOptions ...ddtrace.StartSpanOption) (Span, context.Context) {
+	span, ctx := tracer.StartSpanFromContext(ctx, operationName, spanOptions...)
+	return Span{span}, ctx
+}
+
+// StartSpanFromEnv starts a span using the environment variables to find the parent span.
+func StartSpanFromEnv(ctx context.Context, operationName string, spanOptions ...ddtrace.StartSpanOption) (Span, context.Context) {
+	traceID, ok := os.LookupEnv(EnvTraceID)
+	if !ok {
+		traceID = strconv.FormatUint(rand.Uint64(), 10)
+	}
+	parentID, ok := os.LookupEnv(EnvParentID)
+	if !ok {
+		parentID = "0"
+	}
+	return StartSpanFromIDs(ctx, operationName, traceID, parentID, spanOptions...)
 }
 
 // EnvFromContext returns the environment variables for the context.
@@ -265,4 +280,9 @@ func WithSamplingRules(rules ...tracer.SamplingRule) Option {
 	return func(t *Telemetry) {
 		t.samplingRules = rules
 	}
+}
+
+// WrapRoundTripper wraps the round tripper with the telemetry round tripper.
+func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	return httptrace.WrapRoundTripper(rt)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
ddtrace accounts for 70% of downloader size, and a big chunk of installer too. Preparing the phasing out of the package by moving all references to `telemetry` package
Follow-up from Arthur's work


### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->