### PR TITLE
[NDM] Several helpers

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch.go
@@ -44,17 +44,11 @@ func Fetch(sess session.Session, config *checkconfig.CheckConfig) (*valuestore.R
 		return nil, fmt.Errorf("failed to fetch scalar oids with batching: %v", err)
 	}
 
-	// fetch column values
-	oids := make(map[string]string, len(config.OidConfig.ColumnOids))
-	for _, value := range config.OidConfig.ColumnOids {
-		oids[value] = value
-	}
-
-	columnResults, err := fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, useGetBulk)
+	columnResults, err := fetchColumnOidsWithBatching(sess, config.OidConfig.ColumnOids, config.OidBatchSize, config.BulkMaxRepetitions, useGetBulk)
 	if err != nil {
 		log.Debugf("failed to fetch oids with GetBulk batching: %v", err)
 
-		columnResults, err = fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, useGetNext)
+		columnResults, err = fetchColumnOidsWithBatching(sess, config.OidConfig.ColumnOids, config.OidBatchSize, config.BulkMaxRepetitions, useGetNext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch oids with GetNext batching: %v", err)
 		}

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -47,9 +47,10 @@ func fetchColumnOidsWithBatching(sess session.Session, oids []string, oidBatchSi
 	return retValues, nil
 }
 
-// fetchColumnOids has an `oids` argument representing a `map[string]string`,
-// the key of the map is the column oid, and the value is the oid used to fetch the next value for the column.
-// The value oid might be equal to column oid or a row oid of the same column.
+// fetchColumnOids fetches all values for each specified column OID.
+// bulkMaxRepetitions is the number of entries to request per OID per SNMP
+// request when fetchStrategy = useGetBulk; it is ignored when fetchStrategy is
+// useGetNext.
 func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
 	returnValues := make(valuestore.ColumnResultValuesType, len(oids))
 	alreadyProcessedOids := make(map[string]bool)

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_column.go
@@ -20,23 +20,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 )
 
-func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, oidBatchSize int, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOidsWithBatching(sess session.Session, oids []string, oidBatchSize int, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
 	retValues := make(valuestore.ColumnResultValuesType, len(oids))
 
-	columnOids := getOidsMapKeys(oids)
-	sort.Strings(columnOids) // sorting ColumnOids to make them deterministic for testing purpose
-	batches, err := common.CreateStringBatches(columnOids, oidBatchSize)
+	batches, err := common.CreateStringBatches(oids, oidBatchSize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create column oid batches: %s", err)
 	}
 
 	for _, batchColumnOids := range batches {
-		oidsToFetch := make(map[string]string, len(batchColumnOids))
-		for _, oid := range batchColumnOids {
-			oidsToFetch[oid] = oids[oid]
-		}
-
-		results, err := fetchColumnOids(sess, oidsToFetch, bulkMaxRepetitions, fetchStrategy)
+		results, err := fetchColumnOids(sess, batchColumnOids, bulkMaxRepetitions, fetchStrategy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch column oids: %s", err)
 		}
@@ -57,10 +50,13 @@ func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, o
 // fetchColumnOids has an `oids` argument representing a `map[string]string`,
 // the key of the map is the column oid, and the value is the oid used to fetch the next value for the column.
 // The value oid might be equal to column oid or a row oid of the same column.
-func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOids(sess session.Session, oids []string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
 	returnValues := make(valuestore.ColumnResultValuesType, len(oids))
 	alreadyProcessedOids := make(map[string]bool)
-	curOids := oids
+	curOids := make(map[string]string, len(oids))
+	for _, oid := range oids {
+		curOids[oid] = oid
+	}
 	for {
 		if len(curOids) == 0 {
 			break
@@ -130,14 +126,4 @@ func updateColumnResultValues(valuesToUpdate valuestore.ColumnResultValuesType, 
 			valuesToUpdate[columnOid][oid] = value
 		}
 	}
-}
-
-func getOidsMapKeys(oidsMap map[string]string) []string {
-	keys := make([]string, len(oidsMap))
-	i := 0
-	for k := range oidsMap {
-		keys[i] = k
-		i++
-	}
-	return keys
 }

--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_test.go
@@ -87,7 +87,7 @@ func Test_fetchColumnOids(t *testing.T) {
 	sess.On("GetBulk", []string{"1.1.1.3"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket2, nil)
 	sess.On("GetBulk", []string{"1.1.1.5"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket3, nil)
 
-	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
+	oids := []string{"1.1.1", "1.1.2"}
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	assert.Nil(t, err)
@@ -178,7 +178,7 @@ func Test_fetchColumnOidsBatch_usingGetBulk(t *testing.T) {
 	// Third bulk iteration
 	sess.On("GetBulk", []string{"1.1.1.5"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket3, nil)
 
-	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
+	oids := []string{"1.1.1", "1.1.2"}
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, useGetBulk)
 	assert.Nil(t, err)
@@ -275,7 +275,7 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 	sess.On("GetNext", []string{"1.1.3"}).Return(&secondBatchPacket1, nil)
 	sess.On("GetNext", []string{"1.1.3.1"}).Return(&secondBatchPacket2, nil)
 
-	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2", "1.1.3": "1.1.3"}
+	oids := []string{"1.1.1", "1.1.2", "1.1.3"}
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, useGetBulk)
 	assert.Nil(t, err)
@@ -870,7 +870,7 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 	sess.On("GetBulk", []string{"1.1.1.3", "1.1.2.3"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket2, nil)
 	sess.On("GetBulk", []string{"1.1.1.5", "1.1.2.5"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket3, nil)
 
-	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
+	oids := []string{"1.1.1", "1.1.2"}
 
 	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	assert.Nil(t, err)

--- a/pkg/collector/corechecks/snmp/internal/profile/profile.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile.go
@@ -74,6 +74,9 @@ func getProfileForSysObjectID(profiles ProfileConfigMap, sysObjectID string) (st
 			matchedOids = append(matchedOids, oidPattern)
 		}
 	}
+	if len(matchedOids) == 0 {
+		return "", fmt.Errorf("no profiles found for sysObjectID %q", sysObjectID)
+	}
 	oid, err := getMostSpecificOid(matchedOids)
 	if err != nil {
 		return "", fmt.Errorf("failed to get most specific profile for sysObjectID %q, for matched oids %v: %w", sysObjectID, matchedOids, err)

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_initconfig.go
@@ -17,6 +17,9 @@ func loadInitConfigProfiles(rawInitConfigProfiles ProfileConfigMap) (ProfileConf
 				log.Warnf("unable to load profile %q: %s", name, err)
 				continue
 			}
+			if profDefinition.Name == "" {
+				profDefinition.Name = name
+			}
 			profConfig.Definition = *profDefinition
 		}
 		initConfigProfiles[name] = profConfig

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_test.go
@@ -331,7 +331,7 @@ func Test_getProfileForSysObjectID(t *testing.T) {
 			profiles:        mockProfilesWithInvalidPatternError,
 			sysObjectID:     "1.3.6.1.4.1.3375.2.1.3.4.5.11",
 			expectedProfile: "",
-			expectedError:   "failed to get most specific profile for sysObjectID \"1.3.6.1.4.1.3375.2.1.3.4.5.11\", for matched oids []: cannot get most specific oid from empty list of oids",
+			expectedError:   "no profiles found for sysObjectID \"1.3.6.1.4.1.3375.2.1.3.4.5.11\"",
 		},
 		{
 			name:            "duplicate sysobjectid",

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_yaml.go
@@ -73,6 +73,9 @@ func getProfileDefinitions(profilesFolder string, isUserProfile bool) (ProfileCo
 			log.Warnf("cannot load profile %q: %v", profileName, err)
 			continue
 		}
+		if definition.Name == "" {
+			definition.Name = profileName
+		}
 		profiles[profileName] = ProfileConfig{
 			Definition:    *definition,
 			IsUserProfile: isUserProfile,

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -64,6 +64,7 @@ func FixtureProfileDefinitionMap() ProfileConfigMap {
 	return ProfileConfigMap{
 		"f5-big-ip": ProfileConfig{
 			Definition: profiledefinition.ProfileDefinition{
+				Name:         "f5-big-ip",
 				Metrics:      metrics,
 				Extends:      []string{"_base.yaml", "_generic-if.yaml"},
 				Device:       profiledefinition.DeviceMeta{Vendor: "f5"},
@@ -183,6 +184,7 @@ func FixtureProfileDefinitionMap() ProfileConfigMap {
 		},
 		"another_profile": ProfileConfig{
 			Definition: profiledefinition.ProfileDefinition{
+				Name:         "another_profile",
 				SysObjectIDs: profiledefinition.StringArray{"1.3.6.1.4.1.32473.1.1"},
 				Metrics: []profiledefinition.MetricsConfig{
 					{Symbol: profiledefinition.SymbolConfig{OID: "1.3.6.1.2.1.1.999.0", Name: "anotherMetric"}, MetricType: ""},

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -36,6 +36,19 @@ type ProfileDefinition struct {
 	Version uint64 `yaml:"version,omitempty" json:"version"`
 }
 
+// GetVendor returns the static vendor for this profile, if one is set
+func (p *ProfileDefinition) GetVendor() string {
+	device, ok := p.Metadata["device"]
+	if !ok {
+		return ""
+	}
+	vendor, ok := device.Fields["vendor"]
+	if !ok {
+		return ""
+	}
+	return vendor.Value
+}
+
 // DeviceProfileRcConfig represent the profile stored in remote config.
 type DeviceProfileRcConfig struct {
 	Profile ProfileDefinition `json:"profile_definition"`

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -60,3 +60,11 @@ func NewProfileDefinition() *ProfileDefinition {
 	p.Metadata = make(MetadataConfig)
 	return p
 }
+
+// SplitOIDs returns two slices (scalars, columns) of all scalar and column OIDs requested by this profile.
+func (p *ProfileDefinition) SplitOIDs(includeMetadata bool) ([]string, []string) {
+	if includeMetadata {
+		return splitOIDs(p.Metrics, p.MetricTags, p.Metadata)
+	}
+	return splitOIDs(p.Metrics, p.MetricTags, nil)
+}

--- a/pkg/networkdevice/profile/profiledefinition/splitoids.go
+++ b/pkg/networkdevice/profile/profiledefinition/splitoids.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package profiledefinition
+
+import "sort"
+
+// splitOIDs returns all scalar and column (i.e. table) OIDs from metrics, tags, and metadata
+func splitOIDs(metrics []MetricsConfig, globalTags []MetricTagConfig, metadata MetadataConfig) ([]string, []string) {
+	scalars := make(map[string]bool)
+	columns := make(map[string]bool)
+	// Singular metric values are scalars; metrics with .Symbols are tables,
+	// and their symbols and tags are both expected to be columns.
+	for _, metric := range metrics {
+		scalars[metric.Symbol.OID] = true
+		for _, symbolConfig := range metric.Symbols {
+			columns[symbolConfig.OID] = true
+		}
+		for _, metricTag := range metric.MetricTags {
+			columns[metricTag.Symbol.OID] = true
+		}
+	}
+	// Global tags are scalar by definition
+	for _, tag := range globalTags {
+		scalars[tag.Symbol.OID] = true
+	}
+	// Metadata fields are all columns except when IsMetadataResourceWithScalarOids is true
+	for resource, metadataConfig := range metadata {
+		target := columns
+		if IsMetadataResourceWithScalarOids(resource) {
+			target = scalars
+		}
+		for _, field := range metadataConfig.Fields {
+			target[field.Symbol.OID] = true
+			for _, symbol := range field.Symbols {
+				target[symbol.OID] = true
+			}
+		}
+		for _, tagConfig := range metadataConfig.IDTags {
+			target[tagConfig.Symbol.OID] = true
+		}
+	}
+	scalarValues := make([]string, 0, len(scalars))
+	for key := range scalars {
+		if key == "" {
+			continue
+		}
+		scalarValues = append(scalarValues, key)
+	}
+	columnValues := make([]string, 0, len(columns))
+	for key := range columns {
+		if key == "" {
+			continue
+		}
+		columnValues = append(columnValues, key)
+	}
+	// Sort them for deterministic testing
+	sort.Strings(scalarValues)
+	sort.Strings(columnValues)
+	return scalarValues, columnValues
+}

--- a/pkg/networkdevice/profile/profiledefinition/splitoids_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/splitoids_test.go
@@ -1,0 +1,227 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSplitOIDs(t *testing.T) {
+	type testCase struct {
+		name            string
+		metrics         []MetricsConfig
+		tags            []MetricTagConfig
+		metadata        MetadataConfig
+		expectedScalars []string
+		expectedColumns []string
+	}
+	testCases := []testCase{
+		{
+			name: "scalar metric",
+			metrics: []MetricsConfig{{
+				Symbol: SymbolConfig{
+					OID: "1.2.3.4",
+				},
+			}},
+			expectedScalars: []string{"1.2.3.4"},
+		}, {
+			name: "tabular metric",
+			metrics: []MetricsConfig{{
+				Symbols: []SymbolConfig{{OID: "1.2.3.4"}},
+				MetricTags: []MetricTagConfig{
+					{Symbol: SymbolConfigCompat{
+						OID: "2.3.4.5",
+					}},
+				},
+			}},
+			expectedColumns: []string{"1.2.3.4", "2.3.4.5"},
+		}, {
+			name: "tags",
+			tags: []MetricTagConfig{
+				{Symbol: SymbolConfigCompat{
+					OID: "2.3.4.5",
+				},
+				},
+			},
+			expectedScalars: []string{"2.3.4.5"},
+		}, {
+			name: "metadata",
+			metadata: map[string]MetadataResourceConfig{
+				"device": {
+					Fields: map[string]MetadataField{
+						"vendor": {Value: "static"},
+						"name": {Symbol: SymbolConfig{
+							OID: "1.1",
+						}},
+						"os_name": {Symbols: []SymbolConfig{
+							{
+								OID: "1.2",
+							}, {
+								OID: "1.3",
+							},
+						}},
+					},
+					IDTags: []MetricTagConfig{
+						{Symbol: SymbolConfigCompat{
+							OID: "1.4",
+						}},
+					},
+				},
+				"not_device": {
+					Fields: map[string]MetadataField{
+						"vendor": {Value: "static"},
+						"name": {Symbol: SymbolConfig{
+							OID: "2.1",
+						}},
+						"os_name": {Symbols: []SymbolConfig{
+							{
+								OID: "2.2",
+							}, {
+								OID: "2.3",
+							},
+						}},
+					},
+					IDTags: []MetricTagConfig{
+						{Symbol: SymbolConfigCompat{
+							OID: "2.4",
+						}},
+					},
+				},
+			},
+			expectedScalars: []string{"1.1", "1.2", "1.3", "1.4"},
+			expectedColumns: []string{"2.1", "2.2", "2.3", "2.4"},
+		}, {
+			name: "duplicates",
+			metrics: []MetricsConfig{
+				{
+					Symbol: SymbolConfig{OID: "1.1"},
+				}, {
+					Symbols: []SymbolConfig{
+						{OID: "1.1"},
+					},
+					MetricTags: []MetricTagConfig{
+						{Symbol: SymbolConfigCompat{OID: "1.1"}},
+					},
+				}},
+			metadata: map[string]MetadataResourceConfig{
+				"device": {
+					Fields: map[string]MetadataField{
+						"name": {Symbol: SymbolConfig{
+							OID: "1.1",
+						}},
+					},
+				},
+			},
+			expectedScalars: []string{"1.1"},
+			expectedColumns: []string{"1.1"},
+		}, {
+			name: "sorting",
+			metrics: []MetricsConfig{
+				{Symbol: SymbolConfig{OID: "1.2"}},
+				{Symbol: SymbolConfig{OID: "1.1"}},
+				{
+					Symbols: []SymbolConfig{
+						{OID: "2.4"},
+						{OID: "2.3"},
+					},
+					MetricTags: []MetricTagConfig{
+						{Symbol: SymbolConfigCompat{OID: "2.2"}},
+						{Symbol: SymbolConfigCompat{OID: "2.1"}},
+					},
+				}},
+			expectedScalars: []string{"1.1", "1.2"},
+			expectedColumns: []string{"2.1", "2.2", "2.3", "2.4"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			scalars, columns := splitOIDs(tc.metrics, tc.tags, tc.metadata)
+			expectedScalars := tc.expectedScalars
+			if expectedScalars == nil {
+				expectedScalars = []string{}
+			}
+			assert.Equal(t, expectedScalars, scalars)
+			expectedColumns := tc.expectedColumns
+			if expectedColumns == nil {
+				expectedColumns = []string{}
+			}
+			assert.Equal(t, expectedColumns, columns)
+		})
+	}
+}
+
+func TestProfileSplitOIDs(t *testing.T) {
+	p := ProfileDefinition{
+		Metrics: []MetricsConfig{
+			{Symbol: SymbolConfig{OID: "1.2"}},
+			{Symbol: SymbolConfig{OID: "1.1"}},
+			{
+				Symbols: []SymbolConfig{
+					{OID: "2.4"},
+					{OID: "2.3"},
+				},
+				MetricTags: []MetricTagConfig{
+					{Symbol: SymbolConfigCompat{OID: "2.2"}},
+					{Symbol: SymbolConfigCompat{OID: "2.1"}},
+				},
+			},
+		},
+		MetricTags: []MetricTagConfig{
+			{Symbol: SymbolConfigCompat{OID: "1.4"}},
+			{Symbol: SymbolConfigCompat{OID: "1.3"}},
+		},
+		Metadata: map[string]MetadataResourceConfig{
+			"device": {
+				Fields: map[string]MetadataField{
+					"vendor": {Value: "static"},
+					"name": {Symbol: SymbolConfig{
+						OID: "3.4",
+					}},
+					"os_name": {Symbols: []SymbolConfig{
+						{
+							OID: "3.3",
+						}, {
+							OID: "3.2",
+						},
+					}},
+				},
+				IDTags: []MetricTagConfig{
+					{Symbol: SymbolConfigCompat{
+						OID: "3.1",
+					}},
+				},
+			},
+			"not_device": {
+				Fields: map[string]MetadataField{
+					"vendor": {Value: "static"},
+					"name": {Symbol: SymbolConfig{
+						OID: "4.4",
+					}},
+					"os_name": {Symbols: []SymbolConfig{
+						{
+							OID: "4.3",
+						}, {
+							OID: "4.2",
+						},
+					}},
+				},
+				IDTags: []MetricTagConfig{
+					{Symbol: SymbolConfigCompat{
+						OID: "4.1",
+					}},
+				},
+			},
+		},
+	}
+	scalars, columns := p.SplitOIDs(true)
+	assert.Equal(t, []string{"1.1", "1.2", "1.3", "1.4", "3.1", "3.2", "3.3", "3.4"}, scalars)
+	assert.Equal(t, []string{"2.1", "2.2", "2.3", "2.4", "4.1", "4.2", "4.3", "4.4"}, columns)
+
+	scalars, columns = p.SplitOIDs(false)
+	assert.Equal(t, []string{"1.1", "1.2", "1.3", "1.4"}, scalars)
+	assert.Equal(t, []string{"2.1", "2.2", "2.3", "2.4"}, columns)
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds several things that I need for later PRs, split out into this PR for ease of review. The changes are:
* Add method `ProfileDefinition.Vendor()` gets the vendor from the metadata, falling back to the deprecated `.Device.Vendor`
* Add helper to extract all OIDs required by a profile
* Remove a needless conversion in the fetch logic that was turning a list of OIDs into a map and then back to a list
* Add a method to `ProfileProvider` that reports the last time the provider updated its definitions (which for the existing static provider will never change)
* Make an error message nicer
* Set `Definition.Name` on profile configs when loading them from yaml etc.

### Motivation

Most of these are needed for https://datadoghq.atlassian.net/browse/NDMII-3236; a few are just minor tweaks I made in passing.

### Describe how you validated your changes
All unit tests pass; the nontrivial changes are all just adding new methods, so they can't change existing functionality.
