### PR TITLE
chore(origindetection): remove OriginInfo.PodUID field

### DIFF
--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -416,7 +416,7 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 		// | none                   | not empty       || container prefix + originFromMsg    |
 		if t.datadogConfig.dogstatsdOptOutEnabled && originInfo.Cardinality == types.NoneCardinalityString {
 			originInfo.ContainerIDFromSocket = packets.NoOrigin
-			originInfo.PodUID = ""
+			originInfo.LocalData.PodUID = ""
 			originInfo.LocalData.ContainerID = ""
 			return
 		}
@@ -424,7 +424,7 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 		// We use the UDS socket origin if no origin ID was specify in the tags
 		// or 'dogstatsd_entity_id_precedence' is set to False (default false).
 		if originInfo.ContainerIDFromSocket != packets.NoOrigin &&
-			(originInfo.PodUID == "" || !t.datadogConfig.dogstatsdEntityIDPrecedenceEnabled) &&
+			(originInfo.LocalData.PodUID == "" || !t.datadogConfig.dogstatsdEntityIDPrecedenceEnabled) &&
 			len(originInfo.ContainerIDFromSocket) > containerIDFromSocketCutIndex {
 			containerID := originInfo.ContainerIDFromSocket[containerIDFromSocketCutIndex:]
 			originFromClient := types.NewEntityID(types.ContainerID, containerID)
@@ -435,11 +435,11 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 
 		// originFromClient can either be originInfo.FromTag or originInfo.FromMsg
 		var originFromClient types.EntityID
-		if originInfo.PodUID != "" && originInfo.PodUID != "none" {
+		if originInfo.LocalData.PodUID != "" && originInfo.LocalData.PodUID != "none" {
 			// Check if the value is not "none" in order to avoid calling the tagger for entity that doesn't exist.
 			// Currently only supported for pods
-			originFromClient = types.NewEntityID(types.KubernetesPodUID, originInfo.PodUID)
-		} else if originInfo.PodUID == "" && len(originInfo.LocalData.ContainerID) > 0 {
+			originFromClient = types.NewEntityID(types.KubernetesPodUID, originInfo.LocalData.PodUID)
+		} else if originInfo.LocalData.PodUID == "" && len(originInfo.LocalData.ContainerID) > 0 {
 			// originInfo.FromMsg is the container ID sent by the newer clients.
 			originFromClient = types.NewEntityID(types.ContainerID, originInfo.LocalData.ContainerID)
 		}
@@ -454,7 +454,7 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 		// Disable origin detection if cardinality is none
 		if originInfo.Cardinality == types.NoneCardinalityString {
 			originInfo.ContainerIDFromSocket = packets.NoOrigin
-			originInfo.PodUID = ""
+			originInfo.LocalData.PodUID = ""
 			originInfo.LocalData.ContainerID = ""
 			return
 		}
@@ -472,8 +472,8 @@ func (t *TaggerWrapper) EnrichTags(tb tagset.TagsAccumulator, originInfo taggert
 			t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.ContainerID, err)
 		}
 
-		if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.PodUID), cardinality, tb); err != nil {
-			t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.PodUID, err)
+		if err := t.AccumulateTagsFor(types.NewEntityID(types.KubernetesPodUID, originInfo.LocalData.PodUID), cardinality, tb); err != nil {
+			t.log.Tracef("Cannot get tags for entity %s: %s", originInfo.LocalData.PodUID, err)
 		}
 
 		// Accumulate tags for pod UID

--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -109,18 +109,34 @@ func TestEnrichTags(t *testing.T) {
 			}, expectedTags: []string{"container-low", "container-orch", "container-high"},
 		},
 		{
-			name:         "with local data (podUID) and low cardinality",
-			originInfo:   taggertypes.OriginInfo{PodUID: podUID, Cardinality: "low"},
+			name: "with local data (podUID) and low cardinality",
+			originInfo: taggertypes.OriginInfo{
+				LocalData: origindetection.LocalData{
+					PodUID: podUID,
+				},
+				Cardinality: "low",
+			},
 			expectedTags: []string{"pod-low"},
 		},
 		{
-			name:         "with local data (podUID) and high cardinality",
-			originInfo:   taggertypes.OriginInfo{PodUID: podUID, Cardinality: "high"},
+			name: "with local data (podUID) and high cardinality",
+			originInfo: taggertypes.OriginInfo{
+				LocalData: origindetection.LocalData{
+					PodUID: podUID,
+				},
+				Cardinality: "high",
+			},
 			expectedTags: []string{"pod-low", "pod-orch", "pod-high"},
 		},
 		{
-			name:         "with local data (podUID, containerIDFromSocket) and high cardinality, APM origin",
-			originInfo:   taggertypes.OriginInfo{PodUID: podUID, Cardinality: "high", ContainerIDFromSocket: fmt.Sprintf("container_id://%s", containerID), ProductOrigin: origindetection.ProductOriginAPM},
+			name: "with local data (podUID, containerIDFromSocket) and high cardinality, APM origin",
+			originInfo: taggertypes.OriginInfo{
+				ContainerIDFromSocket: fmt.Sprintf("container_id://%s", containerID),
+				LocalData: origindetection.LocalData{
+					PodUID: podUID,
+				},
+				Cardinality:   "high",
+				ProductOrigin: origindetection.ProductOriginAPM},
 			expectedTags: []string{"container-low", "container-orch", "container-high", "pod-low", "pod-orch", "pod-high"},
 		},
 	} {
@@ -284,9 +300,9 @@ func TestEnrichTagsOptOut(t *testing.T) {
 	// Test without none cardinality
 	tagger.EnrichTags(tb, taggertypes.OriginInfo{
 		ContainerIDFromSocket: "container_id://bar",
-		PodUID:                "pod-uid",
 		LocalData: origindetection.LocalData{
 			ContainerID: "container-id",
+			PodUID:      "pod-uid",
 		},
 		Cardinality:   "low",
 		ProductOrigin: origindetection.ProductOriginDogStatsD,

--- a/comp/dogstatsd/server/batch.go
+++ b/comp/dogstatsd/server/batch.go
@@ -103,13 +103,13 @@ func (s *shardKeyGeneratorPerOrigin) Generate(sample metrics.MetricSample, shard
 	// We fall back on the generic sharding if:
 	// - the sample has a custom cardinality
 	// - we don't have the origin
-	if sample.OriginInfo.Cardinality != "" || (sample.OriginInfo.ContainerIDFromSocket == "" && sample.OriginInfo.PodUID == "" && sample.OriginInfo.LocalData.ContainerID == "") {
+	if sample.OriginInfo.Cardinality != "" || (sample.OriginInfo.ContainerIDFromSocket == "" && sample.OriginInfo.LocalData.PodUID == "" && sample.OriginInfo.LocalData.ContainerID == "") {
 		return s.shardKeyGeneratorBase.Generate(sample, shards)
 	}
 
 	// Otherwise, we isolate the samples based on the origin.
 	i, j := uint64(0), uint64(0)
-	i, j = murmur3.SeedStringSum128(i, j, sample.OriginInfo.PodUID)
+	i, j = murmur3.SeedStringSum128(i, j, sample.OriginInfo.LocalData.PodUID)
 	i, j = murmur3.SeedStringSum128(i, j, sample.OriginInfo.LocalData.ContainerID)
 	i, _ = murmur3.SeedStringSum128(i, j, sample.OriginInfo.ContainerIDFromSocket)
 

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -53,7 +53,7 @@ func extractTagsMetadata(tags []string, originFromUDS string, localData originde
 			host = tag[len(hostTagPrefix):]
 			continue
 		} else if strings.HasPrefix(tag, entityIDTagPrefix) {
-			origin.PodUID = tag[len(entityIDTagPrefix):]
+			origin.LocalData.PodUID = tag[len(entityIDTagPrefix):]
 			continue
 		} else if strings.HasPrefix(tag, CardinalityTagPrefix) {
 			origin.Cardinality = tag[len(CardinalityTagPrefix):]

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -100,7 +100,7 @@ func TestConvertParseMultiple(t *testing.T) {
 		assert.Equal(t, 0, len(parsed[0].Tags))
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
-		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
 		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 
@@ -110,7 +110,7 @@ func TestConvertParseMultiple(t *testing.T) {
 		assert.Equal(t, 0, len(parsed[1].Tags))
 		assert.Equal(t, "default-hostname", parsed[1].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
-		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
 		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[1].SampleRate, epsilon)
 	}
@@ -134,7 +134,7 @@ func TestConvertParseSingle(t *testing.T) {
 		assert.Equal(t, 0, len(parsed[0].Tags))
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
-		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
 		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
@@ -160,7 +160,7 @@ func TestConvertParseSingleWithTags(t *testing.T) {
 		assert.Equal(t, "bench", parsed[0].Tags[1])
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
-		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
 		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
@@ -186,7 +186,7 @@ func TestConvertParseSingleWithHostTags(t *testing.T) {
 		assert.Equal(t, "bench", parsed[0].Tags[1])
 		assert.Equal(t, "custom-host", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
-		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
 		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
@@ -212,7 +212,7 @@ func TestConvertParseSingleWithEmptyHostTags(t *testing.T) {
 		assert.Equal(t, "bench", parsed[0].Tags[1])
 		assert.Equal(t, "", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
-		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
 		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 1.0, parsed[0].SampleRate, epsilon)
 	}
@@ -236,7 +236,7 @@ func TestConvertParseSingleWithSampleRate(t *testing.T) {
 		assert.Equal(t, 0, len(parsed[0].Tags))
 		assert.Equal(t, "default-hostname", parsed[0].Host)
 		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
-		assert.Equal(t, "", parsed[0].OriginInfo.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
 		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
 		assert.InEpsilon(t, 0.21, parsed[0].SampleRate, epsilon)
 	}
@@ -257,7 +257,7 @@ func TestConvertParseSet(t *testing.T) {
 	assert.Equal(t, 0, len(parsed.Tags))
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", parsed.OriginInfo.PodUID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
@@ -277,7 +277,7 @@ func TestConvertParseSetUnicode(t *testing.T) {
 	assert.Equal(t, 0, len(parsed.Tags))
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", parsed.OriginInfo.PodUID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
@@ -297,7 +297,7 @@ func TestConvertParseGaugeWithPoundOnly(t *testing.T) {
 	assert.Equal(t, 0, len(parsed.Tags))
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", parsed.OriginInfo.PodUID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
@@ -318,7 +318,7 @@ func TestConvertParseGaugeWithUnicode(t *testing.T) {
 	assert.Equal(t, "intitulé:T0µ", parsed.Tags[0])
 	assert.Equal(t, "default-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", parsed.OriginInfo.PodUID)
+	assert.Equal(t, "", parsed.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
@@ -394,7 +394,7 @@ func TestConvertServiceCheckMinimal(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
@@ -441,7 +441,7 @@ func TestConvertServiceCheckMetadataTimestamp(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
@@ -459,7 +459,7 @@ func TestConvertServiceCheckMetadataHostname(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
@@ -477,7 +477,7 @@ func TestConvertServiceCheckMetadataHostnameInTag(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{}, sc.Tags)
 }
@@ -495,7 +495,7 @@ func TestConvertServiceCheckMetadataEmptyHostTag(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"other:tag"}, sc.Tags)
 }
@@ -513,7 +513,7 @@ func TestConvertServiceCheckMetadataTags(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"tag1", "tag2:test", "tag3"}, sc.Tags)
 }
@@ -531,7 +531,7 @@ func TestConvertServiceCheckMetadataMessage(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "this is fine", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
@@ -549,7 +549,7 @@ func TestConvertServiceCheckMetadataMultiple(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "this is fine", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"tag1:test", "tag2"}, sc.Tags)
 
@@ -562,7 +562,7 @@ func TestConvertServiceCheckMetadataMultiple(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", sc.OriginInfo.PodUID)
+	assert.Equal(t, "", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string(nil), sc.Tags)
 }
@@ -579,7 +579,7 @@ func TestServiceCheckOriginTag(t *testing.T) {
 	assert.Equal(t, servicecheck.ServiceCheckOK, sc.Status)
 	assert.Equal(t, "this is fine", sc.Message)
 	assert.Equal(t, "", sc.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "testID", sc.OriginInfo.PodUID)
+	assert.Equal(t, "testID", sc.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", sc.OriginInfo.LocalData.ContainerID)
 	assert.Equal(t, []string{"tag1:test", "tag2"}, sc.Tags)
 }
@@ -602,7 +602,7 @@ func TestConvertEventMinimal(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -624,7 +624,7 @@ func TestConvertEventMultilinesText(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -646,7 +646,7 @@ func TestConvertEventPipeInTitle(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -736,7 +736,7 @@ func TestConvertEventMetadataTimestamp(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -758,7 +758,7 @@ func TestConvertEventMetadataPriority(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -780,7 +780,7 @@ func TestConvertEventMetadataHostname(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -802,7 +802,7 @@ func TestConvertEventMetadataHostnameInTag(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -824,7 +824,7 @@ func TestConvertEventMetadataEmptyHostTag(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -846,7 +846,7 @@ func TestConvertEventMetadataAlertType(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -868,7 +868,7 @@ func TestConvertEventMetadataAggregatioKey(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -890,7 +890,7 @@ func TestConvertEventMetadataSourceType(t *testing.T) {
 	assert.Equal(t, "this is the source", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -912,7 +912,7 @@ func TestConvertEventMetadataTags(t *testing.T) {
 	assert.Equal(t, "", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -934,7 +934,7 @@ func TestConvertEventMetadataMultiple(t *testing.T) {
 	assert.Equal(t, "source test", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "", e.OriginInfo.PodUID)
+	assert.Equal(t, "", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 }
 
@@ -956,7 +956,7 @@ func TestEventOriginTag(t *testing.T) {
 	assert.Equal(t, "source test", e.SourceTypeName)
 	assert.Equal(t, "", e.EventType)
 	assert.Equal(t, "", e.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "testID", e.OriginInfo.PodUID)
+	assert.Equal(t, "testID", e.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", e.OriginInfo.LocalData.ContainerID)
 
 }
@@ -1064,7 +1064,7 @@ func TestConvertEntityOriginDetectionNoTags(t *testing.T) {
 	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
 	assert.Equal(t, "my-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "foo", parsed.OriginInfo.PodUID)
+	assert.Equal(t, "foo", parsed.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
@@ -1083,7 +1083,7 @@ func TestConvertEntityOriginDetectionTags(t *testing.T) {
 	assert.ElementsMatch(t, []string{"sometag1:somevalue1", "sometag2:somevalue2"}, parsed.Tags)
 	assert.Equal(t, "my-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "foo", parsed.OriginInfo.PodUID)
+	assert.Equal(t, "foo", parsed.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
@@ -1103,7 +1103,7 @@ func TestConvertEntityOriginDetectionTagsError(t *testing.T) {
 	assert.Equal(t, "sometag2:somevalue2", parsed.Tags[1])
 	assert.Equal(t, "my-hostname", parsed.Host)
 	assert.Equal(t, "", parsed.OriginInfo.ContainerIDFromSocket)
-	assert.Equal(t, "foo", parsed.OriginInfo.PodUID)
+	assert.Equal(t, "foo", parsed.OriginInfo.LocalData.PodUID)
 	assert.Equal(t, "", parsed.OriginInfo.LocalData.ContainerID)
 	assert.InEpsilon(t, 1.0, parsed.SampleRate, epsilon)
 }
@@ -1187,9 +1187,14 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "my-id"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "my-id",
+				},
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1204,9 +1209,14 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: true,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "none"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "none",
+				},
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1221,9 +1231,14 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "42"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "42",
+				},
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1238,9 +1253,15 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "42", Cardinality: "high"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "42",
+				},
+				Cardinality: "high",
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1255,9 +1276,15 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "42", Cardinality: "orchestrator"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "42",
+				},
+				Cardinality: "orchestrator",
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1272,9 +1299,15 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "42", Cardinality: "low"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "42",
+				},
+				Cardinality: "low",
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1289,9 +1322,15 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "42", Cardinality: "unknown"},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "42",
+				},
+				Cardinality: "unknown",
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1306,9 +1345,15 @@ func TestEnrichTags(t *testing.T) {
 					entityIDPrecedenceEnabled: false,
 				},
 			},
-			wantedTags:         []string{"env:prod"},
-			wantedHost:         "foo",
-			wantedOrigin:       taggertypes.OriginInfo{ContainerIDFromSocket: "originID", PodUID: "42", Cardinality: ""},
+			wantedTags: []string{"env:prod"},
+			wantedHost: "foo",
+			wantedOrigin: taggertypes.OriginInfo{
+				ContainerIDFromSocket: "originID",
+				LocalData: origindetection.LocalData{
+					PodUID: "42",
+				},
+				Cardinality: "",
+			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
 		},
 		{
@@ -1329,9 +1374,9 @@ func TestEnrichTags(t *testing.T) {
 			wantedHost: "foo",
 			wantedOrigin: taggertypes.OriginInfo{
 				ContainerIDFromSocket: "originID",
-				PodUID:                "pod-uid",
 				LocalData: origindetection.LocalData{
 					ContainerID: "container-id",
+					PodUID:      "pod-uid",
 				},
 			},
 			wantedMetricSource: metrics.MetricSourceDogstatsd,
@@ -1406,9 +1451,9 @@ func TestEnrichTags(t *testing.T) {
 			wantedHost: "foo",
 			wantedOrigin: taggertypes.OriginInfo{
 				ContainerIDFromSocket: "originID",
-				PodUID:                "pod-uid",
 				LocalData: origindetection.LocalData{
 					ContainerID: "container-id",
+					PodUID:      "pod-uid",
 				},
 				ExternalData: origindetection.ExternalData{
 					Init:          false,

--- a/pkg/tagger/types/types.go
+++ b/pkg/tagger/types/types.go
@@ -11,7 +11,6 @@ import "github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 // OriginInfo contains the Origin Detection information.
 type OriginInfo struct {
 	ContainerIDFromSocket string                        // ContainerIDFromSocket is the origin resolved using Unix Domain Socket.
-	PodUID                string                        // PodUID is the origin resolved from the Kubernetes Pod UID.
 	LocalData             origindetection.LocalData     // LocalData is the local data list.
 	ExternalData          origindetection.ExternalData  // ExternalData is the external data list.
 	Cardinality           string                        // Cardinality is the cardinality of the resolved origin.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the `OriginInfo.PodUID` in favor of `OriginInfo.LocalData.PodUID`.

### Motivation

This is done to allow for migration from `taggertypes` to `origindetection`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

QA done by unit and E2E tests.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A