### PR TITLE
[gitlab] Use --apparent-size option of du to compute directory sizes

### DIFF
--- a/tasks/libs/package/size.py
+++ b/tasks/libs/package/size.py
@@ -84,8 +84,11 @@ def file_size(path):
 
 def directory_size(ctx, path):
     # HACK: For uncompressed size, fall back to native Unix utilities - computing a directory size with Python
+    # NOTE: We use the -A (--apparent-size) option to make the computation consistent. Otherwise, each file's size
+    # is counted as the number of blocks it uses, which means a file's size depends on how it is written to disk.
+    # See https://unix.stackexchange.com/questions/173947/du-s-apparent-size-vs-du-s
     # TODO: To make this work on other OSes, the complete directory walk would need to be implemented
-    return int(ctx.run(f"du -sB1 {path}", hide=True).stdout.split()[0])
+    return int(ctx.run(f"du -A -sB1 {path}", hide=True).stdout.split()[0])
 
 
 def compute_package_size_metrics(

--- a/tasks/libs/package/size.py
+++ b/tasks/libs/package/size.py
@@ -84,8 +84,9 @@ def file_size(path):
 
 def directory_size(ctx, path):
     # HACK: For uncompressed size, fall back to native Unix utilities - computing a directory size with Python
-    # NOTE: We use the --apparent-size option to make the computation consistent. Otherwise, each file's size
-    # is counted as the number of blocks it uses, which means a file's size depends on how it is written to disk.
+    # NOTE: We use the -b (--bytes, equivalent to --apparent-size --block-size 1) option to make the computation
+    # consistent. Otherwise, each file's size is counted as the number of blocks it uses, which means a file's size
+    # depends on how it is written to disk.
     # See https://unix.stackexchange.com/questions/173947/du-s-apparent-size-vs-du-s
     # TODO: To make this work on other OSes, the complete directory walk would need to be implemented
     return int(ctx.run(f"du --apparent-size -sB1 {path}", hide=True).stdout.split()[0])

--- a/tasks/libs/package/size.py
+++ b/tasks/libs/package/size.py
@@ -84,11 +84,11 @@ def file_size(path):
 
 def directory_size(ctx, path):
     # HACK: For uncompressed size, fall back to native Unix utilities - computing a directory size with Python
-    # NOTE: We use the -A (--apparent-size) option to make the computation consistent. Otherwise, each file's size
+    # NOTE: We use the --apparent-size option to make the computation consistent. Otherwise, each file's size
     # is counted as the number of blocks it uses, which means a file's size depends on how it is written to disk.
     # See https://unix.stackexchange.com/questions/173947/du-s-apparent-size-vs-du-s
     # TODO: To make this work on other OSes, the complete directory walk would need to be implemented
-    return int(ctx.run(f"du -A -sB1 {path}", hide=True).stdout.split()[0])
+    return int(ctx.run(f"du --apparent-size -sB1 {path}", hide=True).stdout.split()[0])
 
 
 def compute_package_size_metrics(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates the Agent package size measurement logic used in the `send_pkg_size` job to be consistent across runs.

Without the `--apparent-size` option, `du` computes the size of files using the number of filesystem blocks used by the file. This means we only get an approximate size (whose accuracy depends on the block size of the filesystem), that can vary depending on how files are written on the filesystem. 

When summed over multiple files, the difference can be pretty significant. See these examples on Agent nightlies:
```
root@ffd29b864a53:/# dpkg -x datadog-agent_7.63.0~devel.git.8.57183f8.pipeline.51889460-1_amd64.deb test1
root@ffd29b864a53:/# dpkg -x datadog-agent_7.63.0~devel.git.8.57183f8.pipeline.51889460-1_amd64.deb test2

root@ffd29b864a53:/# du -sB1 test1
1279193088	test1
root@ffd29b864a53:/# du -sB1 test2
1279201280	test2
root@ffd29b864a53:/# du --apparent-size -sB1 test1
1200439760	test1
root@ffd29b864a53:/# du --apparent-size -sB1 test2
1200439760	test2
```

```
root@ffd29b864a53:/# dpkg -x datadog-agent_7.63.0~devel.git.104.5001b19.pipeline.52292226-1_amd64.deb test3
root@ffd29b864a53:/# dpkg -x datadog-agent_7.63.0~devel.git.104.5001b19.pipeline.52292226-1_amd64.deb test4

root@ffd29b864a53:/# du -sB1 test3
1099460608	test3
root@ffd29b864a53:/# du -sB1 test4
1099448320	test4
root@ffd29b864a53:/# du --apparent-size -sB1 test3
1020649315	test3
root@ffd29b864a53:/# du --apparent-size -sB1 test4
1020649315	test4
```


### Motivation

Make Agent package size measurements consistent.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

See examples above.
Check that the `send_pkg_size` job is successful.

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

`-b` is equivalent to `--apparent-size --block-size=1`