### PR TITLE
[go.mod] Require wpa apis module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -167,7 +167,8 @@ require (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.22.0
 	github.com/DataDog/sketches-go v1.4.6
 	github.com/DataDog/viper v1.14.0
-	github.com/DataDog/watermarkpodautoscaler v0.5.3-0.20241023200123-ab786c1724cf
+	// TODO: pin to a WPA released version once there is a release that includes the apis module
+	github.com/DataDog/watermarkpodautoscaler/apis v0.0.0-20250108152814-82e58d0231d1
 	github.com/DataDog/zstd v1.5.6
 	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f // indirect
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/DataDog/trivy v0.0.0-20241223234648-d2ac813bf11b h1:wCKboWBVsnpnFnBKG
 github.com/DataDog/trivy v0.0.0-20241223234648-d2ac813bf11b/go.mod h1:qJj5iHmlvtSbgmRWJDANpAFmmxcXuKGQfucp9VtJfR8=
 github.com/DataDog/viper v1.14.0 h1:dIjTe/uJiah+QFqFZ+MXeqgmUvWhg37l37ZxFWxr3is=
 github.com/DataDog/viper v1.14.0/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
-github.com/DataDog/watermarkpodautoscaler v0.5.3-0.20241023200123-ab786c1724cf h1:nbsZ9srTWTTlHzWDGkVE6R5hnqENXTK9N8doMC2YPps=
-github.com/DataDog/watermarkpodautoscaler v0.5.3-0.20241023200123-ab786c1724cf/go.mod h1:ay+v2Blaq9nA5YngtqXJe6Z9JOdeSmOEyBkmKs1yyQQ=
+github.com/DataDog/watermarkpodautoscaler/apis v0.0.0-20250108152814-82e58d0231d1 h1:9hiwoIk8FOsXDkdcdgNJ48iYaPfn+/7bXEwAnnfKjTc=
+github.com/DataDog/watermarkpodautoscaler/apis v0.0.0-20250108152814-82e58d0231d1/go.mod h1:57ytxiQR5KMYNeDgNqKn9y1LJMoRamBKHj3nvURhAdQ=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=


### PR DESCRIPTION
### What does this PR do?

This PR changes the go.mod so that it requires watermarkpodautoscaler/apis instead of the whole WPA project.
The new module was created in this PR https://github.com/DataDog/watermarkpodautoscaler/pull/250

Hopefully this will generate less conflicts when upgrading the kubernetes libraries versions.

For now the dependency points to the current main. We should change to a released version once there's one that includes the new apis module.


### Describe how you validated your changes

I don't think there's anything specific to test. The project should work exactly as before.