### PR TITLE
🚧[task] add windows-dev-env.run

### DIFF
--- a/tasks/windows_dev_env.py
+++ b/tasks/windows_dev_env.py
@@ -94,9 +94,16 @@ def _ensure_windows_dev_container_running(ctx, host):
     # start the Windows dev container, if not already running
     if should_start_container:
         print("🐳 Starting Windows dev container")
-        ctx.run(
+        result = ctx.run(
             f"ssh {host} 'docker run -v C:\\mnt:c:\\mnt -w C:\\mnt\\datadog-agent -t -d --name {WIN_CONTAINER_NAME} datadog/agent-buildimages-windows_x64:ltsc2022 ping -t localhost'",
+            hide=True,
         )
+        if result is None or not result:
+            raise Exception("Failed to start the Windows development container.")
+        # init go environment
+        exit_code = _run_on_windows_dev_env(ctx, command="tasks\\winbuildscripts\\pre-go-build.ps1")
+        if exit_code != 0:
+            raise Exception("Failed to initialize the Windows development environment.")
 
 
 def _build_rsync_command(host: str) -> str:

--- a/tasks/windows_dev_env.py
+++ b/tasks/windows_dev_env.py
@@ -2,16 +2,19 @@
 Create a remote Windows development environment and keep it in sync with local changes.
 """
 
+import json
 import os
 import re
 import shutil
 import time
 from datetime import timedelta
+from typing import Any
 
 from invoke.context import Context
 from invoke.tasks import task
 
 AMI_WINDOWS_DEV_2022 = "ami-09b68440cb06b26d6"
+WIN_CONTAINER_NAME = "windows-dev-env"
 
 
 @task(
@@ -44,19 +47,25 @@ def stop(
     _stop_windows_dev_env(ctx, name)
 
 
+@task(
+    help={
+        'name': 'Override the default name of the development environment (windows-dev-env).',
+        'command': 'Command to run on a windows dev container',
+    },
+)
+def run(
+    ctx: Context,
+    name: str = "windows-dev-env",
+    command: str = "",
+):
+    """
+    Runs a command on a remote Windows development environment.
+    """
+    _run_on_windows_dev_env(ctx, name, command)
+
+
 def _start_windows_dev_env(ctx, name: str = "windows-dev-env"):
     start_time = time.time()
-    # lazy load watchdog to avoid import error on the CI
-    from watchdog.events import FileSystemEvent, FileSystemEventHandler
-    from watchdog.observers import Observer
-
-    class DDAgentEventHandler(FileSystemEventHandler):
-        def __init__(self, ctx: Context, command: str):
-            self.ctx = ctx
-            self.command = command
-
-        def on_any_event(self, event: FileSystemEvent) -> None:  # noqa # called by watchdog callback
-            _on_changed_path_run_command(self.ctx, event.src_path, self.command)
 
     # Ensure `test-infra-definitions` is cloned.
     if not os.path.isdir('../test-infra-definitions'):
@@ -87,8 +96,33 @@ def _start_windows_dev_env(ctx, name: str = "windows-dev-env"):
         # extract username and address from connection message
         host = connection_message.split()[0]
 
+    # check if Windows dev container is already running
+    should_start_container = True
+    result = ctx.run(f"ssh {host} 'docker ps -q --filter name=windows-dev-env'", warn=True, hide=True)
+    if result is not None and result.exited == 0 and len(result.stdout) > 0:
+        print("🐳 Windows dev env already running")
+        should_start_container = False
+    # start the Windows dev container, if not already running
+    if should_start_container:
+        print("🐳 Starting Windows dev container")
+        ctx.run(
+            f"ssh {host} 'docker run -v C:\\mnt:c:\\mnt -w C:\\mnt\\datadog-agent -t -d --name {WIN_CONTAINER_NAME} datadog/agent-buildimages-windows_x64:ltsc2022 ping -t localhost'",
+        )
     # sync local changes to the remote Windows development environment
-    # -aqzrcIR
+    rsync_command = _build_rsync_command(host)
+    print("Syncing changes to the remote Windows development environment...")
+    ctx.run(rsync_command)
+    print("Syncing changes to the remote Windows development done")
+    # print the time taken to start the dev env
+    elapsed_time = time.time() - start_time
+    print("♻️ Windows dev env started in", timedelta(seconds=elapsed_time))
+    _run_command_on_local_changes(ctx, rsync_command)
+    print("♻️ Windows dev env sync stopped")
+    print("Start it again with `inv windows_dev_env.start`")
+    print("Destroy the Windows dev env with `inv windows-dev-env.stop`")
+
+
+def _build_rsync_command(host: str) -> str:
     # -a: archive mode; equals -rlptgoD (no -H)
     # -z: compress file data during the transfer
     # -r: recurse into directories
@@ -96,19 +130,26 @@ def _start_windows_dev_env(ctx, name: str = "windows-dev-env"):
     # -I: --ignore-times
     # -P: same as --partial --progress, show partial progress during transfer
     # -R: use relative path names
-    rsync_command = f"rsync -azrcIPR --delete --rsync-path='C:\\cygwin\\bin\\rsync.exe' --filter=':- .gitignore' --exclude /.git/ . {host}:/cygdrive/c/mnt/datadog-agent/"
-    print("Syncing changes to the remote Windows development environment...")
-    ctx.run(rsync_command)
-    print("Syncing changes to the remote Windows development done")
-    # print the time taken to start the dev env
-    elapsed_time = time.time() - start_time
-    print("♻️ Windows dev env started in", timedelta(seconds=elapsed_time))
+    return f"rsync -azrcIPR --delete --rsync-path='C:\\cygwin\\bin\\rsync.exe' --filter=':- .gitignore' --exclude /.git/ . {host}:/cygdrive/c/mnt/datadog-agent/"
 
-    event_handler = DDAgentEventHandler(ctx=ctx, command=rsync_command)
+
+def _run_command_on_local_changes(ctx: Context, command: str):
+    # lazy load watchdog to avoid import error on the CI
+    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    class DDAgentEventHandler(FileSystemEventHandler):
+        def __init__(self, ctx: Context, command: str):
+            self.ctx = ctx
+            self.command = command
+
+        def on_any_event(self, event: FileSystemEvent) -> None:  # noqa # called by watchdog callback
+            _on_changed_path_run_command(self.ctx, event.src_path, self.command)
+
+    event_handler = DDAgentEventHandler(ctx=ctx, command=command)
     observer = Observer()
     observer.schedule(event_handler, ".", recursive=True)
     observer.start()
-
     try:
         while True:
             time.sleep(1)
@@ -116,9 +157,6 @@ def _start_windows_dev_env(ctx, name: str = "windows-dev-env"):
         observer.stop()
     finally:
         observer.join()
-    print("♻️ Windows dev env sync stopped")
-    print("Start it again with `inv windows_dev_env.start`")
-    print("Destroy the Windows dev env with `inv windows-dev-env.stop`")
 
 
 # start file watcher and run rsync on changes
@@ -141,3 +179,43 @@ def _on_changed_path_run_command(ctx: Context, path: str, command: str):
 def _stop_windows_dev_env(ctx, name: str = "windows-dev-env"):
     with ctx.cd('../test-infra-definitions'):
         ctx.run(f"inv aws.destroy-vm --stack-name={name}")
+
+
+class RemoteHost:
+    def __init__(self, output: str):
+        remoteHost: Any = json.loads(output)
+        self.address: str = remoteHost["address"]
+        self.user: str = remoteHost["user"]
+        self.password: str | None = "password" in remoteHost and remoteHost["password"] or None
+        self.port: int | None = "port" in remoteHost and remoteHost["port"] or None
+
+
+def _run_on_windows_dev_env(ctx: Context, name: str = "windows-dev-env", command: str = ""):
+    with ctx.cd('../test-infra-definitions'):
+        # find connection info for the VM
+        result = ctx.run(f"inv aws.show-vm --stack-name={name}", hide=True)
+        if result is None or not result:
+            raise Exception("Failed to find the Windows development environment.")
+        host = RemoteHost(result.stdout)
+        # run the command on the Windows development environment
+        docker_command_parts = [
+            'docker',
+            'exec',
+            '-it',
+            WIN_CONTAINER_NAME,
+            'powershell',
+            f"'{command}'",
+        ]
+        command_parts = [
+            'ssh',
+            f'{host.user}@{host.address}',
+            '-p',
+            f'{host.port}',
+            '-t',
+            f'"{' '.join(docker_command_parts)}"',
+        ]
+        ctx.run(
+            ' '.join(command_parts),
+            pty=True,
+            warn=True,
+        )

--- a/tasks/windows_dev_env.py
+++ b/tasks/windows_dev_env.py
@@ -61,7 +61,7 @@ def run(
     """
     Runs a command on a remote Windows development environment.
     """
-    _run_on_windows_dev_env(ctx, name, command)
+    exit(_run_on_windows_dev_env(ctx, name, command))
 
 
 def _start_windows_dev_env(ctx, name: str = "windows-dev-env"):
@@ -190,7 +190,7 @@ class RemoteHost:
         self.port: int | None = "port" in remoteHost and remoteHost["port"] or None
 
 
-def _run_on_windows_dev_env(ctx: Context, name: str = "windows-dev-env", command: str = ""):
+def _run_on_windows_dev_env(ctx: Context, name: str = "windows-dev-env", command: str = "") -> int:
     with ctx.cd('../test-infra-definitions'):
         # find connection info for the VM
         result = ctx.run(f"inv aws.show-vm --stack-name={name}", hide=True)
@@ -214,8 +214,11 @@ def _run_on_windows_dev_env(ctx: Context, name: str = "windows-dev-env", command
             '-t',
             f'"{' '.join(docker_command_parts)}"',
         ]
-        ctx.run(
+        result = ctx.run(
             ' '.join(command_parts),
             pty=True,
             warn=True,
         )
+        if result is None or not result:
+            raise Exception("Failed to run the command on the Windows development environment.")
+        return result.exited

--- a/tasks/windows_dev_env.py
+++ b/tasks/windows_dev_env.py
@@ -215,7 +215,8 @@ def _run_on_windows_dev_env(ctx: Context, name: str = "windows-dev-env", command
             'exec',
             '-it',
             WIN_CONTAINER_NAME,
-            'powershell',
+            'powershell.exe',
+            '-Command',
             f"'{command}'",
         ]
         command_parts = [


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Init go environment on a windows dev env

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Running `pre-go-build.ps1` is currently returning 

```
cd C:\mnt\datadog-agent\rtloader\build && cmake -G "Unix Makefiles" -DBUILD_DEMO:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH=C:\mnt\datadog-agent\dev C:\mnt\datadog-agent\rtloader
CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.-- Configuring incomplete, errors occurred!

CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
Build result is 1
```