### PR TITLE
usm: Include PathId in debug traced program list

### DIFF
--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -31,6 +31,7 @@ type Attacher interface {
 type TracedProgram struct {
 	ProgramType string
 	FilePath    string
+	PathID      PathIdentifier
 	PIDs        []uint32
 }
 
@@ -131,6 +132,7 @@ func (d *tlsDebugger) GetTracedPrograms(moduleName string) []TracedProgram {
 
 			program.ProgramType = programType
 			program.FilePath = registration.sampleFilePath
+			program.PathID = pathID
 		}
 		registry.m.Unlock()
 


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently it's possible to see things like the below where the same paths are displayed as part of separate entries in the traced programs list with no hint as to why this is the case.  Include the PathId to the traced programs list to make it clear exactly which file (dev/inode) is being traced.

Before:

```
 {
   "FilePath": "/usr/lib64/libssl.so.1.0.2k",
   "PIDs": [
     4275,
     1111324,
     3971,
     4240,
     4416,
     1110985
   ],
   "ProgramType": "shared_libraries"
 },
 {
   "FilePath": "/usr/lib64/libssl.so.1.0.2k",
   "PIDs": [
     7562
   ],
   "ProgramType": "shared_libraries"
 },
```

After:

```
 {
   "FilePath": "/usr/lib64/libssl.so.1.0.2k",
    "PathID": {
      "Dev": 64516,
      "Inode": 655961,
    },
   "PIDs": [
     4275,
     1111324,
     3971,
     4240,
     4416,
     1110985
   ],
   "ProgramType": "shared_libraries"
 },
 {
   "FilePath": "/usr/lib64/libssl.so.1.0.2k",
    "PathID": {
      "Dev": 130,
      "Inode": 4421665,
    },
   "PIDs": [
     7562
   ],
   "ProgramType": "shared_libraries"
 },
```

### Motivation

Improve debugging.

### Describe how you validated your changes

Manually verified by checking the output of `sudo curl --unix /opt/datadog-agent/run/sysprobe.sock http://unix/network_tracer/debug/usm/traced_programs | jq .`

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->