### PR TITLE
omnibus: fix false positive when forcing omnibus versions through env

### DIFF
--- a/tasks/libs/common/omnibus.py
+++ b/tasks/libs/common/omnibus.py
@@ -210,8 +210,10 @@ def omnibus_compute_cache_key(ctx):
     omnibus_last_changes = _last_omnibus_changes(ctx)
     h.update(str.encode(omnibus_last_changes))
     h.update(str.encode(os.getenv('CI_JOB_IMAGE', 'local_build')))
-    omnibus_ruby_commit = _get_omnibus_commits('OMNIBUS_RUBY_VERSION')
-    omnibus_software_commit = _get_omnibus_commits('OMNIBUS_SOFTWARE_VERSION')
+    # Omnibus ruby & software versions can be forced through the environment
+    # so we need to read it from there first, and fallback to release.json
+    omnibus_ruby_commit = os.getenv('OMNIBUS_RUBY_VERSION', _get_omnibus_commits('OMNIBUS_RUBY_VERSION'))
+    omnibus_software_commit = os.getenv('OMNIBUS_SOFTWARE_VERSION', _get_omnibus_commits('OMNIBUS_SOFTWARE_VERSION'))
     print(f'Omnibus ruby commit: {omnibus_ruby_commit}')
     print(f'Omnibus software commit: {omnibus_software_commit}')
     h.update(str.encode(omnibus_ruby_commit))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Account for omnibus ruby & software versions being forced through the environment

### Motivation

This fixes a potential false positive when computing the cache key for omnibus-ruby & omnibus-software child pipeline.
An example can be found here: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/748313477

This is not a critical problem since omnibus will realize the recipe changed, but it will upload the updated cache, which will in turn cause a more complete build than is necessary for other pipelines using this cache key.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->