### PR TITLE
[fleet] fix codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,6 +176,7 @@
 
 /.gitlab/package_build/                              @DataDog/agent-delivery
 /.gitlab/package_build/windows.yml                   @DataDog/agent-delivery @DataDog/windows-agent
+/.gitlab/package_build/installer.yml                 @DataDog/agent-delivery @DataDog/fleet
 /.gitlab/packaging/                                  @DataDog/agent-delivery
 
 /.gitlab/benchmarks/benchmarks.yml                   @DataDog/agent-apm


### PR DESCRIPTION
As more devs iterate over installer scripts, adding fleet as codeowner to installer build job to reduce review friction

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->