### PR TITLE
Add common Windows runner config

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1184,3 +1184,26 @@ workflow:
         - test/new-e2e/tests/gpu/**/*
         - pkg/collector/corechecks/gpu/**/*
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+
+# windows_docker_2022 configures the job to use the Windows Server 2022 runners.
+# Use in jobs that need to run on Windows Server 2022 runners.
+.windows_docker_2022:
+  tags: ["runner:windows-docker", "windowsversion:2022"]
+  variables:
+    # Full image name for Agent windows build image, for use in docker run command
+    WINBUILDIMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_ltsc2022_${ARCH}${DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${DATADOG_AGENT_WINBUILDIMAGES}
+
+# windows_docker_2019 configures the job to use the Windows Server 2019 runners.
+# Use in jobs that need to run on Windows Server 2019 runners.
+.windows_docker_2019:
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  variables:
+    # Full image name for Agent windows build image, for use in docker run command
+    WINBUILDIMAGE: registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${DATADOG_AGENT_WINBUILDIMAGES}
+
+# windows_docker_default configures the job to use the default Windows Server runners
+# Use in jobs that may need to have their version updated in the future.
+#
+# Current default: Windows Server 2019
+.windows_docker_default:
+  extends: .windows_docker_2019

--- a/.gitlab/binary_build/windows.yml
+++ b/.gitlab/binary_build/windows.yml
@@ -5,7 +5,7 @@ build_windows_container_entrypoint:
     - !reference [.except_mergequeue]
     - when: on_success
   stage: binary_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   needs: ["lint_windows-x64"]
   variables:
     ARCH: "x64"
@@ -23,7 +23,7 @@ build_windows_container_entrypoint:
       -e WINDOWS_BUILDER=true
       -e AWS_NETWORKING=true
       -e TARGET_ARCH="$ARCH"
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       c:\mnt\Dockerfiles\agent\windows\entrypoint\build.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - get-childitem build-out\${CI_JOB_ID}

--- a/.gitlab/choco_build/choco_build.yml
+++ b/.gitlab/choco_build/choco_build.yml
@@ -7,7 +7,7 @@
   rules:
     !reference [.on_deploy_stable_or_beta_repo_branch]
   stage: choco_and_install_script_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   variables:
     ARCH: "x64"
   script:
@@ -21,7 +21,7 @@
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
       -e BUCKET_BRANCH="$BUCKET_BRANCH"
       -e AWS_NETWORKING=true
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       powershell.exe -C "C:\mnt\tasks\winbuildscripts\Generate-Chocolatey-Package.ps1 -MSIDirectory c:\mnt\omnibus\pkg -Flavor $FLAVOR -InstallDeps 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - $CopyNupkgToS3 = "$S3_CP_CMD --recursive --exclude '*' --include '*.nupkg' build-out $S3_RELEASE_ARTIFACTS_URI/choco/nupkg"

--- a/.gitlab/container_build/docker_windows_agent7.yml
+++ b/.gitlab/container_build/docker_windows_agent7.yml
@@ -2,7 +2,7 @@
 docker_build_agent7_windows1809:
   extends:
     - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+    - .windows_docker_2019
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7
@@ -11,7 +11,7 @@ docker_build_agent7_windows1809:
 docker_build_agent7_windows1809_jmx:
   extends:
     - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+    - .windows_docker_2019
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7-jmx
@@ -20,7 +20,7 @@ docker_build_agent7_windows1809_jmx:
 docker_build_agent7_windows2022_jmx:
   extends:
     - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
+    - .windows_docker_2022
   variables:
     VARIANT: ltsc2022
     TAG_SUFFIX: -7-jmx
@@ -29,7 +29,7 @@ docker_build_agent7_windows2022_jmx:
 docker_build_agent7_windows2022:
   extends:
     - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
+    - .windows_docker_2022
   variables:
     VARIANT: ltsc2022
     TAG_SUFFIX: "-7"
@@ -38,7 +38,7 @@ docker_build_agent7_windows2022:
 docker_build_agent7_windows1809_core:
   extends:
     - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+    - .windows_docker_2019
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7
@@ -47,7 +47,7 @@ docker_build_agent7_windows1809_core:
 docker_build_agent7_windows1809_core_jmx:
   extends:
     - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+    - .windows_docker_2019
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7-jmx
@@ -56,7 +56,7 @@ docker_build_agent7_windows1809_core_jmx:
 docker_build_agent7_windows2022_core:
   extends:
     - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
+    - .windows_docker_2022
   variables:
     VARIANT: ltsc2022
     TAG_SUFFIX: "-7"
@@ -65,7 +65,7 @@ docker_build_agent7_windows2022_core:
 docker_build_agent7_windows2022_core_jmx:
   extends:
     - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
+    - .windows_docker_2022
   variables:
     VARIANT: ltsc2022
     TAG_SUFFIX: -7-jmx
@@ -74,7 +74,7 @@ docker_build_agent7_windows2022_core_jmx:
 docker_build_fips_agent7_windows2022_core:
   extends:
     - .docker_build_fips_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
+    - .windows_docker_2022
   variables:
     VARIANT: ltsc2022
     TAG_SUFFIX: "-7-fips"
@@ -83,7 +83,7 @@ docker_build_fips_agent7_windows2022_core:
 docker_build_fips_agent7_windows2022_core_jmx:
   extends:
     - .docker_build_fips_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
+    - .windows_docker_2022
   variables:
     VARIANT: ltsc2022
     TAG_SUFFIX: -7-fips-jmx

--- a/.gitlab/deploy_packages/winget.yml
+++ b/.gitlab/deploy_packages/winget.yml
@@ -6,7 +6,7 @@ publish_winget_7_x64:
   dependencies: []
   rules: !reference [.on_deploy_stable_or_beta_repo_branch_manual]
   stage: deploy_packages
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   variables:
     ARCH: "x64"
   before_script:
@@ -23,7 +23,7 @@ publish_winget_7_x64:
       -v "$(Get-Location):c:\mnt"
       -e WINGET_GITHUB_ACCESS_TOKEN=${wingetPat}
       -e GENERAL_ARTIFACTS_CACHE_BUCKET_URL=${GENERAL_ARTIFACTS_CACHE_BUCKET_URL}
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       Powershell
       -C "C:\mnt\tasks\winbuildscripts\Update-Winget.ps1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/.gitlab/integration_test/windows.yml
+++ b/.gitlab/integration_test/windows.yml
@@ -5,7 +5,7 @@
     - !reference [.except_mergequeue]
     - when: on_success
   needs: ["go_deps", "go_tools_deps"]
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   before_script:
     - $tmpfile = [System.IO.Path]::GetTempFileName()
     - (& "$CI_PROJECT_DIR\tools\ci\fetch_secret.ps1" -parameterName "$Env:VCPKG_BLOB_SAS_URL" -tempFile "$tmpfile")
@@ -29,7 +29,7 @@
       -e GOMODCACHE="c:\modcache"
       -e VCPKG_BINARY_SOURCES="clear;x-azblob,${vcpkgBlobSaSUrl}"
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-IntegrationTests.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 

--- a/.gitlab/lint/windows.yml
+++ b/.gitlab/lint/windows.yml
@@ -3,7 +3,7 @@
 .lint_windows_base:
   stage: lint
   needs: ["go_deps", "go_tools_deps"]
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -20,7 +20,7 @@
       -e CI_PIPELINE_ID=${CI_PIPELINE_ID}
       -e CI_PROJECT_NAME=${CI_PROJECT_NAME}
       -e GOMODCACHE="c:\modcache"
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:$Env:DATADOG_AGENT_WINBUILDIMAGES
+      ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-Linters.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -193,7 +193,7 @@ installer-arm64-oci:
 
 windows-installer-amd64:
   stage: package_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   needs: ["go_mod_tidy_check", "go_deps"]
   rules:
     - !reference [.except_mergequeue]
@@ -221,7 +221,7 @@ windows-installer-amd64:
       -e S3_OMNIBUS_CACHE_BUCKET="$S3_OMNIBUS_CACHE_BUCKET"
       -e USE_S3_CACHING="$USE_S3_CACHING"
       -e API_KEY_ORG2=${API_KEY_ORG2}
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-InstallerPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
   after_script:
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -1,7 +1,7 @@
 ---
 .windows_msi_base:
   stage: package_build
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   needs: ["go_mod_tidy_check", "go_deps"]
   script:
     - $ErrorActionPreference = 'Stop'
@@ -38,7 +38,7 @@
       -e API_KEY_ORG2=${API_KEY_ORG2}
       -e OMNIBUS_GIT_CACHE_DIR=${Env:TEMP}/${CI_PIPELINE_ID}/omnibus-git-cache
       -e AGENT_FLAVOR=${AGENT_FLAVOR}
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - get-childitem omnibus\pkg
@@ -85,7 +85,7 @@ windows_zip_agent_binaries_x64-a7:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   needs: ["go_mod_tidy_check", "go_deps"]
   variables:
     ARCH: "x64"
@@ -121,7 +121,7 @@ windows_zip_agent_binaries_x64-a7:
       -e BUNDLE_MIRROR__RUBYGEMS__ORG=${BUNDLE_MIRROR__RUBYGEMS__ORG}
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
       -e API_KEY_ORG2=${API_KEY_ORG2}
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-OmnibusTarget.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - get-childitem omnibus\pkg

--- a/.gitlab/powershell_script_signing/powershell_script_signing.yml
+++ b/.gitlab/powershell_script_signing/powershell_script_signing.yml
@@ -1,5 +1,5 @@
 powershell_script_signing:
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   stage: choco_and_install_script_build
   needs: []
   variables:
@@ -12,5 +12,5 @@ powershell_script_signing:
       - $WINDOWS_POWERSHELL_DIR
   script:
     - mkdir $WINDOWS_POWERSHELL_DIR
-    - docker run --rm -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e IS_AWS_CONTAINER=true registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES} powershell -C "dd-wcs sign \mnt\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1"
+    - docker run --rm -v "$(Get-Location):c:\mnt" -e AWS_NETWORKING=true -e IS_AWS_CONTAINER=true ${WINBUILDIMAGE} powershell -C "dd-wcs sign \mnt\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1"
     - copy .\tools\windows\DatadogAgentInstallScript\Install-Datadog.ps1 $WINDOWS_POWERSHELL_DIR\Install-Datadog.ps1

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -6,7 +6,7 @@
     - !reference [.except_disable_unit_tests]
     - !reference [.fast_on_dev_branch_only]
   needs: ["go_deps", "go_tools_deps"]
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -43,7 +43,7 @@
       -e CODECOV_TOKEN="${CODECOV_TOKEN}"
       -e S3_PERMANENT_ARTIFACTS_URI="${S3_PERMANENT_ARTIFACTS_URI}"
       -e COVERAGE_CACHE_FLAG="${COVERAGE_CACHE_FLAG}"
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       powershell.exe -c "c:\mnt\tasks\winbuildscripts\Invoke-UnitTests.ps1 -BuildOutOfSource 1 -CheckGoVersion 1 -InstallDeps 1 -UploadCoverage 1 -UploadTestResults 1"
     - If ($lastExitCode -ne "0") { exit "$lastExitCode" }
   variables:
@@ -65,7 +65,7 @@ tests_windows-x64:
 .tests_windows_sysprobe:
   stage: source_test
   needs: ["go_deps", "go_tools_deps"]
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -79,7 +79,7 @@ tests_windows-x64:
       -e SIGN_WINDOWS_DD_WCS=true
       -e GOMODCACHE="c:\modcache"
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       c:\mnt\tasks\winbuildscripts\sysprobe.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
   artifacts:
@@ -90,7 +90,7 @@ tests_windows-x64:
 .tests_windows_secagent:
   stage: source_test
   needs: ["go_deps", "go_tools_deps"]
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  extends: .windows_docker_default
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -104,7 +104,7 @@ tests_windows-x64:
       -e SIGN_WINDOWS_DD_WCS=true
       -e GOMODCACHE="c:\modcache"
       -e PIP_INDEX_URL=${PIP_INDEX_URL}
-      registry.ddbuild.io/ci/datadog-agent-buildimages/windows_1809_${ARCH}${Env:DATADOG_AGENT_WINBUILDIMAGES_SUFFIX}:${Env:DATADOG_AGENT_WINBUILDIMAGES}
+      ${WINBUILDIMAGE}
       c:\mnt\tasks\winbuildscripts\secagent.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
   artifacts:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add common Windows runner config

Most jobs use
- `.windows_docker_default`: currently 2019, future updates will bump this

Jobs that need a specific version use
- `.windows_docker_2022`: Run on Server 2022 runners, use ltsc2022 container
- `.windows_docker_2019`: Run on Server 2019 runners, use 1809/ltsc2019 container

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1194

Make it easier to update the runners/version/buildimage used by jobs

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->