### PR TITLE
fix(download_with_retry): Prevent calling method with wrong number of arguments

### DIFF
--- a/tasks/libs/ciproviders/github_actions_tools.py
+++ b/tasks/libs/ciproviders/github_actions_tools.py
@@ -324,7 +324,7 @@ def download_with_retry(
     destination=".",
     retry_count=3,
     retry_interval=10,
-    repository="DataDog/datadog-agent-macos-build",
+    repository=None,
 ):
     import requests
 
@@ -332,7 +332,11 @@ def download_with_retry(
 
     while retry > 0:
         try:
-            download_function(run, destination, repository)
+            if repository:
+                # download_artifacts with repository argument
+                download_function(run, destination, repository)
+            else:
+                download_function(run, destination)
             print(color_message(f"Download successful for run {run.id} to {destination}", "blue"))
             return
         except (requests.exceptions.RequestException, ConnectionError):

--- a/tasks/unit_tests/github_actions_tools_tests.py
+++ b/tasks/unit_tests/github_actions_tools_tests.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+from invoke.exceptions import Exit
+
+from tasks.libs.ciproviders.github_actions_tools import download_artifacts, download_logs, download_with_retry
+
+
+class TestDownloadWithRetry(unittest.TestCase):
+    def setUp(self) -> None:
+        self.gh = MagicMock()
+        self.gh._auth.token = "largo_winch"
+
+    @patch('tasks.libs.ciproviders.github_actions_tools.GithubAPI')
+    @patch('tasks.libs.ciproviders.github_actions_tools.zipfile.ZipFile', new=MagicMock())
+    def test_download_log(self, gh_mock):
+        run = MagicMock()
+        gh_mock.return_value = self.gh
+        download_with_retry(download_function=download_logs, run=run, destination='.', retry_count=3, retry_interval=1)
+
+    @patch('tasks.libs.ciproviders.github_actions_tools.GithubAPI')
+    @patch('tasks.libs.ciproviders.github_actions_tools.zipfile.ZipFile', new=MagicMock())
+    def test_downloads_artifacts_with_repository(self, gh_mock):
+        run = MagicMock()
+        gh_mock.return_value = self.gh
+        download_with_retry(
+            download_function=download_artifacts, run=run, destination='.', retry_count=3, retry_interval=1
+        )
+
+    @patch('tasks.libs.ciproviders.github_actions_tools.GithubAPI')
+    @patch('tasks.libs.ciproviders.github_actions_tools.zipfile.ZipFile', new=MagicMock())
+    def test_downloads_artifacts_without_repository(self, gh_mock):
+        run = MagicMock()
+        gh_mock.return_value = self.gh
+        download_with_retry(
+            download_function=download_artifacts,
+            run=run,
+            destination='.',
+            retry_count=3,
+            retry_interval=1,
+            repository="simon_ovronnaz",
+        )
+
+    @patch('builtins.print')
+    @patch('tasks.libs.ciproviders.github_actions_tools.GithubAPI')
+    @patch('tasks.libs.ciproviders.github_actions_tools.zipfile.ZipFile', new=MagicMock(side_effect=ConnectionError))
+    def test_connection_error(self, gh_mock, print_mock):
+        run = MagicMock()
+        gh_mock.return_value = self.gh
+        with self.assertRaises(Exit):
+            download_with_retry(
+                download_function=download_logs, run=run, destination='.', retry_count=2, retry_interval=1
+            )
+        self.assertEqual(print_mock.call_count, 5)
+        print_mock.assert_has_calls([call('Connectivity issue while downloading, retrying... 0 attempts left')])
+
+    @patch('builtins.print')
+    @patch('tasks.libs.ciproviders.github_actions_tools.GithubAPI')
+    @patch('tasks.libs.ciproviders.github_actions_tools.zipfile.ZipFile', new=MagicMock(side_effect=LookupError))
+    def test_other_error(self, gh_mock, print_mock):
+        run = MagicMock()
+        gh_mock.return_value = self.gh
+        with self.assertRaises(LookupError):
+            download_with_retry(
+                download_function=download_logs, run=run, destination='.', retry_count=1, retry_interval=1
+            )
+        self.assertEqual(print_mock.call_count, 2)
+        self.assertTrue(print_mock.call_args_list[-1].startswith('Exception that is not a connectivity issue'))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Prevent call of `download_logs` with the wrong number of arguments. This issue was introduced by #31971, which added a new argument to `download_artifacts`

### Motivation
Prevent [this kind of failure](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/753353508)

### Describe how you validated your changes
Added unit tests
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->