### PR TITLE
Move CORE telemetry to pkg/ebpf

### DIFF
--- a/pkg/ebpf/btf_test.go
+++ b/pkg/ebpf/btf_test.go
@@ -17,8 +17,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 )
 
 func TestEmbeddedBTFMatch(t *testing.T) {
@@ -64,7 +62,7 @@ func TestBTFTelemetry(t *testing.T) {
 	ret, result, err := loader.Get()
 	require.NoError(t, err)
 	require.NotNil(t, ret)
-	require.NotEqual(t, ebpftelemetry.COREResult(ebpftelemetry.BtfNotFound), result)
+	require.NotEqual(t, COREResult(BtfNotFound), result)
 }
 
 func curDir() (string, error) {

--- a/pkg/ebpf/co_re_telemetry.go
+++ b/pkg/ebpf/co_re_telemetry.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package telemetry
+package ebpf
 
 import (
 	"sync"

--- a/pkg/ebpf/co_re_telemetry_test.go
+++ b/pkg/ebpf/co_re_telemetry_test.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package telemetry
+package ebpf
 
 import (
 	"testing"

--- a/pkg/ebpf/status_codes.go
+++ b/pkg/ebpf/status_codes.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package telemetry
+package ebpf
 
 // BTFResult enumerates BTF loading success & failure modes
 type BTFResult int

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -462,7 +462,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	conns.ConnTelemetry = t.state.GetTelemetryDelta(clientID, t.getConnTelemetry(len(active)))
 	conns.CompilationTelemetryByAsset = t.getRuntimeCompilationTelemetry()
 	conns.KernelHeaderFetchResult = int32(kernel.HeaderProvider.GetResult())
-	conns.CORETelemetryByAsset = ebpftelemetry.GetCORETelemetryByAsset()
+	conns.CORETelemetryByAsset = ddebpf.GetCORETelemetryByAsset()
 	conns.PrebuiltAssets = netebpf.GetModulesInUse()
 	t.lastCheck.Store(time.Now().Unix())
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Move CORE telemetry to `pkg/ebpf` to remove dependency of `pkg/ebpf/telemetry`. This allows the telemetry package to import `pkg/ebpf`.

### Motivation
https://github.com/DataDog/datadog-agent/pull/32650 requires using functions from `pkg/ebpf` in `pkg/ebpf/telemetry`. This PR allows us to do that.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This PR just moves files. The existing tests are sufficient to validate the changes.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->