### PR TITLE
Use new option for removing memlock limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.59.1
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/DataDog/datadog-operator v0.7.1-0.20241219210556-f517775059d1
-	github.com/DataDog/ebpf-manager v0.7.4
+	github.com/DataDog/ebpf-manager v0.7.6-0.20241220171630-85822ef099a5
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.8
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.59.1
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/DataDog/datadog-operator v0.7.1-0.20241219210556-f517775059d1
-	github.com/DataDog/ebpf-manager v0.7.6-0.20241220171630-85822ef099a5
+	github.com/DataDog/ebpf-manager v0.7.6-0.20241220173048-7f05839a061d
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.8
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.59.1
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/DataDog/datadog-operator v0.7.1-0.20241219210556-f517775059d1
-	github.com/DataDog/ebpf-manager v0.7.6-0.20241220173048-7f05839a061d
+	github.com/DataDog/ebpf-manager v0.7.6-0.20241223104659-fb57b17b70e0
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.8
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.22.0

--- a/go.mod
+++ b/go.mod
@@ -160,7 +160,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.59.1
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/DataDog/datadog-operator v0.7.1-0.20241219210556-f517775059d1
-	github.com/DataDog/ebpf-manager v0.7.6-0.20241223104659-fb57b17b70e0
+	github.com/DataDog/ebpf-manager v0.7.6
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.8
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11 h1:6vwU//TjBIghQKMgIP9UyIRhN/LWS1y8tYzvRnu8JZw=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11/go.mod h1:woPHoAOfAIM7kl4GauR+qrWui7teNg44Um0verg2rzQ=
-github.com/DataDog/ebpf-manager v0.7.4 h1:fI2fJbDpykDiO/hq3IVIi+YLVVrJ97qG6O8LT7mdCnQ=
-github.com/DataDog/ebpf-manager v0.7.4/go.mod h1:QlCkGTH3koCMDG7E8o9Si6O9UXjBwQspP6z2YtKlyGU=
+github.com/DataDog/ebpf-manager v0.7.6-0.20241220171630-85822ef099a5 h1:Ma7TGpXMWVQ0VmMn5fACH9y6TwwSTtZDu6Ec9Z1oCXI=
+github.com/DataDog/ebpf-manager v0.7.6-0.20241220171630-85822ef099a5/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf/v3 v3.5.1 h1:GWA4ln4DlLxiXm+X7HA/oj0ZLcdCwOS81KQitegRTyY=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11 h1:6vwU//TjBIghQKMgIP9UyIRhN/LWS1y8tYzvRnu8JZw=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11/go.mod h1:woPHoAOfAIM7kl4GauR+qrWui7teNg44Um0verg2rzQ=
-github.com/DataDog/ebpf-manager v0.7.6-0.20241220173048-7f05839a061d h1:GTirhS2E1jRbPFXAxjWSko35E/fuSE1zl5P05r9C7yI=
-github.com/DataDog/ebpf-manager v0.7.6-0.20241220173048-7f05839a061d/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
+github.com/DataDog/ebpf-manager v0.7.6-0.20241223104659-fb57b17b70e0 h1:Rtc+ZZdETVd+1ZKIcFezejQAgR4a5ck3PQ+/ziT9c3c=
+github.com/DataDog/ebpf-manager v0.7.6-0.20241223104659-fb57b17b70e0/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf/v3 v3.5.1 h1:GWA4ln4DlLxiXm+X7HA/oj0ZLcdCwOS81KQitegRTyY=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11 h1:6vwU//TjBIghQKMgIP9UyIRhN/LWS1y8tYzvRnu8JZw=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11/go.mod h1:woPHoAOfAIM7kl4GauR+qrWui7teNg44Um0verg2rzQ=
-github.com/DataDog/ebpf-manager v0.7.6-0.20241220171630-85822ef099a5 h1:Ma7TGpXMWVQ0VmMn5fACH9y6TwwSTtZDu6Ec9Z1oCXI=
-github.com/DataDog/ebpf-manager v0.7.6-0.20241220171630-85822ef099a5/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
+github.com/DataDog/ebpf-manager v0.7.6-0.20241220173048-7f05839a061d h1:GTirhS2E1jRbPFXAxjWSko35E/fuSE1zl5P05r9C7yI=
+github.com/DataDog/ebpf-manager v0.7.6-0.20241220173048-7f05839a061d/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf/v3 v3.5.1 h1:GWA4ln4DlLxiXm+X7HA/oj0ZLcdCwOS81KQitegRTyY=

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11 h1:6vwU//TjBIghQKMgIP9UyIRhN/LWS1y8tYzvRnu8JZw=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11/go.mod h1:woPHoAOfAIM7kl4GauR+qrWui7teNg44Um0verg2rzQ=
-github.com/DataDog/ebpf-manager v0.7.6-0.20241223104659-fb57b17b70e0 h1:Rtc+ZZdETVd+1ZKIcFezejQAgR4a5ck3PQ+/ziT9c3c=
-github.com/DataDog/ebpf-manager v0.7.6-0.20241223104659-fb57b17b70e0/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
+github.com/DataDog/ebpf-manager v0.7.6 h1:EPH1VKeK7DuDRGFiOAmtTqTozdi2/SppTyLW0O1Zsa0=
+github.com/DataDog/ebpf-manager v0.7.6/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf/v3 v3.5.1 h1:GWA4ln4DlLxiXm+X7HA/oj0ZLcdCwOS81KQitegRTyY=

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -104,10 +104,7 @@ func startOOMKillProbe(buf bytecode.AssetReader, managerOptions manager.Options)
 		},
 	}
 
-	managerOptions.RLimit = &unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
-	}
+	managerOptions.RemoveRlimit = true
 
 	if err := m.InitWithOptions(buf, managerOptions); err != nil {
 		return nil, fmt.Errorf("failed to init manager: %w", err)

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -13,8 +13,6 @@ package oomkill
 
 import (
 	"fmt"
-	"math"
-
 	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
@@ -75,10 +75,7 @@ func startTCPQueueLengthProbe(buf bytecode.AssetReader, managerOptions manager.O
 		Maps:   maps,
 	}
 
-	managerOptions.RLimit = &unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
-	}
+	managerOptions.RemoveRlimit = true
 
 	if err := m.InitWithOptions(buf, managerOptions); err != nil {
 		return nil, fmt.Errorf("failed to init manager: %w", err)

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
@@ -13,8 +13,6 @@ package tcpqueuelength
 
 import (
 	"fmt"
-	"math"
-
 	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"

--- a/pkg/ebpf/printk_patcher_test.go
+++ b/pkg/ebpf/printk_patcher_test.go
@@ -64,11 +64,8 @@ func TestPatchPrintkNewline(t *testing.T) {
 	}
 
 	opts := manager.Options{
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
-		MapEditors: make(map[string]*ebpf.Map),
+		RemoveRlimit: true,
+		MapEditors:   make(map[string]*ebpf.Map),
 	}
 	mgr.InstructionPatchers = append(mgr.InstructionPatchers, patchPrintkNewline)
 

--- a/pkg/ebpf/printk_patcher_test.go
+++ b/pkg/ebpf/printk_patcher_test.go
@@ -9,7 +9,6 @@ package ebpf
 
 import (
 	"bufio"
-	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +19,6 @@ import (
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cilium/ebpf"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	ebpfkernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"

--- a/pkg/ebpf/telemetry/errors_telemetry_test.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_test.go
@@ -75,10 +75,7 @@ func triggerTestAndGetTelemetry(t *testing.T) []prometheus.Metric {
 	collector := NewEBPFErrorsCollector()
 
 	options := manager.Options{
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/ebpf/telemetry/errors_telemetry_test.go
+++ b/pkg/ebpf/telemetry/errors_telemetry_test.go
@@ -8,11 +8,8 @@
 package telemetry
 
 import (
-	"math"
 	"os"
 	"testing"
-
-	"golang.org/x/sys/unix"
 
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -68,10 +68,7 @@ func (e *ebpfProgram) Init() error {
 		kprobeAttachMethod = manager.AttachKprobeWithKprobeEvents
 	}
 	err := e.InitWithOptions(e.bytecode, manager.Options{
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -8,10 +8,7 @@
 package dns
 
 import (
-	"math"
-
 	manager "github.com/DataDog/ebpf-manager"
-	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -189,10 +189,7 @@ func newEBPFProgram(c *config.Config) (*manager.Manager, error) {
 		},
 	}
 	options := manager.Options{
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/network/protocols/events/consumer_test.go
+++ b/pkg/network/protocols/events/consumer_test.go
@@ -8,7 +8,6 @@
 package events
 
 import (
-	"math"
 	"os"
 	"path/filepath"
 	"sync"
@@ -23,7 +22,6 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/atomic"
-	"golang.org/x/sys/unix"
 
 	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -170,16 +169,7 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 	}
 
 	mgrOptions := manager.Options{
-		// Extend RLIMIT_MEMLOCK (8) size
-		// On some systems, the default for RLIMIT_MEMLOCK may be as low as 64 bytes.
-		// This will result in an EPERM (Operation not permitted) error, when trying to create an eBPF map
-		// using bpf(2) with BPF_MAP_CREATE.
-		//
-		// We are setting the limit to infinity until we have a better handle on the true requirements.
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 		MapSpecEditors: map[string]manager.MapSpecEditor{
 			probes.ConnMap:                           {MaxEntries: config.MaxTrackedConnections, EditorFlag: manager.EditMaxEntries},
 			probes.TCPStatsMap:                       {MaxEntries: config.MaxTrackedConnections, EditorFlag: manager.EditMaxEntries},

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -36,7 +36,7 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, connCloseEventHa
 
 	m := ddebpf.NewManagerWithDefault(&manager.Manager{}, "network", &ebpftelemetry.ErrorsTelemetryModifier{})
 	err := ddebpf.LoadCOREAsset(netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
-		o.RLimit = mgrOpts.RLimit
+		o.RemoveRlimit = mgrOpts.RemoveRlimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
 

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -275,7 +275,7 @@ func loadCORETracer(config *config.Config, mgrOpts manager.Options, connCloseEve
 	var closeFn func()
 	var err error
 	err = ddebpf.LoadCOREAsset(netebpf.ModuleFileName("tracer", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
-		o.RLimit = mgrOpts.RLimit
+		o.RemoveRlimit = mgrOpts.RemoveRlimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors
 		o.DefaultKprobeAttachMethod = mgrOpts.DefaultKprobeAttachMethod

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -156,10 +156,7 @@ func setupOffsetGuesser(guesser OffsetGuesser, config *config.Config, buf byteco
 	// Enable kernel probes used for offset guessing.
 	offsetMgr := guesser.Manager()
 	offsetOptions := manager.Options{
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 	}
 	enabledProbes, err := guesser.Probes(config)
 	if err != nil {

--- a/pkg/network/tracer/offsetguess/offsetguess.go
+++ b/pkg/network/tracer/offsetguess/offsetguess.go
@@ -9,11 +9,8 @@ package offsetguess
 
 import (
 	"fmt"
-	"math"
 	"sync"
 	"time"
-
-	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
 

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -9,7 +9,6 @@ package tracer
 
 import (
 	"fmt"
-	"math"
 	"net"
 	"slices"
 	"testing"

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -159,17 +159,8 @@ func testOffsetGuess(t *testing.T) {
 	}
 
 	opts := manager.Options{
-		// Extend RLIMIT_MEMLOCK (8) size
-		// On some systems, the default for RLIMIT_MEMLOCK may be as low as 64 bytes.
-		// This will result in an EPERM (Operation not permitted) error, when trying to create an eBPF map
-		// using bpf(2) with BPF_MAP_CREATE.
-		//
-		// We are setting the limit to infinity until we have a better handle on the true requirements.
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
-		MapEditors: make(map[string]*ebpf.Map),
+		RemoveRlimit: true,
+		MapEditors:   make(map[string]*ebpf.Map),
 	}
 
 	require.NoError(t, mgr.InitWithOptions(buf, opts))

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -11,14 +11,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"slices"
 	"unsafe"
 
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
-	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
@@ -381,10 +379,7 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		kprobeAttachMethod = manager.AttachKprobeWithKprobeEvents
 	}
 
-	options.RLimit = &unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
-	}
+	options.RemoveRlimit = true
 
 	options.MapSpecEditors = map[string]manager.MapSpecEditor{
 		connectionStatesMap: {

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -10,14 +10,12 @@ package sharedlibraries
 import (
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"runtime"
 	"strings"
 	"sync"
 
 	manager "github.com/DataDog/ebpf-manager"
-	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -480,10 +480,7 @@ func (e *EbpfProgram) stopImpl() {
 }
 
 func (e *EbpfProgram) init(buf bytecode.AssetReader, options manager.Options) error {
-	options.RLimit = &unix.Rlimit{
-		Cur: math.MaxUint64,
-		Max: math.MaxUint64,
-	}
+	options.RemoveRlimit = true
 
 	for _, probe := range e.Probes {
 		options.ActivatedProbes = append(options.ActivatedProbes,

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -9,10 +9,7 @@
 package ebpf
 
 import (
-	"math"
-
 	manager "github.com/DataDog/ebpf-manager"
-	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 )
@@ -25,16 +22,7 @@ func NewDefaultOptions() manager.Options {
 
 		DefaultPerfRingBufferSize: probes.EventsPerfRingBufferSize,
 
-		// Extend RLIMIT_MEMLOCK (8) size
-		// On some systems, the default for RLIMIT_MEMLOCK may be as low as 64 bytes.
-		// This will result in an EPERM (Operation not permitted) error, when trying to create an eBPF map
-		// using bpf(2) with BPF_MAP_CREATE.
-		//
-		// We are setting the limit to infinity until we have a better handle on the true requirements.
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 	}
 }
 

--- a/pkg/security/probe/constantfetch/offset_guesser.go
+++ b/pkg/security/probe/constantfetch/offset_guesser.go
@@ -10,12 +10,10 @@ package constantfetch
 
 import (
 	"errors"
-	"math"
 	"os"
 	"os/exec"
 
 	manager "github.com/DataDog/ebpf-manager"
-	"golang.org/x/sys/unix"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"

--- a/pkg/security/probe/constantfetch/offset_guesser.go
+++ b/pkg/security/probe/constantfetch/offset_guesser.go
@@ -186,10 +186,7 @@ func (og *OffsetGuesser) FinishAndGetResults() (map[string]uint64, error) {
 				Value: uint64(utils.Getpid()),
 			},
 		},
-		RLimit: &unix.Rlimit{
-			Cur: math.MaxUint64,
-			Max: math.MaxUint64,
-		},
+		RemoveRlimit: true,
 	}
 
 	for _, probe := range probes.AllProbes(true) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Updates the ebpf-manager and uses the new option added in https://github.com/DataDog/ebpf-manager/pull/207 to remove the memlock limit.

### Motivation
The new option does not remove the memlock limit on kernel where eBPF does not use rlimit based memory accounting.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->