### PR TITLE
usm: Remove redundant duplication of flushing events

### DIFF
--- a/pkg/network/ebpf/c/protocols/flush.h
+++ b/pkg/network/ebpf/c/protocols/flush.h
@@ -1,0 +1,31 @@
+#ifndef __USM_FLUSH_H
+#define __USM_FLUSH_H
+
+#include "bpf_bypass.h"
+
+#include "protocols/http/http.h"
+#include "protocols/http2/decoding.h"
+#include "protocols/kafka/kafka-parsing.h"
+#include "protocols/postgres/decoding.h"
+#include "protocols/redis/decoding.h"
+
+// flush all batched events to userspace for all protocols.
+// because perf events can't be sent from socket filter programs.
+static __always_inline void flush(void *ctx) {
+    http_batch_flush(ctx);
+    http2_batch_flush(ctx);
+    terminated_http2_batch_flush(ctx);
+    kafka_batch_flush(ctx);
+    postgres_batch_flush(ctx);
+    redis_batch_flush(ctx);
+}
+
+SEC("tracepoint/net/netif_receive_skb")
+int tracepoint__net__netif_receive_skb(void *ctx) {
+    CHECK_BPF_PROGRAM_BYPASSED()
+    log_debug("tracepoint/net/netif_receive_skb");
+    flush(ctx);
+    return 0;
+}
+
+#endif

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -16,6 +16,7 @@
 #include "pid_tgid.h"
 
 #include "protocols/classification/dispatcher-helpers.h"
+#include "protocols/flush.h"
 #include "protocols/http/buffer.h"
 #include "protocols/http/http.h"
 #include "protocols/http2/decoding.h"
@@ -61,21 +62,6 @@ int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendmsg, struct sock *sk) {
     // map connection tuple during SSL_do_handshake(ctx)
     map_ssl_ctx_to_sock(sk);
 
-    return 0;
-}
-
-SEC("tracepoint/net/netif_receive_skb")
-int tracepoint__net__netif_receive_skb(void *ctx) {
-    CHECK_BPF_PROGRAM_BYPASSED()
-    log_debug("tracepoint/net/netif_receive_skb");
-    // flush batch to userspace
-    // because perf events can't be sent from socket filter programs
-    http_batch_flush(ctx);
-    http2_batch_flush(ctx);
-    terminated_http2_batch_flush(ctx);
-    kafka_batch_flush(ctx);
-    postgres_batch_flush(ctx);
-    redis_batch_flush(ctx);
     return 0;
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Moving flushing implementation into an helper function
Sharing flushing implementation between prebuilt and runtime builds

### Motivation

We had a duplicated implementation between prebuilt and runtime builds for flushing events form the kernel to the user mode.
Instead, we use a single implementation that is shared.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->