### PR TITLE
usm: go-tls: Change BPF_LRU_MAP to BPF_HASH_MAP

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
@@ -11,11 +11,11 @@ BPF_HASH_MAP(offsets_data, go_tls_offsets_data_key_t, tls_offsets_data_t, 1024)
 
 /* go_tls_read_args is used to get the read function info when running in the read-return uprobe.
    The key contains the go routine id and the pid. */
-BPF_LRU_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 2048)
+BPF_HASH_MAP(go_tls_read_args, go_tls_function_args_key_t, go_tls_read_args_data_t, 2048)
 
 /* go_tls_write_args is used to get the read function info when running in the write-return uprobe.
    The key contains the go routine id and the pid. */
-BPF_LRU_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 2048)
+BPF_HASH_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_data_t, 2048)
 
 /* This map associates crypto/tls.(*Conn) values to the corresponding conn_tuple_t* value.
    It is used to implement a simplified version of tup_from_ssl_ctx from usm.c


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replaces BPF_LRU_MAP with BPF_HASH_MAP in GO-TLS.

### Motivation

eBPF LRU is an unstable datastore that can evict items even when the map is not full or nearly full, and once eviction happens, it can remove many entries from the map, which can bring inaccuracies for our monitoring capabilities.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/USMON-1383