### PR TITLE
discovery: e2e: Avoid fail on temporary network errors

### DIFF
--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -170,7 +170,19 @@ func assertRunningCheck(t *assert.CollectT, remoteHost *components.RemoteHost, c
 func (s *linuxTestSuite) provisionServer() {
 	err := s.Env().RemoteHost.CopyFolder("testdata/provision", "/home/ubuntu/e2e-test")
 	require.NoError(s.T(), err)
-	s.Env().RemoteHost.MustExecute("sudo bash /home/ubuntu/e2e-test/provision.sh")
+
+	cmd := "sudo bash /home/ubuntu/e2e-test/provision.sh"
+	_, err = s.Env().RemoteHost.Execute(cmd)
+	if err != nil {
+		// Sometimes temporary network errors are seen which cause the provision
+		// script to fail.
+		s.T().Log("Retrying provision due to failure", err)
+		time.Sleep(30 * time.Second)
+		_, err := s.Env().RemoteHost.Execute(cmd)
+		if err != nil {
+			s.T().Skip("Unable to provision server")
+		}
+	}
 }
 
 func (s *linuxTestSuite) startServices() {


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The server provisioning has been seen to fail in some rare cases due to temporary network errors or server issues on external servers. Avoid failing the test in the case by (1) retrying the provision after a delay if it fails and (2) marking the test as skipped if it fails a second time.

### Motivation

[This](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/738617679) failure caused a page.

### Describe how you validated your changes

Covered by e2e tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->