### PR TITLE
Remove apm-ecosystems-performance from release teams

### DIFF
--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -111,6 +111,7 @@ def get_releasing_teams():
         'single-machine-performance',
         'agent-all',
         'apm-core-reliability-and-performance',
+        'apm-ecosystems-performance',
         'debugger',
         'asm-go',
         'agent-e2e-testing',


### PR DESCRIPTION
### What does this PR do?

Removes apm-ecosystems-performance from release teams as used by the release tooling for various automation tasks.

### Motivation

This team is co-owner of some (benchmarking) code but their involvement is not needed for Agent releases.

### Describe how you validated your changes

N / A

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->