### PR TITLE
[e2e] create a session output directory per TestSuite session

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -613,8 +613,13 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 func (bs *BaseSuite[Env]) GetRootOutputDir() (string, error) {
 	var err error
 	bs.onceTestSessionOutputDir.Do(func() {
+		var outputRoot string
+		outputRoot, err = runner.GetProfile().GetOutputDir()
+		if err != nil {
+			return
+		}
 		// Store the timestamped directory to be used by all tests in the suite
-		bs.testSessionOutputDir, err = CreateTestSessionOutputDir()
+		bs.testSessionOutputDir, err = CreateTestSessionOutputDir(outputRoot)
 	})
 	return bs.testSessionOutputDir, err
 }

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -614,7 +614,7 @@ func (bs *BaseSuite[Env]) GetRootOutputDir() (string, error) {
 	var err error
 	bs.onceTestSessionOutputDir.Do(func() {
 		// Store the timestamped directory to be used by all tests in the suite
-		bs.testSessionOutputDir, err = CreateRootOutputDir()
+		bs.testSessionOutputDir, err = CreateTestSessionOutputDir()
 	})
 	return bs.testSessionOutputDir, err
 }

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -146,7 +146,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 	"testing"
 	"time"
 
@@ -199,8 +198,7 @@ type BaseSuite[Env any] struct {
 	endTime       time.Time
 	initOnly      bool
 
-	testSessionOutputDir     string
-	onceTestSessionOutputDir sync.Once
+	outputDir string
 }
 
 //
@@ -487,6 +485,13 @@ func (bs *BaseSuite[Env]) providerContext(opTimeout time.Duration) (context.Cont
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) SetupSuite() {
 	bs.startTime = time.Now()
+	// Create the root output directory for the test suite session
+	sessionDirectory, err := runner.GetProfile().CreateOutputSubDir(bs.getSuiteSessionSubdirectory())
+	if err != nil {
+		bs.T().Errorf("unable to create session output directory: %v", err)
+	}
+	bs.outputDir = sessionDirectory
+	bs.T().Logf("Suite session output directory: %s", bs.outputDir)
 	// In `SetupSuite` we cannot fail as `TearDownSuite` will not be called otherwise.
 	// Meaning that stack clean up may not be called.
 	// We do implement an explicit recover to handle this manuallay.
@@ -497,7 +502,7 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 		}
 
 		bs.T().Logf("Caught panic in SetupSuite, err: %v. Will try to TearDownSuite", err)
-		bs.firstFailTest = "Initial provisioiningin SetupSuite" // This is required to handle skipDeleteOnFailure
+		bs.firstFailTest = "Initial provisioning SetupSuite" // This is required to handle skipDeleteOnFailure
 		bs.TearDownSuite()
 
 		// As we need to call `recover` to know if there was a panic, we wrap and forward the original panic to,
@@ -522,6 +527,12 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 	}
 }
 
+func (bs *BaseSuite[Env]) getSuiteSessionSubdirectory() string {
+	suiteStartTimePart := bs.startTime.Format("2006_01_02_15_04_05")
+	testPart := common.SanitizeDirectoryName(bs.T().Name())
+	return fmt.Sprintf("%s_%s", testPart, suiteStartTimePart)
+}
+
 // BeforeTest is executed right before the test starts and receives the suite and test names as input.
 // This function is called by [testify Suite].
 //
@@ -537,7 +548,7 @@ func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 	}
 }
 
-// AfterTest is executed right after the test finishes and receives the suite and test names as input.
+// AfterTest is executed right after each test finishes and receives the suite and test names as input.
 // This function is called by [testify Suite].
 //
 // If you override AfterTest in your custom test suite type, the function must call [test.BaseSuite.AfterTest].
@@ -604,35 +615,10 @@ func (bs *BaseSuite[Env]) TearDownSuite() {
 	}
 }
 
-// GetRootOutputDir returns the root output directory for tests to store output files and artifacts.
-// The directory is created on the first call to this function and reused in future calls.
-//
-// See BaseSuite.CreateTestOutputDir() for a function that returns a directory for the current test.
-//
-// See CreateRootOutputDir() for details on the root directory creation.
-func (bs *BaseSuite[Env]) GetRootOutputDir() (string, error) {
-	var err error
-	bs.onceTestSessionOutputDir.Do(func() {
-		var outputRoot string
-		outputRoot, err = runner.GetProfile().GetOutputDir()
-		if err != nil {
-			return
-		}
-		// Store the timestamped directory to be used by all tests in the suite
-		bs.testSessionOutputDir, err = common.CreateTestSessionOutputDir(outputRoot)
-	})
-	return bs.testSessionOutputDir, err
-}
-
-// CreateTestOutputDir returns an output directory for the current test.
-//
-// See also CreateTestOutputDir()
-func (bs *BaseSuite[Env]) CreateTestOutputDir() (string, error) {
-	root, err := bs.GetRootOutputDir()
-	if err != nil {
-		return "", err
-	}
-	return common.CreateTestOutputDir(root, bs.T())
+// SessionOutputDir returns the root output directory for tests to store output files and artifacts.
+// The directory is created at SetupSuite time.
+func (bs *BaseSuite[Env]) SessionOutputDir() string {
+	return bs.outputDir
 }
 
 // Run is a helper function to run a test suite.

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -632,7 +632,7 @@ func (bs *BaseSuite[Env]) CreateTestOutputDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return CreateTestOutputDir(root, bs.T())
+	return common.CreateTestOutputDir(root, bs.T())
 }
 
 // Run is a helper function to run a test suite.

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -619,7 +619,7 @@ func (bs *BaseSuite[Env]) GetRootOutputDir() (string, error) {
 			return
 		}
 		// Store the timestamped directory to be used by all tests in the suite
-		bs.testSessionOutputDir, err = CreateTestSessionOutputDir(outputRoot)
+		bs.testSessionOutputDir, err = common.CreateTestSessionOutputDir(outputRoot)
 	})
 	return bs.testSessionOutputDir, err
 }

--- a/test/new-e2e/pkg/e2e/suite_utils.go
+++ b/test/new-e2e/pkg/e2e/suite_utils.go
@@ -6,11 +6,9 @@
 package e2e
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"testing"
 )
@@ -27,53 +25,6 @@ func (tl testLogger) Write(p []byte) (n int, err error) {
 	tl.t.Helper()
 	tl.t.Log(string(p))
 	return len(p), nil
-}
-
-// CreateTestSessionOutputDir creates and returns a directory for tests to store output files and artifacts.
-// A timestamp is included in the path to distinguish between multiple runs, and os.MkdirTemp() is
-// used to avoid name collisions between parallel runs.
-//
-// A new directory is created on each call to this function, it is recommended to save this result
-// and use it for all tests in a run. For example see BaseSuite.GetRootOutputDir().
-//
-// See runner.GetProfile().GetOutputDir() for the root output directory selection logic.
-//
-// See CreateTestOutputDir and BaseSuite.CreateTestOutputDir for a function that returns a subdirectory for a specific test.
-func CreateTestSessionOutputDir(outputRoot string) (string, error) {
-	// Append timestamp to distinguish between multiple runs
-	// Format: YYYY-MM-DD_HH-MM-SS
-	// Use a custom timestamp format because Windows paths can't contain ':' characters
-	// and we don't need the timezone information.
-	timePart := time.Now().Format("2006-01-02_15-04-05")
-	// create root directory
-	err := os.MkdirAll(outputRoot, 0755)
-	if err != nil {
-		return "", err
-	}
-	// Create final output directory
-	// Use MkdirTemp to avoid name collisions between parallel runs
-	outputRoot, err = os.MkdirTemp(outputRoot, fmt.Sprintf("%s_*", timePart))
-	if err != nil {
-		return "", err
-	}
-	if os.Getenv("CI") == "" {
-		// Create a symlink to the latest run for user convenience
-		// TODO: Is there a standard "ci" vs "local" check?
-		//       This code used to be in localProfile.GetOutputDir()
-		latestLink := filepath.Join(filepath.Dir(outputRoot), "latest")
-		// Remove the symlink if it already exists
-		if _, err := os.Lstat(latestLink); err == nil {
-			err = os.Remove(latestLink)
-			if err != nil {
-				return "", err
-			}
-		}
-		err = os.Symlink(outputRoot, latestLink)
-		if err != nil {
-			return "", err
-		}
-	}
-	return outputRoot, nil
 }
 
 // CreateTestOutputDir creates a directory for a specific test that can be used to store output files and artifacts.

--- a/test/new-e2e/pkg/e2e/suite_utils.go
+++ b/test/new-e2e/pkg/e2e/suite_utils.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
-
 	"testing"
 )
 
@@ -41,18 +39,14 @@ func (tl testLogger) Write(p []byte) (n int, err error) {
 // See runner.GetProfile().GetOutputDir() for the root output directory selection logic.
 //
 // See CreateTestOutputDir and BaseSuite.CreateTestOutputDir for a function that returns a subdirectory for a specific test.
-func CreateTestSessionOutputDir() (string, error) {
-	outputRoot, err := runner.GetProfile().GetOutputDir()
-	if err != nil {
-		return "", err
-	}
+func CreateTestSessionOutputDir(outputRoot string) (string, error) {
 	// Append timestamp to distinguish between multiple runs
 	// Format: YYYY-MM-DD_HH-MM-SS
 	// Use a custom timestamp format because Windows paths can't contain ':' characters
 	// and we don't need the timezone information.
 	timePart := time.Now().Format("2006-01-02_15-04-05")
 	// create root directory
-	err = os.MkdirAll(outputRoot, 0755)
+	err := os.MkdirAll(outputRoot, 0755)
 	if err != nil {
 		return "", err
 	}

--- a/test/new-e2e/pkg/e2e/suite_utils.go
+++ b/test/new-e2e/pkg/e2e/suite_utils.go
@@ -6,10 +6,6 @@
 package e2e
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
-
 	"testing"
 )
 
@@ -25,23 +21,4 @@ func (tl testLogger) Write(p []byte) (n int, err error) {
 	tl.t.Helper()
 	tl.t.Log(string(p))
 	return len(p), nil
-}
-
-// CreateTestOutputDir creates a directory for a specific test that can be used to store output files and artifacts.
-// The test name is used in the directory name, and invalid characters are replaced with underscores.
-//
-// Example:
-//   - test name: TestInstallSuite/TestInstall/install_version=7.50.0
-//   - output directory: <root>/TestInstallSuite/TestInstall/install_version_7_50_0
-func CreateTestOutputDir(root string, t *testing.T) (string, error) {
-	// https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
-	invalidPathChars := strings.Join([]string{"?", "%", "*", ":", "|", "\"", "<", ">", ".", ",", ";", "="}, "")
-
-	testPart := strings.ReplaceAll(t.Name(), invalidPathChars, "_")
-	path := filepath.Join(root, testPart)
-	err := os.MkdirAll(path, 0755)
-	if err != nil {
-		return "", err
-	}
-	return path, nil
 }

--- a/test/new-e2e/pkg/e2e/suite_utils.go
+++ b/test/new-e2e/pkg/e2e/suite_utils.go
@@ -31,7 +31,7 @@ func (tl testLogger) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// CreateRootOutputDir creates and returns a directory for tests to store output files and artifacts.
+// CreateTestSessionOutputDir creates and returns a directory for tests to store output files and artifacts.
 // A timestamp is included in the path to distinguish between multiple runs, and os.MkdirTemp() is
 // used to avoid name collisions between parallel runs.
 //
@@ -41,7 +41,7 @@ func (tl testLogger) Write(p []byte) (n int, err error) {
 // See runner.GetProfile().GetOutputDir() for the root output directory selection logic.
 //
 // See CreateTestOutputDir and BaseSuite.CreateTestOutputDir for a function that returns a subdirectory for a specific test.
-func CreateRootOutputDir() (string, error) {
+func CreateTestSessionOutputDir() (string, error) {
 	outputRoot, err := runner.GetProfile().GetOutputDir()
 	if err != nil {
 		return "", err

--- a/test/new-e2e/pkg/runner/ci_profile.go
+++ b/test/new-e2e/pkg/runner/ci_profile.go
@@ -29,6 +29,8 @@ type ciProfile struct {
 	ciUniqueID string
 }
 
+var _ Profile = ciProfile{}
+
 // NewCIProfile creates a new CI profile
 func NewCIProfile() (Profile, error) {
 	ciSecretPrefix := os.Getenv("CI_SECRET_PREFIX")

--- a/test/new-e2e/pkg/utils/common/output_dirs.go
+++ b/test/new-e2e/pkg/utils/common/output_dirs.go
@@ -6,74 +6,16 @@
 package common
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
-	"testing"
-	"time"
 )
 
-// CreateTestSessionOutputDir creates and returns a directory for tests to store output files and artifacts.
-// A timestamp is included in the path to distinguish between multiple runs, and os.MkdirTemp() is
-// used to avoid name collisions between parallel runs.
-//
-// A new directory is created on each call to this function, it is recommended to save this result
-// and use it for all tests in a run. For example see BaseSuite.GetRootOutputDir().
-//
-// See CreateTestOutputDir and BaseSuite.CreateTestOutputDir for a function that returns a subdirectory for a specific test.
-func CreateTestSessionOutputDir(outputRoot string) (string, error) {
-	// Append timestamp to distinguish between multiple runs
-	// Format: YYYY-MM-DD_HH-MM-SS
-	// Use a custom timestamp format because Windows paths can't contain ':' characters
-	// and we don't need the timezone information.
-	timePart := time.Now().Format("2006-01-02_15-04-05")
-	// create root directory
-	err := os.MkdirAll(outputRoot, 0755)
-	if err != nil {
-		return "", err
-	}
-	// Create final output directory
-	// Use MkdirTemp to avoid name collisions between parallel runs
-	outputRoot, err = os.MkdirTemp(outputRoot, fmt.Sprintf("%s_*", timePart))
-	if err != nil {
-		return "", err
-	}
-	if os.Getenv("CI") == "" {
-		// Create a symlink to the latest run for user convenience
-		// TODO: Is there a standard "ci" vs "local" check?
-		//       This code used to be in localProfile.GetOutputDir()
-		latestLink := filepath.Join(filepath.Dir(outputRoot), "latest")
-		// Remove the symlink if it already exists
-		if _, err := os.Lstat(latestLink); err == nil {
-			err = os.Remove(latestLink)
-			if err != nil {
-				return "", err
-			}
-		}
-		err = os.Symlink(outputRoot, latestLink)
-		if err != nil {
-			return "", err
-		}
-	}
-	return outputRoot, nil
-}
-
-// CreateTestOutputDir creates a local directory for a specific test that can be used to store output files and artifacts.
-// The test name is used in the directory name, and invalid characters are replaced with underscores.
+// SanitizeDirectoryName replace invalid characters in a directory name underscores.
 //
 // Example:
-//   - test name: TestInstallSuite/TestInstall/install_version=7.50.0
+//   - name: TestInstallSuite/TestInstall/install_version=7.50.0
 //   - output directory: <root>/TestInstallSuite/TestInstall/install_version_7_50_0
-func CreateTestOutputDir(root string, t *testing.T) (string, error) {
+func SanitizeDirectoryName(name string) string {
 	// https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
 	invalidPathChars := strings.Join([]string{"?", "%", "*", ":", "|", "\"", "<", ">", ".", ",", ";", "="}, "")
-
-	testPart := strings.ReplaceAll(t.Name(), invalidPathChars, "_")
-	path := filepath.Join(root, testPart)
-	err := os.MkdirAll(path, 0755)
-	if err != nil {
-		return "", err
-	}
-	return path, nil
+	return strings.ReplaceAll(name, invalidPathChars, "_")
 }

--- a/test/new-e2e/pkg/utils/common/output_dirs.go
+++ b/test/new-e2e/pkg/utils/common/output_dirs.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"testing"
 	"time"
 )
 
@@ -55,4 +57,23 @@ func CreateTestSessionOutputDir(outputRoot string) (string, error) {
 		}
 	}
 	return outputRoot, nil
+}
+
+// CreateTestOutputDir creates a local directory for a specific test that can be used to store output files and artifacts.
+// The test name is used in the directory name, and invalid characters are replaced with underscores.
+//
+// Example:
+//   - test name: TestInstallSuite/TestInstall/install_version=7.50.0
+//   - output directory: <root>/TestInstallSuite/TestInstall/install_version_7_50_0
+func CreateTestOutputDir(root string, t *testing.T) (string, error) {
+	// https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
+	invalidPathChars := strings.Join([]string{"?", "%", "*", ":", "|", "\"", "<", ">", ".", ",", ";", "="}, "")
+
+	testPart := strings.ReplaceAll(t.Name(), invalidPathChars, "_")
+	path := filepath.Join(root, testPart)
+	err := os.MkdirAll(path, 0755)
+	if err != nil {
+		return "", err
+	}
+	return path, nil
 }

--- a/test/new-e2e/pkg/utils/common/types.go
+++ b/test/new-e2e/pkg/utils/common/types.go
@@ -10,6 +10,7 @@ import "testing"
 // Context defines an interface that allows to get information about current test context
 type Context interface {
 	T() *testing.T
+	SessionOutputDir() string
 }
 
 // Initializable defines the interface for an object that needs to be initialized

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
@@ -197,9 +198,13 @@ func waitForReadyTimeout(t *testing.T, host *Host, commandRunner *agentCommandRu
 }
 
 func generateAndDownloadFlare(t *testing.T, commandRunner *agentCommandRunner, host *Host) error {
-	root, err := e2e.CreateTestSessionOutputDir()
+	outputRoot, err := runner.GetProfile().GetOutputDir()
 	if err != nil {
 		return fmt.Errorf("could not get root output directory: %w", err)
+	}
+	root, err := e2e.CreateTestSessionOutputDir(outputRoot)
+	if err != nil {
+		return fmt.Errorf("could not get test session output directory: %w", err)
 	}
 	outputDir, err := e2e.CreateTestOutputDir(root, t)
 	if err != nil {

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -8,6 +8,8 @@ package client
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -19,7 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclientparams"
@@ -43,7 +44,7 @@ func NewHostAgentClient(context common.Context, hostOutput remote.HostOutput, wa
 	commandRunner := newAgentCommandRunner(context.T(), ae)
 
 	if params.ShouldWaitForReady {
-		if err := waitForReadyTimeout(context.T(), host, commandRunner, agentReadyTimeout); err != nil {
+		if err := waitForReadyTimeout(context, host, commandRunner, agentReadyTimeout); err != nil {
 			return nil, err
 		}
 	}
@@ -64,7 +65,7 @@ func NewHostAgentClientWithParams(context common.Context, hostOutput remote.Host
 	commandRunner := newAgentCommandRunner(context.T(), ae)
 
 	if params.ShouldWaitForReady {
-		if err := waitForReadyTimeout(context.T(), host, commandRunner, agentReadyTimeout); err != nil {
+		if err := waitForReadyTimeout(context, host, commandRunner, agentReadyTimeout); err != nil {
 			return nil, err
 		}
 	}
@@ -181,35 +182,30 @@ func fetchAuthTokenCommand(authTokenPath string, osFamily osComp.Family) string 
 	return fmt.Sprintf("sudo cat %s", authTokenPath)
 }
 
-func waitForReadyTimeout(t *testing.T, host *Host, commandRunner *agentCommandRunner, timeout time.Duration) error {
+func waitForReadyTimeout(ctx common.Context, host *Host, commandRunner *agentCommandRunner, timeout time.Duration) error {
 	err := commandRunner.waitForReadyTimeout(timeout)
 
 	if err != nil {
 		// Propagate the original error if we have another error here
-		localErr := generateAndDownloadFlare(t, commandRunner, host)
+		localErr := generateAndDownloadFlare(ctx, commandRunner, host)
 
 		if localErr != nil {
-			t.Errorf("Could not generate and get a flare: %v", localErr)
+			ctx.T().Errorf("Could not generate and get a flare: %v", localErr)
 		}
 	}
 
 	return err
 }
 
-func generateAndDownloadFlare(t *testing.T, commandRunner *agentCommandRunner, host *Host) error {
-	outputRoot, err := runner.GetProfile().GetOutputDir()
+func generateAndDownloadFlare(ctx common.Context, commandRunner *agentCommandRunner, host *Host) error {
+	testPart := common.SanitizeDirectoryName(ctx.T().Name())
+	outputDir := filepath.Join(ctx.SessionOutputDir(), testPart)
+	err := os.MkdirAll(outputDir, 0755)
 	if err != nil {
-		return fmt.Errorf("could not get root output directory: %w", err)
-	}
-	root, err := common.CreateTestSessionOutputDir(outputRoot)
-	if err != nil {
-		return fmt.Errorf("could not get test session output directory: %w", err)
-	}
-	outputDir, err := common.CreateTestOutputDir(root, t)
-	if err != nil {
-		return fmt.Errorf("could not get output directory: %w", err)
+		return fmt.Errorf("could not create output directory: %w", err)
 	}
 	flareFound := false
+	t := ctx.T()
 
 	_, err = commandRunner.FlareWithError(agentclient.WithArgs([]string{"--email", "e2e@test.com", "--send", "--local"}))
 	if err != nil {

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -19,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
@@ -206,7 +205,7 @@ func generateAndDownloadFlare(t *testing.T, commandRunner *agentCommandRunner, h
 	if err != nil {
 		return fmt.Errorf("could not get test session output directory: %w", err)
 	}
-	outputDir, err := e2e.CreateTestOutputDir(root, t)
+	outputDir, err := common.CreateTestOutputDir(root, t)
 	if err != nil {
 		return fmt.Errorf("could not get output directory: %w", err)
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -197,7 +197,7 @@ func waitForReadyTimeout(t *testing.T, host *Host, commandRunner *agentCommandRu
 }
 
 func generateAndDownloadFlare(t *testing.T, commandRunner *agentCommandRunner, host *Host) error {
-	root, err := e2e.CreateRootOutputDir()
+	root, err := e2e.CreateTestSessionOutputDir()
 	if err != nil {
 		return fmt.Errorf("could not get root output directory: %w", err)
 	}

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -202,7 +202,7 @@ func generateAndDownloadFlare(t *testing.T, commandRunner *agentCommandRunner, h
 	if err != nil {
 		return fmt.Errorf("could not get root output directory: %w", err)
 	}
-	root, err := e2e.CreateTestSessionOutputDir(outputRoot)
+	root, err := common.CreateTestSessionOutputDir(outputRoot)
 	if err != nil {
 		return fmt.Errorf("could not get test session output directory: %w", err)
 	}

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -59,7 +59,6 @@ type BaseInstallerSuite struct {
 	currentAgentVersion    agentVersion.Version
 	stableInstallerVersion PackageVersion
 	stableAgentVersion     PackageVersion
-	outputDir              string
 }
 
 // Installer the Datadog Installer for testing.
@@ -109,12 +108,7 @@ func (s *BaseInstallerSuite) SetupSuite() {
 // BeforeTest creates a new Datadog Installer and sets the output logs directory for each tests
 func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
 	s.BaseSuite.BeforeTest(suiteName, testName)
-
-	var err error
-	s.outputDir, err = s.CreateTestOutputDir()
-	s.Require().NoError(err, "should get output dir")
-	s.T().Logf("Output dir: %s", s.outputDir)
-	s.installer = NewDatadogInstaller(s.Env(), s.outputDir)
+	s.installer = NewDatadogInstaller(s.Env(), s.SessionOutputDir())
 }
 
 // Require instantiates a suiteAssertions for the current suite.
@@ -127,9 +121,4 @@ func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
 // on the Windows Datadog installer `BaseInstallerSuite` object.
 func (s *BaseInstallerSuite) Require() *suiteasserts.SuiteAssertions {
 	return suiteasserts.New(s.BaseSuite.Require(), s)
-}
-
-// OutputDir returns the output directory for the test
-func (s *BaseInstallerSuite) OutputDir() string {
-	return s.outputDir
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
@@ -79,7 +79,7 @@ func (s *testAgentInstallSuite) uninstallAgentWithMSI() {
 
 	// Act
 	err := windowsAgent.UninstallAgent(s.Env().RemoteHost,
-		filepath.Join(s.OutputDir(), "uninstall.log"),
+		filepath.Join(s.SessionOutputDir(), "uninstall.log"),
 	)
 
 	// Assert

--- a/test/new-e2e/tests/orchestrator/suite_test.go
+++ b/test/new-e2e/tests/orchestrator/suite_test.go
@@ -28,6 +28,7 @@ import (
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/infra"
 )
 
@@ -56,6 +57,9 @@ type k8sSuite struct {
 	Fakeintake      *fakeintake.Client
 	K8sConfig       *restclient.Config
 	K8sClient       *kubernetes.Clientset
+
+	startTime time.Time
+	outputDir string
 }
 
 func TestKindSuite(t *testing.T) {
@@ -64,6 +68,14 @@ func TestKindSuite(t *testing.T) {
 
 func (suite *k8sSuite) SetupSuite() {
 	ctx := context.Background()
+	suite.startTime = time.Now()
+
+	// Create the root output directory for the test suite session
+	sessionDirectory, err := runner.GetProfile().CreateOutputSubDir(suite.getSuiteSessionSubdirectory())
+	if err != nil {
+		suite.T().Errorf("unable to create session output directory: %v", err)
+	}
+	suite.outputDir = sessionDirectory
 
 	stackConfig := runner.ConfigMap{
 		"ddagent:deploy":        auto.ConfigValue{Value: "true"},
@@ -211,4 +223,14 @@ func (suite *k8sSuite) summarizeManifests() {
 			fmt.Printf(" - type:%d, name:%s, ns:%s, kind:%s, apiVer:%s, uid:%s, collected:%s\n", typ, manif.Metadata.Name, manif.Metadata.Namespace, manif.Kind, manif.APIVersion, uid, p.CollectedTime.Format(time.RFC3339))
 		}
 	}
+}
+
+func (suite *k8sSuite) SessionOutputDir() string {
+	return suite.outputDir
+}
+
+func (suite *k8sSuite) getSuiteSessionSubdirectory() string {
+	suiteStartTimePart := suite.startTime.Format("2006_01_02_15_04_05")
+	testPart := common.SanitizeDirectoryName(suite.T().Name())
+	return fmt.Sprintf("%s_%s", testPart, suiteStartTimePart)
 }

--- a/test/new-e2e/tests/windows/base_agent_installer_suite.go
+++ b/test/new-e2e/tests/windows/base_agent_installer_suite.go
@@ -20,14 +20,13 @@ type BaseAgentInstallerSuite[Env any] struct {
 	e2e.BaseSuite[Env]
 
 	AgentPackage *windowsAgent.Package
-	OutputDir    string
 }
 
 // InstallAgent installs the Agent on a given Windows host. It will pass all the parameters to the MSI installer.
 func (b *BaseAgentInstallerSuite[Env]) InstallAgent(host *components.RemoteHost, options ...windowsAgent.InstallAgentOption) (string, error) {
 	b.T().Helper()
 	opts := []windowsAgent.InstallAgentOption{
-		windowsAgent.WithInstallLogFile(filepath.Join(b.OutputDir, "install.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(b.SessionOutputDir(), "install.log")),
 	}
 	opts = append(opts, options...)
 	return windowsAgent.InstallAgent(host, opts...)
@@ -39,28 +38,11 @@ func (b *BaseAgentInstallerSuite[Env]) NewTestClientForHost(host *components.Rem
 	return platformCommon.NewWindowsTestClient(b, host)
 }
 
-// BeforeTest overrides the base BeforeTest to perform some additional per-test setup like configuring the output directory.
-func (b *BaseAgentInstallerSuite[Env]) BeforeTest(suiteName, testName string) {
-	b.BaseSuite.BeforeTest(suiteName, testName)
-
-	var err error
-	b.OutputDir, err = b.CreateTestOutputDir()
-	if err != nil {
-		b.T().Fatalf("should get output dir")
-	}
-	b.T().Logf("Output dir: %s", b.OutputDir)
-}
-
 // SetupSuite overrides the base SetupSuite to perform some additional setups like setting the package to install.
 func (b *BaseAgentInstallerSuite[Env]) SetupSuite() {
 	b.BaseSuite.SetupSuite()
 
 	var err error
-	b.OutputDir, err = b.CreateTestOutputDir()
-	if err != nil {
-		b.T().Fatalf("should get output dir")
-	}
-
 	b.AgentPackage, err = windowsAgent.GetPackageFromEnv()
 	if err != nil {
 		b.T().Fatalf("failed to get MSI URL from env: %v", err)

--- a/test/new-e2e/tests/windows/domain-test/domain_test.go
+++ b/test/new-e2e/tests/windows/domain-test/domain_test.go
@@ -66,7 +66,7 @@ func (suite *testInstallSuite) testGivenDomainUserCanInstallAgent(username strin
 		windowsAgent.WithAgentUserPassword(fmt.Sprintf("\"%s\"", TestPassword)),
 		windowsAgent.WithValidAPIKey(),
 		windowsAgent.WithFakeIntake(suite.Env().FakeIntake),
-		windowsAgent.WithInstallLogFile(filepath.Join(suite.OutputDir, "TC-INS-DC-006_install.log")))
+		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-INS-DC-006_install.log")))
 
 	suite.Require().NoError(err, "should succeed to install Agent on a Domain Controller with a valid domain account & password")
 
@@ -114,7 +114,7 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 		windowsAgent.WithAgentUserPassword(fmt.Sprintf("\"%s\"", TestPassword)),
 		windowsAgent.WithValidAPIKey(),
 		windowsAgent.WithFakeIntake(suite.Env().FakeIntake),
-		windowsAgent.WithInstallLogFile(filepath.Join(suite.OutputDir, "TC-UPG-DC-001_install_last_stable.log")))
+		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_install_last_stable.log")))
 
 	suite.Require().NoError(err, "should succeed to install Agent on a Domain Controller with a valid domain account & password")
 
@@ -123,7 +123,7 @@ func (suite *testUpgradeSuite) TestGivenDomainUserCanUpgradeAgent() {
 
 	_, err = suite.InstallAgent(host,
 		windowsAgent.WithPackage(suite.AgentPackage),
-		windowsAgent.WithInstallLogFile(filepath.Join(suite.OutputDir, "TC-UPG-DC-001_upgrade.log")))
+		windowsAgent.WithInstallLogFile(filepath.Join(suite.SessionOutputDir(), "TC-UPG-DC-001_upgrade.log")))
 	suite.Require().NoError(err, "should succeed to upgrade an Agent on a Domain Controller")
 
 	tc.CheckAgentVersion(suite.T(), suite.AgentPackage.AgentVersion())

--- a/test/new-e2e/tests/windows/install-test/base.go
+++ b/test/new-e2e/tests/windows/install-test/base.go
@@ -71,7 +71,7 @@ func (s *baseAgentMSISuite) AfterTest(suiteName, testName string) {
 		for _, logName := range []string{"System", "Application"} {
 			// collect the full event log as an evtx file
 			s.T().Logf("Exporting %s event log", logName)
-			outputPath := filepath.Join(s.OutputDir, fmt.Sprintf("%s.evtx", logName))
+			outputPath := filepath.Join(s.SessionOutputDir(), fmt.Sprintf("%s.evtx", logName))
 			err := windowsCommon.ExportEventLog(vm, logName, outputPath)
 			s.Assert().NoError(err, "should export %s event log", logName)
 			// Log errors and warnings to the screen for easy access
@@ -101,7 +101,7 @@ func (s *baseAgentMSISuite) installAgentPackage(vm *components.RemoteHost, agent
 	installOpts := []windowsAgent.InstallAgentOption{
 		windowsAgent.WithPackage(agentPackage),
 		// default log file, can be overridden
-		windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "install.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install.log")),
 		// trace-agent requires a valid API key
 		windowsAgent.WithValidAPIKey(),
 	}
@@ -120,7 +120,7 @@ func (s *baseAgentMSISuite) uninstallAgent() bool {
 	host := s.Env().RemoteHost
 	return s.T().Run("uninstall the agent", func(tt *testing.T) {
 		if !tt.Run("uninstall", func(tt *testing.T) {
-			err := windowsAgent.UninstallAgent(host, filepath.Join(s.OutputDir, "uninstall.log"))
+			err := windowsAgent.UninstallAgent(host, filepath.Join(s.SessionOutputDir(), "uninstall.log"))
 			require.NoError(tt, err, "should uninstall the agent")
 		}) {
 			tt.Fatal("uninstall failed")
@@ -227,7 +227,7 @@ func (s *baseAgentMSISuite) cleanupAgent() {
 	if err == nil {
 		defer func() {
 			t.Logf("Uninstalling Datadog Agent")
-			err = windowsAgent.UninstallAgent(host, filepath.Join(s.OutputDir, "uninstall.log"))
+			err = windowsAgent.UninstallAgent(host, filepath.Join(s.SessionOutputDir(), "uninstall.log"))
 			require.NoError(t, err)
 		}()
 	}

--- a/test/new-e2e/tests/windows/install-test/install_test.go
+++ b/test/new-e2e/tests/windows/install-test/install_test.go
@@ -297,7 +297,7 @@ func (s *testRepairSuite) TestRepair() {
 
 	// Run Repair through the MSI
 	if !s.Run("repair install", func() {
-		err = windowsAgent.RepairAllAgent(t.host, "", filepath.Join(s.OutputDir, "repair.log"))
+		err = windowsAgent.RepairAllAgent(t.host, "", filepath.Join(s.SessionOutputDir(), "repair.log"))
 		s.Require().NoError(err)
 	}) {
 		s.T().FailNow()
@@ -334,7 +334,7 @@ func (s *testInstallOptsSuite) TestInstallOpts() {
 	installOpts := []windowsAgent.InstallAgentOption{
 		windowsAgent.WithAPIKey("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 		windowsAgent.WithPackage(s.AgentPackage),
-		windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "install.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install.log")),
 		windowsAgent.WithTags("k1:v1,k2:v2"),
 		windowsAgent.WithHostname("win-installopts"),
 		windowsAgent.WithCmdPort(fmt.Sprintf("%d", cmdPort)),
@@ -458,7 +458,7 @@ func (s *testInstallFailSuite) TestInstallFail() {
 			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithValidAPIKey(),
 			windowsAgent.WithWixFailWhenDeferred(),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "install.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install.log")),
 		)
 		s.Require().Error(err, "should fail to install agent %s", s.AgentPackage.AgentVersion())
 	}) {

--- a/test/new-e2e/tests/windows/install-test/npm_test.go
+++ b/test/new-e2e/tests/windows/install-test/npm_test.go
@@ -213,7 +213,7 @@ func (s *testNPMInstallSuite) testNPMFunctional() {
 func (s *testNPMInstallSuite) upgradeAgent(host *components.RemoteHost, agentPackage *windowsAgent.Package, options ...windowsAgent.InstallAgentOption) {
 	installOpts := []windowsAgent.InstallAgentOption{
 		windowsAgent.WithPackage(agentPackage),
-		windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+		windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 	}
 	installOpts = append(installOpts, options...)
 	if !s.Run(fmt.Sprintf("upgrade to %s", agentPackage.AgentVersion()), func() {

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -57,7 +57,7 @@ func (s *testUpgradeSuite) TestUpgrade() {
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
 		_, err := s.InstallAgent(vm,
 			windowsAgent.WithPackage(s.AgentPackage),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().NoError(err, "should upgrade to agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -94,7 +94,7 @@ func (s *testUpgradeRollbackSuite) TestUpgradeRollback() {
 		_, err := windowsAgent.InstallAgent(vm,
 			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithWixFailWhenDeferred(),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().Error(err, "should fail to install agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -157,7 +157,7 @@ func (s *testUpgradeRollbackWithoutCWSSuite) TestUpgradeRollbackWithoutCWS() {
 		_, err := windowsAgent.InstallAgent(vm,
 			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithWixFailWhenDeferred(),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().Error(err, "should fail to install agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -215,7 +215,7 @@ func (s *testUpgradeChangeUserSuite) TestUpgradeChangeUser() {
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
 		_, err := s.InstallAgent(host,
 			windowsAgent.WithPackage(s.AgentPackage),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 			windowsAgent.WithAgentUser(newUserName),
 		)
 		s.Require().NoError(err, "should upgrade to agent %s", s.AgentPackage.AgentVersion())
@@ -302,7 +302,7 @@ func (s *testUpgradeFromV5Suite) TestUpgrade5() {
 	if !s.Run(fmt.Sprintf("upgrade to %s", s.AgentPackage.AgentVersion()), func() {
 		_, err := s.InstallAgent(host,
 			windowsAgent.WithPackage(s.AgentPackage),
-			windowsAgent.WithInstallLogFile(filepath.Join(s.OutputDir, "upgrade.log")),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
 		)
 		s.Require().NoError(err, "should upgrade to agent %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -324,7 +324,7 @@ func (s *testUpgradeFromV5Suite) installAgent5() {
 	host := s.Env().RemoteHost
 	agentPackage := s.agent5Package
 
-	logFile := filepath.Join(s.OutputDir, "install-agent5.log")
+	logFile := filepath.Join(s.SessionOutputDir(), "install-agent5.log")
 	_, err := s.InstallAgent(host,
 		windowsAgent.WithPackage(agentPackage),
 		windowsAgent.WithValidAPIKey(),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Refactor the session output directory management, centralising it inside the base e2e suite. Root output directory creation is delegated to the runner.profile, that is aware of running on the CI or locally.

This PR also reduces dependencies to `e2e` package out of itself, moving common code to `common` package 

### Motivation

Refactoring required to implement `Diagnosable` interface for Host environment

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Example of output directories for `pre_e2e_tests` job

![image](https://github.com/user-attachments/assets/6db2b5df-f152-42ff-83c6-957f0d053c97)

As we use `suite.T().Name()`, suites running from a single `TestXXX` will all end up with the same output dir prefix `TestXXX`, we might want to add the suite name to ease identifying each suite's session, might change it in a follow up 