### PR TITLE
Remove optional from configsync in favor of an internal enabled/disabled state

### DIFF
--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -112,15 +112,15 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 			}),
 			logfx.Module(),
 			fetchonlyimpl.Module(),
-			// TODO: don't rely on this pattern; remove this `OptionalModuleWithParams` thing
+			// TODO: don't rely on this pattern; remove this `ModuleWithParams` thing
 			//       and instead adapt OptionalModule to allow parameter passing naturally.
 			//       See: https://github.com/DataDog/datadog-agent/pull/28386
-			configsyncimpl.OptionalModuleWithParams(),
+			configsyncimpl.ModuleWithParams(),
 			fx.Provide(func() configsyncimpl.Params {
 				return configsyncimpl.NewParams(params.SyncTimeout, params.SyncDelay, true)
 			}),
 			converterfx.Module(),
-			fx.Provide(func(cp converter.Component, _ optional.Option[configsync.Component]) confmap.Converter {
+			fx.Provide(func(cp converter.Component, _ configsync.Component) confmap.Converter {
 				return cp
 			}),
 			collectorcontribFx.Module(),
@@ -191,10 +191,10 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 		fx.Invoke(func(_ collectordef.Component, _ defaultforwarder.Forwarder, _ optional.Option[logsagentpipeline.Component]) {
 		}),
 
-		// TODO: don't rely on this pattern; remove this `OptionalModuleWithParams` thing
+		// TODO: don't rely on this pattern; remove this `ModuleWithParams` thing
 		//       and instead adapt OptionalModule to allow parameter passing naturally.
 		//       See: https://github.com/DataDog/datadog-agent/pull/28386
-		configsyncimpl.OptionalModuleWithParams(),
+		configsyncimpl.ModuleWithParams(),
 		fx.Provide(func() configsyncimpl.Params {
 			return configsyncimpl.NewParams(params.SyncTimeout, params.SyncDelay, true)
 		}),
@@ -218,7 +218,7 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 
 		// TODO: consider adding configsync.Component as an explicit dependency for traceconfig
 		//       to avoid this sort of dependency tree hack.
-		fx.Provide(func(deps traceconfig.Dependencies, _ optional.Option[configsync.Component]) (traceconfig.Component, error) {
+		fx.Provide(func(deps traceconfig.Dependencies, _ configsync.Component) (traceconfig.Component, error) {
 			// TODO: this would be much better if we could leverage traceconfig.Module
 			//       Must add a new parameter to traconfig.Module to handle this.
 			return traceconfig.NewConfig(deps)
@@ -236,13 +236,13 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 
 // ForwarderBundle returns the fx.Option for the forwarder bundle.
 // TODO: cleanup the forwarder instantiation with fx.
-// This is a bit of a hack because we need to enforce optional.Option[configsync.Component]
+// This is a bit of a hack because we need to enforce configsync.Component
 // is passed to newForwarder to enforce the correct instantiation order. Currently, the
 // new forwarder.BundleWithProvider makes a few assumptions in its generic prototype, and
 // this is the current workaround to leverage it.
 func ForwarderBundle() fx.Option {
 	return defaultforwarder.ModulWithOptionTMP(
-		fx.Provide(func(_ optional.Option[configsync.Component]) defaultforwarder.Params {
+		fx.Provide(func(_ configsync.Component) defaultforwarder.Params {
 			return defaultforwarder.NewParams()
 		}))
 }

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -65,7 +65,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil/logging"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -156,7 +155,7 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		fetchonlyimpl.Module(),
 
 		// Provide configsync module
-		configsyncimpl.OptionalModule(),
+		configsyncimpl.Module(),
 
 		// Provide autoexit module
 		autoexitimpl.Module(),
@@ -215,7 +214,7 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			_ expvars.Component,
 			_ apiserver.Component,
 			cfg config.Component,
-			_ optional.Option[configsync.Component],
+			_ configsync.Component,
 			// TODO: This is needed by the container-provider which is not currently a component.
 			// We should ensure the tagger is a dependency when converting to a component.
 			_ tagger.Component,

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -55,7 +55,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/servicemain"
 )
@@ -166,9 +165,9 @@ func (s *service) Run(svcctx context.Context) error {
 		statusimpl.Module(),
 
 		fetchonlyimpl.Module(),
-		configsyncimpl.OptionalModule(),
+		configsyncimpl.Module(),
 		// Force the instantiation of the component
-		fx.Invoke(func(_ optional.Option[configsync.Component]) {}),
+		fx.Invoke(func(_ configsync.Component) {}),
 		autoexitimpl.Module(),
 		fx.Provide(func(c config.Component) settings.Params {
 			return settings.Params{

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -66,7 +66,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/coredump"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -174,9 +173,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				statusimpl.Module(),
 				fetchonlyimpl.Module(),
-				configsyncimpl.OptionalModule(),
+				configsyncimpl.Module(),
 				// Force the instantiation of the component
-				fx.Invoke(func(_ optional.Option[configsync.Component]) {}),
+				fx.Invoke(func(_ configsync.Component) {}),
 				autoexitimpl.Module(),
 				fx.Supply(pidimpl.NewParams(params.pidfilePath)),
 				fx.Provide(func(c config.Component) settings.Params {

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -113,9 +113,9 @@ func runTraceAgentProcess(ctx context.Context, cliParams *Params, defaultConfPat
 		zstdfx.Module(),
 		trace.Bundle(),
 		fetchonlyimpl.Module(),
-		configsyncimpl.OptionalModule(),
+		configsyncimpl.Module(),
 		// Force the instantiation of the components
-		fx.Invoke(func(_ traceagent.Component, _ optional.Option[configsync.Component], _ autoexit.Component) {}),
+		fx.Invoke(func(_ traceagent.Component, _ configsync.Component, _ autoexit.Component) {}),
 	)
 	if err != nil && errors.Is(err, traceagentimpl.ErrAgentDisabled) {
 		return nil

--- a/comp/core/configsync/configsyncimpl/module_integration_test.go
+++ b/comp/core/configsync/configsyncimpl/module_integration_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/core/configsync"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func TestOptionalModule(t *testing.T) {
@@ -44,16 +43,14 @@ func TestOptionalModule(t *testing.T) {
 		"agent_ipc.port":                    port,
 		"agent_ipc.config_refresh_interval": 1,
 	}
-	csopt := fxutil.Test[optional.Option[configsync.Component]](t, fx.Options(
+	comp := fxutil.Test[configsync.Component](t, fx.Options(
 		core.MockBundle(),
 		fetchonlyimpl.Module(),
-		OptionalModule(),
+		Module(),
 		fx.Populate(&cfg),
 		fx.Replace(config.MockParams{Overrides: overrides}),
 	))
-
-	_, ok := csopt.Get()
-	require.True(t, ok)
+	require.True(t, comp.(configSync).enabled)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		assert.Equal(t, "value1", cfg.Get("key1"))

--- a/comp/core/configsync/configsyncimpl/module_test.go
+++ b/comp/core/configsync/configsyncimpl/module_test.go
@@ -8,34 +8,30 @@ package configsyncimpl
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestNewOptionalConfigSync(t *testing.T) {
+func TestNewConfigSync(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		deps := makeDeps(t)
 		deps.Config.Set("agent_ipc.port", 1234, pkgconfigmodel.SourceFile)
 		deps.Config.Set("agent_ipc.config_refresh_interval", 30, pkgconfigmodel.SourceFile)
-		optConfigSync := newOptionalConfigSync(deps)
-		_, ok := optConfigSync.Get()
-		require.True(t, ok)
+		comp := newComponent(deps)
+		assert.True(t, comp.(configSync).enabled)
 	})
 
 	t.Run("disabled ipc port zero", func(t *testing.T) {
 		deps := makeDeps(t)
 		deps.Config.Set("agent_ipc.port", 0, pkgconfigmodel.SourceFile)
-		optConfigSync := newOptionalConfigSync(deps)
-		_, ok := optConfigSync.Get()
-		require.False(t, ok)
+		comp := newComponent(deps)
+		assert.False(t, comp.(configSync).enabled)
 	})
 
 	t.Run("disabled config refresh interval zero", func(t *testing.T) {
 		deps := makeDeps(t)
 		deps.Config.Set("agent_ipc.config_refresh_interval", 0, pkgconfigmodel.SourceFile)
-		optConfigSync := newOptionalConfigSync(deps)
-		_, ok := optConfigSync.Get()
-		require.False(t, ok)
+		comp := newComponent(deps)
+		assert.False(t, comp.(configSync).enabled)
 	})
 }


### PR DESCRIPTION
### What does this PR do?

The caller should not care if `configsync` is enabled or not. There is no need to expose the internal state of the component to the user since it has no public method.

### Describe how you validated your changes

Running CI is enough.