### PR TITLE
MSI raise error if password contains semicolon

### DIFF
--- a/releasenotes/notes/password-contains-semicolon-error-5c63154508759fa0.yaml
+++ b/releasenotes/notes/password-contains-semicolon-error-5c63154508759fa0.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Windows Agent MSI now shows the user an error message
+    if the provided password contains a semicolon.

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -165,5 +165,19 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_RESET_PASSWORD" && string.IsNullOrEmpty(kvp.Value)).And
                 .Contain(kvp => kvp.Key == "DDAGENTUSER_PROCESSED_PASSWORD" && string.IsNullOrEmpty(kvp.Value));
         }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Catch_Semicolon_In_Password()
+        {
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_NAME"]).Returns("ddagentuser");
+            Test.Session
+                .Setup(session => session["DDAGENTUSER_PASSWORD"]).Returns("password;123");
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Failure);
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -506,6 +506,10 @@ namespace Datadog.CustomActions
                     _session.Log("Ignoring provided password because account is a service account");
                     ddAgentUserPassword = null;
                 }
+                else if (!string.IsNullOrEmpty(ddAgentUserPassword))
+                {
+                    TestValidAgentUserPassword(ddAgentUserPassword);
+                }
 
                 _session["DDAGENTUSER_PROCESSED_PASSWORD"] = ddAgentUserPassword;
             }
@@ -524,6 +528,17 @@ namespace Datadog.CustomActions
             }
 
             return ActionResult.Success;
+        }
+
+        private void TestValidAgentUserPassword(string ddAgentUserPassword)
+        {
+            // password cannot contain semicolon
+            // semicolon is the delimiter for CustomActionData, and we don't have special handling for this.
+            // TODO: WINA-1226
+            if (ddAgentUserPassword.Contains(";"))
+            {
+                throw new InvalidAgentUserConfigurationException("The password provided contains an invalid character. Please provide a password that does not contain a semicolon.");
+            }
         }
 
         public static ActionResult ProcessDdAgentUserCredentials(Session session)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Agent MSI report error to user if password contains a semicolon

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1227

The semicolon isn't handled properly and can lead to an incorrect/incomplete password.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Added unit test

Run MSI in both GUI and silent mode with a password containing a semicolon.
- GUI should show a dialog box with the error.
- MSI log should show the error.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
semicolon is the CustomActionData property delimiter, so the password is cut off at the semicolon when passed to deferred CAs

This limitation is already [documented](https://docs.datadoghq.com/agent/guide/windows-agent-ddagent-user/#installation)