### PR TITLE
(fleet) fix the version used to reference the installer from the install scripts

### DIFF
--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -101,14 +101,13 @@ installer-install-scripts:
     RELEASE_VERSION: "$RELEASE_VERSION_7"
   script:
     - !reference [.retrieve_linux_go_deps]
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
-    - export INSTALLER_VERSION=$(cat agent-version.cache | base64 -)
-    - echo "About to build for $INSTALLER_VERSION"
+    - VERSION="$(inv agent.version --url-safe)-1" || exit $?
+    - echo "About to build for $VERSION"
     - mkdir -p $OMNIBUS_PACKAGE_DIR
-    - inv -e installer.build-linux-script "default" "$INSTALLER_VERSION"
-    - inv -e installer.build-linux-script "databricks" "$INSTALLER_VERSION"
-    - inv -e installer.build-linux-script "emr" "$INSTALLER_VERSION"
-    - inv -e installer.build-linux-script "dataproc" "$INSTALLER_VERSION"
+    - inv -e installer.build-linux-script "default" "$VERSION"
+    - inv -e installer.build-linux-script "databricks" "$VERSION"
+    - inv -e installer.build-linux-script "emr" "$VERSION"
+    - inv -e installer.build-linux-script "dataproc" "$VERSION"
     - mv ./bin/installer/install-*.sh $OMNIBUS_PACKAGE_DIR/
     - ls -la $OMNIBUS_PACKAGE_DIR
   artifacts:

--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -101,12 +101,14 @@ installer-install-scripts:
     RELEASE_VERSION: "$RELEASE_VERSION_7"
   script:
     - !reference [.retrieve_linux_go_deps]
-    - echo "About to build for $RELEASE_VERSION"
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
+    - export INSTALLER_VERSION=$(cat agent-version.cache | base64 -)
+    - echo "About to build for $INSTALLER_VERSION"
     - mkdir -p $OMNIBUS_PACKAGE_DIR
-    - inv -e installer.build-linux-script "default" "$RELEASE_VERSION"
-    - inv -e installer.build-linux-script "databricks" "$RELEASE_VERSION"
-    - inv -e installer.build-linux-script "emr" "$RELEASE_VERSION"
-    - inv -e installer.build-linux-script "dataproc" "$RELEASE_VERSION"
+    - inv -e installer.build-linux-script "default" "$INSTALLER_VERSION"
+    - inv -e installer.build-linux-script "databricks" "$INSTALLER_VERSION"
+    - inv -e installer.build-linux-script "emr" "$INSTALLER_VERSION"
+    - inv -e installer.build-linux-script "dataproc" "$INSTALLER_VERSION"
     - mv ./bin/installer/install-*.sh $OMNIBUS_PACKAGE_DIR/
     - ls -la $OMNIBUS_PACKAGE_DIR
   artifacts:

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -10,7 +10,6 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from tasks.build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
-from tasks.libs.common.git import get_commit_sha
 from tasks.libs.common.utils import REPO_PATH, bin_name, get_build_flags
 from tasks.libs.releasing.version import get_version
 

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -107,10 +107,6 @@ def build_linux_script(
     with open(INSTALL_SCRIPT_TEMPLATE) as f:
         install_script = f.read()
 
-    # default version on pipelines, using the commit sha instead
-    if version == "nightly-a7":
-        version = get_commit_sha(ctx)
-
     archs = ['amd64', 'arm64']
     for arch in archs:
         build_downloader(ctx, flavor=flavor, version=version, os='linux', arch=arch)


### PR DESCRIPTION
This PR fixes the version used to build install script. Currently it's always `nightly-a7` but we want the actual installer version.