### PR TITLE
Improve Leader Election metrics

### DIFF
--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -10,7 +10,6 @@ package leaderelection
 import (
 	"context"
 	"encoding/json"
-	"strconv"
 
 	coordv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
@@ -217,7 +216,11 @@ func (le *LeaderEngine) reportLeaderMetric(isLeader bool) {
 	le.leaderMetric.Delete(metrics.JoinLeaderValue, "false")
 	le.leaderMetric.Delete(metrics.JoinLeaderValue, "true")
 
-	le.leaderMetric.Set(1.0, metrics.JoinLeaderValue, strconv.FormatBool(isLeader))
+	if isLeader {
+		le.leaderMetric.Set(1.0, metrics.JoinLeaderValue, "true")
+	} else {
+		le.leaderMetric.Set(0, metrics.JoinLeaderValue, "false")
+	}
 }
 
 // notify sends a notification to subscribers when the leadership state of the current

--- a/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/metrics/metrics.go
@@ -26,7 +26,7 @@ func NewLeaderMetric() telemetry.Gauge {
 		"leader_election",
 		"is_leader",
 		[]string{JoinLeaderLabel, isLeaderLabel}, // join_leader is for label joins
-		"The label is_leader is true if the reporting pod is leader, equals false otherwise.",
+		"When the pod is leader, is_leader is true, and its value becomes 1. Otherwise, is_leader is false, and the value is 0.",
 		telemetry.Options{NoDoubleUnderscoreSep: true},
 	)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When the pod is leader, is_leader is true, and its value becomes 1. Otherwise, is_leader is false, and the value is 0.

### Motivation

https://github.com/DataDog/integrations-core/pull/19308#discussion_r1897770193

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

```
kubectl exec -it datadog-cluster-agent-5877c6744d-8f52h -c cluster-agent -- curl http://localhost:5000/metrics | grep is_leader
# HELP leader_election_is_leader When the pod is leader, is_leader is true, and its value becomes 1. Otherwise, is_leader is false, and the value is 0.
# TYPE leader_election_is_leader gauge
leader_election_is_leader{is_leader="false",join_leader="true"} 0

kubectl exec -it datadog-cluster-agent-5877c6744d-z2wbp -c cluster-agent -- curl http://localhost:5000/metrics | grep is_leader
# HELP leader_election_is_leader When the pod is leader, is_leader is true, and its value becomes 1. Otherwise, is_leader is false, and the value is 0.
# TYPE leader_election_is_leader gauge
leader_election_is_leader{is_leader="true",join_leader="true"} 1
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->