### PR TITLE
[NDM] Do not always log error on SNMP Autodiscovery unmarshal failure

### DIFF
--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -79,7 +79,7 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	// Auto-activate autodiscovery without listeners: - snmp
 	snmpConfig, err := snmplistener.NewListenerConfig()
 
-	if err != nil && !errors.Is(err, snmplistener.ErrNoConfigGivenError) {
+	if err != nil && !errors.Is(err, snmplistener.ErrNoConfigGiven) {
 		log.Errorf("Error unmarshalling snmp listener config. Error: %v", err)
 	} else if len(snmpConfig.Configs) > 0 {
 		detectedListeners = append(detectedListeners, pkgconfigsetup.Listeners{Name: "snmp"})

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -9,6 +9,8 @@
 package autodiscovery
 
 import (
+	"errors"
+
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
@@ -77,7 +79,7 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	// Auto-activate autodiscovery without listeners: - snmp
 	snmpConfig, err := snmplistener.NewListenerConfig()
 
-	if err != nil {
+	if err != nil && !errors.Is(err, snmplistener.NoConfigGivenError) {
 		log.Errorf("Error unmarshalling snmp listener config. Error: %v", err)
 	} else if len(snmpConfig.Configs) > 0 {
 		detectedListeners = append(detectedListeners, pkgconfigsetup.Listeners{Name: "snmp"})

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -79,7 +79,7 @@ func DiscoverComponentsFromConfig() ([]pkgconfigsetup.ConfigurationProviders, []
 	// Auto-activate autodiscovery without listeners: - snmp
 	snmpConfig, err := snmplistener.NewListenerConfig()
 
-	if err != nil && !errors.Is(err, snmplistener.NoConfigGivenError) {
+	if err != nil && !errors.Is(err, snmplistener.ErrNoConfigGivenError) {
 		log.Errorf("Error unmarshalling snmp listener config. Error: %v", err)
 	} else if len(snmpConfig.Configs) > 0 {
 		detectedListeners = append(detectedListeners, pkgconfigsetup.Listeners{Name: "snmp"})

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -95,8 +95,8 @@ type intOrBoolPtr interface {
 	*int | *bool
 }
 
-// NoConfigGivenError is returned when the SNMP listener config was not found
-var NoConfigGivenError = errors.New("no config given for snmp_listener")
+// ErrNoConfigGivenError is returned when the SNMP listener config was not found
+var ErrNoConfigGivenError = errors.New("no config given for snmp_listener")
 
 // NewListenerConfig parses configuration and returns a built ListenerConfig
 func NewListenerConfig() (ListenerConfig, error) {
@@ -117,7 +117,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 			return snmpConfig, err
 		}
 	} else {
-		return snmpConfig, NoConfigGivenError
+		return snmpConfig, ErrNoConfigGivenError
 	}
 
 	if snmpConfig.AllowedFailures == 0 && snmpConfig.AllowedFailuresLegacy != 0 {

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -95,6 +95,7 @@ type intOrBoolPtr interface {
 	*int | *bool
 }
 
+// NoConfigGivenError is returned when the SNMP listener config was not found
 var NoConfigGivenError = errors.New("no config given for snmp_listener")
 
 // NewListenerConfig parses configuration and returns a built ListenerConfig

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -95,8 +95,8 @@ type intOrBoolPtr interface {
 	*int | *bool
 }
 
-// ErrNoConfigGivenError is returned when the SNMP listener config was not found
-var ErrNoConfigGivenError = errors.New("no config given for snmp_listener")
+// ErrNoConfigGiven is returned when the SNMP listener config was not found
+var ErrNoConfigGiven = errors.New("no config given for snmp_listener")
 
 // NewListenerConfig parses configuration and returns a built ListenerConfig
 func NewListenerConfig() (ListenerConfig, error) {
@@ -117,7 +117,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 			return snmpConfig, err
 		}
 	} else {
-		return snmpConfig, ErrNoConfigGivenError
+		return snmpConfig, ErrNoConfigGiven
 	}
 
 	if snmpConfig.AllowedFailures == 0 && snmpConfig.AllowedFailuresLegacy != 0 {

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -95,6 +95,8 @@ type intOrBoolPtr interface {
 	*int | *bool
 }
 
+var NoConfigGivenError = errors.New("no config given for snmp_listener")
+
 // NewListenerConfig parses configuration and returns a built ListenerConfig
 func NewListenerConfig() (ListenerConfig, error) {
 	var snmpConfig ListenerConfig
@@ -114,7 +116,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 			return snmpConfig, err
 		}
 	} else {
-		return snmpConfig, errors.New("no config given for snmp_listener")
+		return snmpConfig, NoConfigGivenError
 	}
 
 	if snmpConfig.AllowedFailures == 0 && snmpConfig.AllowedFailuresLegacy != 0 {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
#30180 introduced a new error log on SNMP Autodiscovery config unmarshal error. We don't want to log the error when the config is not set.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->