### PR TITLE
[POC] Check Python paths to determine if a check is Python

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -319,6 +319,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// library support will not work reliably in those environments)
 	config.BindEnvAndSetDefault("allow_python_path_heuristics_failure", false)
 
+	config.BindEnvAndSetDefault("python_loader_check_module_paths", true)
+	config.BindEnvAndSetDefault("python_paths_exec_timeout", 1*time.Second)
+
 	// if/when the default is changed to true, make the default platform
 	// dependent; default should remain false on Windows to maintain backward
 	// compatibility with Agent5 behavior/win


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
https://datadoghq.atlassian.net/browse/ASCII-2651
-->
### What does this PR do?
Get Python's `sys.path`, and use it to check if a check has a Python version, rather than loading it.

### Motivation
It would allow checking if a check is Python without loading Python, which would unblock [checks-agent POC](https://github.com/DataDog/datadog-agent/pull/31571) or [lazy loading rtloader POC](https://github.com/DataDog/datadog-agent/pull/32611).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
As is, this doesn't really help, since there is an `io` default check, and also an `io` standard library module, so we would always have to start Python to know if it's an actual check or not.

We could just hardcode that `io` is an exception and we know it's Go, but it also means break any user using an `io` custom check...

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I'm only opening this PR to keep tracks of it.
