### PR TITLE
fix(issue.assign-owner): Change default team

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -25,9 +25,7 @@ def assign_owner(_, issue_id, dry_run=False):
         from slack_sdk import WebClient
 
         client = WebClient(os.environ['SLACK_API_TOKEN'])
-        channel = next(
-            (chan for team, chan in GITHUB_SLACK_MAP.items() if owner.lower() in team), '#agent-ask-anything'
-        )
+        channel = next((chan for team, chan in GITHUB_SLACK_MAP.items() if owner.lower() in team), '#agent-devx-help')
         message = f':githubstatus_partial_outage: *New Community Issue*\n{issue.title} <{issue.html_url}|{gh.repo.name}#{issue_id}>\n'
         if channel == '#agent-ask-anything':
             message += "The CI bot failed to assign this issue to a team.\nPlease assign it manually."


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Redirect to `#agent-devx-help` instead of `#agent-ask-anything` while thinking to a better solution. 

### Motivation
`#agent-ask-anything` is not meant to receive bot notifications, so we will try to redirect from devx-team. An improvement of the bot is required to prevent any human intervention in the process

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->