### PR TITLE
[gitlab] allow triggering a dev bump of test-infra

### DIFF
--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -37,13 +37,19 @@ def update(_: Context, tag: str = "", images: str = "", test: bool = True, list_
     print(f"  {', '.join(modified)}")
 
 
-@task(help={"commit_sha": "commit sha from the test-infra-definitions repository"})
-def update_test_infra_definitions(ctx: Context, commit_sha: str, go_mod_only: bool = False):
+@task(
+    help={
+        "commit_sha": "commit sha from the test-infra-definitions repository",
+        "go_mod_only": "Update only the go.mod file",
+        "is_dev_image": "Is the image bumped to a dev version, used to test changes in test-infra-definitions",
+    }
+)
+def update_test_infra_definitions(ctx: Context, commit_sha: str, go_mod_only: bool = False, is_dev_image: bool = False):
     """
     Update the test-infra-definition image version in the Gitlab CI as well as in the e2e go.mod
     """
     if not go_mod_only:
-        update_test_infra_def(".gitlab/common/test_infra_version.yml", commit_sha[:12])
+        update_test_infra_def(".gitlab/common/test_infra_version.yml", commit_sha[:12], is_dev_image)
 
     os.chdir("test/new-e2e")
     ctx.run(f"go get github.com/DataDog/test-infra-definitions@{commit_sha}")

--- a/tasks/buildimages.py
+++ b/tasks/buildimages.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os
-
 import yaml
 from invoke import Context, Exit, task
 
@@ -51,9 +49,9 @@ def update_test_infra_definitions(ctx: Context, commit_sha: str, go_mod_only: bo
     if not go_mod_only:
         update_test_infra_def(".gitlab/common/test_infra_version.yml", commit_sha[:12], is_dev_image)
 
-    os.chdir("test/new-e2e")
-    ctx.run(f"go get github.com/DataDog/test-infra-definitions@{commit_sha}")
-    ctx.run("go mod tidy")
+    with ctx.cd("test/new-e2e"):
+        ctx.run(f"go get github.com/DataDog/test-infra-definitions@{commit_sha}")
+        ctx.run("go mod tidy")
 
 
 @task(

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -1258,19 +1258,27 @@ def full_config_get_all_stages(full_config: dict) -> set[str]:
     return all_stages
 
 
-def update_test_infra_def(file_path, image_tag):
+def update_test_infra_def(file_path, image_tag, is_dev_image=False):
     """
-    Override TEST_INFRA_DEFINITIONS_BUILDIMAGES in `.gitlab/common/test_infra_version.yml` file
+    Updates TEST_INFRA_DEFINITIONS_BUILDIMAGES in `.gitlab/common/test_infra_version.yml` file
     """
-    with open(file_path) as gl:
-        file_content = gl.readlines()
-    with open(file_path, "w") as gl:
-        for line in file_content:
-            test_infra_def = re.search(r"TEST_INFRA_DEFINITIONS_BUILDIMAGES:\s*(\w+)", line)
-            if test_infra_def:
-                gl.write(line.replace(test_infra_def.group(1), image_tag))
+    import yaml
+
+    test_infra_def = {}
+    with open(file_path) as test_infra_version_file:
+        try:
+            test_infra_def = yaml.safe_load(test_infra_version_file)
+            test_infra_def["variables"]["TEST_INFRA_DEFINITIONS_BUILDIMAGES"] = image_tag
+            if is_dev_image:
+                test_infra_def["variables"]["TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX"] = "-dev"
             else:
-                gl.write(line)
+                test_infra_def["variables"]["TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX"] = ""
+        except yaml.YAMLError as e:
+            raise Exit(f"Error while loading {file_path}: {e}") from e
+    with open(file_path, "w") as test_infra_version_file:
+        # Add explicit_start=True to keep the document start marker ---
+        # See "Document Start" in https://www.yaml.info/learn/document.html for more details
+        yaml.dump(test_infra_def, test_infra_version_file, explicit_start=True)
 
 
 def update_gitlab_config(file_path, tag, images="", test=True, update=True):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allow bumping to a dev test-infra-definitions image

### Motivation

When changing `test-infra-definitions` we sometimes want to check that the integration with `datadog-agent` will work fine. This is a fully manual operation that is cumbersome and can be automated through a manual job on test-infra-definitions side.

We don't expect this to run on every `test-infra-definitions` dev commit.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->