### PR TITLE
chore(origindetection): implement LocalData struct for DogStatsD

### DIFF
--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -470,7 +470,7 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 		// Accumulate tags for pod UID
 		if originInfo.ExternalData.PodUID != "" {
 			if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.ExternalData.PodUID), cardinality, tb); err != nil {
-				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.ContainerID, err)
+				t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.ExternalData.PodUID, err)
 			}
 		}
 

--- a/comp/core/tagger/origindetection/origindetection_test.go
+++ b/comp/core/tagger/origindetection/origindetection_test.go
@@ -12,6 +12,65 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestParseLocalData(t *testing.T) {
+	tests := []struct {
+		name         string
+		rawLocalData string
+		expected     LocalData
+		expectError  bool
+	}{
+		{
+			name:         "Empty string",
+			rawLocalData: "",
+			expected:     LocalData{},
+			expectError:  false,
+		},
+		{
+			name:         "Single container ID",
+			rawLocalData: "ci-abc123",
+			expected:     LocalData{ContainerID: "abc123"},
+			expectError:  false,
+		},
+		{
+			name:         "Single inode",
+			rawLocalData: "in-12345",
+			expected:     LocalData{Inode: 12345},
+			expectError:  false,
+		},
+		{
+			name:         "Multiple values",
+			rawLocalData: "ci-abc123,in-12345",
+			expected:     LocalData{ContainerID: "abc123", Inode: 12345},
+			expectError:  false,
+		},
+		{
+			name:         "Invalid inode",
+			rawLocalData: "in-invalid",
+			expected:     LocalData{},
+			expectError:  true,
+		},
+		{
+			name:         "Old container format",
+			rawLocalData: "abc123",
+			expected:     LocalData{ContainerID: "abc123"},
+			expectError:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ParseLocalData(tc.rawLocalData)
+
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tc.expected, result)
+			}
+
+		})
+	}
+}
+
 func TestParseExternalData(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -37,12 +37,13 @@ type enrichConfig struct {
 }
 
 // extractTagsMetadata returns tags (client tags + host tag) and information needed to query tagger (origins, cardinality).
-func extractTagsMetadata(tags []string, originFromUDS string, originFromMsg []byte, externalData origindetection.ExternalData, conf enrichConfig) ([]string, string, taggertypes.OriginInfo, metrics.MetricSource) {
+func extractTagsMetadata(tags []string, originFromUDS string, localData origindetection.LocalData, externalData origindetection.ExternalData, conf enrichConfig) ([]string, string, taggertypes.OriginInfo, metrics.MetricSource) {
 	host := conf.defaultHostname
 	metricSource := metrics.MetricSourceDogstatsd
 	origin := taggertypes.OriginInfo{
 		ContainerIDFromSocket: originFromUDS,
-		ContainerID:           string(originFromMsg),
+		ContainerID:           localData.ContainerID,
+		LocalData:             localData,
 		ExternalData:          externalData,
 		ProductOrigin:         origindetection.ProductOriginDogStatsD,
 	}
@@ -112,7 +113,7 @@ func tsToFloatForSamples(ts time.Time) float64 {
 
 func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSample, origin string, listenerID string, conf enrichConfig) []metrics.MetricSample {
 	metricName := ddSample.name
-	tags, hostnameFromTags, extractedOrigin, metricSource := extractTagsMetadata(ddSample.tags, origin, ddSample.containerID, ddSample.externalData, conf)
+	tags, hostnameFromTags, extractedOrigin, metricSource := extractTagsMetadata(ddSample.tags, origin, ddSample.localData, ddSample.externalData, conf)
 
 	if !isExcluded(metricName, conf.metricPrefix, conf.metricPrefixBlacklist) {
 		metricName = conf.metricPrefix + metricName
@@ -192,7 +193,7 @@ func enrichEventAlertType(dogstatsdAlertType alertType) metricsevent.AlertType {
 }
 
 func enrichEvent(event dogstatsdEvent, origin string, conf enrichConfig) *metricsevent.Event {
-	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(event.tags, origin, event.containerID, event.externalData, conf)
+	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(event.tags, origin, event.localData, event.externalData, conf)
 
 	enrichedEvent := &metricsevent.Event{
 		Title:          event.title,
@@ -229,7 +230,7 @@ func enrichServiceCheckStatus(status serviceCheckStatus) servicecheck.ServiceChe
 }
 
 func enrichServiceCheck(serviceCheck dogstatsdServiceCheck, origin string, conf enrichConfig) *servicecheck.ServiceCheck {
-	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(serviceCheck.tags, origin, serviceCheck.containerID, serviceCheck.externalData, conf)
+	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(serviceCheck.tags, origin, serviceCheck.localData, serviceCheck.externalData, conf)
 
 	enrichedServiceCheck := &servicecheck.ServiceCheck{
 		CheckName:  serviceCheck.name,

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _ = extractTagsMetadata(baseTags, "", []byte{}, origindetection.ExternalData{}, conf)
+				tags, _, _, _ = extractTagsMetadata(baseTags, "", origindetection.LocalData{}, origindetection.ExternalData{}, conf)
 			}
 		})
 	}

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -1113,6 +1113,7 @@ func TestEnrichTags(t *testing.T) {
 		tags          []string
 		originFromUDS string
 		originFromMsg []byte
+		localData     origindetection.LocalData
 		externalData  origindetection.ExternalData
 		conf          enrichConfig
 	}
@@ -1128,6 +1129,7 @@ func TestEnrichTags(t *testing.T) {
 			name: "empty tags, host=foo",
 			args: args{
 				originFromUDS: "",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1144,6 +1146,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod"},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1160,6 +1163,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          nil,
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1176,6 +1180,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "my-id")},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1192,6 +1197,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "none")},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1208,6 +1214,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42")},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1224,6 +1231,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.HighCardinalityString},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1240,6 +1248,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.OrchestratorCardinalityString},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1256,6 +1265,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.LowCardinalityString},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1272,6 +1282,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix + types.UnknownCardinalityString},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1288,6 +1299,7 @@ func TestEnrichTags(t *testing.T) {
 			args: args{
 				tags:          []string{"env:prod", fmt.Sprintf("%s%s", entityIDTagPrefix, "42"), CardinalityTagPrefix},
 				originFromUDS: "originID",
+				localData:     origindetection.LocalData{},
 				externalData:  origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname:           "foo",
@@ -1305,14 +1317,24 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
-				externalData:  origindetection.ExternalData{},
+				localData: origindetection.LocalData{
+					ContainerID: "container-id",
+				},
+				externalData: origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "pod-uid", ContainerID: "container-id"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				PodUID:                "pod-uid",
+				ContainerID:           "container-id",
+				LocalData: origindetection.LocalData{
+					ContainerID: "container-id",
+				},
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1321,14 +1343,23 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
-				externalData:  origindetection.ExternalData{},
+				localData: origindetection.LocalData{
+					ContainerID: "container-id",
+				},
+				externalData: origindetection.ExternalData{},
 				conf: enrichConfig{
 					defaultHostname: "foo",
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", ContainerID: "container-id"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				ContainerID:           "container-id",
+				LocalData: origindetection.LocalData{
+					ContainerID: "container-id",
+				},
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1347,11 +1378,12 @@ func TestEnrichTags(t *testing.T) {
 			},
 			wantedTags: []string{"env:prod"},
 			wantedHost: "foo",
-			wantedOrigin: taggertypes.OriginInfo{ExternalData: origindetection.ExternalData{
-				Init:          false,
-				ContainerName: "container_name",
-				PodUID:        "pod_uid",
-			}},
+			wantedOrigin: taggertypes.OriginInfo{
+				ExternalData: origindetection.ExternalData{
+					Init:          false,
+					ContainerName: "container_name",
+					PodUID:        "pod_uid",
+				}},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1360,6 +1392,9 @@ func TestEnrichTags(t *testing.T) {
 				tags:          []string{"env:prod", "dd.internal.entity_id:pod-uid"},
 				originFromUDS: "originID",
 				originFromMsg: []byte("container-id"),
+				localData: origindetection.LocalData{
+					ContainerID: "container-id",
+				},
 				externalData: origindetection.ExternalData{
 					Init:          false,
 					ContainerName: "container_name",
@@ -1375,6 +1410,9 @@ func TestEnrichTags(t *testing.T) {
 				ContainerIDFromSocket: "originID",
 				PodUID:                "pod-uid",
 				ContainerID:           "container-id",
+				LocalData: origindetection.LocalData{
+					ContainerID: "container-id",
+				},
 				ExternalData: origindetection.ExternalData{
 					Init:          false,
 					ContainerName: "container_name",
@@ -1388,7 +1426,7 @@ func TestEnrichTags(t *testing.T) {
 		tt.wantedOrigin.ProductOrigin = origindetection.ProductOriginDogStatsD
 
 		t.Run(tt.name, func(t *testing.T) {
-			tags, host, origin, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.originFromMsg, tt.args.externalData, tt.args.conf)
+			tags, host, origin, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.localData, tt.args.externalData, tt.args.conf)
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedHost, host)
 			assert.Equal(t, tt.wantedOrigin, origin)
@@ -1436,7 +1474,7 @@ func TestEnrichTagsWithJMXCheckName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", []byte{}, origindetection.ExternalData{}, enrichConfig{})
+			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", origindetection.LocalData{}, origindetection.ExternalData{}, enrichConfig{})
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedMetricSource, metricSource)
 			assert.NotContains(t, tags, tt.jmxCheckName)

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -206,7 +206,7 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 			rawLocalData := string(optionalField[len(localDataPrefix):])
 			localData, err = origindetection.ParseLocalData(rawLocalData)
 			if err != nil {
-				return dogstatsdMetricSample{}, fmt.Errorf("failed to parse OriginInfo.LocalData %s: %v", rawLocalData, err)
+				return dogstatsdMetricSample{}, fmt.Errorf("failed to parse c: field containing Local Data %s: %v", rawLocalData, err)
 			}
 			// If the container ID is not set in the Local Data, we try to resolve it from the cgroupv2 inode.
 			if localData.ContainerID == "" {
@@ -217,7 +217,7 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 			rawExternalData := string(optionalField[len(externalDataPrefix):])
 			externalData, err = origindetection.ParseExternalData(rawExternalData)
 			if err != nil {
-				return dogstatsdMetricSample{}, fmt.Errorf("failed to parse OriginInfo.ExternalData %s: %v", rawExternalData, err)
+				return dogstatsdMetricSample{}, fmt.Errorf("failed to parse e: field containing External Data %s: %v", rawExternalData, err)
 			}
 		}
 	}

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -213,7 +213,7 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 			rawExternalData := string(optionalField[len(externalDataPrefix):])
 			externalData, err = origindetection.ParseExternalData(rawExternalData)
 			if err != nil {
-				return dogstatsdMetricSample{}, fmt.Errorf("failed to parse e: field containing External Data %s: %v", rawExternalData, err)
+				log.Errorf("failed to parse e: field containing External Data %q: %v", rawExternalData, err)
 			}
 		}
 	}
@@ -279,7 +279,7 @@ func (p *parser) resolveLocalData(rawLocalData []byte) (origindetection.LocalDat
 	var err error
 	localData, err = origindetection.ParseLocalData(localDataString)
 	if err != nil {
-		log.Errorf("failed to parse c: field containing Local Data %s: %v", localDataString, err)
+		log.Errorf("failed to parse c: field containing Local Data %q: %v", localDataString, err)
 	}
 
 	// If the container ID is not set in the Local Data, we try to resolve it from the cgroupv2 inode.

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -40,7 +40,9 @@ type dogstatsdEvent struct {
 	alertType      alertType
 	tags           []string
 	// containerID represents the container ID of the sender (optional).
-	containerID []byte
+	containerID string
+	// localData is used for Origin Detection
+	localData origindetection.LocalData
 	// externalData is used for Origin Detection
 	externalData origindetection.ExternalData
 }
@@ -167,7 +169,12 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 	case bytes.HasPrefix(optionalField, eventTagsPrefix):
 		newEvent.tags = p.parseTags(optionalField[len(eventTagsPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newEvent.containerID = p.resolveContainerIDFromLocalData(optionalField)
+		newEvent.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
+		// If the container ID is not set in the Local Data, we try to resolve it from the cgroupv2 inode.
+		if newEvent.localData.ContainerID == "" {
+			newEvent.localData.ContainerID = p.resolveContainerIDFromInode(newEvent.localData.Inode)
+		}
+		newEvent.containerID = newEvent.localData.ContainerID
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newEvent.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -169,12 +169,10 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 	case bytes.HasPrefix(optionalField, eventTagsPrefix):
 		newEvent.tags = p.parseTags(optionalField[len(eventTagsPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newEvent.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
-		// If the container ID is not set in the Local Data, we try to resolve it from the cgroupv2 inode.
-		if newEvent.localData.ContainerID == "" {
-			newEvent.localData.ContainerID = p.resolveContainerIDFromInode(newEvent.localData.Inode)
+		newEvent.localData, err = p.resolveLocalData(optionalField[len(localDataPrefix):])
+		if err == nil {
+			newEvent.containerID = newEvent.localData.ContainerID
 		}
-		newEvent.containerID = newEvent.localData.ContainerID
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newEvent.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}

--- a/comp/dogstatsd/server/parse_metrics.go
+++ b/comp/dogstatsd/server/parse_metrics.go
@@ -48,7 +48,9 @@ type dogstatsdMetricSample struct {
 	sampleRate float64
 	tags       []string
 	// containerID represents the container ID of the sender (optional).
-	containerID []byte
+	containerID string
+	// localData is used for Origin Detection
+	localData origindetection.LocalData
 	// externalData is used for Origin Detection
 	externalData origindetection.ExternalData
 	// timestamp read in the message if any

--- a/comp/dogstatsd/server/parse_metrics_test.go
+++ b/comp/dogstatsd/server/parse_metrics_test.go
@@ -573,7 +573,7 @@ func TestParseContainerID(t *testing.T) {
 	// Testing with a container ID
 	sample, err := parseMetricSample(t, cfg, []byte("metric:1234|g|c:1234567890abcdef"))
 	require.NoError(t, err)
-	assert.Equal(t, []byte("1234567890abcdef"), sample.containerID)
+	assert.Equal(t, "1234567890abcdef", sample.containerID)
 
 	// Testing with an Inode
 	deps := newServerDeps(t, fx.Replace(config.MockParams{Overrides: cfg}))
@@ -590,5 +590,5 @@ func TestParseContainerID(t *testing.T) {
 
 	sample, err = parseMetricSample(t, cfg, []byte("metric:1234|g|c:in-1234567890"))
 	require.NoError(t, err)
-	assert.Equal(t, []byte("1234567890abcdef"), sample.containerID)
+	assert.Equal(t, "1234567890abcdef", sample.containerID)
 }

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -31,7 +31,9 @@ type dogstatsdServiceCheck struct {
 	message   string
 	tags      []string
 	// containerID represents the container ID of the sender (optional).
-	containerID []byte
+	containerID string
+	// localData is used for Origin Detection
+	localData origindetection.LocalData
 	// externalData is used for Origin Detection
 	externalData origindetection.ExternalData
 }
@@ -101,7 +103,12 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 	case bytes.HasPrefix(optionalField, serviceCheckMessagePrefix):
 		newServiceCheck.message = string(optionalField[len(serviceCheckMessagePrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newServiceCheck.containerID = p.resolveContainerIDFromLocalData(optionalField)
+		newServiceCheck.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
+		// If the container ID is not set in the Local Data, we try to resolve it from the cgroupv2 inode.
+		if newServiceCheck.localData.ContainerID == "" {
+			newServiceCheck.localData.ContainerID = p.resolveContainerIDFromInode(newServiceCheck.localData.Inode)
+		}
+		newServiceCheck.containerID = newServiceCheck.localData.ContainerID
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newServiceCheck.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -103,12 +103,10 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 	case bytes.HasPrefix(optionalField, serviceCheckMessagePrefix):
 		newServiceCheck.message = string(optionalField[len(serviceCheckMessagePrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newServiceCheck.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
-		// If the container ID is not set in the Local Data, we try to resolve it from the cgroupv2 inode.
-		if newServiceCheck.localData.ContainerID == "" {
-			newServiceCheck.localData.ContainerID = p.resolveContainerIDFromInode(newServiceCheck.localData.Inode)
+		newServiceCheck.localData, err = p.resolveLocalData(optionalField[len(localDataPrefix):])
+		if err == nil {
+			newServiceCheck.containerID = newServiceCheck.localData.ContainerID
 		}
-		newServiceCheck.containerID = newServiceCheck.localData.ContainerID
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newServiceCheck.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}

--- a/comp/dogstatsd/server/parse_test.go
+++ b/comp/dogstatsd/server/parse_test.go
@@ -112,104 +112,22 @@ func TestUnsafeParseInt(t *testing.T) {
 	assert.Equal(t, integer, unsafeInteger)
 }
 
-func TestResolveContainerIDFromLocalData(t *testing.T) {
-	const (
-		localDataPrefix   = "c:"
-		containerIDPrefix = "ci-"
-		inodePrefix       = "in-"
-		containerID       = "abcdef"
-		containerInode    = "4242"
-	)
-
+func TestResolveContainerIDFromInode(t *testing.T) {
 	deps := newServerDeps(t)
 	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
 	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
-
 	// Mock the provider to resolve the container ID from the inode
 	mockProvider := mock.NewMetricsProvider()
-	containerInodeUint, _ := strconv.ParseUint(containerInode, 10, 64)
 	mockProvider.RegisterMetaCollector(&mock.MetaCollector{
 		CIDFromInode: map[uint64]string{
-			containerInodeUint: containerID,
+			uint64(1234): "abcdef",
 		},
 	})
 	p.provider = mockProvider
 
-	tests := []struct {
-		name     string
-		input    []byte
-		expected []byte
-	}{
-		{
-			name:     "Empty LocalData",
-			input:    []byte(localDataPrefix),
-			expected: []byte{},
-		},
-		{
-			name:     "LocalData with new container ID",
-			input:    []byte(localDataPrefix + containerIDPrefix + containerID),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData with old container ID format",
-			input:    []byte(localDataPrefix + containerID),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData with inode",
-			input:    []byte(localDataPrefix + inodePrefix + containerInode),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData with invalid inode",
-			input:    []byte(localDataPrefix + inodePrefix + "invalid"),
-			expected: []byte(nil),
-		},
-		{
-			name:     "LocalData as a list",
-			input:    []byte(localDataPrefix + containerIDPrefix + containerID + "," + inodePrefix + containerInode),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData as a list with only inode",
-			input:    []byte(localDataPrefix + inodePrefix + containerInode),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData as a list with only container ID",
-			input:    []byte(localDataPrefix + containerIDPrefix + containerID),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData as a list with only inode with trailing comma",
-			input:    []byte(localDataPrefix + inodePrefix + containerInode + ","),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData as a list with only container ID with trailing comma",
-			input:    []byte(localDataPrefix + containerIDPrefix + containerID + ","),
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData as a list with only inode surrounded by commas",
-			input:    []byte(localDataPrefix + "," + inodePrefix + containerInode + ","), // This is an invalid format, but we should still be able to extract the container ID
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData as a list with only inode surrounded by commas",
-			input:    []byte(localDataPrefix + "," + containerIDPrefix + containerID + ","), // This is an invalid format, but we should still be able to extract the container ID
-			expected: []byte(containerID),
-		},
-		{
-			name:     "LocalData as an invalid list",
-			input:    []byte(localDataPrefix + ","),
-			expected: []byte(nil),
-		},
-	}
+	containerID := p.resolveContainerIDFromInode(uint64(1234))
+	assert.Equal(t, "abcdef", containerID)
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, p.resolveContainerIDFromLocalData(tc.input))
-		})
-	}
+	unsetInode := p.resolveContainerIDFromInode(uint64(0))
+	assert.Equal(t, "", unsetInode)
 }

--- a/pkg/tagger/types/types.go
+++ b/pkg/tagger/types/types.go
@@ -13,6 +13,7 @@ type OriginInfo struct {
 	ContainerIDFromSocket string                        // ContainerIDFromSocket is the origin resolved using Unix Domain Socket.
 	PodUID                string                        // PodUID is the origin resolved from the Kubernetes Pod UID.
 	ContainerID           string                        // ContainerID is the origin resolved from the container ID.
+	LocalData             origindetection.LocalData     // LocalData is the local data list.
 	ExternalData          origindetection.ExternalData  // ExternalData is the external data list.
 	Cardinality           string                        // Cardinality is the cardinality of the resolved origin.
 	ProductOrigin         origindetection.ProductOrigin // ProductOrigin is the product that sent the origin information.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Implements the LocalData structure for DogStatsD.

### Motivation

This is done to allow to switch from `taggertypes` to `origindetection` modules.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

QA is done by both unit tests and E2E tests.

### Possible Drawbacks / Trade-offs

For now we are still relying on the current `OriginInfo.ContainerID` variable. Once every resolution methods (Inode and UDS) has been moved to the `origindetection` module, we will be able to remove those variables and fully switch to `origindetection.Origininfo`.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A