### PR TITLE
Prepare for conductor based nighty builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -383,7 +383,7 @@ variables:
   if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH == "beta" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
 
 .if_scheduled_main: &if_scheduled_main
-  if: $CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_BRANCH == "main"
+  if: ($CI_PIPELINE_SOURCE == "schedule" || ($DDR_WORKFLOW_ID != null && $APPS =~ /^beta-build-/)) && $CI_COMMIT_BRANCH == "main"
 
 # Rule to trigger jobs only when a branch matches the mergequeue pattern.
 .if_mergequeue: &if_mergequeue

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -12,7 +12,7 @@ internal_kubernetes_deploy_experimental:
       when: always
     - if: $CI_COMMIT_BRANCH != "main"
       when: never
-    - if: $DDR != "true"
+    - if: $DDR_WORKFLOW_ID == null
       when: never
     - if: $APPS !~ "/^datadog-agent/"
       when: never
@@ -74,7 +74,7 @@ notify-slack:
       when: always
     - if: $CI_COMMIT_BRANCH != "main"
       when: never
-    - if: $DDR != "true"
+    - if: $DDR_WORKFLOW_ID == null
       when: never
     - if: $APPS !~ "/^datadog-agent/"
       when: never

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -37,7 +37,7 @@ trigger_auto_staging_release:
     AUTO_RELEASE: "true"
     TARGET_REPO: staging
   rules:
-    - if: $DDR == "true"
+    - if: $DDR_WORKFLOW_ID != null
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
@@ -73,13 +73,13 @@ generate_windows_gitlab_runner_bump_pr:
   needs: ["trigger_auto_staging_release"]
   tags: ["arch:amd64"]
   rules:
-    - if: $DDR == "true"
+    - if: $DDR_WORKFLOW_ID != null
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
 
-  script: 
+  script:
     # We are using the agent platform auto PR github app to access the buildenv repository (already used for macOS builds)
     - !reference [.setup_github_app_agent_platform_auto_pr]
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -37,8 +37,6 @@ trigger_auto_staging_release:
     AUTO_RELEASE: "true"
     TARGET_REPO: staging
   rules:
-    - if: $DDR_WORKFLOW_ID != null
-      when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
     - !reference [.on_deploy]

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -53,11 +53,7 @@ def should_notify(pipeline_id):
     from tasks.libs.ciproviders.gitlab_api import get_pipeline
 
     pipeline = get_pipeline(PROJECT_NAME, pipeline_id)
-    return (
-        pipeline.source != 'pipeline'
-        or pipeline.source == 'pipeline'
-        and all(var in os.environ for var in ['DDR', 'DDR_WORKFLOW_ID'])
-    )
+    return pipeline.source != 'pipeline' or pipeline.source == 'pipeline' and 'DDR_WORKFLOW_ID' in os.environ
 
 
 def get_pipeline_type(pipeline):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR prepares our CI for nightly builds being initiated by conductor.

### Motivation

We currently have 2 nightly builds that run concurrently.
* One from the regular gitlab scheduled pipeline
* One initiated by a conductor schedule.i

This PR prepares for dropping the gitlab scheduled pipeline.

### Describe how you validated your changes

I suppose we'll have to test this live, at the risk of missing a nightly build.
In the worst case, the scheduled pipeline drop can easily be reverted since it's configured through terraform.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Relates to https://github.com/DataDog/gitlab-config/pull/270