### PR TITLE
[CWS] Add metrics for cgroup resolver

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -266,6 +266,18 @@ var (
 	// Tags: -
 	MetricSBOMResolverSBOMCacheMiss = newRuntimeMetric(".sbom_resolver.sbom_cache.miss")
 
+	// CGroup resolver metrics
+
+	// MetricCGroupResolverActiveCGroups is the name of the metric used to report the count of cgroups kept in memory
+	// Tags: -
+	MetricCGroupResolverActiveCGroups = newRuntimeMetric(".cgroup_resolver.active_cgroups")
+	// MetricCGroupResolverActiveContainerWorkloads is the name of the metric used to report the count of active cgroups corresponding to a container kept in memory
+	// Tags: -
+	MetricCGroupResolverActiveContainerWorkloads = newRuntimeMetric(".cgroup_resolver.active_containers")
+	// MetricCGroupResolverActiveHostWorkloads is the name of the metric used to report the count of active cgroups not corresponding to a container kept in memory
+	// Tags: -
+	MetricCGroupResolverActiveHostWorkloads = newRuntimeMetric(".cgroup_resolver.active_non_containers")
+
 	// Security Profile metrics
 
 	// MetricSecurityProfileProfiles is the name of the metric used to report the count of Security Profiles per category

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -102,6 +102,10 @@ func (m *EBPFMonitors) SendStats() error {
 			return fmt.Errorf("failed to send mount_resolver stats: %w", err)
 		}
 
+		if err := resolvers.CGroupResolver.SendStats(); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver stats: %w", err)
+		}
+
 		if resolvers.SBOMResolver != nil {
 			if err := resolvers.SBOMResolver.SendStats(); err != nil {
 				return fmt.Errorf("failed to send sbom_resolver stats: %w", err)

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -436,7 +436,7 @@ func TestMountResolver(t *testing.T) {
 		pid uint32 = 1
 	)
 
-	cr, _ := cgroup.NewResolver()
+	cr, _ := cgroup.NewResolver(nil)
 
 	// Create mount resolver
 	mr, _ := NewResolver(nil, cr, ResolverOpts{})

--- a/pkg/security/resolvers/process/resolver_test.go
+++ b/pkg/security/resolvers/process/resolver_test.go
@@ -73,7 +73,7 @@ func newResolver() (*EBPFResolver, error) {
 		return nil, err
 	}
 
-	cgroupsResolver, err := cgroup.NewResolver()
+	cgroupsResolver, err := cgroup.NewResolver(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -93,7 +93,7 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		}
 	}
 
-	cgroupsResolver, err := cgroup.NewResolver()
+	cgroupsResolver, err := cgroup.NewResolver(statsdClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/resolvers_ebpfless.go
+++ b/pkg/security/resolvers/resolvers_ebpfless.go
@@ -32,7 +32,7 @@ type EBPFLessResolvers struct {
 
 // NewEBPFLessResolvers creates a new instance of EBPFLessResolvers
 func NewEBPFLessResolvers(config *config.Config, statsdClient statsd.ClientInterface, scrubber *procutil.DataScrubber, opts Opts) (*EBPFLessResolvers, error) {
-	cgroupsResolver, err := cgroup.NewResolver()
+	cgroupsResolver, err := cgroup.NewResolver(statsdClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add 3 metrics:
- `datadog.runtime_security.cgroup_resolver.active_cgroups`
- `datadog.runtime_security.cgroup_resolver.active_containers`
- `datadog.runtime_security.cgroup_resolver.active_non_containers`

### Motivation

Allow making sure we correctly track the cgroups.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->