### PR TITLE
[CONTP-539] Expose agent telemetry

### DIFF
--- a/cmd/agent/subcommands/subcommands.go
+++ b/cmd/agent/subcommands/subcommands.go
@@ -36,6 +36,7 @@ import (
 	cmdstreamep "github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamep"
 	cmdstreamlogs "github.com/DataDog/datadog-agent/cmd/agent/subcommands/streamlogs"
 	cmdtaggerlist "github.com/DataDog/datadog-agent/cmd/agent/subcommands/taggerlist"
+	cmdtelemetry "github.com/DataDog/datadog-agent/cmd/agent/subcommands/telemetry"
 	cmdversion "github.com/DataDog/datadog-agent/cmd/agent/subcommands/version"
 	cmdworkloadlist "github.com/DataDog/datadog-agent/cmd/agent/subcommands/workloadlist"
 )
@@ -74,5 +75,6 @@ func AgentSubcommands() []command.SubcommandFactory {
 		cmdstop.Commands,
 		cmdcontrolsvc.Commands,
 		cmdprocesschecks.Commands,
+		cmdtelemetry.Commands,
 	}
 }

--- a/cmd/agent/subcommands/telemetry/command.go
+++ b/cmd/agent/subcommands/telemetry/command.go
@@ -15,12 +15,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/flare"
 )
 
+// Commands returns a slice of subcommands for the 'agent' command.
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "telemetry",
 		Short: "Print the telemetry metrics exposed by the agent",
 		Long:  ``,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			payload, err := flare.QueryAgentTelemetry()
 			if err != nil {
 				return err

--- a/cmd/agent/subcommands/telemetry/command.go
+++ b/cmd/agent/subcommands/telemetry/command.go
@@ -18,12 +18,12 @@ import (
 )
 
 // Commands returns a slice of subcommands for the 'agent' command.
-func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+func Commands(_ *command.GlobalParams) []*cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "telemetry",
 		Short: "Print the telemetry metrics exposed by the agent",
 		Long:  ``,
-		RunE: func(_ *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			payload, err := queryAgentTelemetry()
 			if err != nil {
 				return err

--- a/cmd/agent/subcommands/telemetry/command.go
+++ b/cmd/agent/subcommands/telemetry/command.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package telemetry implements 'agent telemetry'.
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/pkg/flare"
+)
+
+func Commands(globalParams *command.GlobalParams) []*cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "telemetry",
+		Short: "Print the telemetry metrics exposed by the agent",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			payload, err := flare.QueryAgentTelemetry()
+			if err != nil {
+				return err
+			}
+			fmt.Print(string(payload))
+			return nil
+		},
+	}
+
+	return []*cobra.Command{cmd}
+}

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -91,6 +91,16 @@ func QueryDCAMetrics() ([]byte, error) {
 	return io.ReadAll(r.Body)
 }
 
+// QueryAgentTelemetry gets the telemetry payload exposed by the agent
+func QueryAgentTelemetry() ([]byte, error) {
+	r, err := http.Get(fmt.Sprintf("http://localhost:%s/telemetry", pkgconfigsetup.Datadog().GetString("expvar_port")))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
 func getMetadataMap(fb flaretypes.FlareBuilder) error {
 	metaList := apiv1.NewMetadataResponse()
 	cl, err := apiserver.GetAPIClient()

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -91,16 +91,6 @@ func QueryDCAMetrics() ([]byte, error) {
 	return io.ReadAll(r.Body)
 }
 
-// QueryAgentTelemetry gets the telemetry payload exposed by the agent
-func QueryAgentTelemetry() ([]byte, error) {
-	r, err := http.Get(fmt.Sprintf("http://localhost:%s/telemetry", pkgconfigsetup.Datadog().GetString("expvar_port")))
-	if err != nil {
-		return nil, err
-	}
-	defer r.Body.Close()
-	return io.ReadAll(r.Body)
-}
-
 func getMetadataMap(fb flaretypes.FlareBuilder) error {
 	metaList := apiv1.NewMetadataResponse()
 	cl, err := apiserver.GetAPIClient()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Exposes the Node Agent telemetry through CLI command

### Motivation

Cluster-Agent has a `agent telemetry` command, Node Agent should as well to make debugging easier

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Deploy the Agent with any `values.yaml` configuration such as the following.
```
datadog:
  kubelet:
    tlsVerify: false
agents:
  enabled: true
  image:
    tag: <INSERT_TAG>
  env:
    - name: DD_EXPVAR_PORT  # Not needed var: defaults to 5000.
      value: 6132
```
Then spin up the Node Agent and run the following command to see the telemetry
```
k exec -it datadog-agent-linux-xxxxx -n datadog-agent -- agent telemetry
...
# HELP workloadmeta_stored_entities Number of entities in the store.
# TYPE workloadmeta_stored_entities gauge
workloadmeta_stored_entities{kind="container",source="node_orchestrator"} 14
workloadmeta_stored_entities{kind="container",source="runtime"} 11
workloadmeta_stored_entities{kind="container_image_metadata",source="runtime"} 18
workloadmeta_stored_entities{kind="kubernetes_pod",source="node_orchestrator"} 9
# HELP workloadmeta_subscribers Number of subscribers.
# TYPE workloadmeta_subscribers gauge
workloadmeta_subscribers 6
```

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Telemetry on the Node Agent is exposed on `localhost:<EXPVAR_PORT>/telemetry` whereas,
Telemetry on the Cluster Agent is exposed on `localhost:<METRICS_PORT>/metrics`