### PR TITLE
[ASCII-2613] Remove golang.org/x/text/cases from some builds

### DIFF
--- a/comp/core/status/render_helpers.go
+++ b/comp/core/status/render_helpers.go
@@ -23,8 +23,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cast"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -291,7 +289,7 @@ func formatTitle(title string) string {
 	title = strings.Join(words, " ")
 
 	// Capitalize the first letter
-	return cases.Title(language.English, cases.NoLower).String(title)
+	return strings.ToUpper(string(title[0])) + title[1:]
 }
 
 func status(check map[string]interface{}) string {

--- a/comp/core/status/render_helpers.go
+++ b/comp/core/status/render_helpers.go
@@ -288,6 +288,10 @@ func formatTitle(title string) string {
 	}
 	title = strings.Join(words, " ")
 
+	if title == "" {
+		return ""
+	}
+
 	// Capitalize the first letter
 	return strings.ToUpper(string(title[0])) + title[1:]
 }

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -78,7 +78,6 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/atomic v1.11.0
 	go.uber.org/fx v1.23.0
-	golang.org/x/text v0.21.0
 )
 
 require (
@@ -148,6 +147,7 @@ require (
 	golang.org/x/exp v0.0.0-20241210194714-1829a127f884 // indirect
 	golang.org/x/net v0.32.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
+	golang.org/x/text v0.21.0 // indirect
 	google.golang.org/protobuf v1.35.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/comp/forwarder/defaultforwarder/internal/retry/telemetry.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/telemetry.go
@@ -9,9 +9,6 @@ import (
 	"expvar"
 	"strings"
 
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
-
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder/transaction"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
@@ -308,11 +305,11 @@ func (t onDiskRetryQueueTelemetry) addDeserializeTransactionsCount(count int) {
 }
 
 func toCamelCase(s string) string {
-	caser := cases.Title(language.English)
 	parts := strings.Split(s, "_")
 	var camelCase string
 	for _, p := range parts {
-		camelCase += caser.String(p)
+		camelCase += strings.ToUpper(string(p[0]))
+		camelCase += string(p[1:])
 	}
 	return camelCase
 }

--- a/comp/forwarder/defaultforwarder/internal/retry/telemetry.go
+++ b/comp/forwarder/defaultforwarder/internal/retry/telemetry.go
@@ -308,6 +308,9 @@ func toCamelCase(s string) string {
 	parts := strings.Split(s, "_")
 	var camelCase string
 	for _, p := range parts {
+		if p == "" {
+			continue
+		}
 		camelCase += strings.ToUpper(string(p[0]))
 		camelCase += string(p[1:])
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove `golang.org/x/text/cases` from some builds.

### Motivation
The dependencies are not needed just to capitalize the first letter of a string. 

I'm hoping this reduces binary size a bit.
EDIT: -0.3MB, not a lot but considering the change is pretty small we might as well merge it.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->