### PR TITLE
feat(fleet): Add install info on installer script install

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent.go
+++ b/pkg/fleet/installer/packages/datadog_agent.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const (
@@ -143,8 +144,7 @@ func SetupAgent(ctx context.Context, _ []string) (err error) {
 	}
 
 	// write installinfo before start, or the agent could write it
-	// TODO: add installer version properly
-	if err = installinfo.WriteInstallInfo("installer_package", "manual_update"); err != nil {
+	if err = installinfo.WriteInstallInfo("installer", fmt.Sprintf("installer-%s", version.AgentVersion), "manual_update"); err != nil {
 		return fmt.Errorf("failed to write install info: %v", err)
 	}
 

--- a/pkg/fleet/installer/setup/common/setup.go
+++ b/pkg/fleet/installer/setup/common/setup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
 	"github.com/DataDog/datadog-agent/pkg/fleet/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -113,6 +114,10 @@ func (s *Setup) Run() (err error) {
 	err = s.installPackage("datadog-installer", installerOCILayoutURL)
 	if err != nil {
 		return fmt.Errorf("failed to install installer: %w", err)
+	}
+	err = installinfo.WriteInstallInfo("installer", fmt.Sprintf("installer-%s", version.AgentVersion), fmt.Sprintf("install-%s.sh", s.flavor))
+	if err != nil {
+		return fmt.Errorf("failed to write install info: %w", err)
 	}
 	for _, p := range packages {
 		url := oci.PackageURL(s.Env, p.name, p.version)

--- a/pkg/util/installinfo/install_info_nix_test.go
+++ b/pkg/util/installinfo/install_info_nix_test.go
@@ -74,11 +74,11 @@ func TestDoubleWrite(t *testing.T) {
 	s, _ := getFromPath(installInfoFile)
 	assert.Nil(t, s)
 
-	assert.NoError(t, WriteInstallInfo("v1", ""))
+	assert.NoError(t, WriteInstallInfo("dpkg", "v1", ""))
 	v1, err := getFromPath(installInfoFile)
 	assert.NoError(t, err)
 
-	assert.NoError(t, WriteInstallInfo("v2", ""))
+	assert.NoError(t, WriteInstallInfo("dpkg", "v2", ""))
 	v2, err := getFromPath(installInfoFile)
 	assert.NoError(t, err)
 
@@ -89,7 +89,7 @@ func TestRmInstallInfo(t *testing.T) {
 	tmpDir := t.TempDir()
 	installInfoFile = filepath.Join(tmpDir, "install_info")
 	installSigFile = filepath.Join(tmpDir, "install.json")
-	assert.NoError(t, WriteInstallInfo("v1", ""))
+	assert.NoError(t, WriteInstallInfo("tool", "v1", ""))
 
 	assert.True(t, fileExists(installInfoFile))
 	assert.True(t, fileExists(installSigFile))

--- a/pkg/util/installinfo/install_info_windows.go
+++ b/pkg/util/installinfo/install_info_windows.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package installinfo
+
+// WriteInstallInfo write install info and signature files
+func WriteInstallInfo(_, _, _ string) error {
+	// Placeholder for Windows, this is done in tools/windows/DatadogAgentInstaller
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?
Adds install method for the "installer install script"

### Motivation
Clean install method for the new "installer install script"; that include flavors

### Describe how you validated your changes
Manual QA on a VM

### Possible Drawbacks / Trade-offs
Only the Datadog installer uses these methods so there will be no impact on the other install methods whatsoever.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->