### PR TITLE
[CWS] move activity dump path utilities to separate package

### DIFF
--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -30,6 +30,7 @@ import (
 	activity_tree "github.com/DataDog/datadog-agent/pkg/security/security_profile/activity_tree"
 	"github.com/DataDog/datadog-agent/pkg/security/security_profile/dump"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/pathutils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -761,7 +762,7 @@ func activityDumpToWorkloadPolicy(_ log.Component, _ config.Component, _ secrets
 	}
 
 	generatedRules := dump.GenerateRules(ads, opts)
-	generatedRules = utils.BuildPatterns(generatedRules)
+	generatedRules = pathutils.BuildPatterns(generatedRules)
 
 	policyDef := rules.PolicyDef{
 		Rules: generatedRules,

--- a/pkg/security/probe/selftests/tester_windows.go
+++ b/pkg/security/probe/selftests/tester_windows.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/pathutils"
 )
 
 // NewSelfTester returns a new SelfTester, enabled or not
@@ -38,7 +38,7 @@ func NewSelfTester(cfg *config.RuntimeSecurityConfig, probe *probe.Probe) (*Self
 
 	keyPath := "Software\\Datadog\\Datadog Agent"
 
-	dirLongPath, err := utils.GetLongPathName(dir)
+	dirLongPath, err := pathutils.GetLongPathName(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/resolvers/process/resolver_windows.go
+++ b/pkg/security/resolvers/process/resolver_windows.go
@@ -22,7 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/pathutils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -135,8 +135,8 @@ func (p *Resolver) AddNewEntry(pid uint32, ppid uint32, file string, envs []stri
 	e := p.processCacheEntryPool.Get()
 	e.PIDContext.Pid = pid
 	e.PPid = ppid
-	e.Process.CmdLine = utils.NormalizePath(commandLine)
-	e.Process.FileEvent.PathnameStr = utils.NormalizePath(file)
+	e.Process.CmdLine = pathutils.NormalizePath(commandLine)
+	e.Process.FileEvent.PathnameStr = pathutils.NormalizePath(file)
 	e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
 	e.Process.EnvsEntry = &model.EnvsEntry{
 		Values: envs,
@@ -244,8 +244,8 @@ func (p *Resolver) Snapshot() {
 		e.PIDContext.Pid = Pid(pid)
 		e.PPid = Pid(proc.Ppid)
 
-		e.Process.CmdLine = utils.NormalizePath(strings.Join(proc.GetCmdline(), " "))
-		e.Process.FileEvent.PathnameStr = utils.NormalizePath(proc.Exe)
+		e.Process.CmdLine = pathutils.NormalizePath(strings.Join(proc.GetCmdline(), " "))
+		e.Process.FileEvent.PathnameStr = pathutils.NormalizePath(proc.Exe)
 		e.Process.FileEvent.BasenameStr = filepath.Base(e.Process.FileEvent.PathnameStr)
 		e.ExecTime = time.Unix(0, proc.Stats.CreateTime*int64(time.Millisecond))
 		entries = append(entries, e)

--- a/pkg/security/security_profile/activity_tree/activity_tree.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/pathutils"
 )
 
 // NodeDroppedReason is used to list the reasons to drop a node
@@ -893,7 +894,7 @@ func (at *ActivityTree) ExtractPaths(_, fimEnabled, lineageEnabled bool) (map[st
 				at.visitFileNode(file, func(fileNode *FileNode) {
 					path, ok := modifiedPaths[fileNode.File.PathnameStr]
 					if !ok {
-						modifiedPaths[fileNode.File.PathnameStr] = utils.CheckForPatterns(fileNode.File.PathnameStr)
+						modifiedPaths[fileNode.File.PathnameStr] = pathutils.CheckForPatterns(fileNode.File.PathnameStr)
 						path = modifiedPaths[fileNode.File.PathnameStr]
 					}
 					if len(path) > 0 {
@@ -905,7 +906,7 @@ func (at *ActivityTree) ExtractPaths(_, fimEnabled, lineageEnabled bool) (map[st
 
 		execPath, ok := modifiedPaths[processNode.Process.FileEvent.PathnameStr]
 		if !ok {
-			modifiedPaths[processNode.Process.FileEvent.PathnameStr] = utils.CheckForPatterns(processNode.Process.FileEvent.PathnameStr)
+			modifiedPaths[processNode.Process.FileEvent.PathnameStr] = pathutils.CheckForPatterns(processNode.Process.FileEvent.PathnameStr)
 			execPath = modifiedPaths[processNode.Process.FileEvent.PathnameStr]
 		}
 

--- a/pkg/security/security_profile/activity_tree/process_node.go
+++ b/pkg/security/security_profile/activity_tree/process_node.go
@@ -19,6 +19,7 @@ import (
 	sprocess "github.com/DataDog/datadog-agent/pkg/security/resolvers/process"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils/pathutils"
 )
 
 // ProcessNodeParent is an interface used to identify the parent of a process node
@@ -168,7 +169,7 @@ func (pn *ProcessNode) scrubAndReleaseArgsEnvs(resolver *sprocess.EBPFResolver) 
 // Matches return true if the process fields used to generate the dump are identical with the provided model.Process
 func (pn *ProcessNode) Matches(entry *model.Process, matchArgs bool, normalize bool) bool {
 	if normalize {
-		match := utils.PathPatternMatch(pn.Process.FileEvent.PathnameStr, entry.FileEvent.PathnameStr, utils.PathPatternMatchOpts{WildcardLimit: 3, PrefixNodeRequired: 1, SuffixNodeRequired: 1, NodeSizeLimit: 8})
+		match := pathutils.PathPatternMatch(pn.Process.FileEvent.PathnameStr, entry.FileEvent.PathnameStr, pathutils.PathPatternMatchOpts{WildcardLimit: 3, PrefixNodeRequired: 1, SuffixNodeRequired: 1, NodeSizeLimit: 8})
 		if !match {
 			return false
 		}

--- a/pkg/security/utils/pathutils/doc.go
+++ b/pkg/security/utils/pathutils/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package pathutils holds path utils related files
+package pathutils

--- a/pkg/security/utils/pathutils/path_linux.go
+++ b/pkg/security/utils/pathutils/path_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package utils
+package pathutils
 
 import (
 	"fmt"

--- a/pkg/security/utils/pathutils/path_linux_test.go
+++ b/pkg/security/utils/pathutils/path_linux_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package utils
+package pathutils
 
 import (
 	"testing"

--- a/pkg/security/utils/pathutils/path_windows.go
+++ b/pkg/security/utils/pathutils/path_windows.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package utils
+package pathutils
 
 import (
 	"strings"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR extracts some activity dump related path utilities to a separate package. Allowing the import of the `pkg/security/utils` package without importing the whole of `pkg/security/secl/model`.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->