### PR TITLE
feat(admission): implement admission controllers deletion

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -212,6 +212,19 @@ func (c *ControllerV1) reconcile() error {
 				log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
+	} else {
+		mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Errorf("Failed to get Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		} else {
+			log.Infof("Mutating Webhook %s was found, deleting it", c.config.getWebhookName())
+			err := c.deleteMutatingWebhook(mutatingWebhook)
+			if err != nil {
+				log.Errorf("Failed to delete Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		}
 	}
 
 	if c.config.validationEnabled {
@@ -229,6 +242,19 @@ func (c *ControllerV1) reconcile() error {
 			err := c.updateValidatingWebhook(secret, validatingWebhook)
 			if err != nil {
 				log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		}
+	} else {
+		validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Errorf("Failed to get Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		} else {
+			log.Infof("Validating Webhook %s was found, deleting it", c.config.getWebhookName())
+			err := c.deleteValidatingWebhook(validatingWebhook)
+			if err != nil {
+				log.Errorf("Failed to delete Validating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
 	}
@@ -273,6 +299,12 @@ func (c *ControllerV1) newValidatingWebhooks(secret *corev1.Secret) []admiv1.Val
 	return webhooks
 }
 
+// deleteValidatingWebhook deletes the ValidatingWebhookConfiguration object.
+func (c *ControllerV1) deleteValidatingWebhook(webhook *admiv1.ValidatingWebhookConfiguration) error {
+	err := c.clientSet.AdmissionregistrationV1().ValidatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
+	return err
+}
+
 // createMutatingWebhook creates a new MutatingWebhookConfiguration object.
 func (c *ControllerV1) createMutatingWebhook(secret *corev1.Secret) error {
 	webhook := &admiv1.MutatingWebhookConfiguration{
@@ -308,6 +340,12 @@ func (c *ControllerV1) newMutatingWebhooks(secret *corev1.Secret) []admiv1.Mutat
 	}
 
 	return webhooks
+}
+
+// deleteMutatingWebhook deletes the MutatingWebhookConfiguration object.
+func (c *ControllerV1) deleteMutatingWebhook(webhook *admiv1.MutatingWebhookConfiguration) error {
+	err := c.clientSet.AdmissionregistrationV1().MutatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
+	return err
 }
 
 // generateTemplates generates the webhook templates from the configuration.

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -213,6 +213,19 @@ func (c *ControllerV1beta1) reconcile() error {
 				log.Errorf("Failed to update Mutating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
+	} else {
+		mutatingWebhook, err := c.mutatingWebhooksLister.Get(c.config.getWebhookName())
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Errorf("Failed to get Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		} else {
+			log.Infof("Mutating Webhook %s was found, deleting it", c.config.getWebhookName())
+			err := c.deleteMutatingWebhook(mutatingWebhook)
+			if err != nil {
+				log.Errorf("Failed to delete Mutating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		}
 	}
 
 	if c.config.validationEnabled {
@@ -230,6 +243,19 @@ func (c *ControllerV1beta1) reconcile() error {
 			err = c.updateValidatingWebhook(secret, validatingWebhook)
 			if err != nil {
 				log.Errorf("Failed to update Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		}
+	} else {
+		validatingWebhook, err := c.validatingWebhooksLister.Get(c.config.getWebhookName())
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Errorf("Failed to get Validating Webhook %s: %v", c.config.getWebhookName(), err)
+			}
+		} else {
+			log.Infof("Validating Webhook %s was found, deleting it", c.config.getWebhookName())
+			err := c.deleteValidatingWebhook(validatingWebhook)
+			if err != nil {
+				log.Errorf("Failed to delete Validating Webhook %s: %v", c.config.getWebhookName(), err)
 			}
 		}
 	}
@@ -274,6 +300,12 @@ func (c *ControllerV1beta1) newValidatingWebhooks(secret *corev1.Secret) []admiv
 	return webhooks
 }
 
+// deleteValidatingWebhook deletes the ValidatingWebhookConfiguration object.
+func (c *ControllerV1beta1) deleteValidatingWebhook(webhook *admiv1beta1.ValidatingWebhookConfiguration) error {
+	err := c.clientSet.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
+	return err
+}
+
 // createMutatingWebhook creates a new MutatingWebhookConfiguration object.
 func (c *ControllerV1beta1) createMutatingWebhook(secret *corev1.Secret) error {
 	webhook := &admiv1beta1.MutatingWebhookConfiguration{
@@ -310,6 +342,12 @@ func (c *ControllerV1beta1) newMutatingWebhooks(secret *corev1.Secret) []admiv1b
 	}
 
 	return webhooks
+}
+
+// deleteMutatingWebhook deletes the MutatingWebhookConfiguration object.
+func (c *ControllerV1beta1) deleteMutatingWebhook(webhook *admiv1beta1.MutatingWebhookConfiguration) error {
+	err := c.clientSet.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Delete(context.TODO(), webhook.Name, metav1.DeleteOptions{})
+	return err
 }
 
 func (c *ControllerV1beta1) generateTemplates() {

--- a/releasenotes-dca/notes/delete_admission_webhooks-5c89ccd6c0d6ff8b.yaml
+++ b/releasenotes-dca/notes/delete_admission_webhooks-5c89ccd6c0d6ff8b.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Cluster Agent is now able to delete the `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook`
+    depending on the `admission_controller.validation.enabled` and `admission_controller.mutation.enabled` settings.
+    Note that the `admission_controller.enabled` needs to the set to `true` to still allow the Cluster Agent to
+    interract with Kubernetes Admission Controller.

--- a/releasenotes-dca/notes/delete_admission_webhooks-5c89ccd6c0d6ff8b.yaml
+++ b/releasenotes-dca/notes/delete_admission_webhooks-5c89ccd6c0d6ff8b.yaml
@@ -8,7 +8,7 @@
 ---
 enhancements:
   - |
-    The Cluster Agent is now able to delete the `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook`
+    The Cluster Agent is now able to delete `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook`
     depending on the `admission_controller.validation.enabled` and `admission_controller.mutation.enabled` settings.
-    Note that the `admission_controller.enabled` needs to the set to `true` to still allow the Cluster Agent to
-    interract with Kubernetes Admission Controller.
+    Note that `admission_controller.enabled` must be set to `true` to allow the Cluster Agent to
+    interact with the Kubernetes Admission Controller.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Implements the deletion of Admission Controller Webhooks by the Cluster Agent.

### Motivation

This is needed to allow the Cluster Agent to delete Admission Controller Webhooks if they are disabled in the configuration.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
* With an Operator built with https://github.com/DataDog/datadog-operator/pull/1591, deploy the Cluster Agent with the following settings
```
    admissionController:
      enabled: true
      validation:
        enabled: true
      mutation:
        enabled: true
``` 

You should see the following RBACs for the Cluster Agent
```
➜ kubectl describe clusterroles.rbac.authorization.k8s.io datadog-cluster-agent
Name:         datadog-cluster-agent
[...]
  mutatingwebhookconfigurations.admissionregistration.k8s.io    []                 [datadog-webhook]                     [get list watch update delete]
  validatingwebhookconfigurations.admissionregistration.k8s.io  []                 [datadog-webhook]                     [get list watch update delete]
```

* Verify that the Webhooks are properly created
```
➜  datadog-dev git:(main) ✗ kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io
NAME              WEBHOOKS   AGE
datadog-webhook   1          105s
```
```
➜  datadog-dev git:(main) ✗ kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io
NAME              WEBHOOKS   AGE
datadog-webhook   3          98s
```

* Re-deploy the Cluster Agent with the following settings
```
    admissionController:
      enabled: true
      validation:
        enabled: false
      mutation:
        enabled: false
```

* Verify that the Webhooks are properly deleted
```
➜  datadog-dev git:(main) ✗ kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io
NAME              WEBHOOKS   AGE
No resources found
```
```
➜  datadog-dev git:(main) ✗ kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io
NAME              WEBHOOKS   AGE
No resources found
```

### Possible Drawbacks / Trade-offs

It is not possible to delete Admission Controllers by setting the `admission_controller.enabled` to `false`.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->