### PR TITLE
process: fix gid and fork values when fetching process data from CWS event stream

### DIFF
--- a/pkg/process/events/consumer/event_copy_linux.go
+++ b/pkg/process/events/consumer/event_copy_linux.go
@@ -33,7 +33,7 @@ func (p *ProcessConsumer) Copy(event *smodel.Event) any {
 	valueUID := event.GetProcessUid()
 	result.UID = valueUID
 
-	valueGID := event.GetProcessUid()
+	valueGID := event.GetProcessGid()
 	result.GID = valueGID
 
 	valueUsername := event.GetProcessUser()

--- a/pkg/process/events/consumer/event_copy_linux.go
+++ b/pkg/process/events/consumer/event_copy_linux.go
@@ -51,7 +51,7 @@ func (p *ProcessConsumer) Copy(event *smodel.Event) any {
 	}
 
 	if event.GetEventType() == smodel.ForkEventType {
-		valueForkTime := event.GetProcessExecTime()
+		valueForkTime := event.GetProcessForkTime()
 		result.ForkTime = valueForkTime
 	}
 

--- a/pkg/process/events/model/model_common.go
+++ b/pkg/process/events/model/model_common.go
@@ -66,7 +66,7 @@ type ProcessEvent struct {
 	Group          string    `json:"group" msg:"group" copy_linux:"GetProcessGroup;event:*"`
 	Exe            string    `json:"exe" msg:"exe" copy_linux:"GetExecFilePath;event:*"`
 	Cmdline        []string  `json:"cmdline" msg:"cmdline" copy_linux:"GetExecCmdargv;event:ExecEventType"`
-	ForkTime       time.Time `json:"fork_time,omitempty" msg:"fork_time,omitempty" copy_linux:"GetProcessExecTime;event:ForkEventType"`
+	ForkTime       time.Time `json:"fork_time,omitempty" msg:"fork_time,omitempty" copy_linux:"GetProcessForkTime;event:ForkEventType"`
 	ExecTime       time.Time `json:"exec_time,omitempty" msg:"exec_time,omitempty" copy:"GetProcessExecTime;event:ExecEventType"`
 	ExitTime       time.Time `json:"exit_time,omitempty" msg:"exit_time,omitempty" copy:"GetProcessExitTime;event:ExitEventType"`
 	ExitCode       uint32    `json:"exit_code,omitempty" msg:"exit_code,omitempty" copy:"GetExitCode;event:ExitEventType"`

--- a/pkg/process/events/model/model_common.go
+++ b/pkg/process/events/model/model_common.go
@@ -61,7 +61,7 @@ type ProcessEvent struct {
 	ContainerID    string    `json:"container_id" msg:"container_id" copy:"GetContainerId;event:*"`
 	Ppid           uint32    `json:"ppid" msg:"ppid" copy:"GetProcessPpid;event:*"`
 	UID            uint32    `json:"uid" msg:"uid" copy_linux:"GetProcessUid;event:*"`
-	GID            uint32    `json:"gid" msg:"gid" copy_linux:"GetProcessUid;event:*"`
+	GID            uint32    `json:"gid" msg:"gid" copy_linux:"GetProcessGid;event:*"`
 	Username       string    `json:"username" msg:"username" copy_linux:"GetProcessUser;event:*"`
 	Group          string    `json:"group" msg:"group" copy_linux:"GetProcessGroup;event:*"`
 	Exe            string    `json:"exe" msg:"exe" copy_linux:"GetExecFilePath;event:*"`


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Very small fix, probably caused by some copy paste mistake, allowing to correctly get the gid and not the uid and the fork time and not the exec time from the process coming from the process data stream (event monitor / process data from the CWS product).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->