### PR TITLE
Stop lint and test tasks on keyboard interrupt

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -78,11 +78,16 @@ def run_golangci_lint(
             concurrency_arg = "" if concurrency is None else f"--concurrency {concurrency}"
             tags_arg = " ".join(sorted(set(tags)))
             timeout_arg_value = "25m0s" if not timeout else f"{timeout}m0s"
-            return ctx.run(
+            res = ctx.run(
                 f'golangci-lint run {verbosity} --timeout {timeout_arg_value} {concurrency_arg} --build-tags "{tags_arg}" --path-prefix "{module_path}" {golangci_lint_kwargs} {target}/...',
                 env=env,
                 warn=True,
             )
+            # early stop on SIGINT: exit code is 128 + signal number, SIGINT is 2, so 130
+            # for some reason this becomes -2 here
+            if res is not None and (res.exited == -2 or res.exited == 130):
+                raise KeyboardInterrupt()
+            return res
 
         target_path = Path(module_path) / target
         result, time_result = TimedOperationResult.run(

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -151,6 +151,9 @@ def test_flavor(
                     out_stream=test_profiler,
                     warn=True,
                 )
+                # early stop on SIGINT: exit code is 128 + signal number, SIGINT is 2, so 130
+                if res is not None and res.exited == 130:
+                    raise KeyboardInterrupt()
 
         module_result.result_json_path = os.path.join(module_path, GO_TEST_RESULT_TMP_JSON)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Actually stop `linter.go` and `test` tasks when hitting Ctrl+C in terminal.

### Motivation
Currently the signal sent by Ctrl+C (SIGINT) is forwarded to respectively `golangci-lint` or `go`, but since we run them for every module it doesn't stop the whole task, it just makes one module fail, so you have to hit Ctrl+C for 10 seconds for the tasks to actually stop. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ensured manually that it behaved as expected.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
It seems that when running `golangci-lint` in invoke, the exit code is given as -2 (while `golangci-lint` seems to exit with 130).
I chose to handle both values the same to be safe.