### PR TITLE
usm: process monitor: tests: Remove code duplication

### DIFF
--- a/pkg/process/monitor/process_monitor_test.go
+++ b/pkg/process/monitor/process_monitor_test.go
@@ -14,10 +14,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/vishvananda/netns"
-	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/consumers/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/telemetry"
@@ -34,20 +34,57 @@ func getProcessMonitor(t *testing.T) *ProcessMonitor {
 	return pm
 }
 
+// pidRecorder is a helper to record pids and check if they were recorded.
+type pidRecorder struct {
+	mu   sync.RWMutex
+	pids map[uint32]struct{}
+}
+
+// newPidRecorder creates a new pidRecorder.
+func newPidRecorder() *pidRecorder {
+	return &pidRecorder{pids: make(map[uint32]struct{})}
+}
+
+// record records a pid.
+func (pr *pidRecorder) record(pid uint32) {
+	pr.mu.Lock()
+	defer pr.mu.Unlock()
+	pr.pids[pid] = struct{}{}
+}
+
+// has checks if a pid was recorded.
+func (pr *pidRecorder) has(pid uint32) bool {
+	pr.mu.RLock()
+	defer pr.mu.RUnlock()
+	_, ok := pr.pids[pid]
+	return ok
+}
+
+// getProcessCallback returns a ProcessCallback wrapper of the pidRecorder.record method.
+func getProcessCallback(r *pidRecorder) *ProcessCallback {
+	f := func(pid uint32) {
+		r.record(pid)
+	}
+	return &f
+}
+
 func waitForProcessMonitor(t *testing.T, pm *ProcessMonitor) {
-	execCounter := atomic.NewInt32(0)
-	execCallback := func(_ uint32) { execCounter.Inc() }
-	registerCallback(t, pm, true, &execCallback)
+	execRecorder := newPidRecorder()
+	registerCallback(t, pm, true, getProcessCallback(execRecorder))
 
-	exitCounter := atomic.NewInt32(0)
-	// Sanity subscribing a callback.
-	exitCallback := func(_ uint32) { exitCounter.Inc() }
-	registerCallback(t, pm, false, &exitCallback)
+	exitRecorder := newPidRecorder()
+	registerCallback(t, pm, false, getProcessCallback(exitRecorder))
 
-	require.Eventually(t, func() bool {
-		_ = exec.Command("/bin/echo").Run()
-		return execCounter.Load() > 0 && exitCounter.Load() > 0
-	}, 10*time.Second, time.Millisecond*200)
+	for i := 0; i < 10; i++ {
+		cmd := exec.Command("/bin/echo")
+		require.NoError(t, cmd.Run())
+		require.NotZero(t, cmd.Process.Pid)
+		t.Logf("running %d", cmd.Process.Pid)
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			require.Truef(ct, execRecorder.has(uint32(cmd.Process.Pid)), "didn't capture exec event %d", cmd.Process.Pid)
+			require.True(ct, exitRecorder.has(uint32(cmd.Process.Pid)), "didn't capture exit event %d", cmd.Process.Pid)
+		}, 1*time.Second, 100*time.Millisecond)
+	}
 }
 
 func initializePM(t *testing.T, pm *ProcessMonitor, useEventStream bool) {
@@ -95,44 +132,21 @@ type processMonitorSuite struct {
 func (s *processMonitorSuite) TestProcessMonitorSanity() {
 	t := s.T()
 	pm := getProcessMonitor(t)
-	execsMutex := sync.RWMutex{}
-	execs := make(map[uint32]struct{})
 	testBinaryPath := getTestBinaryPath(t)
-	callback := func(pid uint32) {
-		execsMutex.Lock()
-		defer execsMutex.Unlock()
-		execs[pid] = struct{}{}
-	}
-	registerCallback(t, pm, true, &callback)
 
-	exitMutex := sync.RWMutex{}
-	exits := make(map[uint32]struct{})
-	exitCallback := func(pid uint32) {
-		exitMutex.Lock()
-		defer exitMutex.Unlock()
-		exits[pid] = struct{}{}
-	}
-	registerCallback(t, pm, false, &exitCallback)
+	execRecorder := newPidRecorder()
+	registerCallback(t, pm, true, getProcessCallback(execRecorder))
+
+	exitRecorder := newPidRecorder()
+	registerCallback(t, pm, false, getProcessCallback(exitRecorder))
 
 	initializePM(t, pm, s.useEventStream)
 	cmd := exec.Command(testBinaryPath, "test")
 	require.NoError(t, cmd.Run())
-	require.Eventually(t, func() bool {
-		execsMutex.RLock()
-		_, execCaptured := execs[uint32(cmd.Process.Pid)]
-		execsMutex.RUnlock()
-		if !execCaptured {
-			t.Logf("didn't capture exec event %d", cmd.Process.Pid)
-		}
-
-		exitMutex.RLock()
-		_, exitCaptured := exits[uint32(cmd.Process.Pid)]
-		exitMutex.RUnlock()
-		if !exitCaptured {
-			t.Logf("didn't capture exit event %d", cmd.Process.Pid)
-		}
-		return execCaptured && exitCaptured
-	}, time.Second, time.Millisecond*200)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.Truef(ct, execRecorder.has(uint32(cmd.Process.Pid)), "didn't capture exec event %d", cmd.Process.Pid)
+		assert.Truef(ct, exitRecorder.has(uint32(cmd.Process.Pid)), "didn't capture exit event %d", cmd.Process.Pid)
+	}, 5*time.Second, time.Millisecond*100)
 
 	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exec.Get(), "events is not >= than exec")
 	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exit.Get(), "events is not >= than exit")
@@ -158,57 +172,28 @@ func (s *processMonitorSuite) TestProcessRegisterMultipleCallbacks() {
 	pm := getProcessMonitor(t)
 
 	const iterations = 10
-	execCountersMutexes := make([]sync.RWMutex, iterations)
-	execCounters := make([]map[uint32]struct{}, iterations)
-	exitCountersMutexes := make([]sync.RWMutex, iterations)
-	exitCounters := make([]map[uint32]struct{}, iterations)
+	execs := make([]*pidRecorder, iterations)
+	exits := make([]*pidRecorder, iterations)
 	for i := 0; i < iterations; i++ {
-		execCountersMutexes[i] = sync.RWMutex{}
-		execCounters[i] = make(map[uint32]struct{})
-		c := execCounters[i]
-		// Sanity subscribing a callback.
-		callback := func(pid uint32) {
-			execCountersMutexes[i].Lock()
-			defer execCountersMutexes[i].Unlock()
-			c[pid] = struct{}{}
-		}
-		registerCallback(t, pm, true, &callback)
+		newExecRecorder := newPidRecorder()
+		registerCallback(t, pm, true, getProcessCallback(newExecRecorder))
+		execs[i] = newExecRecorder
 
-		exitCountersMutexes[i] = sync.RWMutex{}
-		exitCounters[i] = make(map[uint32]struct{})
-		exitc := exitCounters[i]
-		// Sanity subscribing a callback.
-		exitCallback := func(pid uint32) {
-			exitCountersMutexes[i].Lock()
-			defer exitCountersMutexes[i].Unlock()
-			exitc[pid] = struct{}{}
-		}
-		registerCallback(t, pm, false, &exitCallback)
+		newExitRecorder := newPidRecorder()
+		registerCallback(t, pm, false, getProcessCallback(newExitRecorder))
+		exits[i] = newExitRecorder
 	}
 
 	initializePM(t, pm, s.useEventStream)
 	cmd := exec.Command("/bin/sleep", "1")
 	require.NoError(t, cmd.Run())
-	require.Eventuallyf(t, func() bool {
+	require.EventuallyWithTf(t, func(ct *assert.CollectT) {
 		// Instead of breaking immediately when we don't find the event, we want logs to be printed for all iterations.
-		found := true
 		for i := 0; i < iterations; i++ {
-			execCountersMutexes[i].RLock()
-			if _, captured := execCounters[i][uint32(cmd.Process.Pid)]; !captured {
-				t.Logf("iter %d didn't capture exec event", i)
-				found = false
-			}
-			execCountersMutexes[i].RUnlock()
-
-			exitCountersMutexes[i].RLock()
-			if _, captured := exitCounters[i][uint32(cmd.Process.Pid)]; !captured {
-				t.Logf("iter %d didn't capture exit event", i)
-				found = false
-			}
-			exitCountersMutexes[i].RUnlock()
+			assert.Truef(ct, execs[i].has(uint32(cmd.Process.Pid)), "iter %d didn't capture exec event %d", i, cmd.Process.Pid)
+			assert.Truef(ct, exits[i].has(uint32(cmd.Process.Pid)), "iter %d didn't capture exit event %d", i, cmd.Process.Pid)
 		}
-		return found
-	}, time.Second, time.Millisecond*200, "at least of the callbacks didn't capture events")
+	}, 5*time.Second, 100*time.Millisecond, "at least of the callbacks didn't capture events")
 
 	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exec.Get(), "events is not >= than exec")
 	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exit.Get(), "events is not >= than exit")
@@ -236,16 +221,14 @@ func TestProcessMonitorRefcount(t *testing.T) {
 
 func (s *processMonitorSuite) TestProcessMonitorInNamespace() {
 	t := s.T()
-	execSet := sync.Map{}
-	exitSet := sync.Map{}
 
 	pm := getProcessMonitor(t)
 
-	callback := func(pid uint32) { execSet.Store(pid, struct{}{}) }
-	registerCallback(t, pm, true, &callback)
+	execRecorder := newPidRecorder()
+	registerCallback(t, pm, true, getProcessCallback(execRecorder))
 
-	exitCallback := func(pid uint32) { exitSet.Store(pid, struct{}{}) }
-	registerCallback(t, pm, false, &exitCallback)
+	exitRecorder := newPidRecorder()
+	registerCallback(t, pm, false, getProcessCallback(exitRecorder))
 
 	monNs, err := netns.New()
 	require.NoError(t, err, "could not create network namespace for process monitor")
@@ -263,17 +246,10 @@ func (s *processMonitorSuite) TestProcessMonitorInNamespace() {
 	require.NoError(t, cmd.Run(), "could not run process in root namespace")
 	pid := uint32(cmd.ProcessState.Pid())
 
-	require.Eventually(t, func() bool {
-		_, capturedExec := execSet.Load(pid)
-		if !capturedExec {
-			t.Logf("pid %d not captured in exec", pid)
-		}
-		_, capturedExit := exitSet.Load(pid)
-		if !capturedExit {
-			t.Logf("pid %d not captured in exit", pid)
-		}
-		return capturedExec && capturedExit
-	}, time.Second, time.Millisecond*200, "did not capture process EXEC/EXIT from root namespace")
+	require.EventuallyWithTf(t, func(ct *assert.CollectT) {
+		assert.Truef(ct, execRecorder.has(pid), "didn't capture exec event %d", pid)
+		assert.Truef(ct, exitRecorder.has(pid), "didn't capture exit event %d", pid)
+	}, 5*time.Second, 100*time.Millisecond, "did not capture process EXEC/EXIT from root namespace")
 
 	// Process in another NS
 	cmdNs, err := netns.New()
@@ -284,17 +260,10 @@ func (s *processMonitorSuite) TestProcessMonitorInNamespace() {
 	require.NoError(t, kernel.WithNS(cmdNs, cmd.Run), "could not run process in other network namespace")
 	pid = uint32(cmd.ProcessState.Pid())
 
-	require.Eventually(t, func() bool {
-		_, capturedExec := execSet.Load(pid)
-		if !capturedExec {
-			t.Logf("pid %d not captured in exec", pid)
-		}
-		_, capturedExit := exitSet.Load(pid)
-		if !capturedExit {
-			t.Logf("pid %d not captured in exit", pid)
-		}
-		return capturedExec && capturedExit
-	}, time.Second, 200*time.Millisecond, "did not capture process EXEC/EXIT from other namespace")
+	require.EventuallyWithTf(t, func(ct *assert.CollectT) {
+		assert.Truef(ct, execRecorder.has(pid), "didn't capture exec event %d", pid)
+		assert.Truef(ct, exitRecorder.has(pid), "didn't capture exit event %d", pid)
+	}, 5*time.Second, 100*time.Millisecond, "did not capture process EXEC/EXIT from root namespace")
 
 	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exec.Get(), "events is not >= than exec")
 	require.GreaterOrEqual(t, pm.tel.events.Get(), pm.tel.exit.Get(), "events is not >= than exit")


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Introduces a test struct pidRecorder that records PIDs captured via our process monitor

### Motivation

We have a common pattern in the tests, to create a concurrent safe mapping of pids captured while enabling our process monitor. The commit introduces a new struct to encapsulate the common pattern and remove duplication and excessive code

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->