### PR TITLE
[CWS] fix rule filter in local policy check

### DIFF
--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -41,6 +41,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/reporter"
+	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -463,12 +464,22 @@ func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
 		return fmt.Errorf("failed to create agent version filter: %w", err)
 	}
 
+	os := runtime.GOOS
+	if args.windowsModel {
+		os = "windows"
+	}
+
+	ruleFilterModel := filtermodel.NewOSOnlyFilterModel(os)
+	seclRuleFilter := rules.NewSECLRuleFilter(ruleFilterModel)
+
 	loaderOpts := rules.PolicyLoaderOpts{
 		MacroFilters: []rules.MacroFilter{
 			agentVersionFilter,
+			seclRuleFilter,
 		},
 		RuleFilters: []rules.RuleFilter{
 			agentVersionFilter,
+			seclRuleFilter,
 		},
 	}
 

--- a/pkg/security/rules/filtermodel/os_only_filter.go
+++ b/pkg/security/rules/filtermodel/os_only_filter.go
@@ -1,0 +1,103 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package filtermodel holds rules related files
+package filtermodel
+
+import (
+	"reflect"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+// OSOnlyFilterEvent defines an os-only rule filter event
+type OSOnlyFilterEvent struct {
+	os string
+}
+
+// OSOnlyFilterModel defines a filter model
+type OSOnlyFilterModel struct {
+	os string
+}
+
+// NewOSOnlyFilterModel returns a new rule filter model
+func NewOSOnlyFilterModel(os string) *OSOnlyFilterModel {
+	return &OSOnlyFilterModel{
+		os: os,
+	}
+}
+
+// NewEvent returns a new event
+func (m *OSOnlyFilterModel) NewEvent() eval.Event {
+	return &OSOnlyFilterEvent{
+		os: m.os,
+	}
+}
+
+// GetEvaluator gets the evaluator
+func (m *OSOnlyFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eval.Evaluator, error) {
+	switch field {
+	case "os":
+		return &eval.StringEvaluator{
+			EvalFnc: func(_ *eval.Context) string { return m.os },
+			Field:   field,
+		}, nil
+	}
+
+	return nil, &eval.ErrFieldNotFound{Field: field}
+}
+
+// GetFieldValue gets a field value
+func (e *OSOnlyFilterEvent) GetFieldValue(field eval.Field) (interface{}, error) {
+	switch field {
+	case "os":
+		return e.os, nil
+	}
+
+	return nil, &eval.ErrFieldNotFound{Field: field}
+}
+
+// Init inits the rule filter event
+func (e *OSOnlyFilterEvent) Init() {}
+
+// GetFieldEventType returns the event type for the given field
+func (e *OSOnlyFilterEvent) GetFieldEventType(_ eval.Field) (string, error) {
+	return "*", nil
+}
+
+// SetFieldValue sets the value for the given field
+func (e *OSOnlyFilterEvent) SetFieldValue(field eval.Field, _ interface{}) error {
+	return &eval.ErrFieldNotFound{Field: field}
+}
+
+// GetFieldType get the type of the field
+func (e *OSOnlyFilterEvent) GetFieldType(field eval.Field) (reflect.Kind, error) {
+	switch field {
+	case "os":
+		return reflect.String, nil
+	}
+
+	return reflect.Invalid, &eval.ErrFieldNotFound{Field: field}
+}
+
+// GetType returns the type for this event
+func (e *OSOnlyFilterEvent) GetType() string {
+	return "*"
+}
+
+// GetTags returns the tags for this event
+func (e *OSOnlyFilterEvent) GetTags() []string {
+	return []string{}
+}
+
+// ValidateField returns whether the value use against the field is valid
+func (m *OSOnlyFilterModel) ValidateField(_ string, _ eval.FieldValue) error {
+	return nil
+}
+
+// GetFieldRestrictions returns the field event type restrictions
+func (m *OSOnlyFilterModel) GetFieldRestrictions(_ eval.Field) []eval.EventType {
+	return nil
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently when you run
```
security-agent runtime policy check
```

all the rules in the policy will be checked, including the windows one (when running on linux), and including the linux ones (when running with the windows model)

This PR fixes this issue by including a rule filter model. Since we can't use the full one model, this PR introduces a basic model providing just the OS, so that the filtering can be done correctly.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->