### PR TITLE
[CWS] remove `pkg/security/secl/model` usage from cgroup utils

### DIFF
--- a/pkg/security/resolvers/container/resolver.go
+++ b/pkg/security/resolvers/container/resolver.go
@@ -29,5 +29,17 @@ func New() *Resolver {
 // GetContainerContext returns the container id, cgroup context, and cgroup sysfs path of the given pid
 func (cr *Resolver) GetContainerContext(pid uint32) (containerutils.ContainerID, model.CGroupContext, string, error) {
 	// Parse /proc/[pid]/task/[pid]/cgroup and /sys/fs/cgroup/[cgroup]
-	return cr.fs.FindCGroupContext(pid, pid)
+	id, ctx, path, err := cr.fs.FindCGroupContext(pid, pid)
+	if err != nil {
+		return "", model.CGroupContext{}, "", err
+	}
+
+	return id, model.CGroupContext{
+		CGroupID:    ctx.CGroupID,
+		CGroupFlags: ctx.CGroupFlags,
+		CGroupFile: model.PathKey{
+			Inode:   ctx.CGroupFileInode,
+			MountID: ctx.CGroupFileMountID,
+		},
+	}, path, nil
 }

--- a/pkg/security/utils/cgroup_test.go
+++ b/pkg/security/utils/cgroup_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
 
 func TestCGroupvParseLine(t *testing.T) {
@@ -242,7 +241,7 @@ func TestCGroup(t *testing.T) {
 		var (
 			containerID   containerutils.ContainerID
 			runtime       containerutils.CGroupFlags
-			cgroupContext model.CGroupContext
+			cgroupContext CGroupContext
 			cgroupPath    string
 		)
 


### PR DESCRIPTION
### What does this PR do?

Those cgroup functions are also called from the compliance module. This PR removes the usage of some model structures so that using them doesn't bring the whole CWS code as well (important for the security agent and the cluster agent).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->