### PR TITLE
improve system-probe handling of subcommands

### DIFF
--- a/cmd/system-probe/command/command.go
+++ b/cmd/system-probe/command/command.go
@@ -9,6 +9,7 @@ package command
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/fatih/color"
@@ -76,21 +77,24 @@ Runtime Security Monitoring, Universal Service Monitoring, and others.`,
 func SetDefaultCommandIfNonePresent(rootCmd *cobra.Command) {
 	var subCommandNames []string
 	for _, command := range rootCmd.Commands() {
-		subCommandNames = append(subCommandNames, append(command.Aliases, command.Name())...)
+		subCommandNames = append(subCommandNames, command.Name())
+		subCommandNames = append(subCommandNames, command.Aliases...)
 	}
+
+	helpAndCompletionCommands := []string{"help", "-h", "--help", "completion"}
 
 	args := []string{os.Args[0], "run"}
 	if len(os.Args) > 1 {
 		potentialCommand := os.Args[1]
-		if potentialCommand == "help" || potentialCommand == "-h" || potentialCommand == "completion" {
+
+		if slices.Contains(helpAndCompletionCommands, potentialCommand) {
 			return
 		}
 
-		for _, command := range subCommandNames {
-			if command == potentialCommand {
-				return
-			}
+		if slices.Contains(subCommandNames, potentialCommand) {
+			return
 		}
+
 		if !strings.HasPrefix(potentialCommand, "-") {
 			// run command takes no positional arguments, so if one is passed
 			// fallback to default cobra handling for good errors

--- a/cmd/system-probe/subcommands/runtime/command_linux.go
+++ b/cmd/system-probe/subcommands/runtime/command_linux.go
@@ -21,7 +21,7 @@ import (
 func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 	runtimeCmd := &cobra.Command{
 		Use:   "runtime",
-		Short: "runtime Agent utility commands",
+		Short: "Runtime Security Agent (CWS) utility commands",
 	}
 
 	runtimeCmd.AddCommand(commonPolicyCommands(globalParams)...)


### PR DESCRIPTION
### What does this PR do?

Currently when you run `system-probe --help`, you get:
```
Runs the system-probe in the foreground

Usage:
  ./bin/system-probe/system-probe run [flags]

Flags:
  -h, --help         help for run
  -p, --pid string   path to the pidfile

Global Flags:
  -c, --config string   path to directory containing system-probe.yaml
  -n, --no-color        disable color output
```

which is actually the outputs of `system-probe run --help`.

This PR fixes this to actually returns the root help message, similar to `system-probe -h` or `system-probe help` today:
```
The Datadog Agent System Probe runs as superuser in order to instrument
your machine at a deeper level. It is required for features such as Network Performance Monitoring,
Runtime Security Monitoring, Universal Service Monitoring, and others.

Usage:
  ./bin/system-probe/system-probe [command]

Available Commands:
  completion     Generate the autocompletion script for the specified shell
  config         Print the runtime configuration of a running agent
  debug          Print the runtime state of a running system-probe
  help           Help about any command
  module-restart Restart a given system-probe module
  run            Run the System Probe
  runtime        Runtime Security Agent (CWS) utility commands
  version        Print the version info

Flags:
  -c, --config string   path to directory containing system-probe.yaml
  -h, --help            help for ./bin/system-probe/system-probe
  -n, --no-color        disable color output

Use "./bin/system-probe/system-probe [command] --help" for more information about a command.
```

This PR also improves a bit the short description of the runtime subcommands.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->