### PR TITLE
add nolint:staticcheck for security-agent files

### DIFF
--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_dec_v1.go
@@ -39,7 +39,7 @@ func protoDecodeProcessActivityNode(parent ProcessNodeParent, pan *adproto.Proce
 		DNSNames:       make(map[string]*DNSNode, len(pan.DnsNames)),
 		IMDSEvents:     make(map[model.IMDSEvent]*IMDSNode, len(pan.ImdsEvents)),
 		Sockets:        make([]*SocketNode, 0, len(pan.Sockets)),
-		Syscalls:       make([]*SyscallNode, 0, len(pan.Syscalls)),
+		Syscalls:       make([]*SyscallNode, 0, len(pan.Syscalls)), // nolint:staticcheck // TODO: update syscall functionality
 		ImageTags:      pan.ImageTags,
 	}
 
@@ -73,7 +73,7 @@ func protoDecodeProcessActivityNode(parent ProcessNodeParent, pan *adproto.Proce
 		ppan.Sockets = append(ppan.Sockets, protoDecodeProtoSocket(socket))
 	}
 
-	for _, sysc := range pan.Syscalls {
+	for _, sysc := range pan.Syscalls { // nolint:staticcheck // TODO: update syscall functionality
 		ppan.Syscalls = append(ppan.Syscalls, NewSyscallNode(int(sysc), "", Unknown))
 	}
 

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
@@ -71,7 +71,7 @@ func processActivityNodeToProto(pan *ProcessNode) *adproto.ProcessActivityNode {
 	}
 
 	for _, sysc := range pan.Syscalls {
-		ppan.Syscalls = append(ppan.Syscalls, uint32(sysc.Syscall))
+		ppan.Syscalls = append(ppan.Syscalls, uint32(sysc.Syscall)) // nolint:staticcheck // TODO: update syscall functionality
 	}
 
 	return ppan


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
skips deprecation check for pan.Syscall in pkg/security
### Motivation
blocked on PR to update collector dependencies: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/762365960#L982
### Describe how you validated your changes
linters in pipeline
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
needs follow-up work/ticket from security-agent team
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->