### PR TITLE
[APR-248] Consider ADP when determining JMXFetch StatsD configuration.

### DIFF
--- a/comp/dogstatsd/server/component.go
+++ b/comp/dogstatsd/server/component.go
@@ -20,9 +20,6 @@ type Component interface {
 	// IsRunning returns true if the server is running
 	IsRunning() bool
 
-	// UdsListenerRunning returns true if the uds listener is running
-	UdsListenerRunning() bool
-
 	// ServerlessFlush flushes all the data to the aggregator to them send it to the Datadog intake.
 	ServerlessFlush(time.Duration)
 

--- a/comp/dogstatsd/server/server_integration_test.go
+++ b/comp/dogstatsd/server/server_integration_test.go
@@ -136,7 +136,6 @@ func TestUDSConn(t *testing.T) {
 	cfg["dogstatsd_socket"] = socketPath
 
 	deps := fulfillDepsWithConfigOverride(t, cfg)
-	require.True(t, deps.Server.UdsListenerRunning())
 
 	conn, err := net.Dial("unixgram", socketPath)
 	require.NoError(t, err, "cannot connect to DSD socket")
@@ -195,9 +194,7 @@ func TestUDSReceiverNoDir(t *testing.T) {
 	cfg["dogstatsd_no_aggregation_pipeline"] = true // another test may have turned it off
 	cfg["dogstatsd_socket"] = socketPath
 
-	deps := fulfillDepsWithConfigOverride(t, cfg)
-	require.False(t, deps.Server.UdsListenerRunning())
-
+	_ = fulfillDepsWithConfigOverride(t, cfg)
 	_, err := net.Dial("unixgram", socketPath)
 	require.Error(t, err, "UDS listener should be closed")
 }

--- a/comp/dogstatsd/server/server_mock.go
+++ b/comp/dogstatsd/server/server_mock.go
@@ -54,11 +54,6 @@ func (s *serverMock) Capture(_ string, _ time.Duration, _ bool) (string, error) 
 	return "", nil
 }
 
-// UdsListenerRunning is a mocked function that returns false
-func (s *serverMock) UdsListenerRunning() bool {
-	return false
-}
-
 // UDPLocalAddr is a mocked function but UDP isn't enabled on the mock
 func (s *serverMock) UDPLocalAddr() string {
 	return ""

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -9,7 +9,6 @@ package server
 
 import (
 	"fmt"
-	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -30,19 +29,6 @@ func TestNewServer(t *testing.T) {
 	deps := fulfillDepsWithConfigOverride(t, cfg)
 	requireStart(t, deps.Server)
 
-}
-
-func TestUDSReceiverDisabled(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("UDS isn't supported on windows")
-	}
-	cfg := make(map[string]interface{})
-	cfg["dogstatsd_port"] = listeners.RandomPortName
-	cfg["dogstatsd_no_aggregation_pipeline"] = true // another test may have turned it off
-	cfg["dogstatsd_socket"] = ""                    // disabled
-
-	deps := fulfillDepsWithConfigOverride(t, cfg)
-	require.False(t, deps.Server.UdsListenerRunning())
 }
 
 // This test is proving that no data race occurred on the `cachedTlmOriginIds` map.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1937,6 +1937,8 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		// these variables are used by source code integration
 		"DD_GIT_COMMIT_SHA":     {},
 		"DD_GIT_REPOSITORY_URL": {},
+		// signals where or not ADP is enabled
+		"DD_ADP_ENABLED": {},
 	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1937,7 +1937,7 @@ func findUnknownEnvVars(config pkgconfigmodel.Config, environ []string, addition
 		// these variables are used by source code integration
 		"DD_GIT_COMMIT_SHA":     {},
 		"DD_GIT_REPOSITORY_URL": {},
-		// signals where or not ADP is enabled
+		// signals whether or not ADP is enabled
 		"DD_ADP_ENABLED": {},
 	}
 	for _, key := range config.GetEnvVars() {


### PR DESCRIPTION
### What does this PR do?

This PR adds support for considering whether or not Agent Data Plane (ADP) is enabled when deciding how to configure JMXFetch's StatsD client.

Instead of always examining the DSD component, we've simplified the logic somewhat to consider whether or not DSD is _configured_ to run (or ADP is set as enabled), as well as the _configuration_ of either UDS or UDP in the Agent.

In turn, we've updated the logic and the logging to indicate when we're falling back to using UDP to highlight scenarios where there is a misconfiguration.

### Motivation

When running ADP, DSD is disabled in the Core Agent as ADP takes over responsibility. This means that when the current JMXFetch configuration code checks whether or not the Agent is running a DSD UDS listener, it will incorrectly determine that there is no UDS listener, and fallback to UDP. In cases where the UDP listener is present, this will still allow JMXFetch to function, but will likely lead to many spurious JMXFetch logs due to the reduced packet size (determined by the default optimal packet size for the configured transport) leading to an inability to build and send many of the typical metrics payloads that JMXFetch would otherwise send.

In these scenarios, we know that if ADP is enabled, it will be utilizing the same Agent configuration to decide whether or not to run a DSD UDP listener, or UDS listener, and so on... and so the logic simply becomes determining if _any_ DSD server will be started (`use_dogstatsd` == `true`, or `DD_ADP_ENABLED` set to `"true"`) and which listener configuration settings are present (`dogstatsd_socket` != `""`, `dogstatsd_port` != `0`, etc).

Following from this, we also enhance the logic to emit a warning log when we're unable to actually determine that a DSD server should be running, which gives us a signal we did not previously have during Agent startup, to understand potential JMXFetch issues with not sending metrics to the Agent.

### Describe how you validated your changes

I built and ran the Agent locally, which requires JMXFetch to be configured such that JMXFetch gets started by the Core Agent. Following the instructions in the **Testing the agent with JMXFetch** page in Confluence can help get started with this. The normal `agent.build` invoke task will build in JMX support by default.

With `use_dogstatsd: true` and `dogstatsd_port: 8125` in the configuration (or some non-zero value for `dogstatsd_port`), we should end up seeing a log line like this:

> 2025-01-13 10:15:31 EST | JMX | INFO | main | StatsdReporter | Initializing Statsd reporter with parameters host=localhost port=8125 telemetry=false queueSize=4096 entityId=null blocking=true

This indicates that JMXFetch is running and configured to use UDP. If we remove the the `dogstats_port` line and instead set `dogstatsd_socket: /tmp/jmxfetch-adp-support.sock` (path can be whatever, so long as your user has permissions), we should instead see:

> 2025-01-13 10:47:32 EST | JMX | INFO | main | StatsdReporter | Initializing Statsd reporter with parameters host=/tmp/jmxfetch-adp-support.sock port=0 telemetry=false queueSize=4096 entityId=none blocking=true maxPacketSize=8192

We can now see the UDS socket path is being used. So far, this is all replicating of the normal, expected behavior. Now, we'll set `use_dogstatsd: false` but set the `DD_ADP_ENABLED` environment variable to `true` when running the Agent (e.g., `DD_ADP_ENABLED=true bin/agent/agent -c bin/agent/dist run` when running locally), and repeat the two tests above.

The same output should be seen -- `host=localhost port=8125` and `host=/tmp/jmxfetch-adp-support.sock port=0` -- since the same configuration should be used regardless of whether DSD is provided by the Core Agent or ADP.

Finally, we'll simulate a scenario where DSD is disabled in the Core Agent (`use_dogstatsd: false`) and ADP is not enabled (don't set `DD_ADP_ENABLED` this time) which should lead to the Agent warning us that we can't determine the status of DogStatsD, and that we're falling back to UDP:

> 2025-01-13 10:51:23 EST | CORE | WARN | (pkg/jmxfetch/jmxfetch.go:226 in Start) | DogStatsD status is unknown, falling back to UDP. JMXFetch may not be able to report metrics.

Since we're still falling back, we should see the same sort of UDP-specific output further below:

> 2025-01-13 10:51:23 EST | JMX | INFO | main | StatsdReporter | Initializing Statsd reporter with parameters host=localhost port=8125 telemetry=false queueSize=4096 entityId=null blocking=true

### Possible Drawbacks / Trade-offs

### Additional Notes

I removed the `UdsListenerRunning` method from the DogStatsD component, along with the accompanying unit tests for it. Since we only relied on this for the purpose of JMXFetch, it didn't seem prudent to keep it around, especially since it also lacks any differentiation around UDS in datagram vs stream mode.

I'm happy to add it back, but again, it just didn't seem to make sense keeping it with nothing _actually_ depending on it.