### PR TITLE
Adding debug/trace logging to webhook startup

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -104,6 +104,7 @@ func (s *Server) initDecoder() {
 // Register adds an admission webhook handler.
 // Register must be called to register the desired webhook handlers before calling Run.
 func (s *Server) Register(uri string, webhookName string, webhookType admicommon.WebhookType, f WebhookFunc, dc dynamic.Interface, apiClient kubernetes.Interface) {
+	log.Debugf("register admission webhook name=%s at %s", webhookName, uri)
 	s.mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		s.handle(w, r, webhookName, webhookType, f, dc, apiClient)
 	})

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -496,6 +496,7 @@ func start(log log.Component,
 			// Webhook and secret controllers are started successfully
 			// Set up the k8s admission webhook server
 			server := admissioncmd.NewServer()
+			log.Debug("setting  up admission webhook server")
 
 			for _, webhookConf := range webhooks {
 				server.Register(webhookConf.Endpoint(), webhookConf.Name(), webhookConf.WebhookType(), webhookConf.WebhookFunc(), apiCl.DynamicCl, apiCl.Cl)

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -60,8 +60,10 @@ func NewController(
 	demultiplexer demultiplexer.Component,
 ) Controller {
 	if config.useAdmissionV1() {
+		log.Trace("using admissionV1")
 		return NewControllerV1(client, secretInformer, validatingInformers.V1().ValidatingWebhookConfigurations(), mutatingInformers.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa, datadogConfig, demultiplexer)
 	}
+	log.Trace("using admissionV1beta1")
 	return NewControllerV1beta1(client, secretInformer, validatingInformers.V1beta1().ValidatingWebhookConfigurations(), mutatingInformers.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config, wmeta, pa, datadogConfig, demultiplexer)
 }
 
@@ -121,6 +123,9 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 
 	// Add Mutating webhooks.
 	if c.config.isMutationEnabled() {
+
+		log.Debug("mutation enabled adding initializing webhooks")
+
 		mutatingWebhooks = []Webhook{
 			configWebhook.NewWebhook(wmeta, injectionFilter, datadogConfig),
 			tagsfromlabels.NewWebhook(wmeta, datadogConfig, injectionFilter),
@@ -146,6 +151,8 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 				log.Errorf("failed to register CWS Instrumentation webhook: %v", err)
 			}
 		}
+	} else {
+		log.Debug("mutation disabled")
 	}
 
 	return webhooks

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -79,6 +79,7 @@ func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa wo
 		return webhooks, err
 	}
 
+	log.Debug("init webhook controller")
 	webhookConfig := webhook.NewConfig(v1Enabled, nsSelectorEnabled, matchConditionsSupported)
 	webhookController := webhook.NewController(
 		ctx.Client,


### PR DESCRIPTION
### What does this PR do?

This PR adds debug logging to the webhooks.

---

Once the image is built, will add the image tag here so that it's accessible in a cluster.

Helm chart:

```yaml
clusterAgent:
    image: 
        repository: ddstanistan/cluster-agent
        tag: v51736583-f218a2cd-amd64
        doNotCheckTag: true
```

ddstanistan is on dockerhub here: https://hub.docker.com/r/ddstanistan/cluster-agent/tags