### PR TITLE
Mark some FIPS E2E tests as flakey

### DIFF
--- a/test/new-e2e/tests/windows/install-test/mutually_exclusive_product_test.go
+++ b/test/new-e2e/tests/windows/install-test/mutually_exclusive_product_test.go
@@ -31,7 +31,6 @@ type mutuallyExclusiveInstallSuite struct {
 //
 // This test uses the last stable base Agent package and the pipeline produced FIPS Agent package.
 func TestFIPSAgentDoesNotInstallOverAgent(t *testing.T) {
-	flake.Mark(s.T())
 	s := &mutuallyExclusiveInstallSuite{}
 	os.Setenv(windowsAgent.PackageFlavorEnvVar, "base")
 	previousAgentPackage, err := windowsAgent.GetLastStablePackageFromEnv()
@@ -46,7 +45,6 @@ func TestFIPSAgentDoesNotInstallOverAgent(t *testing.T) {
 // This test uses the pipeline produced MSI packages for both flavors. This is necessary for now
 // because the previous Agent versions do not contain the changes to detect mutually exclusive products.
 func TestAgentDoesNotInstallOverFIPSAgent(t *testing.T) {
-	flake.Mark(s.T())
 	s := &mutuallyExclusiveInstallSuite{}
 	os.Setenv(windowsAgent.PackageFlavorEnvVar, "fips")
 	previousAgentPackage, err := windowsAgent.GetPackageFromEnv()

--- a/test/new-e2e/tests/windows/install-test/mutually_exclusive_product_test.go
+++ b/test/new-e2e/tests/windows/install-test/mutually_exclusive_product_test.go
@@ -10,13 +10,15 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type mutuallyExclusiveInstallSuite struct {
@@ -29,6 +31,7 @@ type mutuallyExclusiveInstallSuite struct {
 //
 // This test uses the last stable base Agent package and the pipeline produced FIPS Agent package.
 func TestFIPSAgentDoesNotInstallOverAgent(t *testing.T) {
+	flake.Mark(s.T())
 	s := &mutuallyExclusiveInstallSuite{}
 	os.Setenv(windowsAgent.PackageFlavorEnvVar, "base")
 	previousAgentPackage, err := windowsAgent.GetLastStablePackageFromEnv()
@@ -43,6 +46,7 @@ func TestFIPSAgentDoesNotInstallOverAgent(t *testing.T) {
 // This test uses the pipeline produced MSI packages for both flavors. This is necessary for now
 // because the previous Agent versions do not contain the changes to detect mutually exclusive products.
 func TestAgentDoesNotInstallOverFIPSAgent(t *testing.T) {
+	flake.Mark(s.T())
 	s := &mutuallyExclusiveInstallSuite{}
 	os.Setenv(windowsAgent.PackageFlavorEnvVar, "fips")
 	previousAgentPackage, err := windowsAgent.GetPackageFromEnv()
@@ -66,6 +70,7 @@ func (s *mutuallyExclusiveInstallSuite) SetupSuite() {
 }
 
 func (s *mutuallyExclusiveInstallSuite) TestMutuallyExclusivePackage() {
+	flake.Mark(s.T())
 	host := s.Env().RemoteHost
 
 	// Install second Agent


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR marks the mutually exclusive FIPS E2E tests as flakey.

### Motivation
Stabilize main until the dependency issue is fixed:
https://github.com/DataDog/datadog-agent/pull/32849
https://github.com/DataDog/datadog-agent/pull/32853

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->