### PR TITLE
feat(dogstatsd): add cardinality common field

### DIFF
--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _ = extractTagsMetadata(baseTags, "", 0, origindetection.LocalData{}, origindetection.ExternalData{}, conf)
+				tags, _, _, _ = extractTagsMetadata(baseTags, "", 0, origindetection.LocalData{}, origindetection.ExternalData{}, "", conf)
 			}
 		})
 	}

--- a/comp/dogstatsd/server/parse.go
+++ b/comp/dogstatsd/server/parse.go
@@ -48,6 +48,9 @@ var (
 
 	// externalDataPrefix is the prefix for a common field which contains the external data for Origin Detection.
 	externalDataPrefix = []byte("e:")
+
+	// cardinalityPrefix is the prefix for a common field which contains the cardinality for Origin Detection.
+	cardinalityPrefix = []byte("card:")
 )
 
 // parser parses dogstatsd messages
@@ -174,6 +177,7 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 	var tags []string
 	var localData origindetection.LocalData
 	var externalData origindetection.ExternalData
+	var cardinality string
 	var optionalField []byte
 	var timestamp time.Time
 	for message != nil {
@@ -207,6 +211,9 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 		// external data
 		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 			externalData = p.parseExternalData(optionalField[len(externalDataPrefix):])
+		// cardinality
+		case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, cardinalityPrefix):
+			cardinality = string(optionalField[len(cardinalityPrefix):])
 		}
 	}
 
@@ -220,6 +227,7 @@ func (p *parser) parseMetricSample(message []byte) (dogstatsdMetricSample, error
 		tags:         tags,
 		localData:    localData,
 		externalData: externalData,
+		cardinality:  cardinality,
 		ts:           timestamp,
 	}, nil
 }

--- a/comp/dogstatsd/server/parse_events.go
+++ b/comp/dogstatsd/server/parse_events.go
@@ -43,6 +43,8 @@ type dogstatsdEvent struct {
 	localData origindetection.LocalData
 	// externalData is used for Origin Detection
 	externalData origindetection.ExternalData
+	// cardinality is used for Origin Detection
+	cardinality string
 }
 
 type eventHeader struct {
@@ -170,6 +172,8 @@ func (p *parser) applyEventOptionalField(event dogstatsdEvent, optionalField []b
 		newEvent.localData = p.parseLocalData(optionalField[len(localDataPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newEvent.externalData = p.parseExternalData(optionalField[len(externalDataPrefix):])
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, cardinalityPrefix):
+		newEvent.cardinality = string(optionalField[len(cardinalityPrefix):])
 	}
 	if err != nil {
 		return event, err

--- a/comp/dogstatsd/server/parse_metrics.go
+++ b/comp/dogstatsd/server/parse_metrics.go
@@ -51,6 +51,8 @@ type dogstatsdMetricSample struct {
 	localData origindetection.LocalData
 	// externalData is used for Origin Detection
 	externalData origindetection.ExternalData
+	// cardinality is used for Origin Detection
+	cardinality string
 	// timestamp read in the message if any
 	ts time.Time
 }

--- a/comp/dogstatsd/server/parse_service_checks.go
+++ b/comp/dogstatsd/server/parse_service_checks.go
@@ -34,6 +34,8 @@ type dogstatsdServiceCheck struct {
 	localData origindetection.LocalData
 	// externalData is used for Origin Detection
 	externalData origindetection.ExternalData
+	// cardinality is used for Origin Detection
+	cardinality string
 }
 
 var (
@@ -104,6 +106,8 @@ func (p *parser) applyServiceCheckOptionalField(serviceCheck dogstatsdServiceChe
 		newServiceCheck.localData = p.parseLocalData(optionalField[len(localDataPrefix):])
 	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, externalDataPrefix):
 		newServiceCheck.externalData = p.parseExternalData(optionalField[len(externalDataPrefix):])
+	case p.dsdOriginEnabled && bytes.HasPrefix(optionalField, cardinalityPrefix):
+		newServiceCheck.cardinality = string(optionalField[len(cardinalityPrefix):])
 	}
 	if err != nil {
 		return serviceCheck, err

--- a/releasenotes/notes/dogstatsd_cardinality_field-564b3d846700335c.yaml
+++ b/releasenotes/notes/dogstatsd_cardinality_field-564b3d846700335c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add new `card:` common field to DogStatsD Datagram specification to allow
+    customer to specify the cardinality of the metric. This field is optional.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a new `card:` common field to DogStatsD Datagram spec. This new field is used by the libraries to override the Agent cardinality.

### Motivation

This is done to allow customer to have more granularity for cardinality.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
With the Operator installed, deploy the following manifest:
```
datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  override:
    nodeAgent:
      image:
        tag: TAG
        pullPolicy: Always
    clusterAgent:
      image:
        tag: TAG
        pullPolicy: Always
    clusterChecksRunner:
      image:
        tag: TAG
        pullPolicy: Always
global:
    kubelet:
      tlsVerify: false
    credentials:
      apiSecret:
        secretName: datadog-secret
        keyName: api-key
      appSecret:
        secretName: datadog-secret
        keyName: app-key
    originDetectionUnified:
      enabled: true
  features:
    admissionController:
      enabled: true
    dogstatsd:
      originDetectionEnabled: true
      tagCardinality: "high"
      hostPortConfig:
        enabled: true
```

Deploy the following application:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadogpy
spec:
  replicas: 1
  selector:
    matchLabels:
      app: datadogpy
  template:
    metadata:
      labels:
        app: datadogpy
        admission.datadoghq.com/enabled: "true"
    spec:
      containers:
      - name: datadogpy
        image: wdhifdatadog/datadogpy
        imagePullPolicy: Always
        env:
        - name: USER
          value: "wdhif"
        - name: DD_DOGSTATSD_URL
          value: /var/run/datadog/dsd.socket
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: DD_ENTITY_ID
          valueFrom:
            fieldRef:
              fieldPath: metadata.uid
        volumeMounts:
        - mountPath: /var/run/datadog
          name: dogstatsd-socket
      volumes:
      - name: dogstatsd-socket
        hostPath:
          path: /var/run/datadog/
```

Using this notebook, you should see each metrics with the correct tags: https://dddev.datadoghq.com/notebook/11080048/dogstatsd-cardinality-test?notebookType=legacy&view=view-mode

<img width="832" alt="image" src="https://github.com/user-attachments/assets/959ec04f-8777-4987-b0a4-3a7ac90fa3a2" />
<img width="832" alt="image" src="https://github.com/user-attachments/assets/0d62a31d-dbc2-4d70-a48b-50ba1fba3b8c" />
<img width="832" alt="image" src="https://github.com/user-attachments/assets/792ea685-adad-44fd-b339-866ab0af4bdd" />


### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
None