### PR TITLE
[CONTP-545] fix unit-test bug in leaderelection subscription unit test

### DIFF
--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -211,7 +211,7 @@ func TestSubscribe(t *testing.T) {
 				coreClient:      client.CoreV1(),
 				coordClient:     client.CoordinationV1(),
 				leaderMetric:    &dummyGauge{},
-				lockType:        cmLock.ConfigMapsResourceLock,
+				lockType:        tc.lockType,
 			}
 
 			notif1 := le.Subscribe()
@@ -226,6 +226,9 @@ func TestSubscribe(t *testing.T) {
 
 			le.EnsureLeaderElectionRuns()
 			require.True(t, le.IsLeader())
+
+			err = tc.getTokenFunc(client)
+			require.NoError(t, err)
 
 			counter1, counter2 := 0, 0
 			for {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The TestSubscribe unit test was setting the lock type to `ConfigLockMap` always, regardless of the lockType value specified in the testcase. 

This PR fixes this bug, and adds an extra assertion to ensure this is cached as intended.

### Motivation

Fix the unit test.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests are enough.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

None