### PR TITLE
[CWS] Delete cgroup from cache for non container cgroups

### DIFF
--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -176,17 +176,6 @@ func (cr *Resolver) DelPID(pid uint32) {
 	}
 }
 
-// DelPIDWithID removes a PID from the cgroup cache entry referenced by the provided ID
-func (cr *Resolver) DelPIDWithID(id containerutils.ContainerID, pid uint32) {
-	cr.Lock()
-	defer cr.Unlock()
-
-	entry, exists := cr.containerWorkloads.Get(id)
-	if exists {
-		cr.deleteWorkloadPID(pid, entry)
-	}
-}
-
 // deleteWorkloadPID removes a PID from a workload
 func (cr *Resolver) deleteWorkloadPID(pid uint32, workload *cgroupModel.CacheEntry) {
 	workload.Lock()

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -47,7 +47,6 @@ type ResolverInterface interface {
 	AddPID(*model.ProcessCacheEntry)
 	GetWorkload(containerutils.ContainerID) (*cgroupModel.CacheEntry, bool)
 	DelPID(uint32)
-	DelPIDWithID(containerutils.ContainerID, uint32)
 	Len() int
 	RegisterListener(Event, utils.Listener[*cgroupModel.CacheEntry]) error
 }

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -621,7 +621,7 @@ func (p *EBPFResolver) deleteEntry(pid uint32, exitTime time.Time) {
 	}
 
 	if p.cgroupResolver != nil {
-		p.cgroupResolver.DelPIDWithID(entry.ContainerID, entry.Pid)
+		p.cgroupResolver.DelPID(entry.Pid)
 	}
 
 	entry.Exit(exitTime)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove cgroup from the resolver cache for cgroups that do not map to a container.

### Motivation

This is potential leak for cgroups that contains a random generated part.

### Describe how you validated your changes

Check that the metrics `datadog.runtime_security.cgroup_resolver/*` are accurate.
For instance, you can create a cgroup or a container and check that the metric is properly increased.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->