### PR TITLE
Pass DBMS to SQL obfuscator

### DIFF
--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -433,7 +433,7 @@ func newCheck() check.Check {
 
 //nolint:revive // TODO(DBM) Fix revive linter
 func (c *Check) GetObfuscatedStatement(o *obfuscate.Obfuscator, statement string) (common.ObfuscatedStatement, error) {
-	obfuscatedStatement, err := o.ObfuscateSQLString(statement)
+	obfuscatedStatement, err := o.ObfuscateSQLString(statement, common.IntegrationName)
 	if err == nil {
 		return common.ObfuscatedStatement{
 			Statement:      obfuscatedStatement.Query,

--- a/pkg/collector/corechecks/oracle/oracle_integration_test.go
+++ b/pkg/collector/corechecks/oracle/oracle_integration_test.go
@@ -354,24 +354,24 @@ func TestObfuscator(t *testing.T) {
 		// needs https://datadoghq.atlassian.net/browse/DBM-2295
 		`UPDATE /* comment */ SET t n=1`,
 		`SELECT /* comment */ from dual`} {
-		obfuscatedStatement, err := o.ObfuscateSQLString(statement)
+		obfuscatedStatement, err := o.ObfuscateSQLString(statement, common.IntegrationName)
 		assert.NoError(t, err, "obfuscator error")
 		assert.NotContains(t, obfuscatedStatement.Query, "comment", "comment wasn't removed by the obfuscator")
 	}
 
-	_, err := o.ObfuscateSQLString(`SELECT TRUNC(SYSDATE@!) from dual`)
+	_, err := o.ObfuscateSQLString(`SELECT TRUNC(SYSDATE@!) from dual`, common.IntegrationName)
 	assert.NoError(t, err, "can't obfuscate @!")
 
 	sql := "begin null ; end;"
-	obfuscatedStatement, err := o.ObfuscateSQLString(sql)
+	obfuscatedStatement, err := o.ObfuscateSQLString(sql, common.IntegrationName)
 	assert.Equal(t, obfuscatedStatement.Query, "begin null; end;")
 
 	sql = "select count (*) from dual"
-	obfuscatedStatement, err = o.ObfuscateSQLString(sql)
+	obfuscatedStatement, err = o.ObfuscateSQLString(sql, common.IntegrationName)
 	assert.Equal(t, sql, obfuscatedStatement.Query)
 
 	sql = "select file# from dual"
-	obfuscatedStatement, err = o.ObfuscateSQLString(sql)
+	obfuscatedStatement, err = o.ObfuscateSQLString(sql, common.IntegrationName)
 	assert.Equal(t, sql, obfuscatedStatement.Query)
 }
 

--- a/pkg/collector/corechecks/oracle/statements.go
+++ b/pkg/collector/corechecks/oracle/statements.go
@@ -338,7 +338,7 @@ func (c *Check) copyToPreviousMap(newMap map[StatementMetricsKeyDB]StatementMetr
 
 func handlePredicate(predicateType string, dbValue sql.NullString, payloadValue *string, statement StatementMetricsDB, c *Check, o *obfuscate.Obfuscator) {
 	if dbValue.Valid && dbValue.String != "" {
-		obfuscated, err := o.ObfuscateSQLString(dbValue.String)
+		obfuscated, err := o.ObfuscateSQLString(dbValue.String, common.IntegrationName)
 		if err == nil {
 			*payloadValue = obfuscated.Query
 		} else {

--- a/pkg/obfuscate/json.go
+++ b/pkg/obfuscate/json.go
@@ -86,7 +86,7 @@ func newJSONObfuscator(cfg *JSONConfig, o *Obfuscator) *jsonObfuscator {
 
 func sqlObfuscationTransformer(o *Obfuscator) func(string) string {
 	return func(s string) string {
-		result, err := o.ObfuscateSQLString(s)
+		result, err := o.ObfuscateSQLString(s, emptyDBMS)
 		if err != nil {
 			o.log.Debugf("Failed to obfuscate SQL string '%s': %s", s, err.Error())
 			// instead of returning an empty string we explicitly return an error string here within the result in order

--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -16,6 +16,8 @@ import (
 	sqllexer "github.com/DataDog/go-sqllexer"
 )
 
+const emptyDBMS = ""
+
 var questionMark = []byte("?")
 
 // metadataFinderFilter is a filter which attempts to collect metadata from a query, such as comments and tables.
@@ -290,17 +292,18 @@ func (f *groupingFilter) Reset() {
 // ObfuscateSQLString quantizes and obfuscates the given input SQL query string. Quantization removes
 // some elements such as comments and aliases and obfuscation attempts to hide sensitive information
 // in strings and numbers by redacting them.
-func (o *Obfuscator) ObfuscateSQLString(in string) (*ObfuscatedQuery, error) {
-	return o.ObfuscateSQLStringWithOptions(in, &o.opts.SQL)
+func (o *Obfuscator) ObfuscateSQLString(in string, dbms string) (*ObfuscatedQuery, error) {
+	return o.ObfuscateSQLStringWithOptions(in, dbms, &o.opts.SQL)
 }
 
 // ObfuscateSQLStringWithOptions accepts an optional SQLOptions to change the behavior of the obfuscator
 // to quantize and obfuscate the given input SQL query string. Quantization removes some elements such as comments
-// and aliases and obfuscation attempts to hide sensitive information in strings and numbers by redacting them.
-func (o *Obfuscator) ObfuscateSQLStringWithOptions(in string, opts *SQLConfig) (*ObfuscatedQuery, error) {
+func (o *Obfuscator) ObfuscateSQLStringWithOptions(in string, dbms string, opts *SQLConfig) (*ObfuscatedQuery, error) {
+	// and aliases and obfuscation attempts to hide sensitive information in strings and numbers by redacting them.
 	if opts.ObfuscationMode != "" {
 		// If obfuscation mode is specified, we will use go-sqllexer pkg
 		// to obfuscate (and normalize) the query.
+		opts.DBMS = dbms
 		return o.ObfuscateWithSQLLexer(in, opts)
 	}
 

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -23,6 +23,7 @@ const (
 	tagOpenSearchBody   = "opensearch.body"
 	tagSQLQuery         = "sql.query"
 	tagHTTPURL          = "http.url"
+	tagDBMS             = "db.system"
 )
 
 const (
@@ -51,7 +52,7 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 		if span.Resource == "" {
 			return
 		}
-		oq, err := o.ObfuscateSQLString(span.Resource)
+		oq, err := o.ObfuscateSQLString(span.Resource, span.Meta[tagDBMS])
 		if err != nil {
 			// we have an error, discard the SQL to avoid polluting user resources.
 			log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
@@ -166,7 +167,7 @@ func (a *Agent) obfuscateStatsGroup(b *pb.ClientGroupedStats) {
 
 	switch b.Type {
 	case "sql", "cassandra":
-		oq, err := o.ObfuscateSQLString(b.Resource)
+		oq, err := o.ObfuscateSQLString(b.Resource, b.DBType)
 		if err != nil {
 			log.Errorf("Error obfuscating stats group resource %q: %v", b.Resource, err)
 			b.Resource = textNonParsable


### PR DESCRIPTION
### What does this PR do?

Passes DBMS type to the SQL lexer obfuscator.

### Motivation

Knowing the DBMS type  helps the SQL lexer produce better results.

### Additional notes

This prepares for adding an option to activate SQL normalization. Refer to the [RFC here](https://docs.google.com/document/d/1SPeq309YmZZKvaqVcEibR1jYl1qL7z1XYA_pPqDTu7s/edit?usp=sharing).