### PR TITLE
[SBOM] Do not use cyclonedx 1.6 version for cyclonedx 1.4

### DIFF
--- a/pkg/collector/corechecks/sbom/convert.go
+++ b/pkg/collector/corechecks/sbom/convert.go
@@ -130,7 +130,7 @@ func convertBOM(in *cyclonedx.BOM) *cyclonedx_v1_4.Bom {
 	}
 
 	return &cyclonedx_v1_4.Bom{
-		SpecVersion:        in.SpecVersion.String(),
+		SpecVersion:        cyclonedx.SpecVersion1_4.String(),
 		Version:            pointer.Ptr(int32(in.Version)),
 		SerialNumber:       stringPtr(in.SerialNumber),
 		Metadata:           convertMetadata(in.Metadata),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use the correct specification version for CycloneDX 1.4

### Motivation

When converting from a CycloneDX 1.6 to a 1.4, we also copy the spec version.
So we end up having 1.4 SBOMs sent with the spec version 1.6.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->