### PR TITLE
[EBPF] telemetry: fix beforeStop signature

### DIFF
--- a/pkg/ebpf/telemetry/modifier.go
+++ b/pkg/ebpf/telemetry/modifier.go
@@ -13,6 +13,7 @@ import (
 
 	manager "github.com/DataDog/ebpf-manager"
 
+	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/names"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -27,6 +28,11 @@ const (
 
 // ErrorsTelemetryModifier is a modifier that sets up the manager to handle eBPF telemetry.
 type ErrorsTelemetryModifier struct{}
+
+// Ensure it implements the required interfaces
+var _ ddebpf.ModifierBeforeInit = &ErrorsTelemetryModifier{}
+var _ ddebpf.ModifierAfterInit = &ErrorsTelemetryModifier{}
+var _ ddebpf.ModifierBeforeStop = &ErrorsTelemetryModifier{}
 
 // String returns the name of the modifier.
 func (t *ErrorsTelemetryModifier) String() string {
@@ -172,7 +178,7 @@ func (t *ErrorsTelemetryModifier) AfterInit(m *manager.Manager, module names.Mod
 }
 
 // BeforeStop stops the perf collector from telemetry and removes the modules from the telemetry maps.
-func (t *ErrorsTelemetryModifier) BeforeStop(m *manager.Manager, module names.ModuleName) error {
+func (t *ErrorsTelemetryModifier) BeforeStop(m *manager.Manager, module names.ModuleName, _ manager.MapCleanupType) error {
 	if errorsTelemetry == nil {
 		return nil
 	}

--- a/pkg/ebpf/telemetry/modifier_test.go
+++ b/pkg/ebpf/telemetry/modifier_test.go
@@ -99,7 +99,7 @@ func TestModifierAppliesMultipleTimes(t *testing.T) {
 		require.NotEmpty(t, metrics, "No metrics collected on try %d", i)
 
 		// Run our BeforeStop
-		err = modifier.BeforeStop(mgr, mname)
+		err = modifier.BeforeStop(mgr, mname, manager.CleanAll)
 		require.NoError(t, err, "BeforeStop failed on try %d", i)
 
 		// Stop the manager


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes the signature of the `BeforeStop` function in the telemetry modifier.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Compile time check for the interface, after https://github.com/DataDog/datadog-agent/pull/32721 it can be done without import loops

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->