### PR TITLE
fix(create_rc): Prevent failure when we have more than one active release branch

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -161,7 +161,7 @@ def check_base_branch(branch, release_version):
     Checks if the given branch is either the default branch or the release branch associated
     with the given release version.
     """
-    return branch == get_default_branch() or branch == release_version.branch()
+    return branch == get_default_branch() or branch == release_version
 
 
 def try_git_command(ctx, git_command, non_interactive_retries=2, non_interactive_delay=5):

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -408,10 +408,11 @@ def create_rc(ctx, release_branch, patch_version=False, upstream="origin", slack
         update_branch = f"release/{new_highest_version}-{int(time.time())}"
 
         check_clean_branch_state(ctx, github, update_branch)
-        if not check_base_branch(release_branch, new_highest_version):
+        active_releases = [branch.name for branch in github.latest_unreleased_release_branches()]
+        if not any(check_base_branch(release_branch, unreleased_branch) for unreleased_branch in active_releases):
             raise Exit(
                 color_message(
-                    f"The branch you are on is neither {get_default_branch()} or the correct release branch ({new_highest_version.branch()}). Aborting.",
+                    f"The branch you are on is neither {get_default_branch()} or amongst the active release branches ({active_releases}). Aborting.",
                     "red",
                 ),
                 code=1,
@@ -514,7 +515,7 @@ def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False):
         print(color_message("Checking repository state", "bold"))
 
         # Check that the base branch is valid
-        if not check_base_branch(release_branch, new_version):
+        if not check_base_branch(release_branch, new_version.branch()):
             raise Exit(
                 color_message(
                     f"The branch you are on is neither {get_default_branch()} or the correct release branch ({new_version.branch()}). Aborting.",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Check the valid branch on the `create-rc` task versus all the active release branches

### Motivation
Prevent [failure](https://github.com/DataDog/datadog-agent/actions/runs/12743015267/job/35512189543) in RC creation when we have more than one release to deal with

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->