### PR TITLE
[USM] Revert #32496

### DIFF
--- a/pkg/network/ebpf/c/protocols/flush.h
+++ b/pkg/network/ebpf/c/protocols/flush.h
@@ -28,12 +28,4 @@ int tracepoint__net__netif_receive_skb(void *ctx) {
     return 0;
 }
 
-SEC("raw_tracepoint/net/netif_receive_skb")
-int BPF_PROG(raw_tracepoint__net__netif_receive_skb) {
-    CHECK_BPF_PROGRAM_BYPASSED()
-    log_debug("raw_tracepoint/net/netif_receive_skb");
-    flush(ctx);
-    return 0;
-}
-
 #endif


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR backports [#32496](https://github.com/DataDog/datadog-agent/pull/32496).

### Motivation

This PR backports a fix for a CPU increase when handling TLS traffic.

### Describe how you validated your changes

Validated the impact using the load test and confirmed that the change indeed reduces CPU consumption.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->