### PR TITLE
[CONTP-545] quit leader election if context was cancelled

### DIFF
--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -228,9 +228,15 @@ func (le *LeaderEngine) EnsureLeaderElectionRuns() error {
 
 func (le *LeaderEngine) runLeaderElection() {
 	for {
-		log.Infof("Starting leader election process for %q...", le.HolderIdentity)
-		le.leaderElector.Run(le.ctx)
-		log.Info("Leader election lost")
+		select {
+		case <-le.ctx.Done():
+			log.Infof("Quitting leader election process: context was cancelled")
+			return
+		default:
+			log.Infof("Starting leader election process for %q...", le.HolderIdentity)
+			le.leaderElector.Run(le.ctx)
+			log.Info("Leader election lost")
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR ensures that the go routine running leader election is properly stopped when the main cluster agent context is cancelled.

### Motivation

Avoid go routine leaks.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests and E2E are sufficient.

But for extra validation, you can do the following QA: 

Deploy the DCA with multiple replicas with leader election enabled.

Once a leader is elected, kill the leader, and ensure that a new leader is elected.

Example:

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  logLevel: DEBUG
  kubelet:
    tlsVerify: false

clusterAgent:
  enabled: true
  replicas: 3
```

Wait for a leader to be elected:

From `agent status` on any dca instance:
```
===============
Leader Election
===============
  Leader Election Status:  Running
  Leader Name is: datadog-agent-cluster-agent-6f4947f5b5-n462j
  Last Acquisition of the lease: Wed, 18 Dec 2024 11:26:28 UTC
  Renewed leadership: Wed, 18 Dec 2024 11:26:58 UTC
  Number of leader transitions: 5 transitions
```

Kill the leader:

```
kubectl delete pod  datadog-agent-cluster-agent-6f4947f5b5-n462j
```

Ensure that a new leader is finally elected:

```
===============
Leader Election
===============
  Leader Election Status:  Running
  Leader Name is: datadog-agent-cluster-agent-6f4947f5b5-ngxtw
  Last Acquisition of the lease: Wed, 18 Dec 2024 11:29:06 UTC
  Renewed leadership: Wed, 18 Dec 2024 11:29:06 UTC
  Number of leader transitions: 6 transitions
```

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

None