### PR TITLE
Create a dedicated task to bump the `current_milestone`

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -523,6 +523,9 @@ class GithubAPI:
         """
         return self._repository.create_label(name, color, description)
 
+    def create_milestone(self, title):
+        self._repository.create_milestone(title)
+
     def create_release(self, tag, message, draft=True):
         return self._repository.create_git_release(
             tag=tag,

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -16,6 +16,7 @@ from collections import defaultdict
 from datetime import date
 from time import sleep
 
+import github
 from gitlab import GitlabError
 from invoke import task
 from invoke.exceptions import Exit
@@ -1279,7 +1280,14 @@ def update_current_milestone(ctx, major_version: int = 7, upstream="origin"):
     next.devel = False
 
     print(f"Creating the {next} milestone...")
-    gh.create_milestone(str(next))
+
+    try:
+        gh.create_milestone(str(next))
+    except github.GithubException as e:
+        if e.status == 422:
+            print(f"Milestone {next} already exists")
+        else:
+            raise e
 
     with agent_context(ctx, get_default_branch(major=major_version)):
         milestone_branch = f"release_milestone-{int(time.time())}"

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -16,7 +16,6 @@ from collections import defaultdict
 from datetime import date
 from time import sleep
 
-import github
 from gitlab import GitlabError
 from invoke import task
 from invoke.exceptions import Exit
@@ -1273,6 +1272,8 @@ def update_current_milestone(ctx, major_version: int = 7, upstream="origin"):
     """
     Create a PR to bump the current_milestone in the release.json file
     """
+    import github
+
     gh = GithubAPI()
 
     current = current_version(ctx, major_version)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Create a dedicated task to bump the current_milestone
- Automatically create the milestone on GitHub

### Motivation

Following [this RFC](https://docs.google.com/document/d/1LCXkfwsx5JUJRVeXDCCnRv9UyKZThQQFQ286oyi2PPc/edit?tab=t.0#heading=h.i5md0ho4oh3k), bumping the `current_milestone` will be the first step of the release process from now on

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Tested with https://github.com/DataDog/datadog-agent/pull/32274 and I manually removed the milestone afterward