### PR TITLE
[CWS] Make the ebpf rate-limiter generic and use it for ptrace

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/activity_dump.h
+++ b/pkg/security/ebpf/c/include/helpers/activity_dump.h
@@ -10,6 +10,7 @@
 #include "container.h"
 #include "events.h"
 #include "process.h"
+#include "rate_limiter.h"
 
 __attribute__((always_inline)) struct activity_dump_config *lookup_or_delete_traced_pid(u32 pid, u64 now, u64 *cookie) {
     if (cookie == NULL) {
@@ -244,127 +245,6 @@ __attribute__((always_inline)) void cleanup_traced_state(u32 pid) {
     bpf_map_delete_elem(&traced_pids, &pid);
 }
 
-enum rate_limiter_algo_ids
-{
-    RL_ALGO_BASIC = 0,
-    RL_ALGO_BASIC_HALF,
-    RL_ALGO_DECREASING_DROPRATE,
-    RL_ALGO_INCREASING_DROPRATE,
-    RL_ALGO_TOTAL_NUMBER,
-};
-
-__attribute__((always_inline)) u8 activity_dump_rate_limiter_reset_period(u64 now, struct activity_dump_rate_limiter_ctx *rate_ctx_p) {
-    rate_ctx_p->current_period = now;
-    rate_ctx_p->counter = 0;
-#ifndef __BALOUM__ // do not change algo during unit tests
-    rate_ctx_p->algo_id = now % RL_ALGO_TOTAL_NUMBER;
-#endif /* __BALOUM__ */
-    return 1;
-}
-
-__attribute__((always_inline)) u8 activity_dump_rate_limiter_allow_basic(struct activity_dump_config *config, u64 now, struct activity_dump_rate_limiter_ctx *rate_ctx_p, u64 delta) {
-    if (delta > 1000000000) { // if more than 1 sec ellapsed we reset the period
-        return activity_dump_rate_limiter_reset_period(now, rate_ctx_p);
-    }
-
-    if (rate_ctx_p->counter >= config->events_rate) { // if we already allowed more than rate
-        return 0;
-    } else {
-        return 1;
-    }
-}
-
-__attribute__((always_inline)) u8 activity_dump_rate_limiter_allow_basic_half(struct activity_dump_config *config, u64 now, struct activity_dump_rate_limiter_ctx *rate_ctx_p, u64 delta) {
-    if (delta > 1000000000 / 2) { // if more than 0.5 sec ellapsed we reset the period
-        return activity_dump_rate_limiter_reset_period(now, rate_ctx_p);
-    }
-
-    if (rate_ctx_p->counter >= config->events_rate / 2) { // if we already allowed more than rate / 2
-        return 0;
-    } else {
-        return 1;
-    }
-}
-
-__attribute__((always_inline)) u8 activity_dump_rate_limiter_allow_decreasing_droprate(struct activity_dump_config *config, u64 now, struct activity_dump_rate_limiter_ctx *rate_ctx_p, u64 delta) {
-    if (delta > 1000000000) { // if more than 1 sec ellapsed we reset the period
-        return activity_dump_rate_limiter_reset_period(now, rate_ctx_p);
-    }
-
-    if (rate_ctx_p->counter >= config->events_rate) { // if we already allowed more than rate
-        return 0;
-    } else if (rate_ctx_p->counter < (config->events_rate / 4)) { // first 1/4 is not rate limited
-        return 1;
-    }
-
-    // if we are between rate / 4 and rate, apply a decreasing rate of:
-    // (counter * 100) / (rate) %
-    else if (now % ((rate_ctx_p->counter * 100) / config->events_rate) == 0) {
-        return 1;
-    }
-    return 0;
-}
-
-__attribute__((always_inline)) u8 activity_dump_rate_limiter_allow_increasing_droprate(struct activity_dump_config *config, u64 now, struct activity_dump_rate_limiter_ctx *rate_ctx_p, u64 delta) {
-    if (delta > 1000000000) { // if more than 1 sec ellapsed we reset the period
-        return activity_dump_rate_limiter_reset_period(now, rate_ctx_p);
-    }
-
-    if (rate_ctx_p->counter >= config->events_rate) { // if we already allowed more than rate
-        return 0;
-    } else if (rate_ctx_p->counter < (config->events_rate / 4)) { // first 1/4 is not rate limited
-        return 1;
-    }
-
-    // if we are between rate / 4 and rate, apply an increasing rate of:
-    // 100 - ((counter * 100) / (rate)) %
-    else if (now % (100 - ((rate_ctx_p->counter * 100) / config->events_rate)) == 0) {
-        return 1;
-    }
-    return 0;
-}
-
-__attribute__((always_inline)) u8 activity_dump_rate_limiter_allow(struct activity_dump_config *config, u64 cookie, u64 now, u8 should_count) {
-    struct activity_dump_rate_limiter_ctx *rate_ctx_p = bpf_map_lookup_elem(&activity_dump_rate_limiters, &cookie);
-    if (rate_ctx_p == NULL) {
-        struct activity_dump_rate_limiter_ctx rate_ctx = {
-            .current_period = now,
-            .counter = should_count,
-            .algo_id = now % RL_ALGO_TOTAL_NUMBER,
-        };
-        bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &rate_ctx, BPF_ANY);
-        return 1;
-    }
-
-    if (now < rate_ctx_p->current_period) { // this should never happen, ignore
-        return 0;
-    }
-    u64 delta = now - rate_ctx_p->current_period;
-
-    u8 allow;
-    switch (rate_ctx_p->algo_id) {
-    case RL_ALGO_BASIC:
-        allow = activity_dump_rate_limiter_allow_basic(config, now, rate_ctx_p, delta);
-        break;
-    case RL_ALGO_BASIC_HALF:
-        allow = activity_dump_rate_limiter_allow_basic_half(config, now, rate_ctx_p, delta);
-        break;
-    case RL_ALGO_DECREASING_DROPRATE:
-        allow = activity_dump_rate_limiter_allow_decreasing_droprate(config, now, rate_ctx_p, delta);
-        break;
-    case RL_ALGO_INCREASING_DROPRATE:
-        allow = activity_dump_rate_limiter_allow_increasing_droprate(config, now, rate_ctx_p, delta);
-        break;
-    default: // should never happen, ignore
-        return 0;
-    }
-
-    if (allow && should_count) {
-        __sync_fetch_and_add(&rate_ctx_p->counter, 1);
-    }
-    return (allow);
-}
-
 __attribute__((always_inline)) u32 is_activity_dump_running(void *ctx, u32 pid, u64 now, u32 event_type) {
     u64 cookie = 0;
     struct activity_dump_config *config = NULL;
@@ -399,7 +279,7 @@ __attribute__((always_inline)) u32 is_activity_dump_running(void *ctx, u32 pid, 
         return 0;
     }
 
-    if (!activity_dump_rate_limiter_allow(config, cookie, now, 1)) {
+    if (!activity_dump_rate_limiter_allow(config->events_rate, cookie, now, 1)) {
         return 0;
     }
 

--- a/pkg/security/ebpf/c/include/helpers/approvers.h
+++ b/pkg/security/ebpf/c/include/helpers/approvers.h
@@ -3,6 +3,7 @@
 
 #include "constants/enums.h"
 #include "maps.h"
+#include "rate_limiter.h"
 
 void __attribute__((always_inline)) monitor_event_approved(u64 event_type, u32 approver_type) {
     struct bpf_map_def *approver_stats = select_buffer(&fb_approver_stats, &bb_approver_stats, APPROVER_MONITOR_KEY);
@@ -355,7 +356,7 @@ enum SYSCALL_STATE __attribute__((always_inline)) approve_syscall(struct syscall
         struct activity_dump_config *config = lookup_or_delete_traced_pid(tgid, now, cookie);
         if (config != NULL) {
             // is this event type traced ?
-            if (mask_has_event(config->event_mask, syscall->type) && activity_dump_rate_limiter_allow(config, *cookie, now, 0)) {
+            if (mask_has_event(config->event_mask, syscall->type) && activity_dump_rate_limiter_allow(config->events_rate, *cookie, now, 0)) {
                 if (syscall->state == DISCARDED) {
                     syscall->resolver.flags |= SAVED_BY_ACTIVITY_DUMP;
                 }

--- a/pkg/security/ebpf/c/include/helpers/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/helpers/rate_limiter.h
@@ -1,0 +1,165 @@
+#ifndef _RATE_LIMITER_H_
+#define _RATE_LIMITER_H_
+
+#include "maps.h"
+#include "constants/macros.h"
+#include "structs/rate_limiter.h"
+
+enum rate_limiter_algo_ids
+{
+    RL_ALGO_BASIC = 0,
+    RL_ALGO_BASIC_HALF,
+    RL_ALGO_DECREASING_DROPRATE,
+    RL_ALGO_INCREASING_DROPRATE,
+    RL_ALGO_TOTAL_NUMBER,
+};
+
+__attribute__((always_inline)) u8 rate_limiter_reset_period(u64 now, struct rate_limiter_ctx *rate_ctx_p) {
+    rate_ctx_p->current_period = now;
+    rate_ctx_p->counter = 0;
+#ifndef __BALOUM__ // do not change algo during unit tests
+    rate_ctx_p->algo_id = now % RL_ALGO_TOTAL_NUMBER;
+#endif /* __BALOUM__ */
+    return 1;
+}
+
+__attribute__((always_inline)) u8 rate_limiter_allow_basic(u32 rate, u64 now, struct rate_limiter_ctx *rate_ctx_p, u64 delta) {
+    if (delta > SEC_TO_NS(1)) { // if more than 1 sec ellapsed we reset the period
+        return rate_limiter_reset_period(now, rate_ctx_p);
+    }
+
+    if (rate_ctx_p->counter >= rate) { // if we already allowed more than rate
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+__attribute__((always_inline)) u8 rate_limiter_allow_basic_half(u32 rate, u64 now, struct rate_limiter_ctx *rate_ctx_p, u64 delta) {
+    if (delta > SEC_TO_NS(1) / 2) { // if more than 0.5 sec ellapsed we reset the period
+        return rate_limiter_reset_period(now, rate_ctx_p);
+    }
+
+    if (rate_ctx_p->counter >= rate / 2) { // if we already allowed more than rate / 2
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+__attribute__((always_inline)) u8 rate_limiter_allow_decreasing_droprate(u32 rate, u64 now, struct rate_limiter_ctx *rate_ctx_p, u64 delta) {
+    if (delta > SEC_TO_NS(1)) { // if more than 1 sec ellapsed we reset the period
+        return rate_limiter_reset_period(now, rate_ctx_p);
+    }
+
+    if (rate_ctx_p->counter >= rate) { // if we already allowed more than rate
+        return 0;
+    } else if (rate_ctx_p->counter < (rate / 4)) { // first 1/4 is not rate limited
+        return 1;
+    }
+
+    // if we are between rate / 4 and rate, apply a decreasing rate of:
+    // (counter * 100) / (rate) %
+    else if (now % ((rate_ctx_p->counter * 100) / rate) == 0) {
+        return 1;
+    }
+    return 0;
+}
+
+__attribute__((always_inline)) u8 rate_limiter_allow_increasing_droprate(u32 rate, u64 now, struct rate_limiter_ctx *rate_ctx_p, u64 delta) {
+    if (delta > SEC_TO_NS(1)) { // if more than 1 sec ellapsed we reset the period
+        return rate_limiter_reset_period(now, rate_ctx_p);
+    }
+
+    if (rate_ctx_p->counter >= rate) { // if we already allowed more than rate
+        return 0;
+    } else if (rate_ctx_p->counter < (rate / 4)) { // first 1/4 is not rate limited
+        return 1;
+    }
+
+    // if we are between rate / 4 and rate, apply an increasing rate of:
+    // 100 - ((counter * 100) / (rate)) %
+    else if (now % (100 - ((rate_ctx_p->counter * 100) / rate)) == 0) {
+        return 1;
+    }
+    return 0;
+}
+
+__attribute__((always_inline)) u8 rate_limiter_allow_gen(struct rate_limiter_ctx *rate_ctx_p, u32 rate, u64 now, u8 should_count) {
+    if (now < rate_ctx_p->current_period) { // this should never happen, ignore
+        return 0;
+    }
+    u64 delta = now - rate_ctx_p->current_period;
+
+    u8 allow;
+    switch (rate_ctx_p->algo_id) {
+    case RL_ALGO_BASIC:
+        allow = rate_limiter_allow_basic(rate, now, rate_ctx_p, delta);
+        break;
+    case RL_ALGO_BASIC_HALF:
+        allow = rate_limiter_allow_basic_half(rate, now, rate_ctx_p, delta);
+        break;
+    case RL_ALGO_DECREASING_DROPRATE:
+        allow = rate_limiter_allow_decreasing_droprate(rate, now, rate_ctx_p, delta);
+        break;
+    case RL_ALGO_INCREASING_DROPRATE:
+        allow = rate_limiter_allow_increasing_droprate(rate, now, rate_ctx_p, delta);
+        break;
+    default: // should never happen, ignore
+        return 0;
+    }
+
+    if (allow && should_count) {
+        __sync_fetch_and_add(&rate_ctx_p->counter, 1);
+    }
+    return (allow);
+}
+
+// For now the generic rate is staticaly defined
+// TODO: put it configurable
+#define GENERIC_RATE_LIMITER_RATE 100
+
+__attribute__((always_inline)) u8 rate_limiter_allow(u32 pid, u64 now, u8 should_count) {
+    if (now == 0) {
+        now = bpf_ktime_get_ns();
+    }
+    if (pid == 0) {
+        pid = bpf_get_current_pid_tgid() >> 32;
+    }
+
+    struct rate_limiter_ctx *rate_ctx_p = bpf_map_lookup_elem(&rate_limiters, &pid);
+    if (rate_ctx_p == NULL) {
+        struct rate_limiter_ctx rate_ctx = {
+            .current_period = now,
+            .counter = should_count,
+            .algo_id = now % RL_ALGO_TOTAL_NUMBER,
+        };
+        bpf_map_update_elem(&rate_limiters, &pid, &rate_ctx, BPF_ANY);
+        return 1;
+    }
+
+    u32 rate = GENERIC_RATE_LIMITER_RATE;
+    return rate_limiter_allow_gen(rate_ctx_p, rate, now, should_count);
+}
+#define rate_limiter_allow_simple() rate_limiter_allow(0, 0, 1)
+
+__attribute__((always_inline)) u8 activity_dump_rate_limiter_allow(u32 rate, u64 cookie, u64 now, u8 should_count) {
+    if (now == 0) {
+        now = bpf_ktime_get_ns();
+    }
+
+    struct rate_limiter_ctx *rate_ctx_p = bpf_map_lookup_elem(&activity_dump_rate_limiters, &cookie);
+    if (rate_ctx_p == NULL) {
+        struct rate_limiter_ctx rate_ctx = {
+            .current_period = now,
+            .counter = should_count,
+            .algo_id = now % RL_ALGO_TOTAL_NUMBER,
+        };
+        bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &rate_ctx, BPF_ANY);
+        return 1;
+    }
+
+    return rate_limiter_allow_gen(rate_ctx_p, rate, now, should_count);
+}
+
+#endif /* _RATE_LIMITER_H_ */

--- a/pkg/security/ebpf/c/include/helpers/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/helpers/rate_limiter.h
@@ -5,21 +5,9 @@
 #include "constants/macros.h"
 #include "structs/rate_limiter.h"
 
-enum rate_limiter_algo_ids
-{
-    RL_ALGO_BASIC = 0,
-    RL_ALGO_BASIC_HALF,
-    RL_ALGO_DECREASING_DROPRATE,
-    RL_ALGO_INCREASING_DROPRATE,
-    RL_ALGO_TOTAL_NUMBER,
-};
-
 __attribute__((always_inline)) u8 rate_limiter_reset_period(u64 now, struct rate_limiter_ctx *rate_ctx_p) {
     rate_ctx_p->current_period = now;
     rate_ctx_p->counter = 0;
-#ifndef __BALOUM__ // do not change algo during unit tests
-    rate_ctx_p->algo_id = now % RL_ALGO_TOTAL_NUMBER;
-#endif /* __BALOUM__ */
     return 1;
 }
 
@@ -35,80 +23,12 @@ __attribute__((always_inline)) u8 rate_limiter_allow_basic(u32 rate, u64 now, st
     }
 }
 
-__attribute__((always_inline)) u8 rate_limiter_allow_basic_half(u32 rate, u64 now, struct rate_limiter_ctx *rate_ctx_p, u64 delta) {
-    if (delta > SEC_TO_NS(1) / 2) { // if more than 0.5 sec ellapsed we reset the period
-        return rate_limiter_reset_period(now, rate_ctx_p);
-    }
-
-    if (rate_ctx_p->counter >= rate / 2) { // if we already allowed more than rate / 2
-        return 0;
-    } else {
-        return 1;
-    }
-}
-
-__attribute__((always_inline)) u8 rate_limiter_allow_decreasing_droprate(u32 rate, u64 now, struct rate_limiter_ctx *rate_ctx_p, u64 delta) {
-    if (delta > SEC_TO_NS(1)) { // if more than 1 sec ellapsed we reset the period
-        return rate_limiter_reset_period(now, rate_ctx_p);
-    }
-
-    if (rate_ctx_p->counter >= rate) { // if we already allowed more than rate
-        return 0;
-    } else if (rate_ctx_p->counter < (rate / 4)) { // first 1/4 is not rate limited
-        return 1;
-    }
-
-    // if we are between rate / 4 and rate, apply a decreasing rate of:
-    // (counter * 100) / (rate) %
-    else if (now % ((rate_ctx_p->counter * 100) / rate) == 0) {
-        return 1;
-    }
-    return 0;
-}
-
-__attribute__((always_inline)) u8 rate_limiter_allow_increasing_droprate(u32 rate, u64 now, struct rate_limiter_ctx *rate_ctx_p, u64 delta) {
-    if (delta > SEC_TO_NS(1)) { // if more than 1 sec ellapsed we reset the period
-        return rate_limiter_reset_period(now, rate_ctx_p);
-    }
-
-    if (rate_ctx_p->counter >= rate) { // if we already allowed more than rate
-        return 0;
-    } else if (rate_ctx_p->counter < (rate / 4)) { // first 1/4 is not rate limited
-        return 1;
-    }
-
-    // if we are between rate / 4 and rate, apply an increasing rate of:
-    // 100 - ((counter * 100) / (rate)) %
-    else if (now % (100 - ((rate_ctx_p->counter * 100) / rate)) == 0) {
-        return 1;
-    }
-    return 0;
-}
-
 __attribute__((always_inline)) u8 rate_limiter_allow_gen(struct rate_limiter_ctx *rate_ctx_p, u32 rate, u64 now, u8 should_count) {
     if (now < rate_ctx_p->current_period) { // this should never happen, ignore
         return 0;
     }
     u64 delta = now - rate_ctx_p->current_period;
-
-    u8 allow;
-    switch (rate_ctx_p->algo_id) {
-    case RL_ALGO_BASIC:
-        allow = rate_limiter_allow_basic(rate, now, rate_ctx_p, delta);
-        break;
-    case RL_ALGO_BASIC_HALF:
-        allow = rate_limiter_allow_basic_half(rate, now, rate_ctx_p, delta);
-        break;
-    case RL_ALGO_DECREASING_DROPRATE:
-        allow = rate_limiter_allow_decreasing_droprate(rate, now, rate_ctx_p, delta);
-        break;
-    case RL_ALGO_INCREASING_DROPRATE:
-        allow = rate_limiter_allow_increasing_droprate(rate, now, rate_ctx_p, delta);
-        break;
-    default: // should never happen, ignore
-        return 0;
-    }
-
+    u8 allow = rate_limiter_allow_basic(rate, now, rate_ctx_p, delta);
     if (allow && should_count) {
         __sync_fetch_and_add(&rate_ctx_p->counter, 1);
     }
@@ -132,7 +52,6 @@ __attribute__((always_inline)) u8 rate_limiter_allow(u32 pid, u64 now, u8 should
         struct rate_limiter_ctx rate_ctx = {
             .current_period = now,
             .counter = should_count,
-            .algo_id = now % RL_ALGO_TOTAL_NUMBER,
         };
         bpf_map_update_elem(&rate_limiters, &pid, &rate_ctx, BPF_ANY);
         return 1;
@@ -153,7 +72,6 @@ __attribute__((always_inline)) u8 activity_dump_rate_limiter_allow(u32 rate, u64
         struct rate_limiter_ctx rate_ctx = {
             .current_period = now,
             .counter = should_count,
-            .algo_id = now % RL_ALGO_TOTAL_NUMBER,
         };
         bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &rate_ctx, BPF_ANY);
         return 1;

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -41,7 +41,8 @@ BPF_HASH_MAP(secprofs_syscalls, u64, struct security_profile_syscalls_t, 1) // m
 BPF_HASH_MAP(auid_approvers, u32, struct event_mask_filter_t, 128)
 BPF_HASH_MAP(auid_range_approvers, u32, struct u32_range_filter_t, EVENT_MAX)
 
-BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct activity_dump_rate_limiter_ctx, 1) // max entries will be overridden at runtime
+BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
+BPF_LRU_MAP(rate_limiters, u32, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)
 BPF_LRU_MAP(bpf_maps, u32, struct bpf_map_t, 4096)
 BPF_LRU_MAP(bpf_progs, u32, struct bpf_prog_t, 4096)

--- a/pkg/security/ebpf/c/include/structs/activity_dump.h
+++ b/pkg/security/ebpf/c/include/structs/activity_dump.h
@@ -1,13 +1,6 @@
 #ifndef _STRUCTS_ACTIVITY_DUMP_H_
 #define _STRUCTS_ACTIVITY_DUMP_H_
 
-struct activity_dump_rate_limiter_ctx {
-    u64 current_period;
-    u32 counter;
-    u8 algo_id;
-    u8 padding[3];
-};
-
 struct activity_dump_config {
     u64 event_mask;
     u64 timeout;

--- a/pkg/security/ebpf/c/include/structs/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/structs/rate_limiter.h
@@ -4,6 +4,7 @@
 struct rate_limiter_ctx {
     u64 current_period;
     u32 counter;
+    u32 padding;
 };
 
 

--- a/pkg/security/ebpf/c/include/structs/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/structs/rate_limiter.h
@@ -1,0 +1,12 @@
+#ifndef _STRUCTS_RATE_LIMITER_H_
+#define _STRUCTS_RATE_LIMITER_H_
+
+struct rate_limiter_ctx {
+    u64 current_period;
+    u32 counter;
+    u8 algo_id;
+    u8 padding[3];
+};
+
+
+#endif /* _STRUCTS_RATE_LIMITER_H_ */

--- a/pkg/security/ebpf/c/include/structs/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/structs/rate_limiter.h
@@ -4,8 +4,6 @@
 struct rate_limiter_ctx {
     u64 current_period;
     u32 counter;
-    u8 algo_id;
-    u8 padding[3];
 };
 
 

--- a/pkg/security/ebpf/c/include/tests/activity_dump_ratelimiter_test.h
+++ b/pkg/security/ebpf/c/include/tests/activity_dump_ratelimiter_test.h
@@ -8,8 +8,8 @@
 #define AD_RL_TEST_RATE 500
 #define NUMBER_OF_PERIOD_PER_TEST 10
 
-SEC("test/ad_ratelimiter_basic")
-int test_ad_ratelimiter_basic() {
+SEC("test/ad_ratelimiter")
+int test_ad_ratelimiter() {
     u64 now = bpf_ktime_get_ns();
 
     u32 rate = AD_RL_TEST_RATE;
@@ -17,7 +17,6 @@ int test_ad_ratelimiter_basic() {
     struct rate_limiter_ctx ctx;
     ctx.counter = 0;
     ctx.current_period = now;
-    ctx.algo_id = RL_ALGO_BASIC; // force algo basic
     u64 cookie = 0;
     bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
 
@@ -39,81 +38,6 @@ int test_ad_ratelimiter_basic() {
             "event allowed which should not be");
     }
     return 1;
-}
-
-SEC("test/ad_ratelimiter_basic_half")
-int test_ad_ratelimiter_basic_half() {
-    u64 now = bpf_ktime_get_ns();
-
-    u32 rate = AD_RL_TEST_RATE;
-
-    struct rate_limiter_ctx ctx;
-    ctx.counter = 0;
-    ctx.current_period = now;
-    ctx.algo_id = RL_ALGO_BASIC_HALF; // force algo basic half
-    u64 cookie = 0;
-    bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
-
-    for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(1)) {
-        assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
-            "event not allowed which should be");
-        for (int i = 0; i < AD_RL_TEST_RATE / 2; i++) {
-            assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
-                "event not allowed which should be");
-        }
-
-        assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
-            "event allowed which should not be");
-        for (int i = 0; i < AD_RL_TEST_RATE / 2; i++) {
-            assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
-                "event allowed which should not be");
-        }
-        assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
-            "event allowed which should not be");
-    }
-    return 1;
-}
-
-__attribute__((always_inline)) int test_ad_ratelimiter_variable_droprate(int algo) {
-    u64 now = bpf_ktime_get_ns();
-
-    u32 rate = AD_RL_TEST_RATE;
-
-    struct rate_limiter_ctx ctx;
-    ctx.counter = 0;
-    ctx.current_period = now;
-    ctx.algo_id = algo; // force algo
-    u64 cookie = 0;
-    bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
-
-    for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(2)) {
-        assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
-            "event not allowed which should be");
-        for (int i = 0; i < AD_RL_TEST_RATE / 4; i++) {
-            assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
-                "event not allowed which should be");
-        }
-
-        int total_allowed = 0;
-        for (int i = 0; i < AD_RL_TEST_RATE * 10; i++) {
-            if (activity_dump_rate_limiter_allow(rate, cookie, now + i, 1)) {
-                total_allowed++;
-            }
-        }
-        assert_greater_than(total_allowed, AD_RL_TEST_RATE * 3 / 4, "nope");
-        assert_lesser_than(total_allowed, AD_RL_TEST_RATE / 10, "nope");
-    }
-    return 1;
-}
-
-SEC("test/ad_ratelimiter_decreasing_droprate")
-int test_ad_ratelimiter_decreasing_droprate() {
-    return test_ad_ratelimiter_variable_droprate(RL_ALGO_DECREASING_DROPRATE);
-}
-
-SEC("test/ad_ratelimiter_increasing_droprate")
-int test_ad_ratelimiter_increasing_droprate() {
-    return test_ad_ratelimiter_variable_droprate(RL_ALGO_INCREASING_DROPRATE);
 }
 
 #endif /* _ACTIVITY_DUMP_RATELIMITER_TEST_H_ */

--- a/pkg/security/ebpf/c/include/tests/activity_dump_ratelimiter_test.h
+++ b/pkg/security/ebpf/c/include/tests/activity_dump_ratelimiter_test.h
@@ -12,10 +12,9 @@ SEC("test/ad_ratelimiter_basic")
 int test_ad_ratelimiter_basic() {
     u64 now = bpf_ktime_get_ns();
 
-    struct activity_dump_config config;
-    config.events_rate = AD_RL_TEST_RATE;
+    u32 rate = AD_RL_TEST_RATE;
 
-    struct activity_dump_rate_limiter_ctx ctx;
+    struct rate_limiter_ctx ctx;
     ctx.counter = 0;
     ctx.current_period = now;
     ctx.algo_id = RL_ALGO_BASIC; // force algo basic
@@ -23,20 +22,20 @@ int test_ad_ratelimiter_basic() {
     bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
 
     for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(2)) {
-        assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+        assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
             "event not allowed which should be");
         for (int i = 0; i < AD_RL_TEST_RATE; i++) {
-            assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+            assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
                 "event not allowed which should be");
         }
 
-        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+        assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
             "event allowed which should not be");
         for (int i = 0; i < AD_RL_TEST_RATE; i++) {
-            assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+            assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
                 "event allowed which should not be");
         }
-        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+        assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
             "event allowed which should not be");
     }
     return 1;
@@ -46,10 +45,9 @@ SEC("test/ad_ratelimiter_basic_half")
 int test_ad_ratelimiter_basic_half() {
     u64 now = bpf_ktime_get_ns();
 
-    struct activity_dump_config config;
-    config.events_rate = AD_RL_TEST_RATE;
+    u32 rate = AD_RL_TEST_RATE;
 
-    struct activity_dump_rate_limiter_ctx ctx;
+    struct rate_limiter_ctx ctx;
     ctx.counter = 0;
     ctx.current_period = now;
     ctx.algo_id = RL_ALGO_BASIC_HALF; // force algo basic half
@@ -57,20 +55,20 @@ int test_ad_ratelimiter_basic_half() {
     bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
 
     for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(1)) {
-        assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+        assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
             "event not allowed which should be");
         for (int i = 0; i < AD_RL_TEST_RATE / 2; i++) {
-            assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+            assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
                 "event not allowed which should be");
         }
 
-        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+        assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
             "event allowed which should not be");
         for (int i = 0; i < AD_RL_TEST_RATE / 2; i++) {
-            assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+            assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
                 "event allowed which should not be");
         }
-        assert_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+        assert_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
             "event allowed which should not be");
     }
     return 1;
@@ -79,10 +77,9 @@ int test_ad_ratelimiter_basic_half() {
 __attribute__((always_inline)) int test_ad_ratelimiter_variable_droprate(int algo) {
     u64 now = bpf_ktime_get_ns();
 
-    struct activity_dump_config config;
-    config.events_rate = AD_RL_TEST_RATE;
+    u32 rate = AD_RL_TEST_RATE;
 
-    struct activity_dump_rate_limiter_ctx ctx;
+    struct rate_limiter_ctx ctx;
     ctx.counter = 0;
     ctx.current_period = now;
     ctx.algo_id = algo; // force algo
@@ -90,16 +87,16 @@ __attribute__((always_inline)) int test_ad_ratelimiter_variable_droprate(int alg
     bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
 
     for (int period_cpt = 0; period_cpt < NUMBER_OF_PERIOD_PER_TEST; period_cpt++, now += SEC_TO_NS(2)) {
-        assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now, 0),
+        assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now, 0),
             "event not allowed which should be");
         for (int i = 0; i < AD_RL_TEST_RATE / 4; i++) {
-            assert_not_zero(activity_dump_rate_limiter_allow(&config, cookie, now + i, 1),
+            assert_not_zero(activity_dump_rate_limiter_allow(rate, cookie, now + i, 1),
                 "event not allowed which should be");
         }
 
         int total_allowed = 0;
         for (int i = 0; i < AD_RL_TEST_RATE * 10; i++) {
-            if (activity_dump_rate_limiter_allow(&config, cookie, now + i, 1)) {
+            if (activity_dump_rate_limiter_allow(rate, cookie, now + i, 1)) {
                 total_allowed++;
             }
         }

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -177,6 +177,10 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.Ma
 			MaxEntries: procPidCacheMaxEntries,
 			EditorFlag: manager.EditMaxEntries,
 		},
+		"rate_limiters": {
+			MaxEntries: procPidCacheMaxEntries,
+			EditorFlag: manager.EditMaxEntries,
+		},
 
 		"activity_dumps_config": {
 			MaxEntries: model.MaxTracedCgroupsCount,

--- a/pkg/security/ebpf/tests/activity_dump_ratelimiter_test.go
+++ b/pkg/security/ebpf/tests/activity_dump_ratelimiter_test.go
@@ -16,31 +16,7 @@ import (
 
 func TestActivityDumpRateLimiterBasic(t *testing.T) {
 	var ctx baloum.StdContext
-	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_basic")
-	if err != nil || code != 1 {
-		t.Errorf("unexpected error: %v, %d", err, code)
-	}
-}
-
-func TestActivityDumpRateLimiterBasicHalf(t *testing.T) {
-	var ctx baloum.StdContext
-	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_basic_half")
-	if err != nil || code != 1 {
-		t.Errorf("unexpected error: %v, %d", err, code)
-	}
-}
-
-func TestActivityDumpRateLimiterDecreasingDroprate(t *testing.T) {
-	var ctx baloum.StdContext
-	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_decreasing_droprate")
-	if err != nil || code != 1 {
-		t.Errorf("unexpected error: %v, %d", err, code)
-	}
-}
-
-func TestActivityDumpRateLimiterIncreasingDroprate(t *testing.T) {
-	var ctx baloum.StdContext
-	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter_increasing_droprate")
+	code, err := newVM(t).RunProgram(&ctx, "test/ad_ratelimiter")
 	if err != nil || code != 1 {
 		t.Errorf("unexpected error: %v, %d", err, code)
 	}


### PR DESCRIPTION
### What does this PR do?

It makes the rate-limiter developed for activity dumps generic, let us use it for other purposes.

The AD limiter keeps its own map and won't be impacted about the change.

The generic one has for now a rate of 100 events/sec/pid (the rate is not configurable yet).

Ptrace is the first syscall to benefit from it: except for a given subset of requests we don't want to miss, all the ptrace call are now rate limited.

Also, I've simplified the rate limiter algos to a single basic one (having different ones makes no more sense)

### Motivation

Ptrace could be VERY noisy and have a huge impact on the perf buffer + the agent itself. This will drastically reduce the ptrace pressure.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->