### PR TITLE
[incident-33304] Remove the flaky mark on fixed tests

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -11,8 +11,3 @@ test/new-e2e/tests/containers:
   - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
   - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
-
-  - TestEKSSuite/TestDogstatsdInAgent/metric___custom.metric{^kube_deployment:dogstatsd-udp$,^kube_namespace:workload-dogstatsd$}
-  - TestEKSSuite/TestDogstatsdStandalone/metric___custom.metric{^kube_deployment:dogstatsd-udp$,^kube_namespace:workload-dogstatsd$}
-  - TestKindSuite/TestDogstatsdInAgent/metric___custom.metric{^kube_deployment:dogstatsd-udp$,^kube_namespace:workload-dogstatsd$}
-  - TestKindSuite/TestDogstatsdStandalone/metric___custom.metric{^kube_deployment:dogstatsd-udp$,^kube_namespace:workload-dogstatsd$}


### PR DESCRIPTION
### What does this PR do?

Remove the flaky mark on the `Test(?:EKS|Kind)Suite/TestDogstatsd(?:InAgent|Standalone)/metric___custom.metric{^kube_deployment:dogstatsd-udp$,^kube_namespace:workload-dogstatsd$}` tests, now that they’ve been fixed by #32222.

### Motivation

Close incident-33304.

### Describe how you validated your changes

[CI Visibility shows that those tests are back to green since the merge](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3A%28%22TestEKSSuite%2FTestDogstatsdInAgent%2Fmetric___custom.metric%7B%5Ekube_deployment%3Adogstatsd-udp%24%2C%5Ekube_namespace%3Aworkload-dogstatsd%24%7D%22%20OR%20%22TestEKSSuite%2FTestDogstatsdStandalone%2Fmetric___custom.metric%7B%5Ekube_deployment%3Adogstatsd-udp%24%2C%5Ekube_namespace%3Aworkload-dogstatsd%24%7D%22%20OR%20%22TestKindSuite%2FTestDogstatsdInAgent%2Fmetric___custom.metric%7B%5Ekube_deployment%3Adogstatsd-udp%24%2C%5Ekube_namespace%3Aworkload-dogstatsd%24%7D%22%20OR%20%22TestKindSuite%2FTestDogstatsdStandalone%2Fmetric___custom.metric%7B%5Ekube_deployment%3Adogstatsd-udp%24%2C%5Ekube_namespace%3Aworkload-dogstatsd%24%7D%22%29&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&cols=%40test.status%2Ctimestamp%2C%40test.suite%2C%40test.name%3A1548%2C%40duration%3A300%2C%40test.service%3A196%2C%40git.branch&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&mode=sliding&saved-view-id=2236559&start=1734295652063&end=1734382052063&paused=false) of #32222:
![image](https://github.com/user-attachments/assets/1ed76f6a-d73b-49fe-be94-3233d218db82)

### Possible Drawbacks / Trade-offs

### Additional Notes

The flaky mark removal should have been part of #32222. See this commit: https://github.com/DataDog/datadog-agent/pull/32222/commits/5b5d3e28b50d240d2222d639504f20688822bcdf#diff-35b124e7b2a3a71ff955d3bcc9e094e33d074038069c5dcc54b863e9fc8ff9bb.
But GitHub’s “Squash and merge” strategy lost that change!