### PR TITLE
autoinstrumentation: apm injector volume is RW

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -340,7 +340,6 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				Name:      volumeName,
 				MountPath: "/opt/datadog-packages/datadog-apm-inject",
 				SubPath:   "opt/datadog-packages/datadog-apm-inject",
-				ReadOnly:  true,
 			}, mounts[0], "expected first container volume mount to be the injector")
 			require.Equal(t, corev1.VolumeMount{
 				Name:      etcVolume.Name,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
@@ -123,7 +123,7 @@ func (i *injector) requirements() libRequirement {
 		},
 		volumeMounts: []volumeMount{
 			volumeMountETCDPreloadAppContainer.prepended(),
-			v2VolumeMountInjector.readOnly().prepended(),
+			v2VolumeMountInjector.prepended(),
 		},
 		envVars: []envVar{
 			{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -140,7 +140,7 @@ func (v volumeMount) mutateContainer(c *corev1.Container) error {
 	return nil
 }
 
-func (v volumeMount) readOnly() volumeMount {
+func (v volumeMount) readOnly() volumeMount { // nolint:unused
 	m := v.VolumeMount
 	m.ReadOnly = true
 	return volumeMount{m, v.Prepend}


### PR DESCRIPTION
### What does this PR do?

When adding the inject volume into application containers, no longer set it as ReadOnly.

It is useful to have it RW in case we want to have temporary files there (scoped to the lifecycle of the pod) that the injector can use for container-level metadata.

For example:
- sending container-level telemetry once instead of once per process.

### Motivation

APM injection sends back some telemetry about process/language data and we want to make sure that we do so _less frequently_. For example, if we're measuring pod start time from the container -- really container start time, we want to store some metadata in a deterministic place but we don't have a guarantee that `/tmp` exists and is writeable 

### Describe how you validated your changes

Change is covered by a change in unit tests.

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes

N/A
