### PR TITLE
[DJM Install flavor] Add tracer and injector on Databricks workers

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -172,9 +172,6 @@ func setHostTag(s *common.Setup, tagKey, value string) {
 func setupDatabricksDriver(s *common.Setup) {
 	s.Span.SetTag("spark_node", "driver")
 
-	s.Packages.Install(common.DatadogAPMInjectPackage, databricksInjectorVersion)
-	s.Packages.Install(common.DatadogAPMLibraryJavaPackage, databricksJavaVersion)
-
 	s.Config.DatadogYAML.Tags = append(s.Config.DatadogYAML.Tags, "node_type:driver")
 
 	var sparkIntegration common.IntegrationConfig
@@ -199,8 +196,6 @@ func setupDatabricksDriver(s *common.Setup) {
 
 func setupDatabricksWorker(s *common.Setup) {
 	s.Span.SetTag("spark_node", "worker")
-
-	s.Packages.Install(common.DatadogAgentPackage, databricksAgentVersion)
 
 	s.Config.DatadogYAML.Tags = append(s.Config.DatadogYAML.Tags, "node_type:worker")
 

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	databricksInjectorVersion = "0.26.0-1"
-	databricksJavaVersion     = "1.42.2-1"
-	databricksAgentVersion    = "7.58.2-1"
+	databricksInjectorVersion   = "0.26.0-1"
+	databricksJavaTracerVersion = "1.42.2-1"
+	databricksAgentVersion      = "7.58.2-1"
 )
 
 var (
@@ -65,7 +65,7 @@ var (
 			Service: "databricks",
 		},
 	}
-	tracerEnvConfig = []common.InjectTracerConfigEnvVar{
+	tracerEnvConfigDatabricks = []common.InjectTracerConfigEnvVar{
 		{
 			Key:   "DD_DATA_JOBS_ENABLED",
 			Value: "true",
@@ -80,6 +80,8 @@ var (
 // SetupDatabricks sets up the Databricks environment
 func SetupDatabricks(s *common.Setup) error {
 	s.Packages.Install(common.DatadogAgentPackage, databricksAgentVersion)
+	s.Packages.Install(common.DatadogAPMInjectPackage, databricksInjectorVersion)
+	s.Packages.Install(common.DatadogAPMLibraryJavaPackage, databricksJavaTracerVersion)
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -89,6 +91,8 @@ func SetupDatabricks(s *common.Setup) error {
 	s.Config.DatadogYAML.DJM.Enabled = true
 	s.Config.DatadogYAML.ExpectedTagsDuration = "10m"
 	s.Config.DatadogYAML.ProcessConfig.ExpvarPort = 6063 // avoid port conflict on 6062
+
+	s.Config.InjectTracerYAML.AdditionalEnvironmentVariables = tracerEnvConfigDatabricks
 
 	setupCommonHostTags(s)
 	installMethod := "manual"
@@ -172,7 +176,6 @@ func setupDatabricksDriver(s *common.Setup) {
 	s.Packages.Install(common.DatadogAPMLibraryJavaPackage, databricksJavaVersion)
 
 	s.Config.DatadogYAML.Tags = append(s.Config.DatadogYAML.Tags, "node_type:driver")
-	s.Config.InjectTracerYAML.AdditionalEnvironmentVariables = tracerEnvConfig
 
 	var sparkIntegration common.IntegrationConfig
 	if os.Getenv("DRIVER_LOGS_ENABLED") == "true" {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add the injector and the tracer on Databricks workers. Harmonize variables names with EMR flavor, following this [EMR script PR](https://github.com/DataDog/datadog-agent/pull/32328).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->