### PR TITLE
[gitlab] Run check_pkg_size, allowed to fail, on main and release branches

### DIFF
--- a/.gitlab/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics/pkg_metrics.yml
@@ -82,7 +82,13 @@ check_pkg_size:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   rules:
-    - !reference [.except_main_or_release_branch]
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: on_success
+      allow_failure: true
+    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
+      when: on_success
+      allow_failure: true
+    - !reference [.except_mergequeue]
     - when: on_success
   needs:
     - agent_deb-x64-a7


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Temporary fix after #32775: `check_pkg_size` still needs to run on `main` so that it uploads its data for comparisons on dev branches.

### Motivation

Fix package size comparison misbehaving.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

n/a

### Possible Drawbacks / Trade-offs

This is only meant as a temporary fix to unblock the efforts to make the job mandatory. A proper fix would be to change the behavior of the job so that it does not try to do comparison (and fail when they fail) on `main` and release branches.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This started happening more frequently because of the merge of #32775, see #32796.