### PR TITLE
Force the configsync component to be instantiated by FX when used

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/configsync"
 	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	logcomp "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/pid"
@@ -214,7 +213,6 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 			_ expvars.Component,
 			_ apiserver.Component,
 			cfg config.Component,
-			_ configsync.Component,
 			// TODO: This is needed by the container-provider which is not currently a component.
 			// We should ensure the tagger is a dependency when converting to a component.
 			_ tagger.Component,

--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -29,7 +29,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/configsync"
 	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
@@ -166,8 +165,6 @@ func (s *service) Run(svcctx context.Context) error {
 
 		fetchonlyimpl.Module(),
 		configsyncimpl.Module(configsyncimpl.NewDefaultParams()),
-		// Force the instantiation of the component
-		fx.Invoke(func(_ configsync.Component) {}),
 		autoexitimpl.Module(),
 		fx.Provide(func(c config.Component) settings.Params {
 			return settings.Params{

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -33,7 +33,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/configsync"
 	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/pid"
@@ -174,8 +173,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				statusimpl.Module(),
 				fetchonlyimpl.Module(),
 				configsyncimpl.Module(configsyncimpl.NewDefaultParams()),
-				// Force the instantiation of the component
-				fx.Invoke(func(_ configsync.Component) {}),
 				autoexitimpl.Module(),
 				fx.Supply(pidimpl.NewParams(params.pidfilePath)),
 				fx.Provide(func(c config.Component) settings.Params {

--- a/cmd/trace-agent/subcommands/run/command.go
+++ b/cmd/trace-agent/subcommands/run/command.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit/autoexitimpl"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/configsync"
 	"github.com/DataDog/datadog-agent/comp/core/configsync/configsyncimpl"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logtracefx "github.com/DataDog/datadog-agent/comp/core/log/fx-trace"
@@ -115,7 +114,7 @@ func runTraceAgentProcess(ctx context.Context, cliParams *Params, defaultConfPat
 		fetchonlyimpl.Module(),
 		configsyncimpl.Module(configsyncimpl.NewDefaultParams()),
 		// Force the instantiation of the components
-		fx.Invoke(func(_ traceagent.Component, _ configsync.Component, _ autoexit.Component) {}),
+		fx.Invoke(func(_ traceagent.Component, _ autoexit.Component) {}),
 	)
 	if err != nil && errors.Is(err, traceagentimpl.ErrAgentDisabled) {
 		return nil

--- a/comp/core/configsync/configsyncimpl/module.go
+++ b/comp/core/configsync/configsyncimpl/module.go
@@ -39,6 +39,15 @@ func Module(params Params) fxutil.Module {
 	return fxutil.Component(
 		fx.Provide(newComponent),
 		fx.Supply(params),
+
+		// configSync is a component with no public method, therefore nobody depends on it and FX only instantiates
+		// components when they're needed. Adding a dummy function that takes our Component as a parameter force
+		// the instantiation of configsync. This means that simply using 'configsync.Module()' will run our
+		// component (which is the expected behavior).
+		//
+		// This prevent silent corner case where including 'configsync' in the main function would not actually
+		// instantiate it. This also remove the need for every main using configsync to add the line bellow.
+		fx.Invoke(func(_ configsync.Component) {}),
 	)
 }
 


### PR DESCRIPTION
### What does this PR do?

`configSync` is a component with no public method, therefore nobody depends on it and FX only instantiates components when
they're needed. Adding a dummy function that takes our Component as a parameter force the instantiation of configsync.
This means that simply using `configsync.Module` will run our component (which is the expected behavior).

This prevent silent corner case where including `configsync` in the main function would not actually instantiate it.

### Describe how you validated your changes

This test is validated by the CI
