### PR TITLE
[CWS] remove dependency on `pkg/security/config` from telemetry

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -65,7 +65,11 @@ type CWSConsumer struct {
 
 // NewCWSConsumer initializes the module with options
 func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityConfig, wmeta workloadmeta.Component, opts Opts) (*CWSConsumer, error) {
-	crtelemetry, err := telemetry.NewContainersRunningTelemetry(cfg, evm.StatsdClient, wmeta)
+	crtelemcfg := telemetry.ContainersRunningTelemetryConfig{
+		RuntimeEnabled: cfg.RuntimeEnabled,
+		FIMEnabled:     cfg.FIMEnabled,
+	}
+	crtelemetry, err := telemetry.NewContainersRunningTelemetry(crtelemcfg, evm.StatsdClient, wmeta)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/telemetry/containers_running_telemetry_common.go
+++ b/pkg/security/telemetry/containers_running_telemetry_common.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+// ContainersRunningTelemetryConfig holds the config used by the containers running telemetry
+type ContainersRunningTelemetryConfig struct {
+	RuntimeEnabled bool
+	FIMEnabled     bool
+}

--- a/pkg/security/telemetry/containers_running_telemetry_linux.go
+++ b/pkg/security/telemetry/containers_running_telemetry_linux.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -19,12 +18,12 @@ import (
 
 // ContainersRunningTelemetry reports environment information (e.g containers running) when the runtime security component is running
 type ContainersRunningTelemetry struct {
-	cfg        *config.RuntimeSecurityConfig
+	cfg        ContainersRunningTelemetryConfig
 	containers *ContainersTelemetry
 }
 
 // NewContainersRunningTelemetry creates a new ContainersRunningTelemetry instance
-func NewContainersRunningTelemetry(cfg *config.RuntimeSecurityConfig, statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*ContainersRunningTelemetry, error) {
+func NewContainersRunningTelemetry(cfg ContainersRunningTelemetryConfig, statsdClient statsd.ClientInterface, wmeta workloadmeta.Component) (*ContainersRunningTelemetry, error) {
 	telemetrySender := NewSimpleTelemetrySenderFromStatsd(statsdClient)
 	containersTelemetry, err := NewContainersTelemetry(telemetrySender, wmeta)
 	if err != nil {

--- a/pkg/security/telemetry/containers_running_telemetry_others.go
+++ b/pkg/security/telemetry/containers_running_telemetry_others.go
@@ -11,7 +11,6 @@ import (
 	"context"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
@@ -19,7 +18,7 @@ import (
 type ContainersRunningTelemetry struct{}
 
 // NewContainersRunningTelemetry creates a new ContainersRunningTelemetry instance (not supported on non-linux platforms)
-func NewContainersRunningTelemetry(_ *config.RuntimeSecurityConfig, _ statsd.ClientInterface, _ workloadmeta.Component) (*ContainersRunningTelemetry, error) {
+func NewContainersRunningTelemetry(_ ContainersRunningTelemetryConfig, _ statsd.ClientInterface, _ workloadmeta.Component) (*ContainersRunningTelemetry, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR allows the `pkg/security/telemetry` package to be used without importing the CWS code by splitting the configuration from the security config. This is important because this package is also used to drive the containers telemetry of the compliance package.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->