### PR TITLE
[NDM] Fetch profiles instead of names.

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/profile.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile.go
@@ -67,7 +67,8 @@ func getProfileForSysObjectID(profiles ProfileConfigMap, sysObjectID string) (*P
 					continue
 				}
 				if profiles[prevMatchedProfile.Definition.Name].IsUserProfile == profConfig.IsUserProfile {
-					return nil, fmt.Errorf("profile %q has the same sysObjectID (%s) as %q", profileName, oidPattern, prevMatchedProfile)
+					return nil, fmt.Errorf("profile %q has the same sysObjectID (%s) as %q", profileName, oidPattern,
+						prevMatchedProfile.Definition.Name)
 				}
 			}
 			tmpSysOidToProfile[oidPattern] = &profConfig

--- a/pkg/collector/corechecks/snmp/internal/profile/profile.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile.go
@@ -48,38 +48,39 @@ func loadProfiles(initConfigProfiles ProfileConfigMap) (ProfileConfigMap, error)
 }
 
 // getProfileForSysObjectID return a profile for a sys object id
-func getProfileForSysObjectID(profiles ProfileConfigMap, sysObjectID string) (string, error) {
-	tmpSysOidToProfile := map[string]string{}
-	var matchedOids []string
+func getProfileForSysObjectID(profiles ProfileConfigMap, sysObjectID string) (*ProfileConfig, error) {
+	tmpSysOidToProfile := map[string]*ProfileConfig{}
+	var matchedOIDs []string
 
-	for profile, profConfig := range profiles {
+	for profileName, profConfig := range profiles {
 		for _, oidPattern := range profConfig.Definition.SysObjectIDs {
 			found, err := filepath.Match(oidPattern, sysObjectID)
 			if err != nil {
-				log.Debugf("pattern error in profile %q: %v", profile, err)
+				log.Debugf("pattern error in profile %q: %v", profileName, err)
 				continue
 			}
 			if !found {
 				continue
 			}
 			if prevMatchedProfile, ok := tmpSysOidToProfile[oidPattern]; ok {
-				if profiles[prevMatchedProfile].IsUserProfile && !profConfig.IsUserProfile {
+				if profiles[prevMatchedProfile.Definition.Name].IsUserProfile && !profConfig.IsUserProfile {
 					continue
 				}
-				if profiles[prevMatchedProfile].IsUserProfile == profConfig.IsUserProfile {
-					return "", fmt.Errorf("profile %q has the same sysObjectID (%s) as %q", profile, oidPattern, prevMatchedProfile)
+				if profiles[prevMatchedProfile.Definition.Name].IsUserProfile == profConfig.IsUserProfile {
+					return nil, fmt.Errorf("profile %q has the same sysObjectID (%s) as %q", profileName, oidPattern, prevMatchedProfile)
 				}
 			}
-			tmpSysOidToProfile[oidPattern] = profile
-			matchedOids = append(matchedOids, oidPattern)
+			tmpSysOidToProfile[oidPattern] = &profConfig
+			matchedOIDs = append(matchedOIDs, oidPattern)
 		}
 	}
-	if len(matchedOids) == 0 {
-		return "", fmt.Errorf("no profiles found for sysObjectID %q", sysObjectID)
+	if len(matchedOIDs) == 0 {
+		return nil, fmt.Errorf("no profiles found for sysObjectID %q", sysObjectID)
 	}
-	oid, err := getMostSpecificOid(matchedOids)
+	oid, err := getMostSpecificOid(matchedOIDs)
 	if err != nil {
-		return "", fmt.Errorf("failed to get most specific profile for sysObjectID %q, for matched oids %v: %w", sysObjectID, matchedOids, err)
+		return nil, fmt.Errorf("failed to get most specific profile for sysObjectID %q, for matched oids %v: %w",
+			sysObjectID, matchedOIDs, err)
 	}
 	return tmpSysOidToProfile[oid], nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes the ProfileProvider method that finds the name of the best matching profile for a sysobjectid, instead having it fetch the best profile directly (from which you can get the name if needed)

### Motivation

Cleanup.
https://datadoghq.atlassian.net/browse/NDMII-2360

### Describe how you validated your changes
Unit tests pass and agent runs locally; no behavioral changes expected.