### PR TITLE
Pass DBMS type to SQL Lexer obfuscator

### DIFF
--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -287,10 +287,22 @@ func (f *groupingFilter) Reset() {
 	f.groupMulti = 0
 }
 
+func isSQLLexer(obfuscationMode ObfuscationMode) bool {
+	return obfuscationMode != ""
+}
+
 // ObfuscateSQLString quantizes and obfuscates the given input SQL query string. Quantization removes
 // some elements such as comments and aliases and obfuscation attempts to hide sensitive information
 // in strings and numbers by redacting them.
 func (o *Obfuscator) ObfuscateSQLString(in string) (*ObfuscatedQuery, error) {
+	return o.ObfuscateSQLStringWithOptions(in, &o.opts.SQL)
+}
+
+// ObfuscateSQLStringForDBMS quantizes and obfuscates the given input SQL query string for a specific DBMS.
+func (o *Obfuscator) ObfuscateSQLStringForDBMS(in string, dbms string) (*ObfuscatedQuery, error) {
+	if isSQLLexer(o.opts.SQL.ObfuscationMode) {
+		o.opts.SQL.DBMS = dbms
+	}
 	return o.ObfuscateSQLStringWithOptions(in, &o.opts.SQL)
 }
 

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -23,6 +23,7 @@ const (
 	tagOpenSearchBody   = "opensearch.body"
 	tagSQLQuery         = "sql.query"
 	tagHTTPURL          = "http.url"
+	tagDBMS             = "db.system"
 )
 
 const (
@@ -51,7 +52,7 @@ func (a *Agent) obfuscateSpan(span *pb.Span) {
 		if span.Resource == "" {
 			return
 		}
-		oq, err := o.ObfuscateSQLString(span.Resource)
+		oq, err := o.ObfuscateSQLStringForDBMS(span.Resource, span.Meta[tagDBMS])
 		if err != nil {
 			// we have an error, discard the SQL to avoid polluting user resources.
 			log.Debugf("Error parsing SQL query: %v. Resource: %q", err, span.Resource)
@@ -166,7 +167,7 @@ func (a *Agent) obfuscateStatsGroup(b *pb.ClientGroupedStats) {
 
 	switch b.Type {
 	case "sql", "cassandra":
-		oq, err := o.ObfuscateSQLString(b.Resource)
+		oq, err := o.ObfuscateSQLStringForDBMS(b.Resource, b.DBType)
 		if err != nil {
 			log.Errorf("Error obfuscating stats group resource %q: %v", b.Resource, err)
 			b.Resource = textNonParsable


### PR DESCRIPTION
### What does this PR do?

APM trace agent passes DBMS type to the SQL lexer obfuscator.

### Motivation

Knowing the DBMS type  helps the SQL lexer produce better results.

### Additional notes

This prepares for adding an option to activate SQL normalization. Refer to the [RFC here](https://docs.google.com/document/d/1SPeq309YmZZKvaqVcEibR1jYl1qL7z1XYA_pPqDTu7s/edit?usp=sharing).