### PR TITLE
Improve test coverage of nodetreemodel/config.go

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -164,14 +164,14 @@ func (c *ntmConfig) getTreeBySource(source model.Source) (InnerNode, error) {
 	case model.SourceCLI:
 		return c.cli, nil
 	}
-	return nil, fmt.Errorf("unknown source tree: %s", source)
+	return nil, fmt.Errorf("invalid source tree: %s", source)
 }
 
 // Set assigns the newValue to the given key and marks it as originating from the given source
 func (c *ntmConfig) Set(key string, newValue interface{}, source model.Source) {
 	tree, err := c.getTreeBySource(source)
 	if err != nil {
-		log.Errorf("unknown source: %s", source)
+		log.Errorf("Set invalid source: %s", source)
 		return
 	}
 
@@ -621,6 +621,10 @@ func (c *ntmConfig) MergeConfig(in io.Reader) error {
 	c.Lock()
 	defer c.Unlock()
 
+	if !c.isReady() {
+		return fmt.Errorf("attempt to MergeConfig before config is constructed")
+	}
+
 	content, err := io.ReadAll(in)
 	if err != nil {
 		return err
@@ -781,11 +785,6 @@ func (c *ntmConfig) ConfigFileUsed() string {
 	c.RLock()
 	defer c.RUnlock()
 	return c.configFile
-}
-
-// SetTypeByDefaultValue is a no-op
-func (c *ntmConfig) SetTypeByDefaultValue(_in bool) {
-	// do nothing: nodetreemodel always does this conversion
 }
 
 // BindEnvAndSetDefault binds an environment variable and sets a default for the given key

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -6,10 +6,14 @@
 package nodetreemodel
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -18,7 +22,7 @@ import (
 )
 
 // Test that a setting with a map value is seen as a leaf by the nodetreemodel config
-func TestBuildDefaultMakesTooManyNodes(t *testing.T) {
+func TestLeafNodeCanHaveComplexMapValue(t *testing.T) {
 	cfg := NewConfig("test", "", nil)
 	cfg.BindEnvAndSetDefault("kubernetes_node_annotations_as_tags", map[string]string{"cluster.k8s.io/machine": "kube_machine"})
 	cfg.BuildSchema()
@@ -591,4 +595,176 @@ func TestMergeFleetPolicy(t *testing.T) {
 
 	assert.Equal(t, "baz", config.Get("foo"))
 	assert.Equal(t, model.SourceFleetPolicies, config.GetSource("foo"))
+}
+
+func TestMergeConfig(t *testing.T) {
+	config := NewConfig("test", "TEST", strings.NewReplacer(".", "_")) // nolint: forbidigo
+	config.SetConfigType("yaml")
+	config.SetDefault("foo", "")
+	config.BuildSchema()
+
+	file, err := os.CreateTemp("", "datadog.yaml")
+	assert.NoError(t, err, "failed to create temporary file: %w", err)
+	file.Write([]byte("foo: baz"))
+	file.Seek(0, io.SeekStart)
+	err = config.MergeConfig(file)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "baz", config.Get("foo"))
+	assert.Equal(t, model.SourceFile, config.GetSource("foo"))
+}
+
+func TestOnUpdate(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 1)
+	cfg.BuildSchema()
+
+	var wg sync.WaitGroup
+
+	gotSetting := ""
+	var gotOldValue, gotNewValue interface{}
+	cfg.OnUpdate(func(setting string, oldValue, newValue any) {
+		gotSetting = setting
+		gotOldValue = oldValue
+		gotNewValue = newValue
+		wg.Done()
+	})
+
+	wg.Add(1)
+	go func() {
+		cfg.Set("a", 2, model.SourceAgentRuntime)
+	}()
+	wg.Wait()
+
+	assert.Equal(t, 2, cfg.Get("a"))
+	assert.Equal(t, model.SourceAgentRuntime, cfg.GetSource("a"))
+	assert.Equal(t, "a", gotSetting)
+	assert.Equal(t, 1, gotOldValue)
+	assert.Equal(t, 2, gotNewValue)
+}
+
+func TestSetInvalidSource(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 1)
+	cfg.BuildSchema()
+
+	cfg.Set("a", 2, model.Source("invalid"))
+
+	assert.Equal(t, 1, cfg.Get("a"))
+	assert.Equal(t, model.SourceDefault, cfg.GetSource("a"))
+}
+
+func TestSetWithoutSource(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 1)
+	cfg.BuildSchema()
+
+	cfg.SetWithoutSource("a", 2)
+
+	assert.Equal(t, 2, cfg.Get("a"))
+	assert.Equal(t, model.SourceUnknown, cfg.GetSource("a"))
+}
+
+func TestPanicAfterBuildSchema(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 1)
+	cfg.BuildSchema()
+
+	assert.PanicsWithValue(t, "cannot SetDefault() once the config has been marked as ready for use", func() {
+		cfg.SetDefault("a", 2)
+	})
+
+	assert.Equal(t, 1, cfg.Get("a"))
+	assert.Equal(t, model.SourceDefault, cfg.GetSource("a"))
+
+	assert.PanicsWithValue(t, "cannot SetKnown() once the config has been marked as ready for use", func() {
+		cfg.SetKnown("a")
+	})
+	assert.PanicsWithValue(t, "cannot BindEnv() once the config has been marked as ready for use", func() {
+		cfg.BindEnv("a")
+	})
+	assert.PanicsWithValue(t, "cannot SetEnvKeyReplacer() once the config has been marked as ready for use", func() {
+		cfg.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	})
+}
+
+func TestEnvVarTransformers(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.BindEnvAndSetDefault("list_of_nums", []float64{}, "TEST_LIST_OF_NUMS")
+	cfg.BindEnvAndSetDefault("list_of_fruit", []string{}, "TEST_LIST_OF_FRUIT")
+	cfg.BindEnvAndSetDefault("tag_set", []map[string]string{}, "TEST_TAG_SET")
+	cfg.BindEnvAndSetDefault("list_keypairs", map[string]interface{}{}, "TEST_LIST_KEYPAIRS")
+
+	os.Setenv("TEST_LIST_OF_NUMS", "34,67.5,901.125")
+	os.Setenv("TEST_LIST_OF_FRUIT", "apple,banana,cherry")
+	os.Setenv("TEST_TAG_SET", `[{"cat":"meow"},{"dog":"bark"}]`)
+	os.Setenv("TEST_LIST_KEYPAIRS", `a=1,b=2,c=3`)
+
+	cfg.ParseEnvAsSlice("list_of_nums", func(in string) []interface{} {
+		vals := []interface{}{}
+		for _, str := range strings.Split(in, ",") {
+			f, err := strconv.ParseFloat(str, 64)
+			if err != nil {
+				continue
+			}
+			vals = append(vals, f)
+		}
+		return vals
+	})
+	cfg.ParseEnvAsStringSlice("list_of_fruit", func(in string) []string {
+		return strings.Split(in, ",")
+	})
+	cfg.ParseEnvAsSliceMapString("tag_set", func(in string) []map[string]string {
+		var out []map[string]string
+		if err := json.Unmarshal([]byte(in), &out); err != nil {
+			assert.Fail(t, "failed to json.Unmarshal", err)
+		}
+		return out
+	})
+	cfg.ParseEnvAsMapStringInterface("list_keypairs", func(in string) map[string]interface{} {
+		parts := strings.Split(in, ",")
+		res := map[string]interface{}{}
+		for _, part := range parts {
+			elems := strings.Split(part, "=")
+			val, _ := strconv.ParseInt(elems[1], 10, 64)
+			res[elems[0]] = int(val)
+		}
+		return res
+	})
+
+	cfg.BuildSchema()
+
+	var nums []float64 = cfg.GetFloat64Slice("list_of_nums")
+	assert.Equal(t, []float64{34, 67.5, 901.125}, nums)
+
+	var fruits []string = cfg.GetStringSlice("list_of_fruit")
+	assert.Equal(t, []string{"apple", "banana", "cherry"}, fruits)
+
+	tagsValue := cfg.Get("tag_set")
+	tags, converted := tagsValue.([]map[string]string)
+	assert.Equal(t, true, converted)
+	assert.Equal(t, []map[string]string{{"cat": "meow"}, {"dog": "bark"}}, tags)
+
+	var kvs map[string]interface{} = cfg.GetStringMap("list_keypairs")
+	assert.Equal(t, map[string]interface{}{"a": 1, "b": 2, "c": 3}, kvs)
+}
+
+func TestUnmarshalKeyIsDeprecated(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", []string{"a", "b"})
+	cfg.BuildSchema()
+
+	var texts []string
+	err := cfg.UnmarshalKey("a", &texts)
+	assert.Error(t, err)
+}
+
+func TestSetConfigFile(t *testing.T) {
+	config := NewConfig("test", "TEST", strings.NewReplacer(".", "_")) // nolint: forbidigo
+	config.SetConfigType("yaml")
+	config.SetConfigFile("datadog.yaml")
+	config.SetDefault("foo", "")
+	config.BuildSchema()
+
+	assert.Equal(t, "datadog.yaml", config.ConfigFileUsed())
 }


### PR DESCRIPTION
Before this PR, config.go: 71.7%
After  this PR, config.go: 83.9%

### What does this PR do?

Add tests that improve the test coverage of config.go

### Motivation

### Describe how you validated your changes

Only test code is being added.

### Possible Drawbacks / Trade-offs

### Additional Notes
