### PR TITLE
add error log when failing to parse kubernetes logging annotation

### DIFF
--- a/pkg/logs/schedulers/ad/scheduler.go
+++ b/pkg/logs/schedulers/ad/scheduler.go
@@ -152,6 +152,10 @@ func CreateSources(config integration.Config) ([]*sourcesPkg.LogSource, error) {
 	case names.Container, names.Kubernetes, names.KubeContainer:
 		// config attached to a container label or a pod annotation
 		configs, err = logsConfig.ParseJSON(config.LogsConfig)
+		if err != nil {
+			log.Errorf("Error parsing logs config from Kubernetes label or pod annotation (container=%q service=%q source=%q name=%q): %v",
+			names.Container, config.ServiceID, config.Source, config.Name, err)
+		}
 	case names.RemoteConfig:
 		if pkgconfigsetup.Datadog().GetBool("remote_configuration.agent_integrations.allow_log_config_scheduling") {
 			// config supplied by remote config


### PR DESCRIPTION
### What does this PR do?
Adds an error log line when failing to parse logging config that helps the user track down where the parsing error came from

### Motivation
Currently, when datadog fails to parse a logging configuration annotation, it logs an error like "Failed to create source  could not parse JSON logs config: unexpected end of JSON input" (picture attached).
<img width="767" alt="Screenshot 2025-01-10 at 2 47 04 PM" src="https://github.com/user-attachments/assets/50883513-c9bd-444d-a1bd-5793cba2d7d6" />

This is extremely hard to diagnose! This PR adds a new error log line that provides a hint as to where the error came from, ideally logging enough information for the user to find and fix the bad annotation.


### Describe how you validated your changes
I did not validate these changes, I would love some help with that!

### Possible Drawbacks / Trade-offs
This adds a _second_ error log, which might be even more noisy than before. It might be better for a proper solution here to enrich the "Failed to create source" message instead, tho we might not have the specificity there to provide Kubernetes assistance.

Thank you!