### PR TITLE
[CWS] extract `PrepareK8SUserSessionContext` to own package

### DIFF
--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation.go
@@ -39,7 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8scp"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/cwsinstrumentation/k8sexec"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usersessions"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/k8sutils"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	apiserverUtils "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	apiServerCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
@@ -574,7 +574,7 @@ func (ci *CWSInstrumentation) injectCWSCommandInstrumentation(exec *corev1.PodEx
 	}
 
 	// prepare the user session context
-	userSessionCtx, err := usersessions.PrepareK8SUserSessionContext(userInfo, cwsUserSessionDataMaxSize)
+	userSessionCtx, err := k8sutils.PrepareK8SUserSessionContext(userInfo, cwsUserSessionDataMaxSize)
 	if err != nil {
 		log.Debugf("ignoring instrumentation of %s: %v", mutatecommon.PodString(pod), err)
 		metrics.CWSExecInstrumentationAttempts.Observe(1, ci.mode.String(), "false", cwsCredentialsSerializationErrorReason)

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -26,8 +26,8 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 
 	"github.com/DataDog/datadog-agent/cmd/cws-instrumentation/subcommands/injectcmd"
-	"github.com/DataDog/datadog-agent/pkg/security/resolvers/usersessions"
 	"github.com/DataDog/datadog-agent/pkg/security/tests/testutils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/k8sutils"
 )
 
 var (
@@ -113,7 +113,7 @@ func K8SUserSessionTest(executable string, openPath string) error {
 	}
 
 	// prepare K8S user session context
-	data, err := usersessions.PrepareK8SUserSessionContext(&authenticationv1.UserInfo{
+	data, err := k8sutils.PrepareK8SUserSessionContext(&authenticationv1.UserInfo{
 		Username: "qwerty.azerty@datadoghq.com",
 		UID:      "azerty.qwerty@datadoghq.com",
 		Groups: []string{

--- a/pkg/security/utils/k8sutils/k8s_user_session_context.go
+++ b/pkg/security/utils/k8sutils/k8s_user_session_context.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package usersessions holds model related to the user sessions resolver
-package usersessions
+// Package k8sutils holds kubernetes utils related to the user sessions resolver
+package k8sutils
 
 import (
 	"encoding/json"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `PrepareK8SUserSessionContext` is used by the cluster agent. This PR extracts it from the resolver code to some utils package allowing to use it without importing all the CWS code.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->