### PR TITLE
[Logs agent] Disable HTTP/2 when using a proxy

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -396,6 +396,13 @@ func httpClientFactory(timeout time.Duration, cfg pkgconfigmodel.Reader) func() 
 	var transport *http.Transport
 
 	transportConfig := cfg.Get("logs_config.http_protocol")
+
+	// If any proxy is set, use http1
+	// This will be removed in a future version
+	if cfg.GetProxies() != nil {
+		transportConfig = "http1"
+	}
+
 	// Configure transport based on user setting
 	switch transportConfig {
 	case "http1":

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -494,3 +494,34 @@ func TestTransportProtocol_HTTP1FallBack(t *testing.T) {
 	// Assert that the server automatically falls back to HTTP/1.1
 	assert.Equal(t, "HTTP/1.1", resp.Proto)
 }
+
+func TestTransportProtocol_HTTP1WhenUsingProxy(t *testing.T) {
+	c := configmock.New(t)
+
+	// Force client to use ALNP
+	c.SetWithoutSource("logs_config.http_protocol", "auto")
+	c.SetWithoutSource("skip_ssl_validation", true)
+
+	// The test server uses TLS, so if we set the http proxy (not https), it will still make
+	// a request to the test server, but disable HTTP/2 since a proxy is configured.
+	c.SetWithoutSource("proxy.http", "http://foo.bar")
+
+	server := NewTestHTTPSServer(false)
+	defer server.Close()
+
+	timeout := 5 * time.Second
+	client := httpClientFactory(timeout, c)()
+
+	req, err := http.NewRequest("POST", server.URL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Assert that the server chose HTTP/1.1 because a proxy was configured
+	assert.Equal(t, "HTTP/1.1", resp.Proto)
+}

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -502,7 +502,7 @@ func TestTransportProtocol_HTTP1WhenUsingProxy(t *testing.T) {
 	c.SetWithoutSource("logs_config.http_protocol", "auto")
 	c.SetWithoutSource("skip_ssl_validation", true)
 
-	// The test server uses TLS, so if we set the http proxy (not https), it will still make
+	// The test server uses TLS, so if we set the http proxy (not https), it still makes
 	// a request to the test server, but disable HTTP/2 since a proxy is configured.
 	c.SetWithoutSource("proxy.http", "http://foo.bar")
 

--- a/releasenotes/notes/force-http1-for-log-agent-2cbfba763697ab42.yaml
+++ b/releasenotes/notes/force-http1-for-log-agent-2cbfba763697ab42.yaml
@@ -9,7 +9,7 @@
 features:
   - |
     Introduced a new configuration variable `logs_config.http_protocol`, allowing users to enforce HTTP/1.1 for outgoing HTTP connections in the Datadog Agent. This provides better control over transport protocols and improves compatibility with systems that do not support HTTP/2.
-    By default, the log agent will now attempt to use HTTP/2 and fall back to the best available protocol if HTTP/2 is not supported.
+    By default, the log agent will now attempt to use HTTP/2 (unless a proxy is configured) and fall back to the best available protocol if HTTP/2 is not supported.
 enhancements:
   - |
-    Improved logging to add visiblity for latency and transport protocol
+    Improved logging to add visibility for latency and transport protocol


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Out of an abundance of caution, disable HTTP/2 negotiation for the logs agent when a proxy is configured. 
This will be removed in a future agent version. 

### Motivation

Logs agent transport improvements. 

### Describe how you validated your changes

QA covered by unit test (as it spins up a real server/client) 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->