### PR TITLE
[NDM] Move validation to profiledefinition

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -31,7 +31,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/configvalidation"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/profile"
 )
 
@@ -460,8 +459,8 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	c.RequestedMetrics = append(c.RequestedMetrics, uptimeMetricConfig)
 	profiledefinition.NormalizeMetrics(c.RequestedMetrics)
 	c.RequestedMetricTags = instance.MetricTags
-	errors := configvalidation.ValidateEnrichMetrics(c.RequestedMetrics)
-	errors = append(errors, configvalidation.ValidateEnrichMetricTags(c.RequestedMetricTags)...)
+	errors := profiledefinition.ValidateEnrichMetrics(c.RequestedMetrics)
+	errors = append(errors, profiledefinition.ValidateEnrichMetricTags(c.RequestedMetricTags)...)
 	if len(errors) > 0 {
 		return nil, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
 	}

--- a/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/profile_resolver.go
@@ -13,8 +13,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/configvalidation"
 )
 
 var (
@@ -46,9 +44,9 @@ func loadResolveProfiles(pConfig ProfileConfigMap, defaultProfiles ProfileConfig
 			continue
 		}
 		profiledefinition.NormalizeMetrics(newProfileConfig.Definition.Metrics)
-		errors := configvalidation.ValidateEnrichMetadata(newProfileConfig.Definition.Metadata)
-		errors = append(errors, configvalidation.ValidateEnrichMetrics(newProfileConfig.Definition.Metrics)...)
-		errors = append(errors, configvalidation.ValidateEnrichMetricTags(newProfileConfig.Definition.MetricTags)...)
+		errors := profiledefinition.ValidateEnrichMetadata(newProfileConfig.Definition.Metadata)
+		errors = append(errors, profiledefinition.ValidateEnrichMetrics(newProfileConfig.Definition.Metrics)...)
+		errors = append(errors, profiledefinition.ValidateEnrichMetricTags(newProfileConfig.Definition.MetricTags)...)
 		if len(errors) > 0 {
 			log.Warnf("validation errors in profile %q: %s", name, strings.Join(errors, "\n"))
 			profileExpVar.Set(name, expvar.Func(func() interface{} {

--- a/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_metrics_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/configvalidation"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 )
 
@@ -646,7 +645,7 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 			mockSender := mocksender.NewMockSender("foo")
 			metricSender := MetricSender{sender: mockSender}
 
-			configvalidation.ValidateEnrichMetricTags(tt.metricsTags)
+			profiledefinition.ValidateEnrichMetricTags(tt.metricsTags)
 			tags := metricSender.GetCheckInstanceMetricTags(tt.metricsTags, tt.values)
 
 			assert.ElementsMatch(t, tt.expectedTags, tags)

--- a/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_utils_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/configvalidation"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/valuestore"
 )
 
@@ -778,7 +777,7 @@ metric_tags:
 			m := profiledefinition.MetricsConfig{}
 			yaml.Unmarshal(tt.rawMetricConfig, &m)
 
-			configvalidation.ValidateEnrichMetrics([]profiledefinition.MetricsConfig{m})
+			profiledefinition.ValidateEnrichMetrics([]profiledefinition.MetricsConfig{m})
 			tags := getTagsFromMetricTagConfigList(m.MetricTags, tt.fullIndex, tt.values)
 
 			assert.ElementsMatch(t, tt.expectedTags, tags)

--- a/pkg/networkdevice/profile/go.mod
+++ b/pkg/networkdevice/profile/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	github.com/invopop/jsonschema v0.12.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
+	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.10.0
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -13,10 +14,12 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/networkdevice/profile/go.sum
+++ b/pkg/networkdevice/profile/go.sum
@@ -2,9 +2,12 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
 github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -23,8 +26,13 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=

--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
@@ -1,0 +1,121 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "normalize_cmd FILE [FILE...]",
+	Short: "Validate and normalize profiles.",
+	Long: `normalize_cmd is a tool for validating and normalizing profiles.
+
+	Each profile file passed in will be parsed, and any errors in them will be
+	reported. If an output directory is specified with -o, then the profiles will
+	also be normalized, migrating legacy and deprecated structures to their
+	modern counterparts, and written to the output directory.`,
+
+	Run: func(cmd *cobra.Command, args []string) {
+		outdir, err := cmd.Flags().GetString("outdir")
+		if err != nil {
+			fmt.Printf("parse failure %v, unable to generate output\n", err)
+		}
+		useJSON, err := cmd.Flags().GetBool("json")
+		if err != nil {
+			fmt.Printf("parse failure %v, unable to generate output\n", err)
+		}
+		for _, filePath := range args {
+			filename := filepath.Base(filePath)
+			name := filename[:len(filename)-len(filepath.Ext(filename))] // remove extension
+			def, errors := GetProfile(filePath)
+			if len(errors) > 0 {
+				fmt.Printf("*** %d error(s) in profile %q ***\n", len(errors), filePath)
+				for _, e := range errors {
+					fmt.Println("  ", e)
+				}
+				fmt.Println()
+				continue
+			}
+			if err := WriteProfile(def, name, outdir, useJSON); err != nil {
+				fmt.Println(err)
+			}
+		}
+	},
+}
+
+func GetProfile(filePath string) (*profiledefinition.ProfileDefinition, []string) {
+	buf, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("unable to read file: %v", err)}
+	}
+	def := profiledefinition.NewProfileDefinition()
+	err = yaml.Unmarshal(buf, def)
+	if err != nil {
+		return nil, []string{fmt.Sprintf("unable to parse profile: %v", err)}
+	}
+	errors := profiledefinition.ValidateEnrichProfile(def)
+	if len(errors) > 0 {
+		return nil, errors
+	}
+	return def, nil
+}
+
+func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir string, useJSON bool) error {
+	if outdir == "" {
+		return nil
+	}
+	var filename string
+	var data []byte
+	if useJSON {
+		var err error
+		filename = name + ".json"
+		data, err = json.Marshal(def)
+		if err != nil {
+			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
+		}
+	} else {
+		var err error
+		data, err = yaml.Marshal(def)
+		filename = name + ".yaml"
+		if err != nil {
+			return fmt.Errorf("unable to marshal profile %s: %w", name, err)
+		}
+	}
+	outfile := filepath.Join(outdir, filename)
+	f, err := os.Create(outfile)
+	if err != nil {
+		return fmt.Errorf("unable to create file %s: %w", outfile, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	_, err = f.Write(data)
+	if err != nil {
+		return fmt.Errorf("unable to write to file %s: %w", outfile, err)
+	}
+	return nil
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.Flags().StringP("outdir", "o", "", "Output path for normalized files. If blank, inputs will be validated but not output.")
+	rootCmd.Flags().BoolP("json", "j", false, "Output as JSON")
+}

--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd/root.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package cmd implements a cobra command for validating and normalizing profiles.
 package cmd
 
 import (
@@ -55,6 +56,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+// GetProfile parses a profile from a file path and validates it.
 func GetProfile(filePath string) (*profiledefinition.ProfileDefinition, []string) {
 	buf, err := os.ReadFile(filePath)
 	if err != nil {
@@ -72,6 +74,7 @@ func GetProfile(filePath string) (*profiledefinition.ProfileDefinition, []string
 	return def, nil
 }
 
+// WriteProfile writes a profile to disk.
 func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir string, useJSON bool) error {
 	if outdir == "" {
 		return nil
@@ -108,6 +111,7 @@ func WriteProfile(def *profiledefinition.ProfileDefinition, name string, outdir 
 	return nil
 }
 
+// Execute runs the command.
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {

--- a/pkg/networkdevice/profile/profiledefinition/normalize_cmd/main.go
+++ b/pkg/networkdevice/profile/profiledefinition/normalize_cmd/main.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package main
+
+import "github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition/normalize_cmd/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/networkdevice/profile/profiledefinition/validation.go
+++ b/pkg/networkdevice/profile/profiledefinition/validation.go
@@ -51,22 +51,23 @@ const (
 func ValidateEnrichProfile(profile *ProfileDefinition) []string {
 	NormalizeMetrics(profile.Metrics)
 	// migrate legacy profile.Device.Vendor to metadata field.
-	if profile.Device.Vendor != "" {
-		dev, ok := profile.Metadata["device"]
-		if !ok {
-			profile.Metadata["device"] = MetadataResourceConfig{
-				Fields: make(map[string]MetadataField),
-			}
-			dev = profile.Metadata["device"]
-		}
-		_, ok = dev.Fields["vendor"]
-		if !ok {
-			dev.Fields["vendor"] = MetadataField{
-				Value: profile.Device.Vendor,
-			}
-		}
-		profile.Device.Vendor = ""
-	}
+	// TODO this is commented out because it changes existing behavior; uncomment when we want to support this properly.
+	// if profile.Device.Vendor != "" {
+	// 	dev, ok := profile.Metadata["device"]
+	// 	if !ok {
+	// 		profile.Metadata["device"] = MetadataResourceConfig{
+	// 			Fields: make(map[string]MetadataField),
+	// 		}
+	// 		dev = profile.Metadata["device"]
+	// 	}
+	// 	_, ok = dev.Fields["vendor"]
+	// 	if !ok {
+	// 		dev.Fields["vendor"] = MetadataField{
+	// 			Value: profile.Device.Vendor,
+	// 		}
+	// 	}
+	// 	profile.Device.Vendor = ""
+	// }
 	errors := ValidateEnrichMetadata(profile.Metadata)
 	errors = append(errors, ValidateEnrichMetrics(profile.Metrics)...)
 	errors = append(errors, ValidateEnrichMetricTags(profile.MetricTags)...)

--- a/pkg/networkdevice/profile/profiledefinition/validation.go
+++ b/pkg/networkdevice/profile/profiledefinition/validation.go
@@ -3,14 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package configvalidation contains validation and enrichment functions
-package configvalidation
+package profiledefinition
 
 import (
 	"fmt"
 	"regexp"
-
-	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
 
 var validMetadataResources = map[string]map[string]bool{
@@ -50,8 +47,8 @@ const (
 	MetadataSymbol
 )
 
-// ValidateEnrichMetricTags validates and enrich metric tags
-func ValidateEnrichMetricTags(metricTags []profiledefinition.MetricTagConfig) []string {
+// ValidateEnrichMetricTags validates and normalizes metric tags
+func ValidateEnrichMetricTags(metricTags []MetricTagConfig) []string {
 	var errors []string
 	for i := range metricTags {
 		errors = append(errors, validateEnrichMetricTag(&metricTags[i])...)
@@ -62,7 +59,7 @@ func ValidateEnrichMetricTags(metricTags []profiledefinition.MetricTagConfig) []
 // ValidateEnrichMetrics will validate MetricsConfig and enrich it.
 // Example of enrichment:
 // - storage of compiled regex pattern
-func ValidateEnrichMetrics(metrics []profiledefinition.MetricsConfig) []string {
+func ValidateEnrichMetrics(metrics []MetricsConfig) []string {
 	var errors []string
 	for i := range metrics {
 		metricConfig := &metrics[i]
@@ -100,7 +97,7 @@ func ValidateEnrichMetrics(metrics []profiledefinition.MetricsConfig) []string {
 }
 
 // ValidateEnrichMetadata will validate MetadataConfig and enrich it.
-func ValidateEnrichMetadata(metadata profiledefinition.MetadataConfig) []string {
+func ValidateEnrichMetadata(metadata MetadataConfig) []string {
 	var errors []string
 	for resName := range metadata {
 		_, isValidRes := validMetadataResources[resName]
@@ -136,7 +133,7 @@ func ValidateEnrichMetadata(metadata profiledefinition.MetadataConfig) []string 
 	return errors
 }
 
-func validateEnrichSymbol(symbol *profiledefinition.SymbolConfig, symbolContext SymbolContext) []string {
+func validateEnrichSymbol(symbol *SymbolConfig, symbolContext SymbolContext) []string {
 	var errors []string
 	if symbol.Name == "" {
 		errors = append(errors, fmt.Sprintf("symbol name missing: name=`%s` oid=`%s`", symbol.Name, symbol.OID))
@@ -172,8 +169,7 @@ func validateEnrichSymbol(symbol *profiledefinition.SymbolConfig, symbolContext 
 	}
 	return errors
 }
-
-func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []string {
+func validateEnrichMetricTag(metricTag *MetricTagConfig) []string {
 	var errors []string
 	if (metricTag.Column.OID != "" || metricTag.Column.Name != "") && (metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "") {
 		errors = append(errors, fmt.Sprintf("metric tag symbol and column cannot be both declared: symbol=%v, column=%v", metricTag.Symbol, metricTag.Column))
@@ -181,8 +177,8 @@ func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []str
 
 	// Move deprecated metricTag.Column to metricTag.Symbol
 	if metricTag.Column.OID != "" || metricTag.Column.Name != "" {
-		metricTag.Symbol = profiledefinition.SymbolConfigCompat(metricTag.Column)
-		metricTag.Column = profiledefinition.SymbolConfig{}
+		metricTag.Symbol = SymbolConfigCompat(metricTag.Column)
+		metricTag.Column = SymbolConfig{}
 	}
 
 	// OID/Name to Symbol harmonization:
@@ -200,9 +196,9 @@ func validateEnrichMetricTag(metricTag *profiledefinition.MetricTagConfig) []str
 		metricTag.OID = ""
 	}
 	if metricTag.Symbol.OID != "" || metricTag.Symbol.Name != "" {
-		symbol := profiledefinition.SymbolConfig(metricTag.Symbol)
+		symbol := SymbolConfig(metricTag.Symbol)
 		errors = append(errors, validateEnrichSymbol(&symbol, MetricTagSymbol)...)
-		metricTag.Symbol = profiledefinition.SymbolConfigCompat(symbol)
+		metricTag.Symbol = SymbolConfigCompat(symbol)
 	}
 	if metricTag.Match != "" {
 		pattern, err := regexp.Compile(metricTag.Match)

--- a/pkg/networkdevice/profile/profiledefinition/validation_test.go
+++ b/pkg/networkdevice/profile/profiledefinition/validation_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package configvalidation
+package profiledefinition
 
 import (
 	"fmt"
@@ -11,45 +11,43 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
 )
 
 func Test_ValidateEnrichMetrics(t *testing.T) {
 	tests := []struct {
 		name            string
-		metrics         []profiledefinition.MetricsConfig
+		metrics         []MetricsConfig
 		expectedErrors  []string
-		expectedMetrics []profiledefinition.MetricsConfig
+		expectedMetrics []MetricsConfig
 	}{
 		{
 			name: "either table symbol or scalar symbol must be provided",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{},
 			},
 			expectedErrors: []string{
 				"either a table symbol or a scalar symbol must be provided",
 			},
-			expectedMetrics: []profiledefinition.MetricsConfig{
+			expectedMetrics: []MetricsConfig{
 				{},
 			},
 		},
 		{
 			name: "table column symbols and scalar symbol cannot be both provided",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						OID:  "1.2",
 						Name: "abc",
 					},
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{},
 					},
 				},
 			},
@@ -59,21 +57,21 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "multiple errors",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{},
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						OID:  "1.2",
 						Name: "abc",
 					},
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{},
 					},
 				},
 			},
@@ -84,9 +82,9 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "missing symbol name",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						OID: "1.2.3",
 					},
 				},
@@ -97,9 +95,9 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "table column symbol name missing",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID: "1.2",
 						},
@@ -107,8 +105,8 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{},
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{},
 					},
 				},
 			},
@@ -119,22 +117,22 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "table external metric column tag symbol error",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID: "1.2.3",
 							},
 						},
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name: "abc",
 							},
 						},
@@ -148,15 +146,15 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "missing MetricTags",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{},
+					MetricTags: MetricTagConfigList{},
 				},
 			},
 			expectedErrors: []string{
@@ -165,22 +163,22 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "table external metric column tag MIB error",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID: "1.2.3",
 							},
 						},
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name: "abc",
 							},
 						},
@@ -194,17 +192,17 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "missing match tags",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:  "1.2.3",
 								Name: "abc",
 							},
@@ -219,17 +217,17 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "match cannot compile regex",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:  "1.2.3",
 								Name: "abc",
 							},
@@ -247,22 +245,22 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "match cannot compile regex",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:  "1.2.3",
 								Name: "abc",
 							},
 							Tag: "hello",
-							IndexTransform: []profiledefinition.MetricIndexTransform{
+							IndexTransform: []MetricIndexTransform{
 								{
 									Start: 2,
 									End:   1,
@@ -278,25 +276,25 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "compiling extract_value",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						OID:          "1.2.3",
 						Name:         "myMetric",
 						ExtractValue: `(\d+)C`,
 					},
 				},
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:          "1.2",
 							Name:         "hey",
 							ExtractValue: `(\d+)C`,
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:          "1.2.3",
 								Name:         "abc",
 								ExtractValue: `(\d+)C`,
@@ -306,9 +304,9 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 					},
 				},
 			},
-			expectedMetrics: []profiledefinition.MetricsConfig{
+			expectedMetrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						OID:                  "1.2.3",
 						Name:                 "myMetric",
 						ExtractValue:         `(\d+)C`,
@@ -316,7 +314,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 					},
 				},
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:                  "1.2",
 							Name:                 "hey",
@@ -324,9 +322,9 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 							ExtractValueCompiled: regexp.MustCompile(`(\d+)C`),
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:                  "1.2.3",
 								Name:                 "abc",
 								ExtractValue:         `(\d+)C`,
@@ -341,9 +339,9 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "error compiling extract_value",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						OID:          "1.2.3",
 						Name:         "myMetric",
 						ExtractValue: "[{",
@@ -356,17 +354,17 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "constant_value_one usage in column symbol",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							Name:             "abc",
 							ConstantValueOne: true,
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name: "abc",
 								OID:  "1.2.3",
 							},
@@ -379,9 +377,9 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "constant_value_one usage in scalar symbol",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						Name:             "myMetric",
 						ConstantValueOne: true,
 					},
@@ -393,9 +391,9 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "constant_value_one usage in scalar symbol with OID",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						OID:              "1.2.3",
 						Name:             "myMetric",
 						ConstantValueOne: true,
@@ -408,17 +406,17 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "constant_value_one usage in metric tags",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name:             "abc",
 								ConstantValueOne: true,
 							},
@@ -434,18 +432,18 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "metric_type usage in column symbol",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							Name:       "abc",
 							OID:        "1.2.3",
-							MetricType: profiledefinition.ProfileMetricTypeCounter,
+							MetricType: ProfileMetricTypeCounter,
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name: "abc",
 								OID:  "1.2.3",
 							},
@@ -458,12 +456,12 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "metric_type usage in scalar symbol",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbol: profiledefinition.SymbolConfig{
+					Symbol: SymbolConfig{
 						Name:       "abc",
 						OID:        "1.2.3",
-						MetricType: profiledefinition.ProfileMetricTypeCounter,
+						MetricType: ProfileMetricTypeCounter,
 					},
 				},
 			},
@@ -471,20 +469,20 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "ERROR metric_type usage in metric_tags",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							Name: "abc",
 							OID:  "1.2.3",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name:       "abc",
 								OID:        "1.2.3",
-								MetricType: profiledefinition.ProfileMetricTypeCounter,
+								MetricType: ProfileMetricTypeCounter,
 							},
 							Tag: "hello",
 						},
@@ -497,18 +495,18 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "metric root forced_type converted to metric_type",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					ForcedType: profiledefinition.ProfileMetricTypeCounter,
-					Symbols: []profiledefinition.SymbolConfig{
+					ForcedType: ProfileMetricTypeCounter,
+					Symbols: []SymbolConfig{
 						{
 							Name: "abc",
 							OID:  "1.2.3",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name: "abc",
 								OID:  "1.2.3",
 							},
@@ -517,18 +515,18 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 					},
 				},
 			},
-			expectedMetrics: []profiledefinition.MetricsConfig{
+			expectedMetrics: []MetricsConfig{
 				{
-					MetricType: profiledefinition.ProfileMetricTypeCounter,
-					Symbols: []profiledefinition.SymbolConfig{
+					MetricType: ProfileMetricTypeCounter,
+					Symbols: []SymbolConfig{
 						{
 							Name: "abc",
 							OID:  "1.2.3",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								Name: "abc",
 								OID:  "1.2.3",
 							},
@@ -540,17 +538,17 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 		},
 		{
 			name: "mapping used without tag",
-			metrics: []profiledefinition.MetricsConfig{
+			metrics: []MetricsConfig{
 				{
-					Symbols: []profiledefinition.SymbolConfig{
+					Symbols: []SymbolConfig{
 						{
 							OID:  "1.2",
 							Name: "abc",
 						},
 					},
-					MetricTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					MetricTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:  "1.2",
 								Name: "abc",
 							},
@@ -562,7 +560,7 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 					},
 				},
 			},
-			expectedErrors: []string{"``tag` must be provided if `mapping` (`map[1:abc 2:def]`) is defined"},
+			expectedErrors: []string{"`tag` must be provided if `mapping` (`map[1:abc 2:def]`) is defined"},
 		},
 	}
 	for _, tt := range tests {
@@ -582,23 +580,23 @@ func Test_ValidateEnrichMetrics(t *testing.T) {
 func Test_ValidateEnrichMetricTags(t *testing.T) {
 	tests := []struct {
 		name            string
-		metrics         []profiledefinition.MetricTagConfig
+		metrics         []MetricTagConfig
 		expectedErrors  []string
-		expectedMetrics []profiledefinition.MetricTagConfig
+		expectedMetrics []MetricTagConfig
 	}{
 		{
 			name: "Move OID to Symbol",
-			metrics: []profiledefinition.MetricTagConfig{
+			metrics: []MetricTagConfig{
 				{
 					OID: "1.2.3.4",
-					Symbol: profiledefinition.SymbolConfigCompat{
+					Symbol: SymbolConfigCompat{
 						Name: "mySymbol",
 					},
 				},
 			},
-			expectedMetrics: []profiledefinition.MetricTagConfig{
+			expectedMetrics: []MetricTagConfig{
 				{
-					Symbol: profiledefinition.SymbolConfigCompat{
+					Symbol: SymbolConfigCompat{
 						OID:  "1.2.3.4",
 						Name: "mySymbol",
 					},
@@ -607,10 +605,10 @@ func Test_ValidateEnrichMetricTags(t *testing.T) {
 		},
 		{
 			name: "Metric tag OID and symbol.OID cannot be both declared",
-			metrics: []profiledefinition.MetricTagConfig{
+			metrics: []MetricTagConfig{
 				{
 					OID: "1.2.3.4",
-					Symbol: profiledefinition.SymbolConfigCompat{
+					Symbol: SymbolConfigCompat{
 						OID:  "1.2.3.5",
 						Name: "mySymbol",
 					},
@@ -622,13 +620,13 @@ func Test_ValidateEnrichMetricTags(t *testing.T) {
 		},
 		{
 			name: "metric tag symbol and column cannot be both declared",
-			metrics: []profiledefinition.MetricTagConfig{
+			metrics: []MetricTagConfig{
 				{
-					Symbol: profiledefinition.SymbolConfigCompat{
+					Symbol: SymbolConfigCompat{
 						OID:  "1.2.3.5",
 						Name: "mySymbol",
 					},
-					Column: profiledefinition.SymbolConfig{
+					Column: SymbolConfig{
 						OID:  "1.2.3.5",
 						Name: "mySymbol",
 					},
@@ -640,9 +638,9 @@ func Test_ValidateEnrichMetricTags(t *testing.T) {
 		},
 		{
 			name: "Missing OID",
-			metrics: []profiledefinition.MetricTagConfig{
+			metrics: []MetricTagConfig{
 				{
-					Symbol: profiledefinition.SymbolConfigCompat{
+					Symbol: SymbolConfigCompat{
 						Name: "mySymbol",
 					},
 				},
@@ -669,18 +667,18 @@ func Test_ValidateEnrichMetricTags(t *testing.T) {
 func Test_validateEnrichMetadata(t *testing.T) {
 	tests := []struct {
 		name             string
-		metadata         profiledefinition.MetadataConfig
+		metadata         MetadataConfig
 		expectedErrors   []string
-		expectedMetadata profiledefinition.MetadataConfig
+		expectedMetadata MetadataConfig
 	}{
 		{
 			name: "both field symbol and value can be provided",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
 							Value: "hey",
-							Symbol: profiledefinition.SymbolConfig{
+							Symbol: SymbolConfig{
 								OID:  "1.2.3",
 								Name: "someSymbol",
 							},
@@ -688,12 +686,12 @@ func Test_validateEnrichMetadata(t *testing.T) {
 					},
 				},
 			},
-			expectedMetadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			expectedMetadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
 							Value: "hey",
-							Symbol: profiledefinition.SymbolConfig{
+							Symbol: SymbolConfig{
 								OID:  "1.2.3",
 								Name: "someSymbol",
 							},
@@ -704,11 +702,11 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		},
 		{
 			name: "invalid regex pattern for symbol",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
-							Symbol: profiledefinition.SymbolConfig{
+							Symbol: SymbolConfig{
 								OID:          "1.2.3",
 								Name:         "someSymbol",
 								ExtractValue: "(\\w[)",
@@ -723,11 +721,11 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		},
 		{
 			name: "invalid regex pattern for multiple symbols",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
-							Symbols: []profiledefinition.SymbolConfig{
+							Symbols: []SymbolConfig{
 								{
 									OID:          "1.2.3",
 									Name:         "someSymbol",
@@ -744,11 +742,11 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		},
 		{
 			name: "field regex pattern is compiled",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
-							Symbol: profiledefinition.SymbolConfig{
+							Symbol: SymbolConfig{
 								OID:          "1.2.3",
 								Name:         "someSymbol",
 								ExtractValue: "(\\w)",
@@ -758,11 +756,11 @@ func Test_validateEnrichMetadata(t *testing.T) {
 				},
 			},
 			expectedErrors: []string{},
-			expectedMetadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			expectedMetadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
-							Symbol: profiledefinition.SymbolConfig{
+							Symbol: SymbolConfig{
 								OID:                  "1.2.3",
 								Name:                 "someSymbol",
 								ExtractValue:         "(\\w)",
@@ -775,9 +773,9 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		},
 		{
 			name: "invalid resource",
-			metadata: profiledefinition.MetadataConfig{
-				"invalid-res": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"invalid-res": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
 							Value: "hey",
 						},
@@ -790,9 +788,9 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		},
 		{
 			name: "invalid field",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"invalid-field": {
 							Value: "hey",
 						},
@@ -805,16 +803,16 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		},
 		{
 			name: "invalid idtags",
-			metadata: profiledefinition.MetadataConfig{
-				"interface": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"interface": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"invalid-field": {
 							Value: "hey",
 						},
 					},
-					IDTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					IDTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:  "1.2.3",
 								Name: "abc",
 							},
@@ -833,16 +831,16 @@ func Test_validateEnrichMetadata(t *testing.T) {
 		},
 		{
 			name: "device resource does not support id_tags",
-			metadata: profiledefinition.MetadataConfig{
-				"device": profiledefinition.MetadataResourceConfig{
-					Fields: map[string]profiledefinition.MetadataField{
+			metadata: MetadataConfig{
+				"device": MetadataResourceConfig{
+					Fields: map[string]MetadataField{
 						"name": {
 							Value: "hey",
 						},
 					},
-					IDTags: profiledefinition.MetricTagConfigList{
-						profiledefinition.MetricTagConfig{
-							Symbol: profiledefinition.SymbolConfigCompat{
+					IDTags: MetricTagConfigList{
+						MetricTagConfig{
+							Symbol: SymbolConfigCompat{
 								OID:  "1.2.3",
 								Name: "abc",
 							},


### PR DESCRIPTION
### What does this PR do?

This moves some validation code out of the snmp check's internal package and into the shared profiledefinition package, so that it can be used by other packages.

It also adds a CLI tool to validate and normalize profiles.

### Motivation

We need to be able to load and normalize profiles in code that won't live in the snmp internals.

https://datadoghq.atlassian.net/browse/NDMII-2360

### Describe how you validated your changes
The check behavior doesn't change; tests pass and local agent runs are unchanged.