### PR TITLE
fix(kubernetesadmissionevents): replace AssertCalled with AssertEvent

### DIFF
--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents_test.go
@@ -257,7 +257,7 @@ func TestKubernetesAdmissionEvents(t *testing.T) {
 			assert.NoError(t, err)
 			assert.True(t, validated)
 			if tt.expectedEmitted {
-				mockSender.AssertCalled(t, "Event", tt.expectedEvent)
+				mockSender.AssertEvent(t, tt.expectedEvent, 1*time.Second)
 			} else {
 				mockSender.AssertNotCalled(t, "Event")
 			}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replace `AssertCalled` with `AssertEvent` in the `kubernetesadmissionevents` unit tests.

### Motivation

This is needed to fix flakiness issues.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

QA done by unit tests.

### Possible Drawbacks / Trade-offs

The `AssertEvent` method is not checking the whole event but just selected fields. We might want to add some assertion to validate that other fields are working as expected.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->