### PR TITLE
Don't fail package.check-size if there's no PR attached

### DIFF
--- a/tasks/package.py
+++ b/tasks/package.py
@@ -59,7 +59,7 @@ def check_size(ctx, filename: str = 'package_sizes.json', dry_run: bool = False)
                 display_message(ctx, ancestor, size_message, decision)
             # PR commenter asserts on the numbers of PR's, this will raise if there's no PR
             except AssertionError as exc:
-                print(f"Got `{exc}` while trying to comment on PR, we'll assume that" "this is not a PR.")
+                print(f"Got `{exc}` while trying to comment on PR, we'll assume that this is not a PR.")
         if "Failed" in decision:
             raise Exit(code=1)
 

--- a/tasks/package.py
+++ b/tasks/package.py
@@ -53,7 +53,13 @@ def check_size(ctx, filename: str = 'package_sizes.json', dry_run: bool = False)
             decision = "⚠️ Warning"
         else:
             decision = "✅ Passed"
-        display_message(ctx, ancestor, size_message, decision)
+        # Try to display the message on the PR when a PR exists
+        if os.environ.get("CI_COMMIT_BRANCH"):
+            try:
+                display_message(ctx, ancestor, size_message, decision)
+            # PR commenter asserts on the numbers of PR's, this will raise if there's no PR
+            except AssertionError as exc:
+                print(f"Got `{exc}` while trying to comment on PR, we'll assume that" "this is not a PR.")
         if "Failed" in decision:
             raise Exit(code=1)
 


### PR DESCRIPTION
### What does this PR do?

Makes check-pkg-size pass even if it fails to add a comment to the PR.

### Motivation

Job breaks on release branches and on pipelines without associated branch when trying to add a comment to the GitHub PR. Same would happen to any branch with no PR which is not great.

### Describe how you validated your changes

Waited for a job to run on this branch before opening the PR and it did what we expect:
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/750826179#L153

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->