### PR TITLE
[ADXT-726] Retry on ssh rejected error

### DIFF
--- a/test/new-e2e/pkg/utils/infra/retriable_errors.go
+++ b/test/new-e2e/pkg/utils/infra/retriable_errors.go
@@ -61,5 +61,10 @@ func getKnownErrors() []knownError {
 			errorMessage: `error: awsx:ecs:FargateTaskDefinition resource '.+fakeintake.+' has a problem: grpc: the client connection is closing`,
 			retryType:    ReCreate,
 		},
+		{
+			// https://datadoghq.atlassian.net/browse/ADXT-726
+			errorMessage: `error: .*ssh: rejected: connect failed (No route to host)`,
+			retryType:    ReCreate,
+		},
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Retries errors such as `command: remote-ci-704261148-4670-kernel-matrix-testing-system-probe-x86-64-48834378-x86_64-conn-x86_64-fedora_37-distro_x86_64-no_usm-ddvm-4-12288-cmd-x86_64-fedora_37-distro_x86_64-no_usm-ddvm-4-12288-mount-disk-dev-vdb     vm-command: mount-disk-dev-vdb     error message: error: proxy: after 60 failed attempts: ssh: rejected: connect failed (No route to host)`

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->