### PR TITLE
Switch to ddebpf.Manager in consumer_test.go and related files

### DIFF
--- a/pkg/network/protocols/events/consumer.go
+++ b/pkg/network/protocols/events/consumer.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"unsafe"
 
-	manager "github.com/DataDog/ebpf-manager"
-
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
@@ -57,9 +55,9 @@ type Consumer[V any] struct {
 // `callback` is executed once for every "event" generated on eBPF and must:
 // 1) copy the data it wishes to hold since the underlying byte array is reclaimed;
 // 2) be thread-safe, as the callback may be executed concurrently from multiple go-routines;
-func NewConsumer[V any](proto string, ebpf *manager.Manager, callback func([]V)) (*Consumer[V], error) {
+func NewConsumer[V any](proto string, ebpf *ddebpf.Manager, callback func([]V)) (*Consumer[V], error) {
 	batchMapName := proto + batchMapSuffix
-	batchMap, err := maps.GetMap[batchKey, batch](ebpf, batchMapName)
+	batchMap, err := maps.GetMap[batchKey, batch](ebpf.Manager, batchMapName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find map %s: %s", batchMapName, err)
 	}

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -212,7 +212,7 @@ func newEBPFProgram(c *config.Config) (*ddebpf.Manager, error) {
 	ddEbpfManager := ddebpf.NewManager(m, "usm", &ebpftelemetry.ErrorsTelemetryModifier{})
 
 	Configure(config.New(), "test", ddEbpfManager.Manager, &options)
-	err = m.InitWithOptions(bc, options)
+	err = ddEbpfManager.InitWithOptions(bc, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -54,7 +54,7 @@ func TestConsumer(t *testing.T) {
 		}
 	}
 
-	consumer, err := NewConsumer("test", program.Manager, callback)
+	consumer, err := NewConsumer("test", program, callback)
 	require.NoError(t, err)
 	consumer.Start()
 
@@ -62,7 +62,7 @@ func TestConsumer(t *testing.T) {
 	require.NoError(t, err)
 
 	// generate test events
-	generator := newEventGenerator(program.Manager, t)
+	generator := newEventGenerator(program, t)
 	for i := 0; i < numEvents; i++ {
 		generator.Generate(uint64(i))
 	}
@@ -93,7 +93,7 @@ func TestInvalidBatchCountMetric(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { program.Stop(manager.CleanAll) })
 
-	consumer, err := NewConsumer("test", program.Manager, func([]uint64) {})
+	consumer, err := NewConsumer("test", program, func([]uint64) {})
 	require.NoError(t, err)
 
 	// We are creating a raw sample with a data length of 4, which is smaller than sizeOfBatch
@@ -132,7 +132,7 @@ func recordSample(c *config.Config, consumer *Consumer[uint64], sampleData []byt
 	}
 }
 
-func newEventGenerator(program *manager.Manager, t *testing.T) *eventGenerator {
+func newEventGenerator(program *ddebpf.Manager, t *testing.T) *eventGenerator {
 	m, _, _ := program.GetMap("test")
 	require.NotNilf(t, m, "couldn't find test map")
 
@@ -211,7 +211,7 @@ func newEBPFProgram(c *config.Config) (*ddebpf.Manager, error) {
 
 	ddEbpfManager := ddebpf.NewManager(m, "usm", &ebpftelemetry.ErrorsTelemetryModifier{})
 
-	Configure(config.New(), "test", ddEbpfManager.Manager, &options)
+	Configure(config.New(), "test", ddEbpfManager, &options)
 	err = ddEbpfManager.InitWithOptions(bc, &options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Replaces manager.Manager with ddebpf.Manager in consumer_test.go and related files.

### Motivation
[This PR](https://github.com/DataDog/datadog-agent/pull/32358) is failing due to the missing usage of the ddebpf.Manager object in consumer_test.go.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->