### PR TITLE
[CWS] Improve systemd cgroupv1 parsing

### DIFF
--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -12,7 +12,6 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -95,7 +94,7 @@ func parseProcControlGroupsData(data []byte, fnc func(string, string, string) bo
 		data = data[nextStart:]
 	}
 
-	return errors.New("cgroup resolver error: no good candidate found")
+	return nil
 }
 
 func parseProcControlGroups(tgid, pid uint32, fnc func(string, string, string) bool) error {

--- a/pkg/security/utils/cgroup_test.go
+++ b/pkg/security/utils/cgroup_test.go
@@ -8,6 +8,7 @@
 package utils
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,8 +27,20 @@ func TestCGroupvParseLine(t *testing.T) {
 	assert.Equal(t, "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope", path)
 }
 
-func TestCGroupv1(t *testing.T) {
-	data := `13:blkio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope
+type testCgroup struct {
+	name          string
+	cgroupContent string
+	error         bool
+	containerID   string
+	runtime       containerutils.CGroupFlags
+	path          string
+}
+
+func TestCGroup(t *testing.T) {
+	testsCgroup := []testCgroup{
+		{
+			name: "cgroupv1-cri",
+			cgroupContent: `13:blkio:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope
 12:memory:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope
 11:misc:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope
 10:pids:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope
@@ -41,64 +54,167 @@ func TestCGroupv1(t *testing.T) {
 2:devices:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope
 1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope
 0::/
-`
+`,
+			error:       false,
+			containerID: "e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerCRI),
+			path:        "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod98005c3b_b650_4efe_8b91_2164d784397f.slice/cri-containerd-e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3.scope",
+		},
+
+		{
+			name: "cgroupv1-docker",
+			cgroupContent: `13:memory:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+12:hugetlb:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+11:misc:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+10:blkio:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+9:rdma:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+8:perf_event:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+7:cpuset:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+6:pids:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+5:cpu,cpuacct:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+4:freezer:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+3:devices:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+2:net_cls,net_prio:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+1:name=systemd:/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+0::/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182
+`,
+			error:       false,
+			containerID: "99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerDocker),
+			path:        "/docker/99d24a208bd5b9c9663e18c34e4bd793536f062d8299a5cca0e718994abd9182",
+		},
+
+		{
+			name: "cgroupv1-systemd-service",
+			cgroupContent: `13:memory:/system.slice/cups.service
+12:hugetlb:/
+11:misc:/
+10:blkio:/system.slice/cups.service
+9:rdma:/
+8:perf_event:/
+7:cpuset:/
+6:pids:/system.slice/cups.service
+5:cpu,cpuacct:/system.slice/cups.service
+4:freezer:/
+3:devices:/system.slice/cups.service
+2:net_cls,net_prio:/
+1:name=systemd:/system.slice/cups.service
+0::/system.slice/cups.service
+`,
+			error:       false,
+			containerID: "",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd),
+			path:        "/system.slice/cups.service",
+		},
+
+		{
+			name: "cgroupv1-systemd-subservice",
+			cgroupContent: `13:memory:/user.slice/user-1000.slice/user@1000.service
+12:hugetlb:/
+11:misc:/
+10:blkio:/user.slice
+9:rdma:/
+8:perf_event:/
+7:cpuset:/
+6:pids:/user.slice/user-1000.slice/user@1000.service
+5:cpu,cpuacct:/user.slice
+4:freezer:/
+3:devices:/user.slice
+2:net_cls,net_prio:/
+1:name=systemd:/user.slice/user-1000.slice/user@1000.service/xdg-desktop-portal-gtk.service
+0::/user.slice/user-1000.slice/user@1000.service/xdg-desktop-portal-gtk.service
+`,
+			error:       false,
+			containerID: "",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd),
+			path:        "/user.slice/user-1000.slice/user@1000.service/xdg-desktop-portal-gtk.service",
+		},
+
+		{
+			name: "cgroupv1-systemd-scope",
+			cgroupContent: `13:memory:/user.slice/user-1000.slice/user@1000.service
+12:hugetlb:/
+11:misc:/
+10:blkio:/user.slice
+9:rdma:/
+8:perf_event:/
+7:cpuset:/
+6:pids:/user.slice/user-1000.slice/user@1000.service
+5:cpu,cpuacct:/user.slice
+4:freezer:/
+3:devices:/user.slice
+2:net_cls,net_prio:/
+1:name=systemd:/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-1d0750f1-4e83-4b26-81ae-e3770394b7f3.scope
+0::/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-1d0750f1-4e83-4b26-81ae-e3770394b7f3.scope
+`,
+			error:       false,
+			containerID: "",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
+			path:        "/user.slice/user-1000.slice/user@1000.service/apps.slice/apps-org.gnome.Terminal.slice/vte-spawn-1d0750f1-4e83-4b26-81ae-e3770394b7f3.scope",
+		},
+
+		{
+			name: "cgroupv2-docker",
+			cgroupContent: `0::/system.slice/docker-473a28bd49fcbf3a24eb55563125720311181ee184ae9b88fc9a3fbb30031e47.scope
+`,
+			error:       false,
+			containerID: "473a28bd49fcbf3a24eb55563125720311181ee184ae9b88fc9a3fbb30031e47",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerDocker),
+			path:        "/system.slice/docker-473a28bd49fcbf3a24eb55563125720311181ee184ae9b88fc9a3fbb30031e47.scope",
+		},
+
+		{
+			name: "cgroupv2-systemd-service",
+			cgroupContent: `0::/system.slice/ssh.service
+`,
+			error:       false,
+			containerID: "",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd),
+			path:        "/system.slice/ssh.service",
+		},
+
+		{
+			name: "cgroupv2-systemd-scope",
+			cgroupContent: `0::/user.slice/user-1000.slice/session-4.scope
+`,
+			error:       false,
+			containerID: "",
+			runtime:     containerutils.CGroupFlags(containerutils.CGroupManagerSystemd | containerutils.CGroupManager(containerutils.SystemdScope)),
+			path:        "/user.slice/user-1000.slice/session-4.scope",
+		},
+	}
+
 	var (
 		containerID   containerutils.ContainerID
 		runtime       containerutils.CGroupFlags
 		cgroupContext model.CGroupContext
+		cgroupPath    string
 	)
 
-	err := parseProcControlGroupsData([]byte(data), func(id, ctrl, path string) bool {
-		if path == "/" {
-			return false
-		}
-		cgroup, err := makeControlGroup(id, ctrl, path)
-		if err != nil {
-			return false
-		}
+	for _, test := range testsCgroup {
+		t.Run(test.name, func(t *testing.T) {
+			err := parseProcControlGroupsData([]byte(test.cgroupContent), func(id, ctrl, path string) bool {
+				if path == "/" {
+					return false
+				} else if ctrl != "" && !strings.HasPrefix(ctrl, "name=") {
+					return false
+				}
+				cgroup, err := makeControlGroup(id, ctrl, path)
+				if err != nil {
+					return false
+				}
 
-		containerID, runtime = cgroup.GetContainerContext()
-		cgroupContext.CGroupID = containerutils.CGroupID(cgroup.Path)
-		cgroupContext.CGroupFlags = runtime
+				containerID, runtime = cgroup.GetContainerContext()
+				cgroupContext.CGroupID = containerutils.CGroupID(cgroup.Path)
+				cgroupContext.CGroupFlags = runtime
+				cgroupPath = path
+				return true
+			})
 
-		return true
-	})
-
-	assert.Nil(t, err)
-	assert.NotEmpty(t, containerID)
-	assert.NotZero(t, runtime)
-	assert.Equal(t, containerID, containerutils.ContainerID("e8ac3efec3322d7f13cfa0cdee4344754d01bd4e50fea44e0753e83fdb74cab3"))
-	assert.Equal(t, runtime, containerutils.CGroupFlags(containerutils.CGroupManagerCRI))
-}
-
-func TestCGroupv2(t *testing.T) {
-	data := `0::/system.slice/docker-473a28bd49fcbf3a24eb55563125720311181ee184ae9b88fc9a3fbb30031e47.scope
-`
-	var (
-		containerID   containerutils.ContainerID
-		runtime       containerutils.CGroupFlags
-		cgroupContext model.CGroupContext
-	)
-
-	err := parseProcControlGroupsData([]byte(data), func(id, ctrl, path string) bool {
-		if path == "/" {
-			return false
-		}
-		cgroup, err := makeControlGroup(id, ctrl, path)
-		if err != nil {
-			return false
-		}
-
-		containerID, runtime = cgroup.GetContainerContext()
-		cgroupContext.CGroupID = containerutils.CGroupID(cgroup.Path)
-		cgroupContext.CGroupFlags = runtime
-
-		return true
-	})
-
-	assert.Nil(t, err)
-	assert.NotEmpty(t, containerID)
-	assert.NotZero(t, runtime)
-	assert.Equal(t, containerID, containerutils.ContainerID("473a28bd49fcbf3a24eb55563125720311181ee184ae9b88fc9a3fbb30031e47"))
-	assert.Equal(t, runtime, containerutils.CGroupFlags(containerutils.CGroupManagerDocker))
+			assert.Equal(t, test.error, err != nil)
+			assert.Equal(t, containerutils.ContainerID(test.containerID), containerID)
+			assert.Equal(t, test.runtime, runtime)
+			assert.Equal(t, test.path, cgroupPath)
+		})
+	}
 }


### PR DESCRIPTION
### What does this PR do?

The #32622 introduced a change of behavior of cgroup parsing, returning the first cgroup with a non-empty path.
It fixed the issue with cgroupv1 CRI, but there is still some cases where the parsed line was not the good one.

This PR fixes the issue by returning the "name" ctrl line for cgroupv1 (and don't change the cgroupv2 behavior).

Multiple tests were added to validate the new approach.

NB: as the activity dumps are by default disabled for systemd cgroups, it shouldn't be back-ported.

### Motivation

Fixe and harden the cgroupv1 resolution

### Describe how you validated your changes


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->