### PR TITLE
[SNMP] Retrieve device profiles from remote config

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -589,7 +589,7 @@ func startAgent(
 	jmxfetch.RegisterWith(ac)
 
 	// Set up check collector
-	commonchecks.RegisterChecks(wmeta, tagger, cfg, telemetry)
+	commonchecks.RegisterChecks(wmeta, tagger, cfg, telemetry, rcclient)
 	ac.AddScheduler("check", pkgcollector.InitCheckScheduler(option.New(collector), demultiplexer, logReceiver, tagger), true)
 
 	demultiplexer.AddAgentStartupTelemetry(version.AgentVersion)

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -294,6 +294,9 @@ func run(
 	// TODO: (components) - Until the checks are components we set there context so they can depends on components.
 	check.InitializeInventoryChecksContext(invChecks)
 	pkgcollector.InitPython(common.GetPythonPaths()...)
+	// TODO Ideally we would support RC in the check subcommand,
+	//  but at the moment this is not possible - only one process can access the RC database at a time,
+	//  so the subcommand can't read the RC database if the agent is also running.
 	commonchecks.RegisterChecks(wmeta, tagger, config, telemetry, nil)
 
 	common.LoadComponents(secretResolver, wmeta, ac, pkgconfigsetup.Datadog().GetString("confd_path"))

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -294,7 +294,7 @@ func run(
 	// TODO: (components) - Until the checks are components we set there context so they can depends on components.
 	check.InitializeInventoryChecksContext(invChecks)
 	pkgcollector.InitPython(common.GetPythonPaths()...)
-	commonchecks.RegisterChecks(wmeta, tagger, config, telemetry)
+	commonchecks.RegisterChecks(wmeta, tagger, config, telemetry, nil)
 
 	common.LoadComponents(secretResolver, wmeta, ac, pkgconfigsetup.Datadog().GetString("confd_path"))
 	ac.LoadAndRun(context.Background())

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -438,7 +438,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 			return nil, fmt.Errorf("rc client not initialized, cannot use rc profiles")
 		}
 		if len(initConfig.Profiles) > 0 {
-			return nil, fmt.Errorf("cannot provide profiles in config when use_remote_config_profiles is set")
+			// We don't support merging inline profiles with profiles fetched via remote
+			// config - this would create too much potential for confusing scenarios where
+			// different agents with the same remote config setup disagree on what common
+			// profiles look like.
+			log.Warnf("SNMP init config contains %d inline profile(s); these will be "+
+				"ignored because use_remote_config_profiles is set", len(initConfig.Profiles))
 		}
 		c.ProfileProvider, err = profile.NewRCProvider(rcClient)
 	} else {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -139,7 +139,7 @@ global_metrics:
 oid_batch_size: 10
 bulk_max_repetitions: 20
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 10, config.OidBatchSize)
@@ -279,7 +279,7 @@ workers: 30
 	// language=yaml
 	rawInitConfig := []byte(`
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "127.0.0.0/24", config.Network)
@@ -313,7 +313,7 @@ profiles:
         - {OID: 1.3.6.1.2.1.4.24.6.0, name: IAmAGauge32}
         - {OID: 1.3.6.1.2.1.88.1.1.1.0, name: IAmAnInteger}
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:172.26.0.2", "device_ip:172.26.0.2", "device_id:default:172.26.0.2"}, config.GetStaticTags())
@@ -365,7 +365,7 @@ profiles:
             OID: 1.4.5
             name: myMetric
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
@@ -403,7 +403,7 @@ community_string: abc
 `)
 	// language=yaml
 	rawInitConfig := []byte(``)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, "default", config.Namespace)
@@ -432,7 +432,7 @@ func TestPortConfiguration(t *testing.T) {
 ip_address: 1.2.3.4
 community_string: abc
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint16(161), config.Port)
 
@@ -443,7 +443,7 @@ ip_address: 1.2.3.4
 port: 1234
 community_string: abc
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err = NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint16(1234), config.Port)
 }
@@ -456,7 +456,7 @@ func TestBatchSizeConfiguration(t *testing.T) {
 ip_address: 1.2.3.4
 community_string: abc
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 5, config.OidBatchSize)
 
@@ -467,7 +467,7 @@ ip_address: 1.2.3.4
 community_string: abc
 oid_batch_size: 10
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err = NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 10, config.OidBatchSize)
 
@@ -481,7 +481,7 @@ community_string: abc
 	rawInitConfig := []byte(`
 oid_batch_size: 15
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 15, config.OidBatchSize)
 
@@ -496,7 +496,7 @@ oid_batch_size: 20
 	rawInitConfig = []byte(`
 oid_batch_size: 15
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, 20, config.OidBatchSize)
 }
@@ -509,7 +509,7 @@ func TestBulkMaxRepetitionConfiguration(t *testing.T) {
 ip_address: 1.2.3.4
 community_string: abc
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(10), config.BulkMaxRepetitions)
 
@@ -520,7 +520,7 @@ ip_address: 1.2.3.4
 community_string: abc
 bulk_max_repetitions: 10
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err = NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(10), config.BulkMaxRepetitions)
 
@@ -534,7 +534,7 @@ community_string: abc
 	rawInitConfig := []byte(`
 bulk_max_repetitions: 15
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(15), config.BulkMaxRepetitions)
 
@@ -549,7 +549,7 @@ bulk_max_repetitions: 20
 	rawInitConfig = []byte(`
 bulk_max_repetitions: 15
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint32(20), config.BulkMaxRepetitions)
 
@@ -562,7 +562,7 @@ bulk_max_repetitions: -5
 `)
 	// language=yaml
 	rawInitConfig = []byte(``)
-	_, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	_, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.EqualError(t, err, "bulk max repetition must be a positive integer. Invalid value: -5")
 }
 
@@ -585,7 +585,7 @@ global_metrics:
     OID: 1.2.3.4
     name: aGlobalMetric
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	require.NoError(t, err)
 
 	profile, err := config.BuildProfile("")
@@ -619,7 +619,7 @@ global_metrics:
     OID: 1.2.3.4
     name: aGlobalMetric
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	require.NoError(t, err)
 
 	profile, err := config.BuildProfile("")
@@ -697,7 +697,7 @@ network_address: 10.0.0.0/xx
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig)
+			_, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig, nil)
 			for _, errStr := range tt.expectedErrors {
 				require.NotNil(t, err, "expected error %q", errStr)
 				assert.Contains(t, err.Error(), errStr)
@@ -748,7 +748,7 @@ func Test_Configure_invalidYaml(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig)
+			_, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig, nil)
 			assert.EqualError(t, err, tt.expectedErr)
 		})
 	}
@@ -764,7 +764,7 @@ port: "123"
 timeout: "15"
 retries: "5"
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint16(123), config.Port)
 	assert.Equal(t, 15, config.Timeout)
@@ -779,7 +779,7 @@ func TestExtraTags(t *testing.T) {
 ip_address: 1.2.3.4
 community_string: abc
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, []byte(``))
+	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
 
@@ -789,7 +789,7 @@ ip_address: 1.2.3.4
 community_string: abc
 extra_tags: "extratag1:val1,extratag2:val2"
 `)
-	config, err = NewCheckConfig(rawInstanceConfigWithExtraTags, []byte(``))
+	config, err = NewCheckConfig(rawInstanceConfigWithExtraTags, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.ElementsMatch(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4", "extratag1:val1", "extratag2:val2"}, config.GetStaticTags())
 }
@@ -832,7 +832,7 @@ community_string: "abc"
 	rawInitConfig := []byte(`
 oid_batch_size: 10
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.CollectDeviceMetadata)
 
@@ -846,7 +846,7 @@ community_string: "abc"
 oid_batch_size: 10
 collect_device_metadata: true
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.CollectDeviceMetadata)
 
@@ -860,7 +860,7 @@ collect_device_metadata: true
 	rawInitConfig = []byte(`
 oid_batch_size: 10
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.CollectDeviceMetadata)
 
@@ -875,7 +875,7 @@ collect_device_metadata: false
 oid_batch_size: 10
 collect_device_metadata: true
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, false, config.CollectDeviceMetadata)
 }
@@ -890,7 +890,7 @@ community_string: "abc"
 	rawInitConfig := []byte(`
 oid_batch_size: 10
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.CollectTopology)
 
@@ -904,7 +904,7 @@ community_string: "abc"
 oid_batch_size: 10
 collect_topology: true
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.CollectTopology)
 
@@ -918,7 +918,7 @@ collect_topology: true
 	rawInitConfig = []byte(`
 oid_batch_size: 10
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.CollectTopology)
 
@@ -933,7 +933,7 @@ collect_topology: false
 oid_batch_size: 10
 collect_topology: true
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, false, config.CollectTopology)
 }
@@ -950,7 +950,7 @@ namespace: my-ns
 `)
 	rawInitConfig := []byte(``)
 
-	conf, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	conf, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "my-ns", conf.Namespace)
 
@@ -961,7 +961,7 @@ ip_address: 1.2.3.4
 community_string: "abc"
 `)
 	rawInitConfig = []byte(``)
-	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "default", conf.Namespace)
 
@@ -973,7 +973,7 @@ community_string: "abc"
 `)
 	rawInitConfig = []byte(`
 namespace: ns-from-datadog-conf`)
-	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "ns-from-datadog-conf", conf.Namespace)
 
@@ -985,7 +985,7 @@ community_string: "abc"
 `)
 	rawInitConfig = []byte(``)
 	pkgconfigsetup.Datadog().SetWithoutSource("network_devices.namespace", "totoro")
-	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "totoro", conf.Namespace)
 
@@ -999,7 +999,7 @@ namespace: ""
 `)
 	rawInitConfig = []byte(`
 namespace: ponyo`)
-	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "ponyo", conf.Namespace)
 
@@ -1013,7 +1013,7 @@ community_string: "abc"
 	rawInitConfig = []byte(`
 namespace: `)
 	pkgconfigsetup.Datadog().SetWithoutSource("network_devices.namespace", "mononoke")
-	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "mononoke", conf.Namespace)
 
@@ -1025,7 +1025,7 @@ community_string: "abc"
 `)
 	rawInitConfig = []byte(``)
 	pkgconfigsetup.Datadog().SetWithoutSource("network_devices.namespace", "")
-	_, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	_, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.EqualError(t, err, "namespace cannot be empty")
 }
 
@@ -1039,7 +1039,7 @@ community_string: "abc"
 	rawInitConfig := []byte(`
 oid_batch_size: 10
 `)
-	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, false, config.UseDeviceIDAsHostname)
 
@@ -1053,7 +1053,7 @@ community_string: "abc"
 oid_batch_size: 10
 use_device_id_as_hostname: true
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.UseDeviceIDAsHostname)
 
@@ -1067,7 +1067,7 @@ use_device_id_as_hostname: true
 	rawInitConfig = []byte(`
 oid_batch_size: 10
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, true, config.UseDeviceIDAsHostname)
 
@@ -1082,7 +1082,7 @@ use_device_id_as_hostname: false
 oid_batch_size: 10
 use_device_id_as_hostname: true
 `)
-	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, false, config.UseDeviceIDAsHostname)
 }
@@ -1188,7 +1188,7 @@ min_collection_interval: -10
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig)
+			config, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig, nil)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)
 			} else {
@@ -1260,7 +1260,7 @@ interface_configs: '[{"match_field":"name","match_value":"eth0","in_speed":25,"o
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig)
+			config, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig, nil)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)
 			} else {
@@ -1430,7 +1430,7 @@ ip_address: 1.2.3.4
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig)
+			config, err := NewCheckConfig(tt.rawInstanceConfig, tt.rawInitConfig, nil)
 			if tt.expectedErr != "" {
 				assert.EqualError(t, err, tt.expectedErr)
 			} else {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -55,7 +55,7 @@ profiles:
    definition_file: another_profile.yaml
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
@@ -195,7 +195,7 @@ global_metrics:
     OID: 1.2.3.4.5
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
@@ -244,7 +244,7 @@ community_string: public
 	rawInitConfig := []byte(`
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", session.NewMockSession, agentconfig.NewMock(t))
@@ -275,7 +275,7 @@ community_string: public
 	rawInitConfig := []byte(`
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", session.NewMockSession, agentconfig.NewMock(t))
@@ -341,7 +341,7 @@ profiles:
    definition_file: f5-big-ip.yaml
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
@@ -646,7 +646,7 @@ profiles:
    definition_file: f5-big-ip.yaml
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
@@ -693,7 +693,7 @@ profiles:
    definition_file: another_profile.yaml
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
@@ -844,7 +844,7 @@ profiles:
    definition_file: another_profile.yaml
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, agentconfig.NewMock(t))
@@ -986,7 +986,7 @@ collect_topology: false
 	// language=yaml
 	rawInitConfig := []byte(``)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	assert.Nil(t, err)
 
 	cfg := agentconfig.NewMock(t)

--- a/pkg/collector/corechecks/snmp/internal/profile/rc_provider.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/rc_provider.go
@@ -46,7 +46,7 @@ func buildAndSubscribeRCProvider(rcClient rcclient.Component) (*UpdatableProvide
 	provider.Update(userProfiles, defaultProfiles, time.Now())
 
 	// Subscribe to the RC client
-	log.Debug("Subscribing to remote config profiles")
+	log.Info("Subscribing to remote config for device profiles")
 	rcClient.Subscribe(state.ProductNDMDeviceProfilesCustom, makeOnUpdate(provider))
 
 	return provider, nil
@@ -88,7 +88,7 @@ func unpackRawConfigs(update map[string]state.RawConfig) (ProfileConfigMap, map[
 // receives new profiles.
 func makeOnUpdate(up *UpdatableProvider) func(map[string]state.RawConfig, func(string, state.ApplyStatus)) {
 	onUpdate := func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
-		log.Debugf("Received %d profiles via remote configuration", len(update))
+		log.Infof("Received %d device profiles via remote configuration", len(update))
 		userProfiles, errors := unpackRawConfigs(update)
 		// update is a dict of ALL current custom profiles, so we replace the existing set entirely.
 		up.Update(userProfiles, up.defaultProfiles, time.Now())

--- a/pkg/collector/corechecks/snmp/internal/profile/rc_provider.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/rc_provider.go
@@ -22,6 +22,14 @@ var rcSingleton *UpdatableProvider
 var rcOnce sync.Once
 var rcError error
 
+// ResetRCProvider destroys the singleton instance. This should only be used in tests.
+// TODO Turn this back into a proper Component so that we can mock it instead of using a singleton.
+func ResetRCProvider() {
+	rcSingleton = nil
+	rcOnce = sync.Once{}
+	rcError = nil
+}
+
 // NewRCProvider returns a profile provider that subscribes to remote
 // configuration and receives profile updates from the backend. Multiple calls
 // will return the same singleton object.

--- a/pkg/collector/corechecks/snmp/internal/profile/rc_provider.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/rc_provider.go
@@ -1,0 +1,110 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+)
+
+var rcSingleton *UpdatableProvider
+var rcOnce sync.Once
+var rcError error
+
+// NewRCProvider returns a profile provider that subscribes to remote
+// configuration and receives profile updates from the backend. Multiple calls
+// will return the same singleton object.
+func NewRCProvider(client rcclient.Component) (Provider, error) {
+	rcOnce.Do(func() {
+		rcSingleton, rcError = buildAndSubscribeRCProvider(client)
+	})
+	return rcSingleton, rcError
+}
+
+// buildAndSubscribeRCProvider builds a new UpdatableProvider and subscribes to
+// RC to receive profile updates.
+func buildAndSubscribeRCProvider(rcClient rcclient.Component) (*UpdatableProvider, error) {
+	// Load OOTB profiles from YAML
+	defaultProfiles := getYamlDefaultProfiles()
+	if defaultProfiles == nil {
+		return nil, fmt.Errorf("could not find OOTB profiles")
+	}
+	userProfiles := make(ProfileConfigMap)
+
+	provider := &UpdatableProvider{}
+	provider.Update(userProfiles, defaultProfiles, time.Now())
+
+	// Subscribe to the RC client
+	log.Debug("Subscribing to remote config profiles")
+	rcClient.Subscribe(state.ProductNDMDeviceProfilesCustom, makeOnUpdate(provider))
+
+	return provider, nil
+}
+
+// unpackRawConfigs converts a map of raw remote config data to a map of parsed
+// profiles.
+func unpackRawConfigs(update map[string]state.RawConfig) (ProfileConfigMap, map[string]error) {
+	errors := make(map[string]error)
+	profiles := make(ProfileConfigMap)
+	// iterate over keys in sorted order for determinism
+	keys := slices.Sorted(maps.Keys(update))
+	for _, k := range keys {
+		v := update[k]
+		var def profiledefinition.DeviceProfileRcConfig
+		err := json.Unmarshal(v.Config, &def)
+		if err != nil {
+			err = fmt.Errorf("could not unmarshal device profile config %q: %w", k, err)
+			_ = log.Warn(err)
+			errors[k] = err
+			continue
+		}
+		if _, ok := profiles[def.Profile.Name]; ok {
+			_ = log.Warnf("Received multiple profiles for name: %q", def.Profile.Name)
+			errors[k] = fmt.Errorf("multiple profiles for name: %q", def.Profile.Name)
+			continue
+		}
+		profiles[def.Profile.Name] = ProfileConfig{
+			DefinitionFile: "",
+			Definition:     def.Profile,
+			IsUserProfile:  true,
+		}
+	}
+	return profiles, errors
+}
+
+// makeOnUpdate generates an onUpdate function suitable for rcclient.Component.
+// Subscribe that will update the given UpdatableProvider whenever the RC client
+// receives new profiles.
+func makeOnUpdate(up *UpdatableProvider) func(map[string]state.RawConfig, func(string, state.ApplyStatus)) {
+	onUpdate := func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+		log.Debugf("Received %d profiles via remote configuration", len(update))
+		userProfiles, errors := unpackRawConfigs(update)
+		// update is a dict of ALL current custom profiles, so we replace the existing set entirely.
+		up.Update(userProfiles, up.defaultProfiles, time.Now())
+		// Report successes/errors
+		for k := range update {
+			if errors[k] != nil {
+				applyStateCallback(k, state.ApplyStatus{
+					State: state.ApplyStateError,
+					Error: errors[k].Error(),
+				})
+			} else {
+				applyStateCallback(k, state.ApplyStatus{
+					State: state.ApplyStateAcknowledged,
+				})
+			}
+		}
+	}
+	return onUpdate
+}

--- a/pkg/collector/corechecks/snmp/internal/profile/rc_provider_test.go
+++ b/pkg/collector/corechecks/snmp/internal/profile/rc_provider_test.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package profile
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/profile/profiledefinition"
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestUnpackRawConfigs(t *testing.T) {
+	brokenConfig := state.RawConfig{Config: []byte(`{
+		"profile_definition": {
+			"name": "broken-profile",
+			"metrics": [not valid json]
+		}
+	}`)}
+
+	someProfile := ProfileConfig{
+		Definition: profiledefinition.ProfileDefinition{
+			Name: "some-profile",
+			Metrics: []profiledefinition.MetricsConfig{
+				{Symbol: profiledefinition.SymbolConfig{
+					OID:  "1.2.3.0",
+					Name: "someMetric",
+				}},
+			},
+		},
+		IsUserProfile: true,
+	}
+
+	someProfileRaw := state.RawConfig{Config: []byte(`{
+		"profile_definition": {
+			"name": "some-profile",
+			"metrics": [{
+				"symbol": {
+					"OID": "1.2.3.0",
+					"name": "someMetric"
+				}
+			}]
+		}
+	}`)}
+
+	type testCase struct {
+		name             string
+		configs          map[string]state.RawConfig
+		expectedProfiles ProfileConfigMap
+		expectedErrors   map[string]string
+	}
+
+	for _, tc := range []testCase{{
+		name: "normal profile",
+		configs: map[string]state.RawConfig{
+			"some-id": someProfileRaw,
+		},
+		expectedProfiles: ProfileConfigMap{
+			"some-profile": someProfile,
+		},
+		expectedErrors: nil,
+	}, {
+		name: "broken profile",
+		configs: map[string]state.RawConfig{
+			"some-id": brokenConfig,
+		},
+		expectedProfiles: ProfileConfigMap{},
+		expectedErrors: map[string]string{
+			"some-id": "could not unmarshal",
+		},
+	}, {
+		name: "duplicate profile",
+		configs: map[string]state.RawConfig{
+			"id-1": someProfileRaw,
+			"id-2": someProfileRaw,
+		},
+		expectedProfiles: ProfileConfigMap{
+			"some-profile": someProfile,
+		},
+		expectedErrors: map[string]string{
+			"id-2": "multiple profiles for name: \"some-profile\"",
+		},
+	}, {
+		name: "multiple problems",
+		configs: map[string]state.RawConfig{
+			"id-1":   someProfileRaw,
+			"id-2":   someProfileRaw,
+			"broken": brokenConfig,
+		},
+		expectedProfiles: ProfileConfigMap{
+			"some-profile": someProfile,
+		},
+		expectedErrors: map[string]string{
+			"id-2":   "multiple profiles for name: \"some-profile\"",
+			"broken": "could not unmarshal",
+		},
+	}} {
+		t.Run(tc.name, func(t *testing.T) {
+			profiles, errors := unpackRawConfigs(tc.configs)
+			assert.Equal(t, tc.expectedProfiles, profiles)
+			for k, v := range tc.expectedErrors {
+				err := errors[k]
+				assert.ErrorContains(t, err, v, "expected error %q for key %q", v, k)
+			}
+			for k, v := range errors {
+				if _, ok := tc.expectedErrors[k]; !ok {
+					t.Errorf("unexpected error %q for key %q", v, k)
+				}
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -209,7 +209,7 @@ profiles:
    definition_file: f5-big-ip.yaml
 `)
 
-	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
 	require.Nil(t, err)
 
 	layout := "2006-01-02 15:04:05"

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -996,10 +996,10 @@ community_string: public
 
 func TestCheckID(t *testing.T) {
 	profile.SetConfdPathAndCleanProfiles()
-	check1 := newCheck(agentconfig.NewMock(t))
-	check2 := newCheck(agentconfig.NewMock(t))
-	check3 := newCheck(agentconfig.NewMock(t))
-	checkSubnet := newCheck(agentconfig.NewMock(t))
+	check1 := newCheck(agentconfig.NewMock(t), nil)
+	check2 := newCheck(agentconfig.NewMock(t), nil)
+	check3 := newCheck(agentconfig.NewMock(t), nil)
+	checkSubnet := newCheck(agentconfig.NewMock(t), nil)
 	// language=yaml
 	rawInstanceConfig1 := []byte(`
 ip_address: 1.1.1.1
@@ -1504,8 +1504,8 @@ tags:
 		"1.3.6.1.2.1.1.5.0",
 	}).Return(&packet, nil)
 	sess.On("GetBulk", []string{
-		//"1.3.6.1.2.1.2.2.1.13",
-		//"1.3.6.1.2.1.2.2.1.14",
+		// "1.3.6.1.2.1.2.2.1.13",
+		// "1.3.6.1.2.1.2.2.1.14",
 		"1.3.6.1.2.1.2.2.1.2",
 		"1.3.6.1.2.1.2.2.1.6",
 		"1.3.6.1.2.1.2.2.1.7",
@@ -1950,7 +1950,7 @@ metric_tags:
 	}
 
 	sess.On("GetBulk", []string{
-		//"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7", "1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1"
+		// "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7", "1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1"
 		"1.3.6.1.2.1.2.2.1.2",
 		"1.3.6.1.2.1.2.2.1.6",
 		"1.3.6.1.2.1.2.2.1.7",

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -11,6 +11,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	corecheckLoader "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
@@ -55,14 +56,15 @@ import (
 )
 
 // RegisterChecks registers all core checks
-func RegisterChecks(store workloadmeta.Component, tagger tagger.Component, cfg config.Component, telemetry telemetry.Component) {
+func RegisterChecks(store workloadmeta.Component, tagger tagger.Component, cfg config.Component,
+	telemetry telemetry.Component, rcClient rcclient.Component) {
 	// Required checks
 	corecheckLoader.RegisterCheck(cpu.CheckName, cpu.Factory())
 	corecheckLoader.RegisterCheck(memory.CheckName, memory.Factory())
 	corecheckLoader.RegisterCheck(uptime.CheckName, uptime.Factory())
 	corecheckLoader.RegisterCheck(telemetryCheck.CheckName, telemetryCheck.Factory(telemetry))
 	corecheckLoader.RegisterCheck(ntp.CheckName, ntp.Factory())
-	corecheckLoader.RegisterCheck(snmp.CheckName, snmp.Factory(cfg))
+	corecheckLoader.RegisterCheck(snmp.CheckName, snmp.Factory(cfg, rcClient))
 	corecheckLoader.RegisterCheck(networkpath.CheckName, networkpath.Factory(telemetry))
 	corecheckLoader.RegisterCheck(io.CheckName, io.Factory())
 	corecheckLoader.RegisterCheck(filehandles.CheckName, filehandles.Factory())

--- a/pkg/remoteconfig/state/products.go
+++ b/pkg/remoteconfig/state/products.go
@@ -34,6 +34,7 @@ var validProducts = map[string]struct{}{
 	ProductTesting2:                     {},
 	ProductOrchestratorK8sCRDs:          {},
 	ProductHaAgent:                      {},
+	ProductNDMDeviceProfilesCustom:      {},
 }
 
 const (
@@ -93,4 +94,6 @@ const (
 	ProductOrchestratorK8sCRDs = "ORCHESTRATOR_K8S_CRDS"
 	// ProductHaAgent is the HA Agent product
 	ProductHaAgent = "HA_AGENT"
+	// ProductNDMDeviceProfilesCustom receives user-created SNMP profiles for network device monitoring
+	ProductNDMDeviceProfilesCustom = "NDM_DEVICE_PROFILES_CUSTOM"
 )


### PR DESCRIPTION
### What does this PR do?

This adds a profile.Provider that provides profiles received via remote configuration. A new `use_remote_config_profiles` flag in the SNMP integration config must be set for this to happen - if it is false or not provided, the agent behavior will be unchanged.


### Motivation

The new profile editor in the backend can deliver profiles directly to agents. This PR allows the agents to consume them.

This implements https://datadoghq.atlassian.net/browse/NDMII-3237, which itself is part of https://datadoghq.atlassian.net/browse/NDMII-2360.

### Describe how you validated your changes

Running the agent locally I am able to see the profiles from staging appearing in the logs and being used by my local agent.


### Additional Notes

When the flag is set AND remote config is enabled, profiles will be loaded from remote config instead of from the local `profiles` directory. Out-of-the-box profiles are still loaded from the local `default_profiles` directory.

With local profiles, we allow the SNMP config to contain additional profiles defined inline in the config; this is not allowed when `use_remote_config_profiles` is set.

Marked as no-changelog because the behavior of the agent will not change unless this flag is set; we will publish a changelog when this feature officially launches.