### PR TITLE
[OTEL-2356] fix span.Type and span.Resource for OTel spans

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1392,7 +1392,7 @@ api_key:
   ## The list of items available under apm_config.features is not guaranteed to persist across versions;
   ## a feature may eventually be promoted to its own configuration option on the agent, or dropped entirely.
   #
-  # features: ["error_rare_sample_tracer_drop","table_names","component2name","sqllexer","enable_otlp_compute_top_level_by_span_kind","enable_receive_resource_spans_v2"]
+  # features: ["error_rare_sample_tracer_drop","table_names","component2name","sqllexer","enable_otlp_compute_top_level_by_span_kind","enable_receive_resource_spans_v2", "enable_operation_and_resource_name_logic_v2"]
 
   ## @param additional_endpoints - object - optional
   ## @env DD_APM_ADDITIONAL_ENDPOINTS - object - optional

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -12,22 +12,22 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/transform"
 )
 
 const (
-	tagRedisRawCommand  = "redis.raw_command"
-	tagMemcachedCommand = "memcached.command"
-	tagMongoDBQuery     = "mongodb.query"
-	tagElasticBody      = "elasticsearch.body"
-	tagOpenSearchBody   = "opensearch.body"
-	tagSQLQuery         = "sql.query"
-	tagHTTPURL          = "http.url"
-	tagDBMS             = "db.type"
+	tagRedisRawCommand  = transform.TagRedisRawCommand
+	tagMemcachedCommand = transform.TagMemcachedCommand
+	tagMongoDBQuery     = transform.TagMongoDBQuery
+	tagElasticBody      = transform.TagElasticBody
+	tagOpenSearchBody   = transform.TagOpenSearchBody
+	tagSQLQuery         = transform.TagSQLQuery
+	tagHTTPURL          = transform.TagHTTPURL
+	tagDBMS             = "db.system"
 )
 
 const (
-	textNonParsable = "Non-parsable SQL query"
+	textNonParsable = transform.TextNonParsable
 )
 
 func (a *Agent) obfuscateSpan(span *pb.Span) {
@@ -56,27 +56,17 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 		if err != nil {
 			// we have an error, discard the SQL to avoid polluting user resources.
 			log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
-			span.Resource = textNonParsable
-			traceutil.SetMeta(span, tagSQLQuery, textNonParsable)
 			return
 		}
-
-		span.Resource = oq.Query
-		if len(oq.Metadata.TablesCSV) > 0 {
-			traceutil.SetMeta(span, "sql.tables", oq.Metadata.TablesCSV)
+		if oq == nil {
+			// no error was thrown but no query was found/sanitized either
+			return
 		}
-		traceutil.SetMeta(span, tagSQLQuery, oq.Query)
 	case "redis":
+		// if a span is redis type, it should be quantized regardless of obfuscation setting
 		span.Resource = o.QuantizeRedisString(span.Resource)
 		if a.conf.Obfuscation.Redis.Enabled {
-			if span.Meta == nil || span.Meta[tagRedisRawCommand] == "" {
-				return
-			}
-			if a.conf.Obfuscation.Redis.RemoveAllArgs {
-				span.Meta[tagRedisRawCommand] = o.RemoveAllRedisArgs(span.Meta[tagRedisRawCommand])
-				return
-			}
-			span.Meta[tagRedisRawCommand] = o.ObfuscateRedisString(span.Meta[tagRedisRawCommand])
+			transform.ObfuscateRedisSpan(o, span, a.conf.Obfuscation.Redis.RemoveAllArgs)
 		}
 	case "memcached":
 		if !a.conf.Obfuscation.Memcached.Enabled {

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -23,7 +23,7 @@ const (
 	tagOpenSearchBody   = transform.TagOpenSearchBody
 	tagSQLQuery         = transform.TagSQLQuery
 	tagHTTPURL          = transform.TagHTTPURL
-	tagDBMS             = "db.system"
+	tagDBMS             = transform.TagDBMS
 )
 
 const (
@@ -52,7 +52,7 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 		if span.Resource == "" {
 			return
 		}
-		oq, err := o.ObfuscateSQLStringForDBMS(span.Resource, span.Meta[tagDBMS])
+		oq, err := transform.ObfuscateSQLSpan(o, span)
 		if err != nil {
 			// we have an error, discard the SQL to avoid polluting user resources.
 			log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -1590,55 +1590,7 @@ func TestOTLPHelpers(t *testing.T) {
 		}
 	})
 
-	t.Run("spanKind2Type", func(t *testing.T) {
-		for _, tt := range []struct {
-			kind ptrace.SpanKind
-			meta map[string]string
-			out  string
-		}{
-			{
-				kind: ptrace.SpanKindServer,
-				out:  "web",
-			},
-			{
-				kind: ptrace.SpanKindClient,
-				out:  "http",
-			},
-			{
-				kind: ptrace.SpanKindClient,
-				meta: map[string]string{"db.system": "redis"},
-				out:  "cache",
-			},
-			{
-				kind: ptrace.SpanKindClient,
-				meta: map[string]string{"db.system": "memcached"},
-				out:  "cache",
-			},
-			{
-				kind: ptrace.SpanKindClient,
-				meta: map[string]string{"db.system": "other"},
-				out:  "db",
-			},
-			{
-				kind: ptrace.SpanKindProducer,
-				out:  "custom",
-			},
-			{
-				kind: ptrace.SpanKindConsumer,
-				out:  "custom",
-			},
-			{
-				kind: ptrace.SpanKindInternal,
-				out:  "custom",
-			},
-			{
-				kind: ptrace.SpanKindUnspecified,
-				out:  "custom",
-			},
-		} {
-			assert.Equal(t, tt.out, spanKind2Type(tt.kind, &pb.Span{Meta: tt.meta}))
-		}
-	})
+	// test spanKind2Type moved to pkg/trace/traceutil/otel_util_test.go
 
 	t.Run("tagsFromHeaders", func(t *testing.T) {
 		out := tagsFromHeaders(http.Header(map[string][]string{

--- a/pkg/trace/stats/otel_util.go
+++ b/pkg/trace/stats/otel_util.go
@@ -144,8 +144,8 @@ func obfuscateSpanForConcentrator(o *obfuscate.Obfuscator, span *pb.Span, conf *
 	}
 }
 
-// NewTestObfuscator creates a new obfuscator for testing
-func NewTestObfuscator(conf *config.AgentConfig) *obfuscate.Obfuscator {
+// newTestObfuscator creates a new obfuscator for testing
+func newTestObfuscator(conf *config.AgentConfig) *obfuscate.Obfuscator {
 	oconf := conf.Obfuscation.Export(conf)
 	oconf.Redis.Enabled = true
 	o := obfuscate.NewObfuscator(oconf)

--- a/pkg/trace/stats/otel_util.go
+++ b/pkg/trace/stats/otel_util.go
@@ -6,8 +6,11 @@
 package stats
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/trace/transform"
 	"slices"
+
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-agent/pkg/trace/transform"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.17.0"
@@ -34,6 +37,21 @@ func OTLPTracesToConcentratorInputs(
 	conf *config.AgentConfig,
 	containerTagKeys []string,
 	peerTagKeys []string,
+) []Input {
+	return OTLPTracesToConcentratorInputsWithObfuscation(traces, conf, containerTagKeys, peerTagKeys, nil)
+}
+
+// OTLPTracesToConcentratorInputsWithObfuscation converts eligible OTLP spans to Concentrator Input.
+// The converted Inputs only have the minimal number of fields for APM stats calculation and are only meant
+// to be used in Concentrator.Add(). Do not use them for other purposes.
+// This function enables obfuscation of spans prior to stats calculation and datadogconnector will migrate
+// to this function once this function is published as part of latest pkg/trace module.
+func OTLPTracesToConcentratorInputsWithObfuscation(
+	traces ptrace.Traces,
+	conf *config.AgentConfig,
+	containerTagKeys []string,
+	peerTagKeys []string,
+	obfuscator *obfuscate.Obfuscator,
 ) []Input {
 	spanByID, resByID, scopeByID := traceutil.IndexOTelSpans(traces)
 	topLevelByKind := conf.HasFeature("enable_otlp_compute_top_level_by_span_kind")
@@ -83,7 +101,11 @@ func OTLPTracesToConcentratorInputs(
 			chunks[ckey] = chunk
 		}
 		_, isTop := topLevelSpans[spanID]
-		chunk.Spans = append(chunk.Spans, transform.OtelSpanToDDSpanMinimal(otelspan, otelres, scopeByID[spanID], isTop, topLevelByKind, conf, peerTagKeys))
+		ddSpan := transform.OtelSpanToDDSpanMinimal(otelspan, otelres, scopeByID[spanID], isTop, topLevelByKind, conf, peerTagKeys)
+		if obfuscator != nil {
+			obfuscateSpanForConcentrator(obfuscator, ddSpan, conf)
+		}
+		chunk.Spans = append(chunk.Spans, ddSpan)
 	}
 
 	inputs := make([]Input, 0, len(chunks))
@@ -102,4 +124,30 @@ func OTLPTracesToConcentratorInputs(
 		})
 	}
 	return inputs
+}
+
+func obfuscateSpanForConcentrator(o *obfuscate.Obfuscator, span *pb.Span, conf *config.AgentConfig) {
+	if span.Meta == nil {
+		return
+	}
+	switch span.Type {
+	case "sql", "cassandra":
+		_, err := transform.ObfuscateSQLSpan(o, span)
+		if err != nil {
+			log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
+		}
+	case "redis":
+		span.Resource = o.QuantizeRedisString(span.Resource)
+		if conf.Obfuscation.Redis.Enabled {
+			transform.ObfuscateRedisSpan(o, span, conf.Obfuscation.Redis.RemoveAllArgs)
+		}
+	}
+}
+
+// NewTestObfuscator creates a new obfuscator for testing
+func NewTestObfuscator(conf *config.AgentConfig) *obfuscate.Obfuscator {
+	oconf := conf.Obfuscation.Export(conf)
+	oconf.Redis.Enabled = true
+	o := obfuscate.NewObfuscator(oconf)
+	return o
 }

--- a/pkg/trace/stats/otel_util_test.go
+++ b/pkg/trace/stats/otel_util_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +18,10 @@ import (
 	semconv "go.opentelemetry.io/collector/semconv/v1.17.0"
 	"go.opentelemetry.io/otel/metric/noop"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 var (
@@ -43,22 +45,25 @@ func TestProcessOTLPTraces(t *testing.T) {
 	parentID := pcommon.SpanID(testSpanID2)
 
 	for _, tt := range []struct {
-		name                   string
-		traceID                *pcommon.TraceID
-		spanID                 *pcommon.SpanID
-		parentSpanID           *pcommon.SpanID
-		spanName               string
-		rattrs                 map[string]string
-		sattrs                 map[string]any
-		spanKind               ptrace.SpanKind
-		libname                string
-		spanNameAsResourceName bool
-		spanNameRemappings     map[string]string
-		ignoreRes              []string
-		peerTagsAggr           bool
-		legacyTopLevel         bool
-		ctagKeys               []string
-		expected               *pb.StatsPayload
+		name                             string
+		traceID                          *pcommon.TraceID
+		spanID                           *pcommon.SpanID
+		parentSpanID                     *pcommon.SpanID
+		spanName                         string
+		rattrs                           map[string]string
+		sattrs                           map[string]any
+		spanKind                         ptrace.SpanKind
+		libname                          string
+		spanNameAsResourceName           bool
+		spanNameRemappings               map[string]string
+		ignoreRes                        []string
+		peerTagsAggr                     bool
+		legacyTopLevel                   bool
+		ctagKeys                         []string
+		expected                         *pb.StatsPayload
+		enableObfuscation                bool
+		enableReceiveResourceSpansV2     bool
+		enableOperationAndResourceNameV2 bool
 	}{
 		{
 			name:     "empty trace id",
@@ -168,6 +173,26 @@ func TestProcessOTLPTraces(t *testing.T) {
 			ignoreRes: []string{"GET /home"},
 			expected:  &pb.StatsPayload{AgentEnv: agentEnv, AgentHostname: agentHost},
 		},
+		{
+			name:                             "obfuscate sql span",
+			spanName:                         "spanname8",
+			spanKind:                         ptrace.SpanKindClient,
+			rattrs:                           map[string]string{"service.name": "svc", semconv.AttributeDBSystem: semconv.AttributeDBSystemMSSQL, semconv.AttributeDBStatement: "SELECT username FROM users WHERE id = 12345"},
+			enableObfuscation:                true,
+			enableReceiveResourceSpansV2:     true,
+			enableOperationAndResourceNameV2: true,
+			expected:                         createStatsPayload(agentEnv, agentHost, "svc", "client.request", "sql", "client", "SELECT username FROM users WHERE id = ?", agentHost, agentEnv, "", nil, nil, true, false),
+		},
+		{
+			name:                             "obfuscated redis span",
+			spanName:                         "spanname9",
+			rattrs:                           map[string]string{"service.name": "svc", "host.name": "test-host", "db.system": "redis", "db.statement": "SET key value"},
+			spanKind:                         ptrace.SpanKindClient,
+			enableObfuscation:                true,
+			enableReceiveResourceSpansV2:     true,
+			enableOperationAndResourceNameV2: true,
+			expected:                         createStatsPayload(agentEnv, agentHost, "svc", "client.request", "redis", "client", "SET", "test-host", agentEnv, "", nil, nil, true, false),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			traces := ptrace.NewTraces()
@@ -211,10 +236,13 @@ func TestProcessOTLPTraces(t *testing.T) {
 			conf.Hostname = agentHost
 			conf.DefaultEnv = agentEnv
 			conf.Features["enable_cid_stats"] = struct{}{}
+			if tt.enableReceiveResourceSpansV2 {
+				conf.Features["enable_receive_resource_spans_v2"] = struct{}{}
+			}
 			conf.PeerTagsAggregation = tt.peerTagsAggr
 			conf.OTLPReceiver.AttributesTranslator = attributesTranslator
 			conf.OTLPReceiver.SpanNameAsResourceName = tt.spanNameAsResourceName
-			if conf.OTLPReceiver.SpanNameAsResourceName {
+			if conf.OTLPReceiver.SpanNameAsResourceName || tt.enableOperationAndResourceNameV2 {
 				// Verify that while EnableOperationAndResourceNamesV2 is in alpha, SpanNameAsResourceName overrides it
 				conf.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 			}
@@ -225,7 +253,14 @@ func TestProcessOTLPTraces(t *testing.T) {
 			}
 
 			concentrator := NewTestConcentratorWithCfg(time.Now(), conf)
-			inputs := OTLPTracesToConcentratorInputs(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags())
+			var obfuscator *obfuscate.Obfuscator
+			var inputs []Input
+			if tt.enableObfuscation {
+				obfuscator = NewTestObfuscator(conf)
+				inputs = OTLPTracesToConcentratorInputsWithObfuscation(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags(), obfuscator)
+			} else {
+				inputs = OTLPTracesToConcentratorInputs(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags())
+			}
 			for _, input := range inputs {
 				concentrator.Add(input)
 			}

--- a/pkg/trace/stats/otel_util_test.go
+++ b/pkg/trace/stats/otel_util_test.go
@@ -256,7 +256,7 @@ func TestProcessOTLPTraces(t *testing.T) {
 			var obfuscator *obfuscate.Obfuscator
 			var inputs []Input
 			if tt.enableObfuscation {
-				obfuscator = NewTestObfuscator(conf)
+				obfuscator = newTestObfuscator(conf)
 				inputs = OTLPTracesToConcentratorInputsWithObfuscation(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags(), obfuscator)
 			} else {
 				inputs = OTLPTracesToConcentratorInputs(traces, conf, tt.ctagKeys, conf.ConfiguredPeerTags())

--- a/pkg/trace/stats/oteltest/go.mod
+++ b/pkg/trace/stats/oteltest/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/proto v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/trace v0.56.0-rc.3
 	github.com/DataDog/datadog-go/v5 v5.6.0
@@ -23,7 +24,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.0.0-20241217122454-175edb6c74f2 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.59.0 // indirect

--- a/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
+++ b/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
@@ -70,8 +70,9 @@ func testOTelAPMStatsMatch(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	// fakeAgent1 has OTLP traces go through the old pipeline: ReceiveResourceSpan -> TraceWriter -> ... ->  Concentrator.Run
 	fakeAgent1.Ingest(ctx, traces)
 
+	obfuscator := stats.NewTestObfuscator(tcfg)
 	// fakeAgent2 calls the new API in Concentrator that directly calculates APM stats for OTLP traces
-	inputs := stats.OTLPTracesToConcentratorInputs(traces, tcfg, []string{semconv.AttributeContainerID, semconv.AttributeK8SContainerName}, peerTagKeys)
+	inputs := stats.OTLPTracesToConcentratorInputsWithObfuscation(traces, tcfg, []string{semconv.AttributeContainerID, semconv.AttributeK8SContainerName}, peerTagKeys, obfuscator)
 	for _, input := range inputs {
 		fakeAgent2.Concentrator.Add(input)
 	}
@@ -158,6 +159,7 @@ func getTestTraces() ptrace.Traces {
 	rootattrs.PutInt(semconv.AttributeHTTPStatusCode, 404)
 	rootattrs.PutStr(semconv.AttributePeerService, "test_peer_svc")
 	rootattrs.PutStr(semconv.AttributeDBSystem, "redis")
+	rootattrs.PutStr(semconv.AttributeDBStatement, "SET key value")
 	root.Status().SetCode(ptrace.StatusCodeError)
 
 	child1 := sspan.Spans().AppendEmpty()

--- a/pkg/trace/traceutil/otel_util.go
+++ b/pkg/trace/traceutil/otel_util.go
@@ -10,14 +10,16 @@ import (
 	"encoding/binary"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv117 "go.opentelemetry.io/collector/semconv/v1.17.0"
+	semconv126 "go.opentelemetry.io/collector/semconv/v1.26.0"
 	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
 )
 
 // Util functions for converting OTel semantics to DD semantics.
@@ -31,6 +33,96 @@ const (
 	// TagStatusCode is the tag key for http status code.
 	TagStatusCode = "http.status_code"
 )
+
+// span.Type constants for db systems
+const (
+	spanTypeSQL           = "sql"
+	spanTypeCassandra     = "cassandra"
+	spanTypeRedis         = "redis"
+	spanTypeMemcached     = "memcached"
+	spanTypeMongoDB       = "mongodb"
+	spanTypeElasticsearch = "elasticsearch"
+	spanTypeOpenSearch    = "opensearch"
+	spanTypeDB            = "db"
+)
+
+// DBTypes are semconv types that should map to span.Type values given in the mapping
+var dbTypes = map[string]string{
+	// SQL db types
+	semconv.AttributeDBSystemOtherSQL:      spanTypeSQL,
+	semconv.AttributeDBSystemMSSQL:         spanTypeSQL,
+	semconv.AttributeDBSystemMySQL:         spanTypeSQL,
+	semconv.AttributeDBSystemOracle:        spanTypeSQL,
+	semconv.AttributeDBSystemDB2:           spanTypeSQL,
+	semconv.AttributeDBSystemPostgreSQL:    spanTypeSQL,
+	semconv.AttributeDBSystemRedshift:      spanTypeSQL,
+	semconv.AttributeDBSystemCloudscape:    spanTypeSQL,
+	semconv.AttributeDBSystemHSQLDB:        spanTypeSQL,
+	semconv.AttributeDBSystemMaxDB:         spanTypeSQL,
+	semconv.AttributeDBSystemIngres:        spanTypeSQL,
+	semconv.AttributeDBSystemFirstSQL:      spanTypeSQL,
+	semconv.AttributeDBSystemEDB:           spanTypeSQL,
+	semconv.AttributeDBSystemCache:         spanTypeSQL,
+	semconv.AttributeDBSystemFirebird:      spanTypeSQL,
+	semconv.AttributeDBSystemDerby:         spanTypeSQL,
+	semconv.AttributeDBSystemInformix:      spanTypeSQL,
+	semconv.AttributeDBSystemMariaDB:       spanTypeSQL,
+	semconv.AttributeDBSystemSqlite:        spanTypeSQL,
+	semconv.AttributeDBSystemSybase:        spanTypeSQL,
+	semconv.AttributeDBSystemTeradata:      spanTypeSQL,
+	semconv.AttributeDBSystemVertica:       spanTypeSQL,
+	semconv.AttributeDBSystemH2:            spanTypeSQL,
+	semconv.AttributeDBSystemColdfusion:    spanTypeSQL,
+	semconv.AttributeDBSystemCockroachdb:   spanTypeSQL,
+	semconv.AttributeDBSystemProgress:      spanTypeSQL,
+	semconv.AttributeDBSystemHanaDB:        spanTypeSQL,
+	semconv.AttributeDBSystemAdabas:        spanTypeSQL,
+	semconv.AttributeDBSystemFilemaker:     spanTypeSQL,
+	semconv.AttributeDBSystemInstantDB:     spanTypeSQL,
+	semconv.AttributeDBSystemInterbase:     spanTypeSQL,
+	semconv.AttributeDBSystemNetezza:       spanTypeSQL,
+	semconv.AttributeDBSystemPervasive:     spanTypeSQL,
+	semconv.AttributeDBSystemPointbase:     spanTypeSQL,
+	semconv117.AttributeDBSystemClickhouse: spanTypeSQL, // not in semconv 1.6.1
+
+	// Cassandra db types
+	semconv.AttributeDBSystemCassandra: spanTypeCassandra,
+
+	// Redis db types
+	semconv.AttributeDBSystemRedis: spanTypeRedis,
+
+	// Memcached db types
+	semconv.AttributeDBSystemMemcached: spanTypeMemcached,
+
+	// Mongodb db types
+	semconv.AttributeDBSystemMongoDB: spanTypeMongoDB,
+
+	// Elasticsearch db types
+	semconv.AttributeDBSystemElasticsearch: spanTypeElasticsearch,
+
+	// Opensearch db types, not in semconv 1.6.1
+	semconv117.AttributeDBSystemOpensearch: spanTypeOpenSearch,
+
+	// Generic db types
+	semconv.AttributeDBSystemHive:      spanTypeDB,
+	semconv.AttributeDBSystemHBase:     spanTypeDB,
+	semconv.AttributeDBSystemNeo4j:     spanTypeDB,
+	semconv.AttributeDBSystemCouchbase: spanTypeDB,
+	semconv.AttributeDBSystemCouchDB:   spanTypeDB,
+	semconv.AttributeDBSystemCosmosDB:  spanTypeDB,
+	semconv.AttributeDBSystemDynamoDB:  spanTypeDB,
+	semconv.AttributeDBSystemGeode:     spanTypeDB,
+}
+
+// checkDBType checks if the dbType is a known db type and returns the corresponding span.Type
+func checkDBType(dbType string) string {
+	spanType, ok := dbTypes[dbType]
+	if ok {
+		return spanType
+	}
+	// span type not found, return generic db type
+	return spanTypeDB
+}
 
 // IndexOTelSpans iterates over the input OTel spans and returns 3 maps:
 // OTel spans indexed by span ID, OTel resources indexed by span ID, OTel instrumentation scopes indexed by span ID.
@@ -128,7 +220,33 @@ func GetOTelAttrValInResAndSpanAttrs(span ptrace.Span, res pcommon.Resource, nor
 	return GetOTelAttrVal(span.Attributes(), normalize, keys...)
 }
 
+// SpanKind2Type returns a span's type based on the given kind and other present properties.
+// This function is used in Resource V1 logic only. See GetOtelSpanType for Resource V2 logic.
+func SpanKind2Type(span ptrace.Span, res pcommon.Resource) string {
+	var typ string
+	switch span.Kind() {
+	case ptrace.SpanKindServer:
+		typ = "web"
+	case ptrace.SpanKindClient:
+		typ = "http"
+		db := GetOTelAttrValInResAndSpanAttrs(span, res, true, semconv.AttributeDBSystem)
+		if db == "" {
+			break
+		}
+		switch db {
+		case "redis", "memcached":
+			typ = "cache"
+		default:
+			typ = "db"
+		}
+	default:
+		typ = "custom"
+	}
+	return typ
+}
+
 // GetOTelSpanType returns the DD span type based on OTel span kind and attributes.
+// This logic is used in ReceiveResourceSpansV2 logic
 func GetOTelSpanType(span ptrace.Span, res pcommon.Resource) string {
 	typ := GetOTelAttrValInResAndSpanAttrs(span, res, false, "span.type")
 	if typ != "" {
@@ -139,12 +257,10 @@ func GetOTelSpanType(span ptrace.Span, res pcommon.Resource) string {
 		typ = "web"
 	case ptrace.SpanKindClient:
 		db := GetOTelAttrValInResAndSpanAttrs(span, res, true, semconv.AttributeDBSystem)
-		if db == "redis" || db == "memcached" {
-			typ = "cache"
-		} else if db != "" {
-			typ = "db"
-		} else {
+		if db == "" {
 			typ = "http"
+		} else {
+			typ = checkDBType(db)
 		}
 	default:
 		typ = "custom"
@@ -266,6 +382,20 @@ func GetOTelResourceV2(span ptrace.Span, res pcommon.Resource) (resName string) 
 		}
 		return
 	}
+
+	if m := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeDBSystem); m != "" {
+		// Since traces are obfuscated by span.Resource in pkg/trace/agent/obfuscate.go, we should use span.Resource as the resource name.
+		// https://github.com/DataDog/datadog-agent/blob/62619a69cff9863f5b17215847b853681e36ff15/pkg/trace/agent/obfuscate.go#L32
+		if dbStatement := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv.AttributeDBStatement); dbStatement != "" {
+			resName = dbStatement
+			return
+		}
+		if dbQuery := GetOTelAttrValInResAndSpanAttrs(span, res, false, semconv126.AttributeDBQueryText); dbQuery != "" {
+			resName = dbQuery
+			return
+		}
+	}
+
 	resName = span.Name()
 
 	return

--- a/pkg/trace/traceutil/otel_util_test.go
+++ b/pkg/trace/traceutil/otel_util_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv117 "go.opentelemetry.io/collector/semconv/v1.17.0"
+	semconv126 "go.opentelemetry.io/collector/semconv/v1.26.0"
 	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.opentelemetry.io/otel/metric/noop"
 )
@@ -397,6 +398,26 @@ func TestGetOTelResource(t *testing.T) {
 			normalize:  false,
 			expectedV1: "query myQuery",
 			expectedV2: "query myQuery",
+		},
+		{
+			name: "SQL statement resource",
+			rattrs: map[string]string{
+				semconv.AttributeDBSystem:    "mysql",
+				semconv.AttributeDBStatement: "SELECT * FROM table WHERE id = 12345",
+			},
+			sattrs:     map[string]string{"span.name": "span_name"},
+			expectedV1: "span_name",
+			expectedV2: "SELECT * FROM table WHERE id = 12345",
+		},
+		{
+			name: "Redis command resource",
+			rattrs: map[string]string{
+				semconv.AttributeDBSystem:       "redis",
+				semconv126.AttributeDBQueryText: "SET key value",
+			},
+			sattrs:     map[string]string{"span.name": "span_name"},
+			expectedV1: "span_name",
+			expectedV2: "SET key value",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/trace/transform/obfuscate.go
+++ b/pkg/trace/transform/obfuscate.go
@@ -26,6 +26,8 @@ const (
 	TagSQLQuery = "sql.query"
 	// TagHTTPURL represents an HTTP URL tag
 	TagHTTPURL = "http.url"
+	// TagDBMS represents a DBMS tag
+	TagDBMS = "db.type"
 )
 
 const (
@@ -38,7 +40,7 @@ func ObfuscateSQLSpan(o *obfuscate.Obfuscator, span *pb.Span) (*obfuscate.Obfusc
 	if span.Resource == "" {
 		return nil, nil
 	}
-	oq, err := o.ObfuscateSQLString(span.Resource)
+	oq, err := o.ObfuscateSQLStringForDBMS(span.Resource, span.Meta[TagDBMS])
 	if err != nil {
 		// we have an error, discard the SQL to avoid polluting user resources.
 		span.Resource = TextNonParsable

--- a/pkg/trace/transform/obfuscate.go
+++ b/pkg/trace/transform/obfuscate.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package transform
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
+)
+
+const (
+	// TagRedisRawCommand represents a redis raw command tag
+	TagRedisRawCommand = "redis.raw_command"
+	// TagMemcachedCommand represents a memcached command tag
+	TagMemcachedCommand = "memcached.command"
+	// TagMongoDBQuery represents a MongoDB query tag
+	TagMongoDBQuery = "mongodb.query"
+	// TagElasticBody represents an Elasticsearch body tag
+	TagElasticBody = "elasticsearch.body"
+	// TagOpenSearchBody represents an OpenSearch body tag
+	TagOpenSearchBody = "opensearch.body"
+	// TagSQLQuery represents a SQL query tag
+	TagSQLQuery = "sql.query"
+	// TagHTTPURL represents an HTTP URL tag
+	TagHTTPURL = "http.url"
+)
+
+const (
+	// TextNonParsable is the error text used when a query is non-parsable
+	TextNonParsable = "Non-parsable SQL query"
+)
+
+// ObfuscateSQLSpan obfuscates a SQL span using pkg/obfuscate logic
+func ObfuscateSQLSpan(o *obfuscate.Obfuscator, span *pb.Span) (*obfuscate.ObfuscatedQuery, error) {
+	if span.Resource == "" {
+		return nil, nil
+	}
+	oq, err := o.ObfuscateSQLString(span.Resource)
+	if err != nil {
+		// we have an error, discard the SQL to avoid polluting user resources.
+		span.Resource = TextNonParsable
+		traceutil.SetMeta(span, TagSQLQuery, TextNonParsable)
+		return nil, err
+	}
+	span.Resource = oq.Query
+	if len(oq.Metadata.TablesCSV) > 0 {
+		traceutil.SetMeta(span, "sql.tables", oq.Metadata.TablesCSV)
+	}
+	traceutil.SetMeta(span, TagSQLQuery, oq.Query)
+	return oq, nil
+}
+
+// ObfuscateRedisSpan obfuscates a Redis span using pkg/obfuscate logic
+func ObfuscateRedisSpan(o *obfuscate.Obfuscator, span *pb.Span, removeAllArgs bool) {
+	if span.Meta == nil || span.Meta[TagRedisRawCommand] == "" {
+		return
+	}
+	if removeAllArgs {
+		span.Meta[TagRedisRawCommand] = o.RemoveAllRedisArgs(span.Meta[TagRedisRawCommand])
+		return
+	}
+	span.Meta[TagRedisRawCommand] = o.ObfuscateRedisString(span.Meta[TagRedisRawCommand])
+}

--- a/releasenotes/notes/apm-otel-span-type-fix-b3d5ff36f4224bf5.yaml
+++ b/releasenotes/notes/apm-otel-span-type-fix-b3d5ff36f4224bf5.yaml
@@ -1,0 +1,22 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Datadog span.Type and span.Resource attributes are set correctly for OTel spans 
+    processed via OTel Agent and Datadog Exporter when client span type is a database 
+    span.Type.
+
+    span.Type logic update is limited to ReceiveResourceSpansV2 logic, set using 
+    `"enable_receive_resource_spans_v2"` in `DD_APM_FEATURES`
+
+    span.Resource logic update is limited to OperationAndResourceNameV2 logic, set 
+    using `"enable_operation_and_resource_name_logic_v2"` in `DD_APM_FEATURES`
+
+    Users should set a `span.type` attribute on their telemetry if they wish to
+    override the default span type.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- sets correct "span.Type" for database spans based on existing logic in Agent if `enable_receive_resource_spans_v2` is enabled
- sets correct "span.Resource" for database spans based on existing logic in Agent if `enable_operation_and_resource_name_logic_v2` is enabled

### Motivation
get spans properly obfuscated/redacted based on existing trace agent code

### Describe how you validated your changes
modified and added test cases for existing cases
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
performance hit with complex sql queries; this is expected as we are adding more processing. This will still help with cardinality for apm stats so it is necessary. Improvements to `pkg/obfuscate` including `go-sqllexer` might improve performance
```
BenchmarkOTelStatsWithoutObfuscation-16       201194        5860 ns/op      6304 B/op       59 allocs/op

BenchmarkOTelStatsWithObfuscation-16         92632       13078 ns/op      8176 B/op       65 allocs/op
```
slight breaking change if customers are expecting them to be "db" span.Type (doesn't break if they set custom `span.type` attribute though). Also changes resource name for spans. This is intended and how both dd tracers and dd agent handles with dd span types, so it should be communicated to customers as part of OperationAndResourceNameV2 change.

### Additional Notes
Should add note to release for ReceiveResourceSpansV2 and OprationAndResourceNameV2 @IbraheemA 

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->