### PR TITLE
add update testing target msi to pipeline

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -35,6 +35,7 @@
       - E2E_MSI_TEST: TestInstall
       - E2E_MSI_TEST: TestRepair
       - E2E_MSI_TEST: TestUpgrade
+      - E2E_MSI_TEST: TestUpgradeFromLatest
       - E2E_MSI_TEST: TestUpgradeRollback
       - E2E_MSI_TEST: TestUpgradeRollbackWithoutCWS
       - E2E_MSI_TEST: TestUpgradeChangeUser

--- a/.gitlab/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/e2e_testing_deploy/e2e_deploy.yml
@@ -190,6 +190,7 @@ deploy_windows_testing-a7:
       --recursive
       --exclude "*"
       --include "datadog-agent-7.*.msi"
+      --include "datadog-agent-upgrade-test-7.*.msi"
       --include "datadog-installer-*-1-x86_64.msi"
       --include "datadog-installer-*-1-x86_64.exe"
       $OMNIBUS_PACKAGE_DIR s3://$WIN_S3_BUCKET/$WINDOWS_TESTING_S3_BUCKET_A7

--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -39,7 +39,7 @@
       -e OMNIBUS_GIT_CACHE_DIR=${Env:TEMP}/${CI_PIPELINE_ID}/omnibus-git-cache
       -e AGENT_FLAVOR=${AGENT_FLAVOR}
       ${WINBUILDIMAGE}
-      powershell -C "c:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1"
+      powershell -C "c:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1 -BuildUpgrade 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - get-childitem omnibus\pkg
     - !reference [.upload_sbom_artifacts_windows]

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -272,7 +272,7 @@ def _build_msi(ctx, env, outdir, name, allowlist):
 
 
 def _msi_output_name(env, testing=False):
-    testing_suffix = "testing-" if testing else ""
+    testing_suffix = "upgrade-test-" if testing else ""
     if _is_fips_mode(env):
         return f"datadog-fips-agent-{testing_suffix}{env['PACKAGE_VERSION']}-1-x86_64"
     else:

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -323,10 +323,9 @@ def build(
         # And copy it to the final output path as a build artifact
         shutil.copy2(os.path.join(build_outdir, msi_name + '.msi'), OUTPUT_PATH)
 
-    # if the optional upgrade test helper exists then build that too
+    # Build the optional upgrade test helper
     if build_upgrade:
         print("Building optional upgrade test helper")
-        # Build the optional upgrade test helper
         upgrade_env = env.copy()
         version = _create_version_from_match(VERSION_RE.search(env['PACKAGE_VERSION']))
         next_version = version.next_version(bump_patch=True)

--- a/tasks/msi.py
+++ b/tasks/msi.py
@@ -80,7 +80,7 @@ def _get_env(ctx, major_version='7', release_version='nightly'):
     env['AGENT_FLAVOR'] = os.getenv("AGENT_FLAVOR", "")
     env['AGENT_INSTALLER_OUTPUT_DIR'] = BUILD_OUTPUT_DIR
     env['NUGET_PACKAGES_DIR'] = NUGET_PACKAGES_DIR
-    env['UPGRADE_TEST'] = ""
+    env['AGENT_PRODUCT_NAME_SUFFIX'] = ""
 
     return env
 
@@ -273,9 +273,9 @@ def _build_msi(ctx, env, outdir, name, allowlist):
 
 def _msi_output_name(env):
     if _is_fips_mode(env):
-        return f"datadog-fips-agent-{env['UPGRADE_TEST']}{env['PACKAGE_VERSION']}-1-x86_64"
+        return f"datadog-fips-agent-{env['AGENT_PRODUCT_NAME_SUFFIX']}{env['PACKAGE_VERSION']}-1-x86_64"
     else:
-        return f"datadog-agent-{env['UPGRADE_TEST']}{env['PACKAGE_VERSION']}-1-x86_64"
+        return f"datadog-agent-{env['AGENT_PRODUCT_NAME_SUFFIX']}{env['PACKAGE_VERSION']}-1-x86_64"
 
 
 @task
@@ -330,7 +330,7 @@ def build(
         version = _create_version_from_match(VERSION_RE.search(env['PACKAGE_VERSION']))
         next_version = version.next_version(bump_patch=True)
         upgrade_env['PACKAGE_VERSION'] = upgrade_env['PACKAGE_VERSION'].replace(str(version), str(next_version))
-        upgrade_env['UPGRADE_TEST'] = "upgrade-test-"
+        upgrade_env['AGENT_PRODUCT_NAME_SUFFIX'] = "upgrade-test-"
         _build_wxs(
             ctx,
             upgrade_env,

--- a/tasks/winbuild.py
+++ b/tasks/winbuild.py
@@ -21,6 +21,7 @@ def agent_package(
     flavor=AgentFlavor.base.name,
     release_version="nightly-a7",
     skip_deps=False,
+    build_upgrade=False,
 ):
     # Build agent
     omnibus_build(
@@ -31,7 +32,7 @@ def agent_package(
     )
 
     # Package Agent into MSI
-    build_agent_msi(ctx, release_version=release_version)
+    build_agent_msi(ctx, release_version=release_version, build_upgrade=build_upgrade)
 
     # Package MSI into OCI
     if AgentFlavor[flavor] == AgentFlavor.base:

--- a/tasks/winbuildscripts/Build-AgentPackages.ps1
+++ b/tasks/winbuildscripts/Build-AgentPackages.ps1
@@ -11,6 +11,11 @@ Specifies the release version of the build. Default is the value of the environm
 .PARAMETER Flavor
 Specifies the flavor of the agent. Default is the value of the environment variable AGENT_FLAVOR.
 
+.PARAMETER BuildUpgrade
+Specifies whether to build the upgrade package. Default is false.
+
+Use this options to build an aditional MSI for testing upgrading the MSI.
+
 .PARAMETER BuildOutOfSource
 Specifies whether to build out of source. Default is $false.
 
@@ -38,7 +43,8 @@ param(
     [nullable[bool]] $CheckGoVersion,
     [bool] $InstallDeps = $true,
     [string] $ReleaseVersion = $env:RELEASE_VERSION,
-    [string] $Flavor = $env:AGENT_FLAVOR
+    [string] $Flavor = $env:AGENT_FLAVOR,
+    [bool] $BuildUpgrade = $false
 )
 
 . "$PSScriptRoot\common.ps1"
@@ -61,6 +67,11 @@ Invoke-BuildScript `
         $inv_args += "--flavor"
         $inv_args += $Flavor
         $env:AGENT_FLAVOR=$Flavor
+    }
+
+    if ($BuildUpgrade) {
+        $inv_args += "--build-upgrade"
+        $env:BUILD_UPGRADE=$BuildUpgrade
     }
 
     Write-Host "inv -e winbuild.agent-package $inv_args"

--- a/tasks/winbuildscripts/Build-AgentPackages.ps1
+++ b/tasks/winbuildscripts/Build-AgentPackages.ps1
@@ -71,7 +71,6 @@ Invoke-BuildScript `
 
     if ($BuildUpgrade) {
         $inv_args += "--build-upgrade"
-        $env:BUILD_UPGRADE=$BuildUpgrade
     }
 
     Write-Host "inv -e winbuild.agent-package $inv_args"

--- a/test/new-e2e/tests/windows/common/agent/agent.go
+++ b/test/new-e2e/tests/windows/common/agent/agent.go
@@ -14,12 +14,13 @@ import (
 	"testing"
 	"time"
 
+	infraCommon "github.com/DataDog/test-infra-definitions/common"
+
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
-	infraCommon "github.com/DataDog/test-infra-definitions/common"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,11 @@ func GetCodeSignatureThumbprints() map[string]struct{} {
 // GetDatadogAgentProductCode returns the product code GUID for the Datadog Agent
 func GetDatadogAgentProductCode(host *components.RemoteHost) (string, error) {
 	return windowsCommon.GetProductCodeByName(host, "Datadog Agent")
+}
+
+// GetDatadogProductVersionByName
+func GetDatadogProductVersion(host *components.RemoteHost) (string, error) {
+	return windowsCommon.GetProductVersionByName(host, "Datadog Agent")
 }
 
 // InstallAgent installs the agent and returns the remote MSI path and any errors

--- a/test/new-e2e/tests/windows/common/agent/agent.go
+++ b/test/new-e2e/tests/windows/common/agent/agent.go
@@ -56,7 +56,7 @@ func GetDatadogAgentProductCode(host *components.RemoteHost) (string, error) {
 	return windowsCommon.GetProductCodeByName(host, "Datadog Agent")
 }
 
-// GetDatadogProductVersionByName
+// GetDatadogProductVersion returns the product version for the Datadog Agent
 func GetDatadogProductVersion(host *components.RemoteHost) (string, error) {
 	return windowsCommon.GetProductVersionByName(host, "Datadog Agent")
 }

--- a/test/new-e2e/tests/windows/common/agent/package.go
+++ b/test/new-e2e/tests/windows/common/agent/package.go
@@ -145,14 +145,12 @@ func GetLatestMSIURL(majorVersion string, arch string, flavor string) (string, e
 // majorVersion: 6, 7
 // arch: x86_64
 // flavor: base, fips
-func GetPipelineMSIURL(pipelineID string, majorVersion string, arch string, flavor string, upgradeTest bool) (string, error) {
+func GetPipelineMSIURL(pipelineID string, majorVersion string, arch string, flavor string, nameSuffix string) (string, error) {
 	productName, err := GetFlavorProductName(flavor)
 	if err != nil {
 		return "", err
 	}
-	if upgradeTest {
-		productName = fmt.Sprintf("%s-upgrade-test", productName)
-	}
+	productName = fmt.Sprintf("%s%s", productName, nameSuffix)
 	// Manual URL example: https://s3.amazonaws.com/dd-agent-mstesting?prefix=pipelines/A7/25309493
 	fmt.Printf("Looking for agent MSI for pipeline majorVersion %v %v\n", majorVersion, pipelineID)
 	artifactURL, err := pipeline.GetPipelineArtifact(pipelineID, pipeline.AgentS3BucketTesting, majorVersion, func(artifact string) bool {
@@ -340,7 +338,7 @@ func GetPackageFromEnv() (*Package, error) {
 
 	// check if we should use the URL from a specific CI pipeline
 	if pipelineIDFound {
-		url, err := GetPipelineMSIURL(pipelineID, majorVersion, arch, flavor, false)
+		url, err := GetPipelineMSIURL(pipelineID, majorVersion, arch, flavor, "")
 		if err != nil {
 			return nil, err
 		}
@@ -462,7 +460,7 @@ func GetUpgradeTestPackageFromEnv() (*Package, error) {
 
 	// check if we should use the URL from a specific CI pipeline
 	if pipelineIDFound {
-		url, err := GetPipelineMSIURL(pipelineID, majorVersion, arch, flavor, true)
+		url, err := GetPipelineMSIURL(pipelineID, majorVersion, arch, flavor, "-upgrade-test")
 		if err != nil {
 			return nil, err
 		}

--- a/test/new-e2e/tests/windows/common/product.go
+++ b/test/new-e2e/tests/windows/common/product.go
@@ -28,3 +28,24 @@ func GetProductCodeByName(host *components.RemoteHost, name string) (string, err
 	}
 	return val, nil
 }
+
+// GetProductVersionByName returns the product version for the given product name
+// Pulls version from MSI registry infomration
+func GetProductVersionByName(host *components.RemoteHost, name string) (string, error) {
+	// get GUID
+	guid, err := GetProductCodeByName(host, name)
+	if err != nil {
+		return "", err
+	}
+	// get verion string
+	cmd := fmt.Sprintf(`(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\%s).DisplayVersion`, guid)
+	val, err := host.Execute(cmd)
+	if err != nil {
+		return "", err
+	}
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return "", fmt.Errorf("display version not found")
+	}
+	return val, nil
+}

--- a/test/new-e2e/tests/windows/common/product.go
+++ b/test/new-e2e/tests/windows/common/product.go
@@ -38,7 +38,7 @@ func GetProductVersionByName(host *components.RemoteHost, name string) (string, 
 		return "", err
 	}
 	// get verion string
-	cmd := fmt.Sprintf(`(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\%s).DisplayVersion`, guid)
+	cmd := fmt.Sprintf(`(Get-ItemProperty -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\%s").DisplayVersion`, guid)
 	val, err := host.Execute(cmd)
 	if err != nil {
 		return "", err

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -127,19 +128,21 @@ func (s *testUpgradeFromLatestSuite) TestUpgradeFromLatest() {
 
 	// Get Display Version
 	productVersion, err := windowsAgent.GetDatadogProductVersion(vm)
-	assert.NoError(s.T(), err, "should get product version")
+	s.Require().NoError(err, "should get product version")
 
 	// split version string by .
 	versionParts := strings.Split(productVersion, ".")
 
-	// verify there are three parts
-	assert.Len(s.T(), versionParts, 4, "Version should have four parts")
+	// verify there are four parts
+	require.Len(s.T(), versionParts, 4, "Version should have four parts")
 
 	// get version parts of the upgrade test version
 	ver, _ := version.New(strings.TrimSuffix(s.upgradeAgentPackge.Version, "-1"), "")
 
 	// check if the version is the same as the upgrade test version
-	assert.Equal(s.T(), ver.Patch+1, versionParts[2], "Patch version should increment by 1")
+	patchVersion, err := strconv.Atoi(versionParts[2])
+	s.Require().NoError(err, "should convert patch version to int")
+	assert.Equal(s.T(), ver.Patch+1, patchVersion, "Patch version should increment by 1")
 
 	s.uninstallAgentAndRunUninstallTests(t)
 

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -96,6 +96,7 @@ func (s *testUpgradeFromLatestSuite) TestUpgradeFromLatest() {
 		_, err := s.InstallAgent(vm,
 			windowsAgent.WithPackage(s.AgentPackage),
 			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install.log")),
+			windowsAgent.WithValidAPIKey(),
 		)
 		s.Require().NoError(err, "Agent should be %s", s.AgentPackage.AgentVersion())
 	}) {
@@ -107,6 +108,7 @@ func (s *testUpgradeFromLatestSuite) TestUpgradeFromLatest() {
 		_, err := s.InstallAgent(vm,
 			windowsAgent.WithPackage(s.upgradeAgentPackge),
 			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
+			windowsAgent.WithValidAPIKey(),
 		)
 		s.Require().NoError(err, "should upgrade to agent %s", s.upgradeAgentPackge.AgentVersion())
 	}) {

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -142,7 +142,7 @@ func (s *testUpgradeFromLatestSuite) TestUpgradeFromLatest() {
 	// check if the version is the same as the upgrade test version
 	patchVersion, err := strconv.Atoi(versionParts[2])
 	s.Require().NoError(err, "should convert patch version to int")
-	assert.Equal(s.T(), ver.Patch+1, patchVersion, "Patch version should increment by 1")
+	assert.Equal(s.T(), ver.Patch+1, int64(patchVersion), "Patch version should increment by 1")
 
 	s.uninstallAgentAndRunUninstallTests(t)
 

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/version"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	servicetest "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/install-test/service-test"
 
@@ -125,7 +124,7 @@ func (s *testUpgradeFromLatestSuite) TestUpgradeFromLatest() {
 	}
 
 	// Get Display Version
-	productVersion, err := agent.GetDatadogProductVersion(vm)
+	productVersion, err := windowsAgent.GetDatadogProductVersion(vm)
 	assert.NoError(s.T(), err, "should get product version")
 
 	// split version string by .

--- a/test/new-e2e/tests/windows/install-test/upgrade_test.go
+++ b/test/new-e2e/tests/windows/install-test/upgrade_test.go
@@ -73,6 +73,59 @@ func (s *testUpgradeSuite) TestUpgrade() {
 	s.uninstallAgentAndRunUninstallTests(t)
 }
 
+// TestUpgrade tests upgrading the agent from WINDOWS_AGENT_VERSION to UPGRADE_TEST_VERSION
+func TestUpgradeFromLatest(t *testing.T) {
+	s := &testUpgradeFromLatestSuite{}
+	upgradeAgentPackge, err := windowsAgent.GetUpgradeTestPackageFromEnv()
+	require.NoError(t, err, "should get last stable agent package from env")
+	s.upgradeAgentPackge = upgradeAgentPackge
+	run(t, s)
+}
+
+type testUpgradeFromLatestSuite struct {
+	baseAgentMSISuite
+	upgradeAgentPackge *windowsAgent.Package
+}
+
+func (s *testUpgradeFromLatestSuite) TestUpgradeFromLatest() {
+	vm := s.Env().RemoteHost
+
+	// install current version
+	if !s.Run(fmt.Sprintf("install %s", s.AgentPackage.AgentVersion()), func() {
+		_, err := s.InstallAgent(vm,
+			windowsAgent.WithPackage(s.AgentPackage),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
+		)
+		s.Require().NoError(err, "Agent should be %s", s.AgentPackage.AgentVersion())
+	}) {
+		s.T().FailNow()
+	}
+
+	// upgrade to test agent
+	if !s.Run(fmt.Sprintf("upgrade to %s", s.upgradeAgentPackge.AgentVersion()), func() {
+		_, err := s.InstallAgent(vm,
+			windowsAgent.WithPackage(s.upgradeAgentPackge),
+			windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "upgrade.log")),
+		)
+		s.Require().NoError(err, "should upgrade to agent %s", s.upgradeAgentPackge.AgentVersion())
+	}) {
+		s.T().FailNow()
+	}
+
+	// run tests
+	testerOptions := []TesterOption{
+		WithAgentPackage(s.upgradeAgentPackge),
+	}
+	t, err := NewTester(s, vm, testerOptions...)
+	s.Require().NoError(err, "should create tester")
+	if !t.TestInstallExpectations(s.T()) {
+		s.T().FailNow()
+	}
+
+	s.uninstallAgentAndRunUninstallTests(t)
+
+}
+
 func TestUpgradeRollback(t *testing.T) {
 	s := &testUpgradeRollbackSuite{}
 	run(t, s)

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
@@ -28,34 +28,34 @@ namespace WixSetup.Datadog_Agent
     internal class FIPSAgent : IAgentFlavor
     {
         private readonly AgentVersion _agentVersion;
-        private readonly string _upgradeTestName;
+        private readonly string _agentNameSuffix;
 
         public FIPSAgent(AgentVersion agentVersion)
         {
             _agentVersion = agentVersion;
-            _upgradeTestName = Environment.GetEnvironmentVariable("UPGRADE_TEST");
+            _agentNameSuffix = Environment.GetEnvironmentVariable("AGENT_PRODUCT_NAME_SUFFIX");
         }
 
         public string ProductFullName => "Datadog FIPS Agent";
         public Guid UpgradeCode => new("de421174-9615-4fe9-b8a8-2b3f123bdc4f");
         public string ProductDescription => $"Datadog FIPS Agent {_agentVersion.PackageVersion}";
-        public string PackageOutFileName => $"datadog-fips-agent-{_upgradeTestName}{_agentVersion.PackageVersion}-1-x86_64";
+        public string PackageOutFileName => $"datadog-fips-agent-{_agentNameSuffix}{_agentVersion.PackageVersion}-1-x86_64";
     }
 
     internal class BaseAgent : IAgentFlavor
     {
         private readonly AgentVersion _agentVersion;
-        private readonly string _upgradeTestName;
+        private readonly string _agentNameSuffix;
 
         public BaseAgent(AgentVersion agentVersion)
         {
             _agentVersion = agentVersion;
-            _upgradeTestName = Environment.GetEnvironmentVariable("UPGRADE_TEST");
+            _agentNameSuffix = Environment.GetEnvironmentVariable("AGENT_PRODUCT_NAME_SUFFIX");
         }
 
         public string ProductFullName => "Datadog Agent";
         public Guid UpgradeCode => new("0c50421b-aefb-4f15-a809-7af256d608a5");
         public string ProductDescription => $"Datadog Agent {_agentVersion.PackageVersion}";
-        public string PackageOutFileName => $"datadog-agent-{_upgradeTestName}{_agentVersion.PackageVersion}-1-x86_64";
+        public string PackageOutFileName => $"datadog-agent-{_agentNameSuffix}{_agentVersion.PackageVersion}-1-x86_64";
     }
 }

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentFlavor.cs
@@ -28,30 +28,34 @@ namespace WixSetup.Datadog_Agent
     internal class FIPSAgent : IAgentFlavor
     {
         private readonly AgentVersion _agentVersion;
+        private readonly string _upgradeTestName;
 
         public FIPSAgent(AgentVersion agentVersion)
         {
             _agentVersion = agentVersion;
+            _upgradeTestName = Environment.GetEnvironmentVariable("UPGRADE_TEST");
         }
 
         public string ProductFullName => "Datadog FIPS Agent";
         public Guid UpgradeCode => new("de421174-9615-4fe9-b8a8-2b3f123bdc4f");
         public string ProductDescription => $"Datadog FIPS Agent {_agentVersion.PackageVersion}";
-        public string PackageOutFileName => $"datadog-fips-agent-{_agentVersion.PackageVersion}-1-x86_64";
+        public string PackageOutFileName => $"datadog-fips-agent-{_upgradeTestName}{_agentVersion.PackageVersion}-1-x86_64";
     }
 
     internal class BaseAgent : IAgentFlavor
     {
         private readonly AgentVersion _agentVersion;
+        private readonly string _upgradeTestName;
 
         public BaseAgent(AgentVersion agentVersion)
         {
             _agentVersion = agentVersion;
+            _upgradeTestName = Environment.GetEnvironmentVariable("UPGRADE_TEST");
         }
 
         public string ProductFullName => "Datadog Agent";
         public Guid UpgradeCode => new("0c50421b-aefb-4f15-a809-7af256d608a5");
         public string ProductDescription => $"Datadog Agent {_agentVersion.PackageVersion}";
-        public string PackageOutFileName => $"datadog-agent-{_agentVersion.PackageVersion}-1-x86_64";
+        public string PackageOutFileName => $"datadog-agent-{_upgradeTestName}{_agentVersion.PackageVersion}-1-x86_64";
     }
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a test MSI to the pipe line to test upgrading from latest to fake new version.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-992

Writes test to prevent future problems where latest doesn't correctly upgrade. Also allows for test to third party integrations feature (#32528).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Only adds new e2e tests and msi build.

### Possible Drawbacks / Trade-offs

Tradeoff include that we are only building a new MSI, this means that the version numbers of the agent are not updated. This means we are only partially testing the complete upgrade of the agent. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->