### PR TITLE
Update lading to 0.25.2

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.24.0
+  version: 0.25.0
 
 target:
   cpu_allotment: 8

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: sha-730072b8827b1e6bb4faf5b664949ede8b42929f
+  version: 0.25.2
 
 target:
   cpu_allotment: 8

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.0
+  version: 0.25.1
 
 target:
   cpu_allotment: 8

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.1
+  version: sha-730072b8827b1e6bb4faf5b664949ede8b42929f
 
 target:
   cpu_allotment: 8


### PR DESCRIPTION
### What does this PR do?

This release pulls significantly more data from cgroups v2 and
also procfs smaps. `total_rss_bytes` is calculated now from
`smaps_rollup` and `total_pss_bytes` now exists.

See https://github.com/DataDog/lading/pull/1151 for further details.
