### PR TITLE
Don't run notify gitlab ci changes on merge queue

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -80,8 +80,8 @@ notify_github:
   script:
     - !reference [.setup_agent_github_app]
     # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is 
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615      
+    # In particular, --break-system-packages command line option is
+    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
     - python3 -m pip install -r tasks/libs/requirements-github.txt --break-system-packages
     - messagefile="$(mktemp)"
     - echo "Use this command from [test-infra-definitions](https://github.com/DataDog/test-infra-definitions) to manually test this PR changes on a VM:" >> "$messagefile"
@@ -98,6 +98,7 @@ notify_gitlab_ci_changes:
   needs: [compute_gitlab_ci_config]
   tags: ["arch:amd64"]
   rules:
+    - !reference  [.except_mergequeue]
     - changes:
         paths:
           - .gitlab-ci.yml
@@ -105,8 +106,8 @@ notify_gitlab_ci_changes:
         compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
   script:
     # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is 
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615    
+    # In particular, --break-system-packages command line option is
+    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
     - python3 -m pip install -r tasks/libs/requirements-github.txt --break-system-packages
     - !reference [.setup_agent_github_app]
     - inv -e notify.gitlab-ci-diff --from-diff artifacts/diff.gitlab-ci.yml --pr-comment


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Everything is in the title!

### Motivation

Running notify jobs in the merge queue are useless and can break main

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->