### PR TITLE
Implement caching for GenerateContainerIDFromOriginInfo

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -285,7 +285,7 @@ func (t *remoteTagger) GenerateContainerIDFromOriginInfo(originInfo origindetect
 
 	cachedContainerID, err := cache.GetWithExpiration(key, func() (containerID string, err error) {
 		expBackoff := backoff.NewExponentialBackOff()
-		expBackoff.InitialInterval = 500 * time.Millisecond
+		expBackoff.InitialInterval = 200 * time.Millisecond
 		expBackoff.MaxInterval = 1 * time.Second
 		expBackoff.MaxElapsedTime = 15 * time.Second
 

--- a/pkg/proto/datadog/api/v1/api.proto
+++ b/pkg/proto/datadog/api/v1/api.proto
@@ -55,7 +55,7 @@ service AgentSecure {
     // can be called through the HTTP gateway, and entity will be returned as JSON:
     //	  $ curl -H "authorization: Bearer $(cat /etc/datadog-agent/auth_token)" \
     //	     -XPOST -k -H "Content-Type: application/json" \
-    //	     --data '{"externalDataInit": false,"externalDataPodUID": "54383382-cea3-49e3-9dda-325436ddd5b8","externalDataContainerName": "dd-trace-py"}' \
+    //	     --data '{"externalData": {"init": false,"containerName": "dd-trace-py","podUID": "c4b45c6a-b296-4bd5-88df-7c2d6bcaabef"}}' \
     //	     https://localhost:5001/v1/grpc/tagger/generate_container_id_from_origin_info
     //	  {
     //	    "containerID":"c9fd60251b5237467462dad48999815eb0025f367c6e1abe91e0bd787d5915fc"

--- a/pkg/proto/pbgo/core/api.pb.go
+++ b/pkg/proto/pbgo/core/api.pb.go
@@ -398,7 +398,7 @@ type AgentSecureClient interface {
 	//
 	//	$ curl -H "authorization: Bearer $(cat /etc/datadog-agent/auth_token)" \
 	//	   -XPOST -k -H "Content-Type: application/json" \
-	//	   --data '{"externalDataInit": false,"externalDataPodUID": "54383382-cea3-49e3-9dda-325436ddd5b8","externalDataContainerName": "dd-trace-py"}' \
+	//	   --data '{"externalData": {"init": false,"containerName": "dd-trace-py","podUID": "c4b45c6a-b296-4bd5-88df-7c2d6bcaabef"}}' \
 	//	   https://localhost:5001/v1/grpc/tagger/generate_container_id_from_origin_info
 	//	{
 	//	  "containerID":"c9fd60251b5237467462dad48999815eb0025f367c6e1abe91e0bd787d5915fc"
@@ -680,7 +680,7 @@ type AgentSecureServer interface {
 	//
 	//	$ curl -H "authorization: Bearer $(cat /etc/datadog-agent/auth_token)" \
 	//	   -XPOST -k -H "Content-Type: application/json" \
-	//	   --data '{"externalDataInit": false,"externalDataPodUID": "54383382-cea3-49e3-9dda-325436ddd5b8","externalDataContainerName": "dd-trace-py"}' \
+	//	   --data '{"externalData": {"init": false,"containerName": "dd-trace-py","podUID": "c4b45c6a-b296-4bd5-88df-7c2d6bcaabef"}}' \
 	//	   https://localhost:5001/v1/grpc/tagger/generate_container_id_from_origin_info
 	//	{
 	//	  "containerID":"c9fd60251b5237467462dad48999815eb0025f367c6e1abe91e0bd787d5915fc"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Implement caching for `GenerateContainerIDFromOriginInfo` using the `github.com/DataDog/datadog-agent/pkg/util/cache` implementation.

### Motivation

This is needed to fully support `GenerateContainerIDFromOriginInfo` use cases.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated using the following patch:
```
diff --git a/comp/core/tagger/impl-remote/remote.go b/comp/core/tagger/impl-remote/remote.go
index 7dd668b18a..da9c5ed25e 100644
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -45,7 +45,7 @@ import (
 const (
        noTimeout         = 0 * time.Minute
        streamRecvTimeout = 10 * time.Minute
-       cacheExpiration   = 1 * time.Minute
+       cacheExpiration   = 10 * time.Second
 )

 var (
diff --git a/pkg/util/cache/cache.go b/pkg/util/cache/cache.go
index e78a1562fd..f2c751d12a 100644
--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -7,6 +7,7 @@
 package cache

 import (
+       "github.com/DataDog/datadog-agent/pkg/util/log"
        "strings"
        "time"

@@ -88,8 +89,10 @@ func Get[T any](key string, cb func() (T, error)) (T, error) {
 //     cached with the given expire duration and returned.
 func GetWithExpiration[T any](key string, cb func() (T, error), expire time.Duration) (T, error) {
        if x, found := Cache.Get(key); found {
+               log.Errorf("w: hit for key %s", key)
                return x.(T), nil
        }
+       log.Errorf("w: miss for key %s", key)

        res, err := cb()
        // We don't cache errors
```

And with the same QA process as https://github.com/DataDog/datadog-agent/pull/32295
We can see the logs:
```
2024-12-19 09:59:01 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:92 in ]) | w: hit for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
2024-12-19 09:59:02 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:92 in ]) | w: hit for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
2024-12-19 09:59:02 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:92 in ]) | w: hit for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
2024-12-19 09:59:06 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:92 in ]) | w: hit for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
2024-12-19 09:59:07 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:95 in ]) | w: miss for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
2024-12-19 09:59:10 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:92 in ]) | w: hit for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
2024-12-19 09:59:12 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:92 in ]) | w: hit for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
2024-12-19 09:59:14 UTC | TRACE | ERROR | (pkg/util/cache/cache.go:92 in ]) | w: hit for key agent/remoteTagger/container_id/7c61e76f-5e3c-4989-b479-b977dd9cfe48/dd-trace-py
```

And that we still have the traces correctly tagged:
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/7417ccef-d674-4a51-b972-62407d516acb" />

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A