### PR TITLE
feat(release): Set gitconfig before git write operations

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -119,6 +119,7 @@ jobs:
               env:
                 MATRIX: ${{ matrix.value }}
               run: |
+                git fetch
                 if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then
                   inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT6_RELEASE_SLACK_WEBHOOK }} --patch-version
                 else

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -119,7 +119,6 @@ jobs:
               env:
                 MATRIX: ${{ matrix.value }}
               run: |
-                git fetch
                 if ${{ env.IS_AGENT6_RELEASE == 'true' }}; then
                   inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT6_RELEASE_SLACK_WEBHOOK }} --patch-version
                 else

--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -509,7 +509,7 @@ class CollectorVersionUpdater:
 
 
 @task(post=[tidy])
-def update(ctx):
+def update(_):
     updater = CollectorVersionUpdater()
     updater.update()
     print("Update complete.")
@@ -518,12 +518,12 @@ def update(ctx):
 @task()
 def pull_request(ctx):
     # Save current Git configuration
-    original_config = {'user.name': get_git_config('user.name'), 'user.email': get_git_config('user.email')}
+    original_config = {'user.name': get_git_config(ctx, 'user.name'), 'user.email': get_git_config(ctx, 'user.email')}
 
     try:
         # Set new Git configuration
-        set_git_config('user.name', 'github-actions[bot]')
-        set_git_config('user.email', 'github-actions[bot]@users.noreply.github.com')
+        set_git_config(ctx, 'user.name', 'github-actions[bot]')
+        set_git_config(ctx, 'user.email', 'github-actions[bot]@users.noreply.github.com')
 
         # Perform Git operations
         ctx.run('git add .')
@@ -554,4 +554,4 @@ def pull_request(ctx):
             print("No changes detected, skipping PR creation.")
     finally:
         # Revert to original Git configuration
-        revert_git_config(original_config)
+        revert_git_config(ctx, original_config)

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
 import tempfile
 from contextlib import contextmanager
@@ -304,18 +303,21 @@ def get_last_release_tag(ctx, repo, pattern):
     return last_tag_commit, last_tag_name
 
 
-def get_git_config(key):
-    result = subprocess.run(['git', 'config', '--get', key], capture_output=True, text=True)
-    return result.stdout.strip() if result.returncode == 0 else None
+def get_git_config(ctx, key):
+    try:
+        result = ctx.run(f'git config --get {key}')
+    except Exit:
+        return None
+    return result.stdout.strip() if result.return_code == 0 else None
 
 
-def set_git_config(key, value):
-    subprocess.run(['git', 'config', key, value])
+def set_git_config(ctx, key, value):
+    ctx.run(f'git config {key} {value}')
 
 
-def revert_git_config(original_config):
+def revert_git_config(ctx, original_config):
     for key, value in original_config.items():
         if value is None:
-            subprocess.run(['git', 'config', '--unset', key])
+            ctx.run(f'git config --unset {key}', hide=True)
         else:
-            subprocess.run(['git', 'config', key, value])
+            ctx.run(f'git config {key} {value}', hide=True)

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -506,8 +506,8 @@ def set_gitconfig_in_ci(ctx):
     Set username and email when runing git "write" commands in CI
     """
     if running_in_ci():
-        set_git_config('user.name', 'github-actions[bot]')
-        set_git_config('user.email', 'github-actions[bot]@users.noreply.github.com')
+        set_git_config(ctx, 'user.name', 'github-actions[bot]')
+        set_git_config(ctx, 'user.email', 'github-actions[bot]@users.noreply.github.com')
 
 
 @contextmanager

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -23,7 +23,7 @@ from invoke.exceptions import Exit
 
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.constants import ALLOWED_REPO_ALL_BRANCHES, REPO_PATH
-from tasks.libs.common.git import get_commit_sha, get_default_branch
+from tasks.libs.common.git import get_commit_sha, get_default_branch, set_git_config
 from tasks.libs.releasing.version import get_version
 from tasks.libs.types.arch import Arch
 
@@ -499,6 +499,15 @@ def is_pr_context(branch, pr_id, test_name):
         print(f"PR not found, skipping check for {test_name}.")
         return False
     return True
+
+
+def set_gitconfig_in_ci(ctx):
+    """
+    Set username and email when runing git "write" commands in CI
+    """
+    if running_in_ci():
+        set_git_config('user.name', 'github-actions[bot]')
+        set_git_config('user.email', 'github-actions[bot]@users.noreply.github.com')
 
 
 @contextmanager

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -40,7 +40,7 @@ from tasks.libs.common.git import (
 )
 from tasks.libs.common.gomodules import get_default_modules
 from tasks.libs.common.user_interactions import yes_no_question
-from tasks.libs.common.utils import set_gitconfig_in_ci
+from tasks.libs.common.utils import running_in_github_actions, set_gitconfig_in_ci
 from tasks.libs.common.worktree import agent_context
 from tasks.libs.pipeline.notifications import (
     DEFAULT_JIRA_PROJECT,
@@ -1349,7 +1349,11 @@ def bump_integrations_core(ctx, slack_webhook=None):
     """
     Create a PR to bump the integrations core fields in the release.json file
     """
-    github_workflow_url = f"{os.environ.get('GITHUB_SERVER_URL', 'github.com')}/{GITHUB_REPO_NAME}/actions/runs/{os.environ.get('GITHUB_RUN_ID', '1')}"
+    github_workflow_url = ""
+    if running_in_github_actions():
+        github_workflow_url = (
+            f"{os.environ.get('GITHUB_SERVER_URL')}/{GITHUB_REPO_NAME}/actions/runs/{os.environ.get('GITHUB_RUN_ID')}"
+        )
     commit_hash = get_git_references(ctx, "integrations-core", "HEAD").split()[0]
 
     rj = load_release_json()

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -36,7 +36,6 @@ from tasks.libs.common.git import (
     get_last_commit,
     get_last_release_tag,
     is_agent6,
-    set_git_config,
     try_git_command,
 )
 from tasks.libs.common.gomodules import get_default_modules
@@ -1350,14 +1349,7 @@ def bump_integrations_core(ctx, slack_webhook=None):
     """
     Create a PR to bump the integrations core fields in the release.json file
     """
-    github_workflow_url = ""
-    if os.environ.get("GITHUB_ACTIONS"):
-        set_git_config('user.name', 'github-actions[bot]')
-        set_git_config('user.email', 'github-actions[bot]@users.noreply.github.com')
-        github_server_url = os.environ.get("GITHUB_SERVER_URL")
-        github_run_id = os.environ.get("GITHUB_RUN_ID")
-        github_workflow_url = f"{github_server_url}/{GITHUB_REPO_NAME}/actions/runs/{github_run_id}"
-
+    github_workflow_url = f"{os.environ.get('GITHUB_SERVER_URL', 'github.com')}/{GITHUB_REPO_NAME}/actions/runs/{os.environ.get('GITHUB_RUN_ID', '1')}"
     commit_hash = get_git_references(ctx, "integrations-core", "HEAD").split()[0]
 
     rj = load_release_json()
@@ -1373,6 +1365,7 @@ def bump_integrations_core(ctx, slack_webhook=None):
     ctx.run("git add release.json")
 
     commit_message = "bump integrations core to HEAD"
+    set_gitconfig_in_ci(ctx)
     ok = try_git_command(ctx, f"git commit -m '{commit_message}'")
     if not ok:
         raise Exit(

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -787,7 +787,7 @@ class TestCheckForChanges(unittest.TestCase):
             }
         ),
     )
-    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'true'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'true'})
     @patch('os.chdir', new=MagicMock())
     def test_changes_new_commit_first_repo(self, version_mock, print_mock, _):
         with mock_git_clone():
@@ -871,7 +871,7 @@ class TestCheckForChanges(unittest.TestCase):
         ),
     )
     @patch('os.chdir', new=MagicMock())
-    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
     def test_changes_new_commit_all_repo(self, version_mock, print_mock, _):
         with mock_git_clone():
             next = MagicMock()
@@ -1023,7 +1023,7 @@ class TestCheckForChanges(unittest.TestCase):
             }
         ),
     )
-    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'true'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'true'})
     @patch('os.chdir', new=MagicMock())
     def test_changes_new_commit_second_repo_branch_out(self, version_mock, print_mock, _):
         with mock_git_clone():
@@ -1272,7 +1272,7 @@ class TestUpdateModules(unittest.TestCase):
 class TestTagModules(unittest.TestCase):
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(2)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
     def test_2_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1285,7 +1285,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(3)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
     def test_3_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1298,7 +1298,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(4)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
     def test_4_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1315,7 +1315,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(100)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
     def test_100_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 import sys
 import unittest
@@ -786,6 +787,7 @@ class TestCheckForChanges(unittest.TestCase):
             }
         ),
     )
+    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'true'})
     @patch('os.chdir', new=MagicMock())
     def test_changes_new_commit_first_repo(self, version_mock, print_mock, _):
         with mock_git_clone():
@@ -796,6 +798,8 @@ class TestCheckForChanges(unittest.TestCase):
             c = MockContext(
                 run={
                     'git rev-parse --abbrev-ref HEAD': Result("main"),
+                    'git config user.name github-actions[bot]': Result(""),
+                    'git config user.email github-actions[bot]@users.noreply.github.com': Result(""),
                     'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                         "4n0th3rc0mm1t9        refs/heads/main"
                     ),
@@ -867,6 +871,7 @@ class TestCheckForChanges(unittest.TestCase):
         ),
     )
     @patch('os.chdir', new=MagicMock())
+    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
     def test_changes_new_commit_all_repo(self, version_mock, print_mock, _):
         with mock_git_clone():
             next = MagicMock()
@@ -1018,6 +1023,7 @@ class TestCheckForChanges(unittest.TestCase):
             }
         ),
     )
+    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'true'})
     @patch('os.chdir', new=MagicMock())
     def test_changes_new_commit_second_repo_branch_out(self, version_mock, print_mock, _):
         with mock_git_clone():
@@ -1028,6 +1034,8 @@ class TestCheckForChanges(unittest.TestCase):
             c = MockContext(
                 run={
                     'git rev-parse --abbrev-ref HEAD': Result("main"),
+                    'git config user.name github-actions[bot]': Result(""),
+                    'git config user.email github-actions[bot]@users.noreply.github.com': Result(""),
                     'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/7.55.x"': Result(
                         "4n0th3rc0mm1t0        refs/heads/main"
                     ),
@@ -1264,6 +1272,7 @@ class TestUpdateModules(unittest.TestCase):
 class TestTagModules(unittest.TestCase):
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(2)]))
     @patch('tasks.release.agent_context', new=MagicMock())
+    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
     def test_2_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1276,6 +1285,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(3)]))
     @patch('tasks.release.agent_context', new=MagicMock())
+    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
     def test_3_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1288,6 +1298,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(4)]))
     @patch('tasks.release.agent_context', new=MagicMock())
+    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
     def test_4_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1304,6 +1315,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(100)]))
     @patch('tasks.release.agent_context', new=MagicMock())
+    @patch.dict(os.environ, {'GITHUB_ACTIONS': 'false'})
     def test_100_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Force `username` and `email` in the git configuration before git `write` operations in ci context

### Motivation
We need an identification before doing a push (for a tag or a commit) on upstream. Setting it within the code will prevent [failures](https://github.com/DataDog/datadog-agent/actions/runs/13287147703/job/37098535292) when the actions will be executed in the CI context (as we want to automate all these operations)

### Describe how you validated your changes
I will run the create_rc pipeline from my branch
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
As asked [here](https://github.com/DataDog/datadog-agent/pull/32277#issuecomment-2547822586) I prefer to do the operations in the python code just before I need them.
I submitted [this alternate solution](https://github.com/actions/checkout/pull/2012) on the `actions/checkout` upstream to make it more natural in the future.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->