### PR TITLE
[CWS] improve handling of missing inode key in exec file cache map

### DIFF
--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -519,16 +519,16 @@ func (p *EBPFResolver) retrieveExecFileFields(procExecPath string) (*model.FileF
 		err = lib.ErrKeyNotExist
 	}
 	if err != nil {
-		return nil, fmt.Errorf("unable to get filename for inode `%d`: %v", inode, err)
+		return nil, fmt.Errorf("unable to get filename for inode `%d`: %w", inode, err)
 	}
 
 	var fileFields model.FileFields
 	if _, err := fileFields.UnmarshalBinary(data); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal entry for inode `%d`: %v", inode, err)
+		return nil, fmt.Errorf("unable to unmarshal entry for inode `%d`: %w", inode, err)
 	}
 
 	if fileFields.Inode == 0 {
-		return nil, fmt.Errorf("inode `%d` not found: %v", inode, err)
+		return nil, fmt.Errorf("inode `%d` not found: %w", inode, err)
 	}
 
 	return &fileFields, nil


### PR DESCRIPTION
### What does this PR do?

Currently if the inode is not in the exec file cache map, we spam the log:
```
2025-01-07 12:53:59 UTC | SYS-PROBE | ERROR | (pkg/security/resolvers/process/resolver_ebpf.go:340 in enrichEventFromProc) | snapshot failed for 1192796: couldn't retrieve inode info: unable to unmarshal entry for inode `2147995654`: not enough data
```

This PR fixes this by ensuring we don't log in this case, and skips the whole unmarshalling error as well.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->