### PR TITLE
feat(apm): implement external data resolution

### DIFF
--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -43,7 +43,7 @@ func putBuffer(buffer *bytes.Buffer) {
 
 // ConfigHandler is the HTTP handler for configs
 func ConfigHandler(r *api.HTTPReceiver, cf rcclient.ConfigFetcher, cfg *config.AgentConfig, statsd statsd.ClientInterface, timing timing.Reporter) http.Handler {
-	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot)
+	cidProvider := api.NewIDProvider(cfg.ContainerProcRoot, cfg.ContainerIDFromOriginInfo)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer timing.Since("datadog.trace_agent.receiver.config_process_ms", time.Now())
 		tags := r.TagStats(api.V07, req.Header, "").AsTags()

--- a/comp/otelcol/ddflareextension/impl/go.mod
+++ b/comp/otelcol/ddflareextension/impl/go.mod
@@ -13,6 +13,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/core/log/mock => ../../../core/log/mock
 	github.com/DataDog/datadog-agent/comp/core/secrets => ../../../core/secrets
 	github.com/DataDog/datadog-agent/comp/core/status => ../../../core/status
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection => ../../../core/tagger/origindetection
 	github.com/DataDog/datadog-agent/comp/core/tagger/tags => ../../../core/tagger/tags
 	github.com/DataDog/datadog-agent/comp/core/tagger/types => ../../../core/tagger/types
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils => ../../../core/tagger/utils
@@ -151,6 +152,7 @@ require (
 require go.opentelemetry.io/collector/extension/extensiontest v0.115.0 // indirect
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -12,6 +12,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/core/log/mock => ../../../../../core/log/mock
 	github.com/DataDog/datadog-agent/comp/core/secrets => ../../../../../core/secrets
 	github.com/DataDog/datadog-agent/comp/core/status => ../../../../../core/status
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection => ../../../../../core/tagger/origindetection
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ../../../../../core/telemetry
 	github.com/DataDog/datadog-agent/comp/def => ../../../../../def
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder => ../../../../../forwarder/defaultforwarder
@@ -138,6 +139,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.56.0-rc.3 // indirect

--- a/comp/otelcol/otlp/components/statsprocessor/go.mod
+++ b/comp/otelcol/otlp/components/statsprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsproces
 go 1.22.0
 
 replace (
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection => ../../../../core/tagger/origindetection
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient => ../metricsclient
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../../../../comp/trace/compression/def
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ../../../../../comp/trace/compression/impl-gzip
@@ -33,6 +34,7 @@ require (
 require go.opentelemetry.io/collector/component v0.115.0 // indirect
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.56.0-rc.3 // indirect

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -19,13 +19,14 @@ import (
 
 	"go.opentelemetry.io/collector/component/componenttest"
 
-	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 
 	corecompcfg "github.com/DataDog/datadog-agent/comp/core/config"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/configcheck"
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -120,6 +121,9 @@ func prepareConfig(c corecompcfg.Component, tagger tagger.Component) (*config.Ag
 	}
 	cfg.ContainerTags = func(cid string) ([]string, error) {
 		return tagger.Tag(types.NewEntityID(types.ContainerID, cid), types.HighCardinality)
+	}
+	cfg.ContainerIDFromOriginInfo = func(originInfo origindetection.OriginInfo) (string, error) {
+		return tagger.GenerateContainerIDFromOriginInfo(originInfo)
 	}
 	cfg.ContainerProcRoot = coreConfigObject.GetString("container_proc_root")
 	cfg.GetAgentAuthToken = apiutil.GetAuthToken

--- a/go.mod
+++ b/go.mod
@@ -654,7 +654,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.59.0
 	github.com/DataDog/datadog-agent/comp/core/status v0.59.0-rc.6
 	github.com/DataDog/datadog-agent/comp/core/status/statusimpl v0.56.0-rc.3
-	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-00010101000000-000000000000
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2
 	github.com/DataDog/datadog-agent/comp/core/tagger/tags v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.59.0
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.59.0

--- a/modules.yml
+++ b/modules.yml
@@ -35,7 +35,8 @@ modules:
   comp/core/status:
     used_by_otel: true
   comp/core/status/statusimpl: default
-  comp/core/tagger/origindetection: default
+  comp/core/tagger/origindetection:
+    used_by_otel: true
   comp/core/tagger/tags:
     used_by_otel: true
   comp/core/tagger/types:

--- a/pkg/proto/pbgo/core/model.pb.go
+++ b/pkg/proto/pbgo/core/model.pb.go
@@ -1155,8 +1155,8 @@ type GenerateContainerIDFromOriginInfoRequest_ExternalData struct {
 	unknownFields protoimpl.UnknownFields
 
 	Init          *bool   `protobuf:"varint,1,opt,name=init,proto3,oneof" json:"init,omitempty"`                  // Init is true if the container is an init container.
-	ContainerName *string `protobuf:"bytes,2,opt,name=containerName,proto3,oneof" json:"containerName,omitempty"` // Container name as seen by the Admission Controller.
-	PodUID        *string `protobuf:"bytes,3,opt,name=podUID,proto3,oneof" json:"podUID,omitempty"`               // Pod UID as seen by the Admission Controller.
+	ContainerName *string `protobuf:"bytes,2,opt,name=containerName,proto3,oneof" json:"containerName,omitempty"` // Container name in the Kubernetes Pod spec.
+	PodUID        *string `protobuf:"bytes,3,opt,name=podUID,proto3,oneof" json:"podUID,omitempty"`               // Pod UID in the Kubernetes Pod spec.
 }
 
 func (x *GenerateContainerIDFromOriginInfoRequest_ExternalData) Reset() {

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -141,7 +141,7 @@ func NewHTTPReceiver(
 		}
 	}
 	log.Infof("Receiver configured with %d decoders and a timeout of %dms", semcount, conf.DecoderTimeout)
-	containerIDProvider := NewIDProvider(conf.ContainerProcRoot)
+	containerIDProvider := NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo)
 	telemetryForwarder := NewTelemetryForwarder(conf, containerIDProvider, statsd)
 	return &HTTPReceiver{
 		Stats: info.NewReceiverStats(),

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/api/internal/header"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
@@ -576,7 +577,9 @@ func TestDecodeV05(t *testing.T) {
 	req, err := http.NewRequest("POST", "/v0.5/traces", bytes.NewReader(b))
 	assert.NoError(err)
 	req.Header.Set(header.ContainerID, "abcdef123789456")
-	tp, err := decodeTracerPayload(v05, req, NewIDProvider(""), "python", "3.8.1", "1.2.3")
+	tp, err := decodeTracerPayload(v05, req, NewIDProvider("", func(_ origindetection.OriginInfo) (string, error) {
+		return "abcdef123789456", nil
+	}), "python", "3.8.1", "1.2.3")
 	assert.NoError(err)
 	assert.EqualValues(tp, &pb.TracerPayload{
 		ContainerID:     "abcdef123789456",

--- a/pkg/trace/api/container.go
+++ b/pkg/trace/api/container.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/pkg/trace/api/internal/header"
 )
 
@@ -28,7 +29,7 @@ type IDProvider interface {
 type idProvider struct{}
 
 // NewIDProvider initializes an IDProvider instance, in non-linux environments the procRoot arg is unused.
-func NewIDProvider(_ string) IDProvider {
+func NewIDProvider(_ string, _ func(originInfo origindetection.OriginInfo) (string, error)) IDProvider {
 	return &idProvider{}
 }
 

--- a/pkg/trace/api/container_linux.go
+++ b/pkg/trace/api/container_linux.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/pkg/trace/api/internal/header"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -96,7 +97,7 @@ func (i *noCgroupsProvider) GetContainerID(_ context.Context, h http.Header) str
 }
 
 // NewIDProvider initializes an IDProvider instance using the provided procRoot to perform cgroups lookups in linux environments.
-func NewIDProvider(procRoot string) IDProvider {
+func NewIDProvider(procRoot string, containerIDFromOriginInfo func(originInfo origindetection.OriginInfo) (string, error)) IDProvider {
 	// taken from pkg/util/containers/metrics/system.collector_linux.go
 	var hostPrefix string
 	if strings.HasPrefix(procRoot, "/host") {
@@ -120,10 +121,11 @@ func NewIDProvider(procRoot string) IDProvider {
 	}
 	c := NewCache(1 * time.Minute)
 	return &cgroupIDProvider{
-		procRoot:   procRoot,
-		controller: cgroupController,
-		cache:      c,
-		reader:     reader,
+		procRoot:                  procRoot,
+		controller:                cgroupController,
+		cache:                     c,
+		reader:                    reader,
+		containerIDFromOriginInfo: containerIDFromOriginInfo,
 	}
 }
 
@@ -131,8 +133,9 @@ type cgroupIDProvider struct {
 	procRoot   string
 	controller string
 	// reader is used to retrieve the container ID from its cgroup v2 inode.
-	reader *cgroups.Reader
-	cache  *Cache
+	reader                    *cgroups.Reader
+	cache                     *Cache
+	containerIDFromOriginInfo func(originInfo origindetection.OriginInfo) (string, error)
 }
 
 // GetContainerID returns the container ID.
@@ -155,6 +158,11 @@ func (c *cgroupIDProvider) GetContainerID(ctx context.Context, h http.Header) st
 	// Retrieve the container-id from the pid in its context
 	if containerID := c.resolveContainerIDFromContext(ctx); containerID != "" {
 		return containerID
+	}
+
+	// Retrieve container ID from External Data header
+	if externalData := h.Get(header.ExternalData); externalData != "" {
+		return c.resolveContainerIDFromExternalData(externalData)
 	}
 
 	return ""
@@ -294,6 +302,27 @@ func (c *cgroupIDProvider) getCachedContainerID(key string, retrievalFunc func()
 
 	c.cache.Store(currentTime, key, val, nil)
 	return val, nil
+}
+
+// resolveContainerIDFromExternalData returns the container ID for the given External Data.
+func (c *cgroupIDProvider) resolveContainerIDFromExternalData(rawExternalData string) string {
+	var generatedContainerID string
+
+	externalData, err := origindetection.ParseExternalData(rawExternalData)
+	if err != nil {
+		log.Errorf("Could not parse external data (%s): %v", rawExternalData, err)
+		return ""
+	}
+	generatedContainerID, err = c.containerIDFromOriginInfo(origindetection.OriginInfo{
+		ExternalData:  externalData,
+		ProductOrigin: origindetection.ProductOriginAPM,
+	})
+	if err != nil {
+		log.Errorf("Could not generate container ID from external data (%s): %v", rawExternalData, err)
+		return ""
+	}
+
+	return generatedContainerID
 }
 
 // The below cache is copied from /pkg/util/containers/v2/metrics/provider/cache.go. It is not

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -81,7 +81,7 @@ func debuggerErrorHandler(err error) http.Handler {
 
 // newDebuggerProxy returns a new httputil.ReverseProxy proxying and augmenting requests with headers containing the tags.
 func newDebuggerProxy(conf *config.AgentConfig, transport http.RoundTripper, hostTags string) *httputil.ReverseProxy {
-	cidProvider := NewIDProvider(conf.ContainerProcRoot)
+	cidProvider := NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo)
 	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
 	return &httputil.ReverseProxy{
 		Director:  getDirector(hostTags, cidProvider, conf.ContainerTags),

--- a/pkg/trace/api/evp_proxy.go
+++ b/pkg/trace/api/evp_proxy.go
@@ -86,7 +86,7 @@ func evpProxyForwarder(conf *config.AgentConfig, statsd statsd.ClientInterface) 
 			req.Header["X-Forwarded-For"] = nil
 		},
 		ErrorLog:  logger,
-		Transport: &evpProxyTransport{conf.NewHTTPTransport(), endpoints, conf, NewIDProvider(conf.ContainerProcRoot), statsd},
+		Transport: &evpProxyTransport{conf.NewHTTPTransport(), endpoints, conf, NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo), statsd},
 	}
 }
 

--- a/pkg/trace/api/internal/header/headers.go
+++ b/pkg/trace/api/internal/header/headers.go
@@ -25,6 +25,16 @@ const (
 	// * "ci-<container-id>,in-<cgroupv2-inode>"
 	LocalData = "Datadog-Entity-ID"
 
+	// ExternalData is a list that contain prefixed-items, split by a ','. Current items are:
+	// * "it-<init>" if the container is an init container.
+	// * "cn-<container-name>" for the container name.
+	// * "pu-<pod-uid>" for the pod UID.
+	// Order does not matter.
+	// Possible values:
+	// * "it-false,cn-nginx,pu-3413883c-ac60-44ab-96e0-9e52e4e173e2"
+	// * "cn-init,pu-cb4aba1d-0129-44f1-9f1b-b4dc5d29a3b3,it-true"
+	ExternalData = "Datadog-External-Env"
+
 	// Lang specifies the name of the header which contains the language from
 	// which the traces originate.
 	Lang = "Datadog-Meta-Lang"

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/trace/transform"
 	"math"
 	"net"
 	"net/http"
@@ -26,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/trace/timing"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/transform"
 	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
@@ -102,7 +102,7 @@ func NewOTLPReceiver(out chan<- *Payload, cfg *config.AgentConfig, statsd statsd
 		enableReceiveResourceSpansV2Val = 1.0
 	}
 	_ = statsd.Gauge("datadog.trace_agent.otlp.enable_receive_resource_spans_v2", enableReceiveResourceSpansV2Val, nil, 1)
-	return &OTLPReceiver{out: out, conf: cfg, cidProvider: NewIDProvider(cfg.ContainerProcRoot), statsd: statsd, timing: timing, ignoreResNames: ignoreResNames}
+	return &OTLPReceiver{out: out, conf: cfg, cidProvider: NewIDProvider(cfg.ContainerProcRoot, cfg.ContainerIDFromOriginInfo), statsd: statsd, timing: timing, ignoreResNames: ignoreResNames}
 }
 
 // Start starts the OTLPReceiver, if any of the servers were configured as active.

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -71,7 +71,7 @@ func pipelineStatsErrorHandler(err error) http.Handler {
 // The tags will be added as a header to all proxied requests.
 func newPipelineStatsProxy(conf *config.AgentConfig, urls []*url.URL, apiKeys []string, tags string, statsd statsd.ClientInterface) *httputil.ReverseProxy {
 	log.Debug("[pipeline_stats] Creating reverse proxy")
-	cidProvider := NewIDProvider(conf.ContainerProcRoot)
+	cidProvider := NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo)
 	director := func(req *http.Request) {
 		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", conf.AgentVersion))
 		if _, ok := req.Header["User-Agent"]; !ok {

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -109,7 +109,7 @@ func errorHandler(err error) http.Handler {
 // The tags will be added as a header to all proxied requests.
 // For more details please see multiTransport.
 func newProfileProxy(conf *config.AgentConfig, targets []*url.URL, keys []string, tags string, statsd statsd.ClientInterface) *httputil.ReverseProxy {
-	cidProvider := NewIDProvider(conf.ContainerProcRoot)
+	cidProvider := NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo)
 	director := func(req *http.Request) {
 		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", conf.AgentVersion))
 		if _, ok := req.Header["User-Agent"]; !ok {

--- a/pkg/trace/api/symdb.go
+++ b/pkg/trace/api/symdb.go
@@ -62,7 +62,7 @@ func symDBErrorHandler(err error) http.Handler {
 
 // newSymDBProxy returns a new httputil.ReverseProxy proxying and augmenting requests with headers containing the tags.
 func newSymDBProxy(conf *config.AgentConfig, transport http.RoundTripper, hostTags string) *httputil.ReverseProxy {
-	cidProvider := NewIDProvider(conf.ContainerProcRoot)
+	cidProvider := NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo)
 	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
 	return &httputil.ReverseProxy{
 		Director:  getSymDBDirector(hostTags, cidProvider, conf.ContainerTags),

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
@@ -444,6 +445,9 @@ type AgentConfig struct {
 
 	// ContainerTags ...
 	ContainerTags func(cid string) ([]string, error) `json:"-"`
+
+	// ContainerIDFromOriginInfo ...
+	ContainerIDFromOriginInfo func(originInfo origindetection.OriginInfo) (string, error) `json:"-"`
 
 	// ContainerProcRoot is the root dir for `proc` info
 	ContainerProcRoot string

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -52,6 +52,7 @@ require (
 )
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2
 	github.com/shirou/gopsutil/v4 v4.24.11
 	go.opentelemetry.io/collector/component/componenttest v0.115.0
 )
@@ -116,6 +117,7 @@ require (
 
 replace (
 	github.com/DataDog/datadog-agent => ../../
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection => ../../comp/core/tagger/origindetection
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../comp/trace/compression/def
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip => ../../comp/trace/compression/impl-gzip
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd => ../../comp/trace/compression/impl-zstd

--- a/pkg/trace/stats/oteltest/go.mod
+++ b/pkg/trace/stats/oteltest/go.mod
@@ -20,6 +20,7 @@ require (
 require go.opentelemetry.io/collector/component v0.115.0 // indirect
 
 require (
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.56.0-rc.3 // indirect
@@ -88,6 +89,7 @@ require (
 )
 
 replace (
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection => ../../../../comp/core/tagger/origindetection
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient => ../../../../comp/otelcol/otlp/components/metricsclient
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor => ../../../../comp/otelcol/otlp/components/statsprocessor
 	github.com/DataDog/datadog-agent/comp/trace/compression/def => ../../../../comp/trace/compression/def

--- a/releasenotes/notes/external_data_apm-6538531e3f34f305.yaml
+++ b/releasenotes/notes/external_data_apm-6538531e3f34f305.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Implement External Data resolution for APM. This is needed to support the
+    latest Origin Detection spec and resolution with nested virtualization.
+

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -12,6 +12,7 @@ replace (
 	github.com/DataDog/datadog-agent/comp/core/log/mock => ./../../comp/core/log/mock
 	github.com/DataDog/datadog-agent/comp/core/secrets => ./../../comp/core/secrets
 	github.com/DataDog/datadog-agent/comp/core/status => ../../comp/core/status
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection => ../../comp/core/tagger/origindetection
 	github.com/DataDog/datadog-agent/comp/core/telemetry => ./../../comp/core/telemetry
 	github.com/DataDog/datadog-agent/comp/def => ./../../comp/def
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder => ../../comp/forwarder/defaultforwarder
@@ -129,6 +130,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.59.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.57.1 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.0-rc.3 // indirect


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Implement External Data resolution for APM and the Trace Agent.

### Motivation

This is needed to support the latest Origin Detection spec.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

With the following patch to `dd-trace-py`:
```
diff --git a/ddtrace/internal/runtime/container.py b/ddtrace/internal/runtime/container.py
index c12a091fe..5667b70be 100644
--- a/ddtrace/internal/runtime/container.py
+++ b/ddtrace/internal/runtime/container.py
@@ -163,6 +163,7 @@ def get_container_info(pid="self"):
 
 def update_headers_with_container_info(headers: Dict, container_info: Optional[CGroupInfo]) -> None:
     """Get the container info (either the container ID or the cgroup inode) and add it to the headers."""
+    return # skip
     if container_info is None:
         return
     if container_info.container_id:
@@ -189,3 +190,4 @@ def update_header_with_external_info(headers: Dict) -> None:
                 EXTERNAL_ENV_HEADER_NAME: external_info,
             }
         )
+    log.error("external_info: %s", external_info)
\ No newline at end of file
```
And the following application code:
```
#!/usr/bin/env python3

import time

from ddtrace import tracer

while(1):
  increment = tracer.trace("increment", "dummy_trace_python")
  decrement = tracer.trace("decrement", "dummy_trace_python")
  time.sleep(2)
  increment.finish()
  time.sleep(2)
  decrement.finish()
```
Deployed using:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: dd-trace-py
  labels:
    app: dd-trace-py
spec:
  selector:
    matchLabels:
      app: dd-trace-py
  replicas: 1
  template:
    metadata:
      labels:
        app: dd-trace-py
        admission.datadoghq.com/enabled: "true"
    spec:
      containers:
        - name: dd-trace-py
          image: wdhifdatadog/dd-trace-py
          imagePullPolicy: Always
          env:
          - name: DD_AGENT_HOST
            valueFrom:
              fieldRef:
                fieldPath: status.hostIP
          - name: DD_TRACE_AGENT_URL
            value: "http://$(DD_AGENT_HOST):8126"
          - name: DD_TRACE_DEBUG
            value: "true"
```

We are able to see the following traces being tagged correctly:
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/66c93c22-d597-4c34-a05f-da2dbeac865a" />

### Possible Drawbacks / Trade-offs

Caching has not yet been implemented in the Remote Tagger and will be addressed in a subsequent PR.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->