### PR TITLE
[CWS] fix potential race regarding `newTCNetDevices`

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1663,8 +1663,6 @@ func (p *EBPFProbe) Close() error {
 	// perf map reader are ignored
 	p.cancelFnc()
 
-	close(p.newTCNetDevices)
-
 	// we wait until both the reorderer and the monitor are stopped
 	p.wg.Wait()
 
@@ -1684,6 +1682,8 @@ func (p *EBPFProbe) Close() error {
 	}
 
 	// when we reach this point, we do not generate nor consume events anymore, we can close the resolvers
+	close(p.newTCNetDevices)
+
 	return p.Resolvers.Close()
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the following race:
```
WARNING: DATA RACE
2025-01-08T11:06:33.331925Z 01O Read at 0x00c0009306a0 by goroutine 3124:
2025-01-08T11:06:33.331930Z 01O   runtime.chansend()
2025-01-08T11:06:33.331933Z 01O       /usr/local/go/src/runtime/chan.go:171 +0x0
2025-01-08T11:06:33.331936Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).pushNewTCClassifierRequest()
2025-01-08T11:06:33.331942Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1705 +0x125
2025-01-08T11:06:33.331945Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent()
2025-01-08T11:06:33.331949Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1170 +0x7ae8
2025-01-08T11:06:33.331955Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent-fm()
2025-01-08T11:06:33.331958Z 01O       <autogenerated>:1 +0x64
2025-01-08T11:06:33.331961Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.NewOrderedPerfMap.func1()
2025-01-08T11:06:33.331968Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:111 +0x126
2025-01-08T11:06:33.331971Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*reOrdererHeap).dequeue()
2025-01-08T11:06:33.331976Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/reorderer.go:144 +0x6fa
2025-01-08T11:06:33.331983Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*ReOrderer).Start()
2025-01-08T11:06:33.331986Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/reorderer.go:234 +0x495
2025-01-08T11:06:33.331991Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*OrderedPerfMap).Start.gowrap2()
2025-01-08T11:06:33.331996Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:79 +0x44
2025-01-08T11:06:33.331999Z 01O 
2025-01-08T11:06:33.332001Z 01O Previous write at 0x00c0009306a0 by goroutine 3131:
2025-01-08T11:06:33.332011Z 01O   runtime.closechan()
2025-01-08T11:06:33.332017Z 01O       /usr/local/go/src/runtime/chan.go:397 +0x0
2025-01-08T11:06:33.332021Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).Close()
2025-01-08T11:06:33.332028Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1666 +0x75
2025-01-08T11:06:33.332031Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Close()
2025-01-08T11:06:33.332036Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:196 +0x236
2025-01-08T11:06:33.332041Z 01O   github.com/DataDog/datadog-agent/pkg/eventmonitor.(*EventMonitor).Close()
2025-01-08T11:06:33.332044Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:175 +0x1fe
2025-01-08T11:06:33.332048Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).cleanup()
2025-01-08T11:06:33.332054Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:953 +0x1d31
2025-01-08T11:06:33.332057Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.newTestModuleWithOnDemandProbes()
2025-01-08T11:06:33.332061Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:698 +0x1cf2
2025-01-08T11:06:33.332066Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
2025-01-08T11:06:33.332099Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:574 +0x8f8
2025-01-08T11:06:33.332104Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.TestRawPacket()
2025-01-08T11:06:33.332110Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/network_test.go:119 +0x7a2
2025-01-08T11:06:33.332113Z 01O   testing.tRunner()
2025-01-08T11:06:33.332116Z 01O       /usr/local/go/src/testing/testing.go:1690 +0x226
2025-01-08T11:06:33.332121Z 01O   testing.(*T).Run.gowrap1()
2025-01-08T11:06:33.332124Z 01O       /usr/local/go/src/testing/testing.go:1743 +0x44
2025-01-08T11:06:33.332127Z 01O 
2025-01-08T11:06:33.332131Z 01O Goroutine 3124 (running) created at:
2025-01-08T11:06:33.332134Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer.(*OrderedPerfMap).Start()
2025-01-08T11:06:33.332138Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/reorderer/perfmap.go:79 +0x1cb
2025-01-08T11:06:33.332144Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).Start()
2025-01-08T11:06:33.332147Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:525 +0xda
2025-01-08T11:06:33.332151Z 01O   github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Start()
2025-01-08T11:06:33.332157Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:153 +0x189
2025-01-08T11:06:33.332164Z 01O   github.com/DataDog/datadog-agent/pkg/eventmonitor.(*EventMonitor).Start()
2025-01-08T11:06:33.332169Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:135 +0x5a4
2025-01-08T11:06:33.332179Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.newTestModuleWithOnDemandProbes()
2025-01-08T11:06:33.332188Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:804 +0x3424
2025-01-08T11:06:33.332193Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
2025-01-08T11:06:33.332199Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:574 +0x6a4
2025-01-08T11:06:33.332202Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.TestNetworkCIDR()
2025-01-08T11:06:33.332206Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/network_test.go:57 +0x602
2025-01-08T11:06:33.332211Z 01O   testing.tRunner()
2025-01-08T11:06:33.332213Z 01O       /usr/local/go/src/testing/testing.go:1690 +0x226
2025-01-08T11:06:33.332217Z 01O   testing.(*T).Run.gowrap1()
2025-01-08T11:06:33.332222Z 01O       /usr/local/go/src/testing/testing.go:1743 +0x44
2025-01-08T11:06:33.332224Z 01O 
2025-01-08T11:06:33.332227Z 01O Goroutine 3131 (running) created at:
2025-01-08T11:06:33.332232Z 01O   testing.(*T).Run()
2025-01-08T11:06:33.332235Z 01O       /usr/local/go/src/testing/testing.go:1743 +0x825
2025-01-08T11:06:33.332238Z 01O   testing.runTests.func1()
2025-01-08T11:06:33.332243Z 01O       /usr/local/go/src/testing/testing.go:2168 +0x85
2025-01-08T11:06:33.332245Z 01O   testing.tRunner()
2025-01-08T11:06:33.332249Z 01O       /usr/local/go/src/testing/testing.go:1690 +0x226
2025-01-08T11:06:33.332260Z 01O   testing.runTests()
2025-01-08T11:06:33.332268Z 01O       /usr/local/go/src/testing/testing.go:2166 +0x8be
2025-01-08T11:06:33.332272Z 01O   testing.(*M).Run()
2025-01-08T11:06:33.332282Z 01O       /usr/local/go/src/testing/testing.go:2034 +0xf17
2025-01-08T11:06:33.332289Z 01O   github.com/DataDog/datadog-agent/pkg/security/tests.TestMain()
2025-01-08T11:06:33.332295Z 01O       /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_test.go:26 +0xb3
2025-01-08T11:06:33.332300Z 01O   main.main()
2025-01-08T11:06:33.332302Z 01O       _testmain.go:393 +0x171
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->