### PR TITLE
[VULN-9579] Traps: Validate community string in constant time

### DIFF
--- a/comp/snmptraps/listener/listenerimpl/listener.go
+++ b/comp/snmptraps/listener/listenerimpl/listener.go
@@ -8,6 +8,7 @@ package listenerimpl
 
 import (
 	"context"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"net"
@@ -167,7 +168,8 @@ func validatePacket(p *gosnmp.SnmpPacket, c *config.TrapsConfig) error {
 
 	// At least one of the known community strings must match.
 	for _, community := range c.CommunityStrings {
-		if community == p.Community {
+		// Simple string equality check, but in constant time to avoid timing attacks
+		if subtle.ConstantTimeCompare([]byte(community), []byte(p.Community)) == 1 {
 			return nil
 		}
 	}


### PR DESCRIPTION
A few access control mechanisms use simple string comparison and are therefore vulnerable to timing attacks. An attacker may try to guess confidential data one character at a time by sending all possible characters to the vulnerable mechanism and measuring differences in time that the comparison instruction took to execute.