### PR TITLE
[EBPF] gpu: use the tagger to add GPU-related tags

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -162,13 +162,13 @@ func (c *Check) emitSysprobeMetrics(snd sender.Sender) error {
 }
 
 func (c *Check) getTagsForKey(key model.StatsKey) []string {
-	// Container ID tag will be added or not depending on the tagger configuration
 	// PID is always added
 	tags := []string{
 		// Per-PID metrics are subject to change due to high cardinality
 		fmt.Sprintf("pid:%d", key.PID),
 	}
 
+	// Container ID tag will be added or not depending on the tagger configuration
 	containerEntityID := taggertypes.NewEntityID(taggertypes.ContainerID, key.ContainerID)
 	containerTags, err := c.tagger.Tag(containerEntityID, c.tagger.ChecksCardinality())
 	if err != nil {

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -85,7 +85,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, config, 
 	}
 
 	var err error
-	c.collectors, err = nvidia.BuildCollectors(c.nvmlLib)
+	c.collectors, err = nvidia.BuildCollectors(&nvidia.CollectorDependencies{NVML: c.nvmlLib, Tagger: c.tagger})
 	if err != nil {
 		return fmt.Errorf("failed to build NVML collectors: %w", err)
 	}
@@ -162,21 +162,30 @@ func (c *Check) emitSysprobeMetrics(snd sender.Sender) error {
 }
 
 func (c *Check) getTagsForKey(key model.StatsKey) []string {
-	entityID := taggertypes.NewEntityID(taggertypes.ContainerID, key.ContainerID)
-	tags, err := c.tagger.Tag(entityID, c.tagger.ChecksCardinality())
-	if err != nil {
-		log.Errorf("Error collecting container tags for process %d: %s", key.PID, err)
-	}
-
 	// Container ID tag will be added or not depending on the tagger configuration
-	// PID and GPU UUID are always added as they're not relying on the tagger yet
-	keyTags := []string{
+	// PID is always added
+	tags := []string{
 		// Per-PID metrics are subject to change due to high cardinality
 		fmt.Sprintf("pid:%d", key.PID),
-		fmt.Sprintf("gpu_uuid:%s", key.DeviceUUID),
 	}
 
-	return append(tags, keyTags...)
+	containerEntityID := taggertypes.NewEntityID(taggertypes.ContainerID, key.ContainerID)
+	containerTags, err := c.tagger.Tag(containerEntityID, c.tagger.ChecksCardinality())
+	if err != nil {
+		log.Errorf("Error collecting container tags for process %d: %s", key.PID, err)
+	} else {
+		tags = append(tags, containerTags...)
+	}
+
+	gpuEntityID := taggertypes.NewEntityID(taggertypes.GPU, key.DeviceUUID)
+	gpuTags, err := c.tagger.Tag(gpuEntityID, c.tagger.ChecksCardinality())
+	if err != nil {
+		log.Errorf("Error collecting GPU tags for process %d: %s", key.PID, err)
+	} else {
+		tags = append(tags, gpuTags...)
+	}
+
+	return tags
 }
 
 func (c *Check) emitNvmlMetrics(snd sender.Sender) error {

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -23,12 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-const (
-	tagVendor    = "gpu_vendor:nvidia"
-	tagNameModel = "gpu_model"
-	tagNameUUID  = "gpu_uuid"
-)
-
 // Collector defines a collector that gets metric from a specific NVML subsystem and device
 type Collector interface {
 	// Collect collects metrics from the given NVML device. This method should not fill the tags
@@ -65,9 +59,13 @@ var allSubsystems = map[string]subsystemBuilder{
 	clocksCollectorName:       newClocksCollector,
 }
 
+// CollectorDependencies holds the dependencies needed to create a set of collectors.
 type CollectorDependencies struct {
+	// Tagger is the tagger component used to tag the metrics.
 	Tagger tagger.Component
-	NVML   nvml.Interface
+
+	// NVML is the NVML library interface used to interact with the NVIDIA devices.
+	NVML nvml.Interface
 }
 
 // BuildCollectors returns a set of collectors that can be used to collect metrics from NVML.

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -120,7 +120,7 @@ func getTagsFromDevice(dev nvml.Device, tagger tagger.Component) ([]string, erro
 	entityID := taggertypes.NewEntityID(taggertypes.GPU, uuid)
 	tags, err := tagger.Tag(entityID, tagger.ChecksCardinality())
 	if err != nil {
-		log.Errorf("Error collecting GPU tags for GPU UUID %s: %s", uuid, err)
+		log.Warnf("Error collecting GPU tags for GPU UUID %s: %s", uuid, err)
 	}
 
 	return tags, nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the GPU check to use the tagger for GPU related tags.

### Motivation

Uniform tagging and using the data from WMS.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

E2E tests updated to ensure the metrics have the tags we want.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Requires both https://github.com/DataDog/datadog-agent/pull/32052 and https://github.com/DataDog/datadog-agent/pull/32109 to work properly.