### PR TITLE
workloadmeta: add missing runtime and state fields in container parsed from ECS v1

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
@@ -102,6 +102,7 @@ func (c *collector) parseTaskContainers(
 			Type:   workloadmeta.EventTypeSet,
 			Entity: &workloadmeta.Container{
 				EntityID: entityID,
+				Runtime:  workloadmeta.ContainerRuntimeDocker,
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: container.DockerName,
 				},

--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
@@ -106,6 +106,10 @@ func (c *collector) parseTaskContainers(
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: container.DockerName,
 				},
+				State: workloadmeta.ContainerState{
+					Status: workloadmeta.ContainerStatusUnknown,
+					Health: workloadmeta.ContainerHealthUnknown,
+				},
 			},
 		})
 	}

--- a/comp/core/workloadmeta/def/merge.go
+++ b/comp/core/workloadmeta/def/merge.go
@@ -22,6 +22,7 @@ var (
 	timeType            = reflect.TypeOf(time.Time{})
 	portSliceType       = reflect.TypeOf([]ContainerPort{})
 	containerHealthType = reflect.TypeOf(ContainerHealthUnknown)
+	containerStatusType = reflect.TypeOf(ContainerStatusUnknown)
 	mergerInstance      = merger{}
 )
 
@@ -34,6 +35,9 @@ func (merger) Transformer(typ reflect.Type) func(dst, src reflect.Value) error {
 	// Even though Health is string alias, the matching only matches actual Health
 	case containerHealthType:
 		return healthMerge
+	// Even though Status is string alias, the matching only matches actual Status
+	case containerStatusType:
+		return statusMerge
 	}
 
 	return nil
@@ -48,6 +52,21 @@ func healthMerge(dst, src reflect.Value) error {
 	dstHealth := dst.Interface().(ContainerHealth)
 
 	if srcHealth != "" && srcHealth != ContainerHealthUnknown && (dstHealth == "" || dstHealth == ContainerHealthUnknown) {
+		dst.Set(src)
+	}
+
+	return nil
+}
+
+func statusMerge(dst, src reflect.Value) error {
+	if !dst.CanSet() {
+		return nil
+	}
+
+	srcStatus := src.Interface().(ContainerStatus)
+	dstStatus := dst.Interface().(ContainerStatus)
+
+	if srcStatus != "" && srcStatus != ContainerStatusUnknown && (dstStatus == "" || dstStatus == ContainerStatusUnknown) {
 		dst.Set(src)
 	}
 

--- a/releasenotes/notes/cws-fix-containers-billing-19580e6f968dd79a.yaml
+++ b/releasenotes/notes/cws-fix-containers-billing-19580e6f968dd79a.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue where the remote workloadmeta was not receiving some unset
+    events for ECS containers. This was causing CWS, CSPM, CSM Pro, CSM
+    Enterprise and DevSecOps Enterprise Containers billing to be incorrect.

--- a/releasenotes/notes/cws-fix-containers-billing-19580e6f968dd79a.yaml
+++ b/releasenotes/notes/cws-fix-containers-billing-19580e6f968dd79a.yaml
@@ -9,5 +9,5 @@
 fixes:
   - |
     Fix an issue where the remote workloadmeta was not receiving some unset
-    events for ECS containers. This was causing CWS, CSPM, CSM Pro, CSM
-    Enterprise and DevSecOps Enterprise Containers billing to be incorrect.
+    events for ECS containers, causing incorrect billing in CWS, CSPM, CSM Pro, CSM
+    Enterprise, and DevSecOps Enterprise Containers.


### PR DESCRIPTION
### What does this PR do?

This PR fixes a few issues in the ECS v1 parser (used when the ecs task collection is disabled, which is the default state):
- add the missing `Runtime` field (here docker, since ECS = docker + aws things, same as the v4 parser)
- add the missing `ContainerState` field (and sub-fields set as unknown)
- fix the merge algorithm to correctly merge the container state status, similar to container state health

All those issues are causing protobuf serialization issues, making the remote workloadmeta state diverge from the core state, causing some downstream issues.

Caused by:
- https://github.com/DataDog/datadog-agent/blob/ff41d82f8b3ce74825a2505a9f0823bb21ed9cab/comp/core/workloadmeta/proto/proto.go#L127
- https://github.com/DataDog/datadog-agent/blob/ff41d82f8b3ce74825a2505a9f0823bb21ed9cab/comp/core/workloadmeta/proto/proto.go#L132

### Motivation

### Describe how you validated your changes

Deploy the agent on ECS, with an application on the side. Enable CWS with `DD_RUNTIME_SECURITY_CONFIG_ENABLED=true`.

For this, you can use [this](https://github.com/DataDog/container-agent-envs-doc/tree/main/create_test_env) for cluster creation and workload deployment. You can set the environment variable [here](https://github.com/DataDog/container-agent-envs-doc/blob/main/create_test_env/2_agent_management/ecs-ec2/datadog-agent-task.json).

 Then:
- you should see the `datadog.security_agent.runtime.containers_running` increasing and decreasing following the lifecycle of your side app
- in the agent container, `agent workload-list` should show the correct state/running fields of your app
- same for `security-agent workload-list`
- The following log should never appear in the agent logs :
![image](https://github.com/user-attachments/assets/b21f7dbe-ee4a-4794-a4c8-31f657ba941b)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->