### PR TITLE
[EBPF] gpu: auto-enable agent check if system-probe gpu_monitoring module is enabled

### DIFF
--- a/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
+++ b/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
 
-if grep -Eq '^ *enable_tcp_queue_length *: *true' /etc/datadog-agent/system-probe.yaml || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH" == "true" ]]; then
+sysprobe_cfg="/etc/datadog-agent/system-probe.yaml"
+
+if grep -Eq '^ *enable_tcp_queue_length *: *true' $sysprobe_cfg || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH" == "true" ]]; then
   if [ -f /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example ]; then
     mv /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example \
        /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.default
   fi
 fi
 
-if grep -Eq '^ *enable_oom_kill *: *true' /etc/datadog-agent/system-probe.yaml || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL" == "true" ]]; then
+if grep -Eq '^ *enable_oom_kill *: *true' $sysprobe_cfg || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL" == "true" ]]; then
   if [ -f /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.example ]; then
     mv /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.example \
        /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.default
+  fi
+fi
+
+# Match the key gpu_monitoring.enabled: true using Python's YAML parser, which is included in the base image
+# and is more robust than using regexes.
+gpu_monitoring_enabled=$(python -c "import yaml, sys; data=yaml.safe_load(sys.stdin); print(bool(data.get('gpu_monitoring', {}).get('enabled')))" < $sysprobe_cfg)
+
+# Note gpu_monitoring_enabled is a Python boolean, so casing is important
+if [[ "$gpu_monitoring_enabled" == "True" ]] || [[ "$DD_GPU_MONITORING_ENABLED" == "true" ]]; then
+  if [ -f /etc/datadog-agent/conf.d/gpu.d/conf.yaml.example ]; then
+    mv /etc/datadog-agent/conf.d/gpu.d/conf.yaml.example \
+       /etc/datadog-agent/conf.d/gpu.d/conf.yaml.default
   fi
 fi

--- a/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
+++ b/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
@@ -18,7 +18,7 @@ fi
 
 # Match the key gpu_monitoring.enabled: true using Python's YAML parser, which is included in the base image
 # and is more robust than using regexes.
-gpu_monitoring_enabled=$(python -c "import yaml, sys; data=yaml.safe_load(sys.stdin); print(bool(data.get('gpu_monitoring', {}).get('enabled')))" < $sysprobe_cfg)
+gpu_monitoring_enabled=$(python3 -c "import yaml, sys; data=yaml.safe_load(sys.stdin); print(bool(data.get('gpu_monitoring', {}).get('enabled')))" < $sysprobe_cfg)
 
 # Note gpu_monitoring_enabled is a Python boolean, so casing is important
 if [[ "$gpu_monitoring_enabled" == "True" ]] || [[ "$DD_GPU_MONITORING_ENABLED" == "true" ]]; then

--- a/cmd/agent/dist/conf.d/gpu.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/gpu.d/conf.yaml.example
@@ -1,0 +1,20 @@
+init_config:
+
+instances:
+
+    -
+
+    ## @param nvml_library_path - string - optional - default: ""
+    ## Configure an alternative path for the NVML NVIDIA library. Necessary
+    ## if the library is in a location where the agent cannot automatically find it.
+    #
+    # nvml_library_path: ""
+
+    ## @param tags - list of strings following the pattern: "key:value" - optional
+    ## List of tags to attach to every metric, event, and service check emitted by this integration.
+    ##
+    ## Learn more about tagging: https://docs.datadoghq.com/tagging/
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds automatic detection of the GPU monitoring feature in `60-sysprobe-check.sh` config script for containerized environments, and enables the corresponding necessary agent-side check.

### Motivation

Reduce the possibility of misconfigurations: if system-probe has the GPU monitoring module enabled but the agent gpu check is not enabled, no data will be reported.

This PR also simplifies deployments in k8s environments. As the GPU monitoring feature is deployed in mixed clusters (those where some nodes have GPUs and some don't), we need to override the features based on the node GPU availability. Enabling/disabling the system-probe module is easy enough with environment variables, but enabling/disabling checks is not as simple. This PR removes the need to manually configure the agent side check. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated by manually running the script with different input values.

### Possible Drawbacks / Trade-offs

### Additional Notes

This PR parses the YAML file with Python's YAML module, which is present in the container image so no extra dependencies are required. This is a more robust alternative than using regex: while for other settings (e.g. `enable_oom_kill`) we're looking for a single key, here we're looking for a nested key inside another, so the regex would be more complex and more prone to errors.