### PR TITLE
[OTEL-2241] zstd no cgo compression component

### DIFF
--- a/comp/serializer/compression/def/component.go
+++ b/comp/serializer/compression/def/component.go
@@ -33,3 +33,5 @@ type StreamCompressor interface {
 	io.WriteCloser
 	Flush() error
 }
+
+type ZstdCompressionLevel int

--- a/comp/serializer/compression/def/component.go
+++ b/comp/serializer/compression/def/component.go
@@ -34,4 +34,5 @@ type StreamCompressor interface {
 	Flush() error
 }
 
+// ZstdCompressionLevel is a wrapper type over int for the compression level for zstd compression, if that is selected.
 type ZstdCompressionLevel int

--- a/comp/serializer/compression/fx-zstd-nocgo/fx.go
+++ b/comp/serializer/compression/fx-zstd-nocgo/fx.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fx provides the fx module for the serializer/compression component
+package fx
+
+import (
+	compressionimpl "github.com/DataDog/datadog-agent/comp/serializer/compression/impl-zstd-nocgo"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for the component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			compressionimpl.NewComponent,
+		),
+	)
+}

--- a/comp/serializer/compression/go.mod
+++ b/comp/serializer/compression/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.60.1
 	github.com/DataDog/zstd v1.5.6
+	github.com/klauspost/compress v1.17.11
 )
 
 require (

--- a/comp/serializer/compression/go.sum
+++ b/comp/serializer/compression/go.sum
@@ -102,6 +102,8 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALr
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/comp/serializer/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
+++ b/comp/serializer/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package zstdimpl provides a set of functions for compressing with zstd
+package zstdimpl
+
+import (
+	"bytes"
+
+	"github.com/DataDog/zstd"
+
+	compression "github.com/DataDog/datadog-agent/comp/serializer/compression/def"
+)
+
+// Requires contains the compression level for zstd compression
+type Requires struct {
+	Level int
+}
+
+// Provides contains the compression component
+type Provides struct {
+	Comp compression.Component
+}
+
+// ZstdNoCgoStrategy is the strategy for when serializer_compressor_kind is zstd
+type ZstdNoCgoStrategy struct {
+	level int
+}
+
+// NewComponent returns a new ZstdNoCgoStrategy
+func NewComponent(reqs Requires) Provides {
+	return Provides{
+		Comp: &ZstdNoCgoStrategy{
+			level: reqs.Level,
+		},
+	}
+}
+
+// Compress will compress the data with zstd
+func (s *ZstdNoCgoStrategy) Compress(src []byte) ([]byte, error) {
+	return zstd.CompressLevel(nil, src, s.level)
+}
+
+// Decompress will decompress the data with zstd
+func (s *ZstdNoCgoStrategy) Decompress(src []byte) ([]byte, error) {
+	return zstd.Decompress(nil, src)
+}
+
+// CompressBound returns the worst case size needed for a destination buffer when using zstd
+func (s *ZstdNoCgoStrategy) CompressBound(sourceLen int) int {
+	return zstd.CompressBound(sourceLen)
+}
+
+// ContentEncoding returns the content encoding value for zstd
+func (s *ZstdNoCgoStrategy) ContentEncoding() string {
+	return compression.ZstdEncoding
+}
+
+// NewStreamCompressor returns a new zstd Writer
+func (s *ZstdNoCgoStrategy) NewStreamCompressor(output *bytes.Buffer) compression.StreamCompressor {
+	return zstd.NewWriterLevel(output, s.level)
+}

--- a/comp/serializer/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
+++ b/comp/serializer/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
@@ -8,8 +8,12 @@ package zstdimpl
 
 import (
 	"bytes"
+	"os"
+	"strconv"
+	"sync"
 
-	"github.com/DataDog/zstd"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/klauspost/compress/zstd"
 
 	compression "github.com/DataDog/datadog-agent/comp/serializer/compression/def"
 )
@@ -24,33 +28,63 @@ type Provides struct {
 	Comp compression.Component
 }
 
-// ZstdNoCgoStrategy is the strategy for when serializer_compressor_kind is zstd
+var globalencoder *zstd.Encoder
+var mutex sync.Mutex
+
+// ZstdNoCgoStrategy can be manually selected via component - it's not used by any selector / config option
 type ZstdNoCgoStrategy struct {
-	level int
+	level   int
+	encoder *zstd.Encoder
 }
 
 // NewComponent returns a new ZstdNoCgoStrategy
 func NewComponent(reqs Requires) Provides {
+	log.Debugf("Compressing native zstd at level %d", reqs.Level)
+
+	mutex.Lock()
+	if globalencoder == nil {
+		conc, err := strconv.Atoi(os.Getenv("ZSTD_NOCGO_CONCURRENCY"))
+		if err != nil {
+			conc = 1
+		}
+
+		window, err := strconv.Atoi(os.Getenv("ZSTD_NOCGO_WINDOW"))
+		if err != nil {
+			window = 1 << 15
+		}
+
+		log.Debugf("native zstd concurrency %d", conc)
+		log.Debugf("native zstd window size %d", window)
+		globalencoder, _ = zstd.NewWriter(nil,
+			zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(reqs.Level)),
+			zstd.WithEncoderConcurrency(conc),
+			zstd.WithLowerEncoderMem(true),
+			zstd.WithWindowSize(window))
+	}
+	mutex.Unlock()
+
 	return Provides{
 		Comp: &ZstdNoCgoStrategy{
-			level: reqs.Level,
+			level:   reqs.Level,
+			encoder: globalencoder,
 		},
 	}
 }
 
 // Compress will compress the data with zstd
 func (s *ZstdNoCgoStrategy) Compress(src []byte) ([]byte, error) {
-	return zstd.CompressLevel(nil, src, s.level)
+	return s.encoder.EncodeAll(src, nil), nil
 }
 
 // Decompress will decompress the data with zstd
 func (s *ZstdNoCgoStrategy) Decompress(src []byte) ([]byte, error) {
-	return zstd.Decompress(nil, src)
+	decoder, _ := zstd.NewReader(nil)
+	return decoder.DecodeAll(src, nil)
 }
 
 // CompressBound returns the worst case size needed for a destination buffer when using zstd
 func (s *ZstdNoCgoStrategy) CompressBound(sourceLen int) int {
-	return zstd.CompressBound(sourceLen)
+	return s.encoder.MaxEncodedSize(sourceLen)
 }
 
 // ContentEncoding returns the content encoding value for zstd
@@ -60,5 +94,6 @@ func (s *ZstdNoCgoStrategy) ContentEncoding() string {
 
 // NewStreamCompressor returns a new zstd Writer
 func (s *ZstdNoCgoStrategy) NewStreamCompressor(output *bytes.Buffer) compression.StreamCompressor {
-	return zstd.NewWriterLevel(output, s.level)
+	writer, _ := zstd.NewWriter(output, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(s.level)))
+	return writer
 }

--- a/comp/serializer/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
+++ b/comp/serializer/compression/impl-zstd-nocgo/zstd_nocgo_strategy.go
@@ -19,7 +19,7 @@ import (
 
 // Requires contains the compression level for zstd compression
 type Requires struct {
-	Level int
+	Level compression.ZstdCompressionLevel
 }
 
 // Provides contains the compression component
@@ -35,7 +35,8 @@ type ZstdNoCgoStrategy struct {
 
 // NewComponent returns a new ZstdNoCgoStrategy
 func NewComponent(reqs Requires) Provides {
-	log.Debugf("Compressing native zstd at level %d", reqs.Level)
+	level := int(reqs.Level)
+	log.Debugf("Compressing native zstd at level %d", level)
 
 	conc, err := strconv.Atoi(os.Getenv("ZSTD_NOCGO_CONCURRENCY"))
 	if err != nil {
@@ -46,11 +47,10 @@ func NewComponent(reqs Requires) Provides {
 	if err != nil {
 		window = 1 << 15
 	}
-
 	log.Debugf("native zstd concurrency %d", conc)
 	log.Debugf("native zstd window size %d", window)
 	encoder, err := zstd.NewWriter(nil,
-		zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(reqs.Level)),
+		zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(level)),
 		zstd.WithEncoderConcurrency(conc),
 		zstd.WithLowerEncoderMem(true),
 		zstd.WithWindowSize(window))
@@ -63,7 +63,7 @@ func NewComponent(reqs Requires) Provides {
 
 	return Provides{
 		Comp: &ZstdNoCgoStrategy{
-			level:   reqs.Level,
+			level:   level,
 			encoder: encoder,
 		},
 	}

--- a/comp/serializer/compression/impl-zstd/zstd_strategy.go
+++ b/comp/serializer/compression/impl-zstd/zstd_strategy.go
@@ -16,7 +16,7 @@ import (
 
 // Requires contains the compression level for zstd compression
 type Requires struct {
-	Level int
+	Level compression.ZstdCompressionLevel
 }
 
 // Provides contains the compression component
@@ -33,7 +33,7 @@ type ZstdStrategy struct {
 func NewComponent(reqs Requires) Provides {
 	return Provides{
 		Comp: &ZstdStrategy{
-			level: reqs.Level,
+			level: int(reqs.Level),
 		},
 	}
 }

--- a/comp/serializer/compression/selector/zlib-and-zstd.go
+++ b/comp/serializer/compression/selector/zlib-and-zstd.go
@@ -26,7 +26,7 @@ func NewCompressorReq(req Requires) Provides {
 		return Provides{implzlib.NewComponent().Comp}
 	case common.ZstdKind:
 		level := req.Cfg.GetInt("serializer_zstd_compressor_level")
-		return Provides{implzstd.NewComponent(implzstd.Requires{Level: level}).Comp}
+		return Provides{implzstd.NewComponent(implzstd.Requires{Level: compression.ZstdCompressionLevel(level)}).Comp}
 	case common.NoneKind:
 		log.Warn("no serializer_compressor_kind set. use zlib or zstd")
 		return Provides{implnoop.NewComponent().Comp}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Introduces a component for compression with no cgo.  Ported https://github.com/DataDog/datadog-agent/blob/cf1eefb6c393b96403b2dd59ad625735e2f45126/comp/serializer/compression/compressionimpl/strategy/zstd_native_strategy.go#L27 over into the new component framework
