### PR TITLE
omnibus: ignore GOPROXY when computing cache key

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -116,6 +116,7 @@ def _get_environment_for_cache() -> dict:
             "GET_SOURCES_ATTEMPTS",
             "GO_TEST_SKIP_FLAKE",
             "GONOSUMDB",
+            "GOPROXY",
             "HELM_HOOKS_CI_IMAGE",
             "HELM_HOOKS_PERIODICAL_REBUILD_CONDUCTOR_ENV",
             "HOME",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add `GOPROXY` to the ignored env variables when computing the cache key
### Motivation

This will fix more cache misses when the pipeline runs under conductor 
See: 
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/746608862 
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/746655442/viewer 

Which are running on the same commit, but ended up in a cache miss

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->