### PR TITLE
[OTEL-2125] Add configsync to otel-agent without DD exporter config

### DIFF
--- a/comp/otelcol/ddflareextension/impl/server.go
+++ b/comp/otelcol/ddflareextension/impl/server.go
@@ -116,7 +116,7 @@ func newServer(endpoint string, handler http.Handler, auth bool) (*server, error
 	// no easy way currently to pass required bearer auth token to OSS collector;
 	// skip the validation if running inside a separate collector
 	// TODO: determine way to allow OSS collector to authenticate with agent, OTEL-2226
-	if auth {
+	if auth && util.GetAuthToken() != "" {
 		r.Use(validateToken)
 	}
 


### PR DESCRIPTION
### What does this PR do?
Have otel-agent correctly set up configsync comp when there is no DD exporter config. Also skip auth in dd flares when there is no auth token available.

Split from https://github.com/DataDog/datadog-agent/pull/30069

### Motivation
configsync comp is needed for flare to properly work. Note that when there is no DD exporter config, otel-agent uses a different fx.

### Describe how you validated your changes
E2E test is added in https://github.com/DataDog/datadog-agent/pull/30069