### PR TITLE
[CWS] Snapshot and runtime use the same file to identify cgroups

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -132,7 +132,10 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         container_id = (void *)container_qstr.name;
 
         u64 inode = get_dentry_ino(container_d);
-        resolver->key.ino = inode;
+        // On RHEL kernels, the inode is the one of the folder holding cgroup.procs.
+        // The + 2 is inferred from the code, that won't change since RHEL 7 is EOL.
+        resolver->key.ino = inode + 2;
+
         struct file_t *entry = bpf_map_lookup_elem(&exec_file_cache, &inode);
         if (entry == NULL) {
             return 0;

--- a/pkg/security/resolvers/container/resolver.go
+++ b/pkg/security/resolvers/container/resolver.go
@@ -26,8 +26,8 @@ func New() *Resolver {
 	}
 }
 
-// GetContainerContext returns the container id and cgroup context of the given pid
+// GetContainerContext returns the container id, cgroup context, and cgroup sysfs path of the given pid
 func (cr *Resolver) GetContainerContext(pid uint32) (containerutils.ContainerID, model.CGroupContext, string, error) {
-	// Parse /proc/[pid]/task/[pid]/cgroup and /sys/fs/cgroup/.../cgroup.procs
+	// Parse /proc/[pid]/task/[pid]/cgroup and /sys/fs/cgroup/[cgroup]
 	return cr.fs.FindCGroupContext(pid, pid)
 }

--- a/pkg/security/resolvers/container/resolver.go
+++ b/pkg/security/resolvers/container/resolver.go
@@ -15,10 +15,19 @@ import (
 )
 
 // Resolver is used to resolve the container context of the events
-type Resolver struct{}
+type Resolver struct {
+	fs *utils.CGroupFS
+}
 
-// GetContainerContext returns the container id of the given pid along with its flags
-func (cr *Resolver) GetContainerContext(pid uint32) (containerutils.ContainerID, model.CGroupContext, error) {
-	// Parse /proc/[pid]/task/[pid]/cgroup
-	return utils.GetProcContainerContext(pid, pid)
+// New creates a new container resolver
+func New() *Resolver {
+	return &Resolver{
+		fs: utils.NewCGroupFS(),
+	}
+}
+
+// GetContainerContext returns the container id and cgroup context of the given pid
+func (cr *Resolver) GetContainerContext(pid uint32) (containerutils.ContainerID, model.CGroupContext, string, error) {
+	// Parse /proc/[pid]/task/[pid]/cgroup and /sys/fs/cgroup/.../cgroup.procs
+	return cr.fs.FindCGroupContext(pid, pid)
 }

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -223,14 +222,9 @@ func (r *EBPFResolvers) ResolveCGroupContext(pathKey model.PathKey, cgroupFlags 
 		return cgroupContext, nil
 	}
 
-	path, err := r.DentryResolver.Resolve(pathKey, true)
+	cgroup, err := r.DentryResolver.Resolve(pathKey, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve cgroup file %v: %w", pathKey, err)
-	}
-
-	cgroup := filepath.Dir(string(path))
-	if cgroup == "/" {
-		cgroup = path
 	}
 
 	cgroupContext := &model.CGroupContext{

--- a/pkg/security/resolvers/resolvers_ebpf.go
+++ b/pkg/security/resolvers/resolvers_ebpf.go
@@ -133,7 +133,7 @@ func NewEBPFResolvers(config *config.Config, manager *manager.Manager, statsdCli
 		mountResolver = &mount.NoOpResolver{}
 		pathResolver = &path.NoOpResolver{}
 	}
-	containerResolver := &container.Resolver{}
+	containerResolver := container.New()
 
 	processOpts := process.NewResolverOpts()
 	processOpts.WithEnvsValue(config.Probe.EnvsWithValue)

--- a/pkg/security/resolvers/resolvers_ebpfless.go
+++ b/pkg/security/resolvers/resolvers_ebpfless.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/container"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/hash"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
@@ -24,10 +23,9 @@ import (
 
 // EBPFLessResolvers holds the list of the event attribute resolvers
 type EBPFLessResolvers struct {
-	ContainerResolver *container.Resolver
-	TagsResolver      *tags.LinuxResolver
-	ProcessResolver   *process.EBPFLessResolver
-	HashResolver      *hash.Resolver
+	TagsResolver    *tags.LinuxResolver
+	ProcessResolver *process.EBPFLessResolver
+	HashResolver    *hash.Resolver
 }
 
 // NewEBPFLessResolvers creates a new instance of EBPFLessResolvers

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -342,13 +342,13 @@ func TestCGroupSnapshot(t *testing.T) {
 
 		// Check that we have the right cgroup inode
 		cgroupFS := utils.NewCGroupFS()
-		_, _, cgroupProcsPath, err := cgroupFS.FindCGroupContext(uint32(os.Getpid()), uint32(os.Getpid()))
+		_, _, cgroupSysFSPath, err := cgroupFS.FindCGroupContext(uint32(os.Getpid()), uint32(os.Getpid()))
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		var stats unix.Stat_t
-		if err := unix.Stat(cgroupProcsPath, &stats); err != nil {
+		if err := unix.Stat(cgroupSysFSPath, &stats); err != nil {
 			t.Fatal(err)
 		}
 		assert.Equal(t, stats.Ino, testsuiteEntry.CGroup.CGroupFile.Inode)

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -345,7 +345,7 @@ func TestCGroupSnapshot(t *testing.T) {
 		if err := unix.Stat(cgroupProcsPath, &stats); err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, testsuiteEntry.CGroup.CGroupFile.Inode, stats.Ino)
+		assert.Equal(t, stats.Ino, testsuiteEntry.CGroup.CGroupFile.Inode)
 
 		// Check we filled the kernel maps correctly with the same values than userspace for the testsuite process
 		var newEntry *model.ProcessCacheEntry
@@ -355,7 +355,7 @@ func TestCGroupSnapshot(t *testing.T) {
 		})
 		assert.NotNil(t, newEntry)
 		if newEntry != nil {
-			assert.Equal(t, newEntry.CGroup.CGroupFile.Inode, stats.Ino)
+			assert.Equal(t, stats.Ino, newEntry.CGroup.CGroupFile.Inode)
 		}
 
 		// Check we filled the kernel maps correctly with the same values than userspace for the syscall tester process
@@ -365,7 +365,7 @@ func TestCGroupSnapshot(t *testing.T) {
 		})
 		assert.NotNil(t, newEntry)
 		if newEntry != nil {
-			assert.Equal(t, newEntry.CGroup.CGroupFile.Inode, stats.Ino)
+			assert.Equal(t, stats.Ino, newEntry.CGroup.CGroupFile.Inode)
 		}
 	})
 

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -240,6 +240,12 @@ ExecStart=/usr/bin/touch %s`, testFile2)
 }
 
 func TestCGroupSnapshot(t *testing.T) {
+	if testEnvironment == DockerEnvironment {
+		t.Skip("skipping cgroup ID test in docker")
+	}
+
+	SkipIfNotAvailable(t)
+
 	_, cgroupContext, err := utils.GetProcContainerContext(uint32(os.Getpid()), uint32(os.Getpid()))
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -12,29 +12,84 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
-func createCGroup(name string) (string, error) {
-	cgroupPath := "/sys/fs/cgroup/memory/" + name
-	if err := os.MkdirAll(cgroupPath, 0700); err != nil {
-		return "", err
+type testCGroup struct {
+	cgroupPath         string
+	previousCGroupPath string
+}
+
+func (cg *testCGroup) enter() error {
+	return os.WriteFile(cg.cgroupPath+"/cgroup.procs", []byte(strconv.Itoa(os.Getpid())), 0700)
+}
+
+func (cg *testCGroup) leave(t *testing.T) {
+	if err := os.WriteFile("/sys/fs/cgroup"+cg.previousCGroupPath+"/cgroup.procs", []byte(strconv.Itoa(os.Getpid())), 0700); err != nil {
+		if err := os.WriteFile("/sys/fs/cgroup/systemd"+cg.previousCGroupPath+"/cgroup.procs", []byte(strconv.Itoa(os.Getpid())), 0700); err != nil {
+			t.Log(err)
+			return
+		}
+	}
+}
+
+func (cg *testCGroup) remove(t *testing.T) {
+	if err := os.Remove(cg.cgroupPath); err != nil {
+		if content, err := os.ReadFile(cg.cgroupPath + "/cgroup.procs"); err == nil {
+			t.Logf("Processes in cgroup: %s", string(content))
+		}
+	}
+}
+
+func (cg *testCGroup) create() error {
+	return os.MkdirAll(cg.cgroupPath, 0700)
+}
+
+func newCGroup(name, kind string) (*testCGroup, error) {
+	cgs, err := utils.GetProcControlGroups(uint32(os.Getpid()), uint32(os.Getpid()))
+	if err != nil {
+		return nil, err
 	}
 
-	if err := os.WriteFile(cgroupPath+"/cgroup.procs", []byte(strconv.Itoa(os.Getpid())), 0700); err != nil {
-		return "", err
+	var previousCGroupPath string
+	for _, cg := range cgs {
+		if len(cg.Controllers) == 1 && cg.Controllers[0] == "" {
+			previousCGroupPath = cg.Path
+			break
+		} else {
+			if previousCGroupPath == "" {
+				previousCGroupPath = cg.Path
+			} else if previousCGroupPath == "/" {
+				previousCGroupPath = cg.Path
+			}
+			if slices.Contains(cg.Controllers, kind) || slices.Contains(cg.Controllers, "name="+kind) {
+				previousCGroupPath = cg.Path
+				break
+			}
+		}
 	}
 
-	return cgroupPath, nil
+	cgroupPath := "/sys/fs/cgroup/" + kind + "/" + name
+	cg := &testCGroup{
+		previousCGroupPath: previousCGroupPath,
+		cgroupPath:         cgroupPath,
+	}
+
+	return cg, nil
 }
 
 func TestCGroup(t *testing.T) {
@@ -47,7 +102,7 @@ func TestCGroup(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_cgroup_id",
-			Expression: `open.file.path == "{{.Root}}/test-open" && cgroup.id =~ "*/cg1"`, // "/memory/cg1" or "/cg1"
+			Expression: `open.file.path == "{{.Root}}/test-open" && cgroup.id =~ "*/cg1"`, // "/cpu/cg1" or "/cg1"
 		},
 		{
 			ID:         "test_cgroup_systemd",
@@ -60,11 +115,20 @@ func TestCGroup(t *testing.T) {
 	}
 	defer test.Close()
 
-	cgroupPath, err := createCGroup("cg1")
+	testCGroup, err := newCGroup("cg1", "cpu")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(cgroupPath)
+
+	if err := testCGroup.create(); err != nil {
+		t.Fatal(err)
+	}
+	defer testCGroup.remove(t)
+
+	if err := testCGroup.enter(); err != nil {
+		t.Fatal(err)
+	}
+	defer testCGroup.leave(t)
 
 	testFile, testFilePtr, err := test.Path("test-open")
 	if err != nil {
@@ -90,7 +154,7 @@ func TestCGroup(t *testing.T) {
 			assertFieldEqual(t, event, "container.id", "")
 			assertFieldEqual(t, event, "container.runtime", "")
 			assert.Equal(t, containerutils.CGroupFlags(0), event.CGroupContext.CGroupFlags)
-			assertFieldIsOneOf(t, event, "cgroup.id", "/memory/cg1")
+			assertFieldIsOneOf(t, event, "cgroup.id", "/cpu/cg1")
 			assertFieldIsOneOf(t, event, "cgroup.version", []int{1, 2})
 
 			test.validateOpenSchema(t, event)
@@ -175,4 +239,136 @@ ExecStart=/usr/bin/touch %s`, testFile2)
 			test.validateOpenSchema(t, event)
 		})
 	})
+}
+
+func TestCGroupSnapshot(t *testing.T) {
+	_, cgroupContext, err := utils.GetProcContainerContext(uint32(os.Getpid()), uint32(os.Getpid()))
+
+	testCGroup, err := newCGroup("cg2", "systemd")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := testCGroup.create(); err != nil {
+		t.Fatal(err)
+	}
+	defer testCGroup.remove(t)
+
+	if err := testCGroup.enter(); err != nil {
+		t.Fatal(err)
+	}
+	defer testCGroup.leave(t)
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var testsuiteStats unix.Stat_t
+	if err := unix.Stat(executable, &testsuiteStats); err != nil {
+		t.Fatal(err)
+	}
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_cgroup_snapshot",
+			Expression: `open.file.path == "{{.Root}}/test-open" && cgroup.id != ""`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, _, err := test.Path("test-open")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var syscallTesterStats unix.Stat_t
+	if err := unix.Stat(syscallTester, &syscallTesterStats); err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
+	if !ok {
+		t.Skip("not supported")
+	}
+
+	var cmd *exec.Cmd
+	test.WaitSignal(t, func() error {
+		cmd = exec.Command(syscallTester, "open", testFile)
+		pipe, err := cmd.StdinPipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer pipe.Close()
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		return nil
+	}, func(event *model.Event, rule *rules.Rule) {
+		assertTriggeredRule(t, rule, "test_cgroup_snapshot")
+		test.validateOpenSchema(t, event)
+
+		testsuiteEntry := p.Resolvers.ProcessResolver.Get(uint32(os.Getpid()))
+		syscallTesterEntry := p.Resolvers.ProcessResolver.Get(uint32(cmd.Process.Pid))
+		assert.NotNil(t, testsuiteEntry)
+		assert.NotNil(t, syscallTesterEntry)
+
+		// Check that testsuite has changed cgroup since its start
+		assert.NotEqual(t, cgroupContext.CGroupID, testsuiteEntry.CGroup.CGroupID)
+		assert.Equal(t, int(testsuiteEntry.Pid), os.Getpid())
+
+		// Check that both testsuite and syscall tester share the same cgroup
+		assert.Equal(t, testsuiteEntry.CGroup.CGroupID, syscallTesterEntry.CGroup.CGroupID)
+		assert.Equal(t, testsuiteEntry.CGroup.CGroupFile, syscallTesterEntry.CGroup.CGroupFile)
+
+		// Check that we have the right cgroup inode
+		cgroupFS := utils.NewCGroupFS()
+		_, _, cgroupProcsPath, err := cgroupFS.FindCGroupContext(uint32(os.Getpid()), uint32(os.Getpid()))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var stats unix.Stat_t
+		if err := unix.Stat(cgroupProcsPath, &stats); err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, testsuiteEntry.CGroup.CGroupFile.Inode, stats.Ino)
+
+		// Check we filled the kernel maps correctly with the same values than userspace for the testsuite process
+		var newEntry *model.ProcessCacheEntry
+		ebpfProbe := test.probe.PlatformProbe.(*probe.EBPFProbe)
+		ebpfProbe.Resolvers.ProcessResolver.ResolveFromKernelMaps(uint32(os.Getpid()), uint32(os.Getpid()), testsuiteStats.Ino, func(entry *model.ProcessCacheEntry, err error) {
+			newEntry = entry
+		})
+		assert.NotNil(t, newEntry)
+		if newEntry != nil {
+			assert.Equal(t, newEntry.CGroup.CGroupFile.Inode, stats.Ino)
+		}
+
+		// Check we filled the kernel maps correctly with the same values than userspace for the syscall tester process
+		newEntry = nil
+		ebpfProbe.Resolvers.ProcessResolver.ResolveFromKernelMaps(syscallTesterEntry.Pid, syscallTesterEntry.Pid, syscallTesterStats.Ino, func(entry *model.ProcessCacheEntry, err error) {
+			newEntry = entry
+		})
+		assert.NotNil(t, newEntry)
+		if newEntry != nil {
+			assert.Equal(t, newEntry.CGroup.CGroupFile.Inode, stats.Ino)
+		}
+	})
+
+	if cmd != nil {
+		cmd.Process.Kill()
+	}
 }

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -249,8 +249,9 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 			return false
 		}
 
+		ctrlDirectory := strings.TrimPrefix(ctrl, "name=")
 		for _, mountpoint := range cfs.cGroupMountPoints {
-			procsPath := filepath.Join(mountpoint, ctrl, path, "cgroup.procs")
+			procsPath := filepath.Join(mountpoint, ctrlDirectory, path, "cgroup.procs")
 			if exists, err := checkPidExists(procsPath, pid); err == nil && exists {
 				cgroupID := containerutils.CGroupID(path)
 				ctrID, flags := containerutils.FindContainerID(cgroupID)

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -197,6 +197,8 @@ var defaultCGroupMountpoints = []string{
 	"/sys/fs/cgroup/unified",
 }
 
+var ErrNoCGroupMountpoint = errors.New("no cgroup mount point found")
+
 type CGroupFS struct {
 	cGroupMountPoints []string
 }
@@ -223,7 +225,7 @@ func NewCGroupFS(cgroupMountPoints ...string) *CGroupFS {
 
 func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.ContainerID, model.CGroupContext, string, error) {
 	if len(cfs.cGroupMountPoints) == 0 {
-		return "", model.CGroupContext{}, "", errors.New("no cgroup mount point found")
+		return "", model.CGroupContext{}, "", ErrNoCGroupMountpoint
 	}
 
 	var (

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -226,7 +226,7 @@ func NewCGroupFS(cgroupMountPoints ...string) *CGroupFS {
 	return cfs
 }
 
-// FindCGroupContext returns the container ID, cgroup context and cgroup path the process belongs to.
+// FindCGroupContext returns the container ID, cgroup context and sysfs cgroup path the process belongs to.
 // Returns "" as container ID and sysfs cgroup path, and an empty CGroupContext if the process does not belong to a container.
 func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.ContainerID, model.CGroupContext, string, error) {
 	if len(cfs.cGroupMountPoints) == 0 {
@@ -280,9 +280,8 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 	return containerID, cgroupContext, sysFScGroupPath, nil
 }
 
-func checkPidExists(sysFsPath string, expectedPid uint32) (bool, error) {
-	cgroupProcsPath := filepath.Join(sysFsPath, "cgroup.procs")
-	data, err := os.ReadFile(cgroupProcsPath)
+func checkPidExists(sysFScGroupPath string, expectedPid uint32) (bool, error) {
+	data, err := os.ReadFile(filepath.Join(sysFScGroupPath, "cgroup.procs"))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -260,9 +260,12 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 				containerID = ctrID
 				cgroupProcsPath = procsPath
 
-				var fileStats unix.Statx_t
-				if err := unix.Statx(unix.AT_FDCWD, procsPath, 0, unix.STATX_INO|unix.STATX_MNT_ID, &fileStats); err == nil {
-					cgroupContext.CGroupFile.MountID = uint32(fileStats.Mnt_id)
+				var fileStatx unix.Statx_t
+				var fileStats unix.Stat_t
+				if err := unix.Statx(unix.AT_FDCWD, procsPath, 0, unix.STATX_INO|unix.STATX_MNT_ID, &fileStatx); err == nil {
+					cgroupContext.CGroupFile.MountID = uint32(fileStatx.Mnt_id)
+					cgroupContext.CGroupFile.Inode = fileStatx.Ino
+				} else if err := unix.Stat(procsPath, &fileStats); err == nil {
 					cgroupContext.CGroupFile.Inode = fileStats.Ino
 				}
 				return true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This fixes the snapshot PathKey of cgroup files used to identify cgroups.
The `CGroupFile` struct of a `CGroupContext` should now always reference a `/sys/fs/cgroup/[cgroup]` file.

This also fixes the `CGroupFile` mount id field when it is not possible to retrieve it through statx.

### Motivation

This fixes multiple processes belonging to the same cgroup having distinct cgroup path keys, which would cause the cgroup resolution of such processes to fail. 
In the case of a `CGroupTracing` events, failed cgroup resolution would cause `traced_cgroups` map entries to be leaked.  

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->