### PR TITLE
[ASCII-2597] use contant-time compare for grpc AuthInterceptor callbacks

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -12,6 +12,7 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -116,7 +117,7 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 	logWriter, _ := pkglogsetup.NewTLSHandshakeErrorWriter(4, log.WarnLvl)
 
 	authInterceptor := grpcutil.AuthInterceptor(func(token string) (interface{}, error) {
-		if token != util.GetDCAAuthToken() {
+		if subtle.ConstantTimeCompare([]byte(token), []byte(util.GetDCAAuthToken())) == 0 {
 			return struct{}{}, errors.New("Invalid session token")
 		}
 

--- a/comp/api/api/apiimpl/security.go
+++ b/comp/api/api/apiimpl/security.go
@@ -6,6 +6,7 @@
 package apiimpl
 
 import (
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -34,7 +35,7 @@ func validateToken(next http.Handler) http.Handler {
 // parseToken parses the token and validate it for our gRPC API, it returns an empty
 // struct and an error or nil
 func parseToken(token string) (interface{}, error) {
-	if token != util.GetAuthToken() {
+	if subtle.ConstantTimeCompare([]byte(token), []byte(util.GetAuthToken())) == 0 {
 		return struct{}{}, errors.New("Invalid session token")
 	}
 

--- a/pkg/util/grpc/auth.go
+++ b/pkg/util/grpc/auth.go
@@ -7,6 +7,7 @@ package grpc
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 
@@ -45,7 +46,7 @@ func AuthInterceptor(verifier verifierFunc) grpc_auth.AuthFunc {
 // using the given token.
 func StaticAuthInterceptor(token string) grpc_auth.AuthFunc {
 	return AuthInterceptor(func(reqToken string) (interface{}, error) {
-		if reqToken != token {
+		if subtle.ConstantTimeCompare([]byte(reqToken), []byte(token)) == 0 {
 			return struct{}{}, errors.New("invalid session token")
 		}
 


### PR DESCRIPTION
### What does this PR do?
This PR use subtle [`ConstantTimeCompare`](https://pkg.go.dev/crypto/subtle#ConstantTimeCompare) function to check auth_token in GRPC requests.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
These updates have been verified manually and 2 out of 3 places are covered by unit-tests.