### PR TITLE
[ASCII-1483] Add scrubber to status output

### DIFF
--- a/cmd/agent/subcommands/status/command.go
+++ b/cmd/agent/subcommands/status/command.go
@@ -7,7 +7,6 @@
 package status
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -85,14 +84,6 @@ The --list flag can be used to list all available status sections.`,
 	return []*cobra.Command{cmd}
 }
 
-func scrubMessage(message string) string {
-	msgScrubbed, err := scrubber.ScrubBytes([]byte(message))
-	if err == nil {
-		return string(msgScrubbed)
-	}
-	return "[REDACTED] - failure to clean the message"
-}
-
 func redactError(unscrubbedError error) error {
 	if unscrubbedError == nil {
 		return unscrubbedError
@@ -138,18 +129,7 @@ func setIpcURL(cliParams *cliParams) url.Values {
 }
 
 func renderResponse(res []byte, cliParams *cliParams) error {
-	var s string
-
-	// The rendering is done in the client so that the agent has less work to do
-	if cliParams.prettyPrintJSON {
-		var prettyJSON bytes.Buffer
-		json.Indent(&prettyJSON, res, "", "  ") //nolint:errcheck
-		s = prettyJSON.String()
-	} else if cliParams.jsonStatus {
-		s = string(res)
-	} else {
-		s = scrubMessage(string(res))
-	}
+	s := string(res)
 
 	if cliParams.statusFilePath != "" {
 		return os.WriteFile(cliParams.statusFilePath, []byte(s), 0644)

--- a/comp/core/gui/guiimpl/agent.go
+++ b/comp/core/gui/guiimpl/agent.go
@@ -68,7 +68,11 @@ func getStatus(w http.ResponseWriter, r *http.Request, statusComponent status.Co
 
 	if len(stats) != 0 {
 		// scrub status output
-		stats, err = scrubber.DefaultScrubber.ScrubBytes(stats)
+		var e error
+		stats, e = scrubber.DefaultScrubber.ScrubBytes(stats)
+		if e != nil {
+			stats = []byte("[REDACTED] - failure to clean the message")
+		}
 	}
 
 	if err != nil {

--- a/comp/core/gui/guiimpl/agent.go
+++ b/comp/core/gui/guiimpl/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -63,6 +64,11 @@ func getStatus(w http.ResponseWriter, r *http.Request, statusComponent status.Co
 		stats, err = statusComponent.GetStatusBySections([]string{status.CollectorSection}, "html", verbose)
 	} else {
 		stats, err = statusComponent.GetStatus("html", verbose, status.CollectorSection)
+	}
+
+	if len(stats) != 0 {
+		// scrub status output
+		stats, err = scrubber.DefaultScrubber.ScrubBytes(stats)
 	}
 
 	if err != nil {

--- a/comp/core/gui/guiimpl/agent.go
+++ b/comp/core/gui/guiimpl/agent.go
@@ -72,8 +72,13 @@ func getStatus(w http.ResponseWriter, r *http.Request, statusComponent status.Co
 	}
 
 	if err != nil {
-		log.Errorf("Error getting status: %s", err.Error())
-		w.Write([]byte("Error getting status: " + err.Error()))
+		errMsg := fmt.Sprintf("Error getting status: %v", err)
+		scrubbedMsg, scrubOperationErr := scrubber.DefaultScrubber.ScrubBytes([]byte(errMsg))
+		if scrubOperationErr != nil {
+			scrubbedMsg = []byte("[REDACTED] failed to clean error")
+		}
+		log.Error(string(scrubbedMsg))
+		w.Write(scrubbedMsg)
 		return
 	}
 

--- a/comp/core/status/statusimpl/go.mod
+++ b/comp/core/status/statusimpl/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.59.0
 	github.com/DataDog/datadog-agent/pkg/util/flavor v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.59.1
 	github.com/DataDog/datadog-agent/pkg/version v0.59.1
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.10.0
@@ -74,7 +75,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/log/setup v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/optional v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.59.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.59.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.59.1 // indirect

--- a/comp/core/status/statusimpl/status_api_endpoints.go
+++ b/comp/core/status/statusimpl/status_api_endpoints.go
@@ -47,10 +47,14 @@ func (s *statusImplementation) getStatus(w http.ResponseWriter, r *http.Request,
 	if len(buff) != 0 {
 		// scrub status output
 		s := scrubber.DefaultScrubber
+		var e error
 		if format == "json" {
-			buff, err = s.ScrubJSON(buff)
+			buff, e = s.ScrubJSON(buff)
 		} else {
-			buff, err = s.ScrubBytes(buff)
+			buff, e = s.ScrubBytes(buff)
+		}
+		if e != nil {
+			buff = []byte("[REDACTED] - failure to clean the message")
 		}
 	}
 

--- a/comp/core/status/statusimpl/status_api_endpoints.go
+++ b/comp/core/status/statusimpl/status_api_endpoints.go
@@ -60,7 +60,7 @@ func (s *statusImplementation) getStatus(w http.ResponseWriter, r *http.Request,
 		var scrubOperationErr error
 
 		if format == "text" {
-			errorMsg = fmt.Sprintf("Error getting status. Error: %v", err)
+			errorMsg = fmt.Sprintf("Error getting status. Error: %v.", err)
 			scrubbedMsg, scrubOperationErr = scrubber.DefaultScrubber.ScrubBytes([]byte(errorMsg))
 		} else {
 			errorMsg = fmt.Sprintf("Error getting status. Error: %v, Status: %v", err, buff)
@@ -72,7 +72,7 @@ func (s *statusImplementation) getStatus(w http.ResponseWriter, r *http.Request,
 			scrubbedMsg = []byte("[REDACTED] failed to clean error")
 		}
 
-		http.Error(w, s.log.Error(scrubbedMsg).Error(), http.StatusInternalServerError)
+		http.Error(w, s.log.Error(string(scrubbedMsg)).Error(), http.StatusInternalServerError)
 		if format == "json" {
 			w.Header().Set("Content-Type", "application/json")
 		}

--- a/comp/core/status/statusimpl/status_api_endpoints.go
+++ b/comp/core/status/statusimpl/status_api_endpoints.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+
+	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
 
 var mimeTypeMap = map[string]string{
@@ -46,6 +48,16 @@ func (s *statusImplementation) getStatus(w http.ResponseWriter, r *http.Request,
 		buff, err = s.GetStatusBySections([]string{section}, format, verbose)
 	} else {
 		buff, err = s.GetStatus(format, verbose)
+	}
+
+	if len(buff) != 0 {
+		// scrub status output
+		s := scrubber.DefaultScrubber
+		if format == "json" {
+			buff, err = s.ScrubJSON(buff)
+		} else {
+			buff, err = s.ScrubBytes(buff)
+		}
 	}
 
 	if err != nil {

--- a/comp/core/status/statusimpl/status_api_endpoints_test.go
+++ b/comp/core/status/statusimpl/status_api_endpoints_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -228,7 +229,11 @@ func TestStatusAPIEndpoints(t *testing.T) {
 			require.Equal(t, rr.Code, test.expectedCode)
 
 			// Check the response content type
-			require.Equal(t, test.expectedBody, rr.Body.Bytes())
+			if strings.Contains(test.testedPath, "format=json") {
+				require.JSONEq(t, strings.TrimSpace(string(test.expectedBody)), strings.TrimSpace(rr.Body.String()))
+			} else {
+				require.Equal(t, strings.TrimSpace(string(test.expectedBody)), strings.TrimSpace(rr.Body.String()))
+			}
 
 			// Check additional tests
 			if test.additionalTests != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the scrubber to the status component to scrub sensitive data before sending the status output.

### Motivation

Avoid sending sensitives data

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Run status command with and without json option

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->