### PR TITLE
[OTEL-2099] Add obfuscator option to OTel Stats Utils

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 	"time"
 
-	gzip "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	gzip "github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip"
 
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -11,22 +11,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/transform"
 )
 
 const (
-	tagRedisRawCommand  = "redis.raw_command"
-	tagMemcachedCommand = "memcached.command"
-	tagMongoDBQuery     = "mongodb.query"
-	tagElasticBody      = "elasticsearch.body"
-	tagOpenSearchBody   = "opensearch.body"
-	tagSQLQuery         = "sql.query"
-	tagHTTPURL          = "http.url"
+	tagRedisRawCommand  = transform.TagRedisRawCommand
+	tagMemcachedCommand = transform.TagMemcachedCommand
+	tagMongoDBQuery     = transform.TagMongoDBQuery
+	tagElasticBody      = transform.TagElasticBody
+	tagOpenSearchBody   = transform.TagOpenSearchBody
+	tagSQLQuery         = transform.TagSQLQuery
+	tagHTTPURL          = transform.TagHTTPURL
 )
 
-const (
-	textNonParsable = "Non-parsable SQL query"
-)
+const textNonParsable = transform.TextNonParsable
 
 func (a *Agent) obfuscateSpan(span *pb.Span) {
 	o := a.lazyInitObfuscator()
@@ -43,34 +41,19 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 
 	switch span.Type {
 	case "sql", "cassandra":
-		if span.Resource == "" {
-			return
-		}
-		oq, err := o.ObfuscateSQLString(span.Resource)
+		oq, err := transform.ObfuscateSQLSpan(o, span)
 		if err != nil {
-			// we have an error, discard the SQL to avoid polluting user resources.
 			log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
-			span.Resource = textNonParsable
-			traceutil.SetMeta(span, tagSQLQuery, textNonParsable)
 			return
 		}
-
-		span.Resource = oq.Query
-		if len(oq.Metadata.TablesCSV) > 0 {
-			traceutil.SetMeta(span, "sql.tables", oq.Metadata.TablesCSV)
+		if oq == nil {
+			// no error was thrown but no query was found either
+			return
 		}
-		traceutil.SetMeta(span, tagSQLQuery, oq.Query)
 	case "redis":
 		span.Resource = o.QuantizeRedisString(span.Resource)
 		if a.conf.Obfuscation.Redis.Enabled {
-			if span.Meta == nil || span.Meta[tagRedisRawCommand] == "" {
-				return
-			}
-			if a.conf.Obfuscation.Redis.RemoveAllArgs {
-				span.Meta[tagRedisRawCommand] = o.RemoveAllRedisArgs(span.Meta[tagRedisRawCommand])
-				return
-			}
-			span.Meta[tagRedisRawCommand] = o.ObfuscateRedisString(span.Meta[tagRedisRawCommand])
+			transform.ObfuscateRedisSpan(o, span, a.conf.Obfuscation.Redis.RemoveAllArgs)
 		}
 	case "memcached":
 		if !a.conf.Obfuscation.Memcached.Enabled {

--- a/pkg/trace/stats/otel_benckmark_test.go
+++ b/pkg/trace/stats/otel_benckmark_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -17,6 +16,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/metric/noop"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 func BenchmarkOTelContainerTags(b *testing.B) {
@@ -61,7 +62,7 @@ func BenchmarkOTelContainerTags(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		inputs := OTLPTracesToConcentratorInputs(traces, conf, containerTagKeys, nil)
+		inputs := OTLPTracesToConcentratorInputs(traces, conf, containerTagKeys, nil, nil)
 		assert.Len(b, inputs, 1)
 		input := inputs[0]
 		concentrator.Add(input)
@@ -120,7 +121,7 @@ func benchmarkOTelPeerTags(b *testing.B, initOnce bool) {
 		if !initOnce {
 			peerTagKeys = conf.ConfiguredPeerTags()
 		}
-		inputs := OTLPTracesToConcentratorInputs(traces, conf, nil, peerTagKeys)
+		inputs := OTLPTracesToConcentratorInputs(traces, conf, nil, peerTagKeys, nil)
 		assert.Len(b, inputs, 1)
 		input := inputs[0]
 		concentrator.Add(input)

--- a/pkg/trace/stats/otel_benckmark_test.go
+++ b/pkg/trace/stats/otel_benckmark_test.go
@@ -75,7 +75,12 @@ func benchmarkOTelContainerTags(b *testing.B, enableObfuscation bool) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		inputs := OTLPTracesToConcentratorInputs(traces, conf, containerTagKeys, nil, obfuscator)
+		var inputs []Input
+		if enableObfuscation {
+			inputs = OTLPTracesToConcentratorInputsWithObfuscation(traces, conf, containerTagKeys, nil, obfuscator)
+		} else {
+			inputs = OTLPTracesToConcentratorInputs(traces, conf, containerTagKeys, nil)
+		}
 		assert.Len(b, inputs, 1)
 		input := inputs[0]
 		concentrator.Add(input)
@@ -83,13 +88,6 @@ func benchmarkOTelContainerTags(b *testing.B, enableObfuscation bool) {
 		assert.Len(b, stats.Stats, 1)
 		assert.Equal(b, stats.Stats[0].Tags, expected)
 	}
-}
-
-func newTestObfuscator(conf *config.AgentConfig) *obfuscate.Obfuscator {
-	oconf := conf.Obfuscation.Export(conf)
-	oconf.Redis.Enabled = true
-	o := obfuscate.NewObfuscator(oconf)
-	return o
 }
 
 func BenchmarkOTelPeerTags(b *testing.B) {
@@ -152,7 +150,12 @@ func benchmarkOTelPeerTags(b *testing.B, initOnce bool, enableObfuscation bool) 
 		if !initOnce {
 			peerTagKeys = conf.ConfiguredPeerTags()
 		}
-		inputs := OTLPTracesToConcentratorInputs(traces, conf, nil, peerTagKeys, obfuscator)
+		var inputs []Input
+		if enableObfuscation {
+			inputs = OTLPTracesToConcentratorInputsWithObfuscation(traces, conf, nil, peerTagKeys, obfuscator)
+		} else {
+			inputs = OTLPTracesToConcentratorInputs(traces, conf, nil, peerTagKeys)
+		}
 		assert.Len(b, inputs, 1)
 		input := inputs[0]
 		concentrator.Add(input)

--- a/pkg/trace/stats/otel_util.go
+++ b/pkg/trace/stats/otel_util.go
@@ -37,6 +37,86 @@ func OTLPTracesToConcentratorInputs(
 	conf *config.AgentConfig,
 	containerTagKeys []string,
 	peerTagKeys []string,
+) []Input {
+	spanByID, resByID, scopeByID := traceutil.IndexOTelSpans(traces)
+	topLevelByKind := conf.HasFeature("enable_otlp_compute_top_level_by_span_kind")
+	topLevelSpans := traceutil.GetTopLevelOTelSpans(spanByID, resByID, topLevelByKind)
+	ignoreResNames := make(map[string]struct{})
+	for _, resName := range conf.Ignore["resource"] {
+		ignoreResNames[resName] = struct{}{}
+	}
+	chunks := make(map[chunkKey]*pb.TraceChunk)
+	containerTagsByID := make(map[string][]string)
+	for spanID, otelspan := range spanByID {
+		otelres := resByID[spanID]
+		var resourceName string
+		if transform.OperationAndResourceNameV2Enabled(conf) {
+			resourceName = traceutil.GetOTelResourceV2(otelspan, otelres)
+		} else {
+			resourceName = traceutil.GetOTelResourceV1(otelspan, otelres)
+		}
+		if _, exists := ignoreResNames[resourceName]; exists {
+			continue
+		}
+		env := traceutil.GetOTelEnv(otelres)
+		hostname := traceutil.GetOTelHostname(otelspan, otelres, conf.OTLPReceiver.AttributesTranslator, conf.Hostname)
+		version := traceutil.GetOTelAttrValInResAndSpanAttrs(otelspan, otelres, true, semconv.AttributeServiceVersion)
+		cid := traceutil.GetOTelAttrValInResAndSpanAttrs(otelspan, otelres, true, semconv.AttributeContainerID, semconv.AttributeK8SPodUID)
+		var ctags []string
+		if cid != "" {
+			ctags = traceutil.GetOTelContainerTags(otelres.Attributes(), containerTagKeys)
+			if ctags != nil {
+				// Make sure container tags are sorted per APM stats intake requirement
+				if !slices.IsSorted(ctags) {
+					slices.Sort(ctags)
+				}
+				containerTagsByID[cid] = ctags
+			}
+		}
+		ckey := chunkKey{
+			traceIDUInt64: traceutil.OTelTraceIDToUint64(otelspan.TraceID()),
+			env:           env,
+			version:       version,
+			hostname:      hostname,
+			cid:           cid,
+		}
+		chunk, ok := chunks[ckey]
+		if !ok {
+			chunk = &pb.TraceChunk{}
+			chunks[ckey] = chunk
+		}
+		_, isTop := topLevelSpans[spanID]
+		chunk.Spans = append(chunk.Spans, transform.OtelSpanToDDSpanMinimal(otelspan, otelres, scopeByID[spanID], isTop, topLevelByKind, conf, peerTagKeys))
+	}
+
+	inputs := make([]Input, 0, len(chunks))
+	for ckey, chunk := range chunks {
+		pt := traceutil.ProcessedTrace{
+			TraceChunk:     chunk,
+			Root:           traceutil.GetRoot(chunk.Spans),
+			TracerEnv:      ckey.env,
+			AppVersion:     ckey.version,
+			TracerHostname: ckey.hostname,
+		}
+		inputs = append(inputs, Input{
+			Traces:        []traceutil.ProcessedTrace{pt},
+			ContainerID:   ckey.cid,
+			ContainerTags: containerTagsByID[ckey.cid],
+		})
+	}
+	return inputs
+}
+
+// OTLPTracesToConcentratorInputsWithObfuscation converts eligible OTLP spans to Concentrator Input.
+// The converted Inputs only have the minimal number of fields for APM stats calculation and are only meant
+// to be used in Concentrator.Add(). Do not use them for other purposes.
+// This function enables obfuscation of spans prior to stats calculation and datadogconnector will migrate
+// to this function once this function is published as part of latest pkg/trace module.
+func OTLPTracesToConcentratorInputsWithObfuscation(
+	traces ptrace.Traces,
+	conf *config.AgentConfig,
+	containerTagKeys []string,
+	peerTagKeys []string,
 	obfuscator *obfuscate.Obfuscator,
 ) []Input {
 	spanByID, resByID, scopeByID := traceutil.IndexOTelSpans(traces)

--- a/pkg/trace/stats/otel_util_test.go
+++ b/pkg/trace/stats/otel_util_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +18,9 @@ import (
 	semconv "go.opentelemetry.io/collector/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/metric/noop"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 var (
@@ -225,7 +226,7 @@ func TestProcessOTLPTraces(t *testing.T) {
 			}
 
 			concentrator := NewTestConcentratorWithCfg(time.Now(), conf)
-			inputs := OTLPTracesToConcentratorInputs(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags())
+			inputs := OTLPTracesToConcentratorInputs(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags(), nil)
 			for _, input := range inputs {
 				concentrator.Add(input)
 			}
@@ -287,7 +288,7 @@ func TestProcessOTLPTraces_MutliSpanInOneResAndOp(t *testing.T) {
 	conf.OTLPReceiver.AttributesTranslator = attributesTranslator
 
 	concentrator := NewTestConcentratorWithCfg(time.Now(), conf)
-	inputs := OTLPTracesToConcentratorInputs(traces, conf, nil, nil)
+	inputs := OTLPTracesToConcentratorInputs(traces, conf, nil, nil, nil)
 	for _, input := range inputs {
 		concentrator.Add(input)
 	}

--- a/pkg/trace/stats/oteltest/go.mod
+++ b/pkg/trace/stats/oteltest/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/proto v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/trace v0.56.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.6.0
@@ -23,7 +24,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.59.0 // indirect

--- a/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
+++ b/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
@@ -71,7 +71,7 @@ func testOTelAPMStatsMatch(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	fakeAgent1.Ingest(ctx, traces)
 
 	// fakeAgent2 calls the new API in Concentrator that directly calculates APM stats for OTLP traces
-	inputs := stats.OTLPTracesToConcentratorInputs(traces, tcfg, []string{semconv.AttributeContainerID, semconv.AttributeK8SContainerName}, peerTagKeys)
+	inputs := stats.OTLPTracesToConcentratorInputs(traces, tcfg, []string{semconv.AttributeContainerID, semconv.AttributeK8SContainerName}, peerTagKeys, nil)
 	for _, input := range inputs {
 		fakeAgent2.Concentrator.Add(input)
 	}

--- a/pkg/trace/transform/obfuscate.go
+++ b/pkg/trace/transform/obfuscate.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package transform
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+)
+
+const (
+	// TagRedisRawCommand represents a redis raw command tag
+	TagRedisRawCommand = "redis.raw_command"
+	// TagMemcachedCommand represents a memcached command tag
+	TagMemcachedCommand = "memcached.command"
+	// TagMongoDBQuery represents a MongoDB query tag
+	TagMongoDBQuery = "mongodb.query"
+	// TagElasticBody represents an Elasticsearch body tag
+	TagElasticBody = "elasticsearch.body"
+	// TagOpenSearchBody represents an OpenSearch body tag
+	TagOpenSearchBody = "opensearch.body"
+	// TagSQLQuery represents a SQL query tag
+	TagSQLQuery = "sql.query"
+	// TagHTTPURL represents an HTTP URL tag
+	TagHTTPURL = "http.url"
+)
+
+const (
+	// TextNonParsable is the error text used when a query is non-parsable
+	TextNonParsable = "Non-parsable SQL query"
+)
+
+// ObfuscateSQLSpan obfuscates a SQL span using pkg/obfuscate logic
+func ObfuscateSQLSpan(o *obfuscate.Obfuscator, span *pb.Span) (*obfuscate.ObfuscatedQuery, error) {
+	if span.Resource == "" {
+		return nil, nil
+	}
+	oq, err := o.ObfuscateSQLString(span.Resource)
+	if err != nil {
+		// we have an error, discard the SQL to avoid polluting user resources.
+		span.Resource = TextNonParsable
+		traceutil.SetMeta(span, TagSQLQuery, TextNonParsable)
+		return nil, err
+	}
+	span.Resource = oq.Query
+	if len(oq.Metadata.TablesCSV) > 0 {
+		traceutil.SetMeta(span, "sql.tables", oq.Metadata.TablesCSV)
+	}
+	traceutil.SetMeta(span, TagSQLQuery, oq.Query)
+	return oq, nil
+}
+
+// ObfuscateRedisSpan obfuscates a Redis span using pkg/obfuscate logic
+func ObfuscateRedisSpan(o *obfuscate.Obfuscator, span *pb.Span, removeAllArgs bool) {
+	if span.Meta == nil || span.Meta[TagRedisRawCommand] == "" {
+		return
+	}
+	if removeAllArgs {
+		span.Meta[TagRedisRawCommand] = o.RemoveAllRedisArgs(span.Meta[TagRedisRawCommand])
+		return
+	}
+	span.Meta[TagRedisRawCommand] = o.ObfuscateRedisString(span.Meta[TagRedisRawCommand])
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Refactors slightly the obfuscateSpan logic to break out SQL and Redis functions
- Adds option to pass an obfuscator object to OTel Stats utils
- If obfuscator is passed to OTel Stats utils, obfuscate SQL and redis spans prior to sending to concentrator for stats payload calculation

### Motivation
https://datadoghq.atlassian.net/browse/OTEL-2099

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ran benchmark tests and added comparison tests for "with obfuscation", results here (increase overhead by only about 2%): https://docs.google.com/spreadsheets/d/1ywVfwlHLeghxhfnDwGaXuGmYNs7CaLiuBa2I9vNjA30

Otherwise, existing tests.

### Possible Drawbacks / Trade-offs
I'm not entirely sold on having obfuscate functions in `pkg/trace/transform`, but I couldn't import `pkg/trace/agent` in `pkg/trace/transform` or `pkg/trace/stats` without causing a circular dependency.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->