### PR TITLE
[CWS] remove gopacket dependency from cws-instrumentation

### DIFF
--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -26,7 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
 	"github.com/DataDog/datadog-agent/pkg/network/go/binversion"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -186,7 +186,7 @@ func (pt *ProcessTracker) registerProcess(binID binaryID, pid pid, mTime syscall
 }
 
 func getServiceName(pid uint32) string {
-	envVars, _, err := utils.EnvVars([]string{"DD"}, pid, model.MaxArgsEnvsSize)
+	envVars, _, err := utils.EnvVars([]string{"DD"}, pid, sharedconsts.MaxArgsEnvsSize)
 	if err != nil {
 		return ""
 	}

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"modernc.org/mathutil"
 )
 
@@ -137,7 +137,7 @@ type ForkSyscallMsg struct {
 // ExitSyscallMsg defines an exit message
 type ExitSyscallMsg struct {
 	Code  uint32
-	Cause model.ExitCause
+	Cause sharedconsts.ExitCause
 }
 
 // FileSyscallMsg defines a file message

--- a/pkg/security/ptracer/hooks.go
+++ b/pkg/security/ptracer/hooks.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"golang.org/x/sys/unix"
 )
 
@@ -169,13 +169,13 @@ func (ctx *CWSPtracerCtx) handleExit(process *Process, waitStatus *syscall.WaitS
 	if process.Pid == process.Tgid && waitStatus != nil {
 		exitCtx := &ebpfless.ExitSyscallMsg{}
 		if waitStatus.Exited() {
-			exitCtx.Cause = model.ExitExited
+			exitCtx.Cause = sharedconsts.ExitExited
 			exitCtx.Code = uint32(waitStatus.ExitStatus())
 		} else if waitStatus.CoreDump() {
-			exitCtx.Cause = model.ExitCoreDumped
+			exitCtx.Cause = sharedconsts.ExitCoreDumped
 			exitCtx.Code = uint32(waitStatus.Signal())
 		} else if waitStatus.Signaled() {
-			exitCtx.Cause = model.ExitSignaled
+			exitCtx.Cause = sharedconsts.ExitSignaled
 			exitCtx.Code = uint32(waitStatus.Signal())
 		} else {
 			exitCtx.Code = uint32(waitStatus.Signal())

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -29,7 +29,7 @@ import (
 	usergrouputils "github.com/DataDog/datadog-agent/pkg/security/common/usergrouputils"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
@@ -340,13 +340,13 @@ func getPidTTY(pid int) string {
 
 func truncateArgs(list []string) ([]string, bool) {
 	truncated := false
-	if len(list) > model.MaxArgsEnvsSize {
-		list = list[:model.MaxArgsEnvsSize]
+	if len(list) > sharedconsts.MaxArgsEnvsSize {
+		list = list[:sharedconsts.MaxArgsEnvsSize]
 		truncated = true
 	}
 	for i, l := range list {
-		if len(l) > model.MaxArgEnvSize {
-			list[i] = l[:model.MaxArgEnvSize-4] + "..."
+		if len(l) > sharedconsts.MaxArgEnvSize {
+			list[i] = l[:sharedconsts.MaxArgEnvSize-4] + "..."
 			truncated = true
 		}
 	}
@@ -410,8 +410,8 @@ func truncateEnvs(it StringIterator) ([]string, bool) {
 		if len(text) > 0 {
 			envCounter++
 			if matchesOnePrefix(text, priorityEnvsPrefixes) {
-				if len(text) > model.MaxArgEnvSize {
-					text = text[:model.MaxArgEnvSize-4] + "..."
+				if len(text) > sharedconsts.MaxArgEnvSize {
+					text = text[:sharedconsts.MaxArgEnvSize-4] + "..."
 					truncated = true
 				}
 				priorityEnvs = append(priorityEnvs, text)
@@ -421,8 +421,8 @@ func truncateEnvs(it StringIterator) ([]string, bool) {
 
 	it.Reset()
 
-	if envCounter > model.MaxArgsEnvsSize {
-		envCounter = model.MaxArgsEnvsSize
+	if envCounter > sharedconsts.MaxArgsEnvsSize {
+		envCounter = sharedconsts.MaxArgsEnvsSize
 	}
 
 	// second pass collecting
@@ -430,7 +430,7 @@ func truncateEnvs(it StringIterator) ([]string, bool) {
 	envs = append(envs, priorityEnvs...)
 
 	for it.Next() {
-		if len(envs) >= model.MaxArgsEnvsSize {
+		if len(envs) >= sharedconsts.MaxArgsEnvsSize {
 			return envs, true
 		}
 
@@ -438,8 +438,8 @@ func truncateEnvs(it StringIterator) ([]string, bool) {
 		if len(text) > 0 {
 			// if it matches one prefix, it's already in the envs through priority envs
 			if !matchesOnePrefix(text, priorityEnvsPrefixes) {
-				if len(text) > model.MaxArgEnvSize {
-					text = text[:model.MaxArgEnvSize-4] + "..."
+				if len(text) > sharedconsts.MaxArgEnvSize {
+					text = text[:sharedconsts.MaxArgEnvSize-4] + "..."
 					truncated = true
 				}
 				envs = append(envs, text)

--- a/pkg/security/resolvers/envvars/resolver.go
+++ b/pkg/security/resolvers/envvars/resolver.go
@@ -10,7 +10,7 @@ package envvars
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -42,5 +42,5 @@ func (r *Resolver) ResolveEnvVars(pid uint32) ([]string, bool, error) {
 		// communicate the fact that it was truncated
 		return nil, true, nil
 	}
-	return utils.EnvVars(r.priorityEnvs, pid, model.MaxArgsEnvsSize)
+	return utils.EnvVars(r.priorityEnvs, pid, sharedconsts.MaxArgsEnvsSize)
 }

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -40,6 +40,7 @@ import (
 	spath "github.com/DataDog/datadog-agent/pkg/security/resolvers/path"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usergroup"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	stime "github.com/DataDog/datadog-agent/pkg/util/ktime"
@@ -253,7 +254,7 @@ var argsEnvsInterner = utils.NewLRUStringInterner(argsEnvsValueCacheSize)
 func parseStringArray(data []byte) ([]string, bool) {
 	truncated := false
 	values, err := model.UnmarshalStringArray(data)
-	if err != nil || len(data) == model.MaxArgEnvSize {
+	if err != nil || len(data) == sharedconsts.MaxArgEnvSize {
 		if len(values) > 0 {
 			values[len(values)-1] += "..."
 		}

--- a/pkg/security/secl/model/args_envs.go
+++ b/pkg/security/secl/model/args_envs.go
@@ -9,20 +9,15 @@ package model
 import (
 	"slices"
 	"strings"
-)
 
-const (
-	// MaxArgEnvSize maximum size of one argument or environment variable
-	MaxArgEnvSize = 256
-	// MaxArgsEnvsSize maximum number of args and/or envs
-	MaxArgsEnvsSize = 256
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 )
 
 // ArgsEnvs raw value for args and envs
 type ArgsEnvs struct {
 	ID        uint64
 	Size      uint32
-	ValuesRaw [MaxArgEnvSize]byte
+	ValuesRaw [sharedconsts.MaxArgEnvSize]byte
 }
 
 // ArgsEntry defines a args cache entry

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 )
 
@@ -320,10 +321,10 @@ var (
 	}
 
 	// exitCauseConstants is the list of supported Exit causes
-	exitCauseConstants = map[string]ExitCause{
-		"EXITED":     ExitExited,
-		"COREDUMPED": ExitCoreDumped,
-		"SIGNALED":   ExitSignaled,
+	exitCauseConstants = map[string]sharedconsts.ExitCause{
+		"EXITED":     sharedconsts.ExitExited,
+		"COREDUMPED": sharedconsts.ExitCoreDumped,
+		"SIGNALED":   sharedconsts.ExitSignaled,
 	}
 
 	tlsVersionContants = map[string]uint16{
@@ -342,7 +343,6 @@ var (
 	l3ProtocolStrings    = map[L3Protocol]string{}
 	l4ProtocolStrings    = map[L4Protocol]string{}
 	addressFamilyStrings = map[uint16]string{}
-	exitCauseStrings     = map[ExitCause]string{}
 	tlsVersionStrings    = map[uint16]string{}
 )
 
@@ -423,7 +423,6 @@ func initAddressFamilyConstants() {
 func initExitCauseConstants() {
 	for k, v := range exitCauseConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
-		exitCauseStrings[v] = k
 	}
 }
 
@@ -779,20 +778,4 @@ const (
 	IPProtoMPLS L4Protocol = 137
 	// IPProtoRAW Raw IP packets
 	IPProtoRAW L4Protocol = 255
-)
-
-// ExitCause represents the cause of a process termination
-type ExitCause uint32
-
-func (cause ExitCause) String() string {
-	return exitCauseStrings[cause]
-}
-
-const (
-	// ExitExited Process exited normally
-	ExitExited ExitCause = iota
-	// ExitCoreDumped Process was terminated with a coredump signal
-	ExitCoreDumped
-	// ExitSignaled Process was terminated with a signal other than a coredump
-	ExitSignaled
 )

--- a/pkg/security/secl/model/sharedconsts/argsenvs.go
+++ b/pkg/security/secl/model/sharedconsts/argsenvs.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package sharedconsts holds model related shared constants
+package sharedconsts
+
+const (
+	// MaxArgEnvSize maximum size of one argument or environment variable
+	MaxArgEnvSize = 256
+	// MaxArgsEnvsSize maximum number of args and/or envs
+	MaxArgsEnvsSize = 256
+)

--- a/pkg/security/secl/model/sharedconsts/exitcode.go
+++ b/pkg/security/secl/model/sharedconsts/exitcode.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package sharedconsts holds model related shared constants
+package sharedconsts
+
+// ExitCause represents the cause of a process termination
+type ExitCause uint32
+
+func (cause ExitCause) String() string {
+	switch cause {
+	case ExitExited:
+		return "EXITED"
+	case ExitCoreDumped:
+		return "COREDUMPED"
+	case ExitSignaled:
+		return "SIGNALED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+const (
+	// ExitExited Process exited normally
+	ExitExited ExitCause = iota
+	// ExitCoreDumped Process was terminated with a coredump signal
+	ExitCoreDumped
+	// ExitSignaled Process was terminated with a signal other than a coredump
+	ExitSignaled
+)

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 )
 
 func validateReadSize(size, read int) (int, error) {
@@ -316,14 +317,14 @@ func (e *ExitEvent) UnmarshalBinary(data []byte) (int, error) {
 
 	exitStatus := binary.NativeEndian.Uint32(data[0:4])
 	if exitStatus&0x7F == 0x00 { // process terminated normally
-		e.Cause = uint32(ExitExited)
+		e.Cause = uint32(sharedconsts.ExitExited)
 		e.Code = (exitStatus >> 8) & 0xFF
 	} else if exitStatus&0x7F != 0x7F { // process terminated because of a signal
 		if exitStatus&0x80 == 0x80 { // coredump signal
-			e.Cause = uint32(ExitCoreDumped)
+			e.Cause = uint32(sharedconsts.ExitCoreDumped)
 			e.Code = exitStatus & 0x7F
 		} else { // other signals
-			e.Cause = uint32(ExitSignaled)
+			e.Cause = uint32(sharedconsts.ExitSignaled)
 			e.Code = exitStatus & 0x7F
 		}
 	}

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -352,8 +352,8 @@ func (e *ArgsEnvsEvent) UnmarshalBinary(data []byte) (int, error) {
 
 	e.ID = binary.NativeEndian.Uint64(data[0:8])
 	e.Size = binary.NativeEndian.Uint32(data[8:12])
-	if e.Size > MaxArgEnvSize {
-		e.Size = MaxArgEnvSize
+	if e.Size > sharedconsts.MaxArgEnvSize {
+		e.Size = sharedconsts.MaxArgEnvSize
 	}
 
 	argsEnvSize := int(e.Size)

--- a/pkg/security/seclwin/model/args_envs.go
+++ b/pkg/security/seclwin/model/args_envs.go
@@ -9,20 +9,15 @@ package model
 import (
 	"slices"
 	"strings"
-)
 
-const (
-	// MaxArgEnvSize maximum size of one argument or environment variable
-	MaxArgEnvSize = 256
-	// MaxArgsEnvsSize maximum number of args and/or envs
-	MaxArgsEnvsSize = 256
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 )
 
 // ArgsEnvs raw value for args and envs
 type ArgsEnvs struct {
 	ID        uint64
 	Size      uint32
-	ValuesRaw [MaxArgEnvSize]byte
+	ValuesRaw [sharedconsts.MaxArgEnvSize]byte
 }
 
 // ArgsEntry defines a args cache entry

--- a/pkg/security/seclwin/model/consts_common.go
+++ b/pkg/security/seclwin/model/consts_common.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 )
 
@@ -320,10 +321,10 @@ var (
 	}
 
 	// exitCauseConstants is the list of supported Exit causes
-	exitCauseConstants = map[string]ExitCause{
-		"EXITED":     ExitExited,
-		"COREDUMPED": ExitCoreDumped,
-		"SIGNALED":   ExitSignaled,
+	exitCauseConstants = map[string]sharedconsts.ExitCause{
+		"EXITED":     sharedconsts.ExitExited,
+		"COREDUMPED": sharedconsts.ExitCoreDumped,
+		"SIGNALED":   sharedconsts.ExitSignaled,
 	}
 
 	tlsVersionContants = map[string]uint16{
@@ -342,7 +343,6 @@ var (
 	l3ProtocolStrings    = map[L3Protocol]string{}
 	l4ProtocolStrings    = map[L4Protocol]string{}
 	addressFamilyStrings = map[uint16]string{}
-	exitCauseStrings     = map[ExitCause]string{}
 	tlsVersionStrings    = map[uint16]string{}
 )
 
@@ -423,7 +423,6 @@ func initAddressFamilyConstants() {
 func initExitCauseConstants() {
 	for k, v := range exitCauseConstants {
 		seclConstants[k] = &eval.IntEvaluator{Value: int(v)}
-		exitCauseStrings[v] = k
 	}
 }
 
@@ -779,20 +778,4 @@ const (
 	IPProtoMPLS L4Protocol = 137
 	// IPProtoRAW Raw IP packets
 	IPProtoRAW L4Protocol = 255
-)
-
-// ExitCause represents the cause of a process termination
-type ExitCause uint32
-
-func (cause ExitCause) String() string {
-	return exitCauseStrings[cause]
-}
-
-const (
-	// ExitExited Process exited normally
-	ExitExited ExitCause = iota
-	// ExitCoreDumped Process was terminated with a coredump signal
-	ExitCoreDumped
-	// ExitSignaled Process was terminated with a signal other than a coredump
-	ExitSignaled
 )

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 )
@@ -305,7 +306,7 @@ func newIPPortFamilySerializer(c *model.IPPortContext, family string) IPPortFami
 
 func newExitEventSerializer(e *model.Event) *ExitEventSerializer {
 	return &ExitEventSerializer{
-		Cause: model.ExitCause(e.Exit.Cause).String(),
+		Cause: sharedconsts.ExitCause(e.Exit.Cause).String(),
 		Code:  e.Exit.Code,
 	}
 }

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
@@ -435,7 +436,7 @@ func TestProcessContext(t *testing.T) {
 
 			argv := strings.Split(args.(string), " ")
 			assert.Equal(t, 2, len(argv), "incorrect number of args: %s", argv)
-			assert.Equal(t, model.MaxArgEnvSize-1, len(argv[1]), "wrong arg length")
+			assert.Equal(t, sharedconsts.MaxArgEnvSize-1, len(argv[1]), "wrong arg length")
 			assert.Equal(t, true, strings.HasSuffix(argv[1], "..."), "args not truncated")
 
 			// truncated is reported if a single argument is truncated or if the list is truncated
@@ -480,8 +481,8 @@ func TestProcessContext(t *testing.T) {
 
 			argv := strings.Split(execArgs.(string), " ")
 			if ebpfLessEnabled {
-				assert.Equal(t, model.MaxArgsEnvsSize-1, len(argv), "incorrect number of args: %s", argv)
-				for i := 0; i != model.MaxArgsEnvsSize-1; i++ {
+				assert.Equal(t, sharedconsts.MaxArgsEnvsSize-1, len(argv), "incorrect number of args: %s", argv)
+				for i := 0; i != sharedconsts.MaxArgsEnvsSize-1; i++ {
 					assert.Equal(t, args[i], argv[i], "expected arg not found")
 				}
 			} else {
@@ -530,11 +531,11 @@ func TestProcessContext(t *testing.T) {
 
 			argv := strings.Split(execArgs.(string), " ")
 			if ebpfLessEnabled {
-				assert.Equal(t, model.MaxArgsEnvsSize-1, len(argv), "incorrect number of args: %s", argv)
-				for i := 0; i != model.MaxArgsEnvsSize-1; i++ {
+				assert.Equal(t, sharedconsts.MaxArgsEnvsSize-1, len(argv), "incorrect number of args: %s", argv)
+				for i := 0; i != sharedconsts.MaxArgsEnvsSize-1; i++ {
 					expected := args[i]
-					if len(expected) > model.MaxArgEnvSize {
-						expected = args[i][:model.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
+					if len(expected) > sharedconsts.MaxArgEnvSize {
+						expected = args[i][:sharedconsts.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
 					}
 					assert.Equal(t, expected, argv[i], "expected arg not found")
 				}
@@ -542,8 +543,8 @@ func TestProcessContext(t *testing.T) {
 				assert.Equal(t, 457, len(argv), "incorrect number of args: %s", argv)
 				for i := 0; i != 457; i++ {
 					expected := args[i]
-					if len(expected) > model.MaxArgEnvSize {
-						expected = args[i][:model.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
+					if len(expected) > sharedconsts.MaxArgEnvSize {
+						expected = args[i][:sharedconsts.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
 					}
 					assert.Equal(t, expected, argv[i], "expected arg not found")
 				}
@@ -594,7 +595,7 @@ func TestProcessContext(t *testing.T) {
 
 			envp := (execEnvp.([]string))
 			assert.Equal(t, 2, len(envp), "incorrect number of envs: %s", envp)
-			assert.Equal(t, model.MaxArgEnvSize-1, len(envp[1]), "wrong env length")
+			assert.Equal(t, sharedconsts.MaxArgEnvSize-1, len(envp[1]), "wrong env length")
 			assert.Equal(t, true, strings.HasSuffix(envp[1], "..."), "envs not truncated")
 
 			// truncated is reported if a single environment variable is truncated or if the list is truncated
@@ -645,8 +646,8 @@ func TestProcessContext(t *testing.T) {
 
 			envp := (execEnvp.([]string))
 			if ebpfLessEnabled {
-				assert.Equal(t, model.MaxArgsEnvsSize, len(envp), "incorrect number of envs: %s", envp)
-				for i := 0; i != model.MaxArgsEnvsSize; i++ {
+				assert.Equal(t, sharedconsts.MaxArgsEnvsSize, len(envp), "incorrect number of envs: %s", envp)
+				for i := 0; i != sharedconsts.MaxArgsEnvsSize; i++ {
 					assert.Equal(t, envs[i], envp[i], "expected env not found")
 				}
 			} else {
@@ -707,11 +708,11 @@ func TestProcessContext(t *testing.T) {
 
 			envp := (execEnvp.([]string))
 			if ebpfLessEnabled {
-				assert.Equal(t, model.MaxArgsEnvsSize, len(envp), "incorrect number of envs: %s", envp)
-				for i := 0; i != model.MaxArgsEnvsSize; i++ {
+				assert.Equal(t, sharedconsts.MaxArgsEnvsSize, len(envp), "incorrect number of envs: %s", envp)
+				for i := 0; i != sharedconsts.MaxArgsEnvsSize; i++ {
 					expected := envs[i]
-					if len(expected) > model.MaxArgEnvSize {
-						expected = envs[i][:model.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
+					if len(expected) > sharedconsts.MaxArgEnvSize {
+						expected = envs[i][:sharedconsts.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
 					}
 					assert.Equal(t, expected, envp[i], "expected env not found")
 				}
@@ -719,8 +720,8 @@ func TestProcessContext(t *testing.T) {
 				assert.Equal(t, 863, len(envp), "incorrect number of envs: %s", envp)
 				for i := 0; i != 863; i++ {
 					expected := envs[i]
-					if len(expected) > model.MaxArgEnvSize {
-						expected = envs[i][:model.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
+					if len(expected) > sharedconsts.MaxArgEnvSize {
+						expected = envs[i][:sharedconsts.MaxArgEnvSize-4] + "..." // 4 is the size number of the string
 					}
 					assert.Equal(t, expected, envp[i], "expected env not found")
 				}
@@ -1811,7 +1812,7 @@ func TestProcessExit(t *testing.T) {
 			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_ok")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
-			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
+			assert.Equal(t, uint32(sharedconsts.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
 			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
@@ -1830,7 +1831,7 @@ func TestProcessExit(t *testing.T) {
 			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_error")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
-			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
+			assert.Equal(t, uint32(sharedconsts.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(1), event.Exit.Code, "wrong exit code")
 			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
@@ -1849,7 +1850,7 @@ func TestProcessExit(t *testing.T) {
 			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_coredump")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
-			assert.Equal(t, uint32(model.ExitCoreDumped), event.Exit.Cause, "wrong exit cause")
+			assert.Equal(t, uint32(sharedconsts.ExitCoreDumped), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(syscall.SIGQUIT), event.Exit.Code, "wrong exit code")
 			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
@@ -1870,7 +1871,7 @@ func TestProcessExit(t *testing.T) {
 			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_signal")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
-			assert.Equal(t, uint32(model.ExitSignaled), event.Exit.Cause, "wrong exit cause")
+			assert.Equal(t, uint32(sharedconsts.ExitSignaled), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(syscall.SIGKILL), event.Exit.Code, "wrong exit code")
 			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
@@ -1888,7 +1889,7 @@ func TestProcessExit(t *testing.T) {
 			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_time_1")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
-			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
+			assert.Equal(t, uint32(sharedconsts.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
 			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})
@@ -1906,7 +1907,7 @@ func TestProcessExit(t *testing.T) {
 			test.validateExitSchema(t, event)
 			assertTriggeredRule(t, rule, "test_exit_time_2")
 			assertFieldEqual(t, event, "exit.file.path", sleepExec)
-			assert.Equal(t, uint32(model.ExitExited), event.Exit.Cause, "wrong exit cause")
+			assert.Equal(t, uint32(sharedconsts.ExitExited), event.Exit.Cause, "wrong exit cause")
 			assert.Equal(t, uint32(0), event.Exit.Code, "wrong exit code")
 			assert.False(t, event.ProcessContext.ExitTime.Before(event.ProcessContext.ExecTime), "exit time < exec time")
 		})

--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/shirou/gopsutil/v4/process"
 )
@@ -306,7 +307,7 @@ func EnvVars(priorityEnvsPrefixes []string, pid uint32, maxEnvVars int) ([]strin
 	envs = append(envs, priorityEnvs...)
 
 	for scanner.Scan() {
-		if len(envs) >= model.MaxArgsEnvsSize {
+		if len(envs) >= sharedconsts.MaxArgsEnvsSize {
 			return envs, true, nil
 		}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR moves a few constants out of `pkg/security/secl/model` and into a separate package. This allows all users of those constants to import them without importing the full model, and thus the gopacket dependency. This is especially important for the cws-instrumentation which size is an important metric.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->