### PR TITLE
Warn when using deprecated process_config.enabled

### DIFF
--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -224,7 +224,7 @@ func overrideRunInCoreAgentConfig(config pkgconfigmodel.Config) {
 // loadProcessTransforms loads transforms associated with process config settings.
 func loadProcessTransforms(config pkgconfigmodel.Config) {
 	if config.IsSet("process_config.enabled") {
-		log.Info("process_config.enabled is deprecated, use process_config.container_collection.enabled " +
+		log.Warn("process_config.enabled is deprecated, use process_config.container_collection.enabled " +
 			"and process_config.process_collection.enabled instead, " +
 			"see https://docs.datadoghq.com/infrastructure/process#installation for more information")
 		procConfigEnabled := strings.ToLower(config.GetString("process_config.enabled"))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes the deprecation message log level from INFO to WARN.

### Motivation

https://datadoghq.atlassian.net/browse/CTK-4640

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manually validated by:

1. setting `process_config.enabled` in the agent configuration to `"true"`, e.g.,:

   ```sh
   cat <<-YAML >> /etc/datadog-agent/datadog.yaml
   process_config:
     enabled: "true"
   ```

2. starting the agent with `datadog-agent run`, and 

3. visually confirming the log level in the output.

<img width="1414" alt="image" src="https://github.com/user-attachments/assets/9a5ab50b-7d9d-450b-bf5e-4aa489cdce5d" />

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->