### PR TITLE
usm: tests: Cache event monitor

### DIFF
--- a/pkg/network/usm/ebpf_ssl_test.go
+++ b/pkg/network/usm/ebpf_ssl_test.go
@@ -38,7 +38,7 @@ func testArch(t *testing.T, arch string) {
 	libmmap := filepath.Join(curDir, "testdata", "site-packages", "ddtrace")
 	lib := filepath.Join(libmmap, fmt.Sprintf("libssl.so.%s", arch))
 
-	monitor := setupUSMTLSMonitor(t, cfg)
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 	require.NotNil(t, monitor)
 
 	cmd, err := fileopener.OpenFromAnotherProcess(t, lib)

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -122,7 +122,7 @@ func (s *postgresProtocolParsingSuite) TestLoadPostgresBinary() {
 		t.Run(name, func(t *testing.T) {
 			cfg := getPostgresDefaultTestConfiguration(protocolsUtils.TLSDisabled)
 			cfg.BPFDebug = debug
-			setupUSMTLSMonitor(t, cfg)
+			setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 		})
 	}
 }
@@ -191,7 +191,7 @@ func testDecoding(t *testing.T, isTLS bool) {
 		return count * 2
 	}
 
-	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS))
+	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS), useExistingConsumer)
 	if isTLS {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
 	}
@@ -720,7 +720,7 @@ func (s *postgresProtocolParsingSuite) TestCleanupEBPFEntriesOnTermination() {
 	t := s.T()
 
 	// Creating the monitor
-	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(protocolsUtils.TLSDisabled))
+	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(protocolsUtils.TLSDisabled), useExistingConsumer)
 
 	wg := sync.WaitGroup{}
 
@@ -924,7 +924,7 @@ func testKernelMessagesCount(t *testing.T, isTLS bool) {
 	require.NoError(t, postgres.RunServer(t, serverHost, postgresPort, isTLS))
 	waitForPostgresServer(t, serverAddress, isTLS)
 
-	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS))
+	monitor := setupUSMTLSMonitor(t, getPostgresDefaultTestConfiguration(isTLS), useExistingConsumer)
 	if isTLS {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, os.Getpid(), utils.ManualTracingFallbackEnabled)
 	}

--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -120,7 +120,7 @@ func (s *usmGRPCSuite) TestSimpleGRPCScenarios() {
 	t.Cleanup(cancel)
 	defaultCtx := context.Background()
 
-	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
+	usmMonitor := setupUSMTLSMonitor(t, s.getConfig(), useExistingConsumer)
 	if s.isTLS {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, srv.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
@@ -448,7 +448,7 @@ func (s *usmGRPCSuite) TestLargeBodiesGRPCScenarios() {
 	t.Cleanup(cancel)
 	defaultCtx := context.Background()
 
-	usmMonitor := setupUSMTLSMonitor(t, s.getConfig())
+	usmMonitor := setupUSMTLSMonitor(t, s.getConfig(), useExistingConsumer)
 	if s.isTLS {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, srv.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -132,7 +132,7 @@ func (s *usmHTTP2Suite) TestLoadHTTP2Binary() {
 	for _, debug := range map[string]bool{"enabled": true, "disabled": false} {
 		t.Run(fmt.Sprintf("debug %v", debug), func(t *testing.T) {
 			cfg.BPFDebug = debug
-			setupUSMTLSMonitor(t, cfg)
+			setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 		})
 	}
 }
@@ -150,7 +150,7 @@ func (s *usmHTTP2Suite) TestHTTP2DynamicTableCleanup() {
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
-	monitor := setupUSMTLSMonitor(t, cfg)
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 	if s.isTLS {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
@@ -212,7 +212,7 @@ func (s *usmHTTP2Suite) TestSimpleHTTP2() {
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
-	monitor := setupUSMTLSMonitor(t, cfg)
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 	if s.isTLS {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
@@ -400,7 +400,7 @@ func (s *usmHTTP2Suite) TestHTTP2KernelTelemetry() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			monitor := setupUSMTLSMonitor(t, cfg)
+			monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 			if s.isTLS {
 				utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
@@ -455,7 +455,7 @@ func (s *usmHTTP2Suite) TestHTTP2ManyDifferentPaths() {
 	t.Cleanup(cancel)
 	require.NoError(t, proxy.WaitForConnectionReady(unixPath))
 
-	monitor := setupUSMTLSMonitor(t, cfg)
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 	if s.isTLS {
 		utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 	}
@@ -512,7 +512,7 @@ func (s *usmHTTP2Suite) TestRawTraffic() {
 	t := s.T()
 	cfg := s.getCfg()
 
-	usmMonitor := setupUSMTLSMonitor(t, cfg)
+	usmMonitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 
 	// Start local server and register its cleanup.
 	t.Cleanup(startH2CServer(t, authority, s.isTLS))
@@ -1319,7 +1319,7 @@ func (s *usmHTTP2Suite) TestDynamicTable() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			usmMonitor := setupUSMTLSMonitor(t, cfg)
+			usmMonitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 			if s.isTLS {
 				utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
@@ -1405,7 +1405,7 @@ func (s *usmHTTP2Suite) TestIncompleteFrameTable() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			usmMonitor := setupUSMTLSMonitor(t, cfg)
+			usmMonitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 			if s.isTLS {
 				utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
@@ -1475,7 +1475,7 @@ func (s *usmHTTP2Suite) TestRawHuffmanEncoding() {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			usmMonitor := setupUSMTLSMonitor(t, cfg)
+			usmMonitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 			if s.isTLS {
 				utils.WaitForProgramsToBeTraced(t, consts.USMModuleName, GoTLSAttacherName, proxyProcess.Process.Pid, utils.ManualTracingFallbackEnabled)
 			}
@@ -1513,7 +1513,7 @@ func TestHTTP2InFlightMapCleaner(t *testing.T) {
 	cfg.EnableHTTP2Monitoring = true
 	cfg.HTTP2DynamicTableMapCleanerInterval = 5 * time.Second
 	cfg.HTTPIdleConnectionTTL = time.Second
-	monitor := setupUSMTLSMonitor(t, cfg)
+	monitor := setupUSMTLSMonitor(t, cfg, useExistingConsumer)
 	ebpfNow, err := ddebpf.NowNanoseconds()
 	require.NoError(t, err)
 	http2InFLightMap, _, err := monitor.ebpfProgram.GetMap(usmhttp2.InFlightMap)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Cache event monitoring in usm tests.

### Motivation

We do not need to recreate the event monitor in every test, so the change caches the event monitor and unless explicitly asked to reinitialize, it uses the latest cache

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Cuts about 20m in our tests