### PR TITLE
[fleet] use custom tracer

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2918,9 +2918,6 @@ core,google.golang.org/protobuf/types/known/timestamppb,BSD-3-Clause,Copyright (
 core,google.golang.org/protobuf/types/known/wrapperspb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
 core,google.golang.org/protobuf/types/pluginpb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
 core,gopkg.in/DataDog/dd-trace-go.v1/appsec/events,Apache-2.0,"Copyright 2016-Present Datadog, Inc."
-core,gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/httptrace,Apache-2.0,"Copyright 2016-Present Datadog, Inc."
-core,gopkg.in/DataDog/dd-trace-go.v1/contrib/internal/options,Apache-2.0,"Copyright 2016-Present Datadog, Inc."
-core,gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http,Apache-2.0,"Copyright 2016-Present Datadog, Inc."
 core,gopkg.in/DataDog/dd-trace-go.v1/datastreams/options,Apache-2.0,"Copyright 2016-Present Datadog, Inc."
 core,gopkg.in/DataDog/dd-trace-go.v1/ddtrace,Apache-2.0,"Copyright 2016-Present Datadog, Inc."
 core,gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext,Apache-2.0,"Copyright 2016-Present Datadog, Inc."

--- a/cmd/installer-downloader/main.go
+++ b/cmd/installer-downloader/main.go
@@ -44,12 +44,12 @@ func main() {
 	ctx := context.Background()
 
 	t := telemetry.NewTelemetry(env.HTTPClient(), env.APIKey, env.Site, fmt.Sprintf("datadog-installer-downloader-%s", Flavor))
-	_ = t.Start(ctx)
-	defer func() { _ = t.Stop(ctx) }()
 	var err error
 	span, ctx := telemetry.StartSpanFromEnv(ctx, fmt.Sprintf("downloader-%s", Flavor))
-	defer func() { span.Finish(err) }()
 	err = runDownloader(ctx, env, Version, Flavor)
+
+	span.Finish(err)
+	t.Stop()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Installation failed: %v\n", err)
 		os.Exit(1)

--- a/cmd/installer/subcommands/installer/command.go
+++ b/cmd/installer/subcommands/installer/command.go
@@ -87,7 +87,7 @@ func UnprivilegedCommands(_ *command.GlobalParams) []*cobra.Command {
 type cmd struct {
 	t    *telemetry.Telemetry
 	ctx  context.Context
-	span telemetry.Span
+	span *telemetry.Span
 	env  *env.Env
 }
 
@@ -107,10 +107,7 @@ func newCmd(operation string) *cmd {
 func (c *cmd) Stop(err error) {
 	c.span.Finish(err)
 	if c.t != nil {
-		err := c.t.Stop(context.Background())
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to stop telemetry: %v\n", err)
-		}
+		c.t.Stop()
 	}
 }
 
@@ -225,11 +222,6 @@ func newTelemetry(env *env.Env) *telemetry.Telemetry {
 		site = config.Site
 	}
 	t := telemetry.NewTelemetry(env.HTTPClient(), apiKey, site, "datadog-installer") // No sampling rules for commands
-	err := t.Start(context.Background())
-	if err != nil {
-		fmt.Printf("failed to start telemetry: %v\n", err)
-		return nil
-	}
 	return t
 }
 

--- a/cmd/installer/subcommands/installer/umask_nix.go
+++ b/cmd/installer/subcommands/installer/umask_nix.go
@@ -14,7 +14,7 @@ import (
 )
 
 // setInstallerUmask sets umask 0 to override any inherited umask
-func setInstallerUmask(span telemetry.Span) {
+func setInstallerUmask(span *telemetry.Span) {
 	oldmask := syscall.Umask(0)
 	span.SetTag("inherited_umask", oldmask)
 }

--- a/cmd/installer/subcommands/installer/umask_windows.go
+++ b/cmd/installer/subcommands/installer/umask_windows.go
@@ -10,4 +10,4 @@ package installer
 import "github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 
 // setInstallerUmask no-op on Windows
-func setInstallerUmask(_ telemetry.Span) {}
+func setInstallerUmask(_ *telemetry.Span) {}

--- a/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
+++ b/comp/checks/agentcrashdetect/agentcrashdetectimpl/agentcrashdetect.go
@@ -168,9 +168,20 @@ func (wcd *AgentCrashDetect) Run() error {
 	}
 
 	log.Infof("Sending crash: %v", formatText(crash))
-	lts := internaltelemetry.NewClient(wcd.tconfig.NewHTTPClient(), wcd.tconfig.TelemetryConfig.Endpoints, "ddnpm", true)
+	lts := internaltelemetry.NewClient(wcd.tconfig.NewHTTPClient(), toTelemEndpoints(wcd.tconfig.TelemetryConfig.Endpoints), "ddnpm", true)
 	lts.SendLog("WARN", formatText(crash))
 	return nil
+}
+
+func toTelemEndpoints(endpoints []*traceconfig.Endpoint) []*internaltelemetry.Endpoint {
+	telemEndpoints := make([]*internaltelemetry.Endpoint, 0, len(endpoints))
+	for _, e := range endpoints {
+		telemEndpoints = append(telemEndpoints, &internaltelemetry.Endpoint{
+			Host:   e.Host,
+			APIKey: e.APIKey,
+		})
+	}
+	return telemEndpoints
 }
 
 func newAgentCrashComponent(deps dependencies) agentcrashdetect.Component {

--- a/comp/updater/telemetry/telemetryimpl/telemetry.go
+++ b/comp/updater/telemetry/telemetryimpl/telemetry.go
@@ -39,13 +39,6 @@ func newTelemetry(deps dependencies) (telemetry.Component, error) {
 		Transport: httputils.CreateHTTPTransport(deps.Config),
 	}
 	telemetry := fleettelemetry.NewTelemetry(client, utils.SanitizeAPIKey(deps.Config.GetString("api_key")), deps.Config.GetString("site"), "datadog-installer-daemon")
-	/*
-		fleettelemetry.WithSamplingRules(
-			tracer.NameServiceRule("cdn.*", "datadog-installer-daemon", 0.1),
-			tracer.NameServiceRule("*garbage_collect*", "datadog-installer-daemon", 0.05),
-			tracer.NameServiceRule("HTTPClient.*", "datadog-installer-daemon", 0.05),
-		),
-	)*/
 	deps.Lc.Append(fx.Hook{OnStop: func(context.Context) error { telemetry.Stop(); return nil }})
 	return telemetry, nil
 }

--- a/comp/updater/telemetry/telemetryimpl/telemetry.go
+++ b/comp/updater/telemetry/telemetryimpl/telemetry.go
@@ -7,10 +7,10 @@
 package telemetryimpl
 
 import (
+	"context"
 	"net/http"
 
 	"go.uber.org/fx"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/updater/telemetry"
@@ -38,13 +38,14 @@ func newTelemetry(deps dependencies) (telemetry.Component, error) {
 	client := &http.Client{
 		Transport: httputils.CreateHTTPTransport(deps.Config),
 	}
-	telemetry := fleettelemetry.NewTelemetry(client, utils.SanitizeAPIKey(deps.Config.GetString("api_key")), deps.Config.GetString("site"), "datadog-installer-daemon",
+	telemetry := fleettelemetry.NewTelemetry(client, utils.SanitizeAPIKey(deps.Config.GetString("api_key")), deps.Config.GetString("site"), "datadog-installer-daemon")
+	/*
 		fleettelemetry.WithSamplingRules(
 			tracer.NameServiceRule("cdn.*", "datadog-installer-daemon", 0.1),
 			tracer.NameServiceRule("*garbage_collect*", "datadog-installer-daemon", 0.05),
 			tracer.NameServiceRule("HTTPClient.*", "datadog-installer-daemon", 0.05),
 		),
-	)
-	deps.Lc.Append(fx.Hook{OnStart: telemetry.Start, OnStop: telemetry.Stop})
+	)*/
+	deps.Lc.Append(fx.Hook{OnStop: func(context.Context) error { telemetry.Stop(); return nil }})
 	return telemetry, nil
 }

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -570,7 +570,7 @@ type requestState struct {
 	ErrorCode installerErrors.InstallerErrorCode
 }
 
-func newRequestContext(request remoteAPIRequest) (telemetry.Span, context.Context) {
+func newRequestContext(request remoteAPIRequest) (*telemetry.Span, context.Context) {
 	ctx := context.WithValue(context.Background(), requestStateKey, &requestState{
 		Package: request.Package,
 		ID:      request.ID,

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -40,7 +40,7 @@ type Setup struct {
 	Out      *Output
 	Env      *env.Env
 	Ctx      context.Context
-	Span     telemetry.Span
+	Span     *telemetry.Span
 	Packages Packages
 	Config   Config
 }

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -120,7 +120,7 @@ func (s *Setup) installPackage(name string, url string) (err error) {
 	span, ctx := telemetry.StartSpanFromContext(s.Ctx, "install")
 	defer func() { span.Finish(err) }()
 	span.SetTag("url", url)
-	span.SetTag("_top_level", 1)
+	span.SetTopLevel()
 
 	s.Out.WriteString(fmt.Sprintf("Installing %s...\n", name))
 	err = s.installer.Install(ctx, url, nil)

--- a/pkg/fleet/internal/exec/installer_exec.go
+++ b/pkg/fleet/internal/exec/installer_exec.go
@@ -40,7 +40,7 @@ func NewInstallerExec(env *env.Env, installerBinPath string) *InstallerExec {
 
 type installerCmd struct {
 	*exec.Cmd
-	span telemetry.Span
+	span *telemetry.Span
 	ctx  context.Context
 }
 

--- a/pkg/fleet/telemetry/http_wrapper.go
+++ b/pkg/fleet/telemetry/http_wrapper.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package telemetry provides the telemetry for fleet components.
+package telemetry
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// WrapRoundTripper wraps the round tripper with the telemetry round tripper.
+func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	if rt == nil {
+		rt = http.DefaultTransport
+	}
+	if wrapped, ok := rt.(*roundTripper); ok {
+		rt = wrapped.base
+	}
+	return &roundTripper{
+		base: rt,
+	}
+}
+
+type roundTripper struct {
+	base http.RoundTripper
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err error) {
+	span, _ := StartSpanFromContext(req.Context(), "http.request")
+	defer func() { span.Finish(err) }()
+
+	url := *req.URL
+	url.User = nil
+
+	span.span.Type = "http"
+	span.SetResourceName(req.Method + " " + urlFromRequest(req, true))
+	span.span.Meta["http.method"] = req.Method
+	span.span.Meta["http.url"] = req.URL.String()
+	span.span.Meta["span.kind"] = "client"
+	span.span.Meta["network.destination.name"] = url.Hostname()
+	res, err = rt.base.RoundTrip(req)
+	if err != nil {
+		span.SetTag("http.errors", err.Error())
+		return res, err
+	}
+	span.SetTag("http.status_code", strconv.Itoa(res.StatusCode))
+	if res.StatusCode >= 400 {
+		span.SetTag("http.errors", res.Status)
+	}
+	return res, err
+}
+
+// urlFromRequest returns the URL from the HTTP request. The URL query string is included in the return object iff queryString is true
+// See https://docs.datadoghq.com/tracing/configure_data_security#redacting-the-query-in-the-url for more information.
+func urlFromRequest(r *http.Request, queryString bool) string {
+	// Quoting net/http comments about net.Request.URL on server requests:
+	// "For most requests, fields other than Path and RawQuery will be
+	// empty. (See RFC 7230, Section 5.3)"
+	// This is why we don't rely on url.URL.String(), url.URL.Host, url.URL.Scheme, etc...
+	var url string
+	path := r.URL.EscapedPath()
+	scheme := r.URL.Scheme
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if r.Host != "" {
+		url = strings.Join([]string{scheme, "://", r.Host, path}, "")
+	} else {
+		url = path
+	}
+	// Collect the query string if we are allowed to report it and obfuscate it if possible/allowed
+	if queryString && r.URL.RawQuery != "" {
+		query := r.URL.RawQuery
+		url = strings.Join([]string{url, query}, "?")
+	}
+	if frag := r.URL.EscapedFragment(); frag != "" {
+		url = strings.Join([]string{url, frag}, "#")
+	}
+	return url
+}

--- a/pkg/fleet/telemetry/http_wrapper.go
+++ b/pkg/fleet/telemetry/http_wrapper.go
@@ -37,7 +37,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 	url.User = nil
 
 	span.span.Type = "http"
-	span.SetResourceName(req.Method + " " + urlFromRequest(req, true))
+	span.SetResourceName(req.Method + " " + urlFromRequest(req))
 	span.span.Meta["http.method"] = req.Method
 	span.span.Meta["http.url"] = req.URL.String()
 	span.span.Meta["span.kind"] = "client"
@@ -56,7 +56,7 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (res *http.Response, err er
 
 // urlFromRequest returns the URL from the HTTP request. The URL query string is included in the return object iff queryString is true
 // See https://docs.datadoghq.com/tracing/configure_data_security#redacting-the-query-in-the-url for more information.
-func urlFromRequest(r *http.Request, queryString bool) string {
+func urlFromRequest(r *http.Request) string {
 	// Quoting net/http comments about net.Request.URL on server requests:
 	// "For most requests, fields other than Path and RawQuery will be
 	// empty. (See RFC 7230, Section 5.3)"
@@ -73,7 +73,7 @@ func urlFromRequest(r *http.Request, queryString bool) string {
 		url = path
 	}
 	// Collect the query string if we are allowed to report it and obfuscate it if possible/allowed
-	if queryString && r.URL.RawQuery != "" {
+	if r.URL.RawQuery != "" {
 		query := r.URL.RawQuery
 		url = strings.Join([]string{url, query}, "?")
 	}

--- a/pkg/fleet/telemetry/span.go
+++ b/pkg/fleet/telemetry/span.go
@@ -16,7 +16,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/internaltelemetry"
 )
 
 const spanKey = spanContextKey("span_context")
@@ -26,7 +26,7 @@ type spanContextKey string
 // Span represents a span.
 type Span struct {
 	mu       sync.Mutex
-	span     pb.Span
+	span     internaltelemetry.Span
 	finished atomic.Bool
 }
 
@@ -40,7 +40,7 @@ func newSpan(name string, parentID, traceID uint64) *Span {
 		noParent = true
 	}
 	s := &Span{
-		span: pb.Span{
+		span: internaltelemetry.Span{
 			TraceID:  traceID,
 			ParentID: parentID,
 			SpanID:   rand.Uint64(),

--- a/pkg/fleet/telemetry/span.go
+++ b/pkg/fleet/telemetry/span.go
@@ -31,13 +31,11 @@ type Span struct {
 }
 
 func newSpan(name string, parentID, traceID uint64) *Span {
-	var noParent bool
 	if traceID == 0 {
 		traceID = rand.Uint64()
 		if !headSamplingKeep(name, traceID) {
 			traceID = dropTraceID
 		}
-		noParent = true
 	}
 	s := &Span{
 		span: internaltelemetry.Span{
@@ -51,7 +49,7 @@ func newSpan(name string, parentID, traceID uint64) *Span {
 			Metrics:  make(map[string]float64),
 		},
 	}
-	if noParent {
+	if parentID == 0 {
 		s.SetTopLevel()
 	}
 

--- a/pkg/fleet/telemetry/span.go
+++ b/pkg/fleet/telemetry/span.go
@@ -34,6 +34,9 @@ func newSpan(name string, parentID, traceID uint64) *Span {
 	var noParent bool
 	if traceID == 0 {
 		traceID = rand.Uint64()
+		if !headSamplingKeep(name, traceID) {
+			traceID = dropTraceID
+		}
 		noParent = true
 	}
 	s := &Span{
@@ -49,7 +52,7 @@ func newSpan(name string, parentID, traceID uint64) *Span {
 		},
 	}
 	if noParent {
-		s.SetTag("_top_level", 1)
+		s.SetTopLevel()
 	}
 
 	globalTracer.registerSpan(s)
@@ -80,6 +83,11 @@ func (s *Span) SetResourceName(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.span.Resource = name
+}
+
+// SetTopLevel sets the span as a top level span.
+func (s *Span) SetTopLevel() {
+	s.SetTag("_top_level", 1)
 }
 
 // SetTag sets a tag on the span.

--- a/pkg/fleet/telemetry/span.go
+++ b/pkg/fleet/telemetry/span.go
@@ -7,20 +7,138 @@
 package telemetry
 
 import (
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"runtime/debug"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 )
 
-// Span is an alias for ddtrace.Span until we phase ddtrace out.
-type Span struct{ ddtrace.Span }
+const spanKey = spanContextKey("span_context")
+
+type spanContextKey string
+
+// Span represents a span.
+type Span struct {
+	mu       sync.Mutex
+	span     pb.Span
+	finished atomic.Bool
+}
+
+func newSpan(name string, parentID, traceID uint64) *Span {
+	var noParent bool
+	if traceID == 0 {
+		traceID = rand.Uint64()
+		noParent = true
+	}
+	s := &Span{
+		span: pb.Span{
+			TraceID:  traceID,
+			ParentID: parentID,
+			SpanID:   rand.Uint64(),
+			Name:     name,
+			Resource: name,
+			Start:    time.Now().UnixNano(),
+			Meta:     make(map[string]string),
+			Metrics:  make(map[string]float64),
+		},
+	}
+	if noParent {
+		s.SetTag("_top_level", 1)
+	}
+
+	globalTracer.registerSpan(s)
+	return s
+}
 
 // Finish finishes the span with an error.
 func (s *Span) Finish(err error) {
-	s.Span.Finish(tracer.WithError(err))
+	s.finished.Store(true)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.span.Duration = time.Now().UnixNano() - s.span.Start
+	if err != nil {
+		s.span.Error = 1
+		s.span.Meta = map[string]string{
+			"error.message": err.Error(),
+			"error.stack":   string(debug.Stack()),
+		}
+	}
+	globalTracer.finishSpan(s)
 }
 
 // SetResourceName sets the resource name of the span.
 func (s *Span) SetResourceName(name string) {
-	s.Span.SetTag(ext.ResourceName, name)
+	if s.finished.Load() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.span.Resource = name
+}
+
+// SetTag sets a tag on the span.
+func (s *Span) SetTag(key string, value interface{}) {
+	if s.finished.Load() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if value == nil {
+		s.span.Meta[key] = "nil"
+	}
+	switch v := value.(type) {
+	case string:
+		s.span.Meta[key] = v
+	case bool:
+		s.span.Meta[key] = strconv.FormatBool(v)
+	case int:
+		s.span.Metrics[key] = float64(v)
+	case int8:
+		s.span.Metrics[key] = float64(v)
+	case int16:
+		s.span.Metrics[key] = float64(v)
+	case int32:
+		s.span.Metrics[key] = float64(v)
+	case int64:
+		s.span.Metrics[key] = float64(v)
+	case uint:
+		s.span.Metrics[key] = float64(v)
+	case uint8:
+		s.span.Metrics[key] = float64(v)
+	case uint16:
+		s.span.Metrics[key] = float64(v)
+	case uint32:
+		s.span.Metrics[key] = float64(v)
+	case uint64:
+		s.span.Metrics[key] = float64(v)
+	case float32:
+		s.span.Metrics[key] = float64(v)
+	case float64:
+		s.span.Metrics[key] = v
+	default:
+		s.span.Meta[key] = fmt.Sprintf("not_supported_type %T", v)
+	}
+}
+
+type spanIDs struct {
+	traceID uint64
+	spanID  uint64
+}
+
+func getSpanIDsFromContext(ctx context.Context) (spanIDs, bool) {
+	sIDs, ok := ctx.Value(spanKey).(spanIDs)
+	if !ok {
+		return spanIDs{}, false
+	}
+	return sIDs, true
+}
+
+func setSpanIDsInContext(ctx context.Context, span *Span) context.Context {
+	return context.WithValue(ctx, spanKey, spanIDs{traceID: span.span.TraceID, spanID: span.span.SpanID})
 }

--- a/pkg/fleet/telemetry/telemetry.go
+++ b/pkg/fleet/telemetry/telemetry.go
@@ -93,6 +93,7 @@ func (t *Telemetry) sendCompletedSpans() {
 		span.span.Service = t.service
 		span.span.Meta["env"] = t.env
 		span.span.Meta["version"] = version.AgentVersion
+		span.span.Metrics["_sampling_priority_v1"] = 2
 		traces[span.span.TraceID] = append(traces[span.span.TraceID], &span.span)
 	}
 	tracesArray := make([]pb.Trace, 0, len(traces))
@@ -136,8 +137,8 @@ func StartSpanFromIDs(ctx context.Context, operationName, traceID, parentID stri
 		parentIDInt = 0
 	}
 	span, ctx := startSpanFromIDs(ctx, operationName, traceIDInt, parentIDInt)
-	span.SetTag("_top_level", 1)
-	return startSpanFromIDs(ctx, operationName, traceIDInt, parentIDInt)
+	span.SetTopLevel()
+	return span, ctx
 }
 
 func startSpanFromIDs(ctx context.Context, operationName string, traceID, parentID uint64) (*Span, context.Context) {
@@ -163,12 +164,3 @@ func EnvFromContext(ctx context.Context) []string {
 		fmt.Sprintf("%s=%s", envParentID, strconv.FormatUint(sIDs.spanID, 10)),
 	}
 }
-
-/*
-// WithSamplingRules sets the sampling rules for the telemetry.
-func WithSamplingRules(rules ...tracer.SamplingRule) Option {
-	return func(t *Telemetry) {
-		t.samplingRules = rules
-	}
-}
-*/

--- a/pkg/fleet/telemetry/telemetry.go
+++ b/pkg/fleet/telemetry/telemetry.go
@@ -8,280 +8,167 @@ package telemetry
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
-	"math/rand/v2"
-	"net"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
-	"sync"
+	"time"
 
-	httptrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-
-	"github.com/gorilla/mux"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 
 	"github.com/DataDog/datadog-agent/pkg/internaltelemetry"
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	traceconfig "github.com/DataDog/datadog-agent/pkg/trace/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const (
-	// EnvTraceID is the environment variable key for the trace ID
-	EnvTraceID = "DATADOG_TRACE_ID"
-	// EnvParentID is the environment variable key for the parent ID
-	EnvParentID = "DATADOG_PARENT_ID"
-)
-
-const (
+	envTraceID         = "DATADOG_TRACE_ID"
+	envParentID        = "DATADOG_PARENT_ID"
 	telemetrySubdomain = "instrumentation-telemetry-intake"
-	telemetryEndpoint  = "/v0.4/traces"
 )
 
 // Telemetry handles the telemetry for fleet components.
 type Telemetry struct {
 	telemetryClient internaltelemetry.Client
+	done            chan struct{}
+	flushed         chan struct{}
 
-	site    string
+	env     string
 	service string
-
-	listener *telemetryListener
-	server   *http.Server
-	client   *http.Client
-
-	samplingRules []tracer.SamplingRule
 }
 
-// Option is a functional option for telemetry.
-type Option func(*Telemetry)
-
 // NewTelemetry creates a new telemetry instance
-func NewTelemetry(client *http.Client, apiKey string, site string, service string, opts ...Option) *Telemetry {
+func NewTelemetry(client *http.Client, apiKey string, site string, service string) *Telemetry {
 	endpoint := &traceconfig.Endpoint{
 		Host:   fmt.Sprintf("https://%s.%s", telemetrySubdomain, strings.TrimSpace(site)),
 		APIKey: apiKey,
 	}
-	listener := newTelemetryListener()
+	env := "prod"
+	if site == "datad0g.com" {
+		env = "staging"
+	}
+
 	t := &Telemetry{
 		telemetryClient: internaltelemetry.NewClient(client, []*traceconfig.Endpoint{endpoint}, service, site == "datad0g.com"),
-		site:            site,
+		done:            make(chan struct{}),
+		flushed:         make(chan struct{}),
+		env:             env,
 		service:         service,
-		listener:        listener,
-		server:          &http.Server{},
-		client: &http.Client{
-			Transport: &http.Transport{
-				Dial: listener.Dial,
-			},
-		},
 	}
-	for _, opt := range opts {
-		opt(t)
-	}
-	t.server.Handler = t.handler()
+	t.Start()
 	return t
 }
 
 // Start starts the telemetry
-func (t *Telemetry) Start(_ context.Context) error {
+func (t *Telemetry) Start() {
+	ticker := time.Tick(1 * time.Minute)
 	go func() {
-		err := t.server.Serve(t.listener)
-		if err != nil {
-			log.Infof("telemetry server stopped: %v", err)
+		for {
+			select {
+			case <-ticker:
+				t.sendCompletedSpans()
+			case <-t.done:
+				t.sendCompletedSpans()
+				close(t.flushed)
+				return
+			}
 		}
 	}()
-	env := "prod"
-	if t.site == "datad0g.com" {
-		env = "staging"
-	}
-
-	tracer.Start(
-		tracer.WithService(t.service),
-		tracer.WithServiceVersion(version.AgentVersion),
-		tracer.WithEnv(env),
-		tracer.WithGlobalTag("site", t.site),
-		tracer.WithHTTPClient(t.client),
-		tracer.WithLogStartup(false),
-
-		// We don't need the value, we just need to enforce that it's not
-		// the default. If it is, then the tracer will try to use the socket
-		// if it exists -- and it always exists for newer agents.
-		// If the agent address is the socket, the tracer overrides WithHTTPClient to use it.
-		tracer.WithAgentAddr("192.0.2.42:12345"), // 192.0.2.0/24 is reserved
-		tracer.WithSamplingRules(t.samplingRules),
-	)
-	return nil
 }
 
 // Stop stops the telemetry
-func (t *Telemetry) Stop(ctx context.Context) error {
-	tracer.Flush()
-	tracer.Stop()
-	t.listener.Close()
-	err := t.server.Shutdown(ctx)
-	if err != nil {
-		log.Errorf("error shutting down telemetry server: %v", err)
+func (t *Telemetry) Stop() {
+	close(t.done)
+	<-t.flushed
+}
+
+func (t *Telemetry) sendCompletedSpans() {
+	spans := globalTracer.flushCompletedSpans()
+	if len(spans) == 0 {
+		return
 	}
-	return nil
-}
-
-func (t *Telemetry) handler() http.Handler {
-	r := mux.NewRouter().Headers("Content-Type", "application/msgpack").Subrouter()
-	r.HandleFunc(telemetryEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			log.Errorf("error reading request body: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		var traces pb.Traces
-		_, err = traces.UnmarshalMsg(body)
-		if err != nil {
-			log.Errorf("error unmarshalling traces: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		t.telemetryClient.SendTraces(traces)
-		w.WriteHeader(http.StatusOK)
-	})
-	return r
-}
-
-type telemetryListener struct {
-	conns chan net.Conn
-
-	close     chan struct{}
-	closeOnce sync.Once
-}
-
-func newTelemetryListener() *telemetryListener {
-	return &telemetryListener{
-		conns: make(chan net.Conn),
-		close: make(chan struct{}),
+	traces := make(map[uint64][]*pb.Span)
+	for _, span := range spans {
+		span.span.Service = t.service
+		span.span.Meta["env"] = t.env
+		span.span.Meta["version"] = version.AgentVersion
+		traces[span.span.TraceID] = append(traces[span.span.TraceID], &span.span)
 	}
-}
-
-func (l *telemetryListener) Close() error {
-	l.closeOnce.Do(func() {
-		close(l.close)
-	})
-	return nil
-}
-
-func (l *telemetryListener) Accept() (net.Conn, error) {
-	select {
-	case <-l.close:
-		return nil, errors.New("listener closed")
-	case conn := <-l.conns:
-		return conn, nil
+	tracesArray := make([]pb.Trace, 0, len(traces))
+	for _, trace := range traces {
+		tracesArray = append(tracesArray, pb.Trace(trace))
 	}
+	t.telemetryClient.SendTraces(pb.Traces(tracesArray))
 }
 
-func (l *telemetryListener) Addr() net.Addr {
-	return addr(0)
-}
-
-func (l *telemetryListener) Dial(_, _ string) (net.Conn, error) {
-	select {
-	case <-l.close:
-		return nil, errors.New("listener closed")
-	default:
+// SpanFromContext returns the span from the context if available.
+func SpanFromContext(ctx context.Context) (*Span, bool) {
+	spanIDs, ok := getSpanIDsFromContext(ctx)
+	if !ok {
+		return nil, false
 	}
-	server, client := net.Pipe()
-	l.conns <- server
-	return client, nil
+	return globalTracer.getSpan(spanIDs.spanID)
 }
 
-type addr int
-
-func (addr) Network() string {
-	return "memory"
-}
-
-func (addr) String() string {
-	return "local"
+// StartSpanFromEnv starts a span using the environment variables to find the parent span.
+func StartSpanFromEnv(ctx context.Context, operationName string) (*Span, context.Context) {
+	traceID, ok := os.LookupEnv(envTraceID)
+	if !ok {
+		traceID = "0"
+	}
+	parentID, ok := os.LookupEnv(envParentID)
+	if !ok {
+		parentID = "0"
+	}
+	return StartSpanFromIDs(ctx, operationName, traceID, parentID)
 }
 
 // StartSpanFromIDs starts a span using the trace and parent
 // IDs provided.
-func StartSpanFromIDs(ctx context.Context, operationName, traceID, parentID string, spanOptions ...ddtrace.StartSpanOption) (Span, context.Context) {
-	ctxCarrier := tracer.TextMapCarrier{
-		tracer.DefaultTraceIDHeader:  traceID,
-		tracer.DefaultParentIDHeader: parentID,
-		tracer.DefaultPriorityHeader: "2",
-	}
-	spanCtx, err := tracer.Extract(ctxCarrier)
+func StartSpanFromIDs(ctx context.Context, operationName, traceID, parentID string) (*Span, context.Context) {
+	traceIDInt, err := strconv.ParseUint(traceID, 10, 64)
 	if err != nil {
-		log.Debugf("failed to extract span context from install script params: %v", err)
-		return StartSpanFromContext(ctx, operationName, spanOptions...)
+		traceIDInt = 0
 	}
-	spanOptions = append([]ddtrace.StartSpanOption{tracer.ChildOf(spanCtx)}, spanOptions...)
-	return StartSpanFromContext(ctx, operationName, spanOptions...)
+	parentIDInt, err := strconv.ParseUint(parentID, 10, 64)
+	if err != nil {
+		parentIDInt = 0
+	}
+	span, ctx := startSpanFromIDs(ctx, operationName, traceIDInt, parentIDInt)
+	span.SetTag("_top_level", 1)
+	return startSpanFromIDs(ctx, operationName, traceIDInt, parentIDInt)
 }
 
-// SpanFromContext returns the span from the context if available.
-func SpanFromContext(ctx context.Context) (Span, bool) {
-	span, ok := tracer.SpanFromContext(ctx)
-	if !ok {
-		return Span{}, false
-	}
-	return Span{span}, true
+func startSpanFromIDs(ctx context.Context, operationName string, traceID, parentID uint64) (*Span, context.Context) {
+	s := newSpan(operationName, parentID, traceID)
+	ctx = setSpanIDsInContext(ctx, s)
+	return s, ctx
 }
 
 // StartSpanFromContext starts a span using the context to find the parent span.
-func StartSpanFromContext(ctx context.Context, operationName string, spanOptions ...ddtrace.StartSpanOption) (Span, context.Context) {
-	span, ctx := tracer.StartSpanFromContext(ctx, operationName, spanOptions...)
-	return Span{span}, ctx
-}
-
-// StartSpanFromEnv starts a span using the environment variables to find the parent span.
-func StartSpanFromEnv(ctx context.Context, operationName string, spanOptions ...ddtrace.StartSpanOption) (Span, context.Context) {
-	traceID, ok := os.LookupEnv(EnvTraceID)
-	if !ok {
-		traceID = strconv.FormatUint(rand.Uint64(), 10)
-	}
-	parentID, ok := os.LookupEnv(EnvParentID)
-	if !ok {
-		parentID = "0"
-	}
-	return StartSpanFromIDs(ctx, operationName, traceID, parentID, spanOptions...)
+func StartSpanFromContext(ctx context.Context, operationName string) (*Span, context.Context) {
+	spanIDs, _ := getSpanIDsFromContext(ctx)
+	return startSpanFromIDs(ctx, operationName, spanIDs.traceID, spanIDs.spanID)
 }
 
 // EnvFromContext returns the environment variables for the context.
 func EnvFromContext(ctx context.Context) []string {
-	spanCtx, ok := SpanContextFromContext(ctx)
+	sIDs, ok := getSpanIDsFromContext(ctx)
 	if !ok {
 		return []string{}
 	}
 	return []string{
-		fmt.Sprintf("%s=%d", EnvTraceID, spanCtx.TraceID()),
-		fmt.Sprintf("%s=%d", EnvParentID, spanCtx.SpanID()),
+		fmt.Sprintf("%s=%s", envTraceID, strconv.FormatUint(sIDs.traceID, 10)),
+		fmt.Sprintf("%s=%s", envParentID, strconv.FormatUint(sIDs.spanID, 10)),
 	}
 }
 
-// SpanContextFromContext extracts the span context from the context if available.
-func SpanContextFromContext(ctx context.Context) (ddtrace.SpanContext, bool) {
-	span, ok := tracer.SpanFromContext(ctx)
-	if !ok {
-		return nil, false
-	}
-	return span.Context(), true
-}
-
+/*
 // WithSamplingRules sets the sampling rules for the telemetry.
 func WithSamplingRules(rules ...tracer.SamplingRule) Option {
 	return func(t *Telemetry) {
 		t.samplingRules = rules
 	}
 }
-
-// WrapRoundTripper wraps the round tripper with the telemetry round tripper.
-func WrapRoundTripper(rt http.RoundTripper) http.RoundTripper {
-	return httptrace.WrapRoundTripper(rt)
-}
+*/

--- a/pkg/fleet/telemetry/telemetry_test.go
+++ b/pkg/fleet/telemetry/telemetry_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package telemetry provides the telemetry for fleet components.
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFreshSpan(t *testing.T) {
+	ctx := context.Background()
+	_, ok := SpanFromContext(ctx)
+	require.False(t, ok)
+
+	s, ctx := StartSpanFromContext(ctx, "test")
+	require.NotNil(t, s)
+	s.SetResourceName("new")
+
+	span, ok := SpanFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, s, span)
+
+	assert.Equal(t, "test", s.span.Name)
+	assert.Equal(t, "new", s.span.Resource)
+	assert.Equal(t, "new", s.span.Resource)
+	assert.Equal(t, "new", span.span.Resource)
+}
+
+func TestInheritence(t *testing.T) {
+	ctx := context.Background()
+	s, ctx := StartSpanFromContext(ctx, "test")
+	require.NotNil(t, s)
+
+	child, _ := StartSpanFromContext(ctx, "child")
+	require.NotNil(t, child)
+
+	assert.Equal(t, s.span.SpanID, child.span.ParentID)
+	assert.Equal(t, s.span.TraceID, child.span.TraceID)
+}
+
+func TestStartSpanFromIDs(t *testing.T) {
+	ctx := context.Background()
+	traceID := "100"
+	parentID := "200"
+
+	span, ctx := StartSpanFromIDs(ctx, "ids-operation", traceID, parentID)
+	require.NotNil(t, span, "Expected a span")
+	require.Equal(t, uint64(100), span.span.TraceID)
+	require.Equal(t, uint64(200), span.span.ParentID)
+
+	val, ok := span.span.Metrics["_top_level"]
+	require.True(t, ok)
+	require.Equal(t, 1.0, val)
+
+	spanFromCtx, ok := SpanFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, span, spanFromCtx)
+}

--- a/pkg/fleet/telemetry/tracer.go
+++ b/pkg/fleet/telemetry/tracer.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package telemetry provides the telemetry for fleet components.
+package telemetry
+
+import "sync"
+
+var (
+	globalTracer *tracer
+)
+
+func init() {
+	globalTracer = &tracer{
+		spans: make(map[uint64]*Span),
+	}
+}
+
+type tracer struct {
+	mu             sync.Mutex
+	spans          map[uint64]*Span
+	completedSpans []*Span
+}
+
+func (t *tracer) registerSpan(span *Span) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.spans[span.span.SpanID] = span
+}
+
+func (t *tracer) getSpan(spanID uint64) (*Span, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	span, ok := t.spans[spanID]
+	return span, ok
+}
+
+func (t *tracer) finishSpan(span *Span) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.spans, span.span.SpanID)
+	t.completedSpans = append(t.completedSpans, span)
+}
+
+func (t *tracer) flushCompletedSpans() []*Span {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	newSpanArray := make([]*Span, 0)
+	completedSpans := t.completedSpans
+	t.completedSpans = newSpanArray
+	return completedSpans
+}

--- a/pkg/fleet/telemetry/tracer.go
+++ b/pkg/fleet/telemetry/tracer.go
@@ -12,7 +12,10 @@ import (
 	"sync"
 )
 
-const dropTraceID = 1
+const (
+	dropTraceID      = 1
+	maxSpansInFlight = 1000
+)
 
 var (
 	globalTracer  *tracer
@@ -41,6 +44,11 @@ func (t *tracer) registerSpan(span *Span) {
 	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	// naive maxSpansInFlight check as this is just telemetry
+	// next iteration if needed would be to flush long running spans to troubleshoot
+	if len(t.spans) >= maxSpansInFlight {
+		return
+	}
 	t.spans[span.span.SpanID] = span
 }
 

--- a/pkg/internaltelemetry/client.go
+++ b/pkg/internaltelemetry/client.go
@@ -21,8 +21,6 @@ import (
 
 	"go.uber.org/atomic"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/shirou/gopsutil/v4/host"
@@ -36,13 +34,19 @@ const (
 // Client defines the interface for a telemetry client
 type Client interface {
 	SendLog(level string, message string)
-	SendTraces(traces pb.Traces)
+	SendTraces(traces Traces)
+}
+
+// Endpoit defines the endpoint object
+type Endpoint struct {
+	APIKey string `json:"-"`
+	Host   string
 }
 
 type client struct {
 	m                  sync.Mutex
 	client             httpClient
-	endpoints          []*config.Endpoint
+	endpoints          []*Endpoint
 	sendPayloadTimeout time.Duration
 
 	// we can pre-calculate the host payload structure at init time
@@ -94,7 +98,7 @@ type Application struct {
 
 // TracePayload defines the trace payload object
 type TracePayload struct {
-	Traces []pb.Trace `json:"traces"`
+	Traces []Trace `json:"traces"`
 }
 
 // LogPayload defines the log payload object
@@ -115,7 +119,7 @@ type httpClient interface {
 }
 
 // NewClient creates a new telemetry client
-func NewClient(httpClient httpClient, endpoints []*config.Endpoint, service string, debug bool) Client {
+func NewClient(httpClient httpClient, endpoints []*Endpoint, service string, debug bool) Client {
 	info, err := host.Info()
 	if err != nil {
 		log.Errorf("failed to retrieve host info: %v", err)
@@ -158,7 +162,7 @@ func (c *client) SendLog(level, message string) {
 	c.sendPayload(RequestTypeLogs, payload)
 }
 
-func (c *client) SendTraces(traces pb.Traces) {
+func (c *client) SendTraces(traces Traces) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	payload := TracePayload{
@@ -170,8 +174,8 @@ func (c *client) SendTraces(traces pb.Traces) {
 // sampleTraces is a simple uniform sampling function that samples traces based
 // on the sampling rate, given that there is no trace agent to sample the traces
 // We try to keep the tracer behaviour: the first rule that matches apply its rate to the whole trace
-func (c *client) sampleTraces(traces pb.Traces) pb.Traces {
-	tracesWithSampling := pb.Traces{}
+func (c *client) sampleTraces(traces Traces) Traces {
+	tracesWithSampling := Traces{}
 	for _, trace := range traces {
 		samplingRate := 1.0
 		for _, span := range trace {
@@ -206,7 +210,7 @@ func (c *client) sendPayload(requestType RequestType, payload interface{}) {
 	group := sync.WaitGroup{}
 	for _, endpoint := range c.endpoints {
 		group.Add(1)
-		go func(endpoint *config.Endpoint) {
+		go func(endpoint *Endpoint) {
 			defer group.Done()
 			url := fmt.Sprintf("%s%s", endpoint.Host, telemetryEndpoint)
 			req, err := http.NewRequest("POST", url, bytes.NewReader(serializedPayload))

--- a/pkg/internaltelemetry/client.go
+++ b/pkg/internaltelemetry/client.go
@@ -37,7 +37,7 @@ type Client interface {
 	SendTraces(traces Traces)
 }
 
-// Endpoit defines the endpoint object
+// Endpoint defines the endpoint object
 type Endpoint struct {
 	APIKey string `json:"-"`
 	Host   string

--- a/pkg/internaltelemetry/traces.go
+++ b/pkg/internaltelemetry/traces.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+// Package internaltelemetry full description in README.md
+package internaltelemetry
+
+// Traces is a collection of traces
+type Traces []Trace
+
+// Trace is a collection of spans with the same trace ID
+type Trace []*Span
+
+// Span used for installation telemetry
+type Span struct {
+	// Service is the name of the service that handled this span.
+	Service string `json:"service"`
+	// Name is the name of the operation this span represents.
+	Name string `json:"name"`
+	// Resource is the name of the resource this span represents.
+	Resource string `json:"resource"`
+	// TraceID is the ID of the trace to which this span belongs.
+	TraceID uint64 `json:"trace_id"`
+	// SpanID is the ID of this span.
+	SpanID uint64 `json:"span_id"`
+	// ParentID is the ID of the parent span.
+	ParentID uint64 `json:"parent_id"`
+	// Start is the start time of this span in nanoseconds since the Unix epoch.
+	Start int64 `json:"start""`
+	// Duration is the duration of this span in nanoseconds.
+	Duration int64 `json:"duration"`
+	// Error is the error status of this span.
+	Error int32 `json:"error"`
+	// Meta is a mapping from tag name to tag value for string-valued tags.
+	Meta map[string]string `json:"meta,omitempty"`
+	// Metrics is a mapping from metric name to metric value for numeric metrics.
+	Metrics map[string]float64 `json:"metrics,omitempty"`
+	// Type is the type of the span.
+	Type string `json:"type"`
+}

--- a/pkg/internaltelemetry/traces.go
+++ b/pkg/internaltelemetry/traces.go
@@ -27,7 +27,7 @@ type Span struct {
 	// ParentID is the ID of the parent span.
 	ParentID uint64 `json:"parent_id"`
 	// Start is the start time of this span in nanoseconds since the Unix epoch.
-	Start int64 `json:"start""`
+	Start int64 `json:"start"`
 	// Duration is the duration of this span in nanoseconds.
 	Duration int64 `json:"duration"`
 	// Error is the error status of this span.


### PR DESCRIPTION
- Remove the dependency on go-tracer, immediately reducing downloader and installer by 12MB
- Removed reference of the trace-agent in the telemetry. The reference `Endpoint` result in importing many trace-agent dependencies

Size change:

Before
```
❯ ls -lh ./bin/installer
total 144368
-rwxr-xr-x  1 raphael.gavache  staff    19M 17 déc 22:42 downloader
-rw-r--r--  1 raphael.gavache  staff    52M 17 déc 22:42 install-databricks.sh
```

After
```
ls -lh ./bin/installer
total 55736
-rwxr-xr-x  1 raphael.gavache  staff   7,3M 17 déc 22:43 downloader
-rw-r--r--  1 raphael.gavache  staff    20M 17 déc 22:43 install-databricks.sh
```