### PR TITLE
[CWS] Resolve context using pid for CgroupTracing events

### DIFF
--- a/pkg/security/ebpf/c/include/events_definition.h
+++ b/pkg/security/ebpf/c/include/events_definition.h
@@ -134,6 +134,7 @@ struct cgroup_tracing_event_t {
     struct container_context_t container;
     struct activity_dump_config config;
     u64 cookie;
+    u32 pid;
 };
 
 struct cgroup_write_event_t {

--- a/pkg/security/ebpf/c/include/helpers/activity_dump.h
+++ b/pkg/security/ebpf/c/include/helpers/activity_dump.h
@@ -121,6 +121,7 @@ __attribute__((always_inline)) u64 trace_new_cgroup(void *ctx, u64 now, struct c
     evt->container.cgroup_context = container->cgroup_context;
     evt->cookie = cookie;
     evt->config = config;
+    evt->pid = bpf_get_current_pid_tgid() >> 32;
     send_event_ptr(ctx, EVENT_CGROUP_TRACING, evt);
 
     return cookie;

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -731,6 +731,27 @@ func (p *EBPFProbe) zeroEvent() *model.Event {
 	return p.event
 }
 
+func (p *EBPFProbe) resolveCGroup(pid uint32, cgroupPathKey model.PathKey, cgroupFlags containerutils.CGroupFlags, newEntryCb func(entry *model.ProcessCacheEntry, err error)) (*model.CGroupContext, error) {
+	pce := p.Resolvers.ProcessResolver.Resolve(pid, pid, 0, false, newEntryCb)
+	if pce != nil {
+		cgroupContext, err := p.Resolvers.ResolveCGroupContext(cgroupPathKey, cgroupFlags)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resorve cgroup for pid %d: %w", pid, err)
+		}
+
+		pce.Process.CGroup = *cgroupContext
+		pce.CGroup = *cgroupContext
+		if cgroupContext.CGroupFlags.IsContainer() {
+			containerID, _ := containerutils.FindContainerID(cgroupContext.CGroupID)
+			pce.ContainerID = containerID
+			pce.Process.ContainerID = containerID
+		}
+	} else {
+		return nil, fmt.Errorf("entry not found for pid %d", pid)
+	}
+	return &pce.CGroup, nil
+}
+
 func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 	// handle play snapshot
 	if p.playSnapShotState.Swap(false) {
@@ -810,44 +831,25 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("shouldn't receive Cgroup event if activity dumps are disabled")
 			return
 		}
-
 		if _, err = event.CgroupTracing.UnmarshalBinary(data[offset:]); err != nil {
 			seclog.Errorf("failed to decode cgroup tracing event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
-
-		cgroupContext, err := p.Resolvers.ResolveCGroupContext(event.CgroupTracing.CGroupContext.CGroupFile, containerutils.CGroupFlags(event.CgroupTracing.CGroupContext.CGroupFlags))
-		if err != nil {
-			seclog.Debugf("Failed to resolve cgroup: %s", err)
+		if cgroupContext, err := p.resolveCGroup(event.CgroupTracing.Pid, event.CgroupTracing.CGroupContext.CGroupFile, event.CgroupTracing.CGroupContext.CGroupFlags, newEntryCb); err != nil {
+			seclog.Debugf("Failed to resolve cgroup: %s", err.Error())
 		} else {
 			event.CgroupTracing.CGroupContext = *cgroupContext
 			p.profileManagers.activityDumpManager.HandleCGroupTracingEvent(&event.CgroupTracing)
 		}
-
 		return
 	case model.CgroupWriteEventType:
 		if _, err = event.CgroupWrite.UnmarshalBinary(data[offset:]); err != nil {
 			seclog.Errorf("failed to decode cgroup write released event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
-
-		pce := p.Resolvers.ProcessResolver.Resolve(event.CgroupWrite.Pid, event.CgroupWrite.Pid, 0, false, newEntryCb)
-		if pce != nil {
-			cgroupContext, err := p.Resolvers.ResolveCGroupContext(event.CgroupWrite.File.PathKey, containerutils.CGroupFlags(event.CgroupWrite.CGroupFlags))
-			if err != nil {
-				seclog.Debugf("Failed to resolve cgroup: %s", err)
-			} else {
-				pce.Process.CGroup = *cgroupContext
-				pce.CGroup = *cgroupContext
-
-				if cgroupContext.CGroupFlags.IsContainer() {
-					containerID, _ := containerutils.FindContainerID(cgroupContext.CGroupID)
-					pce.ContainerID = containerID
-					pce.Process.ContainerID = containerID
-				}
-			}
+		if _, err := p.resolveCGroup(event.CgroupWrite.Pid, event.CgroupWrite.File.PathKey, containerutils.CGroupFlags(event.CgroupWrite.CGroupFlags), newEntryCb); err != nil {
+			seclog.Debugf("Failed to resolve cgroup: %s", err.Error())
 		}
-
 		return
 	case model.UnshareMountNsEventType:
 		if _, err = event.UnshareMountNS.UnmarshalBinary(data[offset:]); err != nil {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -634,6 +634,7 @@ type CgroupTracingEvent struct {
 	ContainerContext ContainerContext
 	CGroupContext    CGroupContext
 	Config           ActivityDumpLoadConfig
+	Pid              uint32
 	ConfigCookie     uint64
 }
 

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -985,12 +985,13 @@ func (e *CgroupTracingEvent) UnmarshalBinary(data []byte) (int, error) {
 	}
 	cursor += read
 
-	if len(data)-cursor < 8 {
+	if len(data)-cursor < 12 {
 		return 0, ErrNotEnoughData
 	}
 
 	e.ConfigCookie = binary.NativeEndian.Uint64(data[cursor : cursor+8])
-	return cursor + 8, nil
+	e.Pid = binary.NativeEndian.Uint32(data[cursor+8 : cursor+12])
+	return cursor + 12, nil
 }
 
 // UnmarshalBinary unmarshals a binary representation of itself


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add `pid` to CgroupTracing events and use it to resolve process, cgroup and container contexts.

### Motivation

Using the cgroup file to resolve the context for this event type only introduces subtle bugs when
resolution fails. Using the generic PID based resolution makes use of a safer codepath.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->