### PR TITLE
[CWS] Fix security-agent AD storage using `nil` statsd client

### DIFF
--- a/pkg/security/agent/agent_nix.go
+++ b/pkg/security/agent/agent_nix.go
@@ -12,9 +12,10 @@ import (
 
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
+
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
-	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // NewRuntimeSecurityAgent instantiates a new RuntimeSecurityAgent
@@ -30,7 +31,7 @@ func NewRuntimeSecurityAgent(statsdClient statsd.ClientInterface, hostname strin
 	}
 
 	// on windows do no storage manager
-	storage, err := dump.NewAgentStorageManager()
+	storage, err := dump.NewAgentStorageManager(statsdClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/security_profile/dump/storage_manager_unsupported.go
+++ b/pkg/security/security_profile/dump/storage_manager_unsupported.go
@@ -30,7 +30,7 @@ func (manager *ActivityDumpStorageManager) PersistRaw(_ []config.StorageRequest,
 func (manager *ActivityDumpStorageManager) SendTelemetry() {}
 
 // NewAgentStorageManager returns a new instance of ActivityDumpStorageManager
-func NewAgentStorageManager(statsdClient statsd.ClientInterface) (*ActivityDumpStorageManager, error) {
+func NewAgentStorageManager(_ statsd.ClientInterface) (*ActivityDumpStorageManager, error) {
 	return nil, fmt.Errorf("the activity dump manager is unsupported on this platform")
 }
 

--- a/pkg/security/security_profile/dump/storage_manager_unsupported.go
+++ b/pkg/security/security_profile/dump/storage_manager_unsupported.go
@@ -12,6 +12,8 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
+
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 )
@@ -28,7 +30,7 @@ func (manager *ActivityDumpStorageManager) PersistRaw(_ []config.StorageRequest,
 func (manager *ActivityDumpStorageManager) SendTelemetry() {}
 
 // NewAgentStorageManager returns a new instance of ActivityDumpStorageManager
-func NewAgentStorageManager() (*ActivityDumpStorageManager, error) {
+func NewAgentStorageManager(statsdClient statsd.ClientInterface) (*ActivityDumpStorageManager, error) {
 	return nil, fmt.Errorf("the activity dump manager is unsupported on this platform")
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This function https://github.com/DataDog/datadog-agent/blob/52f0517517169d661a94895a296c73b85424c86d/pkg/security/security_profile/dump/remote_storage.go#L203

is called here https://github.com/DataDog/datadog-agent/blob/52f0517517169d661a94895a296c73b85424c86d/pkg/security/security_profile/dump/storage_manager.go#L155

but the security-agent storage manager never initializes the statsdClient field when created
https://github.com/DataDog/datadog-agent/blob/52f0517517169d661a94895a296c73b85424c86d/pkg/security/security_profile/dump/storage_manager.go#L39-L42

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->