### PR TITLE
[OTEL-2309] Fix panic in /otel-agent -h

### DIFF
--- a/cmd/otel-agent/command/command.go
+++ b/cmd/otel-agent/command/command.go
@@ -73,7 +73,8 @@ func makeCommands(globalParams *subcommands.GlobalParams) *cobra.Command {
 		true, // show env variable value in usage
 	)
 
-	if err := ef.Parse(os.Args[1:]); err != nil {
+	// There may be other env vars in addition to the ones in envflag.NewEnvFlag. Do not panic if those env vars do not have a help message (flag.ErrHelp)
+	if err := ef.Parse(os.Args[1:]); err != nil && err != flag.ErrHelp {
 		panic(err)
 	}
 


### PR DESCRIPTION
### What does this PR do?
Fix a panic when running `./otel-agent -h`. 

### Motivation
The help command in otel-agent will print out help message of env vars, if there are env vars with no help message it returns `flag.ErrHelp`. Previously `flag.ErrHelp` leads to panic, now it is ignored.

### Describe how you validated your changes
Built and ran otel-agent locally:

before the change, panic:
```
% ./bin/otel-agent/otel-agent -h
Usage:
  -config --config=file:/path/to/first --config=file:path/to/second
    	[CONFIG] Locations to the config file(s), note that only a single location can be set per flag entry e.g. --config=file:/path/to/first --config=file:path/to/second.
...
  -sync-to duration
    	[DD_SYNC_TO] Timeout for config sync requests. (default 3s)
panic: flag: help requested

goroutine 1 [running]:
github.com/DataDog/datadog-agent/cmd/otel-agent/command.makeCommands(0x14001a79b90)
	/Users/yang.song/dd/datadog-agent/cmd/otel-agent/command/command.go:77 +0x44c
github.com/DataDog/datadog-agent/cmd/otel-agent/command.MakeRootCommand(...)
	/Users/yang.song/dd/datadog-agent/cmd/otel-agent/command/command.go:42
main.main()
	/Users/yang.song/dd/datadog-agent/cmd/otel-agent/main.go:22 +0x84
```

after the change, no panic:
```
% ./bin/otel-agent/otel-agent -h
Usage:
  -config --config=file:/path/to/first --config=file:path/to/second
    	[CONFIG] Locations to the config file(s), note that only a single location can be set per flag entry e.g. --config=file:/path/to/first --config=file:path/to/second.
...
      --sync-to duration                                                   Timeout for config sync requests. (default 3s)

Use "otel-agent [command] --help" for more information about a command.

```