### PR TITLE
Do not memoize system-probe sock path error

### DIFF
--- a/pkg/process/net/common.go
+++ b/pkg/process/net/common.go
@@ -65,6 +65,11 @@ var _ SysProbeUtilGetter = GetRemoteSystemProbeUtil
 
 // GetRemoteSystemProbeUtil returns a ready to use RemoteSysProbeUtil. It is backed by a shared singleton.
 func GetRemoteSystemProbeUtil(path string) (SysProbeUtil, error) {
+	err := CheckPath(path)
+	if err != nil {
+		return nil, fmt.Errorf("error setting up remote system probe util, %v", err)
+	}
+
 	sysProbeUtil, err := getRemoteSystemProbeUtil(path)
 	if err != nil {
 		return nil, err
@@ -79,13 +84,8 @@ func GetRemoteSystemProbeUtil(path string) (SysProbeUtil, error) {
 }
 
 var getRemoteSystemProbeUtil = funcs.MemoizeArg(func(path string) (*RemoteSysProbeUtil, error) {
-	err := CheckPath(path)
-	if err != nil {
-		return nil, fmt.Errorf("error setting up remote system probe util, %v", err)
-	}
-
 	sysProbeUtil := newSystemProbe(path)
-	err = sysProbeUtil.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
+	err := sysProbeUtil.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
 		Name:          "system-probe-util",
 		AttemptMethod: sysProbeUtil.init,
 		Strategy:      retry.RetryCount,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Do not memoize system-probe sock path error
    
The system-probe socket may not exist temporarily due to expected races
during startup.  This error should not be memoized.
    
This restores the behaviour to how it was before #31150.

### Motivation

Incident

### Describe how you validated your changes

Tested manually by starting the agent first and then system-probe later. The service discovery check initially
fails but then succeeds on later runs after system-probe has been started. Without this PR it always fails even after system-probe starts.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->