### PR TITLE
[e2e] 🚚 move remaining types defined in e2e to common

### DIFF
--- a/test/new-e2e/pkg/components/docker_agent.go
+++ b/test/new-e2e/pkg/components/docker_agent.go
@@ -6,7 +6,6 @@
 package components
 
 import (
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
@@ -24,7 +23,7 @@ type DockerAgent struct {
 	ClientOptions []agentclientparams.Option
 }
 
-var _ e2e.Initializable = (*DockerAgent)(nil)
+var _ common.Initializable = (*DockerAgent)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (a *DockerAgent) Init(ctx common.Context) (err error) {

--- a/test/new-e2e/pkg/components/docker_agent.go
+++ b/test/new-e2e/pkg/components/docker_agent.go
@@ -7,6 +7,7 @@ package components
 
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
@@ -26,7 +27,7 @@ type DockerAgent struct {
 var _ e2e.Initializable = (*DockerAgent)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
-func (a *DockerAgent) Init(ctx e2e.Context) (err error) {
+func (a *DockerAgent) Init(ctx common.Context) (err error) {
 	a.Client, err = client.NewDockerAgentClient(ctx, a.DockerAgentOutput, a.ClientOptions...)
 	return err
 }

--- a/test/new-e2e/pkg/components/ecs_cluster.go
+++ b/test/new-e2e/pkg/components/ecs_cluster.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	clientecs "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/ecs"
 )
 
@@ -23,7 +24,7 @@ type ECSCluster struct {
 var _ e2e.Initializable = &ECSCluster{}
 
 // Init is called by e2e test Suite after the component is provisioned.
-func (c *ECSCluster) Init(e2e.Context) error {
+func (c *ECSCluster) Init(common.Context) error {
 
 	ecsClient, err := clientecs.NewClient(c.ClusterOutput.ClusterName)
 	if err != nil {

--- a/test/new-e2e/pkg/components/ecs_cluster.go
+++ b/test/new-e2e/pkg/components/ecs_cluster.go
@@ -8,8 +8,6 @@ package components
 import (
 	"github.com/DataDog/test-infra-definitions/components/ecs"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	clientecs "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/ecs"
 )
@@ -21,7 +19,7 @@ type ECSCluster struct {
 	ECSClient *clientecs.Client
 }
 
-var _ e2e.Initializable = &ECSCluster{}
+var _ common.Initializable = &ECSCluster{}
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (c *ECSCluster) Init(common.Context) error {

--- a/test/new-e2e/pkg/components/fakeintake.go
+++ b/test/new-e2e/pkg/components/fakeintake.go
@@ -7,7 +7,6 @@ package components
 
 import (
 	"github.com/DataDog/datadog-agent/test/fakeintake/client"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
@@ -20,7 +19,7 @@ type FakeIntake struct {
 	client *client.Client
 }
 
-var _ e2e.Initializable = &FakeIntake{}
+var _ common.Initializable = &FakeIntake{}
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (fi *FakeIntake) Init(common.Context) error {

--- a/test/new-e2e/pkg/components/fakeintake.go
+++ b/test/new-e2e/pkg/components/fakeintake.go
@@ -8,6 +8,7 @@ package components
 import (
 	"github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 )
@@ -22,7 +23,7 @@ type FakeIntake struct {
 var _ e2e.Initializable = &FakeIntake{}
 
 // Init is called by e2e test Suite after the component is provisioned.
-func (fi *FakeIntake) Init(e2e.Context) error {
+func (fi *FakeIntake) Init(common.Context) error {
 	fi.client = client.NewClient(fi.URL)
 	return nil
 }

--- a/test/new-e2e/pkg/components/kubernetes_cluster.go
+++ b/test/new-e2e/pkg/components/kubernetes_cluster.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 
 	"github.com/DataDog/test-infra-definitions/components/kubernetes"
@@ -29,7 +30,7 @@ type KubernetesCluster struct {
 var _ e2e.Initializable = &KubernetesCluster{}
 
 // Init is called by e2e test Suite after the component is provisioned.
-func (kc *KubernetesCluster) Init(e2e.Context) error {
+func (kc *KubernetesCluster) Init(common.Context) error {
 	config, err := clientcmd.RESTConfigFromKubeConfig([]byte(kc.KubeConfig))
 	if err != nil {
 		return err

--- a/test/new-e2e/pkg/components/kubernetes_cluster.go
+++ b/test/new-e2e/pkg/components/kubernetes_cluster.go
@@ -8,7 +8,6 @@ package components
 import (
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 
@@ -27,7 +26,7 @@ type KubernetesCluster struct {
 	KubernetesClient *client.KubernetesClient
 }
 
-var _ e2e.Initializable = &KubernetesCluster{}
+var _ common.Initializable = &KubernetesCluster{}
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (kc *KubernetesCluster) Init(common.Context) error {

--- a/test/new-e2e/pkg/components/remotehost.go
+++ b/test/new-e2e/pkg/components/remotehost.go
@@ -7,6 +7,7 @@ package components
 
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 
 	osComp "github.com/DataDog/test-infra-definitions/components/os"
@@ -18,13 +19,13 @@ type RemoteHost struct {
 	remote.HostOutput
 
 	*client.Host
-	context e2e.Context
+	context common.Context
 }
 
 var _ e2e.Initializable = (*RemoteHost)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
-func (h *RemoteHost) Init(ctx e2e.Context) (err error) {
+func (h *RemoteHost) Init(ctx common.Context) (err error) {
 	h.context = ctx
 	h.Host, err = client.NewHost(ctx, h.HostOutput)
 	return err

--- a/test/new-e2e/pkg/components/remotehost.go
+++ b/test/new-e2e/pkg/components/remotehost.go
@@ -6,7 +6,6 @@
 package components
 
 import (
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 
@@ -22,7 +21,7 @@ type RemoteHost struct {
 	context common.Context
 }
 
-var _ e2e.Initializable = (*RemoteHost)(nil)
+var _ common.Initializable = (*RemoteHost)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (h *RemoteHost) Init(ctx common.Context) (err error) {

--- a/test/new-e2e/pkg/components/remotehost_agent.go
+++ b/test/new-e2e/pkg/components/remotehost_agent.go
@@ -6,7 +6,6 @@
 package components
 
 import (
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
@@ -23,7 +22,7 @@ type RemoteHostAgent struct {
 	ClientOptions []agentclientparams.Option
 }
 
-var _ e2e.Initializable = (*RemoteHostAgent)(nil)
+var _ common.Initializable = (*RemoteHostAgent)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (a *RemoteHostAgent) Init(ctx common.Context) (err error) {

--- a/test/new-e2e/pkg/components/remotehost_agent.go
+++ b/test/new-e2e/pkg/components/remotehost_agent.go
@@ -7,6 +7,7 @@ package components
 
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
@@ -25,7 +26,7 @@ type RemoteHostAgent struct {
 var _ e2e.Initializable = (*RemoteHostAgent)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
-func (a *RemoteHostAgent) Init(ctx e2e.Context) (err error) {
+func (a *RemoteHostAgent) Init(ctx common.Context) (err error) {
 	a.Client, err = client.NewHostAgentClientWithParams(ctx, a.HostAgentOutput.Host, a.ClientOptions...)
 	return err
 }

--- a/test/new-e2e/pkg/components/remotehost_docker.go
+++ b/test/new-e2e/pkg/components/remotehost_docker.go
@@ -6,9 +6,11 @@
 package components
 
 import (
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/test-infra-definitions/components/docker"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 )
 
 // RemoteHostDocker represents an Agent running directly on a Host
@@ -21,7 +23,7 @@ type RemoteHostDocker struct {
 var _ e2e.Initializable = (*RemoteHostDocker)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
-func (d *RemoteHostDocker) Init(ctx e2e.Context) (err error) {
+func (d *RemoteHostDocker) Init(ctx common.Context) (err error) {
 	d.Client, err = client.NewDocker(ctx.T(), d.ManagerOutput)
 	return err
 }

--- a/test/new-e2e/pkg/components/remotehost_docker.go
+++ b/test/new-e2e/pkg/components/remotehost_docker.go
@@ -8,7 +8,6 @@ package components
 import (
 	"github.com/DataDog/test-infra-definitions/components/docker"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 )
@@ -20,7 +19,7 @@ type RemoteHostDocker struct {
 	Client *client.Docker
 }
 
-var _ e2e.Initializable = (*RemoteHostDocker)(nil)
+var _ common.Initializable = (*RemoteHostDocker)(nil)
 
 // Init is called by e2e test Suite after the component is provisioned.
 func (d *RemoteHostDocker) Init(ctx common.Context) (err error) {

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -157,6 +157,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 
 	"github.com/stretchr/testify/suite"
@@ -352,7 +353,7 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 	}
 
 	// If env implements Initializable, we call Init
-	if initializable, ok := any(newEnv).(Initializable); ok {
+	if initializable, ok := any(newEnv).(common.Initializable); ok {
 		if err := initializable.Init(bs); err != nil {
 			return fmt.Errorf("failed to init environment, err: %v", err)
 		}
@@ -447,7 +448,7 @@ func (bs *BaseSuite[Env]) buildEnvFromResources(resources provisioners.RawResour
 			}
 
 			// See if the component requires init
-			if initializable, ok := fieldValue.Interface().(Initializable); ok {
+			if initializable, ok := fieldValue.Interface().(common.Initializable); ok {
 				if err := initializable.Init(bs); err != nil {
 					return fmt.Errorf("failed to init resource named: %s with key: %s, err: %w", field.Name, resourceKey, err)
 				}

--- a/test/new-e2e/pkg/e2e/suite_test.go
+++ b/test/new-e2e/pkg/e2e/suite_test.go
@@ -31,7 +31,7 @@ type testTypeWrapper struct {
 	unrelatedField string //nolint:unused // mimic actual struct to validate reflection code
 }
 
-var _ Initializable = &testTypeWrapper{}
+var _ common.Initializable = &testTypeWrapper{}
 
 func (t *testTypeWrapper) Init(common.Context) error {
 	return nil

--- a/test/new-e2e/pkg/e2e/suite_test.go
+++ b/test/new-e2e/pkg/e2e/suite_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
 type testTypeOutput struct {
@@ -32,7 +33,7 @@ type testTypeWrapper struct {
 
 var _ Initializable = &testTypeWrapper{}
 
-func (t *testTypeWrapper) Init(Context) error {
+func (t *testTypeWrapper) Init(common.Context) error {
 	return nil
 }
 

--- a/test/new-e2e/pkg/e2e/types.go
+++ b/test/new-e2e/pkg/e2e/types.go
@@ -4,13 +4,3 @@
 // Copyright 2016-present Datadog, Inc.
 
 package e2e
-
-// RawResources is the common types returned by provisioners
-type RawResources map[string][]byte
-
-// Merge merges two RawResources maps
-func (rr RawResources) Merge(in RawResources) {
-	for k, v := range in {
-		rr[k] = v
-	}
-}

--- a/test/new-e2e/pkg/e2e/types.go
+++ b/test/new-e2e/pkg/e2e/types.go
@@ -1,6 +1,0 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-package e2e

--- a/test/new-e2e/pkg/e2e/types.go
+++ b/test/new-e2e/pkg/e2e/types.go
@@ -5,18 +5,11 @@
 
 package e2e
 
-import (
-	"testing"
-)
-
-// Context defines an interface that allows to get information about current test context
-type Context interface {
-	T() *testing.T
-}
+import "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 
 // Initializable defines the interface for an object that needs to be initialized
 type Initializable interface {
-	Init(Context) error
+	Init(common.Context) error
 }
 
 // RawResources is the common types returned by provisioners

--- a/test/new-e2e/pkg/e2e/types.go
+++ b/test/new-e2e/pkg/e2e/types.go
@@ -5,13 +5,6 @@
 
 package e2e
 
-import "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
-
-// Initializable defines the interface for an object that needs to be initialized
-type Initializable interface {
-	Init(common.Context) error
-}
-
 // RawResources is the common types returned by provisioners
 type RawResources map[string][]byte
 

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -8,6 +8,7 @@ package environments
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
 // DockerHost is an environment that contains a Docker VM, FakeIntake and Agent configured to talk to each other.
@@ -22,6 +23,6 @@ type DockerHost struct {
 var _ e2e.Initializable = &DockerHost{}
 
 // Init initializes the environment
-func (e *DockerHost) Init(_ e2e.Context) error {
+func (e *DockerHost) Init(_ common.Context) error {
 	return nil
 }

--- a/test/new-e2e/pkg/environments/dockerhost.go
+++ b/test/new-e2e/pkg/environments/dockerhost.go
@@ -7,7 +7,6 @@ package environments
 
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
@@ -20,7 +19,7 @@ type DockerHost struct {
 	Docker     *components.RemoteHostDocker
 }
 
-var _ e2e.Initializable = &DockerHost{}
+var _ common.Initializable = &DockerHost{}
 
 // Init initializes the environment
 func (e *DockerHost) Init(_ common.Context) error {

--- a/test/new-e2e/pkg/environments/host.go
+++ b/test/new-e2e/pkg/environments/host.go
@@ -8,6 +8,7 @@ package environments
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
 // Host is an environment that contains a Host, FakeIntake and Agent configured to talk to each other.
@@ -21,6 +22,6 @@ type Host struct {
 var _ e2e.Initializable = (*Host)(nil)
 
 // Init initializes the environment
-func (e *Host) Init(_ e2e.Context) error {
+func (e *Host) Init(_ common.Context) error {
 	return nil
 }

--- a/test/new-e2e/pkg/environments/host.go
+++ b/test/new-e2e/pkg/environments/host.go
@@ -7,7 +7,6 @@ package environments
 
 import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
@@ -19,7 +18,7 @@ type Host struct {
 	Updater    *components.RemoteHostUpdater
 }
 
-var _ e2e.Initializable = (*Host)(nil)
+var _ common.Initializable = (*Host)(nil)
 
 // Init initializes the environment
 func (e *Host) Init(_ common.Context) error {

--- a/test/new-e2e/pkg/environments/host_win.go
+++ b/test/new-e2e/pkg/environments/host_win.go
@@ -6,9 +6,11 @@
 package environments
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
 // WindowsHost is an environment based on environments.Host but that is specific to Windows.
@@ -25,6 +27,6 @@ type WindowsHost struct {
 var _ e2e.Initializable = &WindowsHost{}
 
 // Init initializes the environment
-func (e *WindowsHost) Init(_ e2e.Context) error {
+func (e *WindowsHost) Init(_ common.Context) error {
 	return nil
 }

--- a/test/new-e2e/pkg/environments/host_win.go
+++ b/test/new-e2e/pkg/environments/host_win.go
@@ -9,7 +9,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
@@ -24,7 +23,7 @@ type WindowsHost struct {
 	Installer       *components.RemoteDatadogInstaller
 }
 
-var _ e2e.Initializable = &WindowsHost{}
+var _ common.Initializable = &WindowsHost{}
 
 // Init initializes the environment
 func (e *WindowsHost) Init(_ common.Context) error {

--- a/test/new-e2e/pkg/utils/common/types.go
+++ b/test/new-e2e/pkg/utils/common/types.go
@@ -11,3 +11,8 @@ import "testing"
 type Context interface {
 	T() *testing.T
 }
+
+// Initializable defines the interface for an object that needs to be initialized
+type Initializable interface {
+	Init(Context) error
+}

--- a/test/new-e2e/pkg/utils/common/types.go
+++ b/test/new-e2e/pkg/utils/common/types.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package common
+
+import "testing"
+
+// Context defines an interface that allows to get information about current test context
+type Context interface {
+	T() *testing.T
+}

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 )
@@ -29,7 +30,7 @@ const (
 )
 
 // NewHostAgentClient creates an Agent client for host install
-func NewHostAgentClient(context e2e.Context, hostOutput remote.HostOutput, waitForAgentReady bool) (agentclient.Agent, error) {
+func NewHostAgentClient(context common.Context, hostOutput remote.HostOutput, waitForAgentReady bool) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(hostOutput.OSFamily)
 	params.ShouldWaitForReady = waitForAgentReady
 
@@ -51,7 +52,7 @@ func NewHostAgentClient(context e2e.Context, hostOutput remote.HostOutput, waitF
 }
 
 // NewHostAgentClientWithParams creates an Agent client for host install with custom parameters
-func NewHostAgentClientWithParams(context e2e.Context, hostOutput remote.HostOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
+func NewHostAgentClientWithParams(context common.Context, hostOutput remote.HostOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(hostOutput.OSFamily, options...)
 
 	host, err := NewHost(context, hostOutput)
@@ -74,7 +75,7 @@ func NewHostAgentClientWithParams(context e2e.Context, hostOutput remote.HostOut
 }
 
 // NewDockerAgentClient creates an Agent client for a Docker install
-func NewDockerAgentClient(context e2e.Context, dockerAgentOutput agent.DockerAgentOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
+func NewDockerAgentClient(context common.Context, dockerAgentOutput agent.DockerAgentOutput, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(dockerAgentOutput.DockerManager.Host.OSFamily, options...)
 	ae := newAgentDockerExecutor(context, dockerAgentOutput)
 	commandRunner := newAgentCommandRunner(context.T(), ae)

--- a/test/new-e2e/pkg/utils/e2e/client/agent_docker.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_docker.go
@@ -6,8 +6,9 @@
 package client
 
 import (
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 )
 
 type agentDockerExecutor struct {
@@ -17,7 +18,7 @@ type agentDockerExecutor struct {
 
 var _ agentCommandExecutor = &agentDockerExecutor{}
 
-func newAgentDockerExecutor(context e2e.Context, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
+func newAgentDockerExecutor(context common.Context, dockerAgentOutput agent.DockerAgentOutput) *agentDockerExecutor {
 	dockerClient, err := NewDocker(context.T(), dockerAgentOutput.DockerManager)
 	if err != nil {
 		panic(err)

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -28,9 +28,9 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/optional"
 )
 
@@ -48,7 +48,7 @@ type convertPathSeparatorFn func(string) string
 type Host struct {
 	client *ssh.Client
 
-	context              e2e.Context
+	context              common.Context
 	username             string
 	host                 string
 	privateKey           []byte
@@ -63,7 +63,7 @@ type Host struct {
 
 // NewHost creates a new ssh client to connect to a remote host with
 // reconnect retry logic
-func NewHost(context e2e.Context, hostOutput remote.HostOutput) (*Host, error) {
+func NewHost(context common.Context, hostOutput remote.HostOutput) (*Host, error) {
 	var privateSSHKey []byte
 
 	privateKeyPath, err := runner.GetProfile().ParamStore().GetWithDefault(parameters.StoreKey(hostOutput.CloudProvider+parameters.PrivateKeyPathSuffix), "")

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	boundport "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common/bound-port"
@@ -183,7 +183,7 @@ func (c *TestClient) ExecuteWithRetry(cmd string) (string, error) {
 }
 
 // NewWindowsTestClient create a TestClient for Windows VM
-func NewWindowsTestClient(context e2e.Context, host *components.RemoteHost) *TestClient {
+func NewWindowsTestClient(context common.Context, host *components.RemoteHost) *TestClient {
 	fileManager := filemanager.NewRemoteHost(host)
 	t := context.T()
 

--- a/test/new-e2e/tests/agent-shared-components/forwarder/nss_failover_test.go
+++ b/test/new-e2e/tests/agent-shared-components/forwarder/nss_failover_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
@@ -43,7 +44,7 @@ type multiFakeIntakeEnv struct {
 	Fakeintake2 *components.FakeIntake
 }
 
-func (e *multiFakeIntakeEnv) Init(ctx e2e.Context) error {
+func (e *multiFakeIntakeEnv) Init(ctx common.Context) error {
 	if e.Agent != nil {
 		agent, err := client.NewHostAgentClient(ctx, e.Host.HostOutput, true)
 		if err != nil {

--- a/test/new-e2e/tests/windows/install-test/installtester.go
+++ b/test/new-e2e/tests/windows/install-test/installtester.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	utilscommon "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	agentClient "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	agentClientParams "github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-platform/common"
@@ -51,7 +51,7 @@ type Tester struct {
 type TesterOption func(*Tester)
 
 // NewTester creates a new Tester
-func NewTester(context e2e.Context, host *components.RemoteHost, opts ...TesterOption) (*Tester, error) {
+func NewTester(context utilscommon.Context, host *components.RemoteHost, opts ...TesterOption) (*Tester, error) {
 	t := &Tester{}
 	tt := context.T()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Move Context from e2e to common
* Move Initializable from e2e to common
* Delete types.go from e2e

### Motivation

Having types defined in the top level package e2e causes circle dependencies when trying to add a new interface for environments and components

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->