### PR TITLE
[NDM] Profile Cloning

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/profile/config_profile.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/config_profile.go
@@ -82,3 +82,11 @@ type ProfileConfig struct {
 
 	IsUserProfile bool `yaml:"-"`
 }
+
+func (p ProfileConfig) Clone() ProfileConfig {
+	return ProfileConfig{
+		DefinitionFile: p.DefinitionFile,
+		Definition:     *p.Definition.Clone(),
+		IsUserProfile:  p.IsUserProfile,
+	}
+}

--- a/pkg/collector/corechecks/snmp/internal/profile/config_profile.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/config_profile.go
@@ -75,6 +75,11 @@ func (pcm ProfileConfigMap) withNames() ProfileConfigMap {
 	return pcm
 }
 
+// Clone duplicates a ProfileConfigMap
+func (pcm ProfileConfigMap) Clone() ProfileConfigMap {
+	return profiledefinition.CloneMap(pcm)
+}
+
 // ProfileConfig represents a profile configuration.
 type ProfileConfig struct {
 	DefinitionFile string                              `yaml:"definition_file"`
@@ -83,6 +88,7 @@ type ProfileConfig struct {
 	IsUserProfile bool `yaml:"-"`
 }
 
+// Clone duplicates a ProfileConfig
 func (p ProfileConfig) Clone() ProfileConfig {
 	return ProfileConfig{
 		DefinitionFile: p.DefinitionFile,

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -10,11 +10,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/mohae/deepcopy"
-
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/configvalidation"
 )
@@ -41,7 +39,7 @@ func loadResolveProfiles(pConfig ProfileConfigMap, defaultProfiles ProfileConfig
 			continue
 		}
 
-		newProfileConfig := deepcopy.Copy(pConfig[name]).(ProfileConfig)
+		newProfileConfig := pConfig[name].Clone()
 		err := recursivelyExpandBaseProfiles(name, &newProfileConfig.Definition, newProfileConfig.Definition.Extends, []string{}, pConfig, defaultProfiles)
 		if err != nil {
 			log.Warnf("failed to expand profile %q: %v", name, err)

--- a/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/testing_utils.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 
-	"github.com/mohae/deepcopy"
-
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
@@ -20,7 +18,7 @@ import (
 
 // CopyProfileDefinition copies a profile, it's used for testing
 func CopyProfileDefinition(profileDef profiledefinition.ProfileDefinition) profiledefinition.ProfileDefinition {
-	return deepcopy.Copy(profileDef).(profiledefinition.ProfileDefinition)
+	return *profileDef.Clone()
 }
 
 // SetConfdPathAndCleanProfiles is used for testing only

--- a/pkg/collector/corechecks/snmp/internal/profile/utils.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils.go
@@ -7,19 +7,17 @@ package profile
 
 import (
 	"os"
-
-	"github.com/mohae/deepcopy"
 )
 
-// mergeProfiles merges two profiles config map
-// we use deepcopy to lower risk of modifying original profiles
+// mergeProfiles merges two ProfileConfigMaps
+// we clone the profiles to lower the risk of modifying original profiles
 func mergeProfiles(profilesA ProfileConfigMap, profilesB ProfileConfigMap) ProfileConfigMap {
 	profiles := make(ProfileConfigMap)
 	for k, v := range profilesA {
-		profiles[k] = deepcopy.Copy(v).(ProfileConfig)
+		profiles[k] = v.Clone()
 	}
 	for k, v := range profilesB {
-		profiles[k] = deepcopy.Copy(v).(ProfileConfig)
+		profiles[k] = v.Clone()
 	}
 	return profiles
 }

--- a/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/utils_test.go
@@ -7,7 +7,6 @@ package profile
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
-	"github.com/mohae/deepcopy"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -34,7 +33,7 @@ func Test_mergeProfiles(t *testing.T) {
 			},
 		},
 	}
-	profilesACopy := deepcopy.Copy(profilesA).(ProfileConfigMap)
+	profilesACopy := profilesA.Clone()
 	profilesB := ProfileConfigMap{
 		"profile-p1": ProfileConfig{
 			Definition: profiledefinition.ProfileDefinition{
@@ -56,7 +55,7 @@ func Test_mergeProfiles(t *testing.T) {
 			},
 		},
 	}
-	profilesBCopy := deepcopy.Copy(profilesB).(ProfileConfigMap)
+	profilesBCopy := profilesB.Clone()
 
 	actualMergedProfiles := mergeProfiles(profilesA, profilesB)
 
@@ -119,6 +118,6 @@ func Test_mergeProfiles(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedMergedProfiles, actualMergedProfiles)
-	assert.Equal(t, profilesACopy, profilesA)
-	assert.Equal(t, profilesBCopy, profilesB)
+	assert.Equal(t, profilesA, profilesACopy)
+	assert.Equal(t, profilesB, profilesBCopy)
 }

--- a/pkg/networkdevice/profile/profiledefinition/clone.go
+++ b/pkg/networkdevice/profile/profiledefinition/clone.go
@@ -13,12 +13,12 @@ type Cloneable[T any] interface {
 }
 
 // CloneSlice clones all the objects in a slice into a new slice.
-func CloneSlice[T Cloneable[T]](t []T) []T {
-	if t == nil {
+func CloneSlice[Slice ~[]T, T Cloneable[T]](s Slice) Slice {
+	if s == nil {
 		return nil
 	}
-	result := make([]T, 0, len(t))
-	for _, v := range t {
+	result := make(Slice, 0, len(s))
+	for _, v := range s {
 		result = append(result, v.Clone())
 	}
 	return result
@@ -26,11 +26,11 @@ func CloneSlice[T Cloneable[T]](t []T) []T {
 
 // CloneMap clones a map[K]T for any cloneable type T.
 // The map keys are shallow-copied; values are cloned.
-func CloneMap[K comparable, T Cloneable[T]](m map[K]T) map[K]T {
+func CloneMap[Map ~map[K]T, K comparable, T Cloneable[T]](m Map) Map {
 	if m == nil {
 		return nil
 	}
-	result := make(map[K]T, len(m))
+	result := make(Map, len(m))
 	for k, v := range m {
 		result[k] = v.Clone()
 	}

--- a/pkg/networkdevice/profile/profiledefinition/clone.go
+++ b/pkg/networkdevice/profile/profiledefinition/clone.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+// Cloneable is a generic type for objects that can duplicate themselves.
+// It is exclusively used in the form [T Cloneable[T]], i.e. a type that
+// has a .Clone() that returns a new instance of itself.
+type Cloneable[T any] interface {
+	Clone() T
+}
+
+// CloneSlice clones all the objects in a slice into a new slice.
+func CloneSlice[T Cloneable[T]](t []T) []T {
+	if t == nil {
+		return nil
+	}
+	result := make([]T, 0, len(t))
+	for _, v := range t {
+		result = append(result, v.Clone())
+	}
+	return result
+}
+
+// CloneMap clones a map[K]T for any cloneable type T.
+// The map keys are shallow-copied; values are cloned.
+func CloneMap[K comparable, T Cloneable[T]](m map[K]T) map[K]T {
+	if m == nil {
+		return nil
+	}
+	result := make(map[K]T, len(m))
+	for k, v := range m {
+		result[k] = v.Clone()
+	}
+	return result
+}

--- a/pkg/networkdevice/profile/profiledefinition/clone_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/clone_test.go
@@ -74,3 +74,28 @@ func TestCloneMap(t *testing.T) {
 		"Item C": item("ccc", 100, 200),
 	}, mCopy)
 }
+
+func TestCustomSliceClone(t *testing.T) {
+	type customSlice []*cloneMe
+
+	items := customSlice{
+		item("a", 1, 2, 3, 4),
+		item("b", 1, 2),
+	}
+	itemsCopy := CloneSlice(items)
+
+	assert.IsType(t, customSlice{}, itemsCopy)
+	assert.Equal(t, items, itemsCopy)
+}
+
+func TestCustomMapClone(t *testing.T) {
+	type customMap map[string]*cloneMe
+
+	m := customMap{
+		"Item A": item("a", 1, 2, 3, 4),
+		"Item B": item("b", 1, 2),
+	}
+	mCopy := CloneMap(m)
+	assert.IsType(t, customMap{}, mCopy)
+	assert.Equal(t, m, mCopy)
+}

--- a/pkg/networkdevice/profile/profiledefinition/clone_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/clone_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"slices"
+	"testing"
+)
+
+type cloneMe struct {
+	label *string
+	ps    []int
+}
+
+func Item(label string, ps ...int) *cloneMe {
+	return &cloneMe{
+		label: &label,
+		ps:    ps,
+	}
+}
+
+func (c *cloneMe) Clone() *cloneMe {
+	c2 := &cloneMe{
+		ps: slices.Clone(c.ps),
+	}
+	if c.label != nil {
+		var tmp string = *c.label
+		c2.label = &tmp
+	}
+	return c2
+}
+
+func TestCloneSlice(t *testing.T) {
+	items := []*cloneMe{
+		Item("a", 1, 2, 3, 4),
+		Item("b", 1, 2),
+	}
+	itemsCopy := CloneSlice(items)
+	*itemsCopy[0].label = "aaa"
+	itemsCopy[1] = Item("bbb", 10, 20)
+	itemsCopy = append(itemsCopy, Item("ccc", 100, 200))
+	// items is unchanged
+	assert.Equal(t, []*cloneMe{
+		Item("a", 1, 2, 3, 4),
+		Item("b", 1, 2),
+	}, items)
+	assert.Equal(t, []*cloneMe{
+		Item("aaa", 1, 2, 3, 4),
+		Item("bbb", 10, 20),
+		Item("ccc", 100, 200),
+	}, itemsCopy)
+}
+
+func TestCloneMap(t *testing.T) {
+	m := map[string]*cloneMe{
+		"Item A": Item("a", 1, 2, 3, 4),
+		"Item B": Item("b", 1, 2),
+	}
+	mCopy := CloneMap(m)
+	mCopy["Item A"].ps[0] = 100
+	mCopy["Item B"] = Item("bbb", 10, 20)
+	mCopy["Item C"] = Item("ccc", 100, 200)
+	assert.Equal(t, map[string]*cloneMe{
+		"Item A": Item("a", 1, 2, 3, 4),
+		"Item B": Item("b", 1, 2),
+	}, m)
+	assert.Equal(t, map[string]*cloneMe{
+		"Item A": Item("a", 100, 2, 3, 4),
+		"Item B": Item("bbb", 10, 20),
+		"Item C": Item("ccc", 100, 200),
+	}, mCopy)
+}

--- a/pkg/networkdevice/profile/profiledefinition/clone_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/clone_test.go
@@ -16,7 +16,7 @@ type cloneMe struct {
 	ps    []int
 }
 
-func Item(label string, ps ...int) *cloneMe {
+func item(label string, ps ...int) *cloneMe {
 	return &cloneMe{
 		label: &label,
 		ps:    ps,
@@ -28,7 +28,7 @@ func (c *cloneMe) Clone() *cloneMe {
 		ps: slices.Clone(c.ps),
 	}
 	if c.label != nil {
-		var tmp string = *c.label
+		var tmp = *c.label
 		c2.label = &tmp
 	}
 	return c2
@@ -36,41 +36,41 @@ func (c *cloneMe) Clone() *cloneMe {
 
 func TestCloneSlice(t *testing.T) {
 	items := []*cloneMe{
-		Item("a", 1, 2, 3, 4),
-		Item("b", 1, 2),
+		item("a", 1, 2, 3, 4),
+		item("b", 1, 2),
 	}
 	itemsCopy := CloneSlice(items)
 	*itemsCopy[0].label = "aaa"
-	itemsCopy[1] = Item("bbb", 10, 20)
-	itemsCopy = append(itemsCopy, Item("ccc", 100, 200))
+	itemsCopy[1] = item("bbb", 10, 20)
+	itemsCopy = append(itemsCopy, item("ccc", 100, 200))
 	// items is unchanged
 	assert.Equal(t, []*cloneMe{
-		Item("a", 1, 2, 3, 4),
-		Item("b", 1, 2),
+		item("a", 1, 2, 3, 4),
+		item("b", 1, 2),
 	}, items)
 	assert.Equal(t, []*cloneMe{
-		Item("aaa", 1, 2, 3, 4),
-		Item("bbb", 10, 20),
-		Item("ccc", 100, 200),
+		item("aaa", 1, 2, 3, 4),
+		item("bbb", 10, 20),
+		item("ccc", 100, 200),
 	}, itemsCopy)
 }
 
 func TestCloneMap(t *testing.T) {
 	m := map[string]*cloneMe{
-		"Item A": Item("a", 1, 2, 3, 4),
-		"Item B": Item("b", 1, 2),
+		"Item A": item("a", 1, 2, 3, 4),
+		"Item B": item("b", 1, 2),
 	}
 	mCopy := CloneMap(m)
 	mCopy["Item A"].ps[0] = 100
-	mCopy["Item B"] = Item("bbb", 10, 20)
-	mCopy["Item C"] = Item("ccc", 100, 200)
+	mCopy["Item B"] = item("bbb", 10, 20)
+	mCopy["Item C"] = item("ccc", 100, 200)
 	assert.Equal(t, map[string]*cloneMe{
-		"Item A": Item("a", 1, 2, 3, 4),
-		"Item B": Item("b", 1, 2),
+		"Item A": item("a", 1, 2, 3, 4),
+		"Item B": item("b", 1, 2),
 	}, m)
 	assert.Equal(t, map[string]*cloneMe{
-		"Item A": Item("a", 100, 2, 3, 4),
-		"Item B": Item("bbb", 10, 20),
-		"Item C": Item("ccc", 100, 200),
+		"Item A": item("a", 100, 2, 3, 4),
+		"Item B": item("bbb", 10, 20),
+		"Item C": item("ccc", 100, 200),
 	}, mCopy)
 }

--- a/pkg/networkdevice/profile/profiledefinition/metadata.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata.go
@@ -29,8 +29,8 @@ func (mc *MetadataConfig) UnmarshalJSON(data []byte) error {
 }
 
 // Clone duplicates this MetadataConfig
-func (m MetadataConfig) Clone() MetadataConfig {
-	return CloneMap(m)
+func (mc MetadataConfig) Clone() MetadataConfig {
+	return CloneMap(mc)
 }
 
 // MetadataResourceConfig holds configs for a metadata resource

--- a/pkg/networkdevice/profile/profiledefinition/metadata.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata.go
@@ -28,10 +28,23 @@ func (mc *MetadataConfig) UnmarshalJSON(data []byte) error {
 	return (*ListMap[MetadataResourceConfig])(mc).UnmarshalJSON(data)
 }
 
+// Clone duplicates this MetadataConfig
+func (m MetadataConfig) Clone() MetadataConfig {
+	return CloneMap(m)
+}
+
 // MetadataResourceConfig holds configs for a metadata resource
 type MetadataResourceConfig struct {
 	Fields ListMap[MetadataField] `yaml:"fields" json:"fields"`
 	IDTags MetricTagConfigList    `yaml:"id_tags,omitempty" json:"id_tags,omitempty"`
+}
+
+// Clone duplicates this MetadataResourceConfig
+func (c MetadataResourceConfig) Clone() MetadataResourceConfig {
+	return MetadataResourceConfig{
+		Fields: CloneMap(c.Fields),
+		IDTags: CloneSlice(c.IDTags),
+	}
 }
 
 // MetadataField holds configs for a metadata field
@@ -39,6 +52,15 @@ type MetadataField struct {
 	Symbol  SymbolConfig   `yaml:"symbol,omitempty" json:"symbol,omitempty"`
 	Symbols []SymbolConfig `yaml:"symbols,omitempty" json:"symbols,omitempty"`
 	Value   string         `yaml:"value,omitempty" json:"value,omitempty"`
+}
+
+// Clone duplicates this MetadataField
+func (c MetadataField) Clone() MetadataField {
+	return MetadataField{
+		Symbol:  c.Symbol.Clone(),
+		Symbols: CloneSlice(c.Symbols),
+		Value:   c.Value,
+	}
 }
 
 // NewMetadataResourceConfig returns a new metadata resource config

--- a/pkg/networkdevice/profile/profiledefinition/metadata_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/metadata_test.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func makeMetadata() MetadataConfig {
+	// This is not actually a valid config, since e.g. it has ExtractValue and
+	// MatchPattern both set; this is just to check that every field gets copied
+	// properly.
+	return MetadataConfig{
+		"device": MetadataResourceConfig{
+			Fields: map[string]MetadataField{
+				"name": {
+					Value: "hey",
+					Symbol: SymbolConfig{
+						OID:                  "1.2.3",
+						Name:                 "someSymbol",
+						ExtractValue:         ".*",
+						ExtractValueCompiled: regexp.MustCompile(".*"),
+						MatchPattern:         ".*",
+						MatchPatternCompiled: regexp.MustCompile(".*"),
+						MatchValue:           "$1",
+						ScaleFactor:          100,
+						Format:               "mac_address",
+						ConstantValueOne:     true,
+						MetricType:           "gauge",
+					},
+				},
+			},
+			IDTags: []MetricTagConfig{
+				{
+					Tag:   "foo",
+					Index: 1,
+					Column: SymbolConfig{
+						Name:                 "bar",
+						OID:                  "1.2.3",
+						ExtractValue:         ".*",
+						ExtractValueCompiled: regexp.MustCompile(".*"),
+					},
+					OID: "2.3.4",
+					Symbol: SymbolConfigCompat{
+						OID:                  "1.2.3",
+						Name:                 "someSymbol",
+						ExtractValue:         ".*",
+						ExtractValueCompiled: regexp.MustCompile(".*"),
+					},
+					IndexTransform: []MetricIndexTransform{
+						{
+							Start: 1,
+							End:   5,
+						},
+					},
+					Mapping: map[string]string{
+						"1": "on",
+						"2": "off",
+					},
+					Match:   ".*",
+					Pattern: regexp.MustCompile(".*"),
+					Tags: map[string]string{
+						"foo": "bar",
+					},
+					SymbolTag: "ok",
+				},
+			},
+		},
+	}
+}
+
+func TestCloneMetadata(t *testing.T) {
+	metadata := makeMetadata()
+	metaCopy := metadata.Clone()
+	assert.Equal(t, metadata, metaCopy)
+	// Modify the copy in place
+	metaCopy["interface"] = MetadataResourceConfig{}
+	metaCopy["device"].Fields["foo"] = MetadataField{
+		Value: "foo",
+	}
+	// Original has not changed
+	assert.Equal(t, makeMetadata(), metadata)
+	// New one is different
+	assert.NotEqual(t, metadata, metaCopy)
+}

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -179,11 +179,8 @@ type MetricsConfig struct {
 }
 
 // Clone duplicates this MetricsConfig
-func (m *MetricsConfig) Clone() *MetricsConfig {
-	if m == nil {
-		return nil
-	}
-	return &MetricsConfig{
+func (m MetricsConfig) Clone() MetricsConfig {
+	return MetricsConfig{
 		MIB:        m.MIB,
 		Table:      m.Table.Clone(),
 		Symbol:     m.Symbol.Clone(),

--- a/pkg/networkdevice/profile/profiledefinition/metrics.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics.go
@@ -6,7 +6,9 @@
 package profiledefinition
 
 import (
+	"maps"
 	"regexp"
+	"slices"
 )
 
 // ProfileMetricType metric type used to override default type of the metric
@@ -51,6 +53,11 @@ const (
 // When this happens, in ValidateEnrichMetricTags we harmonize by moving MetricTagConfig.OID to MetricTagConfig.Symbol.OID.
 type SymbolConfigCompat SymbolConfig
 
+// Clone creates a duplicate of this SymbolConfigCompat
+func (s SymbolConfigCompat) Clone() SymbolConfigCompat {
+	return SymbolConfigCompat(SymbolConfig(s).Clone())
+}
+
 // SymbolConfig holds info for a single symbol/oid
 type SymbolConfig struct {
 	OID  string `yaml:"OID,omitempty" json:"OID,omitempty"`
@@ -73,6 +80,14 @@ type SymbolConfig struct {
 	//   Valid `metric_type` types: `gauge`, `rate`, `monotonic_count`, `monotonic_count_and_rate`
 	//   Deprecated types: `counter` (use `rate` instead), percent (use `scale_factor` instead)
 	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty"`
+}
+
+// Clone creates a duplicate of this SymbolConfig
+func (s SymbolConfig) Clone() SymbolConfig {
+	// SymbolConfig has no mutable members, so simple assignment copies it.
+	// (technically this is false - regexes in go are mutable SOLELY through the
+	// .Longest() method. But we never use that, so we ignore it here)
+	return s
 }
 
 // MetricTagConfig holds metric tag info
@@ -104,6 +119,18 @@ type MetricTagConfig struct {
 	Pattern *regexp.Regexp    `yaml:"-" json:"-"`
 
 	SymbolTag string `yaml:"-" json:"-"`
+}
+
+// Clone duplicates this MetricTagConfig
+func (m MetricTagConfig) Clone() MetricTagConfig {
+	m2 := m // non-pointer assignment shallow-copies members
+	// deep copy symbols and structures
+	m2.Column = m.Column.Clone()
+	m2.Symbol = m.Symbol.Clone()
+	m2.IndexTransform = slices.Clone(m.IndexTransform)
+	m2.Mapping = maps.Clone(m.Mapping)
+	m2.Tags = maps.Clone(m.Tags)
+	return m2
 }
 
 // MetricTagConfigList holds configs for a list of metric tags
@@ -149,6 +176,26 @@ type MetricsConfig struct {
 	MetricType ProfileMetricType `yaml:"metric_type,omitempty" json:"metric_type,omitempty"`
 
 	Options MetricsConfigOption `yaml:"options,omitempty" json:"options,omitempty"`
+}
+
+// Clone duplicates this MetricsConfig
+func (m *MetricsConfig) Clone() *MetricsConfig {
+	if m == nil {
+		return nil
+	}
+	return &MetricsConfig{
+		MIB:        m.MIB,
+		Table:      m.Table.Clone(),
+		Symbol:     m.Symbol.Clone(),
+		OID:        m.OID,
+		Name:       m.Name,
+		Symbols:    CloneSlice(m.Symbols),
+		StaticTags: slices.Clone(m.StaticTags),
+		MetricTags: CloneSlice(m.MetricTags),
+		ForcedType: m.ForcedType,
+		MetricType: m.MetricType,
+		Options:    m.Options,
+	}
 }
 
 // GetSymbolTags returns symbol tags

--- a/pkg/networkdevice/profile/profiledefinition/metrics_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics_test.go
@@ -117,8 +117,8 @@ func TestCloneMetricTagConfig(t *testing.T) {
 }
 
 func TestCloneMetricsConfig(t *testing.T) {
-	buildConf := func() *MetricsConfig {
-		return &MetricsConfig{
+	buildConf := func() MetricsConfig {
+		return MetricsConfig{
 			MIB: "FOO-MIB",
 			Table: SymbolConfig{
 				OID:                  "1.2.3.4",
@@ -171,7 +171,7 @@ func TestCloneMetricsConfig(t *testing.T) {
 
 func TestCloneEmpty(t *testing.T) {
 	mc := MetricsConfig{}
-	assert.Equal(t, &mc, mc.Clone())
+	assert.Equal(t, mc, mc.Clone())
 	sym := SymbolConfig{}
 	assert.Equal(t, sym, sym.Clone())
 	tag := MetricTagConfig{}

--- a/pkg/networkdevice/profile/profiledefinition/metrics_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/metrics_test.go
@@ -1,0 +1,179 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profiledefinition
+
+import (
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func TestCloneSymbolConfig(t *testing.T) {
+	s := SymbolConfig{
+		OID:                  "1.2.3.4",
+		Name:                 "foo",
+		ExtractValue:         ".*",
+		ExtractValueCompiled: regexp.MustCompile(".*"),
+		MatchPattern:         ".*",
+		MatchPatternCompiled: regexp.MustCompile(".*"),
+		MatchValue:           "$1",
+		ScaleFactor:          100,
+		Format:               "mac_address",
+		ConstantValueOne:     true,
+		MetricType:           ProfileMetricTypeCounter,
+	}
+	s2 := s.Clone()
+	assert.Equal(t, s, s2)
+	// An issue with our previous deepcopy was that regexes were duplicated but
+	// didn't keep their private internals, causing them to fail when used, so
+	// double-check that the regex works fine.
+	assert.True(t, s2.ExtractValueCompiled.MatchString("foo"))
+}
+
+func TestCloneSymbolConfigCompat(t *testing.T) {
+	s := SymbolConfigCompat{
+		OID:                  "1.2.3.4",
+		Name:                 "foo",
+		ExtractValue:         ".*",
+		ExtractValueCompiled: regexp.MustCompile(".*"),
+		MatchPattern:         ".*",
+		MatchPatternCompiled: regexp.MustCompile(".*"),
+		MatchValue:           "$1",
+		ScaleFactor:          100,
+		Format:               "mac_address",
+		ConstantValueOne:     true,
+		MetricType:           ProfileMetricTypeCounter,
+	}
+	s2 := s.Clone()
+	assert.Equal(t, s, s2)
+}
+
+func TestCloneMetricTagConfig(t *testing.T) {
+	c := MetricTagConfig{
+		Tag:   "foo",
+		Index: 10,
+		Column: SymbolConfig{
+			OID:                  "1.2.3.4",
+			ExtractValue:         ".*",
+			ExtractValueCompiled: regexp.MustCompile(".*"),
+		},
+		OID:    "2.4",
+		Symbol: SymbolConfigCompat{},
+		IndexTransform: []MetricIndexTransform{
+			{
+				Start: 0,
+				End:   1,
+			},
+		},
+		Mapping: map[string]string{
+			"1": "bar",
+			"2": "baz",
+		},
+		Match:   ".*",
+		Pattern: regexp.MustCompile(".*"),
+		Tags: map[string]string{
+			"foo": "$1",
+		},
+		SymbolTag: "baz",
+	}
+	c2 := c.Clone()
+	assert.Equal(t, c, c2)
+	c2.Tags["bar"] = "$2"
+	c2.IndexTransform = append(c2.IndexTransform, MetricIndexTransform{1, 3})
+	c2.Mapping["3"] = "foo"
+	c2.Tag = "bar"
+	assert.NotEqual(t, c, c2)
+	// Validate that c has not changed
+	assert.Equal(t, c, MetricTagConfig{
+		Tag:   "foo",
+		Index: 10,
+		Column: SymbolConfig{
+			OID:                  "1.2.3.4",
+			ExtractValue:         ".*",
+			ExtractValueCompiled: regexp.MustCompile(".*"),
+		},
+		OID:    "2.4",
+		Symbol: SymbolConfigCompat{},
+		IndexTransform: []MetricIndexTransform{
+			{
+				Start: 0,
+				End:   1,
+			},
+		},
+		Mapping: map[string]string{
+			"1": "bar",
+			"2": "baz",
+		},
+		Match:   ".*",
+		Pattern: regexp.MustCompile(".*"),
+		Tags: map[string]string{
+			"foo": "$1",
+		},
+		SymbolTag: "baz",
+	})
+}
+
+func TestCloneMetricsConfig(t *testing.T) {
+	buildConf := func() *MetricsConfig {
+		return &MetricsConfig{
+			MIB: "FOO-MIB",
+			Table: SymbolConfig{
+				OID:                  "1.2.3.4",
+				ExtractValue:         ".*",
+				ExtractValueCompiled: regexp.MustCompile(".*"),
+			},
+			Symbol: SymbolConfig{
+				OID:                  "1.2.3.4",
+				ExtractValue:         ".*",
+				ExtractValueCompiled: regexp.MustCompile(".*"),
+			},
+			OID:  "1.2.3.4",
+			Name: "foo",
+			Symbols: []SymbolConfig{
+				{
+					OID:                  "1.2.3.4",
+					ExtractValue:         ".*",
+					ExtractValueCompiled: regexp.MustCompile(".*"),
+				},
+			},
+			StaticTags: []string{
+				"foo",
+				"bar",
+			},
+			MetricTags: []MetricTagConfig{
+				{
+					IndexTransform: make([]MetricIndexTransform, 0),
+				},
+			},
+			ForcedType: ProfileMetricTypeCounter,
+			MetricType: ProfileMetricTypeGauge,
+			Options: MetricsConfigOption{
+				Placement:    1,
+				MetricSuffix: ".foo",
+			},
+		}
+	}
+	conf := buildConf()
+	unchanged := buildConf()
+
+	conf2 := conf.Clone()
+	assert.Equal(t, conf, conf2)
+	conf2.StaticTags[0] = "baz"
+	conf2.MetricTags[0].IndexTransform = []MetricIndexTransform{{5, 7}}
+	conf2.Options.Placement = 2
+	conf2.Options.MetricSuffix = ".bar"
+	assert.Equal(t, unchanged, conf)
+	assert.NotEqual(t, conf, conf2)
+}
+
+func TestCloneEmpty(t *testing.T) {
+	mc := MetricsConfig{}
+	assert.Equal(t, &mc, mc.Clone())
+	sym := SymbolConfig{}
+	assert.Equal(t, sym, sym.Clone())
+	tag := MetricTagConfig{}
+	assert.Equal(t, tag, tag.Clone())
+}

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -57,6 +57,7 @@ func (p *ProfileDefinition) SplitOIDs(includeMetadata bool) ([]string, []string)
 	return splitOIDs(p.Metrics, p.MetricTags, nil)
 }
 
+// Clone duplicates this ProfileDefinition
 func (p *ProfileDefinition) Clone() *ProfileDefinition {
 	if p == nil {
 		return nil

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -70,7 +70,7 @@ func (p *ProfileDefinition) Clone() *ProfileDefinition {
 		Metadata:     CloneMap(p.Metadata),
 		MetricTags:   CloneSlice(p.MetricTags),
 		StaticTags:   slices.Clone(p.StaticTags),
-		Metrics:      slices.Clone(p.Metrics),
+		Metrics:      CloneSlice(p.Metrics),
 		Device: DeviceMeta{
 			Vendor: p.Device.Vendor,
 		},

--- a/pkg/networkdevice/profile/profiledefinition/profile_definition.go
+++ b/pkg/networkdevice/profile/profiledefinition/profile_definition.go
@@ -5,6 +5,8 @@
 
 package profiledefinition
 
+import "slices"
+
 // DeviceMeta holds device related static metadata
 // DEPRECATED in favour of profile metadata syntax
 type DeviceMeta struct {
@@ -53,4 +55,24 @@ func (p *ProfileDefinition) SplitOIDs(includeMetadata bool) ([]string, []string)
 		return splitOIDs(p.Metrics, p.MetricTags, p.Metadata)
 	}
 	return splitOIDs(p.Metrics, p.MetricTags, nil)
+}
+
+func (p *ProfileDefinition) Clone() *ProfileDefinition {
+	if p == nil {
+		return nil
+	}
+	return &ProfileDefinition{
+		Name:         p.Name,
+		Description:  p.Description,
+		SysObjectIDs: slices.Clone(p.SysObjectIDs),
+		Extends:      slices.Clone(p.Extends),
+		Metadata:     CloneMap(p.Metadata),
+		MetricTags:   CloneSlice(p.MetricTags),
+		StaticTags:   slices.Clone(p.StaticTags),
+		Metrics:      slices.Clone(p.Metrics),
+		Device: DeviceMeta{
+			Vendor: p.Device.Vendor,
+		},
+		Version: p.Version,
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This adds a `.Clone` method to various profile objects with mutable structures in them, so that we don't need to use the `deepcopy` library.

### Motivation

https://datadoghq.atlassian.net/browse/NDMII-2360

`deepcopy` can't copy private members of objects, so if you `deepcopy` a `regexp.Regexp` you get a new `Regexp` object that panics if you try to use it for anything (because it tries to access an internal structure that's nil).

As a result, we currently can't copy profiles once they've had their regexes compiled.

The `Clone` methods fix that by copying what we need to. Note that regexes are not duplicated (e.g. via `Regexp.Copy`), because regexes in go are immutable except for the largely-obsolete `.Longest()` method, which we never use. A consequence of this is that if we ever do start using `Longest` for some reason we'll need to update the `Clone` logic to duplicate the regexes.

### Describe how you validated your changes
No behavioral changes, only internal adjustments. Behavior is unchanged locally.