### PR TITLE
[USMON-1399] Fix gRPC bug

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -77,6 +77,7 @@ static __always_inline void tls_process(struct pt_regs *ctx, conn_tuple_t *t, vo
 
     // we're in the context of TLS hookpoints, thus the protocol is TLS.
     set_protocol(stack, PROTOCOL_TLS);
+    set_protocol_flag(stack, FLAG_USM_ENABLED);
 
     const __u32 zero = 0;
     protocol_t protocol = get_protocol_from_stack(stack, LAYER_APPLICATION);


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix a bug in gRPC and HTTP/2 traffic that caused an accuracy drop.

### Motivation

We currently have a bug in the HTTP/2 and gRPC decoding flow where we do not mark TLS traffic with `FLAG_USM_ENABLED`, causing the map not to be cleaned, which leads to an accuracy drop.

The fix is to mark TLS traffic with the USM flag so the map cleaner can properly clean it.

### Describe how you validated your changes

* Validate the change using the load test.
* Deployed to staging cluster and observed the accuracy

Example of the change in the [load test](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=pr-31524-fix1-grpc-openssl-base&tpl_var_client-service%5B0%5D=python-k6-client-grpc-tls&tpl_var_compare_agent-env%5B0%5D=pr-31524-fix1-grpc-openssl-new&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=python-grpcbin-tls&tpl_var_tls.library%5B0%5D=openssl&from_ts=1736343542535&to_ts=1736347876931&live=false) which show the impact of the solution. 

Example of the change in the [load test](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=pr-31524-grpc-openssl-base&tpl_var_client-service%5B0%5D=python-k6-client-grpc-tls&tpl_var_compare_agent-env%5B0%5D=pr-31524-grpc-openssl-new&tpl_var_kube_cluster_name%5B0%5D=usm1&tpl_var_server-service%5B0%5D=python-grpcbin-tls&tpl_var_tls.library%5B0%5D=openssl&from_ts=1736324264475&to_ts=1736328559298&live=false) before the change.

We can see that the accuracy now matches the previous version, and there are no accuracy drop as seen in the previous version.


<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->