### PR TITLE
fix(invoke unit tests): Add condition to have successful tests locally

### DIFF
--- a/tasks/unit_tests/package_tests.py
+++ b/tasks/unit_tests/package_tests.py
@@ -14,6 +14,7 @@ class TestCheckSize(unittest.TestCase):
             'OMNIBUS_PACKAGE_DIR': 'tasks/unit_tests/testdata/packages',
             'OMNIBUS_PACKAGE_DIR_SUSE': 'tasks/unit_tests/testdata/packages',
             'CI_COMMIT_REF_NAME': 'pikachu',
+            'CI_COMMIT_BRANCH': 'sequoia',
         },
     )
     @patch('tasks.libs.package.size.find_package', new=MagicMock(return_value='datadog-agent'))
@@ -61,6 +62,31 @@ class TestCheckSize(unittest.TestCase):
         print_mock.assert_called()
         self.assertEqual(print_mock.call_count, 16)
         upload_mock.assert_not_called()
+
+    @patch.dict(
+        'os.environ',
+        {
+            'OMNIBUS_PACKAGE_DIR': 'tasks/unit_tests/testdata/packages',
+            'OMNIBUS_PACKAGE_DIR_SUSE': 'tasks/unit_tests/testdata/packages',
+            'CI_COMMIT_REF_NAME': 'pikachu',
+        },
+        clear=True,
+    )
+    @patch('tasks.libs.package.size.find_package', new=MagicMock(return_value='datadog-agent'))
+    @patch('tasks.package.upload_package_sizes', new=MagicMock())
+    @patch('tasks.package.display_message')
+    def test_dev_no_pr_defined(self, display_mock):
+        flavor = 'datadog-agent'
+        display_mock.side_effect = AssertionError('CI_COMMIT_BRANCH')
+        c = MockContext(
+            run={
+                'git merge-base HEAD origin/main': Result('25'),
+                f"dpkg-deb --info {flavor} | grep Installed-Size | cut -d : -f 2 | xargs": Result(42),
+                f"rpm -qip {flavor} | grep Size | cut -d : -f 2 | xargs": Result(20000000),
+            }
+        )
+        check_size(c, filename='tasks/unit_tests/testdata/package_sizes_real.json', dry_run=True)
+        display_mock.assert_not_called()
 
     @patch.dict(
         'os.environ',


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set `CI_COMMIT_BRANCH` in the `test_branch_ok` test from `package_tests.py` and add another test related to `AssertionError` from the `display_message` method.

### Motivation
Follow-up of #32546: the UT was failing locally because the `CI_COMMIT_BRANCH` was not set in the test. I also added a new test reflecting the initial error fixed by #32546

### Describe how you validated your changes
Unit tests
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->