### PR TITLE
usm: file registry: Save block reason

### DIFF
--- a/pkg/network/usm/utils/debugger.go
+++ b/pkg/network/usm/utils/debugger.go
@@ -45,6 +45,7 @@ type BlockedProcess struct {
 type PathIdentifierWithSamplePath struct {
 	PathIdentifier
 	SamplePath string
+	Reason     string
 }
 
 // GetTracedProgramsEndpoint returns a callback for the given module name, that
@@ -213,11 +214,12 @@ func (d *tlsDebugger) GetBlockedPathIDsWithSamplePath(moduleName, programType st
 
 		blockedIDsWithSampleFile := make([]PathIdentifierWithSamplePath, 0, len(registry.blocklistByID.Keys()))
 		for _, pathIdentifier := range registry.blocklistByID.Keys() {
-			samplePath, ok := registry.blocklistByID.Get(pathIdentifier)
+			entry, ok := registry.blocklistByID.Get(pathIdentifier)
 			if ok {
 				blockedIDsWithSampleFile = append(blockedIDsWithSampleFile, PathIdentifierWithSamplePath{
 					PathIdentifier: pathIdentifier,
-					SamplePath:     samplePath})
+					SamplePath:     entry.Path,
+					Reason:         entry.Reason})
 			}
 		}
 

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -16,9 +16,11 @@ import (
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"go.uber.org/atomic"
 
+	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 // FileRegistry is responsible for tracking open files and executing callbacks
@@ -48,9 +50,15 @@ type FileRegistry struct {
 	byPID    map[uint32]pathIdentifierSet
 
 	// if we can't execute a callback for a given file we don't try more than once
-	blocklistByID *simplelru.LRU[PathIdentifier, string]
+	blocklistByID *simplelru.LRU[PathIdentifier, BlockListEntry]
 
 	telemetry registryTelemetry
+}
+
+// BlockListEntry represents an enty in the block list
+type BlockListEntry struct {
+	Path   string
+	Reason string
 }
 
 // FilePath represents the location of a file from the *root* namespace view
@@ -90,7 +98,7 @@ var ErrEnvironment = errors.New("Environment error, path will not be blocked")
 
 // NewFileRegistry creates a new `FileRegistry` instance
 func NewFileRegistry(moduleName, programName string) *FileRegistry {
-	blocklistByID, err := simplelru.NewLRU[PathIdentifier, string](2000, nil)
+	blocklistByID, err := simplelru.NewLRU[PathIdentifier, BlockListEntry](2000, nil)
 	if err != nil {
 		log.Warnf("running without block cache list, creation error: %s", err)
 		blocklistByID = nil
@@ -120,6 +128,22 @@ var (
 	// path is already in the file registry.
 	ErrPathIsAlreadyRegistered = errors.New("path is already registered")
 )
+
+// getBlockReason creates a string specifying the reason for the block based on
+// the error received. To reduce memory usage of this debugging feature, for
+// very common errors we store a summary instead of the full error string,
+// leaving the latter for more interesting errors.
+func getBlockReason(error error) string {
+	if errors.Is(error, binversion.ErrNotGoExe) {
+		return "not-go"
+	}
+
+	if errors.Is(error, safeelf.ErrNoSymbols) {
+		return "no-symbols"
+	}
+
+	return error.Error()
+}
 
 // Register inserts or updates a new file registration within to the `FileRegistry`;
 //
@@ -193,7 +217,7 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 		if r.blocklistByID != nil {
 			// add `pathID` to blocklist so we don't attempt to re-register files
 			// that are problematic for some reason
-			r.blocklistByID.Add(pathID, path.HostPath)
+			r.blocklistByID.Add(pathID, BlockListEntry{Path: path.HostPath, Reason: getBlockReason(err)})
 		}
 		r.telemetry.fileHookFailed.Add(1)
 		return err

--- a/pkg/network/usm/utils/file_registry_test.go
+++ b/pkg/network/usm/utils/file_registry_test.go
@@ -244,6 +244,9 @@ func TestFailedRegistration(t *testing.T) {
 	assert.Equal(t, 1, registerRecorder.CallsForPathID(pathID))
 
 	assert.Contains(t, debugger.GetBlockedPathIDs(testModuleName, ""), pathID)
+	info := debugger.GetBlockedPathIDsWithSamplePath(testModuleName, "")
+	require.Len(t, info, 1)
+	assert.Equal(t, registerRecorder.ReturnError.Error(), info[0].Reason)
 	debugger.ClearBlocked(testModuleName)
 	assert.Empty(t, debugger.GetBlockedPathIDs(testModuleName, ""))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When we block a path, save the reason and expose it via the debug endpoint, as a debugging aid. For common errors such as "not a Go program", we save a summary instead of the full error message to reduce memory usage.

### Motivation

https://datadoghq.atlassian.net/wiki/spaces/UT/pages/4105764896

### Describe how you validated your changes

Automated test updated to check for this.

Also manually tested by checking the debug endpoint.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->