### PR TITLE
Add test to ensure LastUpdated is well populated for default scrubber rules

### DIFF
--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -474,6 +474,8 @@ func TestAddStrippedKeys(t *testing.T) {
 	AddStrippedKeys([]string{"foobar"})
 
 	assertClean(t, contents, `foobar: "********"`)
+
+	dynamicReplacers = []Replacer{}
 }
 
 func TestAddStrippedKeysNewReplacer(t *testing.T) {
@@ -486,6 +488,8 @@ func TestAddStrippedKeysNewReplacer(t *testing.T) {
 	cleaned, err := newScrubber.ScrubBytes([]byte(contents))
 	require.NoError(t, err)
 	assert.Equal(t, strings.TrimSpace(`foobar: "********"`), strings.TrimSpace(string(cleaned)))
+
+	dynamicReplacers = []Replacer{}
 }
 
 func TestCertConfig(t *testing.T) {

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -104,3 +104,13 @@ func TestScrubBig(t *testing.T) {
 	_, err := scrubber.ScrubBytes(content)
 	require.NoError(t, err)
 }
+
+func TestLastUpdated(t *testing.T) {
+	scrubber := NewWithDefaults()
+	for _, replacer := range scrubber.singleLineReplacers {
+		assert.NotNil(t, replacer.LastUpdated)
+	}
+	for _, replacer := range scrubber.multiLineReplacers {
+		assert.NotNil(t, replacer.LastUpdated)
+	}
+}

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -28,6 +28,16 @@ func TestNewWithDefaults(t *testing.T) {
 	assert.Equal(t, len(scrubberEmpty.multiLineReplacers), len(scrubber.multiLineReplacers))
 }
 
+func TestLastUpdated(t *testing.T) {
+	scrubber := NewWithDefaults()
+	for _, replacer := range scrubber.singleLineReplacers {
+		assert.NotNil(t, replacer.LastUpdated, "single line replacer has no LastUpdated: %v", replacer)
+	}
+	for _, replacer := range scrubber.multiLineReplacers {
+		assert.NotNil(t, replacer.LastUpdated, "multi line replacer has no LastUpdated: %v", replacer)
+	}
+}
+
 func TestRepl(t *testing.T) {
 	scrubber := New()
 	scrubber.AddReplacer(SingleLine, Replacer{
@@ -103,14 +113,4 @@ func TestScrubBig(t *testing.T) {
 
 	_, err := scrubber.ScrubBytes(content)
 	require.NoError(t, err)
-}
-
-func TestLastUpdated(t *testing.T) {
-	scrubber := NewWithDefaults()
-	for _, replacer := range scrubber.singleLineReplacers {
-		assert.NotNil(t, replacer.LastUpdated)
-	}
-	for _, replacer := range scrubber.multiLineReplacers {
-		assert.NotNil(t, replacer.LastUpdated)
-	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a test to ensure LastUpdated field in the replacers are well set.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->