### PR TITLE
fix(installer): Make policy metadata files root-owned & world-readable

### DIFF
--- a/pkg/fleet/internal/cdn/cdn.go
+++ b/pkg/fleet/internal/cdn/cdn.go
@@ -165,27 +165,16 @@ func (c *CDN) Close() error {
 }
 
 // writePolicyMetadata writes the policy metadata to the given directory
-// and makes it readable to dd-agent
+// and makes it world-readable
 func writePolicyMetadata(config Config, dir string) error {
-	ddAgentUID, ddAgentGID, err := getAgentIDs()
-	if err != nil {
-		return fmt.Errorf("error getting dd-agent user and group IDs: %w", err)
-	}
-
 	state := config.State()
 	stateBytes, err := json.Marshal(state)
 	if err != nil {
 		return fmt.Errorf("could not marshal state: %w", err)
 	}
-	err = os.WriteFile(filepath.Join(dir, policyMetadataFilename), stateBytes, 0440)
+	err = os.WriteFile(filepath.Join(dir, policyMetadataFilename), stateBytes, 0444)
 	if err != nil {
 		return fmt.Errorf("could not write %s: %w", policyMetadataFilename, err)
-	}
-	if runtime.GOOS != "windows" {
-		err = os.Chown(filepath.Join(dir, policyMetadataFilename), ddAgentUID, ddAgentGID)
-		if err != nil {
-			return fmt.Errorf("could not chown %s: %w", policyMetadataFilename, err)
-		}
 	}
 	return nil
 }

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -410,8 +410,8 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeSuccessful() {
 	state.AssertDirExists("/etc/datadog-agent/managed/datadog-agent", 0755, "root", "root")
 	state.AssertSymlinkExists("/etc/datadog-agent/managed/datadog-agent/stable", "/etc/datadog-agent/managed/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d", "root", "root")
 	// Verify metadata
-	state.AssertFileExists("/etc/datadog-agent/managed/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d/policy.metadata", 0440, "dd-agent", "dd-agent")
-	file := s.Env().RemoteHost.MustExecute("sudo cat /etc/datadog-agent/managed/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d/policy.metadata")
+	state.AssertFileExists("/etc/datadog-agent/managed/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d/policy.metadata", 0444, "root", "root")
+	file := s.Env().RemoteHost.MustExecute("cat /etc/datadog-agent/managed/datadog-agent/e94406c45ae766b7d34d2793e4759b9c4d15ed5d5e2b7f73ce1bf0e6836f728d/policy.metadata")
 	policiesState := &pbgo.PoliciesState{}
 	err := json.Unmarshal([]byte(file), policiesState)
 	require.NoError(s.T(), err)


### PR DESCRIPTION
### What does this PR do?
Fixes a bug at installer install: we try to write the policy metadata files as dd-agent before having created the dd-agent user.
This PR makes the file owned by root instead, and world-readable so that the daemon can read it. There is no sensitive data in this file anyway.

### Motivation

### Describe how you validated your changes
Tested manually on a VM + E2E tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->