### PR TITLE
[CONTINT-4550] Fix pkg/clusteragent/autoscaling/workload/loadstore/TestStoreAndPurgeEntities

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/loadstore/store_test.go
+++ b/pkg/clusteragent/autoscaling/workload/loadstore/store_test.go
@@ -119,16 +119,13 @@ func TestStoreAndPurgeEntities(t *testing.T) {
 	}
 	storeInfo := store.GetStoreInfo()
 	assert.Equal(t, 2, len(storeInfo.StatsResults))
-	for id, statsResult := range storeInfo.StatsResults {
+	for _, statsResult := range storeInfo.StatsResults {
 		assert.Equal(t, numPayloads, statsResult.Count)
-		if id == 0 {
-			assert.Equal(t, "test", statsResult.Namespace)
-			assert.Equal(t, "redis_test", statsResult.PodOwner)
+		assert.Equal(t, "test", statsResult.Namespace)
+		assert.Contains(t, []string{"redis_test", "nginx_test"}, statsResult.PodOwner)
+		if statsResult.PodOwner == "redis_test" {
 			assert.Equal(t, "container.memory.usage", statsResult.MetricName)
-		} else {
-			assert.Equal(t, numPayloads, statsResult.Count)
-			assert.Equal(t, "test", statsResult.Namespace)
-			assert.Equal(t, "nginx_test", statsResult.PodOwner)
+		} else { // nginx_test
 			assert.Equal(t, "container.cpu.usage", statsResult.MetricName)
 		}
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix TestStoreAndPurgeEntities by checking the PodOwner field explicitly. 

### Motivation
The unit test dump the results by array. The elements in the array is ordered by their hash value: HashFunc<namespace, deployment, metricName>. 
```
func generateHash(strings ...string) uint64 {
	// Initialize a new FNV-1a hasher
	hasher := fnv.New64a()
	// Iterate over the strings and write each one to the hasher
	for _, str := range strings {
		hasher.Write([]byte(str))
	}
	return hasher.Sum64()
}
```
The FNV algorithm itself is independent of machine architecture. The input <namespace, deployment, metricName> to the hash function is derived from binary data, the **endianness** (byte order) of the machine might affect the input. Therefore the order of the result array is not independent of machine architecture. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA done by unit test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->