### PR TITLE
chore(origindetection): consolidate External Data

### DIFF
--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -17,8 +17,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"reflect"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -43,21 +41,6 @@ import (
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
-
-const (
-	// External Data Prefixes
-	// These prefixes are used to build the External Data Environment Variable.
-	// This variable is then used for Origin Detection.
-	externalDataInitPrefix          = "it-"
-	externalDataContainerNamePrefix = "cn-"
-	externalDataPodUIDPrefix        = "pu-"
-)
-
-type externalData struct {
-	init          bool
-	containerName string
-	podUID        string
-}
 
 // Requires defines the dependencies of the tagger component.
 type Requires struct {
@@ -484,51 +467,23 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 			t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.PodUID, err)
 		}
 
-		// Tag using External Data.
-		// External Data is a list that contain prefixed-items, split by a ','. Current items are:
-		// * "it-<init>" if the container is an init container.
-		// * "cn-<container-name>" for the container name.
-		// * "pu-<pod-uid>" for the pod UID.
-		// Order does not matter.
-		// Possible values:
-		// * "it-false,cn-nginx,pu-3413883c-ac60-44ab-96e0-9e52e4e173e2"
-		// * "cn-init,pu-cb4aba1d-0129-44f1-9f1b-b4dc5d29a3b3,it-true"
-		if originInfo.ExternalData != "" {
-			// Parse the external data and get the tags for the entity
-			var parsedExternalData externalData
-			var initParsingError error
-			for _, item := range strings.Split(originInfo.ExternalData, ",") {
-				switch {
-				case strings.HasPrefix(item, externalDataInitPrefix):
-					parsedExternalData.init, initParsingError = strconv.ParseBool(item[len(externalDataInitPrefix):])
-					if initParsingError != nil {
-						t.log.Tracef("Cannot parse bool from %s: %s", item[len(externalDataInitPrefix):], initParsingError)
-					}
-				case strings.HasPrefix(item, externalDataContainerNamePrefix):
-					parsedExternalData.containerName = item[len(externalDataContainerNamePrefix):]
-				case strings.HasPrefix(item, externalDataPodUIDPrefix):
-					parsedExternalData.podUID = item[len(externalDataPodUIDPrefix):]
-				}
+		// Accumulate tags for pod UID
+		if originInfo.ExternalData.PodUID != "" {
+			if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.ExternalData.PodUID), cardinality, tb); err != nil {
+				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.ContainerID, err)
 			}
+		}
 
-			// Accumulate tags for pod UID
-			if parsedExternalData.podUID != "" {
-				if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, parsedExternalData.podUID), cardinality, tb); err != nil {
-					t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.ContainerID, err)
-				}
-			}
+		// Generate container ID from External Data
+		generatedContainerID, err := t.generateContainerIDFromExternalData(originInfo.ExternalData, metrics.GetProvider(option.New(t.wmeta)).GetMetaCollector())
+		if err != nil {
+			t.log.Tracef("Failed to generate container ID from %s: %s", originInfo.ExternalData, err)
+		}
 
-			// Generate container ID from External Data
-			generatedContainerID, err := t.generateContainerIDFromExternalData(parsedExternalData, metrics.GetProvider(option.New(t.wmeta)).GetMetaCollector())
-			if err != nil {
-				t.log.Tracef("Failed to generate container ID from %s: %s", originInfo.ExternalData, err)
-			}
-
-			// Accumulate tags for generated container ID
-			if generatedContainerID != "" {
-				if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, generatedContainerID), cardinality, tb); err != nil {
-					t.log.Tracef("Cannot get tags for entity %s: %s", generatedContainerID, err)
-				}
+		// Accumulate tags for generated container ID
+		if generatedContainerID != "" {
+			if err := t.AccumulateTagsFor(types.NewEntityID(types.ContainerID, generatedContainerID), cardinality, tb); err != nil {
+				t.log.Tracef("Cannot get tags for entity %s: %s", generatedContainerID, err)
 			}
 		}
 	}
@@ -544,8 +499,8 @@ func (t *TaggerWrapper) GenerateContainerIDFromOriginInfo(originInfo origindetec
 }
 
 // generateContainerIDFromExternalData generates a container ID from the External Data.
-func (t *TaggerWrapper) generateContainerIDFromExternalData(e externalData, metricsProvider provider.ContainerIDForPodUIDAndContNameRetriever) (string, error) {
-	return metricsProvider.ContainerIDForPodUIDAndContName(e.podUID, e.containerName, e.init, time.Second)
+func (t *TaggerWrapper) generateContainerIDFromExternalData(e origindetection.ExternalData, metricsProvider provider.ContainerIDForPodUIDAndContNameRetriever) (string, error) {
+	return metricsProvider.ContainerIDForPodUIDAndContName(e.PodUID, e.ContainerName, e.Init, time.Second)
 }
 
 // ChecksCardinality defines the cardinality of tags we should send for check metrics

--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -138,32 +138,70 @@ func TestEnrichTags(t *testing.T) {
 		setup        func() // register the proper meta collector for the test
 	}{
 		{
-			name:         "with external data (containerName) and high cardinality",
-			originInfo:   taggertypes.OriginInfo{ProductOrigin: origindetection.ProductOriginAPM, ExternalData: fmt.Sprintf("cn-%s,it-false", containerName), Cardinality: "high"},
+			name: "with external data (containerName) and high cardinality",
+			originInfo: taggertypes.OriginInfo{
+				ProductOrigin: origindetection.ProductOriginAPM,
+				ExternalData: origindetection.ExternalData{
+					Init:          false,
+					ContainerName: containerName,
+				},
+				Cardinality: "high",
+			},
 			expectedTags: []string{},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&containerMetaCollector) },
 		},
 		{
-			name:         "with external data (containerName, podUID) and low cardinality",
-			originInfo:   taggertypes.OriginInfo{ProductOrigin: origindetection.ProductOriginAPM, ExternalData: fmt.Sprintf("it-invalid,cn-%s,pu-%s", containerName, podUID), Cardinality: "low"},
+			name: "with external data (containerName, podUID) and low cardinality",
+			originInfo: taggertypes.OriginInfo{
+				ProductOrigin: origindetection.ProductOriginAPM,
+				ExternalData: origindetection.ExternalData{
+					Init:          false,
+					ContainerName: containerName,
+					PodUID:        podUID,
+				},
+				Cardinality: "low",
+			},
 			expectedTags: []string{"pod-low", "container-low"},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&containerMetaCollector) },
 		},
 		{
-			name:         "with external data (podUID) and high cardinality",
-			originInfo:   taggertypes.OriginInfo{ProductOrigin: origindetection.ProductOriginAPM, ExternalData: fmt.Sprintf("pu-%s,it-false", podUID), Cardinality: "high"},
+			name: "with external data (podUID) and high cardinality",
+			originInfo: taggertypes.OriginInfo{
+				ProductOrigin: origindetection.ProductOriginAPM,
+				ExternalData: origindetection.ExternalData{
+					Init:   false,
+					PodUID: podUID,
+				},
+				Cardinality: "high",
+			},
 			expectedTags: []string{"pod-low", "pod-orch", "pod-high"},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&containerMetaCollector) },
 		},
 		{
-			name:         "with external data (containerName, podUID) and high cardinality",
-			originInfo:   taggertypes.OriginInfo{ProductOrigin: origindetection.ProductOriginAPM, ExternalData: fmt.Sprintf("pu-%s,it-false,cn-%s", podUID, containerName), Cardinality: "high"},
+			name: "with external data (containerName, podUID) and high cardinality",
+			originInfo: taggertypes.OriginInfo{
+				ProductOrigin: origindetection.ProductOriginAPM,
+				ExternalData: origindetection.ExternalData{
+					Init:          false,
+					ContainerName: containerName,
+					PodUID:        podUID,
+				},
+				Cardinality: "high",
+			},
 			expectedTags: []string{"pod-low", "pod-orch", "pod-high", "container-low", "container-orch", "container-high"},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&containerMetaCollector) },
 		},
 		{
-			name:         "with external data (containerName, podUID, initContainer) and low cardinality",
-			originInfo:   taggertypes.OriginInfo{ProductOrigin: origindetection.ProductOriginAPM, ExternalData: fmt.Sprintf("pu-%s,cn-%s,it-true", podUID, initContainerName), Cardinality: "low"},
+			name: "with external data (containerName, podUID, initContainer) and low cardinality",
+			originInfo: taggertypes.OriginInfo{
+				ProductOrigin: origindetection.ProductOriginAPM,
+				ExternalData: origindetection.ExternalData{
+					Init:          true,
+					ContainerName: initContainerName,
+					PodUID:        podUID,
+				},
+				Cardinality: "low",
+			},
 			expectedTags: []string{"pod-low", "init-container-low"},
 			setup:        func() { mockMetricsProvider.RegisterMetaCollector(&initContainerMetaCollector) },
 		},
@@ -235,22 +273,22 @@ func TestEnrichTagsOptOut(t *testing.T) {
 func TestGenerateContainerIDFromExternalData(t *testing.T) {
 	for _, tt := range []struct {
 		name         string
-		externalData externalData
+		externalData origindetection.ExternalData
 		expected     string
 		cidProvider  *fakeCIDProvider
 	}{
 		{
 			name:         "empty",
-			externalData: externalData{},
+			externalData: origindetection.ExternalData{},
 			expected:     "",
 			cidProvider:  &fakeCIDProvider{},
 		},
 		{
 			name: "found container",
-			externalData: externalData{
-				init:          false,
-				containerName: "containerName",
-				podUID:        "podUID",
+			externalData: origindetection.ExternalData{
+				Init:          false,
+				ContainerName: "containerName",
+				PodUID:        "podUID",
 			},
 			expected: "containerID",
 			cidProvider: &fakeCIDProvider{
@@ -262,10 +300,10 @@ func TestGenerateContainerIDFromExternalData(t *testing.T) {
 		},
 		{
 			name: "found init container",
-			externalData: externalData{
-				init:          true,
-				containerName: "initContainerName",
-				podUID:        "podUID",
+			externalData: origindetection.ExternalData{
+				Init:          true,
+				ContainerName: "initContainerName",
+				PodUID:        "podUID",
 			},
 			expected: "initContainerID",
 			cidProvider: &fakeCIDProvider{
@@ -277,10 +315,10 @@ func TestGenerateContainerIDFromExternalData(t *testing.T) {
 		},
 		{
 			name: "container not found",
-			externalData: externalData{
-				init:          true,
-				containerName: "containerName",
-				podUID:        "podUID",
+			externalData: origindetection.ExternalData{
+				Init:          true,
+				ContainerName: "containerName",
+				PodUID:        "podUID",
 			},
 			expected: "",
 			cidProvider: &fakeCIDProvider{

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -37,7 +37,7 @@ type enrichConfig struct {
 }
 
 // extractTagsMetadata returns tags (client tags + host tag) and information needed to query tagger (origins, cardinality).
-func extractTagsMetadata(tags []string, originFromUDS string, originFromMsg []byte, externalData string, conf enrichConfig) ([]string, string, taggertypes.OriginInfo, metrics.MetricSource) {
+func extractTagsMetadata(tags []string, originFromUDS string, originFromMsg []byte, externalData origindetection.ExternalData, conf enrichConfig) ([]string, string, taggertypes.OriginInfo, metrics.MetricSource) {
 	host := conf.defaultHostname
 	metricSource := metrics.MetricSourceDogstatsd
 	origin := taggertypes.OriginInfo{

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
@@ -34,7 +35,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, "", conf)
+				tags, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, origindetection.ExternalData{}, conf)
 			}
 		})
 	}

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -1113,7 +1113,7 @@ func TestEnrichTags(t *testing.T) {
 		tags          []string
 		originFromUDS string
 		originFromMsg []byte
-		externalData  string
+		externalData  origindetection.ExternalData
 		conf          enrichConfig
 	}
 	tests := []struct {
@@ -1128,7 +1128,7 @@ func TestEnrichTags(t *testing.T) {
 			name: "empty tags, host=foo",
 			args: args{
 				originFromUDS: "",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1144,7 +1144,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod"},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1160,7 +1160,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          nil,
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1176,7 +1176,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "my-id")},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1192,7 +1192,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "none")},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: true,
@@ -1208,7 +1208,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42")},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1224,7 +1224,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.HighCardinalityString},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1240,7 +1240,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.OrchestratorCardinalityString},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1256,7 +1256,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.LowCardinalityString},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1272,7 +1272,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.UnknownCardinalityString},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1288,7 +1288,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix},
 				originFromUDS: "originID",
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
 					entityIDPrecedenceEnabled: false,
@@ -1305,7 +1305,7 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
@@ -1321,7 +1321,7 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
-				externalData:  "",
+				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
@@ -1336,14 +1336,22 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod"},
 				originFromUDS: "",
-				externalData:  "it-false,cn-container_name,pu-pod_uid",
+				externalData: origindetection.ExternalData{
+					Init:          false,
+					ContainerName: "container_name",
+					PodUID:        "pod_uid",
+				},
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ExternalData: "it-false,cn-container_name,pu-pod_uid"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{ExternalData: origindetection.ExternalData{
+				Init:          false,
+				ContainerName: "container_name",
+				PodUID:        "pod_uid",
+			}},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1352,7 +1360,11 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
-				externalData:  "it-false,cn-container_name,pu-pod_uid",
+				externalData: origindetection.ExternalData{
+					Init:          false,
+					ContainerName: "container_name",
+					PodUID:        "pod_uid",
+				},
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
@@ -1363,7 +1375,11 @@ func TestEnrichTags(t *testing.T) {
 				ContainerIDFromSocket: "originID",
 				PodUID:                "pod-uid",
 				ContainerID:           "container-id",
-				ExternalData:          "it-false,cn-container_name,pu-pod_uid",
+				ExternalData: origindetection.ExternalData{
+					Init:          false,
+					ContainerName: "container_name",
+					PodUID:        "pod_uid",
+				},
 			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
@@ -1420,7 +1436,7 @@ func TestEnrichTagsWithJMXCheckName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", []byte{}, "", enrichConfig{})
+			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", []byte{}, origindetection.ExternalData{}, enrichConfig{})
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedMetricSource, metricSource)
 			assert.NotContains(t, tags, tt.jmxCheckName)

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/provider"
@@ -177,7 +178,7 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 	sampleRate := 1.0
 	var tags []string
 	var containerID []byte
-	var externalData string
+	var externalData origindetection.ExternalData
 	var optionalField []byte
 	var timestamp time.Time
 	for message != nil {
@@ -210,7 +211,11 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 			containerID = p.resolveContainerIDFromLocalData(optionalField)
 		// external data
 		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
-			externalData = string(optionalField[len(externalDataPrefix):])
+			rawExternalData := string(optionalField[len(externalDataPrefix):])
+			externalData, err = origindetection.ParseExternalData(rawExternalData)
+			if err != nil {
+				return dogstatsdMetricSample{}, fmt.Errorf("failed to parse OriginInfo.ExternalData %s: %v", rawExternalData, err)
+			}
 		}
 	}
 

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -41,7 +42,7 @@ type dogstatsdEvent struct {
 	// containerID represents the container ID of the sender (optional).
 	containerID []byte
 	// externalData is used for Origin Detection
-	externalData string
+	externalData origindetection.ExternalData
 }
 
 type eventHeader struct {
@@ -168,7 +169,7 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
 		newEvent.containerID = p.resolveContainerIDFromLocalData(optionalField)
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
-		newEvent.externalData = string(optionalField[len(externalDataPrefix):])
+		newEvent.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}
 	if err != nil {
 		return event, err

--- a/comp/dogstatsd/server/parse_metrics.go
+++ b/comp/dogstatsd/server/parse_metrics.go
@@ -8,6 +8,7 @@ package server
 import (
 	"bytes"
 	"fmt"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"time"
 )
 
@@ -49,7 +50,7 @@ type dogstatsdMetricSample struct {
 	// containerID represents the container ID of the sender (optional).
 	containerID []byte
 	// externalData is used for Origin Detection
-	externalData string
+	externalData origindetection.ExternalData
 	// timestamp read in the message if any
 	ts time.Time
 }

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -32,7 +33,7 @@ type dogstatsdServiceCheck struct {
 	// containerID represents the container ID of the sender (optional).
 	containerID []byte
 	// externalData is used for Origin Detection
-	externalData string
+	externalData origindetection.ExternalData
 }
 
 var (
@@ -102,7 +103,7 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
 		newServiceCheck.containerID = p.resolveContainerIDFromLocalData(optionalField)
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
-		newServiceCheck.externalData = string(optionalField[len(externalDataPrefix):])
+		newServiceCheck.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}
 	if err != nil {
 		return serviceCheck, err

--- a/pkg/tagger/types/types.go
+++ b/pkg/tagger/types/types.go
@@ -13,7 +13,7 @@ type OriginInfo struct {
 	ContainerIDFromSocket string                        // ContainerIDFromSocket is the origin resolved using Unix Domain Socket.
 	PodUID                string                        // PodUID is the origin resolved from the Kubernetes Pod UID.
 	ContainerID           string                        // ContainerID is the origin resolved from the container ID.
-	ExternalData          string                        // ExternalData is the external data list.
+	ExternalData          origindetection.ExternalData  // ExternalData is the external data list.
 	Cardinality           string                        // Cardinality is the cardinality of the resolved origin.
 	ProductOrigin         origindetection.ProductOrigin // ProductOrigin is the product that sent the origin information.
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Consolidate `taggertypes.ExternalData` to `origindetection.ExternalData`. In future PRs, `taggertypes` will be replaced by `origindetection`.

### Motivation

This is done to avoid having two implementation of Origin Detection logics in the Agent.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Done by unit tests and E2E tests. A full QA will be done once we have `taggertypes` fully removed.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A