### PR TITLE
Better handling of dependencies in flake finder

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -315,7 +315,6 @@ new-e2e-cws:
     - qa_agent
     - qa_dca
   variables:
-    SHOULD_RUN_IN_FLAKES_FINDER: "false" # Currently broken in flake finder ADXT-687
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
     CWS_INSTRUMENTATION_FULLIMAGEPATH: 669783387624.dkr.ecr.us-east-1.amazonaws.com/cws-instrumentation:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
@@ -532,7 +531,6 @@ new-e2e-windows-systemprobe:
   variables:
     TARGETS: ./tests/sysprobe-functional
     TEAM: windows-kernel-integrations
-    SHOULD_RUN_IN_FLAKES_FINDER: "false" # Currently broken in flake finder ADXT-687
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestUSMAutoTaggingSuite
@@ -671,6 +669,7 @@ generate-flakes-finder-pipeline:
     - qa_dogstatsd
     - qa_agent
     - qa_agent_ot
+    - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:
     - inv -e testwasher.generate-flake-finder-pipeline

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -655,21 +655,21 @@ generate-flakes-finder-pipeline:
     - !reference [.manual]
   needs:
     - compute_gitlab_ci_config
-    - deploy_deb_testing-a7_arm64
-    - deploy_deb_testing-a7_x64
-    - deploy_rpm_testing-a7_arm64
-    - deploy_rpm_testing-a7_x64
-    - deploy_suse_rpm_testing_arm64-a7
-    - deploy_suse_rpm_testing_x64-a7
-    - deploy_windows_testing-a7
-    - deploy_installer_oci
-    - deploy_agent_oci
-    - qa_cws_instrumentation
-    - qa_dca
-    - qa_dogstatsd
-    - qa_agent
-    - qa_agent_ot
-    - tests_windows_sysprobe_x64
+  #   - deploy_deb_testing-a7_arm64
+  #   - deploy_deb_testing-a7_x64
+  #   - deploy_rpm_testing-a7_arm64
+  #   - deploy_rpm_testing-a7_x64
+  #   - deploy_suse_rpm_testing_arm64-a7
+  #   - deploy_suse_rpm_testing_x64-a7
+  #   - deploy_windows_testing-a7
+  #   - deploy_installer_oci
+  #   - deploy_agent_oci
+  #   - qa_cws_instrumentation
+  #   - qa_dca
+  #   - qa_dogstatsd
+  #   - qa_agent
+  #   - qa_agent_ot
+  #   - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:
     - inv -e testwasher.generate-flake-finder-pipeline

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -687,6 +687,7 @@ trigger-flakes-finder:
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     PARENT_COMMIT_SHA: $CI_COMMIT_SHORT_SHA
+    PARENT_COMMIT_SHORT_SHA: $CI_COMMIT_SHORT_SHA
   trigger:
     include:
       - artifact: flake-finder-gitlab-ci.yml

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -655,21 +655,21 @@ generate-flakes-finder-pipeline:
     - !reference [.manual]
   needs:
     - compute_gitlab_ci_config
-  #   - deploy_deb_testing-a7_arm64
-  #   - deploy_deb_testing-a7_x64
-  #   - deploy_rpm_testing-a7_arm64
-  #   - deploy_rpm_testing-a7_x64
-  #   - deploy_suse_rpm_testing_arm64-a7
-  #   - deploy_suse_rpm_testing_x64-a7
-  #   - deploy_windows_testing-a7
-  #   - deploy_installer_oci
-  #   - deploy_agent_oci
-  #   - qa_cws_instrumentation
-  #   - qa_dca
-  #   - qa_dogstatsd
-  #   - qa_agent
-  #   - qa_agent_ot
-  #   - tests_windows_sysprobe_x64
+    - deploy_deb_testing-a7_arm64
+    - deploy_deb_testing-a7_x64
+    - deploy_rpm_testing-a7_arm64
+    - deploy_rpm_testing-a7_x64
+    - deploy_suse_rpm_testing_arm64-a7
+    - deploy_suse_rpm_testing_x64-a7
+    - deploy_windows_testing-a7
+    - deploy_installer_oci
+    - deploy_agent_oci
+    - qa_cws_instrumentation
+    - qa_dca
+    - qa_dogstatsd
+    - qa_agent
+    - qa_agent_ot
+    - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:
     - inv -e testwasher.generate-flake-finder-pipeline

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -233,18 +233,21 @@ def _add_parent_pipeline(needs):
     Add the parent pipeline to the need, only for the jobs that are not the artifacts deploy jobs.
     """
 
+    deps_to_keep = [
+        "tests_windows_secagent_x64",
+        "tests_windows_sysprobe_x64",
+        "go_e2e_deps",
+    ]  # Needs that should be kept on jobs, because the e2e test actually needs the artifact from these jobs
+
     new_needs = []
     for need in needs:
         if isinstance(need, str):
-            if need.startswith("deploy") or need.startswith("qa"):
+            if need not in deps_to_keep:
                 continue
             new_needs.append({"pipeline": "$PARENT_PIPELINE_ID", "job": need})
         elif isinstance(need, dict):
-            if "job" in need and (need["job"].startswith("deploy") or need["job"].startswith("qa")):
+            if "job" in need and need["job"] not in deps_to_keep:
                 continue
-            del need[
-                "optional"
-            ]  # Not supported in child pipeline, see: https://gitlab.com/gitlab-org/gitlab/-/issues/349538
             new_needs.append({**need, "pipeline": "$PARENT_PIPELINE_ID"})
         elif isinstance(need, list):
             new_needs.extend(_add_parent_pipeline(need))

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -230,13 +230,18 @@ def _clean_job(job):
 
 def _add_parent_pipeline(needs):
     """
-    Add the parent pipeline to the need
+    Add the parent pipeline to the need, only for the jobs that are not the artifacts deploy jobs.
     """
+
     new_needs = []
     for need in needs:
         if isinstance(need, str):
+            if need.startswith("deploy") or need.startswith("qa"):
+                continue
             new_needs.append({"pipeline": "$PARENT_PIPELINE_ID", "job": need})
         elif isinstance(need, dict):
+            if "job" in need and (need["job"].startswith("deploy") or need["job"].startswith("qa")):
+                continue
             del need[
                 "optional"
             ]  # Not supported in child pipeline, see: https://gitlab.com/gitlab-org/gitlab/-/issues/349538

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -237,6 +237,9 @@ def _add_parent_pipeline(needs):
         if isinstance(need, str):
             new_needs.append({"pipeline": "$PARENT_PIPELINE_ID", "job": need})
         elif isinstance(need, dict):
+            del need[
+                "optional"
+            ]  # Not supported in child pipeline, see: https://gitlab.com/gitlab-org/gitlab/-/issues/349538
             new_needs.append({**need, "pipeline": "$PARENT_PIPELINE_ID"})
         elif isinstance(need, list):
             new_needs.extend(_add_parent_pipeline(need))

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -182,7 +182,7 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
             if 'variables' in new_job:
                 # Variables that reference the parent pipeline should be updated
                 for key, value in new_job['variables'].items():
-                    if isinstance(value, str):
+                    if not isinstance(value, str):
                         continue
                     if "CI_PIPELINE_ID" in value:
                         new_job['variables'][key] = value.replace("CI_PIPELINE_ID", "PARENT_PIPELINE_ID")

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -182,14 +182,17 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
             if 'variables' in new_job:
                 # Variables that reference the parent pipeline should be updated
                 for key, value in new_job['variables'].items():
+                    new_value = value
                     if not isinstance(value, str):
                         continue
                     if "CI_PIPELINE_ID" in value:
-                        new_job['variables'][key] = value.replace("CI_PIPELINE_ID", "PARENT_PIPELINE_ID")
+                        new_value = new_value.replace("CI_PIPELINE_ID", "PARENT_PIPELINE_ID")
                     if "CI_COMMIT_SHA" in value:
-                        new_job['variables'][key] = value.replace("CI_COMMIT_SHA", "PARENT_COMMIT_SHA")
+                        new_value = new_value.replace("CI_COMMIT_SHA", "PARENT_COMMIT_SHA")
                     if "CI_COMMIT_SHORT_SHA" in value:
-                        new_job['variables'][key] = value.replace("CI_COMMIT_SHORT_SHA", "PARENT_COMMIT_SHORT_SHA")
+                        new_value = new_value.replace("CI_COMMIT_SHORT_SHA", "PARENT_COMMIT_SHORT_SHA")
+
+                    new_job['variables'][key] = new_value
 
                 if (
                     'E2E_PIPELINE_ID' in new_job['variables']

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -179,7 +179,6 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
         for i in range(n):
             new_job = copy.deepcopy(kept_job[job])
             new_job["stage"] = f"flake-finder-{i}"
-            new_job["dependencies"] = ["go_e2e_deps"]
             if 'variables' in new_job:
                 # Variables that reference the parent pipeline should be updated
                 for key, value in new_job['variables'].items():
@@ -205,6 +204,8 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
                 if 'E2E_PRE_INITIALIZED' in new_job['variables']:
                     del new_job['variables']['E2E_PRE_INITIALIZED']
             new_job["rules"] = [{"when": "always"}]
+            if i > 0:
+                new_job["needs"].append(f"{job}-{i - 1}")
             new_jobs[f"{job}-{i}"] = new_job
 
     with open("flake-finder-gitlab-ci.yml", "w") as f:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Handle better dependencies from the main pipelines in child flake finder pipelines. It should fix two of the e2e tests that were disabled because broken. They are reenabled with that PR.


### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->