### PR TITLE
[CWS] allow custom builds to deploy `cws-instrumentation`

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -20,7 +20,7 @@ include:
 # will push the `7.xx.y-rc.z` tags
 deploy_containers-cws-instrumentation-rc-versioned:
   extends: .deploy_containers-cws-instrumentation-base
-  rules: !reference [.on_deploy_rc]
+  rules: !reference [.on_deploy_manual_auto_on_rc]
 
 # will update the `rc` tag
 deploy_containers-cws-instrumentation-rc-mutable:


### PR DESCRIPTION
### What does this PR do?

Currently when trying to create a custom build following https://datadoghq.atlassian.net/wiki/spaces/agent/pages/1568966971/How+to+create+custom+Agent+builds, you cannot publish the `cws-instrumentation` image to registries.

This PR fixes this by ensuring the job is available (with a manual trigger) on custom build pipelines. 

### Motivation

Being able to ship bug fixes through custom builds of the cws-instrumentation binary.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->