### PR TITLE
[ebpfless] Add 5 second expiry to pending connections

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -40,6 +40,7 @@ const (
 )
 
 var statsTelemetry = struct {
+	expiredPendingConns     telemetry.Counter
 	droppedPendingConns     telemetry.Counter
 	droppedEstablishedConns telemetry.Counter
 	missedTCPHandshakes     telemetry.Counter
@@ -48,6 +49,7 @@ var statsTelemetry = struct {
 	tcpRstAndSyn            telemetry.Counter
 	tcpRstAndFin            telemetry.Counter
 }{
+	expiredPendingConns:     telemetry.NewCounter(ebpflessModuleName, "expired_pending_conns", nil, "Counter measuring the number of TCP connections which expired because it took too long to complete the handshake"),
 	droppedPendingConns:     telemetry.NewCounter(ebpflessModuleName, "dropped_pending_conns", nil, "Counter measuring the number of TCP connections which were dropped during the handshake (because the map was full)"),
 	droppedEstablishedConns: telemetry.NewCounter(ebpflessModuleName, "dropped_established_conns", nil, "Counter measuring the number of TCP connections which were dropped while established (because the map was full)"),
 	missedTCPHandshakes:     telemetry.NewCounter(ebpflessModuleName, "missed_tcp_handshakes", nil, "Counter measuring the number of TCP connections where we missed the SYN handshake"),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a 5 second expiry to pending connections that didn't complete the handshake in time.

### Motivation
Pending connections don't have a ConnectionStats object yet so the existing tracer logic won't expire them. Plus it's probably better to have a shorter timeout for pending connections (although the exact number we can decide, it will be a config later)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Run the TCP processor test suite:
```
go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer/connection/ebpfless
```
In particular, the new test `TestPendingConnExpiry` should pass.

### Possible Drawbacks / Trade-offs
This adds a timestamp into the `connectionState` structure which is effectively redundant with `ConnectionStats`. The reason to have it is, the `ConnectionStats` won't exist yet until the connection moves out of pending, so it has to be stored somewhere. But I think it would be good to refactor this in the future, will have to think about how to combine these responsibilities.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->