### PR TITLE
Update lading version to 0.25.3

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.2
+  version: 0.25.3
 
 target:
 


### PR DESCRIPTION
### What does this PR do?

Updates `lading` tool used by SMP experiments to latest version https://github.com/DataDog/lading/releases/tag/v0.25.3

### Motivation

More metrics.

### Describe how you validated your changes

SMP tests provide validation

### Possible Drawbacks / Trade-offs

### Additional Notes
