### PR TITLE
[CWS] move `AuditUIDUnset` constant to sharedconsts

### DIFF
--- a/pkg/security/probe/kfilters/process.go
+++ b/pkg/security/probe/kfilters/process.go
@@ -12,12 +12,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
 const (
 	auidField               = "process.auid"
-	maxAUID                 = model.AuditUIDUnset - 1
+	maxAUID                 = sharedconsts.AuditUIDUnset - 1
 	auidApproversTable      = "auid_approvers"
 	auidRangeApproversTable = "auid_range_approvers"
 )
@@ -29,14 +30,14 @@ var processCapabilities = rules.FieldCapabilities{
 		FilterMode:       rules.ApproverOnlyMode,
 		RangeFilterValue: &rules.RangeFilterValue{Min: 0, Max: maxAUID},
 		FilterWeight:     100,
-		// convert  `!= model.AuditUIDUnset`` to the max range
+		// convert  `!= sharedconsts.AuditUIDUnset`` to the max range
 		HandleNotApproverValue: func(fieldValueType eval.FieldValueType, value interface{}) (eval.FieldValueType, interface{}, bool) {
 			if fieldValueType != eval.ScalarValueType {
 				return fieldValueType, value, false
 			}
 
-			if i, ok := value.(int); ok && uint32(i) == model.AuditUIDUnset {
-				return eval.RangeValueType, rules.RangeFilterValue{Min: 0, Max: model.AuditUIDUnset - 1}, true
+			if i, ok := value.(int); ok && uint32(i) == sharedconsts.AuditUIDUnset {
+				return eval.RangeValueType, rules.RangeFilterValue{Min: 0, Max: sharedconsts.AuditUIDUnset - 1}, true
 			}
 
 			return fieldValueType, value, false

--- a/pkg/security/secl/model/consts_linux.go
+++ b/pkg/security/secl/model/consts_linux.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"golang.org/x/sys/unix"
 )
@@ -984,13 +985,8 @@ func initBPFMapNamesConstants() {
 }
 
 func initAUIDConstants() {
-	seclConstants["AUDIT_AUID_UNSET"] = &eval.IntEvaluator{Value: AuditUIDUnset}
+	seclConstants["AUDIT_AUID_UNSET"] = &eval.IntEvaluator{Value: sharedconsts.AuditUIDUnset}
 }
-
-const (
-	// AuditUIDUnset is used to specify that a login uid is not set
-	AuditUIDUnset = math.MaxUint32
-)
 
 func bitmaskToStringArray(bitmask int, intToStrMap map[int]string) []string {
 	var strs []string

--- a/pkg/security/secl/model/sharedconsts/auditid.go
+++ b/pkg/security/secl/model/sharedconsts/auditid.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package sharedconsts holds model related shared constants
+package sharedconsts
+
+import "math"
+
+const (
+	// AuditUIDUnset is used to specify that a login uid is not set
+	AuditUIDUnset = math.MaxUint32
+)

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -161,7 +161,7 @@ func (e *Credentials) UnmarshalBinary(data []byte) (int, error) {
 	e.FSGID = binary.NativeEndian.Uint32(data[20:24])
 	e.AUID = binary.NativeEndian.Uint32(data[24:28])
 	if binary.NativeEndian.Uint32(data[28:32]) != 1 {
-		e.AUID = AuditUIDUnset
+		e.AUID = sharedconsts.AuditUIDUnset
 	}
 	e.CapEffective = binary.NativeEndian.Uint64(data[32:40])
 	e.CapPermitted = binary.NativeEndian.Uint64(data[40:48])

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 )
 
 type testFieldValues map[eval.Field][]interface{}
@@ -892,15 +893,15 @@ func TestRuleSetAUDApprovers(t *testing.T) {
 			Field:            "process.auid",
 			TypeBitmask:      eval.ScalarValueType | eval.RangeValueType,
 			FilterMode:       ApproverOnlyMode,
-			RangeFilterValue: &RangeFilterValue{Min: 0, Max: model.AuditUIDUnset - 1},
+			RangeFilterValue: &RangeFilterValue{Min: 0, Max: sharedconsts.AuditUIDUnset - 1},
 			FilterWeight:     10,
 			HandleNotApproverValue: func(fieldValueType eval.FieldValueType, value interface{}) (eval.FieldValueType, interface{}, bool) {
 				if fieldValueType != eval.ScalarValueType {
 					return fieldValueType, value, false
 				}
 
-				if i, ok := value.(int); ok && uint32(i) == model.AuditUIDUnset {
-					return eval.RangeValueType, RangeFilterValue{Min: 0, Max: model.AuditUIDUnset - 1}, true
+				if i, ok := value.(int); ok && uint32(i) == sharedconsts.AuditUIDUnset {
+					return eval.RangeValueType, RangeFilterValue{Min: 0, Max: sharedconsts.AuditUIDUnset - 1}, true
 				}
 
 				return fieldValueType, value, false
@@ -955,7 +956,7 @@ func TestRuleSetAUDApprovers(t *testing.T) {
 		}
 
 		rge := approvers["process.auid"][0].Value.(RangeFilterValue)
-		if rge.Min != 0 || rge.Max != model.AuditUIDUnset-1 {
+		if rge.Min != 0 || rge.Max != sharedconsts.AuditUIDUnset-1 {
 			t.Fatalf("unexpected range")
 		}
 	})

--- a/pkg/security/utils/proc_linux.go
+++ b/pkg/security/utils/proc_linux.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/shirou/gopsutil/v4/process"
@@ -163,18 +162,18 @@ func ModulesPath() string {
 func GetLoginUID(pid uint32) (uint32, error) {
 	content, err := os.ReadFile(LoginUIDPath(pid))
 	if err != nil {
-		return model.AuditUIDUnset, err
+		return sharedconsts.AuditUIDUnset, err
 	}
 
 	data := strings.TrimSuffix(string(content), "\n")
 	if len(data) == 0 {
-		return model.AuditUIDUnset, fmt.Errorf("invalid login uid: %v", data)
+		return sharedconsts.AuditUIDUnset, fmt.Errorf("invalid login uid: %v", data)
 	}
 
 	// parse login uid
 	auid, err := strconv.ParseUint(data, 10, 32)
 	if err != nil {
-		return model.AuditUIDUnset, fmt.Errorf("coudln't parse loginuid: %v", err)
+		return sharedconsts.AuditUIDUnset, fmt.Errorf("coudln't parse loginuid: %v", err)
 	}
 	return uint32(auid), nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR moves `AuditUIDUnset` to the shared consts package, allowing `pkg/security/utils` to not import `pkg/security/secl/model`.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->