### PR TITLE
Multiline log adjustment

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator_test.go
@@ -213,9 +213,11 @@ func TestSingleLineTooLongTruncation(t *testing.T) {
 	ag.Aggregate(newMessage(""), startGroup)
 
 	msg := <-outputChan
-	assertMessageContent(t, msg, "123...TRUNCATED...")
+	assert.Equal(t, "123...TRUNCATED...", string(msg.GetContent()))
+	assert.Equal(t, msg.IsMultiLine, true)
 	msg = <-outputChan
-	assertMessageContent(t, msg, "...TRUNCATED...456")
+	assert.Equal(t, "...TRUNCATED...456", string(msg.GetContent()))
+	assert.Equal(t, msg.IsMultiLine, true)
 	msg = <-outputChan
 	assertMessageContent(t, msg, "123456...TRUNCATED...")
 	msg = <-outputChan


### PR DESCRIPTION
Alter aggregation logic in an attempt to catch a multiline log getting truncated at its second log line

