### PR TITLE
[gitlab] Fix ancestor computation for check_pkg_size

### DIFF
--- a/tasks/libs/package/utils.py
+++ b/tasks/libs/package/utils.py
@@ -148,7 +148,7 @@ def get_ancestor(ctx, package_sizes, on_main):
     """
     ancestor = get_common_ancestor(ctx, "HEAD")
     if not on_main and ancestor not in package_sizes:
-        return min(package_sizes, key=lambda x: package_sizes[x]['timestamp'])
+        return max(package_sizes, key=lambda x: package_sizes[x]['timestamp'])
     return ancestor
 
 

--- a/tasks/unit_tests/package_lib_tests.py
+++ b/tasks/unit_tests/package_lib_tests.py
@@ -141,7 +141,7 @@ class TestGetPreviousSize(unittest.TestCase):
     @patch.dict('os.environ', {'CI_COMMIT_REF_NAME': 'puppet'})
     def test_not_found_on_dev(self):
         c = MockContext(run={'git merge-base HEAD origin/main': Result('grand_pa')})
-        self.assertEqual(get_ancestor(c, self.package_sizes, False), "grand_ma")
+        self.assertEqual(get_ancestor(c, self.package_sizes, False), "ma")
 
     @patch.dict('os.environ', {'CI_COMMIT_REF_NAME': 'main'})
     def test_on_main(self):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes the `get_ancestor` method to ensure it works as intended, taking the most recent recorded commit when a direct ancestor is not found instead of the oldest one.

### Motivation

Avoid wrong comparisons like in https://github.com/DataDog/datadog-agent/pull/32789 and https://github.com/DataDog/datadog-agent/pull/32757.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

n/a

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

There is an open discussion on whether we should align with SMP's ancestor computation method (which uses the first recorded ancestor instead), to be tackled in a follow-up PR.