### PR TITLE
[EBPF] gpu: automatically configure cgroups for NVIDIA permissions

### DIFF
--- a/cmd/system-probe/modules/gpu.go
+++ b/cmd/system-probe/modules/gpu.go
@@ -10,6 +10,7 @@ package modules
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -46,6 +47,12 @@ var GPUMonitoring = module.Factory{
 
 		if processEventConsumer == nil {
 			return nil, fmt.Errorf("process event consumer not initialized")
+		}
+
+		// TODO: Use config path for rootfs
+		err := gpu.ConfigureDeviceCgroupsForProcess(uint32(os.Getpid()), "/host")
+		if err != nil {
+			log.Warnf("Failed to configure device cgroups for process: %v", err)
 		}
 
 		c := gpuconfig.New()

--- a/cmd/system-probe/modules/gpu.go
+++ b/cmd/system-probe/modules/gpu.go
@@ -56,7 +56,7 @@ var GPUMonitoring = module.Factory{
 			log.Info("Configuring GPU device cgroup permissions for system-probe")
 			err := gpu.ConfigureDeviceCgroupsForProcess(uint32(os.Getpid()), hostRoot())
 			if err != nil {
-				log.Warnf("Failed to configure device cgroups for process: %v", err)
+				log.Warnf("Failed to configure device cgroups for process: %v, gpu-monitoring module might not work properly", err)
 			}
 		}
 

--- a/cmd/system-probe/modules/gpu.go
+++ b/cmd/system-probe/modules/gpu.go
@@ -54,7 +54,7 @@ var GPUMonitoring = module.Factory{
 
 		if c.ConfigureCgroupPerms {
 			log.Info("Configuring GPU device cgroup permissions for system-probe")
-			err := gpu.ConfigureDeviceCgroupsForProcess(uint32(os.Getpid()), hostRoot())
+			err := gpu.ConfigureDeviceCgroups(uint32(os.Getpid()), hostRoot())
 			if err != nil {
 				log.Warnf("Failed to configure device cgroups for process: %v, gpu-monitoring module might not work properly", err)
 			}

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -428,6 +428,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnv(join(gpuNS, "nvml_lib_path"))
 	cfg.BindEnvAndSetDefault(join(gpuNS, "process_scan_interval_seconds"), 5)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "initial_process_sync"), true)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "configure_cgroup_perms"), false)
 
 	initCWSSystemProbeConfig(cfg)
 }

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -61,7 +61,8 @@ func configureSystemdDeviceAllow(containerID string, rootfs string) error {
 	}
 	defer systemdDeviceAllow.Close()
 
-	// Allow access to the NVIDIA character device
+	// Allow access to the NVIDIA character device.
+	// Hardcode the string to avoid this from being accidentally changed to another value or set dynamically.
 	_, err = systemdDeviceAllow.WriteString("DeviceAllow=char-nvidia rwm\n")
 	if err != nil {
 		return fmt.Errorf("failed to write to %s: %w", systemdDeviceAllowPath, err)
@@ -86,6 +87,7 @@ func configureCgroupDeviceAllow(containerID, rootfs string) error {
 	defer cgroupDeviceAllow.Close()
 
 	// Allow access to the NVIDIA character device. 195 is the major number for the NVIDIA character device.
+	// Hardcode the string to avoid this from being accidentally changed to another value or set dynamically.
 	_, err = cgroupDeviceAllow.WriteString("c 195:* rwm\n")
 	if err != nil {
 		return fmt.Errorf("failed to write to %s: %w", cgroupDeviceAllowPath, err)

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -1,0 +1,122 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux
+
+package gpu
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func ConfigureDeviceCgroupsForProcess(pid uint32, rootfs string) error {
+	containerID, context, err := utils.GetProcContainerContext(pid, pid)
+	if err != nil {
+		return fmt.Errorf("failed to get container ID for pid %d: %w", pid, err)
+	}
+
+	if containerID == "" || string(context.CGroupID) == "" {
+		// Nothing to do if the process is not in a container
+		return nil
+	}
+
+	// Configure systemd device allow first, so that in case of a reload we get the correct permissions
+	// The containerID for systemd is the last part of the cgroup path
+	cgroupParts := strings.Split(string(context.CGroupID), "/")
+	systemdContainerID := cgroupParts[len(cgroupParts)-1]
+	if err := configureSystemdDeviceAllow(systemdContainerID, rootfs); err != nil {
+		return fmt.Errorf("failed to configure systemd device allow for container %s: %w", systemdContainerID, err)
+	}
+
+	// Configure cgroup device allow
+	if err := configureCgroupDeviceAllow(string(context.CGroupID), rootfs); err != nil {
+		return fmt.Errorf("failed to configure cgroup device allow for container %s: %w", containerID, err)
+	}
+
+	return nil
+}
+
+func configureSystemdDeviceAllow(containerID string, rootfs string) error {
+	systemdDeviceAllowPath, err := buildSafePath(rootfs, "run/systemd/transient", containerID+".d", "50-DeviceAllow.conf")
+	if err != nil {
+		return fmt.Errorf("failed to build systemd/transient path: %w", err)
+	}
+
+	log.Warnf("Configuring systemd device allow for container %s: %s", containerID, systemdDeviceAllowPath)
+
+	// Open the systemd device allow file
+	systemdDeviceAllow, err := os.OpenFile(systemdDeviceAllowPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", systemdDeviceAllowPath, err)
+	}
+	defer systemdDeviceAllow.Close()
+
+	// Allow access to the NVIDIA character device
+	_, err = systemdDeviceAllow.WriteString("DeviceAllow=char-nvidia rwm\n")
+	if err != nil {
+		return fmt.Errorf("failed to write to %s: %w", systemdDeviceAllowPath, err)
+	}
+
+	return nil
+}
+
+func configureCgroupDeviceAllow(containerID, rootfs string) error {
+	cgroupDeviceAllowPath, err := buildSafePath(rootfs, "sys/fs/cgroup/devices", containerID, "devices.allow")
+	if err != nil {
+		return fmt.Errorf("failed to build cgroup/devices path: %w", err)
+	}
+
+	log.Warnf("Configuring systemd device allow for container %s: %s", containerID, cgroupDeviceAllowPath)
+
+	// Open the cgroup device allow file
+	cgroupDeviceAllow, err := os.OpenFile(cgroupDeviceAllowPath, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open %s: %w", cgroupDeviceAllowPath, err)
+	}
+	defer cgroupDeviceAllow.Close()
+
+	// Allow access to the NVIDIA character device. 195 is the major number for the NVIDIA character device.
+	_, err = cgroupDeviceAllow.WriteString("c 195:* rwm\n")
+	if err != nil {
+		return fmt.Errorf("failed to write to %s: %w", cgroupDeviceAllowPath, err)
+	}
+
+	return nil
+}
+
+// buildSafePath builds a safe path from the rootfs and basedir, and appends the
+// parts to it. It assumes that rootfs and basedir are already validated paths,
+// and check that the parts being added to the path do not cause the final path
+// to escape the rootfs/basedir.
+func buildSafePath(rootfs string, basedir string, parts ...string) (string, error) {
+	// Remove trailing slashes from rootfs
+	if strings.HasSuffix(rootfs, "/") {
+		rootfs = rootfs[:len(rootfs)-1]
+	}
+
+	// And remove leading slashes from basedir
+	if strings.HasPrefix(basedir, "/") {
+		basedir = basedir[1:]
+	}
+
+	// that way we can now join the paths using Sprintf to build the base directory
+	root := fmt.Sprintf("%s/%s", rootfs, basedir)
+
+	// Join the parts to the base directory and create a full path. Note that this will also remove any ".." from the path
+	fullPath := path.Join(append([]string{root}, parts...)...)
+
+	// Check that the resulting path is a child of root and that we haven't escaped the rootfs/basedir
+	if !strings.HasPrefix(fullPath, root) {
+		return "", fmt.Errorf("invalid path %s, should be a child of %s", fullPath, root)
+	}
+
+	return fullPath, nil
+}

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -54,7 +54,7 @@ func configureSystemdDeviceAllow(containerID string, rootfs string) error {
 		return fmt.Errorf("failed to build systemd/transient path: %w", err)
 	}
 
-	log.Debugf("Configuring systemd device allow for container %s: %s", containerID, systemdDeviceAllowPath)
+	log.Debugf("configuring systemd device allow for container %s: %s", containerID, systemdDeviceAllowPath)
 
 	// Open the systemd device allow file
 	systemdDeviceAllow, err := os.OpenFile(systemdDeviceAllowPath, os.O_APPEND|os.O_WRONLY, 0)
@@ -79,7 +79,7 @@ func configureCgroupDeviceAllow(containerID, rootfs string) error {
 		return fmt.Errorf("failed to build cgroup/devices path: %w", err)
 	}
 
-	log.Debugf("Configuring systemd device allow for container %s: %s", containerID, cgroupDeviceAllowPath)
+	log.Debugf("configuring systemd device allow for container %s: %s", containerID, cgroupDeviceAllowPath)
 
 	// Open the cgroup device allow file
 	cgroupDeviceAllow, err := os.OpenFile(cgroupDeviceAllowPath, os.O_APPEND|os.O_WRONLY, 0)

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -52,7 +52,7 @@ func configureSystemdDeviceAllow(containerID string, rootfs string) error {
 		return fmt.Errorf("failed to build systemd/transient path: %w", err)
 	}
 
-	log.Warnf("Configuring systemd device allow for container %s: %s", containerID, systemdDeviceAllowPath)
+	log.Debugf("Configuring systemd device allow for container %s: %s", containerID, systemdDeviceAllowPath)
 
 	// Open the systemd device allow file
 	systemdDeviceAllow, err := os.OpenFile(systemdDeviceAllowPath, os.O_APPEND|os.O_WRONLY, 0)
@@ -77,7 +77,7 @@ func configureCgroupDeviceAllow(containerID, rootfs string) error {
 		return fmt.Errorf("failed to build cgroup/devices path: %w", err)
 	}
 
-	log.Warnf("Configuring systemd device allow for container %s: %s", containerID, cgroupDeviceAllowPath)
+	log.Debugf("Configuring systemd device allow for container %s: %s", containerID, cgroupDeviceAllowPath)
 
 	// Open the cgroup device allow file
 	cgroupDeviceAllow, err := os.OpenFile(cgroupDeviceAllowPath, os.O_APPEND|os.O_WRONLY, 0)

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -34,8 +34,7 @@ func ConfigureDeviceCgroups(pid uint32, rootfs string) error {
 
 	// Configure systemd device allow first, so that in case of a reload we get the correct permissions
 	// The containerID for systemd is the last part of the cgroup path
-	cgroupParts := strings.Split(string(cgroup.Path), "/")
-	systemdContainerID := cgroupParts[len(cgroupParts)-1]
+	systemdContainerID := filepath.Base(string(cgroup.Path))
 	if err := configureSystemdDeviceAllow(systemdContainerID, rootfs); err != nil {
 		return fmt.Errorf("failed to configure systemd device allow for container %s: %w", systemdContainerID, err)
 	}

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -10,7 +10,7 @@ package gpu
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
@@ -110,7 +110,7 @@ func buildSafePath(rootfs string, basedir string, parts ...string) (string, erro
 	root := fmt.Sprintf("%s/%s", rootfs, basedir)
 
 	// Join the parts to the base directory and create a full path. Note that this will also remove any ".." from the path
-	fullPath := path.Join(append([]string{root}, parts...)...)
+	fullPath := filepath.Join(append([]string{root}, parts...)...)
 
 	// Check that the resulting path is a child of root and that we haven't escaped the rootfs/basedir
 	if !strings.HasPrefix(fullPath, root) {

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -28,6 +28,8 @@ func ConfigureDeviceCgroups(pid uint32, rootfs string) error {
 		return fmt.Errorf("no cgroups found for pid %d", pid)
 	}
 
+	// Each cgroup is for a different subsystem, we only want the cgroup ID
+	// and we can extract that from any cgroup
 	cgroup := cgroups[0]
 
 	// Configure systemd device allow first, so that in case of a reload we get the correct permissions

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -52,8 +52,8 @@ const (
 	systemdDeviceAllowDir  = "run/systemd/transient"
 	cgroupDeviceAllowFile  = "devices.allow"
 	cgroupDeviceAllowDir   = "sys/fs/cgroup/devices"
-	nvidiaDeviceAllow      = "DeviceAllow=char-nvidia rwm\n"
-	nvidiaCgroupAllow      = "c 195:* rwm\n"
+	nvidiaDeviceAllow      = "DeviceAllow=char-nvidia rwm\n" // Allow access to the NVIDIA character devices
+	nvidiaCgroupAllow      = "c 195:* rwm\n"                 // 195 is the major number for the NVIDIA character devices
 )
 
 type deviceType string

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -17,8 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// ConfigureDeviceCgroupsForProcess configures the cgroups for a process to allow access to the NVIDIA character devices
-func ConfigureDeviceCgroupsForProcess(pid uint32, rootfs string) error {
+// ConfigureDeviceCgroups configures the cgroups for a process to allow access to the NVIDIA character devices
+func ConfigureDeviceCgroups(pid uint32, rootfs string) error {
 	cgroups, err := utils.GetProcControlGroups(pid, pid)
 	if err != nil {
 		return fmt.Errorf("failed to get cgroups for pid %d: %w", pid, err)

--- a/pkg/gpu/cgroups.go
+++ b/pkg/gpu/cgroups.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// ConfigureDeviceCgroupsForProcess configures the cgroups for a process to allow access to the NVIDIA character devices
 func ConfigureDeviceCgroupsForProcess(pid uint32, rootfs string) error {
 	containerID, context, err := utils.GetProcContainerContext(pid, pid)
 	if err != nil {
@@ -97,15 +98,8 @@ func configureCgroupDeviceAllow(containerID, rootfs string) error {
 // and check that the parts being added to the path do not cause the final path
 // to escape the rootfs/basedir.
 func buildSafePath(rootfs string, basedir string, parts ...string) (string, error) {
-	// Remove trailing slashes from rootfs
-	if strings.HasSuffix(rootfs, "/") {
-		rootfs = rootfs[:len(rootfs)-1]
-	}
-
-	// And remove leading slashes from basedir
-	if strings.HasPrefix(basedir, "/") {
-		basedir = basedir[1:]
-	}
+	rootfs = strings.TrimSuffix(rootfs, "/")   // Remove trailing slashes from rootfs
+	basedir = strings.TrimPrefix(basedir, "/") // Remove leading slashes from basedir
 
 	// that way we can now join the paths using Sprintf to build the base directory
 	root := fmt.Sprintf("%s/%s", rootfs, basedir)

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	InitialProcessSync bool
 	// NVMLLibraryPath is the path of the native libnvidia-ml.so library
 	NVMLLibraryPath string
+	// ConfigureCgroupPerms indicates whether the probe should configure cgroup permissions for GPU monitoring
+	ConfigureCgroupPerms bool
 }
 
 // New generates a new configuration for the GPU monitoring probe.
@@ -43,5 +45,6 @@ func New() *Config {
 		InitialProcessSync:              spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "initial_process_sync")),
 		NVMLLibraryPath:                 spCfg.GetString(sysconfig.FullKeyPath(GPUNS, "nvml_lib_path")),
 		Enabled:                         spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enabled")),
+		ConfigureCgroupPerms:            spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "configure_cgroup_perms")),
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds an option to the system-probe GPU monitoring module, to automatically correct permissions to access NVIDIA devices. 

This behavior, disabled by default, can be enabled with the system-probe setting `gpu_monitoring.configure_cgroup_perms`. When enabled, the GPU monitoring module will perform two changes to the cgroup permissions:

- It will change the SystemD `50-DeviceAllow.conf` file for the `system-probe` cgroup to add read/write permissions to NVIDIA character devices.
- It will change the cgroup permissions to add the same permissions for the NVIDIA character devices (major number 195).


### Motivation

During deployment of the GPU monitoring module in our staging environment, we've discovered an issue with the nvidia-container-runtime, where it sets the GPU permissions directly via cgroups instead of via the SystemD manager. This means that, whenever SystemD reloads the group permissions (e.g., when the cpuset manager changes the cpuset of a container), the permissions get overwritten and we lose access to the NVIDIA devices. This causes NVML init to fail with `Unknown Error`.

The problem is the same as described https://github.com/NVIDIA/nvidia-container-toolkit/issues/48. However, the workarounds posted there do not work for us: they rely on the k8s-device-plugin defining the devices that the pod is going to use, so that Kubernetes can add them to the SystemD security rules. We cannot use the device plugin directly (that is, via `resources: nvidia.com/gpu: X`) because that would stop other pods from using the GPUs. We tell the NVIDIA container runtime to expose the devices via the `NVIDIA_VISIBLE_DEVICES` environment variable or the corresponding mount `/var/run/nvidia-container-devices/all`, which means that the device plugin is not involved and SystemD device rules are not correctly configured. Therefore, we need some kind of manual configuration. As there's no way to tell K8s which character devices we need enabled in the SystemD device rules using the pod spec, this is the only solution we have found to solve the problem.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated in a staging deployment in `venomoth.us1.staging.dog`.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This change is still being validated. However, in order to deploy to our nightly clusters we need this change to be merged into `main`.