### PR TITLE
[CWS] allow publishing dev custom build of cws-instrumentation on branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -644,11 +644,6 @@ workflow:
 .on_all_builds:
   - <<: *if_run_all_builds
 
-.on_all_builds_manual:
-  - <<: *if_run_all_builds
-    when: manual
-    allow_failure: true
-
 .on_e2e_tests:
   - <<: *if_installer_tests
 

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -126,7 +126,7 @@ dca_dev_branch:
 dca_dev_branch_multiarch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_all_builds_manual]
+  rules: !reference [.manual]
   needs:
     - docker_build_cluster_agent_amd64
     - docker_build_cluster_agent_arm64
@@ -149,7 +149,7 @@ dca_dev_master:
 cws_instrumentation_dev_branch_multiarch:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy
-  rules: !reference [.on_all_builds_manual]
+  rules: !reference [.manual]
   needs:
     - docker_build_cws_instrumentation_amd64
     - docker_build_cws_instrumentation_arm64


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR allows the `dca_dev_branch_multiarch` and `cws_instrumentation_dev_branch_multiarch` to be present on regular branches (similar to the regular agent jobs). Those jobs are manual anyway, so there is no real reason to gate them under "deploy" pipelines.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->