### PR TITLE
fix(release): Improve matching to get the last release tag

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -273,7 +273,7 @@ def get_last_release_tag(ctx, repo, pattern):
             code=1,
         )
 
-    release_pattern = re.compile(r'^.*7\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?(^{})?$')
+    release_pattern = re.compile(r'^.*7\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?(\^{})?$')
     tags_without_suffix = [
         line for line in tags.splitlines() if not line.endswith("^{}") and release_pattern.match(line)
     ]

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -273,7 +273,7 @@ def get_last_release_tag(ctx, repo, pattern):
             code=1,
         )
 
-    release_pattern = re.compile(r'.*7\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?$')
+    release_pattern = re.compile(r'^.*7\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?(^{})?$')
     tags_without_suffix = [
         line for line in tags.splitlines() if not line.endswith("^{}") and release_pattern.match(line)
     ]

--- a/tasks/unit_tests/libs/common/git_tests.py
+++ b/tasks/unit_tests/libs/common/git_tests.py
@@ -117,7 +117,9 @@ class TestGetLastTag(unittest.TestCase):
         c = MockContext(
             run={
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
-                    "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
+                    """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
+                       7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2
+                       2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
                 )
             }
         )
@@ -128,7 +130,9 @@ class TestGetLastTag(unittest.TestCase):
         c = MockContext(
             run={
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
-                    "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.11\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
+                    """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
+                       7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.11
+                       2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
                 )
             }
         )
@@ -139,7 +143,9 @@ class TestGetLastTag(unittest.TestCase):
         c = MockContext(
             run={
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
-                    "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2^{}\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
+                    """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
+                       7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2^{}
+                       2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
                 )
             }
         )
@@ -150,7 +156,9 @@ class TestGetLastTag(unittest.TestCase):
         c = MockContext(
             run={
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
-                    "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.3^{}\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
+                    """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
+                       7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.3^{}
+                       2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
                 )
             }
         )
@@ -161,7 +169,9 @@ class TestGetLastTag(unittest.TestCase):
         c = MockContext(
             run={
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
-                    "e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1\n7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.4^{}\n2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"
+                    """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
+                       7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.4^{}
+                       2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
                 )
             }
         )
@@ -172,7 +182,30 @@ class TestGetLastTag(unittest.TestCase):
         c = MockContext(
             run={
                 'git ls-remote -t https://github.com/DataDog/woof "7.57.*"': Result(
-                    "43638bd55a74fd6ec51264cc7b3b1003d0b1c7ac\trefs/tags/7.57.0-dbm-mongo-1.5\ne01bcf3d12e6d6742b1fa8296882938c6dba9922\trefs/tags/7.57.0-devel\n6a5ad7fda590c7b8ba7036bca70dc8a0872e7afe\trefs/tags/7.57.0-devel^{}\n2c2eb2293cccd33100d7d930a59c136319942915\trefs/tags/7.57.0-installer-0.5.0-rc.1\n2c2eb2293cccd33100d7d930a59c136319942915\trefs/tags/7.57.0-installer-0.5.0-rc.2\n6a91fcca0ade9f77f08cd98d923a8d9ec18d7e8f\trefs/tags/7.57.0-installer-0.5.0-rc.3\n7e8ffc3de15f0486e6cb2184fa59f02da6ecfab9\trefs/tags/7.57.0-rc.1\nfa72fd12e3483a2d5957ea71fe01a8b1af376424\trefs/tags/7.57.0-rc.1^{}\n22587b746d6a0876cb7477b9b335e8573bdc3ac5\trefs/tags/7.57.0-rc.2\nd6c151a36487c3b54145ae9bf200f6c356bb9348\trefs/tags/7.57.0-rc.2^{}\n948ed4dd8c8cdf0aae467997086bb2229d4f1916\trefs/tags/7.57.0-rc.3\n259ed086a45960006e110622332cc8a39f9c6bb9\trefs/tags/7.57.0-rc.3^{}\na249f4607e5da894715a3e011dba8046b46678ed\trefs/tags/7.57.0-rc.4\n51a3b405a244348aec711d38e5810a6d88075b77\trefs/tags/7.57.0-rc.4^{}\n06519be707d6f24fb8265cde5a50cf0a66d5cb02\trefs/tags/7.57.0-rc.5\n7f43a5180446290f498742e68d8b28a75da04188\trefs/tags/7.57.0-rc.5^{}\n6bb640559e7626131290c63dab3959ba806c9886\trefs/tags/7.57.0-rc.6\nc5ed1f8b4734d31e94c2a83f307dbcb2b5a1faac\trefs/tags/7.57.0-rc.6^{}\n260697e624bb1d92ad306fdc301aab9b2975a627\trefs/tags/7.57.0-rc.7\n48617a0f56747e33b75d3dcf570bc2237726dc0e\trefs/tags/7.57.0-rc.7^{}\n5e11e104ff99b40b01ff2cfa702c0e4a465f98de\trefs/tags/7.57.1-beta-ndm-rdns-enrichment\n91c7c85d7c8fbb94421a90b273aea75630617eef\trefs/tags/7.57.1-beta-ndm-rdns-enrichment^{}\n3ad359da2894fa3de6e265c56dea8fabdb128454\trefs/tags/7.57.1-beta-ndm-rdns-enrichment2\n86683ad80578912014cc947dcf247ba020532403\trefs/tags/7.57.1-beta-ndm-rdns-enrichment2^{}"
+                    """"43638bd55a74fd6ec51264cc7b3b1003d0b1c7ac    refs/tags/7.57.0-dbm-mongo-1.5
+                        e01bcf3d12e6d6742b1fa8296882938c6dba9922    refs/tags/7.57.0-devel
+                        6a5ad7fda590c7b8ba7036bca70dc8a0872e7afe    refs/tags/7.57.0-devel^{}
+                        2c2eb2293cccd33100d7d930a59c136319942915    refs/tags/7.57.0-installer-0.5.0-rc.1
+                        2c2eb2293cccd33100d7d930a59c136319942915    refs/tags/7.57.0-installer-0.5.0-rc.2
+                        6a91fcca0ade9f77f08cd98d923a8d9ec18d7e8f    refs/tags/7.57.0-installer-0.5.0-rc.3
+                        7e8ffc3de15f0486e6cb2184fa59f02da6ecfab9    refs/tags/7.57.0-rc.1
+                        fa72fd12e3483a2d5957ea71fe01a8b1af376424    refs/tags/7.57.0-rc.1^{}
+                        22587b746d6a0876cb7477b9b335e8573bdc3ac5    refs/tags/7.57.0-rc.2
+                        d6c151a36487c3b54145ae9bf200f6c356bb9348    refs/tags/7.57.0-rc.2^{}
+                        948ed4dd8c8cdf0aae467997086bb2229d4f1916    refs/tags/7.57.0-rc.3
+                        259ed086a45960006e110622332cc8a39f9c6bb9    refs/tags/7.57.0-rc.3^{}
+                        a249f4607e5da894715a3e011dba8046b46678ed    refs/tags/7.57.0-rc.4
+                        51a3b405a244348aec711d38e5810a6d88075b77    refs/tags/7.57.0-rc.4^{}
+                        06519be707d6f24fb8265cde5a50cf0a66d5cb02    refs/tags/7.57.0-rc.5
+                        7f43a5180446290f498742e68d8b28a75da04188    refs/tags/7.57.0-rc.5^{}
+                        6bb640559e7626131290c63dab3959ba806c9886    refs/tags/7.57.0-rc.6
+                        c5ed1f8b4734d31e94c2a83f307dbcb2b5a1faac    refs/tags/7.57.0-rc.6^{}
+                        260697e624bb1d92ad306fdc301aab9b2975a627    refs/tags/7.57.0-rc.7
+                        48617a0f56747e33b75d3dcf570bc2237726dc0e    refs/tags/7.57.0-rc.7^{}
+                        5e11e104ff99b40b01ff2cfa702c0e4a465f98de    refs/tags/7.57.1-beta-ndm-rdns-enrichment
+                        91c7c85d7c8fbb94421a90b273aea75630617eef    refs/tags/7.57.1-beta-ndm-rdns-enrichment^{}
+                        3ad359da2894fa3de6e265c56dea8fabdb128454    refs/tags/7.57.1-beta-ndm-rdns-enrichment2
+                        86683ad80578912014cc947dcf247ba020532403    refs/tags/7.57.1-beta-ndm-rdns-enrichment2^{}"""
                 )
             }
         )
@@ -182,15 +215,16 @@ class TestGetLastTag(unittest.TestCase):
     def test_final_and_rc_tag_on_same_commit(self):
         c = MockContext(
             run={
-                # 'git ls-remote -t https://github.com/DataDog/baubau "7.61.*"': Result("8dd145cf716b5c047e81bb287dc58e150b8c2b94\trefs/tags/7.61.0\n45f19a6a26c01dae9fdfce944d3fceae7f4e6498\trefs/tags/7.61.0^{}\n1cfbd72c75d6fcfe920707b2d08764ee89ec8793\trefs/tags/7.61.0-rc.1\n52fd18ccf4391ed5da0647dad2c1fdeea8a8a70c\trefs/tags/7.61.0-rc.1^{}\n3b7310d32b0ad4d347fa64f60a02261caf910a99\trefs/tags/7.61.0-rc.4\n3944948c0c26ddcbc4026b98c2709c188d95b702\trefs/tags/7.61.0-rc.4^{}\nc54e5d5694879c51ae5ff8675dacc92976630587\trefs/tags/7.61.0-rc.5\n45f19a6a26c01dae9fdfce944d3fceae7f4e6498\trefs/tags/7.61.0-rc.5^{}\n")})
-                'git ls-remote -t https://github.com/DataDog/baubau "7.61.*"': Result("""8dd145cf716b5c047e81bb287dc58e150b8c2b94	refs/tags/7.61.0
-45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0^{}
-1cfbd72c75d6fcfe920707b2d08764ee89ec8793	refs/tags/7.61.0-rc.1
-52fd18ccf4391ed5da0647dad2c1fdeea8a8a70c	refs/tags/7.61.0-rc.1^{}
-3b7310d32b0ad4d347fa64f60a02261caf910a99	refs/tags/7.61.0-rc.4
-3944948c0c26ddcbc4026b98c2709c188d95b702	refs/tags/7.61.0-rc.4^{}
-c54e5d5694879c51ae5ff8675dacc92976630587	refs/tags/7.61.0-rc.5
-45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0-rc.5^{}""")
+                'git ls-remote -t https://github.com/DataDog/baubau "7.61.*"': Result(
+                    """8dd145cf716b5c047e81bb287dc58e150b8c2b94	refs/tags/7.61.0
+                       45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0^{}
+                       1cfbd72c75d6fcfe920707b2d08764ee89ec8793	refs/tags/7.61.0-rc.1
+                       52fd18ccf4391ed5da0647dad2c1fdeea8a8a70c	refs/tags/7.61.0-rc.1^{}
+                       3b7310d32b0ad4d347fa64f60a02261caf910a99	refs/tags/7.61.0-rc.4
+                       3944948c0c26ddcbc4026b98c2709c188d95b702	refs/tags/7.61.0-rc.4^{}
+                       c54e5d5694879c51ae5ff8675dacc92976630587	refs/tags/7.61.0-rc.5
+                       45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0-rc.5^{}"""
+                )
             }
         )
 

--- a/tasks/unit_tests/libs/common/git_tests.py
+++ b/tasks/unit_tests/libs/common/git_tests.py
@@ -178,3 +178,21 @@ class TestGetLastTag(unittest.TestCase):
         )
         _, name = get_last_release_tag(c, "woof", "7.57.*")
         self.assertEqual(name, "7.57.0-rc.7")
+
+    def test_final_and_rc_tag_on_same_commit(self):
+        c = MockContext(
+            run={
+                # 'git ls-remote -t https://github.com/DataDog/baubau "7.61.*"': Result("8dd145cf716b5c047e81bb287dc58e150b8c2b94\trefs/tags/7.61.0\n45f19a6a26c01dae9fdfce944d3fceae7f4e6498\trefs/tags/7.61.0^{}\n1cfbd72c75d6fcfe920707b2d08764ee89ec8793\trefs/tags/7.61.0-rc.1\n52fd18ccf4391ed5da0647dad2c1fdeea8a8a70c\trefs/tags/7.61.0-rc.1^{}\n3b7310d32b0ad4d347fa64f60a02261caf910a99\trefs/tags/7.61.0-rc.4\n3944948c0c26ddcbc4026b98c2709c188d95b702\trefs/tags/7.61.0-rc.4^{}\nc54e5d5694879c51ae5ff8675dacc92976630587\trefs/tags/7.61.0-rc.5\n45f19a6a26c01dae9fdfce944d3fceae7f4e6498\trefs/tags/7.61.0-rc.5^{}\n")})
+                'git ls-remote -t https://github.com/DataDog/baubau "7.61.*"': Result("""8dd145cf716b5c047e81bb287dc58e150b8c2b94	refs/tags/7.61.0
+45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0^{}
+1cfbd72c75d6fcfe920707b2d08764ee89ec8793	refs/tags/7.61.0-rc.1
+52fd18ccf4391ed5da0647dad2c1fdeea8a8a70c	refs/tags/7.61.0-rc.1^{}
+3b7310d32b0ad4d347fa64f60a02261caf910a99	refs/tags/7.61.0-rc.4
+3944948c0c26ddcbc4026b98c2709c188d95b702	refs/tags/7.61.0-rc.4^{}
+c54e5d5694879c51ae5ff8675dacc92976630587	refs/tags/7.61.0-rc.5
+45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0-rc.5^{}""")
+            }
+        )
+
+        commit, _ = get_last_release_tag(c, "baubau", "7.61.*")
+        self.assertEqual(commit, "45f19a6a26c01dae9fdfce944d3fceae7f4e6498")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Improve matching to get the last release tag. The current regex was ignoring the "final" tags (`x.y.z`) from the `with_suffix` part of what `git ls-remote` returns. As such it was understanding this tag as a commit on head instead as a tag.

### Motivation
Prevent to send false positive messages to teams during the release process

### Describe how you validated your changes
Added a UT to cover this situation
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->