### PR TITLE
release.create-github-release: Use current version not next one

### DIFF
--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -444,7 +444,7 @@ def get_matching_pattern(ctx, major_version, release=False):
     return pattern
 
 
-def deduce_version(ctx, branch, as_str=True, trust=False, next_version=True) -> str | Version:
+def deduce_version(ctx, branch, as_str: bool = True, trust: bool = False, next_version: bool = True) -> str | Version:
     """Deduces the version from the release branch name.
 
     Args:
@@ -484,7 +484,7 @@ def get_all_version_tags(ctx) -> list[str]:
     return ctx.run(cmd, hide=True).stdout.strip().split('\n')
 
 
-def get_next_version_from_branch(ctx, branch: str, as_str=True, next_version=True) -> str | Version:
+def get_next_version_from_branch(ctx, branch: str, as_str: bool = True, next_version: bool = True) -> str | Version:
     """Returns the latest version + 1 belonging to a branch.
 
     Args:

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -6,6 +6,7 @@ import sys
 from invoke import Exit
 
 from tasks.libs.ciproviders.github_api import GithubAPI
+from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.constants import (
     AGENT_VERSION_CACHE_NAME,
     ALLOWED_REPO_NIGHTLY_BRANCHES,
@@ -441,3 +442,65 @@ def get_matching_pattern(ctx, major_version, release=False):
         )
         pattern = max(tags, key=cmp_to_key(semver.compare))
     return pattern
+
+
+def deduce_version(ctx, branch, as_str=True, trust=False) -> str | Version:
+    release_version = get_next_version_from_branch(ctx, branch, as_str=as_str)
+
+    print(
+        f'{color_message("Info", Color.BLUE)}: Version {release_version} deduced from branch {branch}', file=sys.stderr
+    )
+
+    if (
+        trust
+        or not os.isatty(sys.stdin.fileno())
+        or yes_no_question(
+            'Is this the version you want to use?',
+            color="orange",
+            default=False,
+        )
+    ):
+        return release_version
+
+    raise Exit(color_message("Aborting.", "red"), code=1)
+
+
+def get_version_major(branch: str) -> int:
+    """Get the major version from a branch name."""
+
+    return 7 if branch == 'main' else int(branch.split('.')[0])
+
+
+def get_all_version_tags(ctx) -> list[str]:
+    """Returns the tags for all the versions of the Agent in git."""
+
+    cmd = "bash -c 'git tag | grep -E \"^[0-9]\\.[0-9]+\\.[0-9]+$\"'"
+
+    return ctx.run(cmd, hide=True).stdout.strip().split('\n')
+
+
+def get_next_version_from_branch(ctx, branch: str, as_str=True) -> str | Version:
+    """Returns the latest version + 1 belonging to a branch.
+
+    Example:
+        get_latest_version_from_branch("7.55.x") -> Version(7, 55, 4) if there are 7.55.0, 7.55.1, 7.55.2, 7.55.3 tags.
+        get_latest_version_from_branch("6.99.x") -> Version(6, 99, 0) if there are no 6.99.* tags.
+    """
+
+    re_branch = re.compile(r"^([0-9]\.[0-9]+\.)x$")
+
+    try:
+        matched = re_branch.match(branch).group(1)
+    except Exception as e:
+        raise Exit(
+            f'{color_message("Error:", "red")}: Branch {branch} is not a release branch (should be X.Y.x)', code=1
+        ) from e
+
+    tags = [tuple(map(int, tag.split('.'))) for tag in get_all_version_tags(ctx) if tag.startswith(matched)]
+    versions = sorted(Version(*tag) for tag in tags)
+
+    minor, major = tuple(map(int, branch.split('.')[:2]))
+
+    latest = versions[-1].next_version(bump_patch=True) if versions else Version(minor, major, 0)
+
+    return str(latest) if as_str else latest

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1165,7 +1165,7 @@ def create_github_release(ctx, release_branch, draft=True):
     )
 
     notes = []
-    version = deduce_version(ctx, release_branch)
+    version = deduce_version(ctx, release_branch, next_version=False)
 
     with agent_context(ctx, release_branch):
         for section, filename in sections:

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -70,10 +70,11 @@ from tasks.libs.releasing.version import (
     VERSION_RE,
     _create_version_from_match,
     current_version,
+    deduce_version,
+    get_version_major,
     next_final_version,
     next_rc_version,
 )
-from tasks.libs.types.version import Version
 from tasks.pipeline import edit_schedule, run
 from tasks.release_metrics.metrics import get_prs_metrics, get_release_lead_time
 
@@ -83,68 +84,6 @@ GITLAB_FILES_TO_UPDATE = [
 ]
 
 BACKPORT_LABEL_COLOR = "5319e7"
-
-
-def deduce_version(ctx, branch, as_str=True, trust=False) -> str | Version:
-    release_version = get_next_version_from_branch(ctx, branch, as_str=as_str)
-
-    print(
-        f'{color_message("Info", Color.BLUE)}: Version {release_version} deduced from branch {branch}', file=sys.stderr
-    )
-
-    if (
-        trust
-        or not os.isatty(sys.stdin.fileno())
-        or yes_no_question(
-            'Is this the version you want to use?',
-            color="orange",
-            default=False,
-        )
-    ):
-        return release_version
-
-    raise Exit(color_message("Aborting.", "red"), code=1)
-
-
-def get_version_major(branch: str) -> int:
-    """Get the major version from a branch name."""
-
-    return 7 if branch == 'main' else int(branch.split('.')[0])
-
-
-def get_all_version_tags(ctx) -> list[str]:
-    """Returns the tags for all the versions of the Agent in git."""
-
-    cmd = "bash -c 'git tag | grep -E \"^[0-9]\\.[0-9]+\\.[0-9]+$\"'"
-
-    return ctx.run(cmd, hide=True).stdout.strip().split('\n')
-
-
-def get_next_version_from_branch(ctx, branch: str, as_str=True) -> str | Version:
-    """Returns the latest version + 1 belonging to a branch.
-
-    Example:
-        get_latest_version_from_branch("7.55.x") -> Version(7, 55, 4) if there are 7.55.0, 7.55.1, 7.55.2, 7.55.3 tags.
-        get_latest_version_from_branch("6.99.x") -> Version(6, 99, 0) if there are no 6.99.* tags.
-    """
-
-    re_branch = re.compile(r"^([0-9]\.[0-9]+\.)x$")
-
-    try:
-        matched = re_branch.match(branch).group(1)
-    except Exception as e:
-        raise Exit(
-            f'{color_message("Error:", "red")}: Branch {branch} is not a release branch (should be X.Y.x)', code=1
-        ) from e
-
-    tags = [tuple(map(int, tag.split('.'))) for tag in get_all_version_tags(ctx) if tag.startswith(matched)]
-    versions = sorted(Version(*tag) for tag in tags)
-
-    minor, major = tuple(map(int, branch.split('.')[:2]))
-
-    latest = versions[-1].next_version(bump_patch=True) if versions else Version(minor, major, 0)
-
-    return str(latest) if as_str else latest
 
 
 @task


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

> [!NOTE]
> You should review the 2 commits distinctly.

This task used the next tag but should use the latest one instead.

Moved version helpers within the proper module.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->