### PR TITLE
[CWS] cut allocation in `GetProcContainerContext`

### DIFF
--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -62,12 +62,18 @@ func GetLastProcControlGroups(tgid, pid uint32) (ControlGroup, error) {
 	index := bytes.LastIndexByte(data, '\n')
 	if index < 0 {
 		index = 0
+	} else {
+		index++ // to skip the \n
 	}
-	firstLine := string(data[index:])
+	if index >= len(data) {
+		return ControlGroup{}, fmt.Errorf("invalid cgroup data: %s", data)
+	}
 
-	idstr, rest, ok := strings.Cut(firstLine, ":")
+	lastLine := string(data[index:])
+
+	idstr, rest, ok := strings.Cut(lastLine, ":")
 	if !ok {
-		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", firstLine)
+		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", lastLine)
 	}
 
 	id, err := strconv.Atoi(idstr)
@@ -77,7 +83,7 @@ func GetLastProcControlGroups(tgid, pid uint32) (ControlGroup, error) {
 
 	controllers, path, ok := strings.Cut(rest, ":")
 	if !ok {
-		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", firstLine)
+		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", lastLine)
 	}
 
 	return ControlGroup{

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -12,6 +12,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/sha256"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -47,6 +48,43 @@ func (cg ControlGroup) GetContainerContext() (containerutils.ContainerID, contai
 func (cg ControlGroup) GetContainerID() containerutils.ContainerID {
 	id, _ := containerutils.FindContainerID(containerutils.CGroupID(cg.Path))
 	return containerutils.ContainerID(id)
+}
+
+// GetLastProcControlGroups returns the first cgroup membership of the specified task.
+func GetLastProcControlGroups(tgid, pid uint32) (ControlGroup, error) {
+	data, err := os.ReadFile(CgroupTaskPath(tgid, pid))
+	if err != nil {
+		return ControlGroup{}, err
+	}
+
+	data = bytes.TrimSpace(data)
+
+	index := bytes.LastIndexByte(data, '\n')
+	if index < 0 {
+		index = 0
+	}
+	firstLine := string(data[index:])
+
+	idstr, rest, ok := strings.Cut(firstLine, ":")
+	if !ok {
+		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", firstLine)
+	}
+
+	id, err := strconv.Atoi(idstr)
+	if err != nil {
+		return ControlGroup{}, err
+	}
+
+	controllers, path, ok := strings.Cut(rest, ":")
+	if !ok {
+		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", firstLine)
+	}
+
+	return ControlGroup{
+		ID:          id,
+		Controllers: strings.Split(controllers, ","),
+		Path:        path,
+	}, nil
 }
 
 // GetProcControlGroups returns the cgroup membership of the specified task.
@@ -85,15 +123,14 @@ func GetProcContainerID(tgid, pid uint32) (containerutils.ContainerID, error) {
 // GetProcContainerContext returns the container ID which the process belongs to along with its manager. Returns "" if the process does not belong
 // to a container.
 func GetProcContainerContext(tgid, pid uint32) (containerutils.ContainerID, model.CGroupContext, error) {
-	cgroups, err := GetProcControlGroups(tgid, pid)
-	if err != nil || len(cgroups) == 0 {
+	cgroup, err := GetLastProcControlGroups(tgid, pid)
+	if err != nil {
 		return "", model.CGroupContext{}, err
 	}
 
-	lastCgroup := len(cgroups) - 1
-	containerID, runtime := cgroups[lastCgroup].GetContainerContext()
+	containerID, runtime := cgroup.GetContainerContext()
 	cgroupContext := model.CGroupContext{
-		CGroupID:    containerutils.CGroupID(cgroups[lastCgroup].Path),
+		CGroupID:    containerutils.CGroupID(cgroup.Path),
 		CGroupFlags: runtime,
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The function `GetProcContainerContext` is called a lot, and each code results in a read of the proc cgroup file. This PR improves this situation a bit by reading only the last cgroup (which is the one we use for proc context right now), and cuts most of split related allocations.

[Example profile](https://app.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20datacenter%3Aus1.ddbuild.io%20runtime_os%3Alinux&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZPOfmt73FosLQAAABhBWlBPZm11REFBQ2xaQXRrbk5kU1ZRQUEAAAAkMDE5M2NlN2YtZTRlZC00ZDA0LWJlZGItMzA4NWFlNjFmNjVlAAWngQ&my_code=disabled&profile_type=alloc-size&profileId=AZPOfmuDAAClZAtknNdSVQAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1734333150058&to_ts=1734336750058&live=false) showing why it's important

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->