### PR TITLE
[e2e] dump flare on test failures for host environments

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -145,6 +145,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -503,6 +505,18 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 
 		bs.T().Logf("Caught panic in SetupSuite, err: %v. Will try to TearDownSuite", err)
 		bs.firstFailTest = "Initial provisioning SetupSuite" // This is required to handle skipDeleteOnFailure
+
+		// run environment diagnose
+		if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok {
+			// at least one test failed, diagnose the environment
+			diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
+			if diagnoseErr != nil {
+				bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+			} else {
+				bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+			}
+		}
+
 		bs.TearDownSuite()
 
 		// As we need to call `recover` to know if there was a panic, we wrap and forward the original panic to,
@@ -541,7 +555,7 @@ func (bs *BaseSuite[Env]) getSuiteSessionSubdirectory() string {
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 	// Reset provisioners to original provisioners
-	// In `Test` scope we can `panic`, it will be recovered and `AfterTest` will be called.
+	// In `Test` scope we can `panic`, it will be recovered and `t` will be called.
 	// Next tests will be called as well
 	if err := bs.reconcileEnv(bs.originalProvisioners); err != nil {
 		panic(err)
@@ -555,14 +569,35 @@ func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 //
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
-	if bs.T().Failed() && bs.firstFailTest == "" {
-		// As far as I know, there is no way to prevent other tests from being
-		// run when a test fail. Even calling panic doesn't work.
-		// Instead, this code stores the name of the first fail test and prevents
-		// the environment to be updated.
-		// Note: using os.Exit(1) prevents other tests from being run but at the
-		// price of having no test output at all.
-		bs.firstFailTest = fmt.Sprintf("%v.%v", suiteName, testName)
+	if bs.T().Failed() {
+		// create output directory for this failed test
+		testPart := common.SanitizeDirectoryName(testName)
+		testOutputDir := filepath.Join(bs.SessionOutputDir(), testPart)
+		err := os.MkdirAll(testOutputDir, 0755)
+		if err != nil {
+			bs.T().Logf("unable to create test output directory: %v", err)
+		} else {
+			// run environment diagnose if the test failed
+			if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok {
+				// at least one test failed, diagnose the environment
+				diagnose, diagnoseErr := diagnosableEnv.Diagnose(testOutputDir)
+				if diagnoseErr != nil {
+					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+				} else {
+					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+				}
+			}
+		}
+
+		if bs.firstFailTest == "" {
+			// As far as I know, there is no way to prevent other tests from being
+			// run when a test fail. Even calling panic doesn't work.
+			// Instead, this code stores the name of the first fail test and prevents
+			// the environment to be updated.
+			// Note: using os.Exit(1) prevents other tests from being run but at the
+			// price of having no test output at all.
+			bs.firstFailTest = fmt.Sprintf("%v.%v", suiteName, testName)
+		}
 	}
 }
 

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -285,7 +285,7 @@ func (bs *BaseSuite[Env]) reconcileEnv(targetProvisioners provisioners.Provision
 
 	bs.T().Logf("Updating environment with new provisioners")
 
-	logger := newTestLogger(bs.T())
+	logger := common.NewTestLogger(bs.T())
 	ctx, cancel := bs.providerContext(createTimeout)
 	defer cancel()
 
@@ -598,7 +598,7 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 			}
 		}
 
-		if err := provisioner.Destroy(ctx, bs.params.stackName, newTestLogger(bs.T())); err != nil {
+		if err := provisioner.Destroy(ctx, bs.params.stackName, common.NewTestLogger(bs.T())); err != nil {
 			bs.T().Errorf("unable to delete stack: %s, provisioner %s, err: %v", bs.params.stackName, id, err)
 		}
 	}
@@ -614,7 +614,12 @@ func (bs *BaseSuite[Env]) GetRootOutputDir() (string, error) {
 	var err error
 	bs.onceTestSessionOutputDir.Do(func() {
 		// Store the timestamped directory to be used by all tests in the suite
-		bs.testSessionOutputDir, err = CreateRootOutputDir()
+		var outputRoot string
+		outputRoot, err = runner.GetProfile().GetOutputDir()
+		if err != nil {
+			return
+		}
+		bs.testSessionOutputDir, err = common.CreateRootOutputDir(outputRoot)
 	})
 	return bs.testSessionOutputDir, err
 }
@@ -627,7 +632,7 @@ func (bs *BaseSuite[Env]) CreateTestOutputDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return CreateTestOutputDir(root, bs.T())
+	return common.CreateTestOutputDir(root, bs.T())
 }
 
 // Run is a helper function to run a test suite.

--- a/test/new-e2e/pkg/environments/host.go
+++ b/test/new-e2e/pkg/environments/host.go
@@ -6,8 +6,14 @@
 package environments
 
 import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
 
 // Host is an environment that contains a Host, FakeIntake and Agent configured to talk to each other.
@@ -23,4 +29,65 @@ var _ common.Initializable = (*Host)(nil)
 // Init initializes the environment
 func (e *Host) Init(_ common.Context) error {
 	return nil
+}
+
+var _ common.Diagnosable = (*Host)(nil)
+
+// Diagnose returns a string containing the diagnosis of the environment
+func (e *Host) Diagnose(outputDir string) (string, error) {
+	diagnoses := []string{}
+	if e.RemoteHost == nil {
+		return "", fmt.Errorf("RemoteHost component is not initialized")
+	}
+	// add Agent diagnose
+	if e.Agent != nil {
+		diagnoses = append(diagnoses, "==== Agent ====")
+		dstPath, err := e.generateAndDownloadAgentFlare(outputDir)
+		if err != nil {
+			return "", fmt.Errorf("failed to generate and download agent flare: %w", err)
+		}
+		diagnoses = append(diagnoses, fmt.Sprintf("Flare archive downloaded to %s", dstPath))
+		diagnoses = append(diagnoses, "\n")
+	}
+
+	return strings.Join(diagnoses, "\n"), nil
+}
+
+func (e *Host) generateAndDownloadAgentFlare(outputDir string) (string, error) {
+	if e.Agent == nil || e.RemoteHost == nil {
+		return "", fmt.Errorf("Agent or RemoteHost component is not initialized, cannot generate flare")
+	}
+	// generate a local flare
+	// todo skip uploading it to backend, requires further changes in agent executor
+	// to redirect stdin to null, on linux adding `</dev/null`
+	// on windows prepending command with `@() |`, pre-piping with an empty array
+	// discard error, flare command might return error if there is no intake, but it the archive is still generated
+	flareCommandOutput, err := e.Agent.Client.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e-tests@datadog-agent", "--send", "--local"}))
+
+	// on error, the flare output is in the error message
+	flareCommandOutput = strings.Join([]string{flareCommandOutput, err.Error()}, "\n")
+
+	// find <path to flare>.zip in flare command output
+	// (?m) is a flag that allows ^ and $ to match the beginning and end of each line
+	re := regexp.MustCompile(`(?m)^(.+\.zip) is going to be uploaded to Datadog$`)
+	matches := re.FindStringSubmatch(flareCommandOutput)
+	if len(matches) < 2 {
+		return "", fmt.Errorf("output does not contain the path to the flare archive, output: %s", flareCommandOutput)
+	}
+	flarePath := matches[1]
+	flareFileInfo, err := e.RemoteHost.Lstat(flarePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat flare archive: %w", err)
+	}
+	dstPath := filepath.Join(outputDir, flareFileInfo.Name())
+
+	err = e.RemoteHost.EnsureFileIsReadable(flarePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to ensure flare archive is readable: %w", err)
+	}
+	err = e.RemoteHost.GetFile(flarePath, dstPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to download flare archive: %w", err)
+	}
+	return dstPath, nil
 }

--- a/test/new-e2e/pkg/provisioners/provisioners.go
+++ b/test/new-e2e/pkg/provisioners/provisioners.go
@@ -11,7 +11,7 @@ import (
 	"io"
 )
 
-// Diagnosable defines the interface for a diagnosable provider.
+// Diagnosable defines the interface for a diagnosable provisioner.
 type Diagnosable interface {
 	Diagnose(ctx context.Context, stackName string) (string, error)
 }

--- a/test/new-e2e/pkg/runner/local_profile.go
+++ b/test/new-e2e/pkg/runner/local_profile.go
@@ -118,3 +118,7 @@ func (p localProfile) NamePrefix() string {
 func (p localProfile) AllowDevMode() bool {
 	return true
 }
+
+func (p localProfile) CreateOutputDir() (string, error) {
+	return p.GetOutputDir()
+}

--- a/test/new-e2e/pkg/runner/parameters/store_env.go
+++ b/test/new-e2e/pkg/runner/parameters/store_env.go
@@ -29,6 +29,7 @@ var envVariablesByStoreKey = map[StoreKey]string{
 	GCPPrivateKeyPath:            "E2E_GCP_PRIVATE_KEY_PATH",
 	GCPPublicKeyPath:             "E2E_GCP_PUBLIC_KEY_PATH",
 	GCPPrivateKeyPassword:        "E2E_GCP_PRIVATE_KEY_PASSWORD",
+	LocalPublicKeyPath:           "E2E_LOCAL_PUBLIC_KEY_PATH",
 	PulumiPassword:               "E2E_PULUMI_PASSWORD",
 	SkipDeleteOnFailure:          "E2E_SKIP_DELETE_ON_FAILURE",
 	StackParameters:              "E2E_STACK_PARAMS",

--- a/test/new-e2e/pkg/runner/profile.go
+++ b/test/new-e2e/pkg/runner/profile.go
@@ -62,9 +62,9 @@ type Profile interface {
 	AllowDevMode() bool
 	// GetOutputDir returns the root output directory for tests to store output files and artifacts.
 	// e.g. /tmp/e2e-output/ or ~/e2e-output/
-	//
-	// It is recommended to use GetTestOutputDir to create a subdirectory for a specific test.
 	GetOutputDir() (string, error)
+	// CreateOutputSubDir creates an output directory inside the runner root directory for tests to store output files and artifacts.
+	CreateOutputSubDir(subdirectory string) (string, error)
 }
 
 // Shared implementations for common profiles methods
@@ -162,7 +162,7 @@ func (p baseProfile) GetOutputDir() (string, error) {
 	return filepath.Join(os.TempDir(), "e2e-output"), nil
 }
 
-// GetWorkspacePath returns the directory for CI Pulumi workspace.
+// GetWorkspacePath returns the directory for Pulumi workspace.
 // Since one Workspace supports one single program and we have one program per stack,
 // the path should be unique for each stack.
 func (p baseProfile) GetWorkspacePath(stackName string) string {
@@ -173,6 +173,26 @@ func hashString(s string) string {
 	hasher := fnv.New64a()
 	_, _ = io.WriteString(hasher, s)
 	return fmt.Sprintf("%016x", hasher.Sum64())
+}
+
+// CreateOutputSubDir creates an output directory inside the runner root directory for tests to store output files and artifacts.
+func (p baseProfile) CreateOutputSubDir(subdirectory string) (string, error) {
+	rootOutputDir, err := p.GetOutputDir()
+	if err != nil {
+		return "", err
+	}
+	// create root directory
+	err = os.MkdirAll(rootOutputDir, 0755)
+	if err != nil {
+		return "", err
+	}
+	// Create final output directory
+	// Use MkdirTemp to avoid name collisions between parallel runs
+	outputDir, err := os.MkdirTemp(rootOutputDir, fmt.Sprintf("%s_*", subdirectory))
+	if err != nil {
+		return "", err
+	}
+	return outputDir, nil
 }
 
 // GetProfile return a profile initialising it at first call

--- a/test/new-e2e/pkg/utils/common/helpers.go
+++ b/test/new-e2e/pkg/utils/common/helpers.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package e2e
+package common
 
 import (
 	"fmt"
@@ -12,20 +12,21 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
-
 	"testing"
 )
 
-type testLogger struct {
+// TestLogger is a logger that writes to the test log.
+type TestLogger struct {
 	t *testing.T
 }
 
-func newTestLogger(t *testing.T) testLogger {
-	return testLogger{t: t}
+// NewTestLogger creates a new TestLogger that writes to the test log.
+func NewTestLogger(t *testing.T) TestLogger {
+	return TestLogger{t: t}
 }
 
-func (tl testLogger) Write(p []byte) (n int, err error) {
+// Write writes the given bytes to the test log.
+func (tl TestLogger) Write(p []byte) (n int, err error) {
 	tl.t.Helper()
 	tl.t.Log(string(p))
 	return len(p), nil
@@ -41,18 +42,14 @@ func (tl testLogger) Write(p []byte) (n int, err error) {
 // See runner.GetProfile().GetOutputDir() for the root output directory selection logic.
 //
 // See CreateTestOutputDir and BaseSuite.CreateTestOutputDir for a function that returns a subdirectory for a specific test.
-func CreateRootOutputDir() (string, error) {
-	outputRoot, err := runner.GetProfile().GetOutputDir()
-	if err != nil {
-		return "", err
-	}
+func CreateRootOutputDir(outputRoot string) (string, error) {
 	// Append timestamp to distinguish between multiple runs
 	// Format: YYYY-MM-DD_HH-MM-SS
 	// Use a custom timestamp format because Windows paths can't contain ':' characters
 	// and we don't need the timezone information.
 	timePart := time.Now().Format("2006-01-02_15-04-05")
 	// create root directory
-	err = os.MkdirAll(outputRoot, 0755)
+	err := os.MkdirAll(outputRoot, 0755)
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +79,7 @@ func CreateRootOutputDir() (string, error) {
 	return outputRoot, nil
 }
 
-// CreateTestOutputDir creates a directory for a specific test that can be used to store output files and artifacts.
+// CreateTestOutputDir creates a local directory for a specific test that can be used to store output files and artifacts.
 // The test name is used in the directory name, and invalid characters are replaced with underscores.
 //
 // Example:

--- a/test/new-e2e/pkg/utils/common/helpers.go
+++ b/test/new-e2e/pkg/utils/common/helpers.go
@@ -6,11 +6,7 @@
 package common
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
-	"time"
 
 	"testing"
 )
@@ -32,68 +28,13 @@ func (tl TestLogger) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// CreateRootOutputDir creates and returns a directory for tests to store output files and artifacts.
-// A timestamp is included in the path to distinguish between multiple runs, and os.MkdirTemp() is
-// used to avoid name collisions between parallel runs.
-//
-// A new directory is created on each call to this function, it is recommended to save this result
-// and use it for all tests in a run. For example see BaseSuite.GetRootOutputDir().
-//
-// See runner.GetProfile().GetOutputDir() for the root output directory selection logic.
-//
-// See CreateTestOutputDir and BaseSuite.CreateTestOutputDir for a function that returns a subdirectory for a specific test.
-func CreateRootOutputDir(outputRoot string) (string, error) {
-	// Append timestamp to distinguish between multiple runs
-	// Format: YYYY-MM-DD_HH-MM-SS
-	// Use a custom timestamp format because Windows paths can't contain ':' characters
-	// and we don't need the timezone information.
-	timePart := time.Now().Format("2006-01-02_15-04-05")
-	// create root directory
-	err := os.MkdirAll(outputRoot, 0755)
-	if err != nil {
-		return "", err
-	}
-	// Create final output directory
-	// Use MkdirTemp to avoid name collisions between parallel runs
-	outputRoot, err = os.MkdirTemp(outputRoot, fmt.Sprintf("%s_*", timePart))
-	if err != nil {
-		return "", err
-	}
-	if os.Getenv("CI") == "" {
-		// Create a symlink to the latest run for user convenience
-		// TODO: Is there a standard "ci" vs "local" check?
-		//       This code used to be in localProfile.GetOutputDir()
-		latestLink := filepath.Join(filepath.Dir(outputRoot), "latest")
-		// Remove the symlink if it already exists
-		if _, err := os.Lstat(latestLink); err == nil {
-			err = os.Remove(latestLink)
-			if err != nil {
-				return "", err
-			}
-		}
-		err = os.Symlink(outputRoot, latestLink)
-		if err != nil {
-			return "", err
-		}
-	}
-	return outputRoot, nil
-}
-
-// CreateTestOutputDir creates a local directory for a specific test that can be used to store output files and artifacts.
-// The test name is used in the directory name, and invalid characters are replaced with underscores.
+// SanitizeDirectoryName replace invalid characters in a directory name underscores.
 //
 // Example:
-//   - test name: TestInstallSuite/TestInstall/install_version=7.50.0
+//   - name: TestInstallSuite/TestInstall/install_version=7.50.0
 //   - output directory: <root>/TestInstallSuite/TestInstall/install_version_7_50_0
-func CreateTestOutputDir(root string, t *testing.T) (string, error) {
+func SanitizeDirectoryName(name string) string {
 	// https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
 	invalidPathChars := strings.Join([]string{"?", "%", "*", ":", "|", "\"", "<", ">", ".", ",", ";", "="}, "")
-
-	testPart := strings.ReplaceAll(t.Name(), invalidPathChars, "_")
-	path := filepath.Join(root, testPart)
-	err := os.MkdirAll(path, 0755)
-	if err != nil {
-		return "", err
-	}
-	return path, nil
+	return strings.ReplaceAll(name, invalidPathChars, "_")
 }

--- a/test/new-e2e/pkg/utils/common/types.go
+++ b/test/new-e2e/pkg/utils/common/types.go
@@ -16,3 +16,9 @@ type Context interface {
 type Initializable interface {
 	Init(Context) error
 }
+
+// Diagnosable defines the interface for an object that can dump diagnostic information
+// and store files in an output directory
+type Diagnosable interface {
+	Diagnose(outputDir string) (string, error)
+}

--- a/test/new-e2e/pkg/utils/common/types.go
+++ b/test/new-e2e/pkg/utils/common/types.go
@@ -10,6 +10,7 @@ import "testing"
 // Context defines an interface that allows to get information about current test context
 type Context interface {
 	T() *testing.T
+	SessionOutputDir() string
 }
 
 // Initializable defines the interface for an object that needs to be initialized

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
@@ -197,11 +197,15 @@ func waitForReadyTimeout(t *testing.T, host *Host, commandRunner *agentCommandRu
 }
 
 func generateAndDownloadFlare(t *testing.T, commandRunner *agentCommandRunner, host *Host) error {
-	root, err := e2e.CreateRootOutputDir()
+	outputRoot, err := runner.GetProfile().GetOutputDir()
+	if err != nil {
+		return err
+	}
+	root, err := common.CreateRootOutputDir(outputRoot)
 	if err != nil {
 		return fmt.Errorf("could not get root output directory: %w", err)
 	}
-	outputDir, err := e2e.CreateTestOutputDir(root, t)
+	outputDir, err := common.CreateTestOutputDir(root, t)
 	if err != nil {
 		return fmt.Errorf("could not get output directory: %w", err)
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_commands.go
@@ -113,11 +113,7 @@ func (agent *agentCommandRunner) Flare(commandArgs ...agentclient.AgentArgsOptio
 
 // FlareWithError runs flare command and returns the output or an error. You should use the FakeIntake client to fetch the flare archive
 func (agent *agentCommandRunner) FlareWithError(commandArgs ...agentclient.AgentArgsOption) (string, error) {
-	args, err := optional.MakeParams(commandArgs...)
-	require.NoError(agent.t, err)
-
-	arguments := append([]string{"flare"}, args.Args...)
-	return agent.executor.execute(arguments)
+	return agent.executeCommandWithError("flare", commandArgs...)
 }
 
 // Health runs health command and returns the runtime agent health

--- a/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agentclient/agent.go
@@ -32,6 +32,9 @@ type Agent interface {
 	// Flare runs flare command and returns the output. You should use the FakeIntake client to fetch the flare archive
 	Flare(commandArgs ...AgentArgsOption) string
 
+	// FlareWithError runs flare command and returns the output and error, if any. You should use the FakeIntake client to fetch the flare archive
+	FlareWithError(commandArgs ...AgentArgsOption) (string, error)
+
 	// Health runs health command and returns the runtime agent health
 	Health() (string, error)
 

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -224,6 +224,18 @@ func (h *Host) FileExists(path string) (bool, error) {
 	return info.Mode().IsRegular(), nil
 }
 
+// EnsureFileIsReadable add readable rights to a remote file
+func (h *Host) EnsureFileIsReadable(path string) error {
+	// ensure the file is readable on the remote host
+	if h.osFamily != oscomp.WindowsFamily {
+		_, err := h.Execute(fmt.Sprintf("sudo chmod +r %s", path))
+		if err != nil {
+			return fmt.Errorf("failed to make file readable: %w", err)
+		}
+	}
+	return nil
+}
+
 // GetFile create a sftp session and copy a single file from the remote host through SSH
 func (h *Host) GetFile(src string, dst string) error {
 	h.context.T().Logf("Copying file from remote %s to local %s", src, dst)

--- a/test/new-e2e/test-infra-definition/agent_test.go
+++ b/test/new-e2e/test-infra-definition/agent_test.go
@@ -30,3 +30,10 @@ func (v *agentSuite) TestAgentCommandNoArg() {
 	assert.NotNil(v.T(), status)
 	assert.NotEmpty(v.T(), status.Content)
 }
+
+func (v *agentSuite) TestAgentForceFailure() {
+	status, err := v.Env().Agent.Client.StatusWithError()
+	require.NoError(v.T(), err)
+	assert.NotNil(v.T(), status)
+	assert.Empty(v.T(), status.Content)
+}

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -59,7 +59,6 @@ type BaseInstallerSuite struct {
 	currentAgentVersion    agentVersion.Version
 	stableInstallerVersion PackageVersion
 	stableAgentVersion     PackageVersion
-	outputDir              string
 }
 
 // Installer the Datadog Installer for testing.
@@ -109,12 +108,7 @@ func (s *BaseInstallerSuite) SetupSuite() {
 // BeforeTest creates a new Datadog Installer and sets the output logs directory for each tests
 func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
 	s.BaseSuite.BeforeTest(suiteName, testName)
-
-	var err error
-	s.outputDir, err = s.CreateTestOutputDir()
-	s.Require().NoError(err, "should get output dir")
-	s.T().Logf("Output dir: %s", s.outputDir)
-	s.installer = NewDatadogInstaller(s.Env(), s.outputDir)
+	s.installer = NewDatadogInstaller(s.Env(), s.SessionOutputDir())
 }
 
 // Require instantiates a suiteAssertions for the current suite.
@@ -127,9 +121,4 @@ func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
 // on the Windows Datadog installer `BaseInstallerSuite` object.
 func (s *BaseInstallerSuite) Require() *suiteasserts.SuiteAssertions {
 	return suiteasserts.New(s.BaseSuite.Require(), s)
-}
-
-// OutputDir returns the output directory for the test
-func (s *BaseInstallerSuite) OutputDir() string {
-	return s.outputDir
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
@@ -79,7 +79,7 @@ func (s *testAgentInstallSuite) uninstallAgentWithMSI() {
 
 	// Act
 	err := windowsAgent.UninstallAgent(s.Env().RemoteHost,
-		filepath.Join(s.OutputDir(), "uninstall.log"),
+		filepath.Join(s.SessionOutputDir(), "uninstall.log"),
 	)
 
 	// Assert

--- a/test/new-e2e/tests/orchestrator/suite_test.go
+++ b/test/new-e2e/tests/orchestrator/suite_test.go
@@ -28,6 +28,7 @@ import (
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 )
 
@@ -56,6 +57,9 @@ type k8sSuite struct {
 	Fakeintake      *fakeintake.Client
 	K8sConfig       *restclient.Config
 	K8sClient       *kubernetes.Clientset
+
+	startTime time.Time
+	outputDir string
 }
 
 func TestKindSuite(t *testing.T) {
@@ -64,6 +68,14 @@ func TestKindSuite(t *testing.T) {
 
 func (suite *k8sSuite) SetupSuite() {
 	ctx := context.Background()
+	suite.startTime = time.Now()
+
+	// Create the root output directory for the test suite session
+	sessionDirectory, err := runner.GetProfile().CreateOutputSubDir(suite.getSuiteSessionSubdirectory())
+	if err != nil {
+		suite.T().Errorf("unable to create session output directory: %v", err)
+	}
+	suite.outputDir = sessionDirectory
 
 	stackConfig := runner.ConfigMap{
 		"ddagent:deploy":        auto.ConfigValue{Value: "true"},
@@ -211,4 +223,14 @@ func (suite *k8sSuite) summarizeManifests() {
 			fmt.Printf(" - type:%d, name:%s, ns:%s, kind:%s, apiVer:%s, uid:%s, collected:%s\n", typ, manif.Metadata.Name, manif.Metadata.Namespace, manif.Kind, manif.APIVersion, uid, p.CollectedTime.Format(time.RFC3339))
 		}
 	}
+}
+
+func (suite *k8sSuite) SessionOutputDir() string {
+	return suite.outputDir
+}
+
+func (suite *k8sSuite) getSuiteSessionSubdirectory() string {
+	suiteStartTimePart := suite.startTime.Format("2006_01_02_15_04_05")
+	testPart := common.SanitizeDirectoryName(suite.T().Name())
+	return fmt.Sprintf("%s_%s", testPart, suiteStartTimePart)
 }

--- a/test/new-e2e/tests/windows/base_agent_installer_suite.go
+++ b/test/new-e2e/tests/windows/base_agent_installer_suite.go
@@ -20,14 +20,13 @@ type BaseAgentInstallerSuite[Env any] struct {
 	e2e.BaseSuite[Env]
 
 	AgentPackage *windowsAgent.Package
-	OutputDir    string
 }
 
 // InstallAgent installs the Agent on a given Windows host. It will pass all the parameters to the MSI installer.
 func (b *BaseAgentInstallerSuite[Env]) InstallAgent(host *components.RemoteHost, options ...windowsAgent.InstallAgentOption) (string, error) {
 	b.T().Helper()
 	opts := []windowsAgent.InstallAgentOption{
-		windowsAgent.WithInstallLogFile(filepath.Join(b.OutputDir, "install.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(b.SessionOutputDir(), "install.log")),
 	}
 	opts = append(opts, options...)
 	return windowsAgent.InstallAgent(host, opts...)
@@ -39,28 +38,11 @@ func (b *BaseAgentInstallerSuite[Env]) NewTestClientForHost(host *components.Rem
 	return platformCommon.NewWindowsTestClient(b, host)
 }
 
-// BeforeTest overrides the base BeforeTest to perform some additional per-test setup like configuring the output directory.
-func (b *BaseAgentInstallerSuite[Env]) BeforeTest(suiteName, testName string) {
-	b.BaseSuite.BeforeTest(suiteName, testName)
-
-	var err error
-	b.OutputDir, err = b.CreateTestOutputDir()
-	if err != nil {
-		b.T().Fatalf("should get output dir")
-	}
-	b.T().Logf("Output dir: %s", b.OutputDir)
-}
-
 // SetupSuite overrides the base SetupSuite to perform some additional setups like setting the package to install.
 func (b *BaseAgentInstallerSuite[Env]) SetupSuite() {
 	b.BaseSuite.SetupSuite()
 
 	var err error
-	b.OutputDir, err = b.CreateTestOutputDir()
-	if err != nil {
-		b.T().Fatalf("should get output dir")
-	}
-
 	b.AgentPackage, err = windowsAgent.GetPackageFromEnv()
 	if err != nil {
 		b.T().Fatalf("failed to get MSI URL from env: %v", err)

--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -66,7 +66,7 @@ func (suite *testInstallSuite) testGivenDomainUserCanInstallAgent(username strin
 		windowsAgent.WithAgentUserPassword(fmt.Sprintf("\"%s\"", TestPassword)),
 		windowsAgent.WithValidAPIKey(),
 		windowsAgent.WithFakeIntake(suite.Env().FakeIntake),
-		windowsAgent.WithInstallLogFile(filepath.Join(suite.OutputDir, "TC-INS-DC-006_install.log")))
+		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-INS-DC-006_install.log")))
 
 	suite.Require().NoError(err, "should succeed to install Agent on a Domain Controller with a valid domain account & password")
 
@@ -114,7 +114,7 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		windowsAgent.WithAgentUserPassword(fmt.Sprintf("\"%s\"", TestPassword)),
 		windowsAgent.WithValidAPIKey(),
 		windowsAgent.WithFakeIntake(suite.Env().FakeIntake),
-		windowsAgent.WithInstallLogFile(filepath.Join(suite.OutputDir, "TC-UPG-DC-001_install_last_stable.log")))
+		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_install_last_stable.log")))
 
 	suite.Require().NoError(err, "should succeed to install Agent on a Domain Controller with a valid domain account & password")
 
@@ -123,7 +123,7 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 
 	_, err = suite.InstallAgent(host,
 		windowsAgent.WithPackage(suite.AgentPackage),
-		windowsAgent.WithInstallLogFile(filepath.Join(suite.OutputDir, "TC-UPG-DC-001_upgrade.log")))
+		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_upgrade.log")))
 	suite.Require().NoError(err, "should succeed to upgrade an Agent on a Domain Controller")
 
 	tc.CheckAgentVersion(suite.T(), suite.AgentPackage.AgentVersion())

--- a/test/new-e2e/tests/windows/install-test/base.go
+++ b/test/new-e2e/tests/windows/install-test/base.go
@@ -71,7 +71,7 @@ func (s *baseAgentMSISuite) AfterTest(suiteName, testName string) {
 		for _, logName := range []string{"System", "Application"} {
 			// collect the full event log as an evtx file
 			s.T().Logf("Exporting %s event log", logName)
-			outputPath := filepath.Join(s.OutputDir, fmt.Sprintf("%s.evtx", logName))
+			outputPath := filepath.Join(s.SessionOutputDir(), fmt.Sprintf("%s.evtx", logName))
 			err := windowsCommon.ExportEventLog(vm, logName, outputPath)
 			s.Assert().NoError(err, "should export %s event log", logName)
 			// Log errors and warnings to the screen for easy access
@@ -101,7 +101,7 @@ func (s *baseAgentMSISuite) installAgentPackage(vm *components.RemoteHost, agent
 	installOpts := []windowsAgent.InstallAgentOption{
 		windowsAgent.WithPackage(agentPackage),
 		// default log file, can be overridden
-		windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "install.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install.log")),
 		// trace-agent requires a valid API key
 		windowsAgent.WithValidAPIKey(),
 	}
@@ -120,7 +120,7 @@ func (s *baseAgentMSISuite) uninstallAgent() bool {
 	host := s.Env().RemoteHost
 	return s.T().Run("uninstall the agent", func(tt *testing.T) {
 		if !tt.Run("uninstall", func(tt *testing.T) {
-			err := windowsAgent.UninstallAgent(host, filepath.Join(s.OutputDir, "uninstall.log"))
+			err := windowsAgent.UninstallAgent(host, filepath.Join(s.SessionOutputDir(), "uninstall.log"))
 			require.NoError(tt, err, "should uninstall the agent")
 		}) {
 			tt.Fatal("uninstall failed")
@@ -227,7 +227,7 @@ func (s *baseAgentMSISuite) cleanupAgent() {
 	if err == nil {
 		defer func() {
 			t.Logf("Uninstalling Datadog Agent")
-			err = windowsAgent.UninstallAgent(host, filepath.Join(s.OutputDir, "uninstall.log"))
+			err = windowsAgent.UninstallAgent(host, filepath.Join(s.SessionOutputDir(), "uninstall.log"))
 			require.NoError(t, err)
 		}()
 	}

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -297,7 +297,7 @@ func (s *testRepairSuite) TestRepair() {
 
 	// Run Repair through the MSI
 	if !s.Run("repair install", func() {
-		err = windowsAgent.RepairAllAgent(t.host, "", filepath.Join(s.OutputDir, "repair.log"))
+		err = windowsAgent.RepairAllAgent(t.host, "", filepath.Join(s.SessionOutputDir(), "repair.log"))
 		s.Require().NoError(err)
 	}) {
 		s.T().FailNow()
@@ -334,7 +334,7 @@ func (s *testInstallOptsSuite) TestInstallOpts() {
 	installOpts := []windowsAgent.InstallAgentOption{
 		windowsAgent.WithAPIKey("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 		windowsAgent.WithPackage(s.AgentPackage),
-		windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "install.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install.log")),
 		windowsAgent.WithTags("k1:v1,k2:v2"),
 		windowsAgent.WithHostname("win-installopts"),
 		windowsAgent.WithCmdPort(fmt.Sprintf("%d", cmdPort)),
@@ -458,7 +458,7 @@ func (s *testInstallFailSuite) TestInstallFail() {
 			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithValidAPIKey(),
 			windowsAgent.WithWixFailWhenDeferred(),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "install.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install.log")),
 		)
 		s.Require().Error(err, "should fail to install agent %s", s.AgentPackage.AgentVersion())
 	}) {

--- a/test/new-e2e/tests/windows/install-test/npm_test.go
+++ b/test/new-e2e/tests/windows/install-test/npm_test.go
@@ -213,7 +213,7 @@ func (s *testNPMInstallSuite) testNPMFunctional() {
 func (s *testNPMInstallSuite) upgradeAgent(host *components.RemoteHost, agentPackage *windowsAgent.Package, options ...windowsAgent.InstallAgentOption) {
 	installOpts := []windowsAgent.InstallAgentOption{
 		windowsAgent.WithPackage(agentPackage),
-		windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 	}
 	installOpts = append(installOpts, options...)
 	if !s.Run(fmt.Sprintf("upgrade to %s", agentPackage.AgentVersion()), func() {

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -57,7 +57,7 @@ func (s *testUpgradeSuite) TestUpgrade() {
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
 		_, err := s.InstallAgent(vm,
 			windowsAgent.WithPackage(s.AgentPackage),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().NoError(err, "should upgrade to agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -94,7 +94,7 @@ func (s *testUpgradeRollbackSuite) TestUpgradeRollback() {
 		_, err := windowsAgent.InstallAgent(vm,
 			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithWixFailWhenDeferred(),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().Error(err, "should fail to install agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -157,7 +157,7 @@ func (s *testUpgradeRollbackWithoutCWSSuite) TestUpgradeRollbackWithoutCWS() {
 		_, err := windowsAgent.InstallAgent(vm,
 			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithWixFailWhenDeferred(),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().Error(err, "should fail to install agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -215,7 +215,7 @@ func (s *testUpgradeChangeUserSuite) TestUpgradeChangeUser() {
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
 		_, err := s.InstallAgent(host,
 			windowsAgent.WithPackage(s.AgentPackage),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 			windowsAgent.WithAgentUser(newUserName),
 		)
 		s.Require().NoError(err, "should upgrade to agent %s", s.AgentPackage.AgentVersion())
@@ -302,7 +302,7 @@ func (s *testUpgradeFromV5Suite) TestUpgrade5() {
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
 		_, err := s.InstallAgent(host,
 			windowsAgent.WithPackage(s.AgentPackage),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().NoError(err, "should upgrade to agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -324,7 +324,7 @@ func (s *testUpgradeFromV5Suite) installAgent5() {
 	host := s.Env().RemoteHost
 	agentPackage := s.agent5Package
 
-	logFile := filepath.Join(s.OutputDir, "install-agent5.log")
+	logFile := filepath.Join(s.SessionOutputDir(), "install-agent5.log")
 	_, err := s.InstallAgent(host,
 		windowsAgent.WithPackage(agentPackage),
 		windowsAgent.WithValidAPIKey(),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Move helpers from e2e to utils/common to avoid circular dependencies
* Add Diagnosable interface for environments
* Implement Diagnosable on Host environment
* Create one output dir per suite session

### Motivation

This should help investigations for failing e2e tests, storing in artifacts a flare of the agent under test, including its configuration and its logs. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Best reviewed commit per commit. I cleaned up some code that introduced output dir, moving it to base suite.