### PR TITLE
[CONTP-269] Create an IsInitialized() method for WorkloadMeta collectors

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -98,7 +98,7 @@ const (
 	// MaxWmetaWaitTime is the maximum time to wait for wmeta being ready
 	MaxWmetaWaitTime = 10 * time.Second
 	// WmetaCheckInterval is the interval to check if wmeta is ready
-	WmetaCheckInterval = 1 * time.Second
+	WmetaCheckInterval = 200 * time.Microsecond
 )
 
 type provides struct {

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -135,7 +135,7 @@ func (l *listenerCandidate) try() (listeners.ServiceListener, error) {
 
 // newAutoConfig creates an AutoConfig instance and starts it.
 func newAutoConfig(deps dependencies) autodiscovery.Component {
-	ac := createNewAutoConfig(scheduler.NewController(), deps.Secrets, deps.WMeta, deps.TaggerComp, deps.Log, deps.Telemetry)
+	ac := createNewAutoConfig(scheduler.NewControllerWithWmeta(deps.WMeta), deps.Secrets, deps.WMeta, deps.TaggerComp, deps.Log, deps.Telemetry)
 	deps.Lc.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
 			ac.Start()

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -97,12 +97,12 @@ type AutoConfig struct {
 }
 
 const (
-	// maxWmetaWaitTime is the maximum time to wait for wmeta being ready
-	maxWmetaWaitTime = 10 * time.Second
-	// WmetawmetaCheckMinIntervalCheckMinInterval is the initial interval to check if wmeta is ready
-	wmetaCheckMinInterval = 20 * time.Millisecond
+	// wmetaCheckInitialInterval is the initial interval to check if wmeta is ready
+	wmetaCheckInitialInterval = 20 * time.Millisecond
 	// wmetaCheckMaxInterval is the maximum interval to check if wmeta is ready
 	wmetaCheckMaxInterval = 1 * time.Second
+	// wmetaCheckMaxElapsedTime is the maximum time to wait for wmeta being ready
+	wmetaCheckMaxElapsedTime = 10 * time.Second
 )
 
 type provides struct {
@@ -146,14 +146,14 @@ func (l *listenerCandidate) try() (listeners.ServiceListener, error) {
 
 // newAutoConfig creates an AutoConfig instance and starts it.
 func newAutoConfig(deps dependencies) autodiscovery.Component {
-	schController := scheduler.CreateNewController()
+	schController := scheduler.NewController()
 	// Non-blocking start of the scheduler controller
 	go func() {
 		retries := 0
 		expBackoff := backoff.NewExponentialBackOff()
-		expBackoff.InitialInterval = wmetaCheckMinInterval
+		expBackoff.InitialInterval = wmetaCheckInitialInterval
 		expBackoff.MaxInterval = wmetaCheckMaxInterval
-		expBackoff.MaxElapsedTime = maxWmetaWaitTime
+		expBackoff.MaxElapsedTime = wmetaCheckMaxElapsedTime
 		err := backoff.Retry(func() error {
 			instance, found := deps.WMeta.Get()
 			if found {

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"sort"
 	"sync"
@@ -46,6 +47,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"github.com/cenkalti/backoff"
 )
 
 var listenerCandidateIntl = 30 * time.Second
@@ -97,8 +99,10 @@ type AutoConfig struct {
 const (
 	// MaxWmetaWaitTime is the maximum time to wait for wmeta being ready
 	MaxWmetaWaitTime = 10 * time.Second
-	// WmetaCheckInterval is the interval to check if wmeta is ready
-	WmetaCheckInterval = 200 * time.Microsecond
+	// WmetaCheckMinInterval is the initial interval to check if wmeta is ready
+	WmetaCheckMinInterval = 200 * time.Microsecond
+	// WmetaCheckMaxInterval is the maximum interval to check if wmeta is ready
+	WmetaCheckMaxInterval = 1 * time.Second
 )
 
 type provides struct {
@@ -145,26 +149,28 @@ func newAutoConfig(deps dependencies) autodiscovery.Component {
 	schController := scheduler.CreateNewController()
 	// Non-blocking start of the scheduler controller
 	go func() {
-		instance, found := deps.WMeta.Get()
-		if found {
-			ticker := time.NewTicker(WmetaCheckInterval)
-			defer ticker.Stop()
-			timeout := time.After(MaxWmetaWaitTime)
-			for {
-				select {
-				case <-ticker.C:
-					if instance.IsInitialized() {
-						log.Infof("Workloadmeta collectors are ready, starting autodiscovery scheduler controller")
-						schController.Start()
-						return
-					}
-				case <-timeout:
-					log.Warnf("Workloadmeta collectors are not ready, starting autodiscovery scheduler controller anyway")
+		retries := 0
+		expBackoff := backoff.NewExponentialBackOff()
+		expBackoff.InitialInterval = WmetaCheckMinInterval
+		expBackoff.MaxInterval = WmetaCheckMaxInterval
+		expBackoff.MaxElapsedTime = MaxWmetaWaitTime
+		err := backoff.Retry(func() error {
+			instance, found := deps.WMeta.Get()
+			if found {
+				if instance.IsInitialized() {
+					deps.Log.Infof("Workloadmeta collectors are ready, starting autodiscovery scheduler controller")
 					schController.Start()
-					return
+					return nil
 				}
+				retries++
+				deps.Log.Warnf("Workloadmeta collectors are not ready, will possibly retry")
+				return errors.New("workloadmeta not initialized")
 			}
-		} else {
+			schController.Start()
+			return nil
+		}, expBackoff)
+		if err != nil {
+			deps.Log.Errorf("Workloadmeta collectors are not ready after %d retries: %s, starting check scheduler controller anyway.", retries, err)
 			schController.Start()
 		}
 	}()

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -97,12 +97,12 @@ type AutoConfig struct {
 }
 
 const (
-	// MaxWmetaWaitTime is the maximum time to wait for wmeta being ready
-	MaxWmetaWaitTime = 10 * time.Second
-	// WmetaCheckMinInterval is the initial interval to check if wmeta is ready
-	WmetaCheckMinInterval = 200 * time.Microsecond
-	// WmetaCheckMaxInterval is the maximum interval to check if wmeta is ready
-	WmetaCheckMaxInterval = 1 * time.Second
+	// maxWmetaWaitTime is the maximum time to wait for wmeta being ready
+	maxWmetaWaitTime = 10 * time.Second
+	// WmetawmetaCheckMinIntervalCheckMinInterval is the initial interval to check if wmeta is ready
+	wmetaCheckMinInterval = 20 * time.Millisecond
+	// wmetaCheckMaxInterval is the maximum interval to check if wmeta is ready
+	wmetaCheckMaxInterval = 1 * time.Second
 )
 
 type provides struct {
@@ -151,9 +151,9 @@ func newAutoConfig(deps dependencies) autodiscovery.Component {
 	go func() {
 		retries := 0
 		expBackoff := backoff.NewExponentialBackOff()
-		expBackoff.InitialInterval = WmetaCheckMinInterval
-		expBackoff.MaxInterval = WmetaCheckMaxInterval
-		expBackoff.MaxElapsedTime = MaxWmetaWaitTime
+		expBackoff.InitialInterval = wmetaCheckMinInterval
+		expBackoff.MaxInterval = wmetaCheckMaxInterval
+		expBackoff.MaxElapsedTime = maxWmetaWaitTime
 		err := backoff.Retry(func() error {
 			instance, found := deps.WMeta.Get()
 			if found {
@@ -163,7 +163,7 @@ func newAutoConfig(deps dependencies) autodiscovery.Component {
 					return nil
 				}
 				retries++
-				deps.Log.Warnf("Workloadmeta collectors are not ready, will possibly retry")
+				deps.Log.Debugf("Workloadmeta collectors are not ready, will possibly retry")
 				return errors.New("workloadmeta not initialized")
 			}
 			schController.Start()

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -94,6 +94,13 @@ type AutoConfig struct {
 	ranOnce *atomic.Bool
 }
 
+const (
+	// MaxWmetaWaitTime is the maximum time to wait for wmeta being ready
+	MaxWmetaWaitTime = 10 * time.Second
+	// WmetaCheckInterval is the interval to check if wmeta is ready
+	WmetaCheckInterval = 1 * time.Second
+)
+
 type provides struct {
 	fx.Out
 
@@ -135,7 +142,34 @@ func (l *listenerCandidate) try() (listeners.ServiceListener, error) {
 
 // newAutoConfig creates an AutoConfig instance and starts it.
 func newAutoConfig(deps dependencies) autodiscovery.Component {
-	ac := createNewAutoConfig(scheduler.NewControllerWithWmeta(deps.WMeta), deps.Secrets, deps.WMeta, deps.TaggerComp, deps.Log, deps.Telemetry)
+	schController := scheduler.CreateNewController()
+	// Non-blocking start of the scheduler controller
+	go func() {
+		instance, found := deps.WMeta.Get()
+		if found {
+			ticker := time.NewTicker(WmetaCheckInterval)
+			defer ticker.Stop()
+			timeout := time.After(MaxWmetaWaitTime)
+			for {
+				select {
+				case <-ticker.C:
+					if instance.IsInitialized() {
+						log.Infof("Workloadmeta collectors are ready, starting autodiscovery scheduler controller")
+						schController.Start()
+						return
+					}
+				case <-timeout:
+					log.Warnf("Workloadmeta collectors are not ready, starting autodiscovery scheduler controller anyway")
+					schController.Start()
+					return
+				}
+			}
+		} else {
+			schController.Start()
+		}
+	}()
+
+	ac := createNewAutoConfig(schController, deps.Secrets, deps.WMeta, deps.TaggerComp, deps.Log, deps.Telemetry)
 	deps.Lc.Append(fx.Hook{
 		OnStart: func(_ context.Context) error {
 			ac.Start()

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -197,7 +197,7 @@ func getAutoConfig(schedulerController *scheduler.Controller, secretResolver sec
 
 func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
 	assert.Len(suite.T(), ac.configPollers, 0)
 	mp := &MockProvider{}
 	ac.AddConfigProvider(mp, false, 0)
@@ -214,7 +214,7 @@ func (suite *AutoConfigTestSuite) TestAddConfigProvider() {
 
 func (suite *AutoConfigTestSuite) TestAddListener() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
 	assert.Len(suite.T(), ac.listeners, 0)
 
 	ml := &MockListener{}
@@ -252,7 +252,7 @@ func (suite *AutoConfigTestSuite) TestDiffConfigs() {
 
 func (suite *AutoConfigTestSuite) TestStop() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
 
 	ml := &MockListener{}
 	listeners.Register("mock", ml.fakeFactory, ac.serviceListenerFactories)
@@ -265,7 +265,7 @@ func (suite *AutoConfigTestSuite) TestStop() {
 
 func (suite *AutoConfigTestSuite) TestListenerRetry() {
 	mockResolver := MockSecretResolver{suite.T(), nil}
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, suite.deps.WMeta, suite.deps.TaggerComp, suite.deps.LogsComp, suite.deps.Telemetry)
 
 	// Hack the retry delay to shorten the test run time
 	initialListenerCandidateIntl := listenerCandidateIntl
@@ -368,7 +368,7 @@ func TestResolveTemplate(t *testing.T) {
 	deps := createDeps(t)
 	ctx := context.Background()
 
-	msch := scheduler.NewController()
+	msch := scheduler.NewControllerAndStart()
 	sch := &MockScheduler{scheduled: make(map[string]integration.Config)}
 	msch.Register("mock", sch, false)
 
@@ -410,7 +410,7 @@ func TestRemoveTemplate(t *testing.T) {
 
 	mockResolver := MockSecretResolver{t, nil}
 
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
 	// Add static config
 	c := integration.Config{
 		Name: "memory",
@@ -463,7 +463,7 @@ func TestDecryptConfig(t *testing.T) {
 		},
 	}}
 
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
 	ac.processNewService(ctx, &dummyService{ID: "abcd", ADIdentifiers: []string{"redis"}})
 
 	tpl := integration.Config{
@@ -507,7 +507,7 @@ func TestProcessClusterCheckConfigWithSecrets(t *testing.T) {
 			returnedError:  nil,
 		},
 	}}
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
 
 	tpl := integration.Config{
 		Provider:     names.ClusterChecks,
@@ -542,7 +542,7 @@ func TestWriteConfigEndpoint(t *testing.T) {
 	configName := "testConfig"
 
 	mockResolver := MockSecretResolver{t, nil}
-	ac := getAutoConfig(scheduler.NewController(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
+	ac := getAutoConfig(scheduler.NewControllerAndStart(), &mockResolver, deps.WMeta, deps.TaggerComp, deps.LogsComp, deps.Telemetry)
 
 	tpl := integration.Config{
 		Provider:     names.ClusterChecks,

--- a/comp/core/autodiscovery/scheduler/controller.go
+++ b/comp/core/autodiscovery/scheduler/controller.go
@@ -38,15 +38,15 @@ type Controller struct {
 	stopChannel chan struct{}
 }
 
-// NewController inits a scheduler controller without waiting, for unit test only
-func NewController() *Controller {
-	schedulerController := CreateNewController()
+// NewControllerAndStart inits a scheduler controller without waiting
+func NewControllerAndStart() *Controller {
+	schedulerController := NewController()
 	schedulerController.Start()
 	return schedulerController
 }
 
-// CreateNewController creates a new controller without starting it
-func CreateNewController() *Controller {
+// NewController creates a new controller without starting it
+func NewController() *Controller {
 	return &Controller{
 		scheduledConfigs: make(map[Digest]*integration.Config),
 		activeSchedulers: make(map[string]Scheduler),

--- a/comp/core/autodiscovery/scheduler/controller_test.go
+++ b/comp/core/autodiscovery/scheduler/controller_test.go
@@ -6,23 +6,13 @@
 package scheduler
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	compConfig "github.com/DataDog/datadog-agent/comp/core/config"
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
-	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func makeConfig(name string) integration.Config {
@@ -66,14 +56,7 @@ func (s *scheduler) reset() {
 }
 
 func TestController(t *testing.T) {
-	// Create a workload meta global store
-	workloadmetaStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
-		fx.Provide(func() log.Component { return logmock.New(t) }),
-		compConfig.MockModule(),
-		fx.Supply(context.Background()),
-		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-	))
-	ms := NewControllerWithWmeta(optional.NewOption[workloadmeta.Component](workloadmetaStore))
+	ms := NewController()
 
 	// schedule some configs before registering
 	c1 := makeConfig("one")

--- a/comp/core/autodiscovery/scheduler/controller_test.go
+++ b/comp/core/autodiscovery/scheduler/controller_test.go
@@ -56,7 +56,7 @@ func (s *scheduler) reset() {
 }
 
 func TestController(t *testing.T) {
-	ms := NewController()
+	ms := NewControllerAndStart()
 
 	// schedule some configs before registering
 	c1 := makeConfig("one")

--- a/comp/core/autodiscovery/scheduler/controller_test.go
+++ b/comp/core/autodiscovery/scheduler/controller_test.go
@@ -6,13 +6,23 @@
 package scheduler
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	compConfig "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
 )
 
 func makeConfig(name string) integration.Config {
@@ -56,7 +66,14 @@ func (s *scheduler) reset() {
 }
 
 func TestController(t *testing.T) {
-	ms := NewController()
+	// Create a workload meta global store
+	workloadmetaStore := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		compConfig.MockModule(),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	ms := NewControllerWithWmeta(optional.NewOption[workloadmeta.Component](workloadmetaStore))
 
 	// schedule some configs before registering
 	c1 := makeConfig("one")

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -132,6 +132,6 @@ type Component interface {
 	// Only EventTypeSet and EventTypeUnset event types are allowed.
 	Push(source Source, events ...Event) error
 
-	// IsInitialized: If startCandidates is run at least once, return true.
+	// IsInitialized If startCandidates is run at least once, return true.
 	IsInitialized() bool
 }

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -132,6 +132,6 @@ type Component interface {
 	// Only EventTypeSet and EventTypeUnset event types are allowed.
 	Push(source Source, events ...Event) error
 
-	// IsInitialzed: If startCandidates is run at least once, return true.
-	IsInitialzed() bool
+	// IsInitialized: If startCandidates is run at least once, return true.
+	IsInitialized() bool
 }

--- a/comp/core/workloadmeta/def/component.go
+++ b/comp/core/workloadmeta/def/component.go
@@ -131,4 +131,7 @@ type Component interface {
 	// Push allows external sources to push events to the metadata store.
 	// Only EventTypeSet and EventTypeUnset event types are allowed.
 	Push(source Source, events ...Event) error
+
+	// IsInitialzed: If startCandidates is run at least once, return true.
+	IsInitialzed() bool
 }

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1501,6 +1501,7 @@ func (g GPU) String(verbose bool) string {
 
 	return sb.String()
 }
+<<<<<<< HEAD
 
 // GPUComputeCapability represents the compute capability version of a GPU.
 type GPUComputeCapability struct {
@@ -1514,3 +1515,17 @@ type GPUComputeCapability struct {
 func (gcc GPUComputeCapability) String() string {
 	return fmt.Sprintf("%d.%d", gcc.Major, gcc.Minor)
 }
+=======
+// CollectorStatus is the status of collector which is used to determine if the collectors
+// are not started, starting, started (pulled once)
+type CollectorStatus uint8
+
+const (
+	// CollectorsNotStarted means workloadmeta collectors are not started
+	CollectorsNotStarted CollectorStatus = iota
+	// CollectorsStarting means workloadmeta collectors are starting
+	CollectorsStarting
+	// CollectorsInitialized means workloadmeta collectors have been at least pulled once
+	CollectorsInitialized
+)
+>>>>>>> 25d2a08642 (update wmeta and autodiscovery scher)

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1501,7 +1501,6 @@ func (g GPU) String(verbose bool) string {
 
 	return sb.String()
 }
-<<<<<<< HEAD
 
 // GPUComputeCapability represents the compute capability version of a GPU.
 type GPUComputeCapability struct {
@@ -1515,7 +1514,7 @@ type GPUComputeCapability struct {
 func (gcc GPUComputeCapability) String() string {
 	return fmt.Sprintf("%d.%d", gcc.Major, gcc.Minor)
 }
-=======
+
 // CollectorStatus is the status of collector which is used to determine if the collectors
 // are not started, starting, started (pulled once)
 type CollectorStatus uint8
@@ -1528,4 +1527,3 @@ const (
 	// CollectorsInitialized means workloadmeta collectors have been at least pulled once
 	CollectorsInitialized
 )
->>>>>>> 25d2a08642 (update wmeta and autodiscovery scher)

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -505,8 +505,8 @@ func (w *workloadmeta) Reset(newEntities []wmdef.Entity, source wmdef.Source) {
 
 // IsInitialized: If startCandidates is run at least once, return true.
 func (w *workloadmeta) IsInitialized() bool {
-	w.storeMut.RLock()
-	defer w.storeMut.RUnlock()
+	w.collectorMut.RLock()
+	defer w.collectorMut.RUnlock()
 	return w.collectorsInited == wmdef.CollectorsInitialized
 }
 

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -600,13 +600,13 @@ func (w *workloadmeta) startCandidates(ctx context.Context) bool {
 
 func (w *workloadmeta) updateCollectorStatus(status wmdef.CollectorStatus) {
 	w.collectorMut.Lock()
+	defer w.collectorMut.Unlock()
 	if w.collectorsInited == wmdef.CollectorsInitialized {
 		return // already initialized
 	} else if status == wmdef.CollectorsInitialized && w.collectorsInited == wmdef.CollectorsNotStarted {
 		return // no collectors to initialize yet
 	}
 	w.collectorsInited = status
-	w.collectorMut.Unlock()
 }
 
 func (w *workloadmeta) pull(ctx context.Context) {

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -503,8 +503,8 @@ func (w *workloadmeta) Reset(newEntities []wmdef.Entity, source wmdef.Source) {
 	w.Notify(events)
 }
 
-// IsInitialzed: If startCandidates is run at least once, return true.
-func (w *workloadmeta) IsInitialzed() bool {
+// IsInitialized: If startCandidates is run at least once, return true.
+func (w *workloadmeta) IsInitialized() bool {
 	w.storeMut.RLock()
 	defer w.storeMut.RUnlock()
 	return w.collectorsInited == wmdef.CollectorsInitialized
@@ -557,9 +557,7 @@ func (w *workloadmeta) startCandidatesWithRetry(ctx context.Context) error {
 		default:
 		}
 
-		startCandidatesFinished := w.startCandidates(ctx)
-		w.updateCollectorStatus(wmdef.CollectorsStarting)
-		if startCandidatesFinished {
+		if w.startCandidates(ctx) {
 			return nil
 		}
 
@@ -594,13 +592,13 @@ func (w *workloadmeta) startCandidates(ctx context.Context) bool {
 		// next tick
 		delete(w.candidates, id)
 	}
+	w.collectorsInited = wmdef.CollectorsStarting
 	return len(w.candidates) == 0
 }
 
 func (w *workloadmeta) updateCollectorStatus(status wmdef.CollectorStatus) {
 	w.collectorMut.Lock()
 	defer w.collectorMut.Unlock()
-	// Status can not be reverted
 	if w.collectorsInited == wmdef.CollectorsInitialized {
 		return // already initialized
 	} else if status == wmdef.CollectorsInitialized && w.collectorsInited == wmdef.CollectorsNotStarted {

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -592,19 +592,21 @@ func (w *workloadmeta) startCandidates(ctx context.Context) bool {
 		// next tick
 		delete(w.candidates, id)
 	}
-	w.collectorsInited = wmdef.CollectorsStarting
+	if w.collectorsInited == wmdef.CollectorsNotStarted {
+		w.collectorsInited = wmdef.CollectorsStarting
+	}
 	return len(w.candidates) == 0
 }
 
 func (w *workloadmeta) updateCollectorStatus(status wmdef.CollectorStatus) {
 	w.collectorMut.Lock()
-	defer w.collectorMut.Unlock()
 	if w.collectorsInited == wmdef.CollectorsInitialized {
 		return // already initialized
 	} else if status == wmdef.CollectorsInitialized && w.collectorsInited == wmdef.CollectorsNotStarted {
 		return // no collectors to initialize yet
 	}
 	w.collectorsInited = status
+	w.collectorMut.Unlock()
 }
 
 func (w *workloadmeta) pull(ctx context.Context) {

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -507,7 +507,7 @@ func (w *workloadmeta) Reset(newEntities []wmdef.Entity, source wmdef.Source) {
 func (w *workloadmeta) IsInitialized() bool {
 	w.collectorMut.RLock()
 	defer w.collectorMut.RUnlock()
-	return w.collectorsInited == wmdef.CollectorsInitialized
+	return w.collectorsInitialized == wmdef.CollectorsInitialized
 }
 
 func (w *workloadmeta) validatePushEvents(events []wmdef.Event) error {
@@ -592,8 +592,8 @@ func (w *workloadmeta) startCandidates(ctx context.Context) bool {
 		// next tick
 		delete(w.candidates, id)
 	}
-	if w.collectorsInited == wmdef.CollectorsNotStarted {
-		w.collectorsInited = wmdef.CollectorsStarting
+	if w.collectorsInitialized == wmdef.CollectorsNotStarted {
+		w.collectorsInitialized = wmdef.CollectorsStarting
 	}
 	return len(w.candidates) == 0
 }
@@ -601,12 +601,12 @@ func (w *workloadmeta) startCandidates(ctx context.Context) bool {
 func (w *workloadmeta) updateCollectorStatus(status wmdef.CollectorStatus) {
 	w.collectorMut.Lock()
 	defer w.collectorMut.Unlock()
-	if w.collectorsInited == wmdef.CollectorsInitialized {
+	if w.collectorsInitialized == wmdef.CollectorsInitialized {
 		return // already initialized
-	} else if status == wmdef.CollectorsInitialized && w.collectorsInited == wmdef.CollectorsNotStarted {
+	} else if status == wmdef.CollectorsInitialized && w.collectorsInitialized == wmdef.CollectorsNotStarted {
 		return // no collectors to initialize yet
 	}
-	w.collectorsInited = status
+	w.collectorsInitialized = status
 }
 
 func (w *workloadmeta) pull(ctx context.Context) {

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -502,6 +502,11 @@ func (w *workloadmeta) Reset(newEntities []wmdef.Entity, source wmdef.Source) {
 	w.Notify(events)
 }
 
+// IsInitialzed: If startCandidates is run at least once, return true.
+func (w *workloadmeta) IsInitialzed() bool {
+	return w.candidatesInited
+}
+
 func (w *workloadmeta) validatePushEvents(events []wmdef.Event) error {
 	for _, event := range events {
 		if event.Type != wmdef.EventTypeSet && event.Type != wmdef.EventTypeUnset {
@@ -584,7 +589,7 @@ func (w *workloadmeta) startCandidates(ctx context.Context) bool {
 		// next tick
 		delete(w.candidates, id)
 	}
-
+	w.candidatesInited = true
 	return len(w.candidates) == 0
 }
 

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -40,7 +40,7 @@ type workloadmeta struct {
 	collectorMut     sync.RWMutex
 	candidates       map[string]wmdef.Collector
 	collectors       map[string]wmdef.Collector
-	candidatesInited bool
+	collectorsInited wmdef.CollectorStatus
 
 	eventCh chan []wmdef.CollectorEvent
 
@@ -81,7 +81,7 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 
 		store:            make(map[wmdef.Kind]map[string]*cachedEntity),
 		candidates:       candidates,
-		candidatesInited: false,
+		collectorsInited: wmdef.CollectorsNotStarted,
 		collectors:       make(map[string]wmdef.Collector),
 		eventCh:          make(chan []wmdef.CollectorEvent, eventChBufferSize),
 		ongoingPulls:     make(map[string]time.Time),

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -37,9 +37,10 @@ type workloadmeta struct {
 	subscribersMut sync.RWMutex
 	subscribers    []subscriber
 
-	collectorMut sync.RWMutex
-	candidates   map[string]wmdef.Collector
-	collectors   map[string]wmdef.Collector
+	collectorMut     sync.RWMutex
+	candidates       map[string]wmdef.Collector
+	collectors       map[string]wmdef.Collector
+	candidatesInited bool
 
 	eventCh chan []wmdef.CollectorEvent
 
@@ -78,11 +79,12 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 		log:    deps.Log,
 		config: deps.Config,
 
-		store:        make(map[wmdef.Kind]map[string]*cachedEntity),
-		candidates:   candidates,
-		collectors:   make(map[string]wmdef.Collector),
-		eventCh:      make(chan []wmdef.CollectorEvent, eventChBufferSize),
-		ongoingPulls: make(map[string]time.Time),
+		store:            make(map[wmdef.Kind]map[string]*cachedEntity),
+		candidates:       candidates,
+		candidatesInited: false,
+		collectors:       make(map[string]wmdef.Collector),
+		eventCh:          make(chan []wmdef.CollectorEvent, eventChBufferSize),
+		ongoingPulls:     make(map[string]time.Time),
 	}
 
 	deps.Lc.Append(compdef.Hook{OnStart: func(_ context.Context) error {

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -37,10 +37,10 @@ type workloadmeta struct {
 	subscribersMut sync.RWMutex
 	subscribers    []subscriber
 
-	collectorMut     sync.RWMutex
-	candidates       map[string]wmdef.Collector
-	collectors       map[string]wmdef.Collector
-	collectorsInited wmdef.CollectorStatus
+	collectorMut          sync.RWMutex
+	candidates            map[string]wmdef.Collector
+	collectors            map[string]wmdef.Collector
+	collectorsInitialized wmdef.CollectorStatus
 
 	eventCh chan []wmdef.CollectorEvent
 
@@ -79,12 +79,12 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 		log:    deps.Log,
 		config: deps.Config,
 
-		store:            make(map[wmdef.Kind]map[string]*cachedEntity),
-		candidates:       candidates,
-		collectors:       make(map[string]wmdef.Collector),
-		eventCh:          make(chan []wmdef.CollectorEvent, eventChBufferSize),
-		ongoingPulls:     make(map[string]time.Time),
-		collectorsInited: wmdef.CollectorsNotStarted,
+		store:                 make(map[wmdef.Kind]map[string]*cachedEntity),
+		candidates:            candidates,
+		collectors:            make(map[string]wmdef.Collector),
+		eventCh:               make(chan []wmdef.CollectorEvent, eventChBufferSize),
+		ongoingPulls:          make(map[string]time.Time),
+		collectorsInitialized: wmdef.CollectorsNotStarted,
 	}
 
 	deps.Lc.Append(compdef.Hook{OnStart: func(_ context.Context) error {

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -81,10 +81,10 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 
 		store:            make(map[wmdef.Kind]map[string]*cachedEntity),
 		candidates:       candidates,
-		collectorsInited: wmdef.CollectorsNotStarted,
 		collectors:       make(map[string]wmdef.Collector),
 		eventCh:          make(chan []wmdef.CollectorEvent, eventChBufferSize),
 		ongoingPulls:     make(map[string]time.Time),
+		collectorsInited: wmdef.CollectorsNotStarted,
 	}
 
 	deps.Lc.Append(compdef.Hook{OnStart: func(_ context.Context) error {

--- a/comp/core/workloadmeta/impl/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_mock.go
@@ -29,6 +29,7 @@ func NewWorkloadMetaMock(deps Dependencies) wmmock.Mock {
 	w := &workloadMetaMock{
 		workloadmeta: NewWorkloadMeta(deps).Comp.(*workloadmeta),
 	}
+	w.updateCollectorStatus(wmdef.CollectorsInitialized)
 	return w
 }
 

--- a/comp/core/workloadmeta/impl/workloadmeta_mock.go
+++ b/comp/core/workloadmeta/impl/workloadmeta_mock.go
@@ -29,7 +29,6 @@ func NewWorkloadMetaMock(deps Dependencies) wmmock.Mock {
 	w := &workloadMetaMock{
 		workloadmeta: NewWorkloadMeta(deps).Comp.(*workloadmeta),
 	}
-	w.updateCollectorStatus(wmdef.CollectorsInitialized)
 	return w
 }
 

--- a/pkg/logs/internal/util/adlistener/ad_test.go
+++ b/pkg/logs/internal/util/adlistener/ad_test.go
@@ -25,7 +25,7 @@ import (
 
 //nolint:revive // TODO(AML) Fix revive linter
 func TestListenersGetScheduleCalls(t *testing.T) {
-	adsched := scheduler.NewController()
+	adsched := scheduler.NewControllerAndStart()
 	ac := fxutil.Test[autodiscovery.Mock](t,
 		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: adsched}),
 		secretsimpl.MockModule(),

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -33,7 +33,7 @@ func CheckAgentBehaviour(t *testing.T, client *TestClient) {
 		var statusOutputJSON map[string]any
 		var err error
 		result := false
-		for try := 0; try < 5 && !result; try++ {
+		for try := 0; try < 10 && !result; try++ {
 			err = json.Unmarshal([]byte(client.AgentClient.Status(agentclient.WithArgs([]string{"-j"})).Content), &statusOutputJSON)
 			if err != nil {
 				time.Sleep(1 * time.Second)

--- a/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_behaviour.go
@@ -33,7 +33,7 @@ func CheckAgentBehaviour(t *testing.T, client *TestClient) {
 		var statusOutputJSON map[string]any
 		var err error
 		result := false
-		for try := 0; try < 10 && !result; try++ {
+		for try := 0; try < 15 && !result; try++ {
 			err = json.Unmarshal([]byte(client.AgentClient.Status(agentclient.WithArgs([]string{"-j"})).Content), &statusOutputJSON)
 			if err != nil {
 				time.Sleep(1 * time.Second)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

1. Introduced an **IsInitialized**() method for WorkloadMeta to return True when all workload metadata collections have started.
2. **Reordered** startCandidates (collector creation) and the initial data pull from collectors.
3. Ensured that integration checks triggered by autodiscovery wait for WorkloadMeta to complete initialization before scheduling. The maximum wait time is set to 10 seconds, aligning with the 5-second pulling cycle of WorkloadMeta. Previously, there was no wait, sometimes resulting in missing important tags [CONS-6815].
4. Other scheduler functionalities remain unchanged, except for a slight delay(max 10s) in check scheduling during startup.
5. Updated the e2e test by extending the "agent status" waiting time from 5s to 10s to accommodate the initialization delay.

### Motivation
See below before vs after logs

**Before**
```
2025-02-19 15:04:04 UTC | CORE | WARN | (pkg/collector/python/check_context.go:54 in initializeCheckContext) | Log receiver not provided. Logs from integrations will not be collected.
2025-02-19 15:04:04 UTC | CORE | INFO | (comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:170 in collectOnce) | file provider: collected 63 new configurations, removed 0
2025-02-19 15:04:04 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check container with an interval of 15s
2025-02-19 15:04:04 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check container_image with an interval of 15s
2025-02-19 15:04:04 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check container_lifecycle with an interval of 15s
2025-02-19 15:04:04 UTC | CORE | INFO | (comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:409 in LoadAndRun) | Started config provider "file"
2025-02-19 15:04:04 UTC | CORE | INFO | (pkg/util/containerd/containerd_util.go:181 in connect) | Connected to containerd - Version 1.7.24-0ubuntu0~22.04.1~gke1/
2025-02-19 15:04:04 UTC | CORE | INFO | (comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:407 in LoadAndRun) | Started config provider "endpoints-checks", polled every 10s
2025-02-19 15:04:04 UTC | CORE | INFO | (comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:409 in LoadAndRun) | Started config provider "kubernetes-container-allinone"
2025-02-19 15:04:04 UTC | CORE | INFO | (comp/core/tagger/server/server.go:162 in TaggerStreamEntities) | cluster tagger has just finished initialization for subscription "streaming-client-2dcefb28-d446-4253-b223-db4b3786a3b6" at time 1739977444
2025-02-19 15:04:04 UTC | CORE | INFO | (pkg/process/runner/runner.go:243 in logCheckDuration) | Finished process_discovery check #1 in 321.038383ms
2025-02-19 15:04:04 UTC | CORE | INFO | (comp/metadata/host/hostimpl/hosttags/tags.go:132 in Get) | Adding both tags cluster_name and kube_cluster_name. You can use 'disable_cluster_name_tag_key' in the Agent config to keep the kube_cluster_name tag only
2025-02-19 15:04:04 UTC | CORE | INFO | (comp/metadata/host/hostimpl/hosttags/tags.go:132 in Get) | Adding both tags cluster_name and kube_cluster_name. You can use 'disable_cluster_name_tag_key' in the Agent config to keep the kube_cluster_name tag only
2025-02-19 15:04:04 UTC | CORE | INFO | (pkg/config/remote/service/service.go:606 in pollOrgStatus) | [Remote Config] Remote Configuration is enabled for this organization but disabled for this agent. Add the Remote Configuration Read permission to its API key to enable it for this agent.
2025-02-19 15:04:05 UTC | CORE | INFO | (comp/forwarder/defaultforwarder/transaction/transaction.go:454 in internalProcess) | Successfully posted payload to "https://process.datadoghq.com/api/v1/discovery" (202 Accepted), the agent will only log transaction success every 500 transactions
2025-02-19 15:04:05 UTC | CORE | INFO | (comp/metadata/host/hostimpl/utils/host.go:115 in getNetworkMeta) | Adding public IPv4 35.234.107.189 to network metadata
2025-02-19 15:04:05 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:40 in CheckStarted) | check:container | Running check...
2025-02-19 15:04:05 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:59 in CheckFinished) | check:container | Done running check
2025-02-19 15:04:05 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check containerd with an interval of 15s
2025-02-19 15:04:05 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check cpu with an interval of 15s
2025-02-19 15:04:05 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check cri with an interval of 15s
.....
2025-02-19 15:04:05 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check service_discovery with an interval of 1m0s
2025-02-19 15:04:06 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check telemetry with an interval of 15s
2025-02-19 15:04:06 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check uptime with an interval of 15s
2025-02-19 15:04:06 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:40 in CheckStarted) | check:orchestrator_pod | Running check...
2025-02-19 15:04:06 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:59 in CheckFinished) | check:orchestrator_pod | Done running check
2025-02-19 15:04:06 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:576 in startCandidates) | workloadmeta collector "containerd" started successfully
2025-02-19 15:04:06 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:579 in startCandidates) | workloadmeta collector "local-process-collector" could not start. error: component workloadmeta-process is disabled: language detection or core agent process collection is disabled
2025-02-19 15:04:06 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:579 in startCandidates) | workloadmeta collector "ecs_fargate" could not start. error: component workloadmeta-ecs_fargate is disabled: Agent is not running on ECS Fargate
....
2025-02-19 15:04:06 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:579 in startCandidates) | workloadmeta collector "ecs" could not start. error: component workloadmeta-ecs is disabled: Agent is not running on ECS EC2
2025-02-19 15:04:06 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:579 in startCandidates) | workloadmeta collector "podman" could not start. error: component workloadmeta-podman is disabled: Podman not detected
```


**After**: checks scheduled after workloadmeta collection is finished in first iteration. 
```
2025-02-19 14:58:11 UTC | CORE | INFO | (comp/core/tagger/server/server.go:162 in TaggerStreamEntities) | cluster tagger has just finished initialization for subscription "streaming-client-3bfb0a1d-1dd2-4a55-912e-822364545b47" at time 1739977091
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:584 in startCandidates) | workloadmeta collector "containerd" started successfully
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:584 in startCandidates) | workloadmeta collector "docker" started successfully
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:587 in startCandidates) | workloadmeta collector "ecs" could not start. error: component workloadmeta-ecs is disabled: Agent is not running on ECS EC2
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:587 in startCandidates) | workloadmeta collector "podman" could not start. error: component workloadmeta-podman is disabled: Podman not detected
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:587 in startCandidates) | workloadmeta collector "local-process-collector" could not start. error: component workloadmeta-process is disabled: language detection or core agent process collecti
on is disabled
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:587 in startCandidates) | workloadmeta collector "ecs_fargate" could not start. error: component workloadmeta-ecs_fargate is disabled: Agent is not running on ECS Fargate
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:584 in startCandidates) | workloadmeta collector "kube_metadata" started successfully
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:587 in startCandidates) | workloadmeta collector "cloudfoundry-vm" could not start. error: component workloadmeta-cloudfoundry-vm is disabled: Agent is not running on CloudFoundry
......
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/workloadmeta/impl/store.go:584 in startCandidates) | workloadmeta collector "kubelet" started successfully
2025-02-19 14:58:13 UTC | CORE | INFO | (comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:107 in stream) | kubernetes-container-allinone provider: collected 1 new configurations, removed 0
2025-02-19 14:58:14 UTC | CORE | INFO | (comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:158 in func1) | Workloadmeta collectors are ready, starting autodiscovery scheduler controller
2025-02-19 14:58:14 UTC | CORE | INFO | (comp/core/autodiscovery/scheduler/controller.go:72 in Start) | Autodiscovery scheduler controller started
2025-02-19 14:58:14 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check container with an interval of 15s
2025-02-19 14:58:14 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check container_image with an interval of 15s
2025-02-19 14:58:14 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check container_lifecycle with an interval of 15s
.....
2025-02-19 14:58:14 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check kube_dns:e49f0bdbea4a5690 with an interval of 15s
2025-02-19 14:58:14 UTC | CORE | WARN | (pkg/collector/python/check.go:313 in Configure) | could not get a 'prometheus' check instance with the new api: GenericPrometheusCheck.__init__() missing 1 required positional argument: 'agentConfig'
2025-02-19 14:58:14 UTC | CORE | WARN | (pkg/collector/python/check.go:314 in Configure) | trying to instantiate the check with the old api, passing agentConfig to the constructor
2025-02-19 14:58:14 UTC | CORE | WARN | (pkg/collector/python/check.go:336 in Configure) | passing `agentConfig` to the constructor is deprecated, please use the `get_config` function from the 'datadog_agent' package (prometheus).
2025-02-19 14:58:14 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check prometheus:datadog.cluster_agent:cbc0a2cb4ebb13cf with an interval of 15s
2025-02-19 14:58:14 UTC | CORE | INFO | (pkg/collector/scheduler/scheduler.go:93 in Enter) | Scheduling check datadog_cluster_agent:7e1139d7d24e3ec6 with an interval of 15s
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
See logs above

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[CONS-6815]: https://datadoghq.atlassian.net/browse/CONS-6815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ