### PR TITLE
[CWS] Fix Mmap tests

### DIFF
--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -38,7 +38,7 @@ var (
 	defaultPerRuleLimiters = map[eval.RuleID]rate.Limit{
 		RulesetLoadedRuleID:             rate.Inf, // No limit on ruleset loaded
 		HeartbeatRuleID:                 rate.Inf, // No limit on heartbeat
-		AbnormalPathRuleID:              rate.Every(30 * time.Second),
+		AbnormalPathRuleID:              rate.Every(1 * time.Millisecond),
 		NoProcessContextErrorRuleID:     rate.Every(30 * time.Second),
 		BrokenProcessLineageErrorRuleID: rate.Every(30 * time.Second),
 		EBPFLessHelloMessageRuleID:      rate.Inf, // No limit on hello message

--- a/pkg/security/events/rate_limiter.go
+++ b/pkg/security/events/rate_limiter.go
@@ -38,7 +38,7 @@ var (
 	defaultPerRuleLimiters = map[eval.RuleID]rate.Limit{
 		RulesetLoadedRuleID:             rate.Inf, // No limit on ruleset loaded
 		HeartbeatRuleID:                 rate.Inf, // No limit on heartbeat
-		AbnormalPathRuleID:              rate.Every(1 * time.Millisecond),
+		AbnormalPathRuleID:              rate.Every(30 * time.Second),
 		NoProcessContextErrorRuleID:     rate.Every(30 * time.Second),
 		BrokenProcessLineageErrorRuleID: rate.Every(30 * time.Second),
 		EBPFLessHelloMessageRuleID:      rate.Inf, // No limit on hello message

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -35,7 +35,7 @@ import (
 const (
 	numAllowedMountIDsToResolvePerPeriod = 5
 	fallbackLimiterPeriod                = time.Second
-	redemptionTime                       = 2 * time.Second
+	redemptionTime                       = 5 * time.Second
 )
 
 type redemptionEntry struct {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -364,31 +364,6 @@ func (tm *testModule) GetCustomEventSent(tb testing.TB, action func() error, cb 
 	}
 }
 
-// WaitForPotentialAbnormalPath waits for potential abnormal_path errors. It is use to check before closing the test module
-func (tm *testModule) WaitForPotentialAbnormalPath(timeout time.Duration) bool {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	message := make(chan string, 1)
-
-	tm.RegisterCustomSendEventHandler(func(rule *rules.Rule, _ *events.CustomEvent) {
-		if rule.ID == events.AbnormalPathRuleID {
-			message <- "FOUND"
-			cancel()
-		}
-	})
-	defer tm.RegisterCustomSendEventHandler(nil)
-
-	select {
-	case <-message:
-		return true
-	case <-time.After(timeout):
-		return false
-	case <-ctx.Done():
-		return false
-	}
-}
-
 func (tm *testModule) GetEventSent(tb testing.TB, action func() error, cb func(rule *rules.Rule, event *model.Event) bool, timeout time.Duration, ruleID eval.RuleID) error {
 	tb.Helper()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -906,6 +906,8 @@ func (fs *fakeMsgSender) Send(msg *api.SecurityEventMessage, _ func(*api.Securit
 	}
 
 	fs.msgs[msgStruct.AgentContext.RuleID] = msg
+	fmt.Println("------------ SEND", msg.RuleID)
+
 }
 
 func (fs *fakeMsgSender) getMsg(ruleID eval.RuleID) *api.SecurityEventMessage {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -371,7 +371,7 @@ func (tm *testModule) WaitForPotentialAbnormalPath(timeout time.Duration) bool {
 
 	message := make(chan string, 1)
 
-	tm.RegisterCustomSendEventHandler(func(rule *rules.Rule, event *events.CustomEvent) {
+	tm.RegisterCustomSendEventHandler(func(rule *rules.Rule, _ *events.CustomEvent) {
 		if rule.ID == events.AbnormalPathRuleID {
 			message <- "FOUND"
 			cancel()

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/module"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
@@ -955,6 +956,8 @@ func (tm *testModule) cleanup() {
 
 func (tm *testModule) validateAbnormalPaths() {
 	assert.Zero(tm.t, tm.statsdClient.Get("datadog.runtime_security.rules.rate_limiter.allow:rule_id:abnormal_path"), "abnormal error detected")
+	assert.Nil(tm.t, tm.msgSender.getMsg(events.AbnormalPathRuleID), "abnormal error detected 2")
+
 }
 
 func (tm *testModule) validateSyscallsInFlight() {
@@ -965,10 +968,10 @@ func (tm *testModule) validateSyscallsInFlight() {
 }
 
 func (tm *testModule) Close() {
-	tm.WaitForPotentialAbnormalPath(2 * time.Second)
+	// tm.WaitForPotentialAbnormalPath(2 * time.Second)
 
 	if !tm.opts.staticOpts.disableRuntimeSecurity {
-		// The stats from the rate_limiter should sent, tm.eventMonitor.SendStats() does not do that
+		// The stats from the rate_limiter should be sent, tm.eventMonitor.SendStats() does not do that
 		tm.cws.SendStats()
 		tm.eventMonitor.SendStats()
 	}

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -956,7 +956,9 @@ func (tm *testModule) cleanup() {
 
 func (tm *testModule) validateAbnormalPaths() {
 	assert.Zero(tm.t, tm.statsdClient.Get("datadog.runtime_security.rules.rate_limiter.allow:rule_id:abnormal_path"), "abnormal error detected")
-	assert.Nil(tm.t, tm.msgSender.getMsg(events.AbnormalPathRuleID), "abnormal error detected 2")
+	if tm.msgSender != nil {
+		assert.Nil(tm.t, tm.msgSender.getMsg(events.AbnormalPathRuleID), "abnormal error detected 2")
+	}
 
 }
 

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -37,7 +37,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
-	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/module"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
@@ -966,8 +965,7 @@ func (tm *testModule) validateSyscallsInFlight() {
 }
 
 func (tm *testModule) Close() {
-
-	waitForPotentialEventError(tm, nil, 2*time.Second)
+	tm.WaitForPotentialAbnormalPath(2 * time.Second)
 
 	if !tm.opts.staticOpts.disableRuntimeSecurity {
 		// The stats from the rate_limiter should sent, tm.eventMonitor.SendStats() does not do that
@@ -1108,12 +1106,6 @@ func waitForIMDSResponseProbeEvent(test *testModule, action func() error, proces
 			value: "response",
 		},
 	}...)
-}
-
-func waitForPotentialEventError(test *testModule, action func() error, timeout time.Duration) error {
-	return test.GetCustomEventSent(test.t, action, func(rule *rules.Rule, event *events.CustomEvent) bool {
-		return true
-	}, timeout, model.CustomEventType, events.AbnormalPathRuleID)
 }
 
 //nolint:deadcode,unused

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1113,7 +1113,7 @@ func waitForIMDSResponseProbeEvent(test *testModule, action func() error, proces
 func waitForPotentialEventError(test *testModule, action func() error, timeout time.Duration) error {
 	return test.GetCustomEventSent(test.t, action, func(rule *rules.Rule, event *events.CustomEvent) bool {
 		return true
-	}, timeout, model.CustomEventType, events.AbnormalPathRuleID, events.BrokenProcessLineageErrorRuleID, events.NoProcessContextErrorRuleID)
+	}, timeout, model.CustomEventType, events.AbnormalPathRuleID)
 }
 
 //nolint:deadcode,unused

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -955,9 +955,8 @@ func (tm *testModule) cleanup() {
 }
 
 func (tm *testModule) validateAbnormalPaths() {
-	assert.Zero(tm.t, tm.statsdClient.Get("datadog.runtime_security.rules.rate_limiter.allow:rule_id:abnormal_path"), "abnormal error detected")
-	if tm.msgSender != nil {
-		assert.Nil(tm.t, tm.msgSender.getMsg(events.AbnormalPathRuleID), "abnormal error detected 2")
+	if !tm.opts.staticOpts.disableRuntimeSecurity {
+		assert.Nil(tm.t, tm.msgSender.getMsg(events.AbnormalPathRuleID), "abnormal error detected")
 	}
 
 }
@@ -970,7 +969,6 @@ func (tm *testModule) validateSyscallsInFlight() {
 }
 
 func (tm *testModule) Close() {
-	// tm.WaitForPotentialAbnormalPath(2 * time.Second)
 
 	if !tm.opts.staticOpts.disableRuntimeSecurity {
 		// The stats from the rate_limiter should be sent, tm.eventMonitor.SendStats() does not do that

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/module"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
@@ -954,7 +955,9 @@ func (tm *testModule) cleanup() {
 }
 
 func (tm *testModule) validateAbnormalPaths() {
-	assert.Zero(tm.t, tm.statsdClient.Get("datadog.runtime_security.rules.rate_limiter.allow:rule_id:abnormal_path"), "abnormal error detected")
+	if tm.msgSender != nil {
+		assert.Nil(tm.t, tm.msgSender.getMsg(events.AbnormalPathRuleID), "abnormal error detected")
+	}
 }
 
 func (tm *testModule) validateSyscallsInFlight() {

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -37,7 +37,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
-	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/module"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
@@ -955,10 +954,7 @@ func (tm *testModule) cleanup() {
 }
 
 func (tm *testModule) validateAbnormalPaths() {
-	if !tm.opts.staticOpts.disableRuntimeSecurity {
-		assert.Nil(tm.t, tm.msgSender.getMsg(events.AbnormalPathRuleID), "abnormal error detected")
-	}
-
+	assert.Zero(tm.t, tm.statsdClient.Get("datadog.runtime_security.rules.rate_limiter.allow:rule_id:abnormal_path"), "abnormal error detected")
 }
 
 func (tm *testModule) validateSyscallsInFlight() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR aims to fix the failing `TestMMapEvent` test. How ?
`TestMmapEvent` was failing because we were detecting an `abnomal_path` error that was coming from a previous test `TestMkdirError`.
The `abnomal_path` error was not detected in `TestMkdirError` when we ran `validateAbnormalPaths` on closing because:
- the event with `AbnormalPathRuleID` was not handled yet
- the `rate_limiter` did not send the most recent stats (as we use in `validateAbnormalPaths` to access wether there was an error or not)

So this PR makes sure that these 2 things are done for sure.

`TestMmap` is now passing

`TestMkdirError` is not failing as it should and needs to be fixed before merging this PR

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->