### PR TITLE
Move winproc to windows corechecks

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -82,7 +82,6 @@ AGENT_CORECHECKS = [
     "systemd",
     "tcp_queue_length",
     "uptime",
-    "winproc",
     "jetson",
     "telemetry",
     "orchestrator_pod",
@@ -98,6 +97,7 @@ WINDOWS_CORECHECKS = [
     "windows_registry",
     "winkmem",
     "wincrashdetect",
+    "winproc",
     "win32_event_log",
 ]
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Move the `winproc` check to the list of windows specific core checks.

### Motivation
I had the following logs on Darwin:
```
DEBUG | (pkg/collector/scheduler.go:192 in getChecks) | Loading check instance for check 'winproc' using default loaders
DEBUG | (pkg/collector/python/loader.go:163 in Load) | Unable to load python module - datadog_checks.winproc: unable to import module 'datadog_checks.winproc': No module named 'datadog_checks.winproc'
DEBUG | (pkg/collector/python/loader.go:163 in Load) | Unable to load python module - winproc: unable to import module 'winproc': No module named 'winproc'
DEBUG | (pkg/collector/python/loader.go:171 in Load) | PyLoader returning unable to import module 'winproc': No module named 'winproc' for winproc
ERROR | (pkg/collector/scheduler.go:213 in getChecks) | Unable to load a check from instance of config 'winproc': Python Check Loader: unable to import module 'winproc': No module named 'winproc'; Core Check Loader: Check winproc not found in Catalog
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Checked that I didn't have those logs with the change.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->