### PR TITLE
[Serverless] Increase time to wait for metric samples in tests.

### DIFF
--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -224,7 +224,7 @@ func TestProcessMessageValid(t *testing.T) {
 
 	lc.processMessage(&message)
 
-	received, timed := demux.WaitForNumberOfSamples(7, 0, 100*time.Millisecond)
+	received, timed := demux.WaitForNumberOfSamples(7, 0, 125*time.Millisecond)
 	assert.Len(t, received, 7)
 	assert.Len(t, timed, 0)
 	demux.Reset()
@@ -232,7 +232,7 @@ func TestProcessMessageValid(t *testing.T) {
 	lc.enhancedMetricsEnabled = false
 	lc.processMessage(&message)
 
-	received, timed = demux.WaitForSamples(100 * time.Millisecond)
+	received, timed = demux.WaitForSamples(125 * time.Millisecond)
 	assert.Len(t, received, 0, "we should NOT have received metrics")
 	assert.Len(t, timed, 0)
 }
@@ -366,7 +366,7 @@ func TestProcessMessageShouldNotProcessArnNotSet(t *testing.T) {
 
 	go lc.processMessage(message)
 
-	received, timed := demux.WaitForSamples(100 * time.Millisecond)
+	received, timed := demux.WaitForSamples(125 * time.Millisecond)
 	assert.Len(t, received, 0, "We should NOT have received metrics")
 	assert.Len(t, timed, 0)
 }
@@ -394,7 +394,7 @@ func TestProcessMessageShouldNotProcessLogsDropped(t *testing.T) {
 
 	go lc.processMessage(message)
 
-	received, timed := demux.WaitForSamples(100 * time.Millisecond)
+	received, timed := demux.WaitForSamples(125 * time.Millisecond)
 	assert.Len(t, received, 0, "We should NOT have received metrics")
 	assert.Len(t, timed, 0)
 }
@@ -424,11 +424,13 @@ func TestProcessMessageShouldProcessLogTypeFunctionOutOfMemory(t *testing.T) {
 
 	go lc.processMessage(message)
 
-	received, timed := demux.WaitForNumberOfSamples(2, 0, 100*time.Millisecond)
+	received, timed := demux.WaitForNumberOfSamples(2, 0, 125*time.Millisecond)
 	assert.Len(t, received, 2)
 	assert.Len(t, timed, 0)
-	assert.Equal(t, serverlessMetrics.OutOfMemoryMetric, received[0].Name)
-	assert.Equal(t, serverlessMetrics.ErrorsMetric, received[1].Name)
+	if len(received) == 2 {
+		assert.Equal(t, serverlessMetrics.OutOfMemoryMetric, received[0].Name)
+		assert.Equal(t, serverlessMetrics.ErrorsMetric, received[1].Name)
+	}
 }
 
 func TestProcessMessageShouldProcessLogTypePlatformReportOutOfMemory(t *testing.T) {
@@ -465,7 +467,7 @@ func TestProcessMessageShouldProcessLogTypePlatformReportOutOfMemory(t *testing.
 
 	go lc.processMessage(message)
 
-	received, timed := demux.WaitForNumberOfSamples(2, 0, 100*time.Millisecond)
+	received, timed := demux.WaitForNumberOfSamples(2, 0, 125*time.Millisecond)
 	assert.Len(t, received, 8)
 	assert.Len(t, timed, 0)
 	assert.Equal(t, serverlessMetrics.OutOfMemoryMetric, received[6].Name)
@@ -497,7 +499,7 @@ func TestProcessMessageShouldSendFailoverMetric(t *testing.T) {
 
 	lc.processMessage(&message)
 
-	received, timed := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	received, timed := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 	assert.Len(t, received, 1)
 	assert.Len(t, timed, 0)
 	demux.Reset()
@@ -507,7 +509,7 @@ func TestProcessMessageShouldSendFailoverMetric(t *testing.T) {
 	message.stringRecord = "{\"DD_EXTENSION_FALLBACK_REASON\":\"test-reason\"}" // add again bc processing empties it
 	lc.processMessage(&message)
 
-	received, timed = demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	received, timed = demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 	assert.Len(t, received, 1)
 	assert.Len(t, timed, 0)
 }
@@ -549,7 +551,7 @@ func TestProcessLogMessageLogsEnabled(t *testing.T) {
 		assert.NotNil(t, received)
 		assert.Equal(t, "my-arn", received.Lambda.ARN)
 		assert.Equal(t, "myRequestID", received.Lambda.RequestID)
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(125 * time.Millisecond):
 		assert.Fail(t, "We should have received logs")
 	}
 }
@@ -597,7 +599,7 @@ func TestProcessLogMessageLogsEnabledForMixedUnorderedMessages(t *testing.T) {
 			assert.NotNil(t, received)
 			assert.Equal(t, "my-arn", received.Lambda.ARN)
 			assert.Equal(t, expectedRequestIDs[i], received.Lambda.RequestID)
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(125 * time.Millisecond):
 			assert.Fail(t, "We should have received logs")
 		}
 	}
@@ -628,7 +630,7 @@ func TestProcessLogMessageNoStringRecordPlatformLog(t *testing.T) {
 	select {
 	case <-logChannel:
 		assert.Fail(t, "We should not have received logs")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(125 * time.Millisecond):
 		// nothing to do here
 	}
 }
@@ -663,7 +665,7 @@ func TestProcessLogMessageNoStringRecordFunctionLog(t *testing.T) {
 		assert.NotNil(t, received)
 		assert.Equal(t, "my-arn", received.Lambda.ARN)
 		assert.Equal(t, "myRequestID", received.Lambda.RequestID)
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(125 * time.Millisecond):
 		assert.Fail(t, "We should have received logs")
 	}
 }
@@ -700,7 +702,7 @@ func TestProcessLogMessageLogsNotEnabled(t *testing.T) {
 	select {
 	case <-logChannel:
 		assert.Fail(t, "We should not have received logs")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(125 * time.Millisecond):
 		// nothing to do here
 	}
 }
@@ -763,7 +765,7 @@ func TestProcessLogMessagesTimeoutLogFromReportLog(t *testing.T) {
 					assert.Equal(t, "myRequestID", received.Lambda.RequestID)
 					assert.Equal(t, expectedStringRecord[i], string(received.Content))
 					assert.Equal(t, expectedErrors[i], received.IsError)
-				case <-time.After(100 * time.Millisecond):
+				case <-time.After(125 * time.Millisecond):
 					assert.Fail(t, "We should have received logs")
 				}
 			}
@@ -858,7 +860,7 @@ func TestProcessMultipleLogMessagesTimeoutLogFromReportLog(t *testing.T) {
 			} else {
 				assert.False(t, received.IsError)
 			}
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(125 * time.Millisecond):
 			assert.Fail(t, "We should have received logs")
 		}
 	}
@@ -904,7 +906,7 @@ func TestProcessLogMessagesOutOfMemoryError(t *testing.T) {
 		assert.Equal(t, "my-arn", received.Lambda.ARN)
 		assert.Equal(t, "myRequestID", received.Lambda.RequestID)
 		assert.Equal(t, true, received.IsError)
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(125 * time.Millisecond):
 		assert.Fail(t, "We should have received logs")
 	}
 }
@@ -943,7 +945,7 @@ func TestProcessLogMessageLogsNoRequestID(t *testing.T) {
 	select {
 	case <-logChannel:
 		assert.Fail(t, "We should not have received logs")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(125 * time.Millisecond):
 		// nothing to do here
 	}
 
@@ -952,7 +954,7 @@ func TestProcessLogMessageLogsNoRequestID(t *testing.T) {
 		for _, msg := range received {
 			assert.Equal(t, "", msg.objectRecord.requestID)
 		}
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(125 * time.Millisecond):
 		assert.Fail(t, "We should have received logs")
 	}
 }
@@ -1228,7 +1230,7 @@ func TestRuntimeMetricsMatchLogs(t *testing.T) {
 	lc.processMessage(doneMessage)
 	lc.processMessage(reportMessage)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(10, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(10, 0, 125*time.Millisecond)
 	postRuntimeMetricTimestamp := float64(reportLogTime.UnixNano()) / float64(time.Second)
 	runtimeMetricTimestamp := float64(endTime.UnixNano()) / float64(time.Second)
 	assert.Equal(t, generatedMetrics[0], metrics.MetricSample{
@@ -1314,7 +1316,7 @@ func TestRuntimeMetricsMatchLogsProactiveInit(t *testing.T) {
 	lc.processMessage(doneMessage)
 	lc.processMessage(reportMessage)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(10, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(10, 0, 125*time.Millisecond)
 	postRuntimeMetricTimestamp := float64(reportLogTime.UnixNano()) / float64(time.Second)
 	runtimeMetricTimestamp := float64(endTime.UnixNano()) / float64(time.Second)
 	assert.Equal(t, generatedMetrics[0], metrics.MetricSample{
@@ -1416,7 +1418,7 @@ func TestRuntimeMetricsOnTimeout(t *testing.T) {
 	assert.Nil(t, restoreErr)
 	lc.processMessage(reportMessage)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(10, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(10, 0, 125*time.Millisecond)
 	postRuntimeMetricTimestamp := float64(reportLogTime.UnixNano()) / float64(time.Second)
 	runtimeMetricTimestamp := float64(endTime.UnixNano()) / float64(time.Second)
 	assert.Equal(t, generatedMetrics[0], metrics.MetricSample{

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -34,7 +34,7 @@ func TestGenerateEnhancedMetricsFromFunctionLogOutOfMemory(t *testing.T) {
 		GenerateOutOfMemoryEnhancedMetrics(reportLogTime, tags, demux)
 	}
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(2, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(2, 0, 125*time.Millisecond)
 	assert.True(t, isOOM)
 	assert.Len(t, generatedMetrics, 2, "two enhanced metrics should have been generated")
 	assert.Len(t, timedMetrics, 0)
@@ -63,7 +63,7 @@ func TestGenerateEnhancedMetricsFromFunctionLogNoMetric(t *testing.T) {
 		GenerateOutOfMemoryEnhancedMetrics(time.Now(), tags, demux)
 	}
 
-	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForSamples(125 * time.Millisecond)
 	assert.False(t, isOOM)
 	assert.Len(t, generatedMetrics, 0, "no metrics should have been generated")
 	assert.Len(t, timedMetrics, 0)
@@ -89,7 +89,7 @@ func TestGenerateEnhancedMetricsFromReportLogColdStart(t *testing.T) {
 	}
 	go GenerateEnhancedMetricsFromReportLog(args)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(7, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(7, 0, 125*time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:7], []metrics.MetricSample{{
 		Name:       maxMemoryUsedMetric,
@@ -164,7 +164,7 @@ func TestGenerateEnhancedMetricsFromReportLogNoColdStart(t *testing.T) {
 	}
 	go GenerateEnhancedMetricsFromReportLog(args)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(6, 0, 0100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(6, 0, 125*time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:6], []metrics.MetricSample{{
 		Name:       maxMemoryUsedMetric,
@@ -218,7 +218,7 @@ func TestSendTimeoutEnhancedMetric(t *testing.T) {
 
 	go SendTimeoutEnhancedMetric(tags, demux)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       timeoutsMetric,
@@ -238,7 +238,7 @@ func TestSendInvocationEnhancedMetric(t *testing.T) {
 
 	go SendInvocationEnhancedMetric(tags, demux)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       invocationsMetric,
@@ -264,7 +264,7 @@ func TestDisableEnhancedMetrics(t *testing.T) {
 		SendInvocationEnhancedMetric(tags, demux)
 	}()
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Len(t, generatedMetrics, 0)
 	assert.Len(t, timedMetrics, 0)
@@ -279,7 +279,7 @@ func TestSendOutOfMemoryEnhancedMetric(t *testing.T) {
 	mockTime := time.Now()
 	go SendOutOfMemoryEnhancedMetric(tags, mockTime, demux)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       OutOfMemoryMetric,
@@ -298,7 +298,7 @@ func TestSendErrorsEnhancedMetric(t *testing.T) {
 	mockTime := time.Now()
 	go SendErrorsEnhancedMetric(tags, mockTime, demux)
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Equal(t, generatedMetrics[:1], []metrics.MetricSample{{
 		Name:       ErrorsMetric,
@@ -366,7 +366,7 @@ func TestGenerateEnhancedMetricsFromRuntimeDoneLogNoStartDate(t *testing.T) {
 		Demux:            demux,
 	}
 	go GenerateEnhancedMetricsFromRuntimeDoneLog(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 125*time.Millisecond)
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
 		Name:       responseLatencyMetric,
 		Value:      19,
@@ -407,7 +407,7 @@ func TestGenerateEnhancedMetricsFromRuntimeDoneLogNoEndDate(t *testing.T) {
 		Demux:            demux,
 	}
 	go GenerateEnhancedMetricsFromRuntimeDoneLog(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 125*time.Millisecond)
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
 		Name:       responseLatencyMetric,
 		Value:      19,
@@ -448,7 +448,7 @@ func TestGenerateEnhancedMetricsFromRuntimeDoneLogOK(t *testing.T) {
 		Demux:            demux,
 	}
 	go GenerateEnhancedMetricsFromRuntimeDoneLog(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(4, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(4, 0, 125*time.Millisecond)
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
 		Name:       runtimeDurationMetric,
 		Value:      153,
@@ -487,7 +487,7 @@ func TestGenerateCPUEnhancedMetrics(t *testing.T) {
 	now := float64(time.Now().UnixNano()) / float64(time.Second)
 	args := generateCPUEnhancedMetricsArgs{100, 53, 200, tags, demux, now}
 	go generateCPUEnhancedMetrics(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(4, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(4, 0, 125*time.Millisecond)
 	assert.Equal(t, []metrics.MetricSample{
 		{
 			Name:       cpuSystemTimeMetric,
@@ -530,7 +530,7 @@ func TestDisableCPUEnhancedMetrics(t *testing.T) {
 		SendCPUEnhancedMetrics(&proc.CPUData{}, 0, tags, demux)
 	}()
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Len(t, generatedMetrics, 0)
 	assert.Len(t, timedMetrics, 0)
@@ -560,7 +560,7 @@ func TestGenerateCPUUtilizationEnhancedMetrics(t *testing.T) {
 		Time:             now,
 	}
 	go GenerateCPUUtilizationEnhancedMetrics(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(5, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(5, 0, 125*time.Millisecond)
 	assert.Equal(t, []metrics.MetricSample{
 		{
 			Name:       cpuTotalUtilizationPctMetric,
@@ -621,7 +621,7 @@ func TestGenerateNetworkEnhancedMetrics(t *testing.T) {
 		Time:          now,
 	}
 	go generateNetworkEnhancedMetrics(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 125*time.Millisecond)
 	assert.Equal(t, []metrics.MetricSample{
 		{
 			Name:       rxBytesMetric,
@@ -664,7 +664,7 @@ func TestNetworkEnhancedMetricsDisabled(t *testing.T) {
 		SendNetworkEnhancedMetrics(&proc.NetworkData{}, tags, demux)
 	}()
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Len(t, generatedMetrics, 0)
 	assert.Len(t, timedMetrics, 0)
@@ -685,7 +685,7 @@ func TestSendTmpEnhancedMetrics(t *testing.T) {
 		Time:    now,
 	}
 	go generateTmpEnhancedMetrics(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 125*time.Millisecond)
 	assert.Equal(t, []metrics.MetricSample{
 		{
 			Name:       tmpUsedMetric,
@@ -722,7 +722,7 @@ func TestSendTmpEnhancedMetricsDisabled(t *testing.T) {
 		SendTmpEnhancedMetrics(make(chan bool), tags, &metricAgent)
 	}()
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Len(t, generatedMetrics, 0)
 	assert.Len(t, timedMetrics, 0)
@@ -743,7 +743,7 @@ func TestSendFdEnhancedMetrics(t *testing.T) {
 		Time:  now,
 	}
 	go generateFdEnhancedMetrics(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 125*time.Millisecond)
 	assert.Equal(t, []metrics.MetricSample{
 		{
 			Name:       fdMaxMetric,
@@ -779,7 +779,7 @@ func TestSendThreadEnhancedMetrics(t *testing.T) {
 		Time:       now,
 	}
 	go generateThreadEnhancedMetrics(args)
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(3, 0, 125*time.Millisecond)
 	assert.Equal(t, []metrics.MetricSample{
 		{
 			Name:       threadsMaxMetric,
@@ -816,7 +816,7 @@ func TestSendProcessEnhancedMetricsDisabled(t *testing.T) {
 		SendProcessEnhancedMetrics(make(chan bool), tags, &metricAgent)
 	}()
 
-	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, timedMetrics := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 
 	assert.Len(t, generatedMetrics, 0)
 	assert.Len(t, timedMetrics, 0)
@@ -829,7 +829,7 @@ func TestSendFailoverReasonMetric(t *testing.T) {
 	demux := createDemultiplexer(t)
 	tags := []string{"reason:test-reason"}
 	go SendFailoverReasonMetric(tags, demux)
-	generatedMetrics, _ := demux.WaitForNumberOfSamples(1, 0, 100*time.Millisecond)
+	generatedMetrics, _ := demux.WaitForNumberOfSamples(1, 0, 125*time.Millisecond)
 	assert.Len(t, generatedMetrics, 1)
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increase time to wait for metric samples from 100ms to 125ms in tests.

### Motivation

We have seen a few of flaky test failures recently. While I'm not certain increasing the wait time will fix these failures, it's a good place to start since each of the failures was due to a timeout to wait for metric samples.

Related flaky test failures:
+ [github.com/DataDog/datadog-agent/pkg/serverless/logs. TestProcessLogMessagesOutOfMemoryError](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fserverless%2Flogs.TestProcessLogMessagesOutOfMemoryError%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZO7n8C4440S_QAAABhBWk83bjhDNEFBQWljZ3NJMU80ejhCYmkAAAAkMDE5M2JiYTEtNzE0Yy00YzE0LTkyZTUtMDE4ZGM1ZDEzYmQ2AACs_Q&fromUser=false&graphType=flamegraph&index=citest&testId=AwAAAZO7n8C4440S_QAAABhBWk83bjhDNEFBQWljZ3NJMU80ejhCYmkAAAAkMDE5M2JiYTEtNzE0Yy00YzE0LTkyZTUtMDE4ZGM1ZDEzYmQ2AACs_Q&trace=AwAAAZO7n8C4440S_QAAABhBWk83bjhDNEFBQWljZ3NJMU80ejhCYmkAAAAkMDE5M2JiYTEtNzE0Yy00YzE0LTkyZTUtMDE4ZGM1ZDEzYmQ2AACs_Q&start=1733345373043&end=1734641373043&paused=false)
+ [github.com/DataDog/datadog-agent/pkg/serverless/logs. TestProcessMessageShouldProcessLogTypeFunctionOutOfMemory](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fserverless%2Flogs.TestProcessMessageShouldProcessLogTypeFunctionOutOfMemory%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZPZp9E2zNzDewAAABhBWlBacDlFMkFBQXhKSGpEeDZOUmRSU3IAAAAkMDE5M2Q5YTktMjAzZi00NWRjLTgyOGQtYTY1Zjg1YTEzYzRkAAa8Gw&fromUser=false&graphType=flamegraph&index=citest&testId=AwAAAZPZp9E2zNzDewAAABhBWlBacDlFMkFBQXhKSGpEeDZOUmRSU3IAAAAkMDE5M2Q5YTktMjAzZi00NWRjLTgyOGQtYTY1Zjg1YTEzYzRkAAa8Gw&trace=AwAAAZPZp9E2zNzDewAAABhBWlBacDlFMkFBQXhKSGpEeDZOUmRSU3IAAAAkMDE5M2Q5YTktMjAzZi00NWRjLTgyOGQtYTY1Zjg1YTEzYzRkAAa8Gw&start=1734468632995&end=1734641432995&paused=false)
+ [github.com/DataDog/datadog-agent/pkg/serverless/metrics.TestSendFdEnhancedMetrics](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fserverless%2Fmetrics.TestSendFdEnhancedMetrics%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZPa3QmQQoQxCQAAABhBWlBhM1FtUUFBRERaOVFnWTNDWWl5MFoAAAAkMDE5M2RhZGYtN2Q0Mi00N2FiLWIzNDYtMGVmN2U1ZjM1NjdlAAGiiw&fromUser=false&graphType=flamegraph&index=citest&testId=AwAAAZPa3QmQQoQxCQAAABhBWlBhM1FtUUFBRERaOVFnWTNDWWl5MFoAAAAkMDE5M2RhZGYtN2Q0Mi00N2FiLWIzNDYtMGVmN2U1ZjM1NjdlAAGiiw&trace=AwAAAZPa3QmQQoQxCQAAABhBWlBhM1FtUUFBRERaOVFnWTNDWWl5MFoAAAAkMDE5M2RhZGYtN2Q0Mi00N2FiLWIzNDYtMGVmN2U1ZjM1NjdlAAGiiw&start=1734468896966&end=1734641696966&paused=false)
+ [github.com/DataDog/datadog-agent/pkg/serverless/metrics.TestGenerateEnhancedMetricsFromRuntimeDoneLogNoStartDate](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.status%3Afail%20%40test.full_name%3A%22github.com%2FDataDog%2Fdatadog-agent%2Fpkg%2Fserverless%2Fmetrics.TestGenerateEnhancedMetricsFromRuntimeDoneLogNoStartDate%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=AwAAAZPeIqciVPI_ugAAABhBWlBlSXFjaUFBQTQySGJEU2ZERGdQbGcAAAAkMDE5M2RlMjUtMzIzYS00ODcwLWJmNTctN2MzNDkwNGY3YjY0AABtZg&fromUser=false&graphType=flamegraph&index=citest&testId=AwAAAZPeIqciVPI_ugAAABhBWlBlSXFjaUFBQTQySGJEU2ZERGdQbGcAAAAkMDE5M2RlMjUtMzIzYS00ODcwLWJmNTctN2MzNDkwNGY3YjY0AABtZg&trace=AwAAAZPeIqciVPI_ugAAABhBWlBlSXFjaUFBQTQySGJEU2ZERGdQbGcAAAAkMDE5M2RlMjUtMzIzYS00ODcwLWJmNTctN2MzNDkwNGY3YjY0AABtZg&start=1734468899968&end=1734641699968&paused=false)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->