### PR TITLE
fix(installer): Don't run preinst when there is nothing to do

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -169,10 +169,6 @@ func (i *installerImpl) Install(ctx context.Context, url string, args []string) 
 		span.SetResourceName(pkg.Name)
 		span.SetTag("package_version", pkg.Version)
 	}
-	err = i.preparePackage(ctx, pkg.Name, args) // Preinst
-	if err != nil {
-		return fmt.Errorf("could not prepare package: %w", err)
-	}
 	dbPkg, err := i.db.GetPackage(pkg.Name)
 	if err != nil && !errors.Is(err, db.ErrPackageNotFound) {
 		return fmt.Errorf("could not get package: %w", err)
@@ -180,6 +176,10 @@ func (i *installerImpl) Install(ctx context.Context, url string, args []string) 
 	if dbPkg.Name == pkg.Name && dbPkg.Version == pkg.Version {
 		log.Infof("package %s version %s is already installed", pkg.Name, pkg.Version)
 		return nil
+	}
+	err = i.preparePackage(ctx, pkg.Name, args) // Preinst
+	if err != nil {
+		return fmt.Errorf("could not prepare package: %w", err)
 	}
 	err = checkAvailableDiskSpace(i.packages, pkg)
 	if err != nil {

--- a/pkg/fleet/installer/packages/datadog_agent.go
+++ b/pkg/fleet/installer/packages/datadog_agent.go
@@ -77,11 +77,6 @@ func PrepareAgent(ctx context.Context) (err error) {
 	span, ctx := telemetry.StartSpanFromContext(ctx, "prepare_agent")
 	defer func() { span.Finish(err) }()
 
-	err = removeDebRPMPackage(ctx, "datadog-agent")
-	if err != nil {
-		return fmt.Errorf("failed to remove deb/rpm datadog-agent package: %w", err)
-	}
-
 	for _, unit := range stableUnits {
 		if err := stopUnit(ctx, unit); err != nil {
 			log.Warnf("Failed to stop %s: %s", unit, err)


### PR DESCRIPTION
### What does this PR do?
Re-running an installer script causes the agent units to be stopped after https://github.com/DataDog/datadog-agent/pull/32156/s

### Motivation

### Describe how you validated your changes
Tested manually

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->