### PR TITLE
Correctly tag mulitline logs for regex multi line handler.

### DIFF
--- a/pkg/logs/internal/decoder/multiline_handler.go
+++ b/pkg/logs/internal/decoder/multiline_handler.go
@@ -168,7 +168,7 @@ func (h *MultiLineHandler) sendBuffer() {
 		if h.isBufferTruncated && pkgconfigsetup.Datadog().GetBool("logs_config.tag_truncated_logs") {
 			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.TruncatedReasonTag("multiline_regex"))
 		}
-		if h.isBufferTruncated && pkgconfigsetup.Datadog().GetBool("logs_config.tag_multi_line_logs") {
+		if h.linesCombined > 1 && pkgconfigsetup.Datadog().GetBool("logs_config.tag_multi_line_logs") {
 			msg.ParsingExtra.Tags = append(msg.ParsingExtra.Tags, message.MultiLineSourceTag(h.multiLineTagValue))
 		}
 		h.outputFn(msg)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes tagging multiline logs when using the regex multiline handler. We should be tagging multiline logs even when they are not truncated. This is a telemetry only change, and is disabled by default so there is no functional impact. 

### Motivation

### Describe how you validated your changes
1. setup the agent with the following config

```yaml
logs_config:
    auto_multi_line_detection: true
    tag_multi_line_logs: true
```

2. send some multiline logs that will be detected by the auto multiline handler
ex (but with more lines): 
```
2024-08-14 18:06:05 INFO Main main Some log line 150
2024-08-14 18:06:05 SEVERE Main main Exception occur
java.lang.Exception: boom
	at Main.funcd(Main.java:50)
	at Main.funcc(Main.java:49)
	at Main.funcb(Main.java:48)
	at Main.funca(Main.java:47)
	at Main.main(Main.java:29)

2024-08-14 18:06:05 INFO Main main Some log line 151
2024-08-14 18:06:05 INFO Main main Some log line 152
```

3. Confirm in the logs explorer that the logs are correctly aggregated and tagged with the `multiline` tag. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[](https://datadoghq.atlassian.net/browse/AMLII-2230)