### PR TITLE
omnibus: vcredist: move the actual file copy to the recipe

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -81,7 +81,6 @@ else
     license "Python-2.0"
 
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_3_embedded)}\""
-    command "copy /y \"#{windows_safe_path(vcrt140_root)}\\*.dll\" \"#{windows_safe_path(python_3_embedded)}\""
 
     # Install pip
     python = "#{windows_safe_path(python_3_embedded)}\\python.exe"

--- a/omnibus/config/software/vc_redist_14.rb
+++ b/omnibus/config/software/vc_redist_14.rb
@@ -23,5 +23,5 @@ build do
    else
      source_msm = "Microsoft_VC141_CRT_x64.msm"
    end
-   command "powershell -C \"#{windows_safe_path(script_root)} -file #{source_msm} -targetDir \"#{windows_safe_path(python_3_embedded)}\""
+   command "powershell -C \"#{windows_safe_path(script_root)} -file #{source_msm} -targetDir \"#{windows_safe_path(python_3_embedded)}\"\""
 end

--- a/omnibus/config/software/vc_redist_14.rb
+++ b/omnibus/config/software/vc_redist_14.rb
@@ -23,5 +23,5 @@ build do
    else
      source_msm = "Microsoft_VC141_CRT_x64.msm"
    end
-   command "powershell -C \"#{windows_safe_path(script_root)} -file #{source_msm} -targetDir .\\expanded\""
+   command "powershell -C \"#{windows_safe_path(script_root)} -file #{source_msm} -targetDir \"#{windows_safe_path(python_3_embedded)}\""
 end


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Extract the files to their final destination without an intermediate folder and implicit dependency on python recipe.

### Motivation

This way we get something to cache in the omnibus cache and avoid problem when restoring vcredist and not python

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->