### PR TITLE
[EBPF] manager: add BeforeStop method to modifiers

### DIFF
--- a/pkg/ebpf/helper_call_patcher.go
+++ b/pkg/ebpf/helper_call_patcher.go
@@ -88,3 +88,7 @@ func (h *helperCallRemover) AfterInit(*manager.Manager, names.ModuleName, *manag
 func (h *helperCallRemover) String() string {
 	return fmt.Sprintf("HelperCallRemover[%+v]", h.helpers)
 }
+
+func (h *helperCallRemover) BeforeStop(*manager.Manager, names.ModuleName) error {
+	return nil
+}

--- a/pkg/ebpf/helper_call_patcher.go
+++ b/pkg/ebpf/helper_call_patcher.go
@@ -92,3 +92,7 @@ func (h *helperCallRemover) String() string {
 func (h *helperCallRemover) BeforeStop(*manager.Manager, names.ModuleName) error {
 	return nil
 }
+
+func (h *helperCallRemover) AfterStop(*manager.Manager, names.ModuleName) error {
+	return nil
+}

--- a/pkg/ebpf/manager_test.go
+++ b/pkg/ebpf/manager_test.go
@@ -40,6 +40,10 @@ func (t *dummyModifier) BeforeStop(_ *manager.Manager, _ names.ModuleName) error
 	return nil
 }
 
+func (t *dummyModifier) AfterStop(_ *manager.Manager, _ names.ModuleName) error {
+	return nil
+}
+
 func TestNewManagerWithDefault(t *testing.T) {
 	type args struct {
 		mgr       *manager.Manager

--- a/pkg/ebpf/manager_test.go
+++ b/pkg/ebpf/manager_test.go
@@ -9,9 +9,10 @@ package ebpf
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/ebpf/names"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf/names"
 )
 
 // PrintkPatcherModifier adds an InstructionPatcher to the manager that removes the newline character from log_debug calls if needed
@@ -31,6 +32,11 @@ func (t *dummyModifier) BeforeInit(_ *manager.Manager, _ names.ModuleName, _ *ma
 
 // AfterInit is a no-op for this modifier
 func (t *dummyModifier) AfterInit(_ *manager.Manager, _ names.ModuleName, _ *manager.Options) error {
+	return nil
+}
+
+// BeforeStop is a no-op for this modifier
+func (t *dummyModifier) BeforeStop(_ *manager.Manager, _ names.ModuleName) error {
 	return nil
 }
 

--- a/pkg/ebpf/printk_patcher.go
+++ b/pkg/ebpf/printk_patcher.go
@@ -232,3 +232,8 @@ func (t *PrintkPatcherModifier) AfterInit(_ *manager.Manager, _ names.ModuleName
 func (t *PrintkPatcherModifier) BeforeStop(_ *manager.Manager, _ names.ModuleName) error {
 	return nil
 }
+
+// AfterStop is a no-op for this modifier
+func (t *PrintkPatcherModifier) AfterStop(_ *manager.Manager, _ names.ModuleName) error {
+	return nil
+}

--- a/pkg/ebpf/printk_patcher.go
+++ b/pkg/ebpf/printk_patcher.go
@@ -227,3 +227,8 @@ func (t *PrintkPatcherModifier) BeforeInit(m *manager.Manager, _ names.ModuleNam
 func (t *PrintkPatcherModifier) AfterInit(_ *manager.Manager, _ names.ModuleName, _ *manager.Options) error {
 	return nil
 }
+
+// BeforeStop is a no-op for this modifier
+func (t *PrintkPatcherModifier) BeforeStop(_ *manager.Manager, _ names.ModuleName) error {
+	return nil
+}

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -140,3 +140,8 @@ func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, module names.Mod
 func (t *ErrorsTelemetryModifier) BeforeStop(_ *manager.Manager, _ names.ModuleName) error {
 	return nil
 }
+
+// AfterStop is a no-op
+func (t *ErrorsTelemetryModifier) AfterStop(_ *manager.Manager, _ names.ModuleName) error {
+	return nil
+}

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -135,3 +135,8 @@ func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, module names.Mod
 
 	return nil
 }
+
+// BeforeStop is a no-op for now
+func (t *ErrorsTelemetryModifier) BeforeStop(m *manager.Manager, module names.ModuleName, _ *manager.Options) error {
+	return nil
+}

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -137,6 +137,6 @@ func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, module names.Mod
 }
 
 // BeforeStop is a no-op for now
-func (t *ErrorsTelemetryModifier) BeforeStop(m *manager.Manager, module names.ModuleName, _ *manager.Options) error {
+func (t *ErrorsTelemetryModifier) BeforeStop(m *manager.Manager, module names.ModuleName) error {
 	return nil
 }

--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -137,6 +137,6 @@ func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, module names.Mod
 }
 
 // BeforeStop is a no-op for now
-func (t *ErrorsTelemetryModifier) BeforeStop(m *manager.Manager, module names.ModuleName) error {
+func (t *ErrorsTelemetryModifier) BeforeStop(_ *manager.Manager, _ names.ModuleName) error {
 	return nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a `BeforeStop` method to the `Modifier` interface, so that modifiers can clean up their structures before the manager stops.

### Motivation

The telemetry modifier needs to clean up some structures so that the same program can be unloaded and reloaded multiple times. The `shared-libraries` program was having problems with this case.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Linting/building/unit tests passing.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->