### PR TITLE
Revert "[ASCII-2587] Migrating TraceAgent to use IPC cert"

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -175,18 +175,10 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 
 	type pprofGetter func(path string) ([]byte, error)
 
-	tcpGet := func(portConfig string, onHTTPS bool) pprofGetter {
-		endpoint := url.URL{
-			Scheme: "http",
-			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(pkgconfigsetup.Datadog().GetInt(portConfig))),
-			Path:   "/debug/pprof",
-		}
-		if onHTTPS {
-			endpoint.Scheme = "https"
-		}
-
+	tcpGet := func(portConfig string) pprofGetter {
+		pprofURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", pkgconfigsetup.Datadog().GetInt(portConfig))
 		return func(path string) ([]byte, error) {
-			return util.DoGet(c, endpoint.String()+path, util.LeaveConnectionOpen)
+			return util.DoGet(c, pprofURL+path, util.LeaveConnectionOpen)
 		}
 	}
 
@@ -236,15 +228,15 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 	}
 
 	agentCollectors := map[string]agentProfileCollector{
-		"core":           serviceProfileCollector(tcpGet("expvar_port", false), seconds),
-		"security-agent": serviceProfileCollector(tcpGet("security_agent.expvar_port", false), seconds),
+		"core":           serviceProfileCollector(tcpGet("expvar_port"), seconds),
+		"security-agent": serviceProfileCollector(tcpGet("security_agent.expvar_port"), seconds),
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("process_config.enabled") ||
 		pkgconfigsetup.Datadog().GetBool("process_config.container_collection.enabled") ||
 		pkgconfigsetup.Datadog().GetBool("process_config.process_collection.enabled") {
 
-		agentCollectors["process"] = serviceProfileCollector(tcpGet("process_config.expvar_port", false), seconds)
+		agentCollectors["process"] = serviceProfileCollector(tcpGet("process_config.expvar_port"), seconds)
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("apm_config.enabled") {
@@ -257,7 +249,7 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 			traceCpusec = 4
 		}
 
-		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port", true), traceCpusec)
+		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port"), traceCpusec)
 	}
 
 	if pkgconfigsetup.SystemProbe().GetBool("system_probe_config.enabled") {

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -101,7 +101,7 @@ func traceAgentSecretRefresh(conf config.Component) ([]byte, error) {
 	c := apiutil.GetClient(false)
 	c.Timeout = conf.GetDuration("server_timeout") * time.Second
 
-	url := fmt.Sprintf("https://127.0.0.1:%d/secret/refresh", port)
+	url := fmt.Sprintf("http://127.0.0.1:%d/secret/refresh", port)
 	res, err := apiutil.DoGet(c, url, apiutil.CloseConnection)
 	if err != nil {
 		return nil, fmt.Errorf("could not contact trace-agent: %s", err)

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -24,7 +24,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
@@ -69,7 +68,6 @@ type dependencies struct {
 	Statsd             statsd.Component
 	Tagger             tagger.Component
 	Compressor         compression.Component
-	At                 authtoken.Component
 }
 
 var _ traceagent.Component = (*component)(nil)
@@ -95,7 +93,6 @@ type component struct {
 	params             *Params
 	tagger             tagger.Component
 	telemetryCollector telemetry.TelemetryCollector
-	at                 authtoken.Component
 	wg                 *sync.WaitGroup
 }
 
@@ -118,7 +115,6 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 		params:             deps.Params,
 		telemetryCollector: deps.TelemetryCollector,
 		tagger:             deps.Tagger,
-		at:                 deps.At,
 		wg:                 &sync.WaitGroup{},
 	}
 	statsdCl, err := setupMetrics(deps.Statsd, c.config, c.telemetryCollector)

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -98,9 +98,6 @@ func runAgentSidekicks(ag component) error {
 		}))
 	}
 
-	// Configure the Trace Agent Debug server to use the IPC certificate
-	ag.Agent.DebugServer.SetTLSConfig(ag.at.GetTLSServerConfig())
-
 	log.Infof("Trace agent running on host %s", tracecfg.Hostname)
 	if pcfg := profilingConfig(tracecfg); pcfg != nil {
 		if err := profiling.Start(*pcfg); err != nil {

--- a/comp/trace/bundle_test.go
+++ b/comp/trace/bundle_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/api/authtoken/createandfetchimpl"
-	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -47,7 +45,6 @@ func TestBundleDependencies(t *testing.T) {
 		zstdfx.Module(),
 		taggerfx.Module(tagger.Params{}),
 		fx.Supply(&traceagentimpl.Params{}),
-		createandfetchimpl.Module(),
 	)
 }
 
@@ -78,7 +75,6 @@ func TestMockBundleDependencies(t *testing.T) {
 		fx.Invoke(func(_ traceagent.Component) {}),
 		MockBundle(),
 		taggerfx.Module(tagger.Params{}),
-		fetchonlyimpl.MockModule(),
 	))
 
 	require.NotNil(t, cfg.Object())

--- a/comp/trace/status/statusimpl/status.go
+++ b/comp/trace/status/statusimpl/status.go
@@ -95,7 +95,7 @@ func (s statusProvider) populateStatus() map[string]interface{} {
 	port := s.Config.GetInt("apm_config.debug.port")
 
 	c := client()
-	url := fmt.Sprintf("https://localhost:%d/debug/vars", port)
+	url := fmt.Sprintf("http://localhost:%d/debug/vars", port)
 	resp, err := apiutil.DoGet(c, url, apiutil.CloseConnection)
 	if err != nil {
 		return map[string]interface{}{

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -71,7 +71,7 @@ func TraceAgentConfig(config config.Reader) (string, error) {
 	c := util.GetClient(false)
 	c.Timeout = config.GetDuration("server_timeout") * time.Second
 
-	ipcAddressWithPort := fmt.Sprintf("https://127.0.0.1:%d/config", port)
+	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
 
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "trace-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 	return client.FullConfig()

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -214,7 +214,7 @@ func getExpVar(fb flaretypes.FlareBuilder) error {
 
 	apmDebugPort := pkgconfigsetup.Datadog().GetInt("apm_config.debug.port")
 	f := filepath.Join("expvar", "trace-agent")
-	resp, err := http.Get(fmt.Sprintf("https://127.0.0.1:%d/debug/vars", apmDebugPort))
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/vars", apmDebugPort))
 	if err != nil {
 		return fb.AddFile(f, []byte(fmt.Sprintf("Error retrieving vars: %v", err)))
 	}

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -1039,26 +1039,14 @@ func TestExpvar(t *testing.T) {
 	}
 
 	c := newTestReceiverConfig()
-	c.DebugServerPort = 6789
+	c.DebugServerPort = 5012
 	info.InitInfo(c)
-
-	// Starting a TLS httptest server to retrieve tlsCert
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-	tlsConfig := ts.TLS.Clone()
-	// Setting a client with the proper TLS configuration
-	client := ts.Client()
-	ts.Close()
-
-	// Starting Debug Server
 	s := NewDebugServer(c)
-	s.SetTLSConfig(tlsConfig)
-
-	// Starting the Debug server
 	s.Start()
 	defer s.Stop()
 
-	resp, err := client.Get(fmt.Sprintf("https://127.0.0.1:%d/debug/vars", c.DebugServerPort))
-	require.NoError(t, err)
+	resp, err := http.Get("http://127.0.0.1:5012/debug/vars")
+	assert.NoError(t, err)
 	defer resp.Body.Close()
 
 	t.Run("read-expvars", func(t *testing.T) {

--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -9,7 +9,6 @@ package api
 
 import (
 	"context"
-	"crypto/tls"
 	"expvar"
 	"fmt"
 	"net"
@@ -30,10 +29,9 @@ const (
 
 // DebugServer serves /debug/* endpoints
 type DebugServer struct {
-	conf      *config.AgentConfig
-	server    *http.Server
-	mux       *http.ServeMux
-	tlsConfig *tls.Config
+	conf   *config.AgentConfig
+	server *http.Server
+	mux    *http.ServeMux
 }
 
 // NewDebugServer returns a debug server
@@ -55,14 +53,13 @@ func (ds *DebugServer) Start() {
 		WriteTimeout: defaultTimeout,
 		Handler:      ds.setupMux(),
 	}
-	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(ds.conf.DebugServerPort)))
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", ds.conf.DebugServerPort))
 	if err != nil {
 		log.Errorf("Error creating debug server listener: %s", err)
 		return
 	}
-	tlsListener := tls.NewListener(listener, ds.tlsConfig)
 	go func() {
-		if err := ds.server.Serve(tlsListener); err != nil && err != http.ErrServerClosed {
+		if err := ds.server.Serve(listener); err != nil && err != http.ErrServerClosed {
 			log.Errorf("Could not start debug server: %s. Debug server disabled.", err)
 		}
 	}()
@@ -83,11 +80,6 @@ func (ds *DebugServer) Stop() {
 // AddRoute adds a route to the DebugServer
 func (ds *DebugServer) AddRoute(route string, handler http.Handler) {
 	ds.mux.Handle(route, handler)
-}
-
-// SetTLSConfig adds the provided tls.Config to the internal http.Server
-func (ds *DebugServer) SetTLSConfig(config *tls.Config) {
-	ds.tlsConfig = config
 }
 
 func (ds *DebugServer) setupMux() *http.ServeMux {

--- a/pkg/trace/info/info.go
+++ b/pkg/trace/info/info.go
@@ -8,7 +8,6 @@ package info
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"expvar" // automatically publish `/debug/vars` on HTTP port
 	"fmt"
@@ -237,9 +236,8 @@ func getProgramBanner(version string) (string, string) {
 // If error is nil, means the program is running.
 // If not, it displays a pretty-printed message anyway (for support)
 func Info(w io.Writer, conf *config.AgentConfig) error {
-	url := fmt.Sprintf("https://127.0.0.1:%d/debug/vars", conf.DebugServerPort)
-	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
-	client := http.Client{Timeout: 3 * time.Second, Transport: tr}
+	url := fmt.Sprintf("http://127.0.0.1:%d/debug/vars", conf.DebugServerPort)
+	client := http.Client{Timeout: 3 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
 		// OK, here, we can't even make an http call on the agent port,

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -63,7 +63,7 @@ func (h *testServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func testServer(t *testing.T, testFile string) *httptest.Server {
 	t.Helper()
-	server := httptest.NewTLSServer(&testServerHandler{t: t, testFile: testFile})
+	server := httptest.NewServer(&testServerHandler{t: t, testFile: testFile})
 	t.Logf("test server (serving fake yet valid data) listening on %s", server.URL)
 	return server
 }
@@ -94,7 +94,7 @@ func (h *testServerWarningHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 }
 
 func testServerWarning(t *testing.T) *httptest.Server {
-	server := httptest.NewTLSServer(&testServerWarningHandler{t: t})
+	server := httptest.NewServer(&testServerWarningHandler{t: t})
 	t.Logf("test server (serving data containing worrying values) listening on %s", server.URL)
 	return server
 }
@@ -119,7 +119,7 @@ func (h *testServerErrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 }
 
 func testServerError(t *testing.T) *httptest.Server {
-	server := httptest.NewTLSServer(&testServerErrorHandler{t: t})
+	server := httptest.NewServer(&testServerErrorHandler{t: t})
 	t.Logf("test server (serving bad data to trigger errors) listening on %s", server.URL)
 	return server
 }
@@ -331,7 +331,7 @@ func TestError(t *testing.T) {
 	assert.Equal(len(lines[1]), len(lines[2]))
 	assert.Equal("", lines[3])
 	assert.Regexp(regexp.MustCompile(`^  Error: .*$`), lines[4])
-	assert.Equal(fmt.Sprintf("  URL: https://127.0.0.1:%d/debug/vars", port), lines[5])
+	assert.Equal(fmt.Sprintf("  URL: http://127.0.0.1:%d/debug/vars", port), lines[5])
 	assert.Equal("", lines[6])
 	assert.Equal("", lines[7])
 }


### PR DESCRIPTION
Reverts DataDog/datadog-agent#31847

#incident-33344

This PR has broken new-e2e-agent-shared-components tests in main: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/743239227