### PR TITLE
Update Regression Detector experiments to have own target allotments

### DIFF
--- a/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_0ms_latency_http1/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency_http1/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 1.5GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_0ms_latency_http2/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency_http2/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 1.5GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 30g
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/file_tree/experiment.yaml
+++ b/test/regression/cases/file_tree/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/otel_to_otel_logs/experiment.yaml
+++ b/test/regression/cases/otel_to_otel_logs/experiment.yaml
@@ -3,8 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  cpu_allotment: 4
-  memory_allotment: 2GiB
+  cpu_allotment: 8
+  memory_allotment: 24GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/otel_to_otel_logs/experiment.yaml
+++ b/test/regression/cases/otel_to_otel_logs/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 24GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -8,8 +8,7 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
+  cpu_allotment: 4
   memory_allotment: 500MiB
 
   environment:

--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -35,7 +35,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "365.0 MiB"
+      upper_bound: "372.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -46,7 +46,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "755.0 MiB"
+      upper_bound: "775.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -46,7 +46,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "775.0 MiB"
+      upper_bound: "779.0 MiB"
 
 report_links:
   - text: "bounds checks dashboard"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -8,8 +8,7 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
+  cpu_allotment: 4
   memory_allotment: 1GiB
 
   environment:

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_rss_bytes
-      upper_bound: 420MiB
+      upper_bound: 427MiB
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_rss_bytes
-      upper_bound: 427MiB
+      upper_bound: 429MiB
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 500MiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/tcp_dd_logs_filter_exclude/experiment.yaml
+++ b/test/regression/cases/tcp_dd_logs_filter_exclude/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/tcp_syslog_to_blackhole/experiment.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/uds_dogstatsd_to_api/experiment.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/uds_dogstatsd_to_api_cpu/experiment.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_cpu/experiment.yaml
@@ -3,9 +3,8 @@ erratic: false
 
 target:
   name: datadog-agent
-  command: /bin/entrypoint.sh
-  cpu_allotment: 8
-  memory_allotment: 4GiB
+  cpu_allotment: 4
+  memory_allotment: 2GiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -2,8 +2,6 @@ lading:
   version: 0.25.2
 
 target:
-  cpu_allotment: 8
-  memory_allotment: 30g
 
 # Link templates for reports.
 #


### PR DESCRIPTION
### What does this PR do?

This commit updates the Regression Detector configuration so that every
experiment has its own memory and CPU allotments. We scale these down
where memory checks do not exist to a generous 2GiB and where memory
checks are set we leave a buffer on top of the check limit. CPU is limited
now to 4 across all experiments.
