### PR TITLE
Do not clear host SBOM on non container cgroups deletion

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -240,6 +240,7 @@ func (r *Resolver) Start(ctx context.Context) error {
 			return err
 		}
 		r.hostSBOM.SetReport(report)
+		r.hostSBOM.scanSuccessful.Store(true)
 	}
 
 	go func() {
@@ -535,7 +536,9 @@ func (r *Resolver) GetWorkload(id containerutils.ContainerID) *SBOM {
 
 // OnCGroupDeletedEvent is used to handle a CGroupDeleted event
 func (r *Resolver) OnCGroupDeletedEvent(cgroup *cgroupModel.CacheEntry) {
-	r.Delete(cgroup.ContainerID)
+	if cgroup.ContainerID != "" {
+		r.Delete(cgroup.ContainerID)
+	}
 }
 
 // Delete removes the SBOM of the provided cgroup id


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Properly mark host SBOM as successful and do not clear it when a cgroup that doesn't map to a container is deleted.

### Motivation

When a cgroup not tied to a container is deleted, it's `ContainerID` field is empty,
which maps to the SBOM of the host. Fortunately, the host SBOM was not marked as successful
so it was not cleared.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->