### PR TITLE
fix(notify): Mock environ in all situations

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -28,23 +28,8 @@ notify:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN
     - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt
-    - |
-      # Do not send notifications if this is a child pipeline of another repo
-      # The triggering repo should already have its own notification system
-      if [ "$CI_PIPELINE_SOURCE" != "pipeline" ]; then
-        if [ "$DEPLOY_AGENT" = "true" ]; then
-          invoke -e notify.send-message --notification-type "deploy"
-        elif [ "$CI_PIPELINE_SOURCE" != "push" ]; then
-          invoke -e notify.send-message --notification-type "trigger"
-        else
-          invoke -e notify.send-message --notification-type "merge"
-        fi
-        if [ "$CI_COMMIT_BRANCH" = "$CI_DEFAULT_BRANCH" ]; then
-          invoke notify.check-consistent-failures
-        fi
-      else
-        echo "This pipeline was triggered by another repository, skipping notification."
-      fi
+    - invoke -e notify.send-message -p $CI_PIPELINE_ID
+    - invoke -e notify.check-consistent-failures -p $CI_PIPELINE_ID
 
 send_pipeline_stats:
   stage: notify

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from typing import Any
 from urllib.parse import quote
@@ -43,3 +44,29 @@ def get_ci_visibility_job_url(
         extra_args = ''.join([f'&{key}={value}' for key, value in extra_args.items()])
 
     return CI_VISIBILITY_JOB_URL.format(name=name, extra_flags=extra_flags, extra_args=extra_args)
+
+
+def should_notify(pipeline_id):
+    """
+    Check if the pipeline should notify the channel: only for non-downstream pipelines, unless conductor triggered it
+    """
+    from tasks.libs.ciproviders.gitlab_api import get_pipeline
+
+    pipeline = get_pipeline(PROJECT_NAME, pipeline_id)
+    return (
+        pipeline.source != 'pipeline'
+        or pipeline.source == 'pipeline'
+        and all(var in os.environ for var in ['DDR', 'DDR_WORKFLOW_ID'])
+    )
+
+
+def get_pipeline_type(pipeline):
+    """
+    Return the type of notification to send (related to the type of pipeline, amongst 'deploy', 'trigger' and 'merge')
+    """
+    if os.environ.get('DEPLOY_AGENT', '') == 'true':
+        return 'deploy'
+    elif pipeline.source != 'push':
+        return 'trigger'
+    else:
+        return 'merge'

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -20,7 +20,7 @@ from tasks.libs.common.datadog_api import send_metrics
 from tasks.libs.common.utils import gitlab_section
 from tasks.libs.notify import alerts, failure_summary, pipeline_status
 from tasks.libs.notify.jira_failing_tests import close_issue, get_failing_tests_names, get_jira
-from tasks.libs.notify.utils import PROJECT_NAME
+from tasks.libs.notify.utils import PROJECT_NAME, should_notify
 from tasks.libs.pipeline.notifications import (
     check_for_missing_owners_slack_and_jira,
 )
@@ -41,13 +41,16 @@ def check_teams(_):
 
 
 @task
-def send_message(ctx: Context, notification_type: str = "merge", dry_run: bool = False):
+def send_message(ctx: Context, pipeline_id: str, dry_run: bool = False):
     """
     Send notifications for the current pipeline. CI-only task.
     Use the --dry-run option to test this locally, without sending
     real slack messages.
     """
-    pipeline_status.send_message(ctx, notification_type, dry_run)
+    if should_notify(pipeline_id):
+        pipeline_status.send_message(ctx, pipeline_id, dry_run)
+    else:
+        print("This pipeline is a non-conductor downstream pipeline, skipping notifications")
 
 
 @task
@@ -72,7 +75,7 @@ def send_stats(_, dry_run=False):
 
 
 @task
-def check_consistent_failures(ctx, job_failures_file="job_executions.v2.json"):
+def check_consistent_failures(ctx, pipeline_id, job_failures_file="job_executions.v2.json"):
     # Retrieve the stored document in aws s3. It has the following format:
     # {
     #     "pipeline_id": 123,
@@ -87,13 +90,16 @@ def check_consistent_failures(ctx, job_failures_file="job_executions.v2.json"):
     # The jobs dictionary contains the consecutive and cumulative failures for each job
     # The consecutive failures are reset to 0 when the job is not failing, and are raising an alert when reaching the CONSECUTIVE_THRESHOLD (3)
     # The cumulative failures list contains 1 for failures, 0 for succes. They contain only then CUMULATIVE_LENGTH(10) last executions and raise alert when 50% failure rate is reached
+    if not should_notify(pipeline_id) or os.environ['CI_COMMIT_BRANCH'] != os.environ['CI_DEFAULT_BRANCH']:
+        print("Consistent failures check is only run on the not-downstream default branch")
+        return
 
     job_executions = alerts.retrieve_job_executions(ctx, job_failures_file)
 
     # By-pass if the pipeline chronological order is not respected
-    if job_executions.pipeline_id > int(os.environ["CI_PIPELINE_ID"]):
+    if job_executions.pipeline_id > int(pipeline_id):
         return
-    job_executions.pipeline_id = int(os.environ["CI_PIPELINE_ID"])
+    job_executions.pipeline_id = int(pipeline_id)
 
     alert_jobs, job_executions = alerts.update_statistics(job_executions)
 

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -31,26 +31,33 @@ def get_github_slack_map():
 
 
 class TestSendMessage(unittest.TestCase):
-    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
-    def test_merge(self, api_mock):
+    @patch('builtins.print')
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_merge(self, api_mock, print_mock):
         repo_mock = api_mock.return_value.projects.get.return_value
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.jobs.get.return_value.trace.return_value = b"Log trace"
         repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.source = "push"
         list_mock = repo_mock.pipelines.get.return_value.jobs.list
         list_mock.side_effect = [get_fake_jobs(), []]
-        notify.send_message(MockContext(), notification_type="merge", dry_run=True)
+        notify.send_message(MockContext(), "42", dry_run=True)
         list_mock.assert_called()
+        repo_mock.pipelines.get.assert_called_with("42")
+        self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
+        repo_mock.jobs.get.assert_called()
 
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('tasks.libs.notify.pipeline_status.get_failed_jobs')
+    @patch('builtins.print')
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
-    def test_merge_without_get_failed_call(self, get_failed_jobs_mock, api_mock):
+    def test_merge_without_get_failed_call(self, print_mock, get_failed_jobs_mock, api_mock):
         repo_mock = api_mock.return_value.projects.get.return_value
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.jobs.get.return_value.trace.return_value = b"Log trace"
         repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.source = "push"
 
         failed = FailedJobs()
         failed.add_failed_job(
@@ -114,9 +121,10 @@ class TestSendMessage(unittest.TestCase):
             )
         )
         get_failed_jobs_mock.return_value = failed
-        notify.send_message(MockContext(), notification_type="merge", dry_run=True)
-
+        notify.send_message(MockContext(), "42", dry_run=True)
+        self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
         get_failed_jobs_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
 
     @patch("tasks.libs.owners.parsing.read_owners")
     def test_route_e2e_internal_error(self, read_owners_mock):
@@ -192,8 +200,9 @@ class TestSendMessage(unittest.TestCase):
         self.assertNotIn("@DataDog/agent-delivery", owners)
 
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
-    def test_merge_with_get_failed_call(self, api_mock):
+    def test_merge_with_get_failed_call(self, print_mock, api_mock):
         repo_mock = api_mock.return_value.projects.get.return_value
         trace_mock = repo_mock.jobs.get.return_value.trace
         list_mock = repo_mock.pipelines.get.return_value.jobs.list
@@ -202,11 +211,83 @@ class TestSendMessage(unittest.TestCase):
         list_mock.return_value = get_fake_jobs()
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.source = "push"
 
-        notify.send_message(MockContext(), notification_type="merge", dry_run=True)
-
+        notify.send_message(MockContext(), "42", dry_run=True)
+        self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
         trace_mock.assert_called()
         list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'true'})
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
+    @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    def test_deploy_with_get_failed_call(self, print_mock, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        trace_mock = repo_mock.jobs.get.return_value.trace
+        list_mock = repo_mock.pipelines.get.return_value.jobs.list
+
+        trace_mock.return_value = b"no basic auth credentials"
+        list_mock.return_value = get_fake_jobs()
+        repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
+        repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.source = "push"
+
+        notify.send_message(MockContext(), "42", dry_run=True)
+        self.assertTrue("rocket" in print_mock.mock_calls[0].args[0])
+        trace_mock.assert_called()
+        list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
+    @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    def test_trigger_with_get_failed_call(self, print_mock, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        trace_mock = repo_mock.jobs.get.return_value.trace
+        list_mock = repo_mock.pipelines.get.return_value.jobs.list
+
+        trace_mock.return_value = b"no basic auth credentials"
+        list_mock.return_value = get_fake_jobs()
+        repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
+        repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.source = "api"
+
+        notify.send_message(MockContext(), "42", dry_run=True)
+        self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
+        trace_mock.assert_called()
+        list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch.dict('os.environ', {'DDR': 'true', 'DDR_WORKFLOW_ID': '1337'})
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    @patch('builtins.print')
+    @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    def test_trigger_with_get_failed_call_conductor(self, print_mock, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        trace_mock = repo_mock.jobs.get.return_value.trace
+        list_mock = repo_mock.pipelines.get.return_value.jobs.list
+
+        trace_mock.return_value = b"no basic auth credentials"
+        list_mock.return_value = get_fake_jobs()
+        repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
+        repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.source = "pipeline"
+
+        notify.send_message(MockContext(), "42", dry_run=True)
+        self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
+        trace_mock.assert_called()
+        list_mock.assert_called()
+        repo_mock.jobs.get.assert_called()
+
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_dismiss_notification(self, api_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        repo_mock.pipelines.get.return_value.source = "pipeline"
+
+        notify.send_message(MockContext(), "42", dry_run=True)
+        repo_mock.jobs.get.assert_not_called()
 
     def test_post_to_channel1(self):
         self.assertFalse(pipeline_status.should_send_message_to_author("main", default_branch="main"))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Re-apply #32165 that was reverted by #32494
Update the unit tests so that they work in the different main branch configuration (`standard` main branch, `scheduled` and `scheduled conductor`)

### Motivation
Prevent failures that caused the initial revert

### Describe how you validated your changes
Updated unit tests. Now the full `os.environ` is under control
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->