### PR TITLE
[CWS] remove useless `kv.Code != 0` checks

### DIFF
--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -435,7 +435,7 @@ func getBpfProgAuxIDOffset(kv *kernel.Version) uint64 {
 		idOffset = 24
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_8, kernel.Kernel5_13):
 		idOffset = 28
-	case kv.Code != 0 && kv.Code >= kernel.Kernel5_13:
+	case kv.Code >= kernel.Kernel5_13:
 		idOffset = 32
 	}
 
@@ -483,7 +483,7 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 544
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_17, kernel.Kernel6_1):
 		nameOffset = 528
-	case kv.Code != 0 && kv.Code >= kernel.Kernel6_1:
+	case kv.Code >= kernel.Kernel6_1:
 		nameOffset = 912
 	}
 
@@ -588,7 +588,7 @@ func getPipeInodeInfoBufsOffset(kv *kernel.Version) uint64 {
 	case kv.IsInRangeCloseOpen(kernel.Kernel5_6, kernel.Kernel5_8) ||
 		kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
 		offset = 144
-	case kv.Code != 0 && kv.Code >= kernel.Kernel5_8:
+	case kv.Code >= kernel.Kernel5_8:
 		offset = 152
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

As the title says

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->