### PR TITLE
Check if key supports batch API in Map() ctor

### DIFF
--- a/pkg/ebpf/maps/generic_map.go
+++ b/pkg/ebpf/maps/generic_map.go
@@ -130,8 +130,17 @@ func Map[K any, V any](m *ebpf.Map) (*GenericMap[K, V], error) {
 		return nil, err
 	}
 
+	// See if we can perform binary.Read on the key type. If we can't we can't use the batch API
+	// for this map
+	var kval K
+	keySupportsBatchAPI := canBinaryReadKey[K]()
+	if !keySupportsBatchAPI {
+		log.Warnf("Key type %T does not support binary.Read, batch API will not be used for this map", kval)
+	}
+
 	return &GenericMap[K, V]{
-		m: m,
+		m:                   m,
+		keySupportsBatchAPI: keySupportsBatchAPI,
 	}, nil
 }
 

--- a/pkg/ebpf/maps/generic_map_test.go
+++ b/pkg/ebpf/maps/generic_map_test.go
@@ -574,10 +574,6 @@ func TestIterateWithPointerKey(t *testing.T) {
 }
 
 func TestGenericHashMapCanUseBatchAPI(t *testing.T) {
-	if !BatchAPISupported() {
-		t.Skip("Skipping because batch API not supported")
-	}
-
 	hash, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
 		KeySize:    4,
@@ -592,5 +588,5 @@ func TestGenericHashMapCanUseBatchAPI(t *testing.T) {
 	gm, err := Map[int32, int32](hash)
 	require.NoError(t, err)
 
-	require.True(t, gm.CanUseBatchAPI())
+	require.Equal(t, BatchAPISupported(), gm.CanUseBatchAPI())
 }

--- a/pkg/ebpf/maps/generic_map_test.go
+++ b/pkg/ebpf/maps/generic_map_test.go
@@ -574,6 +574,10 @@ func TestIterateWithPointerKey(t *testing.T) {
 }
 
 func TestGenericHashMapCanUseBatchAPI(t *testing.T) {
+	if !BatchAPISupported() {
+		t.Skip("Skipping because batch API not supported")
+	}
+
 	hash, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
 		KeySize:    4,

--- a/pkg/ebpf/maps/generic_map_test.go
+++ b/pkg/ebpf/maps/generic_map_test.go
@@ -580,9 +580,7 @@ func TestGenericHashMapCanUseBatchAPI(t *testing.T) {
 		ValueSize:  4,
 		MaxEntries: 10,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { hash.Close() })
 
 	gm, err := Map[int32, int32](hash)

--- a/pkg/ebpf/maps/generic_map_test.go
+++ b/pkg/ebpf/maps/generic_map_test.go
@@ -572,3 +572,21 @@ func TestIterateWithPointerKey(t *testing.T) {
 	require.NoError(t, it.Err())
 	require.Equal(t, expectedNumbers, actualNumbers)
 }
+
+func TestGenericHashMapCanUseBatchAPI(t *testing.T) {
+	hash, err := ebpf.NewMap(&ebpf.MapSpec{
+		Type:       ebpf.Hash,
+		KeySize:    4,
+		ValueSize:  4,
+		MaxEntries: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { hash.Close() })
+
+	gm, err := Map[int32, int32](hash)
+	require.NoError(t, err)
+
+	require.True(t, gm.CanUseBatchAPI())
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix bug introduced in https://github.com/DataDog/datadog-agent/pull/29220 which does not set `keySupportsBatchAPI` boolean in the `Map()` constructor for a generic map.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Changes validated by new test added in this PR.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->