### PR TITLE
omnibus: fips-provider: use the same build env as other recipes

### DIFF
--- a/omnibus/config/software/openssl-fips-provider.rb
+++ b/omnibus/config/software/openssl-fips-provider.rb
@@ -22,14 +22,15 @@ source url: "https://www.openssl.org/source/#{OPENSSL_FIPS_MODULE_FILENAME}",
 relative_path "openssl-#{OPENSSL_FIPS_MODULE_VERSION}"
 
 build do
+    env = with_standard_compiler_flags()
     # Exact build steps from security policy:
     # https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4282.pdf
     #
     # ---------------- DO NOT MODIFY LINES BELOW HERE ----------------
-    command "./Configure enable-fips"
+    command "./Configure enable-fips", env: env
 
-    command "make"
-    command "make install"
+    command "make", env: env
+    command "make install", env: env
     # ---------------- DO NOT MODIFY LINES ABOVE HERE ----------------
 
     mkdir "#{install_dir}/embedded/ssl"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Provide the same build environment as other recipes

### Motivation

Our current FIPS provider build are built with the default compiler, which makes the fips provider depend on the glibc version used by the build image distribution (2.34 in this case)
This change ensures we use the correct toolchain, which targets our minimally supported versions (2.17 for x86, 2.23 for arm64)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->