### PR TITLE
[CONTP-60] Improved telemetry on cluster check configs dangling

### DIFF
--- a/pkg/clusteragent/clusterchecks/dangling_config.go
+++ b/pkg/clusteragent/clusterchecks/dangling_config.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build clusterchecks
+
+package clusterchecks
+
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+)
+
+type danglingConfigWrapper struct {
+	config                   integration.Config
+	time                     time.Time
+	detectedExtendedDangling bool
+}
+
+// createConfigEntry creates a new integrationConfigEntry
+// This is used to keep track of the time a config was added to the store
+func createConfigEntry(config integration.Config) *danglingConfigWrapper {
+	return &danglingConfigWrapper{
+		config:                   config,
+		time:                     time.Now(),
+		detectedExtendedDangling: false,
+	}
+}
+
+// isStuckScheduling returns true if the config has been in the
+// store for longer than expectedScheduleTime
+func (e *danglingConfigWrapper) isStuckScheduling(expectedScheduleTime time.Duration) bool {
+	return time.Since(e.time) > expectedScheduleTime
+}

--- a/pkg/clusteragent/clusterchecks/dangling_config.go
+++ b/pkg/clusteragent/clusterchecks/dangling_config.go
@@ -8,29 +8,27 @@
 package clusterchecks
 
 import (
-	"time"
-
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 )
 
 type danglingConfigWrapper struct {
 	config                   integration.Config
-	time                     time.Time
+	rescheduleAttempts       int
 	detectedExtendedDangling bool
 }
 
-// createConfigEntry creates a new integrationConfigEntry
-// This is used to keep track of the time a config was added to the store
-func createConfigEntry(config integration.Config) *danglingConfigWrapper {
+// createDanglingConfig creates a new danglingConfigWrapper
+// This is used to keep track of the lifecycle of a dangling config
+func createDanglingConfig(config integration.Config) *danglingConfigWrapper {
 	return &danglingConfigWrapper{
 		config:                   config,
-		time:                     time.Now(),
+		rescheduleAttempts:       0,
 		detectedExtendedDangling: false,
 	}
 }
 
-// isStuckScheduling returns true if the config has been in the
-// store for longer than expectedScheduleTime
-func (e *danglingConfigWrapper) isStuckScheduling(expectedScheduleTime time.Duration) bool {
-	return time.Since(e.time) > expectedScheduleTime
+// isStuckScheduling returns true if the config has been attempted
+// rescheduling more than attemptLimit times
+func (c *danglingConfigWrapper) isStuckScheduling(attemptLimit int) bool {
+	return c.rescheduleAttempts > attemptLimit
 }

--- a/pkg/clusteragent/clusterchecks/dangling_config.go
+++ b/pkg/clusteragent/clusterchecks/dangling_config.go
@@ -32,5 +32,6 @@ func createDanglingConfig(config integration.Config) *danglingConfigWrapper {
 // isStuckScheduling returns true if the config has been in the store
 // for longer than the unscheduledCheckThresholdSeconds
 func (c *danglingConfigWrapper) isStuckScheduling(unscheduledCheckThresholdSeconds int64) bool {
-	return time.Since(c.timeCreated).Seconds() > float64(unscheduledCheckThresholdSeconds)
+	expectCheckIsScheduledTime := c.timeCreated.Add(time.Duration(unscheduledCheckThresholdSeconds) * time.Second)
+	return time.Now().After(expectCheckIsScheduledTime)
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -28,7 +28,7 @@ func (d *dispatcher) getState() (types.StateResponse, error) {
 
 	response := types.StateResponse{
 		Warmup:   !d.store.active,
-		Dangling: makeConfigArray(d.store.danglingConfigs),
+		Dangling: makeConfigArrayFromEntry(d.store.danglingConfigs),
 	}
 	for _, node := range d.store.nodes {
 		n := types.StateNodeResponse{
@@ -41,7 +41,7 @@ func (d *dispatcher) getState() (types.StateResponse, error) {
 	return response, nil
 }
 
-func (d *dispatcher) addConfig(config integration.Config, targetNodeName string) {
+func (d *dispatcher) addConfig(config integration.Config, targetNodeName string) bool {
 	d.store.Lock()
 	defer d.store.Unlock()
 
@@ -58,10 +58,13 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 	}
 
 	// No target node specified: store in danglingConfigs
-	if targetNodeName == "" {
-		danglingConfigs.Inc(le.JoinLeaderValue)
-		d.store.danglingConfigs[digest] = config
-		return
+	if targetNodeName == "" || true {
+		// Only update if it's a new dangling config
+		if _, found := d.store.danglingConfigs[digest]; !found {
+			danglingConfigs.Inc(le.JoinLeaderValue)
+			d.store.danglingConfigs[digest] = createConfigEntry(config)
+		}
+		return false
 	}
 
 	currentNode, foundCurrent := d.store.getNodeStore(d.store.digestToNode[digest])
@@ -82,6 +85,8 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 		currentNode.removeConfig(digest)
 		currentNode.Unlock()
 	}
+
+	return true
 }
 
 func (d *dispatcher) removeConfig(digest string) {
@@ -94,7 +99,7 @@ func (d *dispatcher) removeConfig(digest string) {
 
 	delete(d.store.digestToNode, digest)
 	delete(d.store.digestToConfig, digest)
-	delete(d.store.danglingConfigs, digest)
+	d.deleteDangling([]string{digest})
 
 	// This is a list because each instance in a config has its own check ID and
 	// all of them need to be deleted.
@@ -131,14 +136,25 @@ func (d *dispatcher) shouldDispatchDangling() bool {
 	return len(d.store.danglingConfigs) > 0 && len(d.store.nodes) > 0
 }
 
-// retrieveAndClearDangling extracts dangling configs from the store
-func (d *dispatcher) retrieveAndClearDangling() []integration.Config {
-	d.store.Lock()
-	defer d.store.Unlock()
-	configs := makeConfigArray(d.store.danglingConfigs)
-	d.store.clearDangling()
-	danglingConfigs.Set(0, le.JoinLeaderValue)
+// retrieveDangling extracts dangling configs from the store
+func (d *dispatcher) retrieveDangling() []integration.Config {
+	d.store.RLock()
+	defer d.store.RUnlock()
+
+	configs := makeConfigArrayFromEntry(d.store.danglingConfigs)
 	return configs
+}
+
+// deleteDangling clears the dangling configs from the store
+func (d *dispatcher) deleteDangling(ids []string) {
+	for _, id := range ids {
+		c := d.store.danglingConfigs[id]
+		delete(d.store.danglingConfigs, id)
+		danglingConfigs.Dec(le.JoinLeaderValue)
+		if c.detectedExtendedDangling {
+			extendedDanglingConfigs.Dec(le.JoinLeaderValue, c.config.Name, c.config.Source)
+		}
+	}
 }
 
 // patchConfiguration transforms the configuration from AD into a config

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -148,11 +148,12 @@ func (d *dispatcher) retrieveDangling() []integration.Config {
 // deleteDangling clears the dangling configs from the store
 func (d *dispatcher) deleteDangling(ids []string) {
 	for _, id := range ids {
-		c := d.store.danglingConfigs[id]
-		delete(d.store.danglingConfigs, id)
-		danglingConfigs.Dec(le.JoinLeaderValue)
-		if c.detectedExtendedDangling {
-			extendedDanglingConfigs.Dec(le.JoinLeaderValue, c.config.Name, c.config.Source)
+		if c, found := d.store.danglingConfigs[id]; found {
+			delete(d.store.danglingConfigs, id)
+			danglingConfigs.Dec(le.JoinLeaderValue)
+			if c.detectedExtendedDangling {
+				extendedDanglingConfigs.Dec(le.JoinLeaderValue, c.config.Name, c.config.Source)
+			}
 		}
 	}
 }

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -28,7 +28,7 @@ func (d *dispatcher) getState() (types.StateResponse, error) {
 
 	response := types.StateResponse{
 		Warmup:   !d.store.active,
-		Dangling: makeConfigArrayFromEntry(d.store.danglingConfigs),
+		Dangling: makeConfigArrayFromDangling(d.store.danglingConfigs),
 	}
 	for _, node := range d.store.nodes {
 		n := types.StateNodeResponse{
@@ -62,7 +62,7 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 		// Only update if it's a new dangling config
 		if _, found := d.store.danglingConfigs[digest]; !found {
 			danglingConfigs.Inc(le.JoinLeaderValue)
-			d.store.danglingConfigs[digest] = createConfigEntry(config)
+			d.store.danglingConfigs[digest] = createDanglingConfig(config)
 		}
 		return false
 	}
@@ -141,7 +141,7 @@ func (d *dispatcher) retrieveDangling() []integration.Config {
 	d.store.RLock()
 	defer d.store.RUnlock()
 
-	configs := makeConfigArrayFromEntry(d.store.danglingConfigs)
+	configs := makeConfigArrayFromDangling(d.store.danglingConfigs)
 	return configs
 }
 

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -58,7 +58,7 @@ func (d *dispatcher) addConfig(config integration.Config, targetNodeName string)
 	}
 
 	// No target node specified: store in danglingConfigs
-	if targetNodeName == "" || true {
+	if targetNodeName == "" {
 		// Only update if it's a new dangling config
 		if _, found := d.store.danglingConfigs[digest]; !found {
 			danglingConfigs.Inc(le.JoinLeaderValue)

--- a/pkg/clusteragent/clusterchecks/dispatcher_configs.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_configs.go
@@ -151,8 +151,8 @@ func (d *dispatcher) deleteDangling(ids []string) {
 		if c, found := d.store.danglingConfigs[id]; found {
 			delete(d.store.danglingConfigs, id)
 			danglingConfigs.Dec(le.JoinLeaderValue)
-			if c.detectedExtendedDangling {
-				extendedDanglingConfigs.Dec(le.JoinLeaderValue, c.config.Name, c.config.Source)
+			if c.unscheduledCheck {
+				unscheduledCheck.Dec(le.JoinLeaderValue, c.config.Name, c.config.Source)
 			}
 		}
 	}

--- a/pkg/clusteragent/clusterchecks/dispatcher_main.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_main.go
@@ -208,9 +208,8 @@ func (d *dispatcher) reset() {
 	d.store.reset()
 }
 
-// scanExtendedDanglingConfigs scans the store for extended dangling configs
-// The attemptLimit is the number of times a reschedule is attempted before
-// considering a config as extended dangling.
+// scanUnscheduledChecks scans the store for configs that have been
+// unscheduled for longer than the unscheduledCheckThresholdSeconds
 func (d *dispatcher) scanUnscheduledChecks() {
 	d.store.Lock()
 	defer d.store.Unlock()

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -150,7 +150,7 @@ func (d *dispatcher) expireNodes() {
 			for digest, config := range node.digestToConfig {
 				delete(d.store.digestToNode, digest)
 				log.Debugf("Adding %s:%s as a dangling Cluster Check config", config.Name, digest)
-				d.store.danglingConfigs[digest] = createConfigEntry(config)
+				d.store.danglingConfigs[digest] = createDanglingConfig(config)
 				danglingConfigs.Inc(le.JoinLeaderValue)
 
 				// TODO: Use partial label matching when it becomes available:

--- a/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_nodes.go
@@ -150,7 +150,7 @@ func (d *dispatcher) expireNodes() {
 			for digest, config := range node.digestToConfig {
 				delete(d.store.digestToNode, digest)
 				log.Debugf("Adding %s:%s as a dangling Cluster Check config", config.Name, digest)
-				d.store.danglingConfigs[digest] = config
+				d.store.danglingConfigs[digest] = createConfigEntry(config)
 				danglingConfigs.Inc(le.JoinLeaderValue)
 
 				// TODO: Use partial label matching when it becomes available:

--- a/pkg/clusteragent/clusterchecks/dispatcher_test.go
+++ b/pkg/clusteragent/clusterchecks/dispatcher_test.go
@@ -348,9 +348,10 @@ func TestRescheduleDanglingFromExpiredNodes(t *testing.T) {
 
 	// Ensure we have 1 dangling to schedule, as new available node is registered
 	assert.True(t, dispatcher.shouldDispatchDangling())
-	configs := dispatcher.retrieveAndClearDangling()
+	configs := dispatcher.retrieveDangling()
 	// Assert the check is scheduled
-	dispatcher.reschedule(configs)
+	scheduledIDs := dispatcher.reschedule(configs)
+	dispatcher.deleteDangling(scheduledIDs)
 	danglingConfig, err := dispatcher.getAllConfigs()
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(danglingConfig))
@@ -423,7 +424,8 @@ func TestDanglingConfig(t *testing.T) {
 	assert.True(t, dispatcher.shouldDispatchDangling())
 
 	// get the danglings and make sure they are removed from the store
-	configs := dispatcher.retrieveAndClearDangling()
+	configs := dispatcher.retrieveDangling()
+	dispatcher.deleteDangling([]string{config.Digest()})
 	assert.Len(t, configs, 1)
 	assert.Equal(t, 0, len(dispatcher.store.danglingConfigs))
 }

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
-	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
@@ -84,21 +82,4 @@ func orderedKeys(m map[string]int) []string {
 	}
 	sort.Strings(keys)
 	return keys
-}
-
-// scanExtendedDanglingConfigs scans the store for extended dangling configs
-// The attemptLimit is the number of times a reschedule is attempted before
-// considering a config as extended dangling.
-func scanExtendedDanglingConfigs(store *clusterStore, attemptLimit int) {
-	store.Lock()
-	defer store.Unlock()
-
-	for _, c := range store.danglingConfigs {
-		c.rescheduleAttempts++
-		if !c.detectedExtendedDangling && c.isStuckScheduling(attemptLimit) {
-			log.Warnf("Detected extended dangling config. Name:%s, Source:%s", c.config.Name, c.config.Source)
-			c.detectedExtendedDangling = true
-			extendedDanglingConfigs.Inc(le.JoinLeaderValue, c.config.Name, c.config.Source)
-		}
-	}
 }

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -33,6 +33,17 @@ func makeConfigArray(configMap map[string]integration.Config) []integration.Conf
 	return configSlice
 }
 
+// makeConfigArrayFromEntry flattens a map of configs into a slice. Creating a new slice
+// allows for thread-safe usage by other external, as long as the field values in
+// the config objects are not modified.
+func makeConfigArrayFromEntry(configMap map[string]*danglingConfigWrapper) []integration.Config {
+	configSlice := make([]integration.Config, 0, len(configMap))
+	for _, c := range configMap {
+		configSlice = append(configSlice, c.config)
+	}
+	return configSlice
+}
+
 func timestampNowNano() int64 {
 	return time.Now().UnixNano()
 }

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
+	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
@@ -33,10 +35,10 @@ func makeConfigArray(configMap map[string]integration.Config) []integration.Conf
 	return configSlice
 }
 
-// makeConfigArrayFromEntry flattens a map of configs into a slice. Creating a new slice
+// makeConfigArrayFromDangling flattens a map of configs into a slice. Creating a new slice
 // allows for thread-safe usage by other external, as long as the field values in
 // the config objects are not modified.
-func makeConfigArrayFromEntry(configMap map[string]*danglingConfigWrapper) []integration.Config {
+func makeConfigArrayFromDangling(configMap map[string]*danglingConfigWrapper) []integration.Config {
 	configSlice := make([]integration.Config, 0, len(configMap))
 	for _, c := range configMap {
 		configSlice = append(configSlice, c.config)
@@ -82,4 +84,21 @@ func orderedKeys(m map[string]int) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// scanExtendedDanglingConfigs scans the store for extended dangling configs
+// The attemptLimit is the number of times a reschedule is attempted before
+// considering a config as extended dangling.
+func scanExtendedDanglingConfigs(store *clusterStore, attemptLimit int) {
+	store.Lock()
+	defer store.Unlock()
+
+	for _, c := range store.danglingConfigs {
+		c.rescheduleAttempts += 1
+		if !c.detectedExtendedDangling && c.isStuckScheduling(attemptLimit) {
+			log.Warnf("Detected extended dangling config. Name:%s, Source:%s", c.config.Name, c.config.Source)
+			c.detectedExtendedDangling = true
+			extendedDanglingConfigs.Inc(le.JoinLeaderValue, c.config.Name, c.config.Source)
+		}
+	}
 }

--- a/pkg/clusteragent/clusterchecks/helpers.go
+++ b/pkg/clusteragent/clusterchecks/helpers.go
@@ -94,7 +94,7 @@ func scanExtendedDanglingConfigs(store *clusterStore, attemptLimit int) {
 	defer store.Unlock()
 
 	for _, c := range store.danglingConfigs {
-		c.rescheduleAttempts += 1
+		c.rescheduleAttempts++
 		if !c.detectedExtendedDangling && c.isStuckScheduling(attemptLimit) {
 			log.Warnf("Detected extended dangling config. Name:%s, Source:%s", c.config.Name, c.config.Source)
 			c.detectedExtendedDangling = true

--- a/pkg/clusteragent/clusterchecks/helpers_test.go
+++ b/pkg/clusteragent/clusterchecks/helpers_test.go
@@ -10,9 +10,6 @@ package clusterchecks
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 )
 
@@ -153,28 +150,4 @@ func Test_calculateBusyness(t *testing.T) {
 			}
 		})
 	}
-}
-
-func Test_scanExtendedDanglingConfigs(t *testing.T) {
-	attemptLimit := 3
-	store := newClusterStore()
-	c1 := createDanglingConfig(integration.Config{
-		Name:   "config1",
-		Source: "source1",
-	})
-	store.danglingConfigs[c1.config.Digest()] = c1
-
-	for i := 0; i < attemptLimit; i++ {
-		scanExtendedDanglingConfigs(store, attemptLimit)
-	}
-
-	assert.Equal(t, attemptLimit, c1.rescheduleAttempts)
-	assert.False(t, c1.detectedExtendedDangling)
-	assert.False(t, c1.isStuckScheduling(attemptLimit))
-
-	scanExtendedDanglingConfigs(store, attemptLimit)
-
-	assert.Equal(t, attemptLimit+1, c1.rescheduleAttempts)
-	assert.True(t, c1.detectedExtendedDangling)
-	assert.True(t, c1.isStuckScheduling(attemptLimit))
 }

--- a/pkg/clusteragent/clusterchecks/helpers_test.go
+++ b/pkg/clusteragent/clusterchecks/helpers_test.go
@@ -10,6 +10,9 @@ package clusterchecks
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 )
 
@@ -150,4 +153,28 @@ func Test_calculateBusyness(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_scanExtendedDanglingConfigs(t *testing.T) {
+	attemptLimit := 3
+	store := newClusterStore()
+	c1 := createDanglingConfig(integration.Config{
+		Name:   "config1",
+		Source: "source1",
+	})
+	store.danglingConfigs[c1.config.Digest()] = c1
+
+	for i := 0; i < attemptLimit; i++ {
+		scanExtendedDanglingConfigs(store, attemptLimit)
+	}
+
+	assert.Equal(t, attemptLimit, c1.rescheduleAttempts)
+	assert.False(t, c1.detectedExtendedDangling)
+	assert.False(t, c1.isStuckScheduling(attemptLimit))
+
+	scanExtendedDanglingConfigs(store, attemptLimit)
+
+	assert.Equal(t, attemptLimit+1, c1.rescheduleAttempts)
+	assert.True(t, c1.detectedExtendedDangling)
+	assert.True(t, c1.isStuckScheduling(attemptLimit))
 }

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -8,11 +8,8 @@
 package clusterchecks
 
 import (
-	"time"
-
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
@@ -56,18 +53,3 @@ var (
 		[]string{"node", le.JoinLeaderLabel}, "Utilization predicted by the rebalance algorithm",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 )
-
-func scanExtendedDanglingConfigs(store *clusterStore, expectedScheduleTime time.Duration) {
-	store.Lock()
-	defer store.Unlock()
-
-	for _, c := range store.danglingConfigs {
-		if !c.detectedExtendedDangling && c.isStuckScheduling(expectedScheduleTime) {
-			log.Errorf("Stuck scheduling")
-			extendedDanglingConfigs.Inc(le.JoinLeaderValue, c.config.Name, c.config.Source)
-			c.detectedExtendedDangling = true
-		} else {
-			log.Errorf("Not stuck scheduling")
-		}
-	}
-}

--- a/pkg/clusteragent/clusterchecks/metrics.go
+++ b/pkg/clusteragent/clusterchecks/metrics.go
@@ -19,8 +19,8 @@ var (
 	danglingConfigs = telemetry.NewGaugeWithOpts("cluster_checks", "configs_dangling",
 		[]string{le.JoinLeaderLabel}, "Number of check configurations not dispatched.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	extendedDanglingConfigs = telemetry.NewGaugeWithOpts("cluster_checks", "configs_extended_dangling",
-		[]string{le.JoinLeaderLabel, "config_name", "config_source"}, "Number of check configurations not dispatched, for extended number of scheduling attempts.",
+	unscheduledCheck = telemetry.NewGaugeWithOpts("cluster_checks", "unscheduled_check",
+		[]string{le.JoinLeaderLabel, "config_name", "config_source"}, "Number of check configurations not scheduled.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	dispatchedConfigs = telemetry.NewGaugeWithOpts("cluster_checks", "configs_dispatched",
 		[]string{"node", le.JoinLeaderLabel}, "Number of check configurations dispatched, by node.",

--- a/pkg/clusteragent/clusterchecks/stats.go
+++ b/pkg/clusteragent/clusterchecks/stats.go
@@ -60,19 +60,19 @@ func (d *dispatcher) getStats() *types.Stats {
 	for _, m := range d.store.digestToConfig {
 		checkNames[m.Name] = struct{}{}
 	}
-	extendedDanglingConfigs := 0
+	unscheduledChecks := 0
 	for _, c := range d.store.danglingConfigs {
-		if c.detectedExtendedDangling {
-			extendedDanglingConfigs++
+		if c.unscheduledCheck {
+			unscheduledChecks++
 		}
 	}
 	return &types.Stats{
-		Active:                  d.store.active,
-		NodeCount:               len(d.store.nodes),
-		ActiveConfigs:           len(d.store.digestToNode),
-		DanglingConfigs:         len(d.store.danglingConfigs),
-		ExtendedDanglingConfigs: extendedDanglingConfigs,
-		TotalConfigs:            len(d.store.digestToConfig),
-		CheckNames:              checkNames,
+		Active:            d.store.active,
+		NodeCount:         len(d.store.nodes),
+		ActiveConfigs:     len(d.store.digestToNode),
+		DanglingConfigs:   len(d.store.danglingConfigs),
+		UnscheduledChecks: unscheduledChecks,
+		TotalConfigs:      len(d.store.digestToConfig),
+		CheckNames:        checkNames,
 	}
 }

--- a/pkg/clusteragent/clusterchecks/stats.go
+++ b/pkg/clusteragent/clusterchecks/stats.go
@@ -60,12 +60,19 @@ func (d *dispatcher) getStats() *types.Stats {
 	for _, m := range d.store.digestToConfig {
 		checkNames[m.Name] = struct{}{}
 	}
+	extendedDanglingConfigs := 0
+	for _, c := range d.store.danglingConfigs {
+		if c.detectedExtendedDangling {
+			extendedDanglingConfigs++
+		}
+	}
 	return &types.Stats{
-		Active:          d.store.active,
-		NodeCount:       len(d.store.nodes),
-		ActiveConfigs:   len(d.store.digestToNode),
-		DanglingConfigs: len(d.store.danglingConfigs),
-		TotalConfigs:    len(d.store.digestToConfig),
-		CheckNames:      checkNames,
+		Active:                  d.store.active,
+		NodeCount:               len(d.store.nodes),
+		ActiveConfigs:           len(d.store.digestToNode),
+		DanglingConfigs:         len(d.store.danglingConfigs),
+		ExtendedDanglingConfigs: extendedDanglingConfigs,
+		TotalConfigs:            len(d.store.digestToConfig),
+		CheckNames:              checkNames,
 	}
 }

--- a/pkg/clusteragent/clusterchecks/stores.go
+++ b/pkg/clusteragent/clusterchecks/stores.go
@@ -27,7 +27,7 @@ type clusterStore struct {
 	digestToConfig   map[string]integration.Config            // All configurations to dispatch
 	digestToNode     map[string]string                        // Node running a config
 	nodes            map[string]*nodeStore                    // All nodes known to the cluster-agent
-	danglingConfigs  map[string]integration.Config            // Configs we could not dispatch to any node
+	danglingConfigs  map[string]*danglingConfigWrapper        // Configs we could not dispatch to any node
 	endpointsConfigs map[string]map[string]integration.Config // Endpoints configs to be consumed by node agents
 	idToDigest       map[checkid.ID]string                    // link check IDs to check configs
 }
@@ -44,7 +44,7 @@ func (s *clusterStore) reset() {
 	s.digestToConfig = make(map[string]integration.Config)
 	s.digestToNode = make(map[string]string)
 	s.nodes = make(map[string]*nodeStore)
-	s.danglingConfigs = make(map[string]integration.Config)
+	s.danglingConfigs = make(map[string]*danglingConfigWrapper)
 	s.endpointsConfigs = make(map[string]map[string]integration.Config)
 	s.idToDigest = make(map[checkid.ID]string)
 }
@@ -74,7 +74,7 @@ func (s *clusterStore) getOrCreateNodeStore(nodeName, clientIP string) *nodeStor
 
 // clearDangling resets the danglingConfigs map to a new empty one
 func (s *clusterStore) clearDangling() {
-	s.danglingConfigs = make(map[string]integration.Config)
+	s.danglingConfigs = make(map[string]*danglingConfigWrapper)
 }
 
 // nodeStore holds the state store for one node.

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -74,13 +74,14 @@ type Stats struct {
 	LeaderIP string
 
 	// Leading
-	Leader          bool
-	Active          bool
-	NodeCount       int
-	ActiveConfigs   int
-	DanglingConfigs int
-	TotalConfigs    int
-	CheckNames      map[string]struct{}
+	Leader                  bool
+	Active                  bool
+	NodeCount               int
+	ActiveConfigs           int
+	DanglingConfigs         int
+	ExtendedDanglingConfigs int
+	TotalConfigs            int
+	CheckNames              map[string]struct{}
 }
 
 // LeaderIPCallback describes the leader-election method we

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -74,14 +74,14 @@ type Stats struct {
 	LeaderIP string
 
 	// Leading
-	Leader                  bool
-	Active                  bool
-	NodeCount               int
-	ActiveConfigs           int
-	DanglingConfigs         int
-	ExtendedDanglingConfigs int
-	TotalConfigs            int
-	CheckNames              map[string]struct{}
+	Leader            bool
+	Active            bool
+	NodeCount         int
+	ActiveConfigs     int
+	DanglingConfigs   int
+	UnscheduledChecks int
+	TotalConfigs      int
+	CheckNames        map[string]struct{}
 }
 
 // LeaderIPCallback describes the leader-election method we

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -710,6 +710,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)
 	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30) // value in seconds
 	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)         // value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.extended_dangling_attempt_threshold", 3)
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -708,9 +708,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.support_hybrid_ignore_ad_tags", false) // TODO(CINT)(Agent 7.53+) Remove this flag when hybrid ignore_ad_tags is fully deprecated
 	config.BindEnvAndSetDefault("cluster_checks.enabled", false)
-	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30) // value in seconds
-	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)         // value in seconds
-	config.BindEnvAndSetDefault("cluster_checks.extended_dangling_attempt_threshold", 3)
+	config.BindEnvAndSetDefault("cluster_checks.node_expiration_timeout", 30)     // value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.warmup_duration", 30)             // value in seconds
+	config.BindEnvAndSetDefault("cluster_checks.unscheduled_check_threshold", 60) // value in seconds
 	config.BindEnvAndSetDefault("cluster_checks.cluster_tag_name", "cluster_name")
 	config.BindEnvAndSetDefault("cluster_checks.extra_tags", []string{})
 	config.BindEnvAndSetDefault("cluster_checks.advanced_dispatching_enabled", false)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a new telemetry metric to keep track of cluster check configs that have gone an extended period of time without being scheduled.

### Motivation

We would like to monitor the state of the cluster-check scheduling in order to be sure we detect issues before applications get paged for missing metrics.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Existing unit tests cover dispatching logic. Update to a unit test verifies the unscheduledCheck flag behavior.

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Previously, on each rescheduling attempt, all the dangling configs were deleted from the dangling store initially. If they failed to be rescheduled, then they would be readded the dangling config store.

This PR changes this behavior because we want to track how long the config exists in the dangling state. Hence, we only remove the config from the dangling store once it's confirmed to be scheduled.