### PR TITLE
[CWS] look directly for the 0 id cgroup when reading /proc

### DIFF
--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -50,30 +50,10 @@ func (cg ControlGroup) GetContainerID() containerutils.ContainerID {
 	return containerutils.ContainerID(id)
 }
 
-// GetLastProcControlGroups returns the first cgroup membership of the specified task.
-func GetLastProcControlGroups(tgid, pid uint32) (ControlGroup, error) {
-	data, err := os.ReadFile(CgroupTaskPath(tgid, pid))
-	if err != nil {
-		return ControlGroup{}, err
-	}
-
-	data = bytes.TrimSpace(data)
-
-	index := bytes.LastIndexByte(data, '\n')
-	if index < 0 {
-		index = 0
-	} else {
-		index++ // to skip the \n
-	}
-	if index >= len(data) {
-		return ControlGroup{}, fmt.Errorf("invalid cgroup data: %s", data)
-	}
-
-	lastLine := string(data[index:])
-
-	idstr, rest, ok := strings.Cut(lastLine, ":")
+func parseCgroupLine(line string, expectedID int) (ControlGroup, error) {
+	idstr, rest, ok := strings.Cut(line, ":")
 	if !ok {
-		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", lastLine)
+		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", line)
 	}
 
 	id, err := strconv.Atoi(idstr)
@@ -81,9 +61,13 @@ func GetLastProcControlGroups(tgid, pid uint32) (ControlGroup, error) {
 		return ControlGroup{}, err
 	}
 
+	if expectedID >= 0 && expectedID != id {
+		return ControlGroup{}, fmt.Errorf("found cgroup, but with wrong ID (%d, but expected %d): %s", id, expectedID, line)
+	}
+
 	controllers, path, ok := strings.Cut(rest, ":")
 	if !ok {
-		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", lastLine)
+		return ControlGroup{}, fmt.Errorf("invalid cgroup line: %s", line)
 	}
 
 	return ControlGroup{
@@ -91,6 +75,40 @@ func GetLastProcControlGroups(tgid, pid uint32) (ControlGroup, error) {
 		Controllers: strings.Split(controllers, ","),
 		Path:        path,
 	}, nil
+}
+
+// GetProcControlGroup0 returns the cgroup membership with index 0 of the specified task.
+func GetProcControlGroup0(tgid, pid uint32) (ControlGroup, error) {
+	data, err := os.ReadFile(CgroupTaskPath(tgid, pid))
+	if err != nil {
+		return ControlGroup{}, err
+	}
+	data = bytes.TrimSpace(data)
+
+	var lastLine []byte
+
+	for len(data) != 0 {
+		eol := bytes.IndexByte(data, '\n')
+		if eol < 0 {
+			eol = len(data)
+		}
+		line := data[:eol]
+		if bytes.HasPrefix(line, []byte("0:")) {
+			return parseCgroupLine(string(line), 0)
+		}
+
+		if bytes.ContainsRune(line, ':') {
+			lastLine = line
+		}
+
+		nextStart := eol + 1
+		if nextStart >= len(data) {
+			break
+		}
+		data = data[nextStart:]
+	}
+
+	return parseCgroupLine(string(lastLine), -1)
 }
 
 // GetProcControlGroups returns the cgroup membership of the specified task.
@@ -103,16 +121,9 @@ func GetProcControlGroups(tgid, pid uint32) ([]ControlGroup, error) {
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		t := scanner.Text()
-		parts := strings.Split(t, ":")
-		var ID int
-		ID, err = strconv.Atoi(parts[0])
+		c, err := parseCgroupLine(t, -1)
 		if err != nil {
-			continue
-		}
-		c := ControlGroup{
-			ID:          ID,
-			Controllers: strings.Split(parts[1], ","),
-			Path:        parts[2],
+			return nil, err
 		}
 		cgroups = append(cgroups, c)
 	}
@@ -129,7 +140,7 @@ func GetProcContainerID(tgid, pid uint32) (containerutils.ContainerID, error) {
 // GetProcContainerContext returns the container ID which the process belongs to along with its manager. Returns "" if the process does not belong
 // to a container.
 func GetProcContainerContext(tgid, pid uint32) (containerutils.ContainerID, model.CGroupContext, error) {
-	cgroup, err := GetLastProcControlGroups(tgid, pid)
+	cgroup, err := GetProcControlGroup0(tgid, pid)
 	if err != nil {
 		return "", model.CGroupContext{}, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR improves the cgroup reading function by first trying to get the cgroup 0 before returning the last cgroup entry. This PR also reduces to the minimum the amount of allocation required during this parsing.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->