### PR TITLE
Add metrics origins for Quarkus integration

### DIFF
--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -308,6 +308,7 @@ const (
 	MetricSourceAnyscale
 	MetricSourceMilvus
 	MetricSourceNvidiaNim
+	MetricSourceMilvus
 )
 
 // String returns a string representation of MetricSource
@@ -879,6 +880,8 @@ func (ms MetricSource) String() string {
 		return "aws_neuron"
 	case MetricSourceMilvus:
 		return "milvus"
+	case MetricSourceQuarkus:
+		return "quarkus"
 	default:
 		return "<unknown>"
 	}
@@ -1421,6 +1424,8 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceTibcoEMS
 	case "milvus":
 		return MetricSourceMilvus
+	case "quarkus":
+		return MetricSourceQuarkus
 	default:
 		return MetricSourceUnknown
 	}

--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -308,7 +308,7 @@ const (
 	MetricSourceAnyscale
 	MetricSourceMilvus
 	MetricSourceNvidiaNim
-	MetricSourceMilvus
+	MetricSourceQuarkus
 )
 
 // String returns a string representation of MetricSource

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -308,6 +308,7 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceZk,
 		metrics.MetricSourceAwsNeuron,
 		metrics.MetricSourceNvidiaNim,
+		metrics.MetricSourceQuarkus,
 		metrics.MetricSourceMilvus:
 		return 11 // integrationMetrics
 	default:
@@ -902,6 +903,8 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 425
 	case metrics.MetricSourceNvidiaNim:
 		return 426
+	case metrics.MetricSourceQuarkus:
+		return 427
 	default:
 		return 0
 	}

--- a/releasenotes/notes/Add-metrics-origins-for-Quarkus-integration.-e2ff9ac00b7ea6df.yaml
+++ b/releasenotes/notes/Add-metrics-origins-for-Quarkus-integration.-e2ff9ac00b7ea6df.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Add metrics origins for Quarkus integration.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
metrics origins for quarkus integration

### Motivation
need us some quarkus

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Followed these (internal) [docs](https://datadoghq.atlassian.net/wiki/spaces/METRICSIN/pages/2827650029/internal+Adding+new+metrics+origins).

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->