### PR TITLE
[e2e] recreate stack on fakeintake grpc error

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -55,5 +55,11 @@ func getKnownErrors() []knownError {
 			errorMessage: `ssh: handshake failed: ssh: unable to authenticate`,
 			retryType:    ReCreate,
 		},
+		{
+			// https://datadoghq.atlassian.net/browse/ADXT-798
+			// https://datadoghq.atlassian.net/browse/ADXT-813
+			errorMessage: `error: awsx:ecs:FargateTaskDefinition resource '.+fakeintake.+' has a problem: grpc: the client connection is closing`,
+			retryType:    ReCreate,
+		},
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Recreate stack on grpc error from fakeintake

### Motivation

We had a couple of internal e2e stack errors with this message, worth recreating the stack as the fakeintake cannot recover 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->