### PR TITLE
Rearrange struct fields to save memory

### DIFF
--- a/comp/core/workloadmeta/def/filter_test.go
+++ b/comp/core/workloadmeta/def/filter_test.go
@@ -16,8 +16,8 @@ import (
 func TestIsNodeMetadata(t *testing.T) {
 
 	tests := []struct {
-		name                 string
 		metadataEntity       KubernetesMetadata
+		name                 string
 		shouldBeNodeMetadata bool
 	}{
 		{
@@ -61,9 +61,9 @@ func TestFilterBuilder_Build(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
 		builderFunc    func() *FilterBuilder
 		expectedFilter *Filter
+		name           string
 	}{
 		{
 			name:        "filter with default options",
@@ -158,8 +158,8 @@ func TestFilter_MatchSource(t *testing.T) {
 
 func TestFilter_MatchEventType(t *testing.T) {
 	tests := []struct {
-		name                 string
 		filter               *Filter
+		name                 string
 		eventType            EventType
 		expectMatchEventType bool
 	}{
@@ -254,9 +254,9 @@ func TestFilter_MatchKind(t *testing.T) {
 
 func TestFilter_MatchEntity(t *testing.T) {
 	tests := []struct {
-		name        string
-		filter      *Filter
 		entity      Entity
+		filter      *Filter
+		name        string
 		expectMatch bool
 	}{
 		{

--- a/comp/core/workloadmeta/def/params.go
+++ b/comp/core/workloadmeta/def/params.go
@@ -7,8 +7,8 @@ package workloadmeta
 
 // Params provides the kind of agent we're instantiating workloadmeta for
 type Params struct {
-	AgentType  AgentType
 	InitHelper InitHelper
+	AgentType  AgentType
 }
 
 // NewParams creates a Params struct with the default NodeAgent configuration

--- a/comp/core/workloadmeta/def/type_bench_test.go
+++ b/comp/core/workloadmeta/def/type_bench_test.go
@@ -1,0 +1,168 @@
+package workloadmeta
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+)
+
+func getAContainerEntity(id, image string) Entity {
+	return &Container{
+		EntityID: EntityID{
+			ID:   id,
+			Kind: KindContainer,
+		},
+		EntityMeta: EntityMeta{
+			Labels: map[string]string{
+				"com.datadoghq.ad.check_names":  "[\"apache\"]",
+				"com.datadoghq.ad.init_configs": "[{}]",
+				"com.datadoghq.ad.instances":    "[{\"apache_status_url\": \"http://%%host%%/server-status?auto\"}]",
+			},
+		},
+		Runtime: ContainerRuntimeDocker,
+		Image: ContainerImage{
+			Name: image,
+		},
+	}
+}
+
+func getAContainerState() ContainerState {
+	return ContainerState{
+		CreatedAt:  time.Time{},
+		StartedAt:  time.Time{},
+		FinishedAt: time.Time{},
+		ExitCode:   pointer.Ptr(int64(100)),
+		Health:     ContainerHealthHealthy,
+	}
+}
+
+func getAPodEntity(id string) Entity {
+	return &KubernetesPod{
+		EntityMeta: EntityMeta{
+			Annotations: map[string]string{
+				"ad.datadoghq.com/apache.checks": `{
+					"http_check": {
+						"instances": [
+							{
+								"name": "My service",
+								"url": "http://%%host%%",
+								"timeout": 1
+							}
+						]
+					}
+				}`,
+				"ad.datadoghq.com/apache.check_names":  "[\"invalid\"]",
+				"ad.datadoghq.com/apache.init_configs": "[{}]",
+				"ad.datadoghq.com/apache.instances":    "[{}]",
+			},
+		},
+		EntityID: EntityID{
+			ID: id,
+		},
+
+		Containers: []OrchestratorContainer{
+			{
+				Name: "abc",
+				ID:   "3b8efe0c50e1",
+			},
+		},
+	}
+}
+
+func getAProcessEntity() Entity {
+	return &Process{
+		EntityID: EntityID{
+			ID:   "123",
+			Kind: KindProcess,
+		},
+	}
+}
+
+func BenchmarkProcessCollectorEvent(b *testing.B) {
+	containerEntity := getAContainerEntity("3b8efe0c50e1", "cassandra")
+	podEntity := getAPodEntity("3b8efe0c50e1")
+	processEntity := getAProcessEntity()
+	events := []CollectorEvent{
+		{
+			Type:   EventType(0),
+			Source: "container",
+			Entity: containerEntity,
+		},
+		{
+			Type:   EventType(1),
+			Source: "kubernetes",
+			Entity: podEntity,
+		},
+		{
+			Type:   EventType(2),
+			Source: "processes",
+			Entity: processEntity,
+		},
+	}
+
+	for _, event := range events {
+		b.Run("Run collector event bench test on "+string(event.Source), func(b *testing.B) {
+			b.ReportAllocs() // Report memory allocations
+			b.ResetTimer()
+			// process events
+			for i := 0; i < b.N; i++ {
+				size := 1000
+				events := make([]CollectorEvent, size)
+				for i := 0; i < size; i++ {
+					events[i] = event
+				}
+				// Simulate some processing
+				for i := 0; i < size; i++ {
+					_ = events[i]
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkProcessEntity(b *testing.B) {
+	containerEntity := getAContainerEntity("3b8efe0c50e1", "cassandra")
+	podEntity := getAPodEntity("3b8efe0c50e1")
+	procEntity := getAProcessEntity()
+	entities := []Entity{containerEntity, podEntity, procEntity}
+
+	for _, entity := range entities {
+		b.Run("Run process entity bench test on "+string(entity.GetID().Kind), func(b *testing.B) {
+			b.ReportAllocs() // Report memory allocations
+			b.ResetTimer()
+			// process entities
+			for i := 0; i < b.N; i++ {
+				size := 10
+				entities := make([]Entity, size)
+				for i := 0; i < size; i++ {
+					entities[i] = entity.DeepCopy()
+				}
+				// Simulate some processing
+				for i := 0; i < size; i++ {
+					_ = entities[i]
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkProcessContainerState(b *testing.B) {
+	b.Run("Run process container state bench test", func(b *testing.B) {
+		b.ReportAllocs() // Report memory allocations
+		b.ResetTimer()
+		// process container states
+		for i := 0; i < b.N; i++ {
+			size := 1000
+			states := make([]ContainerState, size)
+			for i := 0; i < size; i++ {
+				states[i] = getAContainerState()
+			}
+			// Simulate some processing
+			var sum int64 = 0
+			for i := 0; i < size; i++ {
+				sum += *(states[i].ExitCode)
+			}
+		}
+	})
+}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -235,10 +235,10 @@ func (i EntityID) String(_ bool) string {
 
 // EntityMeta represents generic metadata about an Entity.
 type EntityMeta struct {
-	Name        string
-	Namespace   string
 	Annotations map[string]string
 	Labels      map[string]string
+	Name        string
+	Namespace   string
 }
 
 // String returns a string representation of EntityMeta.
@@ -315,13 +315,13 @@ func (c ContainerImage) String(verbose bool) string {
 
 // ContainerState is the state of a container.
 type ContainerState struct {
-	Running    bool
-	Status     ContainerStatus
-	Health     ContainerHealth
 	CreatedAt  time.Time
 	StartedAt  time.Time
 	FinishedAt time.Time
 	ExitCode   *int64
+	Status     ContainerStatus
+	Health     ContainerHealth
+	Running    bool
 }
 
 // String returns a string representation of ContainerState.
@@ -346,8 +346,8 @@ func (c ContainerState) String(verbose bool) string {
 // ContainerPort is a port open in the container.
 type ContainerPort struct {
 	Name     string
-	Port     int
 	Protocol string
+	Port     int
 	HostPort uint16
 }
 
@@ -423,13 +423,13 @@ func (c ContainerHealthStatus) String(verbose bool) string {
 
 // ContainerResources is resources requests or limitations for a container
 type ContainerResources struct {
-	GPURequest    *uint64 // Number of GPUs
+	GPURequest    *uint64
 	GPULimit      *uint64
-	GPUVendorList []string // The type of GPU requested (eg. nvidia, amd, intel)
-	CPURequest    *float64 // Percentage 0-100*numCPU (aligned with CPU Limit from metrics provider)
+	CPURequest    *float64
 	CPULimit      *float64
-	MemoryRequest *uint64 // Bytes
+	MemoryRequest *uint64
 	MemoryLimit   *uint64
+	GPUVendorList []string
 }
 
 // String returns a string representation of ContainerPort.
@@ -481,17 +481,17 @@ func (o OrchestratorContainer) String(_ bool) string {
 
 // ECSContainer is a reference to a container running in ECS
 type ECSContainer struct {
-	DisplayName   string
-	Networks      []ContainerNetwork
-	Volumes       []ContainerVolume
 	Health        *ContainerHealthStatus
+	LogOptions    map[string]string
+	DisplayName   string
 	DesiredStatus string
 	KnownStatus   string
 	Type          string
 	LogDriver     string
-	LogOptions    map[string]string
 	ContainerARN  string
 	Snapshotter   string
+	Networks      []ContainerNetwork
+	Volumes       []ContainerVolume
 }
 
 // String returns a string representation of ECSContainer.
@@ -529,35 +529,25 @@ func (e ECSContainer) String(verbose bool) string {
 
 // Container is an Entity representing a containerized workload.
 type Container struct {
-	EntityID
+	State     ContainerState
+	Resources ContainerResources
 	EntityMeta
-	// ECSContainer contains properties specific to container running in ECS
-	*ECSContainer
-	// EnvVars are limited to variables included in pkg/util/containers/env_vars_filter.go
-	EnvVars       map[string]string
-	Hostname      string
-	Image         ContainerImage
-	NetworkIPs    map[string]string
-	PID           int
-	Ports         []ContainerPort
-	Runtime       ContainerRuntime
-	RuntimeFlavor ContainerRuntimeFlavor
-	State         ContainerState
-	// CollectorTags represent tags coming from the collector itself
-	// and that it would be impossible to compute later on
-	CollectorTags   []string
-	Owner           *EntityID
+	NetworkIPs      map[string]string
 	SecurityContext *ContainerSecurityContext
-	Resources       ContainerResources
-
-	// AllocatedResources is the list of resources allocated to this pod. Requires the
-	// PodResources API to query that data.
+	EnvVars         map[string]string
+	*ECSContainer
+	Owner *EntityID
+	Image ContainerImage
+	EntityID
+	Hostname           string
+	CgroupPath         string
+	Runtime            ContainerRuntime
+	RuntimeFlavor      ContainerRuntimeFlavor
+	Ports              []ContainerPort
+	CollectorTags      []string
 	AllocatedResources []ContainerAllocatedResource
-	// CgroupPath is a path to the cgroup of the container.
-	// It can be relative to the cgroup parent.
-	// Linux only.
-	CgroupPath   string
-	RestartCount int
+	PID                int
+	RestartCount       int
 }
 
 // GetID implements Entity#GetID.
@@ -660,8 +650,8 @@ type PodSecurityContext struct {
 // ContainerSecurityContext is the Security Context of a Container
 type ContainerSecurityContext struct {
 	*Capabilities
-	Privileged     bool
 	SeccompProfile *SeccompProfile
+	Privileged     bool
 }
 
 // Capabilities is the capabilities a certain Container security context is capable of
@@ -693,24 +683,24 @@ var GetRunningContainers EntityFilterFunc[*Container] = func(container *Containe
 
 // KubernetesPod is an Entity representing a Kubernetes Pod.
 type KubernetesPod struct {
-	EntityID
 	EntityMeta
-	Owners                     []KubernetesPodOwner
-	PersistentVolumeClaimNames []string
-	InitContainers             []OrchestratorContainer
-	Containers                 []OrchestratorContainer
-	Ready                      bool
+	FinishedAt           time.Time
+	SecurityContext      *PodSecurityContext
+	NamespaceAnnotations map[string]string
+	NamespaceLabels      map[string]string
+	EntityID
+	RuntimeClass               string
 	Phase                      string
 	IP                         string
 	PriorityClass              string
 	QOSClass                   string
 	GPUVendorList              []string
-	RuntimeClass               string
 	KubeServices               []string
-	NamespaceLabels            map[string]string
-	NamespaceAnnotations       map[string]string
-	FinishedAt                 time.Time
-	SecurityContext            *PodSecurityContext
+	Containers                 []OrchestratorContainer
+	InitContainers             []OrchestratorContainer
+	PersistentVolumeClaimNames []string
+	Owners                     []KubernetesPodOwner
+	Ready                      bool
 }
 
 // GetID implements Entity#GetID.
@@ -824,9 +814,9 @@ type KubeMetadataEntityID string
 
 // KubernetesMetadata is an Entity representing kubernetes resource metadata
 type KubernetesMetadata struct {
-	EntityID
 	EntityMeta
 	GVR *schema.GroupVersionResource
+	EntityID
 }
 
 // GetID implements Entity#GetID.
@@ -871,19 +861,13 @@ var _ Entity = &KubernetesMetadata{}
 
 // KubernetesDeployment is an Entity representing a Kubernetes Deployment.
 type KubernetesDeployment struct {
-	EntityID
 	EntityMeta
+	InjectableLanguages langUtil.ContainersLanguages
+	DetectedLanguages   langUtil.ContainersLanguages
+	EntityID
 	Env     string
 	Service string
 	Version string
-
-	// InjectableLanguages indicate containers languages that can be injected by the admission controller
-	// These languages are determined by parsing the deployment annotations
-	InjectableLanguages langUtil.ContainersLanguages
-
-	// DetectedLanguages languages indicate containers languages detected and reported by the language
-	// detection server.
-	DetectedLanguages langUtil.ContainersLanguages
 }
 
 // GetID implements Entity#GetID.
@@ -967,27 +951,27 @@ type MapTags map[string]string
 
 // ECSTask is an Entity representing an ECS Task.
 type ECSTask struct {
-	EntityID
 	EntityMeta
+	PullStartedAt           *time.Time
 	Tags                    MapTags
 	ContainerInstanceTags   MapTags
-	ClusterName             string
-	AWSAccountID            int
-	Region                  string
-	AvailabilityZone        string
-	Family                  string
-	Version                 string
-	DesiredStatus           string
-	KnownStatus             string
-	PullStartedAt           *time.Time
-	PullStoppedAt           *time.Time
-	ExecutionStoppedAt      *time.Time
-	VPCID                   string
-	ServiceName             string
-	EphemeralStorageMetrics map[string]int64
 	Limits                  map[string]float64
-	LaunchType              ECSLaunchType
-	Containers              []OrchestratorContainer
+	EphemeralStorageMetrics map[string]int64
+	ExecutionStoppedAt      *time.Time
+	PullStoppedAt           *time.Time
+	EntityID
+	VPCID            string
+	DesiredStatus    string
+	KnownStatus      string
+	Version          string
+	Family           string
+	AvailabilityZone string
+	Region           string
+	ServiceName      string
+	ClusterName      string
+	LaunchType       ECSLaunchType
+	Containers       []OrchestratorContainer
+	AWSAccountID     int
 }
 
 // GetID implements Entity#GetID.
@@ -1059,36 +1043,36 @@ var _ Entity = &ECSTask{}
 
 // ContainerImageMetadata is an Entity that represents container image metadata
 type ContainerImageMetadata struct {
-	EntityID
 	EntityMeta
-	RepoTags     []string
-	RepoDigests  []string
+	SBOM *SBOM
+	EntityID
 	MediaType    string
-	SizeBytes    int64
 	OS           string
 	OSVersion    string
 	Architecture string
 	Variant      string
+	RepoTags     []string
+	RepoDigests  []string
 	Layers       []ContainerImageLayer
-	SBOM         *SBOM
+	SizeBytes    int64
 }
 
 // ContainerImageLayer represents a layer of a container image
 type ContainerImageLayer struct {
+	History   *v1.History
 	MediaType string
 	Digest    string
-	SizeBytes int64
 	URLs      []string
-	History   *v1.History
+	SizeBytes int64
 }
 
 // SBOM represents the Software Bill Of Materials (SBOM) of a container
 type SBOM struct {
-	CycloneDXBOM       *cyclonedx.BOM
 	GenerationTime     time.Time
-	GenerationDuration time.Duration
+	CycloneDXBOM       *cyclonedx.BOM
 	Status             SBOMStatus
-	Error              string // needs to be stored as a string otherwise the merge() will favor the nil value
+	Error              string
+	GenerationDuration time.Duration
 }
 
 // GetID implements Entity#GetID.
@@ -1187,12 +1171,11 @@ var _ Entity = &ContainerImageMetadata{}
 
 // Process is an Entity that represents a process
 type Process struct {
-	EntityID // EntityID.ID is the PID
-
-	NsPid        int32
-	ContainerID  string
 	CreationTime time.Time
 	Language     *languagemodels.Language
+	EntityID
+	ContainerID string
+	NsPid       int32
 }
 
 var _ Entity = &Process{}
@@ -1276,30 +1259,15 @@ func (p HostTags) String(verbose bool) string {
 // CollectorEvent is an event generated by a metadata collector, to be handled
 // by the metadata store.
 type CollectorEvent struct {
-	Type   EventType
-	Source Source
 	Entity Entity
+	Source Source
+	Type   EventType
 }
 
 // Event represents a change to an entity.
 type Event struct {
-	// Type gives the type of this event.
-	//
-	// When Type is EventTypeSet, this represents an added or updated entity.
-	// Multiple set events may be sent for a single entity.
-	//
-	// When Type is EventTypeUnset, this represents a removed entity.
-	Type EventType
-
-	// Entity is the entity involved in this event.  For an EventTypeSet event,
-	// this may contain information "merged" from multiple sources.  For an
-	// unset event it contains only an EntityID.
-	//
-	// For Type == EventTypeSet, this field can be cast unconditionally to the
-	// concrete type corresponding to its kind (Entity.GetID().Kind).  For Type
-	// == EventTypeUnset, only the Entity ID is available and such a cast will
-	// fail.
 	Entity Entity
+	Type   EventType
 }
 
 // SubscriberPriority is a priority for subscribers to the store.  Subscribers
@@ -1332,11 +1300,8 @@ const (
 // complete.  Other subscribers should close the channel immediately.
 // See the example for Store#Subscribe for details.
 type EventBundle struct {
-	// Events gives the events in this bundle.
+	Ch     chan struct{}
 	Events []Event
-
-	// Ch should be closed once the subscriber has handled the event.
-	Ch chan struct{}
 }
 
 // Acknowledge acknowledges that the subscriber has handled the event.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation
Run fieldalignment

```
# [github.com/DataDog/datadog-agent/comp/core/workloadmeta/def]
comp/core/workloadmeta/def/params.go:9:13: struct with 16 pointer bytes could be 8
comp/core/workloadmeta/def/types.go:237:17: struct with 48 pointer bytes could be 40
comp/core/workloadmeta/def/types.go:317:21: struct with 120 pointer bytes could be 104
comp/core/workloadmeta/def/types.go:347:20: struct with 32 pointer bytes could be 24
comp/core/workloadmeta/def/types.go:425:25: struct with 72 pointer bytes could be 56
comp/core/workloadmeta/def/types.go:483:19: struct with 168 pointer bytes could be 160
comp/core/workloadmeta/def/types.go:531:16: struct with 560 pointer bytes could be 544
comp/core/workloadmeta/def/types.go:661:31: struct with 24 pointer bytes could be 16
comp/core/workloadmeta/def/types.go:695:20: struct with 360 pointer bytes could be 336
comp/core/workloadmeta/def/types.go:826:25: struct with 88 pointer bytes could be 80
comp/core/workloadmeta/def/types.go:873:27: struct with 144 pointer bytes could be 136
comp/core/workloadmeta/def/types.go:969:14: struct with 312 pointer bytes could be 304
comp/core/workloadmeta/def/types.go:1061:29: struct with 248 pointer bytes could be 224
comp/core/workloadmeta/def/types.go:1077:26: struct with 72 pointer bytes could be 48
comp/core/workloadmeta/def/types.go:1086:11: struct with 64 pointer bytes could be 56
comp/core/workloadmeta/def/types.go:1189:14: struct with 88 pointer bytes could be 72
comp/core/workloadmeta/def/types.go:1278:21: struct with 40 pointer bytes could be 24
comp/core/workloadmeta/def/types.go:1285:12: struct with 24 pointer bytes could be 16
comp/core/workloadmeta/def/types.go:1334:18: struct with 32 pointer bytes could be 16
comp/core/workloadmeta/def/filter_test.go:18:13: struct with 104 pointer bytes could be 96
comp/core/workloadmeta/def/filter_test.go:63:13: struct with 32 pointer bytes could be 24
comp/core/workloadmeta/def/filter_test.go:160:13: struct with 24 pointer bytes could be 16
comp/core/workloadmeta/def/filter_test.go:256:13: struct with 40 pointer bytes could be 32
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Create a benchmark [test](https://github.com/DataDog/datadog-agent/pull/32589/files#diff-afaa3674002bea7865da86b3db5c940ee980aea2aa1e9fc5b3ab215d62b7fa82R72)

Take collector event for example: 16 bytes saved
`comp/core/workloadmeta/def/types.go:1278:21: struct with 40 pointer bytes could be 24
`
go test -bench=. -benchtime= 200000x
Old
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/comp/core/workloadmeta/def
cpu: Apple M1 Max
BenchmarkProcessCollectorEvent/Run_collector_event_bench_test_on_container-10            200000             18007 ns/op
BenchmarkProcessCollectorEvent/Run_collector_event_bench_test_on_kubernetes-10           200000             17095 ns/op
BenchmarkProcessCollectorEvent/Run_collector_event_bench_test_on_processes-10            200000             16513 ns/op
BenchmarkProcessEntity/Run_process_entity_bench_test_on_container-10                      200000             47944 ns/op
BenchmarkProcessEntity/Run_process_entity_bench_test_on_-10                               200000             47806 ns/op
BenchmarkProcessEntity/Run_process_entity_bench_test_on_process-10                        200000              6810 ns/op
PASS
ok      github.com/DataDog/datadog-agent/comp/core/workloadmeta/def     31.394s
```

New
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/comp/core/workloadmeta/def
cpu: Apple M1 Max
BenchmarkProcessCollectorEvent/Run_collector_event_bench_test_on_container-10            200000             12384 ns/op
BenchmarkProcessCollectorEvent/Run_collector_event_bench_test_on_kubernetes-10           200000             10668 ns/op
BenchmarkProcessCollectorEvent/Run_collector_event_bench_test_on_processes-10            200000             10491 ns/op
BenchmarkProcessEntity/Run_process_entity_bench_test_on_container-10                      200000             40858 ns/op
BenchmarkProcessEntity/Run_process_entity_bench_test_on_-10                               200000             41816 ns/op
BenchmarkProcessEntity/Run_process_entity_bench_test_on_process-10                        200000              6147 ns/op
PASS
ok      github.com/DataDog/datadog-agent/comp/core/workloadmeta/def     25.037s
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->