### PR TITLE
[Backport 7.62.x][incident-33684] Reuse sysprobe-client between traceroute calls

### DIFF
--- a/pkg/networkpath/traceroute/traceroute_linux.go
+++ b/pkg/networkpath/traceroute/traceroute_linux.go
@@ -12,9 +12,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -37,12 +35,8 @@ type LinuxTraceroute struct {
 func New(cfg config.Config, _ telemetry.Component) (*LinuxTraceroute, error) {
 	log.Debugf("Creating new traceroute with config: %+v", cfg)
 	return &LinuxTraceroute{
-		cfg: cfg,
-		sysprobeClient: &http.Client{
-			Transport: &http.Transport{
-				DialContext: sysprobeclient.DialContextFunc(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")),
-			},
-		},
+		cfg:            cfg,
+		sysprobeClient: getSysProbeClient(),
 	}, nil
 }
 

--- a/pkg/networkpath/traceroute/traceroute_sysprobe.go
+++ b/pkg/networkpath/traceroute/traceroute_sysprobe.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux || windows
+
+package traceroute
+
+import (
+	"net/http"
+
+	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+
+	"github.com/DataDog/datadog-agent/pkg/util/funcs"
+)
+
+var getSysProbeClient = funcs.MemoizeNoError(func() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: sysprobeclient.DialContextFunc(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")),
+		},
+	}
+})

--- a/pkg/networkpath/traceroute/traceroute_sysprobe.go
+++ b/pkg/networkpath/traceroute/traceroute_sysprobe.go
@@ -12,7 +12,6 @@ import (
 
 	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 )
 

--- a/pkg/networkpath/traceroute/traceroute_windows.go
+++ b/pkg/networkpath/traceroute/traceroute_windows.go
@@ -13,9 +13,7 @@ import (
 	"errors"
 	"net/http"
 
-	sysprobeclient "github.com/DataDog/datadog-agent/cmd/system-probe/api/client"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -45,12 +43,8 @@ func New(cfg config.Config, _ telemetry.Component) (*WindowsTraceroute, error) {
 	}
 
 	return &WindowsTraceroute{
-		cfg: cfg,
-		sysprobeClient: &http.Client{
-			Transport: &http.Transport{
-				DialContext: sysprobeclient.DialContextFunc(pkgconfigsetup.SystemProbe().GetString("system_probe_config.sysprobe_socket")),
-			},
-		},
+		cfg:            cfg,
+		sysprobeClient: getSysProbeClient(),
 	}, nil
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/32709

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->