### PR TITLE
Add tmp_free enhanced lambda metric

### DIFF
--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -61,6 +61,7 @@ const (
 	totalNetworkMetric           = "aws.lambda.enhanced.total_network"
 	tmpUsedMetric                = "aws.lambda.enhanced.tmp_used"
 	tmpMaxMetric                 = "aws.lambda.enhanced.tmp_max"
+	tmpFreeMetric                = "aws.lambda.enhanced.tmp_free"
 	fdMaxMetric                  = "aws.lambda.enhanced.fd_max"
 	fdUseMetric                  = "aws.lambda.enhanced.fd_use"
 	threadsMaxMetric             = "aws.lambda.enhanced.threads_max"
@@ -521,6 +522,14 @@ func generateTmpEnhancedMetrics(args generateTmpEnhancedMetricsArgs) {
 	args.Demux.AggregateSample(metrics.MetricSample{
 		Name:       tmpMaxMetric,
 		Value:      args.TmpMax,
+		Mtype:      metrics.DistributionType,
+		Tags:       args.Tags,
+		SampleRate: 1,
+		Timestamp:  args.Time,
+	})
+	args.Demux.AggregateSample(metrics.MetricSample{
+		Name:       tmpFreeMetric,
+		Value:      args.TmpMax - args.TmpUsed,
 		Mtype:      metrics.DistributionType,
 		Tags:       args.Tags,
 		SampleRate: 1,

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -2,6 +2,9 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
 package metrics
 
 import (
@@ -698,6 +701,14 @@ func TestSendTmpEnhancedMetrics(t *testing.T) {
 		{
 			Name:       tmpMaxMetric,
 			Value:      550461440,
+			Mtype:      metrics.DistributionType,
+			Tags:       tags,
+			SampleRate: 1,
+			Timestamp:  now,
+		},
+		{
+			Name:       tmpFreeMetric,
+			Value:      538331440,
 			Mtype:      metrics.DistributionType,
 			Tags:       tags,
 			SampleRate: 1,

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -2,9 +2,6 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
-
-//go:build test
-
 package metrics
 
 import (

--- a/test/integration/serverless/snapshots/error-csharp
+++ b/test/integration/serverless/snapshots/error-csharp
@@ -1251,6 +1251,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-csharp",
+      "functionname:integration-tests-extension-XXXXXX-error-csharp",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-csharp",
+      "runtime:dotnet6",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-csharp",
+      "functionname:integration-tests-extension-XXXXXX-error-csharp",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-csharp",
+      "runtime:dotnet6",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/error-java
+++ b/test/integration/serverless/snapshots/error-java
@@ -1251,6 +1251,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-java",
+      "functionname:integration-tests-extension-XXXXXX-error-java",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-java",
+      "runtime:java8.al2",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-java",
+      "functionname:integration-tests-extension-XXXXXX-error-java",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-java",
+      "runtime:java8.al2",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/error-node
+++ b/test/integration/serverless/snapshots/error-node
@@ -1255,6 +1255,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-node",
+      "functionname:integration-tests-extension-XXXXXX-error-node",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-node",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-node",
+      "functionname:integration-tests-extension-XXXXXX-error-node",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-node",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/error-proxy
+++ b/test/integration/serverless/snapshots/error-proxy
@@ -1251,6 +1251,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-proxy",
+      "functionname:integration-tests-extension-XXXXXX-error-proxy",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-proxy",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-proxy",
+      "functionname:integration-tests-extension-XXXXXX-error-proxy",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-proxy",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/error-python
+++ b/test/integration/serverless/snapshots/error-python
@@ -1257,6 +1257,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-python",
+      "functionname:integration-tests-extension-XXXXXX-error-python",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-python",
+      "runtime:python3.8",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-error-python",
+      "functionname:integration-tests-extension-XXXXXX-error-python",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-error-python",
+      "runtime:python3.8",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/metric-csharp
+++ b/test/integration/serverless/snapshots/metric-csharp
@@ -1203,6 +1203,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-csharp",
+      "functionname:integration-tests-extension-XXXXXX-metric-csharp",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-csharp",
+      "runtime:dotnet6",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-csharp",
+      "functionname:integration-tests-extension-XXXXXX-metric-csharp",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-csharp",
+      "runtime:dotnet6",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/metric-go
+++ b/test/integration/serverless/snapshots/metric-go
@@ -1203,6 +1203,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-go",
+      "functionname:integration-tests-extension-XXXXXX-metric-go",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-go",
+      "runtime:provided.al2",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-go",
+      "functionname:integration-tests-extension-XXXXXX-metric-go",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-go",
+      "runtime:provided.al2",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/metric-java
+++ b/test/integration/serverless/snapshots/metric-java
@@ -1203,6 +1203,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-java",
+      "functionname:integration-tests-extension-XXXXXX-metric-java",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-java",
+      "runtime:java8.al2",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-java",
+      "functionname:integration-tests-extension-XXXXXX-metric-java",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-java",
+      "runtime:java8.al2",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/metric-node
+++ b/test/integration/serverless/snapshots/metric-node
@@ -1203,6 +1203,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-node",
+      "functionname:integration-tests-extension-XXXXXX-metric-node",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-node",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-node",
+      "functionname:integration-tests-extension-XXXXXX-metric-node",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-node",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/metric-proxy
+++ b/test/integration/serverless/snapshots/metric-proxy
@@ -1203,6 +1203,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-proxy",
+      "functionname:integration-tests-extension-XXXXXX-metric-proxy",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-proxy",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-proxy",
+      "functionname:integration-tests-extension-XXXXXX-metric-proxy",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-proxy",
+      "runtime:nodejs18.x",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",

--- a/test/integration/serverless/snapshots/metric-python
+++ b/test/integration/serverless/snapshots/metric-python
@@ -1203,6 +1203,54 @@
   {
     "distributions": null,
     "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-python",
+      "functionname:integration-tests-extension-XXXXXX-metric-python",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-python",
+      "runtime:python3.8",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
+    "metric": "aws.lambda.enhanced.tmp_free",
+    "tags": [
+      "account_id:############",
+      "architecture:XXX",
+      "aws_account:############",
+      "dd_extension_version:123",
+      "env:integration-tests-env",
+      "function_arn:arn:aws:lambda:eu-west-1:############:function:integration-tests-extension-XXXXXX-metric-python",
+      "functionname:integration-tests-extension-XXXXXX-metric-python",
+      "memorysize:1024",
+      "region:eu-west-1",
+      "resource:integration-tests-extension-XXXXXX-metric-python",
+      "runtime:python3.8",
+      "service:integration-tests-service",
+      "taga:valuea",
+      "tagb:valueb",
+      "tagc:valuec",
+      "tagd:valued",
+      "version:integration-tests-version"
+    ]
+  },
+  {
+    "distributions": null,
+    "dogsketches": [],
     "metric": "aws.lambda.enhanced.tmp_max",
     "tags": [
       "account_id:############",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds the `aws.lambda.enhanced.tmp_free` enhanced metric representing bytes available in `/tmp`.

### Motivation
This metric was added in the new bottlecap extension as AWS Lambda Insights reports this metric.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- [Build the lambda extension](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2723611380/Lambda+Extension#Manual-Testing)
- Create a lambda function with the extension built in previous step
- Turn on lambda insights / add the [lambda insights extension](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-Getting-Started.html) to your function
- Invoke the function
- View the new enhanced metrics in metrics explorer or [this dashboard](https://ddserverless.datadoghq.com/dashboard/ker-x4u-kbr?fromUser=true&refresh_mode=sliding&view=spans&from_ts=1716303324812&to_ts=1716305124812&live=true)
- [Compare with lambda insight metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-view-metrics.html) 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->