### PR TITLE
Commit data when writing `auth_token` file

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -239,7 +239,7 @@ func validateAuthToken(authToken string) error {
 // writes auth token(s) to a file with the same permissions as datadog.yaml
 func saveAuthToken(token, tokenPath string) error {
 	log.Infof("Saving a new authentication token in %s", tokenPath)
-	if err := os.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
+	if err := writeFileAndSync(tokenPath, []byte(token), 0o600); err != nil {
 		return err
 	}
 
@@ -255,4 +255,20 @@ func saveAuthToken(token, tokenPath string) error {
 
 	log.Infof("Wrote auth token in %s", tokenPath)
 	return nil
+}
+
+// call the file.Sync method to flush the file to disk and catch potential I/O errors
+func writeFileAndSync(name string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(data)
+	if err1 := f.Sync(); err1 != nil && err == nil {
+		err = err1
+	}
+	if err2 := f.Close(); err2 != nil && err == nil {
+		err = err2
+	}
+	return err
 }

--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -264,11 +264,13 @@ func writeFileAndSync(name string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	_, err = f.Write(data)
-	if err1 := f.Sync(); err1 != nil && err == nil {
-		err = err1
+	// only sync data if the write was successful
+	if err == nil {
+		err = f.Sync()
 	}
-	if err2 := f.Close(); err2 != nil && err == nil {
-		err = err2
+	// but always close the file and report the first error that occurred
+	if err1 := f.Close(); err1 != nil && err == nil {
+		err = err1
 	}
 	return err
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Call `file.Sync()` when writing the `auth_token` file.

### Motivation

This allows catching potential I/O errors masked by asynchronous disk writes.

The token is only 32 bytes and is only written once at agent startup so the performance impact of this change should be   insignificant.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->