### PR TITLE
[ASCII-2653] Split the cluster agent flare logic into a separate package.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -431,7 +431,7 @@
 /pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
 /pkg/dynamicinstrumentation/            @DataDog/debugger
 /pkg/flare/                             @DataDog/agent-shared-components
-/pkg/flare/manifests.go                 @DataDog/container-ecosystems
+/pkg/flare/clusteragent/                @DataDog/container-ecosystems
 /pkg/flare/*_win.go                     @Datadog/windows-agent
 /pkg/flare/*_windows.go                 @Datadog/windows-agent
 /pkg/flare/*_windows_test.go            @Datadog/windows-agent

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -431,7 +431,7 @@
 /pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
 /pkg/dynamicinstrumentation/            @DataDog/debugger
 /pkg/flare/                             @DataDog/agent-shared-components
-/pkg/flare/clusteragent/                @DataDog/container-ecosystems
+/pkg/flare/clusteragent/manifests.go    @DataDog/container-ecosystems
 /pkg/flare/*_win.go                     @Datadog/windows-agent
 /pkg/flare/*_windows.go                 @Datadog/windows-agent
 /pkg/flare/*_windows_test.go            @Datadog/windows-agent

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -22,7 +22,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/flare"
+	clusterAgentFlare "github.com/DataDog/datadog-agent/pkg/flare/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -129,7 +129,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request, statusComponent status.Co
 	log.Infof("Making a flare")
 	w.Header().Set("Content-Type", "application/json")
 
-	var profile flare.ProfileData
+	var profile clusterAgentFlare.ProfileData
 
 	if r.Body != http.NoBody {
 		body, err := io.ReadAll(r.Body)
@@ -148,7 +148,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request, statusComponent status.Co
 	if logFile == "" {
 		logFile = defaultpaths.DCALogFile
 	}
-	filePath, err := flare.CreateDCAArchive(false, defaultpaths.GetDistPath(), logFile, profile, statusComponent)
+	filePath, err := clusterAgentFlare.CreateDCAArchive(false, defaultpaths.GetDistPath(), logFile, profile, statusComponent)
 	if err != nil || filePath == "" {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)

--- a/cmd/cluster-agent/subcommands/telemetry/command.go
+++ b/cmd/cluster-agent/subcommands/telemetry/command.go
@@ -11,9 +11,10 @@ package telemetry
 import (
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
-	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/command"
+	clusterAgentFlare "github.com/DataDog/datadog-agent/pkg/flare/clusteragent"
 )
 
 // Commands returns a slice of subcommands for the 'cluster-agent' command.
@@ -25,7 +26,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 		Short: "Print the telemetry metrics exposed by the cluster agent",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			payload, err := flare.QueryDCAMetrics()
+			payload, err := clusterAgentFlare.QueryDCAMetrics()
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/subcommands/clusterchecks/command.go
+++ b/pkg/cli/subcommands/clusterchecks/command.go
@@ -23,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/flare"
+	clusterAgentFlare "github.com/DataDog/datadog-agent/pkg/flare/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -119,11 +119,11 @@ func bundleParams(globalParams GlobalParams) core.BundleParams {
 
 //nolint:revive // TODO(CINT) Fix revive linter
 func run(_ log.Component, _ config.Component, cliParams *cliParams) error {
-	if err := flare.GetClusterChecks(color.Output, cliParams.checkName); err != nil {
+	if err := clusterAgentFlare.GetClusterChecks(color.Output, cliParams.checkName); err != nil {
 		return err
 	}
 
-	return flare.GetEndpointsChecks(color.Output, cliParams.checkName)
+	return clusterAgentFlare.GetEndpointsChecks(color.Output, cliParams.checkName)
 }
 
 func rebalance(_ log.Component, config config.Component, cliParams *cliParams) error {

--- a/pkg/cli/subcommands/dcaconfigcheck/command.go
+++ b/pkg/cli/subcommands/dcaconfigcheck/command.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	"github.com/DataDog/datadog-agent/pkg/flare"
+	clusterAgentFlare "github.com/DataDog/datadog-agent/pkg/flare/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -62,7 +62,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 }
 
 func run(_ log.Component, _ config.Component, cliParams *cliParams) error {
-	if err := flare.GetClusterAgentConfigCheck(color.Output, cliParams.verbose); err != nil {
+	if err := clusterAgentFlare.GetClusterAgentConfigCheck(color.Output, cliParams.verbose); err != nil {
 		return fmt.Errorf("the agent ran into an error while checking config: %w", err)
 	}
 

--- a/pkg/cli/subcommands/dcaflare/command.go
+++ b/pkg/cli/subcommands/dcaflare/command.go
@@ -26,6 +26,7 @@ import (
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/flare"
+	clusterAgentFlare "github.com/DataDog/datadog-agent/pkg/flare/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/input"
@@ -105,8 +106,8 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 	return cmd
 }
 
-func readProfileData(seconds int) (flare.ProfileData, error) {
-	pdata := flare.ProfileData{}
+func readProfileData(seconds int) (clusterAgentFlare.ProfileData, error) {
+	pdata := clusterAgentFlare.ProfileData{}
 	c := util.GetClient(false)
 
 	fmt.Fprintln(color.Output, color.BlueString("Getting a %ds profile snapshot from datadog-cluster-agent.", seconds))
@@ -152,7 +153,7 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 func run(cliParams *cliParams, _ config.Component) error {
 	fmt.Fprintln(color.Output, color.BlueString("Asking the Cluster Agent to build the flare archive."))
 	var (
-		profile flare.ProfileData
+		profile clusterAgentFlare.ProfileData
 		e       error
 	)
 	c := util.GetClient(false) // FIX: get certificates right then make this true
@@ -208,7 +209,7 @@ func run(cliParams *cliParams, _ config.Component) error {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be missing."))
-		filePath, e = flare.CreateDCAArchive(true, defaultpaths.GetDistPath(), logFile, profile, nil)
+		filePath, e = clusterAgentFlare.CreateDCAArchive(true, defaultpaths.GetDistPath(), logFile, profile, nil)
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -43,12 +43,12 @@ func createSecurityAgentArchive(fb flaretypes.FlareBuilder, logFilePath string, 
 		}
 	}
 
-	getLogFiles(fb, logFilePath)
-	getConfigFiles(fb, searchPaths{})
+	GetLogFiles(fb, logFilePath)
+	GetConfigFiles(fb, searchPaths{})
 	getComplianceFiles(fb)                        //nolint:errcheck
 	getRuntimeFiles(fb)                           //nolint:errcheck
-	getExpVar(fb)                                 //nolint:errcheck
-	fb.AddFileFromFunc("envvars.log", getEnvVars) //nolint:errcheck
+	GetExpVar(fb)                                 //nolint:errcheck
+	fb.AddFileFromFunc("envvars.log", GetEnvVars) //nolint:errcheck
 
 	addSecurityAgentPlatformSpecificEntries(fb)
 }

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -50,7 +50,7 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	defer os.Remove("./test/system-probe.yaml")
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	getConfigFiles(mock.Fb, searchPaths{"": "./test/confd"})
+	GetConfigFiles(mock.Fb, searchPaths{"": "./test/confd"})
 
 	mock.AssertFileExists("etc", "datadog.yaml")
 	mock.AssertFileExists("etc", "system-probe.yaml")
@@ -60,7 +60,7 @@ func TestIncludeConfigFiles(t *testing.T) {
 	configmock.New(t)
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	getConfigFiles(mock.Fb, searchPaths{"": "./test/confd"})
+	GetConfigFiles(mock.Fb, searchPaths{"": "./test/confd"})
 
 	mock.AssertFileExists("etc/confd/test.yaml")
 	mock.AssertFileExists("etc/confd/test.Yml")
@@ -71,7 +71,7 @@ func TestIncludeConfigFilesWithPrefix(t *testing.T) {
 	configmock.New(t)
 
 	mock := flarehelpers.NewFlareBuilderMock(t, false)
-	getConfigFiles(mock.Fb, searchPaths{"prefix": "./test/confd"})
+	GetConfigFiles(mock.Fb, searchPaths{"prefix": "./test/confd"})
 
 	mock.AssertFileExists("etc/confd/prefix/test.yaml")
 	mock.AssertFileExists("etc/confd/prefix/test.Yml")

--- a/pkg/flare/clusteragent/cluster_checks.go
+++ b/pkg/flare/clusteragent/cluster_checks.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package flare
+package clusteragent
 
 import (
 	"encoding/json"
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/clusterchecks/types"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/flare"
 )
 
 // GetClusterChecks dumps the clustercheck dispatching state to the writer
@@ -74,7 +75,7 @@ func GetClusterChecks(w io.Writer, checkName string) error {
 	if len(cr.Dangling) > 0 {
 		fmt.Fprintf(w, "=== %s configurations ===\n", color.RedString("Unassigned"))
 		for _, c := range cr.Dangling {
-			PrintConfig(w, c, checkName)
+			flare.PrintConfig(w, c, checkName)
 		}
 		fmt.Fprintln(w, "")
 	}
@@ -101,7 +102,7 @@ func GetClusterChecks(w io.Writer, checkName string) error {
 		}
 		fmt.Fprintf(w, "\n===== Checks on %s =====\n", color.HiMagentaString(node.Name))
 		for _, c := range node.Configs {
-			PrintConfig(w, c, checkName)
+			flare.PrintConfig(w, c, checkName)
 		}
 	}
 
@@ -146,7 +147,7 @@ func GetEndpointsChecks(w io.Writer, checkName string) error {
 	// Print summary of pod-backed endpointschecks
 	fmt.Fprintf(w, "\n===== %d Pod-backed Endpoints-Checks scheduled =====\n", len(cr.Configs))
 	for _, c := range cr.Configs {
-		PrintConfig(w, c, checkName)
+		flare.PrintConfig(w, c, checkName)
 	}
 
 	return nil

--- a/pkg/flare/clusteragent/diagnose.go
+++ b/pkg/flare/clusteragent/diagnose.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package flare
+package clusteragent
 
 import (
 	"io"

--- a/pkg/flare/clusteragent/manifests.go
+++ b/pkg/flare/clusteragent/manifests.go
@@ -5,7 +5,7 @@
 
 //go:build kubeapiserver
 
-package flare
+package clusteragent
 
 import (
 	"bytes"

--- a/pkg/flare/clusteragent/manifests_nocompile.go
+++ b/pkg/flare/clusteragent/manifests_nocompile.go
@@ -5,7 +5,7 @@
 
 //go:build !kubeapiserver
 
-package flare
+package clusteragent
 
 import (
 	"errors"
@@ -19,7 +19,7 @@ var (
 	ErrNotCompiled = errors.New("kubernetes apiserver support not compiled in")
 )
 
-// getAgentDaemonSet retrieves the DaemonSet manifest of the Agent
+// GetAgentDaemonSet retrieves the DaemonSet manifest of the Agent
 func getAgentDaemonSet() ([]byte, error) {
 	return nil, log.Errorf("getAgentDaemonSet not implemented %s", ErrNotCompiled.Error())
 }

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -6,53 +6,14 @@
 package flare
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
 
 	"github.com/fatih/color"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
-	"github.com/DataDog/datadog-agent/pkg/api/util"
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 )
-
-// GetClusterAgentConfigCheck gets config check from the server for cluster agent
-func GetClusterAgentConfigCheck(w io.Writer, withDebug bool) error {
-	c := util.GetClient(false) // FIX: get certificates right then make this true
-
-	// Set session token
-	err := util.SetAuthToken(pkgconfigsetup.Datadog())
-	if err != nil {
-		return err
-	}
-
-	targetURL := url.URL{
-		Scheme: "https",
-		Host:   fmt.Sprintf("localhost:%v", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")),
-		Path:   "config-check",
-	}
-
-	r, err := util.DoGet(c, targetURL.String(), util.LeaveConnectionOpen)
-	if err != nil {
-		if r != nil && string(r) != "" {
-			return fmt.Errorf("the agent ran into an error while checking config: %s", string(r))
-		}
-		return fmt.Errorf("failed to query the agent (running?): %s", err)
-	}
-
-	cr := integration.ConfigCheckResponse{}
-	err = json.Unmarshal(r, &cr)
-	if err != nil {
-		return err
-	}
-
-	PrintConfigCheck(w, cr, withDebug)
-
-	return nil
-}
 
 // PrintConfigCheck prints a human-readable representation of the config check response
 func PrintConfigCheck(w io.Writer, cr integration.ConfigCheckResponse, withDebug bool) {

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -160,9 +160,9 @@ func getAllowedEnvvars() []string {
 	return found
 }
 
-// getEnvVars collects allowed envvars that can affect the agent's
+// GetEnvVars collects allowed envvars that can affect the agent's
 // behaviour while not being handled by viper, in addition to the envvars handled by viper
-func getEnvVars() ([]byte, error) {
+func GetEnvVars() ([]byte, error) {
 	envvars := getAllowedEnvvars()
 
 	var b bytes.Buffer


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The cluster agent flare archive imports k8s related packages that not all flavors of the agent require. With this change we attempt to remove certain packages from non cluster agent flavors.

### Motivation

Remove unnecessary imports

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Multiple unit tests and e2e cover the different parts of these changes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->