### PR TITLE
bump to ltsc2022 images/runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1206,6 +1206,6 @@ workflow:
 # windows_docker_default configures the job to use the default Windows Server runners
 # Use in jobs that may need to have their version updated in the future.
 #
-# Current default: Windows Server 2019
+# Current default: Windows Server 2022
 .windows_docker_default:
-  extends: .windows_docker_2019
+  extends: .windows_docker_2022


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Change default Windows Docker job runner/image to 2022

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1194

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ensure Windows test/build jobs still pass.

Check docker run command line on [live processes](https://app.datadoghq.com/process?query=buildimage%20os%3Awindows%20host%3Ai-05ad041e31b3b1702&inspect=0200000091ca1ceeee1e4223b316bdbcc046b77d&selectedTopGraph=timeseries&from_ts=1736191352686&to_ts=1736194952686&live=false) uses 2022 image

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
See previous PoC PR: https://github.com/DataDog/datadog-agent/pull/31498

Number of 2022 runners increased here: https://github.com/DataDog/cloud-inventory/pull/26412