### PR TITLE
fix(release) [Agent6] Prevent updating a `/pkg/util/optional` in agent6 RC

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -122,6 +122,13 @@ def update_modules(ctx, release_branch=None, version=None, trust=False):
         for module in modules.values():
             for dependency in module.dependencies:
                 dependency_mod = modules[dependency]
+                if (
+                    agent_version.startswith('6')
+                    and 'pkg/util/optional' in dependency_mod.dependency_path(agent_version)
+                    and 'test/new-e2e' in module.go_mod_path()
+                ):
+                    # Skip this dependency update in new-e2e for Agent 6, as it's incompatible.
+                    continue
                 ctx.run(f"go mod edit -require={dependency_mod.dependency_path(agent_version)} {module.go_mod_path()}")
 
 

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 import unittest
 from collections import OrderedDict
@@ -11,6 +12,7 @@ from invoke import Context, MockContext, Result
 from invoke.exceptions import Exit
 
 from tasks import release
+from tasks.libs.common.gomodules import GoModule
 from tasks.libs.releasing.documentation import nightly_entry_for, parse_table, release_entry_for
 from tasks.libs.releasing.json import (
     COMPATIBLE_MAJOR_VERSIONS,
@@ -1198,3 +1200,43 @@ class TestCheckForChanges(unittest.TestCase):
         ]
         print_mock.assert_has_calls(calls)
         self.assertEqual(print_mock.call_count, 2)
+
+
+class TestUpdateModules(unittest.TestCase):
+    @patch('tasks.release.agent_context', new=MagicMock())
+    def test_update_module_no_run_for_optional_in_agent_6(self):
+        c = MockContext(run=Result("yolo"))
+        new_e2e = GoModule('test/new-e2e')
+        new_e2e._dependencies = ['pkg/util/optional', 'pkg/utils/pointer']
+        optional = GoModule('pkg/util/optional')
+        optional._dependencies = []
+        pointer = GoModule('pkg/utils/pointer')
+        pointer._dependencies = []
+        with patch('tasks.release.get_default_modules') as mock_modules:
+            mock_dict = MagicMock()
+            mock_dict.values.return_value = [new_e2e]
+            mock_dict.__getitem__.side_effect = [new_e2e, optional, pointer]
+            mock_modules.return_value = mock_dict
+            release.update_modules(c, version="6.53.1337")
+        edit_optional = re.compile(r"pkg/util/optional.*test/new-e2e")
+        self.assertFalse(any(edit_optional.search(call[0][0]) for call in c.run.call_args_list))
+        self.assertEqual(c.run.call_count, 1)
+
+    @patch('tasks.release.agent_context', new=MagicMock())
+    def test_update_module_optional_in_agent_7(self):
+        c = MockContext(run=Result("yolo"))
+        new_e2e = GoModule('test/new-e2e')
+        new_e2e._dependencies = ['pkg/util/optional', 'pkg/utils/pointer']
+        optional = GoModule('pkg/util/optional')
+        optional._dependencies = []
+        pointer = GoModule('pkg/utils/pointer')
+        pointer._dependencies = []
+        with patch('tasks.release.get_default_modules') as mock_modules:
+            mock_dict = MagicMock()
+            mock_dict.values.return_value = [new_e2e]
+            mock_dict.__getitem__.side_effect = [new_e2e, optional, pointer]
+            mock_modules.return_value = mock_dict
+            release.update_modules(c, version="7.53.1337")
+        edit_optional = re.compile(r"pkg/util/optional.*test/new-e2e")
+        self.assertTrue(any(edit_optional.search(call[0][0]) for call in c.run.call_args_list))
+        self.assertEqual(c.run.call_count, 2)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Prevent the update of `pkg/util/optional` in the go.mod of `test/new-e2e` for Agent6 during RC creation

### Motivation
Today all depedencies are updated when the RC is created ([example](https://github.com/DataDog/datadog-agent/pull/32674/files#diff-fee3041315eef2d6446d1e0f565e42851503923fb40e53cf4c91ac5641ebc4e0R243))
But this causes a go mod [issue](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/755037488) for `test/new-e2e` module.
To prevent fixing the automatic RC creation I propose to ignore the update on this specific case

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
This is an ugly quickfix to prevent additional action during RC management for Agent6.
We might sort this with further bumps of dependencies in agent6 branch. This solution should be a temporary workaround.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->