### PR TITLE
[CONTP-544] chore(dogstatsd): move inode resolution to tagger

### DIFF
--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -90,14 +90,23 @@ func TestEnrichTags(t *testing.T) {
 			expectedTags: []string{},
 		},
 		{
-			name:         "with local data (containerID) and low cardinality",
-			originInfo:   taggertypes.OriginInfo{ContainerID: containerID, Cardinality: "low"},
+			name: "with local data (containerID) and low cardinality",
+			originInfo: taggertypes.OriginInfo{
+				LocalData: origindetection.LocalData{
+					ContainerID: containerID,
+				},
+				Cardinality: "low",
+			},
 			expectedTags: []string{"container-low"},
 		},
 		{
-			name:         "with local data (containerID) and high cardinality",
-			originInfo:   taggertypes.OriginInfo{ContainerID: containerID, Cardinality: "high"},
-			expectedTags: []string{"container-low", "container-orch", "container-high"},
+			name: "with local data (containerID) and high cardinality",
+			originInfo: taggertypes.OriginInfo{
+				LocalData: origindetection.LocalData{
+					ContainerID: containerID,
+				},
+				Cardinality: "high",
+			}, expectedTags: []string{"container-low", "container-orch", "container-high"},
 		},
 		{
 			name:         "with local data (podUID) and low cardinality",
@@ -262,11 +271,26 @@ func TestEnrichTagsOptOut(t *testing.T) {
 
 	tb := tagset.NewHashingTagsAccumulator()
 	// Test with none cardinality
-	tagger.EnrichTags(tb, taggertypes.OriginInfo{ContainerIDFromSocket: "container_id://bar", ContainerID: "container-id", Cardinality: "none", ProductOrigin: origindetection.ProductOriginDogStatsD})
+	tagger.EnrichTags(tb, taggertypes.OriginInfo{
+		ContainerIDFromSocket: "container_id://bar",
+		LocalData: origindetection.LocalData{
+			ContainerID: "container-id",
+		},
+		Cardinality:   "none",
+		ProductOrigin: origindetection.ProductOriginDogStatsD,
+	})
 	assert.Equal(t, []string{}, tb.Get())
 
 	// Test without none cardinality
-	tagger.EnrichTags(tb, taggertypes.OriginInfo{ContainerIDFromSocket: "container_id://bar", PodUID: "pod-uid", ContainerID: "container-id", Cardinality: "low", ProductOrigin: origindetection.ProductOriginDogStatsD})
+	tagger.EnrichTags(tb, taggertypes.OriginInfo{
+		ContainerIDFromSocket: "container_id://bar",
+		PodUID:                "pod-uid",
+		LocalData: origindetection.LocalData{
+			ContainerID: "container-id",
+		},
+		Cardinality:   "low",
+		ProductOrigin: origindetection.ProductOriginDogStatsD,
+	})
 	assert.Equal(t, []string{"container-low"}, tb.Get())
 }
 
@@ -332,6 +356,45 @@ func TestGenerateContainerIDFromExternalData(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeTagger := TaggerWrapper{}
 			containerID, err := fakeTagger.generateContainerIDFromExternalData(tt.externalData, tt.cidProvider)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, containerID)
+		})
+	}
+}
+
+func TestGenerateContainerIDFromInode(t *testing.T) {
+	// Create mock metrics provider
+	mockProvider := collectormock.NewMetricsProvider()
+	mockProvider.RegisterMetaCollector(&collectormock.MetaCollector{
+		CIDFromInode: map[uint64]string{
+			uint64(1234): "abcdef",
+		},
+	})
+
+	for _, tt := range []struct {
+		name          string
+		localData     origindetection.LocalData
+		expected      string
+		inodeProvider *collectormock.MetricsProvider
+	}{
+		{
+			name:          "empty",
+			localData:     origindetection.LocalData{},
+			expected:      "",
+			inodeProvider: mockProvider,
+		},
+		{
+			name: "found container",
+			localData: origindetection.LocalData{
+				Inode: 1234,
+			},
+			expected:      "abcdef",
+			inodeProvider: mockProvider,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeTagger := TaggerWrapper{}
+			containerID, err := fakeTagger.generateContainerIDFromInode(tt.localData, mockProvider.GetMetaCollector())
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, containerID)
 		})

--- a/comp/dogstatsd/server/batch.go
+++ b/comp/dogstatsd/server/batch.go
@@ -103,14 +103,14 @@ func (s *shardKeyGeneratorPerOrigin) Generate(sample metrics.MetricSample, shard
 	// We fall back on the generic sharding if:
 	// - the sample has a custom cardinality
 	// - we don't have the origin
-	if sample.OriginInfo.Cardinality != "" || (sample.OriginInfo.ContainerIDFromSocket == "" && sample.OriginInfo.PodUID == "" && sample.OriginInfo.ContainerID == "") {
+	if sample.OriginInfo.Cardinality != "" || (sample.OriginInfo.ContainerIDFromSocket == "" && sample.OriginInfo.PodUID == "" && sample.OriginInfo.LocalData.ContainerID == "") {
 		return s.shardKeyGeneratorBase.Generate(sample, shards)
 	}
 
 	// Otherwise, we isolate the samples based on the origin.
 	i, j := uint64(0), uint64(0)
 	i, j = murmur3.SeedStringSum128(i, j, sample.OriginInfo.PodUID)
-	i, j = murmur3.SeedStringSum128(i, j, sample.OriginInfo.ContainerID)
+	i, j = murmur3.SeedStringSum128(i, j, sample.OriginInfo.LocalData.ContainerID)
 	i, _ = murmur3.SeedStringSum128(i, j, sample.OriginInfo.ContainerIDFromSocket)
 
 	return fastrange(ckey.ContextKey(i), shards)

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -42,7 +42,6 @@ func extractTagsMetadata(tags []string, originFromUDS string, localData originde
 	metricSource := metrics.MetricSourceDogstatsd
 	origin := taggertypes.OriginInfo{
 		ContainerIDFromSocket: originFromUDS,
-		ContainerID:           localData.ContainerID,
 		LocalData:             localData,
 		ExternalData:          externalData,
 		ProductOrigin:         origindetection.ProductOriginDogStatsD,

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -101,7 +101,7 @@ func TestConvertParseMultiple(t *testing.T) {
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
 		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
-		assert.Equal(t, "", parsed[0].OriginInfo.ContainerID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 
 		assert.Equal(t, "daemon", parsed[1].Name)
@@ -111,7 +111,7 @@ func TestConvertParseMultiple(t *testing.T) {
 		assert.Equal(t, "default-hostname", parsed[1].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
 		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
-		assert.Equal(t, "", parsed[0].OriginInfo.ContainerID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[1].SampleRate, epsilon)
 	}
 }
@@ -135,7 +135,7 @@ func TestConvertParseSingle(t *testing.T) {
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
 		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
-		assert.Equal(t, "", parsed[0].OriginInfo.ContainerID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
 }
@@ -161,7 +161,7 @@ func TestConvertParseSingleWithTags(t *testing.T) {
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
 		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
-		assert.Equal(t, "", parsed[0].OriginInfo.ContainerID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
 }
@@ -187,7 +187,7 @@ func TestConvertParseSingleWithHostTags(t *testing.T) {
 		assert.Equal(t, "custom-host", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
 		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
-		assert.Equal(t, "", parsed[0].OriginInfo.ContainerID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
 }
@@ -213,7 +213,7 @@ func TestConvertParseSingleWithEmptyHostTags(t *testing.T) {
 		assert.Equal(t, "", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
 		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
-		assert.Equal(t, "", parsed[0].OriginInfo.ContainerID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
 }
@@ -237,7 +237,7 @@ func TestConvertParseSingleWithSampleRate(t *testing.T) {
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
 		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
-		assert.Equal(t, "", parsed[0].OriginInfo.ContainerID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 0.21, parsed[0].SampleRate, epsilon)
 	}
 }
@@ -258,7 +258,7 @@ func TestConvertParseSet(t *testing.T) {
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", parsed.OriginInfo.PodUID)
-	assert.Equal(t, "", parsed.OriginInfo.ContainerID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
@@ -278,7 +278,7 @@ func TestConvertParseSetUnicode(t *testing.T) {
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", parsed.OriginInfo.PodUID)
-	assert.Equal(t, "", parsed.OriginInfo.ContainerID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
@@ -298,7 +298,7 @@ func TestConvertParseGaugeWithPoundOnly(t *testing.T) {
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", parsed.OriginInfo.PodUID)
-	assert.Equal(t, "", parsed.OriginInfo.ContainerID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
@@ -319,7 +319,7 @@ func TestConvertParseGaugeWithUnicode(t *testing.T) {
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", parsed.OriginInfo.PodUID)
-	assert.Equal(t, "", parsed.OriginInfo.ContainerID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
@@ -395,7 +395,7 @@ func TestConvertServiceCheckMinimal(t *testing.T) {
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
 
@@ -442,7 +442,7 @@ func TestConvertServiceCheckMetadataTimestamp(t *testing.T) {
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
 
@@ -460,7 +460,7 @@ func TestConvertServiceCheckMetadataHostname(t *testing.T) {
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
 
@@ -478,7 +478,7 @@ func TestConvertServiceCheckMetadataHostnameInTag(t *testing.T) {
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{}, sc.Tags)
 }
 
@@ -496,7 +496,7 @@ func TestConvertServiceCheckMetadataEmptyHostTag(t *testing.T) {
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"other:tag"}, sc.Tags)
 }
 
@@ -514,7 +514,7 @@ func TestConvertServiceCheckMetadataTags(t *testing.T) {
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"tag1", "tag2:test", "tag3"}, sc.Tags)
 }
 
@@ -532,7 +532,7 @@ func TestConvertServiceCheckMetadataMessage(t *testing.T) {
 	assert.Equal(t, "this is fine", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
 
@@ -550,7 +550,7 @@ func TestConvertServiceCheckMetadataMultiple(t *testing.T) {
 	assert.Equal(t, "this is fine", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"tag1:test", "tag2"}, sc.Tags)
 
 	// multiple time the same tag
@@ -563,7 +563,7 @@ func TestConvertServiceCheckMetadataMultiple(t *testing.T) {
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
 
@@ -580,7 +580,7 @@ func TestServiceCheckOriginTag(t *testing.T) {
 	assert.Equal(t, "this is fine", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "testID", sc.OriginInfo.PodUID)
-	assert.Equal(t, "", sc.OriginInfo.ContainerID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"tag1:test", "tag2"}, sc.Tags)
 }
 
@@ -603,7 +603,7 @@ func TestConvertEventMinimal(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMultilinesText(t *testing.T) {
@@ -625,7 +625,7 @@ func TestConvertEventMultilinesText(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventPipeInTitle(t *testing.T) {
@@ -647,7 +647,7 @@ func TestConvertEventPipeInTitle(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventError(t *testing.T) {
@@ -737,7 +737,7 @@ func TestConvertEventMetadataTimestamp(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataPriority(t *testing.T) {
@@ -759,7 +759,7 @@ func TestConvertEventMetadataPriority(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataHostname(t *testing.T) {
@@ -781,7 +781,7 @@ func TestConvertEventMetadataHostname(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataHostnameInTag(t *testing.T) {
@@ -803,7 +803,7 @@ func TestConvertEventMetadataHostnameInTag(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataEmptyHostTag(t *testing.T) {
@@ -825,7 +825,7 @@ func TestConvertEventMetadataEmptyHostTag(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataAlertType(t *testing.T) {
@@ -847,7 +847,7 @@ func TestConvertEventMetadataAlertType(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataAggregatioKey(t *testing.T) {
@@ -869,7 +869,7 @@ func TestConvertEventMetadataAggregatioKey(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataSourceType(t *testing.T) {
@@ -891,7 +891,7 @@ func TestConvertEventMetadataSourceType(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataTags(t *testing.T) {
@@ -913,7 +913,7 @@ func TestConvertEventMetadataTags(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestConvertEventMetadataMultiple(t *testing.T) {
@@ -935,7 +935,7 @@ func TestConvertEventMetadataMultiple(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
 func TestEventOriginTag(t *testing.T) {
@@ -957,7 +957,7 @@ func TestEventOriginTag(t *testing.T) {
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "testID", e.OriginInfo.PodUID)
-	assert.Equal(t, "", e.OriginInfo.ContainerID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 
 }
 func TestConvertNamespace(t *testing.T) {
@@ -1065,7 +1065,7 @@ func TestConvertEntityOriginDetectionNoTags(t *testing.T) {
 	assert.Equal(t, "my-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "foo", parsed.OriginInfo.PodUID)
-	assert.Equal(t, "", parsed.OriginInfo.ContainerID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
@@ -1084,7 +1084,7 @@ func TestConvertEntityOriginDetectionTags(t *testing.T) {
 	assert.Equal(t, "my-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "foo", parsed.OriginInfo.PodUID)
-	assert.Equal(t, "", parsed.OriginInfo.ContainerID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
@@ -1104,7 +1104,7 @@ func TestConvertEntityOriginDetectionTagsError(t *testing.T) {
 	assert.Equal(t, "my-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
 	assert.Equal(t, "foo", parsed.OriginInfo.PodUID)
-	assert.Equal(t, "", parsed.OriginInfo.ContainerID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
 
@@ -1330,7 +1330,6 @@ func TestEnrichTags(t *testing.T) {
 			wantedOrigin: taggertypes.OriginInfo{
 				ContainerIDFromSocket: "originID",
 				PodUID:                "pod-uid",
-				ContainerID:           "container-id",
 				LocalData: origindetection.LocalData{
 					ContainerID: "container-id",
 				},
@@ -1355,7 +1354,6 @@ func TestEnrichTags(t *testing.T) {
 			wantedHost: "foo",
 			wantedOrigin: taggertypes.OriginInfo{
 				ContainerIDFromSocket: "originID",
-				ContainerID:           "container-id",
 				LocalData: origindetection.LocalData{
 					ContainerID: "container-id",
 				},
@@ -1409,7 +1407,6 @@ func TestEnrichTags(t *testing.T) {
 			wantedOrigin: taggertypes.OriginInfo{
 				ContainerIDFromSocket: "originID",
 				PodUID:                "pod-uid",
-				ContainerID:           "container-id",
 				LocalData: origindetection.LocalData{
 					ContainerID: "container-id",
 				},

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -203,18 +203,10 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 			timestamp = time.Unix(ts, 0)
 		// local data
 		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-			rawLocalData := string(optionalField[len(localDataPrefix):])
-			localData, err = origindetection.ParseLocalData(rawLocalData)
-			if err != nil {
-				log.Errorf("failed to parse c: field containing Local Data %q: %v", rawLocalData, err)
-			}
+			localData = p.parseLocalData(optionalField[len(localDataPrefix):])
 		// external data
 		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
-			rawExternalData := string(optionalField[len(externalDataPrefix):])
-			externalData, err = origindetection.ParseExternalData(rawExternalData)
-			if err != nil {
-				log.Errorf("failed to parse e: field containing External Data %q: %v", rawExternalData, err)
-			}
+			externalData = p.parseExternalData(optionalField[len(externalDataPrefix):])
 		}
 	}
 
@@ -230,6 +222,32 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 		externalData: externalData,
 		ts:           timestamp,
 	}, nil
+}
+
+// parseLocalData parses the local data string into a LocalData struct.
+func (p *parser) parseLocalData(rawLocalData []byte) origindetection.LocalData {
+	localDataString := string(rawLocalData)
+
+	localData, err := origindetection.ParseLocalData(localDataString)
+	if err != nil {
+		log.Errorf("failed to parse c: field containing Local Data %q: %v", localDataString, err)
+	}
+
+	// return localData even if there was a parsing error as some fields might have been parsed correctly.
+	return localData
+}
+
+// parseExternalData parses the external data string into an ExternalData struct.
+func (p *parser) parseExternalData(rawExternalData []byte) origindetection.ExternalData {
+	externalDataString := string(rawExternalData)
+
+	externalData, err := origindetection.ParseExternalData(externalDataString)
+	if err != nil {
+		log.Errorf("failed to parse e: field containing External Data %q: %v", externalDataString, err)
+	}
+
+	// return externalData even if there was a parsing error as some fields might have been parsed correctly.
+	return externalData
 }
 
 // parseFloat64List parses a list of float64 separated by colonSeparator.

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -39,8 +39,6 @@ type dogstatsdEvent struct {
 	sourceType     string
 	alertType      alertType
 	tags           []string
-	// containerID represents the container ID of the sender (optional).
-	containerID string
 	// localData is used for Origin Detection
 	localData origindetection.LocalData
 	// externalData is used for Origin Detection
@@ -169,10 +167,7 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 	case bytes.HasPrefix(optionalField, eventTagsPrefix):
 		newEvent.tags = p.parseTags(optionalField[len(eventTagsPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newEvent.localData, err = p.resolveLocalData(optionalField[len(localDataPrefix):])
-		if err == nil {
-			newEvent.containerID = newEvent.localData.ContainerID
-		}
+		newEvent.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newEvent.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -167,9 +167,9 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 	case bytes.HasPrefix(optionalField, eventTagsPrefix):
 		newEvent.tags = p.parseTags(optionalField[len(eventTagsPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newEvent.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
+		newEvent.localData = p.parseLocalData(optionalField[len(localDataPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
-		newEvent.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
+		newEvent.externalData = p.parseExternalData(optionalField[len(externalDataPrefix):])
 	}
 	if err != nil {
 		return event, err

--- a/comp/dogstatsd/server/parse_metrics.go
+++ b/comp/dogstatsd/server/parse_metrics.go
@@ -47,8 +47,6 @@ type dogstatsdMetricSample struct {
 	metricType metricType
 	sampleRate float64
 	tags       []string
-	// containerID represents the container ID of the sender (optional).
-	containerID string
 	// localData is used for Origin Detection
 	localData origindetection.LocalData
 	// externalData is used for Origin Detection

--- a/comp/dogstatsd/server/parse_metrics_test.go
+++ b/comp/dogstatsd/server/parse_metrics_test.go
@@ -14,7 +14,6 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/mock"
 )
 
 func parseMetricSample(t *testing.T, overrides map[string]any, rawSample []byte) (dogstatsdMetricSample, error) {
@@ -573,22 +572,5 @@ func TestParseContainerID(t *testing.T) {
 	// Testing with a container ID
 	sample, err := parseMetricSample(t, cfg, []byte("metric:1234|g|c:1234567890abcdef"))
 	require.NoError(t, err)
-	assert.Equal(t, "1234567890abcdef", sample.containerID)
-
-	// Testing with an Inode
-	deps := newServerDeps(t, fx.Replace(config.MockParams{Overrides: cfg}))
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
-	mockProvider := mock.NewMetricsProvider()
-	mockProvider.RegisterMetaCollector(&mock.MetaCollector{
-		CIDFromInode: map[uint64]string{
-			1234567890: "1234567890abcdef",
-		},
-	})
-	p.provider = mockProvider
-	cfg["parser"] = p
-
-	sample, err = parseMetricSample(t, cfg, []byte("metric:1234|g|c:in-1234567890"))
-	require.NoError(t, err)
-	assert.Equal(t, "1234567890abcdef", sample.containerID)
+	assert.Equal(t, "1234567890abcdef", sample.localData.ContainerID)
 }

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -30,8 +30,6 @@ type dogstatsdServiceCheck struct {
 	hostname  string
 	message   string
 	tags      []string
-	// containerID represents the container ID of the sender (optional).
-	containerID string
 	// localData is used for Origin Detection
 	localData origindetection.LocalData
 	// externalData is used for Origin Detection
@@ -103,10 +101,7 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 	case bytes.HasPrefix(optionalField, serviceCheckMessagePrefix):
 		newServiceCheck.message = string(optionalField[len(serviceCheckMessagePrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newServiceCheck.localData, err = p.resolveLocalData(optionalField[len(localDataPrefix):])
-		if err == nil {
-			newServiceCheck.containerID = newServiceCheck.localData.ContainerID
-		}
+		newServiceCheck.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newServiceCheck.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
 	}

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -101,9 +101,9 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 	case bytes.HasPrefix(optionalField, serviceCheckMessagePrefix):
 		newServiceCheck.message = string(optionalField[len(serviceCheckMessagePrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, localDataPrefix):
-		newServiceCheck.localData, err = origindetection.ParseLocalData(string(optionalField[len(localDataPrefix):]))
+		newServiceCheck.localData = p.parseLocalData(optionalField[len(localDataPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
-		newServiceCheck.externalData, err = origindetection.ParseExternalData(string(optionalField[len(externalDataPrefix):]))
+		newServiceCheck.externalData = p.parseExternalData(optionalField[len(externalDataPrefix):])
 	}
 	if err != nil {
 		return serviceCheck, err

--- a/comp/dogstatsd/server/parse_test.go
+++ b/comp/dogstatsd/server/parse_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics/mock"
 )
 
 func TestIdentifyEvent(t *testing.T) {
@@ -110,24 +108,4 @@ func TestUnsafeParseInt(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, integer, unsafeInteger)
-}
-
-func TestResolveContainerIDFromInode(t *testing.T) {
-	deps := newServerDeps(t)
-	stringInternerTelemetry := newSiTelemetry(false, deps.Telemetry)
-	p := newParser(deps.Config, newFloat64ListPool(deps.Telemetry), 1, deps.WMeta, stringInternerTelemetry)
-	// Mock the provider to resolve the container ID from the inode
-	mockProvider := mock.NewMetricsProvider()
-	mockProvider.RegisterMetaCollector(&mock.MetaCollector{
-		CIDFromInode: map[uint64]string{
-			uint64(1234): "abcdef",
-		},
-	})
-	p.provider = mockProvider
-
-	containerID := p.resolveContainerIDFromInode(uint64(1234))
-	assert.Equal(t, "abcdef", containerID)
-
-	unsetInode := p.resolveContainerIDFromInode(uint64(0))
-	assert.Equal(t, "", unsetInode)
 }

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -150,19 +150,19 @@ func testContainerIDParsing(t *testing.T, cfg map[string]interface{}) {
 	metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container"), "", "", false)
 	assert.NoError(err)
 	assert.Len(metrics, 1)
-	assert.Equal("metric-container", metrics[0].OriginInfo.ContainerID)
+	assert.Equal("metric-container", metrics[0].OriginInfo.LocalData.ContainerID)
 
 	// Event
 	event, err := s.parseEventMessage(parser, []byte("_e{10,10}:event title|test\\ntext|c:event-container"), "")
 	assert.NoError(err)
 	assert.NotNil(event)
-	assert.Equal("event-container", event.OriginInfo.ContainerID)
+	assert.Equal("event-container", event.OriginInfo.LocalData.ContainerID)
 
 	// Service check
 	serviceCheck, err := s.parseServiceCheckMessage(parser, []byte("_sc|service-check.name|0|c:service-check-container"), "")
 	assert.NoError(err)
 	assert.NotNil(serviceCheck)
-	assert.Equal("service-check-container", serviceCheck.OriginInfo.ContainerID)
+	assert.Equal("service-check-container", serviceCheck.OriginInfo.LocalData.ContainerID)
 }
 
 func TestContainerIDParsing(t *testing.T) {
@@ -194,19 +194,19 @@ func TestOrigin(t *testing.T) {
 		metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container|#dd.internal.card:none"), "", "", false)
 		assert.NoError(err)
 		assert.Len(metrics, 1)
-		assert.Equal("metric-container", metrics[0].OriginInfo.ContainerID)
+		assert.Equal("metric-container", metrics[0].OriginInfo.LocalData.ContainerID)
 
 		// Event
 		event, err := s.parseEventMessage(parser, []byte("_e{10,10}:event title|test\\ntext|c:event-container|#dd.internal.card:none"), "")
 		assert.NoError(err)
 		assert.NotNil(event)
-		assert.Equal("event-container", event.OriginInfo.ContainerID)
+		assert.Equal("event-container", event.OriginInfo.LocalData.ContainerID)
 
 		// Service check
 		serviceCheck, err := s.parseServiceCheckMessage(parser, []byte("_sc|service-check.name|0|c:service-check-container|#dd.internal.card:none"), "")
 		assert.NoError(err)
 		assert.NotNil(serviceCheck)
-		assert.Equal("service-check-container", serviceCheck.OriginInfo.ContainerID)
+		assert.Equal("service-check-container", serviceCheck.OriginInfo.LocalData.ContainerID)
 	})
 }
 

--- a/pkg/tagger/types/types.go
+++ b/pkg/tagger/types/types.go
@@ -12,7 +12,6 @@ import "github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 type OriginInfo struct {
 	ContainerIDFromSocket string                        // ContainerIDFromSocket is the origin resolved using Unix Domain Socket.
 	PodUID                string                        // PodUID is the origin resolved from the Kubernetes Pod UID.
-	ContainerID           string                        // ContainerID is the origin resolved from the container ID.
 	LocalData             origindetection.LocalData     // LocalData is the local data list.
 	ExternalData          origindetection.ExternalData  // ExternalData is the external data list.
 	Cardinality           string                        // Cardinality is the cardinality of the resolved origin.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Move the Inode resolution to the `tagger`. Removes unused `containerID` fields from DogStatsD.

### Motivation

Origin Detection resolutions mechanism should be moved to the `tagger`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

QA is done by unit and E2E tests.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
None