### PR TITLE
feat(ci): Enable timestamp in logs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,6 +276,7 @@ variables:
   # Feature flags
   FF_SCRIPT_SECTIONS: 1 # Prevent multiline scripts log collapsing, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/3392
   FF_KUBERNETES_HONOR_ENTRYPOINT: true # Honor the entrypoint in the Docker image when running Kubernetes jobs
+  FF_TIMESTAMPS: true
 
 #
 # Condition mixins for simplification of rules


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Print timestamps in Gitlab [logs](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/743497150). As we moved our gitlab version recently we can enable this [feature](https://gitlab.com/gitlab-org/gitlab/-/issues/202293)

### Motivation
Having access to the timestamp is a really important feature for a CI provider, very useful for investigation

### Describe how you validated your changes
This is a gitlab feature
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
This PR activates timestamp on the whole config. It should be possible to enable it per job.
It seems not possible to change the timestamp format which is quite long 
```
2024-12-18T10:30:09.950336Z
```
However the full precision can still be useful so I guess we can accept the display impact

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->