### PR TITLE
usm: sharedlibraries: Change BPF_LRU_MAP to BPF_HASH_MAP

### DIFF
--- a/pkg/network/ebpf/c/shared-libraries/maps.h
+++ b/pkg/network/ebpf/c/shared-libraries/maps.h
@@ -4,7 +4,9 @@
 #include "shared-libraries/types.h"
 #include "map-defs.h"
 
-BPF_LRU_MAP(open_at_args, __u64, lib_path_t, 1024)
+// This map is used with 3 different probes, each can be called up to 1024 times each.
+// Thus we need to have a map that can store 1024*3 entries. I'm using a larger map to be safe.
+BPF_HASH_MAP(open_at_args, __u64, lib_path_t, 10240)
 
 /*
  * These maps are used for notifying userspace of a shared library being loaded


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replaces BPF_LRU_MAP with BPF_HASH_MAP in Native-TLS.

### Motivation

eBPF LRU is an unstable datastore that can evict items even when the map is not full or nearly full, and once eviction happens, it can remove many entries from the map, which can bring inaccuracies for our monitoring capabilities.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/USMON-1384