### PR TITLE
[CWS] Add namespace ID field resolver for ptrace

### DIFF
--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/args"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -230,7 +231,7 @@ func (fh *EBPFFieldHandlers) ResolveRights(_ *model.Event, e *model.FileFields) 
 	return int(e.Mode) & (syscall.S_ISUID | syscall.S_ISGID | syscall.S_ISVTX | syscall.S_IRWXU | syscall.S_IRWXG | syscall.S_IRWXO)
 }
 
-// ResolveChownUID resolves the ResolveProcessCacheEntry id of a chown event to a username
+// ResolveChownUID resolves the user id of a chown event to a username
 func (fh *EBPFFieldHandlers) ResolveChownUID(ev *model.Event, e *model.ChownEvent) string {
 	if len(e.User) == 0 {
 		e.User, _ = fh.resolvers.UserGroupResolver.ResolveUser(int(e.UID), ev.ContainerContext.ContainerID)
@@ -730,4 +731,18 @@ func (fh *EBPFFieldHandlers) ResolveOnDemandArg4Str(_ *model.Event, e *model.OnD
 // ResolveOnDemandArg4Uint resolves the uint value of the fourth argument of hooked function
 func (fh *EBPFFieldHandlers) ResolveOnDemandArg4Uint(_ *model.Event, e *model.OnDemandEvent) int {
 	return int(binary.NativeEndian.Uint64(e.Data[192 : 192+8]))
+}
+
+// ResolveProcessNSID resolves the process namespace ID
+func (fh *EBPFFieldHandlers) ResolveProcessNSID(e *model.Event) (uint64, error) {
+	if e.ProcessCacheEntry.Process.NSID != 0 {
+		return e.ProcessCacheEntry.Process.NSID, nil
+	}
+
+	nsid, err := utils.GetProcessPidNamespace(e.ProcessCacheEntry.Process.Pid)
+	if err != nil {
+		return 0, err
+	}
+	e.ProcessCacheEntry.Process.NSID = nsid
+	return nsid, nil
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1090,7 +1090,14 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 				if containerID == "" && event.PTrace.Request != unix.PTRACE_ATTACH {
 					pidToResolve = event.PTrace.NSPID
 				} else {
-					pid, err := utils.TryToResolveTraceePid(event.ProcessContext.Process.Pid, event.PTrace.NSPID)
+					nsid, err := p.fieldHandlers.ResolveProcessNSID(event)
+					if err != nil {
+						seclog.Debugf("PTrace NSID resolution error for process %s in container %s: %v",
+							event.ProcessContext.Process.FileEvent.PathnameStr, containerID, err)
+						return
+					}
+
+					pid, err := utils.TryToResolveTraceePid(event.ProcessContext.Process.Pid, nsid, event.PTrace.NSPID)
 					if err != nil {
 						seclog.Debugf("PTrace tracee resolution error for process %s in container %s: %v",
 							event.ProcessContext.Process.FileEvent.PathnameStr, containerID, err)

--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -567,22 +567,14 @@ var isNsPidAvailable = sync.OnceValue(func() bool {
 })
 
 // TryToResolveTraceePid tries to resolve and returnt the HOST tracee PID, given the HOST tracer PID and the namespaced tracee PID.
-func TryToResolveTraceePid(hostTracerPID, NsTraceePid uint32) (uint32, error) {
+func TryToResolveTraceePid(hostTracerPID uint32, tracerNSID uint64, NsTraceePid uint32) (uint32, error) {
 	// Look if the NSpid status field is available or not (it should be, except for Centos7).
 	if isNsPidAvailable() {
 		/*
 		   If it's available, we will search for an host pid having the same PID namespace as the
 		   tracer, and having the corresponding NS PID in its status field
 		*/
-
-		// 1. get the pid namespace of the tracer
-		ns, err := GetProcessPidNamespace(hostTracerPID)
-		if err != nil {
-			return 0, fmt.Errorf("Failed to resolve PID namespace: %v", err)
-		}
-
-		// 2. find the host pid matching the arg pid with he tracer namespace
-		pid, err := FindPidNamespace(NsTraceePid, ns)
+		pid, err := FindPidNamespace(NsTraceePid, tracerNSID)
 		if err != nil {
 			return 0, fmt.Errorf("Failed to resolve tracee PID namespace: %v", err)
 		}


### PR DESCRIPTION
### What does this PR do?

It adds process cache entry NSID field resolver (NB: the field was already present and used in ebpfless mode).

### Motivation

Resolving it only once per process for all its ptrace calls will reduce drastically the number of proc resolutions.

But more important: as it's now cached, we "no longer" have a race where it cannot be resolved anymore due to process termination, resulting in tracee resolution errors.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->