### PR TITLE
[NPM-4125] Refactor connection direction to be stateful based on SYN packets

### DIFF
--- a/pkg/network/tracer/connection/ebpfless/tcp_utils.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_utils.go
@@ -135,11 +135,15 @@ func labelForState(tcpState connStatus) string {
 	return "BadState-" + strconv.Itoa(idx)
 }
 
+// ConnDirection represents what the TCPProcessor knows about the direction of a connection.
 type ConnDirection uint8
 
 const (
+	// ConnDirectionUnknown means we don't know the direction (because we missed the SYN)
 	ConnDirectionUnknown ConnDirection = iota
+	// ConnDirectionIncoming means the connection is incoming to the host
 	ConnDirectionIncoming
+	// ConnDirectionOutgoing means the connection is outgoing from the host
 	ConnDirectionOutgoing
 )
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR uses the SYN from traffic as the connection direction and, importantly, refactors connection tuples within the TCP processor to not include connection direction. This is because the TCP processor can't infer connection direction from packet headers.
### Motivation
More accurate handling of connection direction - previously it was calling determineConnectionDirection every packet instead of once when the connection is established. I think it was incidentally correct most of the time before, but this is more robust.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->