### PR TITLE
discovery: e2e: add test for Container ID reporting

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -333,6 +333,7 @@ new-e2e-discovery:
   needs:
     - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_x64
+    - qa_agent
   rules:
     - !reference [.on_discovery_or_e2e_changes]
     - !reference [.manual]

--- a/test/fakeintake/aggregator/servicediscoveryAggregator.go
+++ b/test/fakeintake/aggregator/servicediscoveryAggregator.go
@@ -34,6 +34,7 @@ type ServiceDiscoveryPayload struct {
 		ServiceNameSource    string  `json:"service_name_source,omitempty"`
 		RSSMemory            uint64  `json:"rss_memory"`
 		CPUCores             float64 `json:"cpu_cores"`
+		ContainerID          string  `json:"container_id"`
 	} `json:"payload"`
 }
 

--- a/test/new-e2e/tests/discovery/docker_test.go
+++ b/test/new-e2e/tests/discovery/docker_test.go
@@ -52,7 +52,11 @@ func (s *dockerDiscoveryTestSuite) TestServiceDiscoveryContainerID() {
 
 	s.assertDockerAgentDiscoveryRunning()
 
-	s.Env().RemoteHost.MustExecute("docker pull " + pythonImage)
+	_, err = s.Env().RemoteHost.Execute("docker pull " + pythonImage)
+	if err != nil {
+		s.T().Skipf("could not pull docker image for service discovery E2E test: %s", err)
+	}
+
 	containerID := s.Env().RemoteHost.MustExecute("docker run -d --name e2e-test-python-server --publish 8090:8090 " + pythonImage + " python -m http.server 8090")
 	t.Cleanup(func() {
 		s.Env().RemoteHost.MustExecute("docker stop e2e-test-python-server && docker rm e2e-test-python-server")

--- a/test/new-e2e/tests/discovery/docker_test.go
+++ b/test/new-e2e/tests/discovery/docker_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	pythonImage = "public.ecr.aws/docker/library/python:3"
+)
+
 type dockerDiscoveryTestSuite struct {
 	e2e.BaseSuite[environments.DockerHost]
 }
@@ -48,7 +52,8 @@ func (s *dockerDiscoveryTestSuite) TestServiceDiscoveryContainerID() {
 
 	s.assertDockerAgentDiscoveryRunning()
 
-	containerID := s.Env().RemoteHost.MustExecute("docker run -d --name e2e-test-python-server --publish 8090:8090 public.ecr.aws/docker/library/python:3 python -m http.server 8090")
+	s.Env().RemoteHost.MustExecute("docker pull " + pythonImage)
+	containerID := s.Env().RemoteHost.MustExecute("docker run -d --name e2e-test-python-server --publish 8090:8090 " + pythonImage + " python -m http.server 8090")
 	t.Cleanup(func() {
 		s.Env().RemoteHost.MustExecute("docker stop e2e-test-python-server && docker rm e2e-test-python-server")
 	})

--- a/test/new-e2e/tests/discovery/docker_test.go
+++ b/test/new-e2e/tests/discovery/docker_test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package discovery
+
+import (
+	_ "embed"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/docker"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
+	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type dockerDiscoveryTestSuite struct {
+	e2e.BaseSuite[environments.DockerHost]
+}
+
+func TestDiscoveryDocker(t *testing.T) {
+	agentOpts := []dockeragentparams.Option{
+		dockeragentparams.WithAgentServiceEnvVariable("DD_DISCOVERY_ENABLED", pulumi.StringPtr("true")),
+	}
+
+	e2e.Run(t,
+		&dockerDiscoveryTestSuite{},
+		e2e.WithProvisioner(
+			awsdocker.Provisioner(
+				awsdocker.WithAgentOptions(agentOpts...),
+			)))
+}
+
+func (s *dockerDiscoveryTestSuite) TestServiceDiscoveryContainerID() {
+	t := s.T()
+
+	client := s.Env().FakeIntake.Client()
+	err := client.FlushServerAndResetAggregators()
+	require.NoError(t, err)
+
+	s.assertDockerAgentDiscoveryRunning()
+
+	containerID := s.Env().RemoteHost.MustExecute("docker run -d --name e2e-test-python-server --publish 8090:8090 public.ecr.aws/docker/library/python:3 python -m http.server 8090")
+	t.Cleanup(func() {
+		s.Env().RemoteHost.MustExecute("docker stop e2e-test-python-server && docker rm e2e-test-python-server")
+	})
+	containerID = strings.TrimSuffix(containerID, "\n")
+	t.Logf("service container ID: %v", containerID)
+
+	services := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName, "curl", "-s", "--unix-socket", "/opt/datadog-agent/run/sysprobe.sock", "http://unix/discovery/services")
+	t.Logf("system-probe services: %v", services)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		payloads, err := client.GetServiceDiscoveries()
+		require.NoError(t, err)
+
+		foundMap := make(map[string]*aggregator.ServiceDiscoveryPayload)
+		for _, p := range payloads {
+			name := p.Payload.ServiceName
+			t.Log("RequestType", p.RequestType, "ServiceName", name)
+
+			if p.RequestType == "start-service" {
+				foundMap[name] = p
+			}
+		}
+
+		require.NotEmpty(c, foundMap)
+		require.Contains(c, foundMap, "http.server")
+		require.Equal(c, containerID, foundMap["http.server"].Payload.ContainerID)
+	}, 3*time.Minute, 10*time.Second)
+}
+
+func (s *dockerDiscoveryTestSuite) assertDockerAgentDiscoveryRunning() {
+	t := s.T()
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		statusOutput := s.Env().Agent.Client.Status(agentclient.WithArgs([]string{"collector", "--json"})).Content
+		assertCollectorStatusFromJSON(c, statusOutput, "service_discovery")
+	}, 2*time.Minute, 10*time.Second)
+}

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -156,15 +156,18 @@ type collectorStatus struct {
 	RunnerStats runnerStats `json:"runnerStats"`
 }
 
-// assertRunningCheck asserts that the given process agent check is running
-func assertRunningCheck(t *assert.CollectT, remoteHost *components.RemoteHost, check string) {
-	statusOutput := remoteHost.MustExecute("sudo datadog-agent status collector --json")
-
+func assertCollectorStatusFromJSON(t *assert.CollectT, statusOutput, check string) {
 	var status collectorStatus
 	err := json.Unmarshal([]byte(statusOutput), &status)
 	require.NoError(t, err, "failed to unmarshal agent status")
 
 	assert.Contains(t, status.RunnerStats.Checks, check)
+}
+
+// assertRunningCheck asserts that the given process agent check is running
+func assertRunningCheck(t *assert.CollectT, remoteHost *components.RemoteHost, check string) {
+	statusOutput := remoteHost.MustExecute("sudo datadog-agent status collector --json")
+	assertCollectorStatusFromJSON(t, statusOutput, check)
 }
 
 func (s *linuxTestSuite) provisionServer() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds an E2E test to test the container ID reporting feature of service discovery.

### Motivation

USMON-1266

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

The change is a test.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->