### PR TITLE
[CWS] ebpfless: Add network handlers (socket, accept, connect, bind)

### DIFF
--- a/pkg/security/probe/model_ebpfless.go
+++ b/pkg/security/probe/model_ebpfless.go
@@ -47,7 +47,10 @@ func NewEBPFLessModel() *model.Model {
 				!strings.HasPrefix(field, "chdir.") &&
 				!strings.HasPrefix(field, "mount.") &&
 				!strings.HasPrefix(field, "umount.") &&
-				!strings.HasPrefix(field, "event.") {
+				!strings.HasPrefix(field, "event.") &&
+				!strings.HasPrefix(field, "accept.") &&
+				!strings.HasPrefix(field, "bind.") &&
+				!strings.HasPrefix(field, "connect.") {
 				return rules.ErrEventTypeNotEnabled
 			}
 			return nil

--- a/pkg/security/proto/ebpfless/msg.go
+++ b/pkg/security/proto/ebpfless/msg.go
@@ -8,6 +8,7 @@ package ebpfless
 
 import (
 	"encoding/json"
+	"net"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/sharedconsts"
@@ -90,6 +91,12 @@ const (
 	SyscallTypeMount
 	// SyscallTypeUmount umount/umount2 type
 	SyscallTypeUmount
+	// SyscallTypeAccept accept
+	SyscallTypeAccept
+	// SyscallTypeConnect connect
+	SyscallTypeConnect
+	// SyscallTypeBind bind
+	SyscallTypeBind
 )
 
 // ContainerContext defines a container context
@@ -164,6 +171,12 @@ type DupSyscallFakeMsg struct {
 // PipeSyscallFakeMsg defines a pipe message
 type PipeSyscallFakeMsg struct {
 	FdsPtr uint64
+}
+
+// SocketSyscallFakeMsg represents the socket message
+type SocketSyscallFakeMsg struct {
+	AddressFamily uint16
+	Protocol      uint16
 }
 
 // ChdirSyscallMsg defines a chdir message
@@ -297,6 +310,31 @@ type UmountSyscallMsg struct {
 	Path string
 }
 
+// MsgSocketInfo defines the base information for a socket message
+type MsgSocketInfo struct {
+	AddressFamily uint16
+	Addr          net.IP
+	Port          uint16
+}
+
+// BindSyscallMsg defines a bind message
+type BindSyscallMsg struct {
+	MsgSocketInfo
+	Protocol uint16
+}
+
+// ConnectSyscallMsg defines a connect message
+type ConnectSyscallMsg struct {
+	MsgSocketInfo
+	Protocol uint16
+}
+
+// AcceptSyscallMsg defines an accept message
+type AcceptSyscallMsg struct {
+	MsgSocketInfo
+	SocketFd int32
+}
+
 // SyscallMsg defines a syscall message
 type SyscallMsg struct {
 	Type         SyscallType
@@ -328,10 +366,14 @@ type SyscallMsg struct {
 	Chdir        *ChdirSyscallMsg        `json:",omitempty"`
 	Mount        *MountSyscallMsg        `json:",omitempty"`
 	Umount       *UmountSyscallMsg       `json:",omitempty"`
+	Bind         *BindSyscallMsg         `json:",omitempty"`
+	Connect      *ConnectSyscallMsg      `json:",omitempty"`
+	Accept       *AcceptSyscallMsg       `json:",omitempty"`
 
 	// internals
-	Dup  *DupSyscallFakeMsg  `json:",omitempty"`
-	Pipe *PipeSyscallFakeMsg `json:",omitempty"`
+	Dup    *DupSyscallFakeMsg    `json:",omitempty"`
+	Pipe   *PipeSyscallFakeMsg   `json:",omitempty"`
+	Socket *SocketSyscallFakeMsg `json:",omitempty"`
 }
 
 // String returns string representation

--- a/pkg/security/ptracer/cws.go
+++ b/pkg/security/ptracer/cws.go
@@ -285,6 +285,7 @@ func registerSyscallHandlers() (map[int]syscallHandler, []string) {
 	syscalls := registerFIMHandlers(handlers)
 	syscalls = append(syscalls, registerProcessHandlers(handlers)...)
 	syscalls = append(syscalls, registerERPCHandlers(handlers)...)
+	syscalls = append(syscalls, registerNetworkHandlers(handlers)...)
 	return handlers, syscalls
 }
 

--- a/pkg/security/ptracer/fim_handlers.go
+++ b/pkg/security/ptracer/fim_handlers.go
@@ -612,6 +612,7 @@ func handlePipe2(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs sysc
 func handleClose(tracer *Tracer, process *Process, _ *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
 	fd := tracer.ReadArgInt32(regs, 0)
 	delete(process.FdRes.Fd, fd)
+	delete(process.FdToSocket, fd)
 	return nil
 }
 

--- a/pkg/security/ptracer/network_handlers.go
+++ b/pkg/security/ptracer/network_handlers.go
@@ -1,0 +1,276 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package ptracer holds the start command of CWS injector
+package ptracer
+
+import (
+	"encoding/binary"
+	"errors"
+	"golang.org/x/sys/unix"
+	"net"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/security/proto/ebpfless"
+)
+
+func registerNetworkHandlers(handlers map[int]syscallHandler) []string {
+	processHandlers := []syscallHandler{
+		{
+			ID:         syscallID{ID: AcceptNr, Name: "accept"},
+			Func:       handleAccept,
+			ShouldSend: shouldSendAccept,
+			RetFunc:    handleAcceptRet,
+		},
+		{
+			ID:         syscallID{ID: Accept4Nr, Name: "accept4"},
+			Func:       handleAccept,
+			ShouldSend: shouldSendAccept,
+			RetFunc:    handleAcceptRet,
+		},
+		{
+			ID:         syscallID{ID: BindNr, Name: "bind"},
+			Func:       handleBind,
+			ShouldSend: shouldSendBind,
+			RetFunc:    nil,
+		},
+		{
+			ID:         syscallID{ID: ConnectNr, Name: "connect"},
+			Func:       handleConnect,
+			ShouldSend: shouldSendConnect,
+			RetFunc:    nil,
+		},
+		{
+			ID:         syscallID{ID: SocketNr, Name: "socket"},
+			Func:       handleSocket,
+			ShouldSend: nil,
+			RetFunc:    handleSocketRet,
+		},
+	}
+
+	syscallList := []string{}
+	for _, h := range processHandlers {
+		if h.ID.ID >= 0 { // insert only available syscalls
+			handlers[h.ID.ID] = h
+			syscallList = append(syscallList, h.ID.Name)
+		}
+	}
+	return syscallList
+}
+
+type addrInfo struct {
+	ip   net.IP
+	port uint16
+	af   uint16
+}
+
+func parseAddrInfo(tracer *Tracer, process *Process, regs syscall.PtraceRegs, addrlen int32) (*addrInfo, error) {
+	if addrlen < 16 {
+		return nil, errors.New("invalid address length")
+	}
+
+	if addrlen > 28 {
+		addrlen = 28
+	}
+
+	data, err := tracer.ReadArgData(process.Pid, regs, 1, uint(addrlen))
+	if err != nil {
+		return nil, err
+	}
+
+	var addr addrInfo
+
+	addr.af = binary.NativeEndian.Uint16(data[0:2])
+	addr.port = binary.BigEndian.Uint16(data[2:4])
+
+	if addr.af == unix.AF_INET {
+		addr.ip = data[4:8]
+	} else if addr.af == unix.AF_INET6 {
+		if addrlen < 28 {
+			return nil, errors.New("invalid address length")
+		}
+
+		addr.ip = data[8:24]
+	} else {
+		return nil, errors.New("unsupported address family")
+	}
+
+	return &addr, nil
+}
+
+func handleBind(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	socketfd := tracer.ReadArgUint32(regs, 0)
+
+	socketInfo, ok := process.FdToSocket[int32(socketfd)]
+	if !ok {
+		return errors.New("unable to find socket")
+	}
+
+	var addrlen int32
+	if socketInfo.AddressFamily == unix.AF_INET {
+		addrlen = 16
+	} else if socketInfo.AddressFamily == unix.AF_INET6 {
+		addrlen = 28
+	} else if socketInfo.AddressFamily == unix.AF_UNIX {
+		addrlen = 0
+	} else {
+		return errors.New("unsupported address family")
+	}
+
+	if socketInfo.AddressFamily == unix.AF_UNIX {
+		msg.Type = ebpfless.SyscallTypeBind
+		msg.Bind = &ebpfless.BindSyscallMsg{
+			MsgSocketInfo: ebpfless.MsgSocketInfo{
+				AddressFamily: unix.AF_UNIX,
+				Addr:          net.IP{},
+				Port:          0,
+			},
+			Protocol: 0,
+		}
+		return nil
+	}
+
+	addr, err := parseAddrInfo(tracer, process, regs, addrlen)
+	if err != nil {
+		return err
+	}
+
+	msg.Type = ebpfless.SyscallTypeBind
+	msg.Bind = &ebpfless.BindSyscallMsg{
+		MsgSocketInfo: ebpfless.MsgSocketInfo{
+			AddressFamily: addr.af,
+			Addr:          addr.ip,
+			Port:          addr.port,
+		},
+		Protocol: socketInfo.Protocol,
+	}
+
+	socketInfo.BoundToPort = addr.port
+	process.FdToSocket[int32(socketfd)] = socketInfo
+
+	return nil
+}
+
+func handleConnect(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	addrlen := tracer.ReadArgInt32(regs, 2)
+	addr, err := parseAddrInfo(tracer, process, regs, int32(addrlen))
+
+	if err != nil {
+		return err
+	}
+	socketfd := int32(tracer.ReadArgUint32(regs, 0))
+
+	m, ok := process.FdToSocket[socketfd]
+
+	if !ok {
+		return errors.New("unable to find protocol")
+	}
+
+	msg.Type = ebpfless.SyscallTypeConnect
+	msg.Connect = &ebpfless.ConnectSyscallMsg{
+		MsgSocketInfo: ebpfless.MsgSocketInfo{
+			AddressFamily: addr.af,
+			Addr:          addr.ip,
+			Port:          addr.port,
+		},
+		Protocol: m.Protocol,
+	}
+
+	return nil
+}
+
+func handleSocket(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	socketMsg := &ebpfless.SocketSyscallFakeMsg{
+		AddressFamily: uint16(tracer.ReadArgInt32(regs, 0)),
+	}
+
+	if socketMsg.AddressFamily != unix.AF_INET && socketMsg.AddressFamily != unix.AF_INET6 && socketMsg.AddressFamily != unix.AF_UNIX {
+		return nil
+	}
+
+	protocol := int16(tracer.ReadArgInt32(regs, 1))
+	// This argument can be masked, so just get what we need
+	protocol &= 0b1111
+
+	switch protocol {
+	case unix.SOCK_STREAM:
+		socketMsg.Protocol = unix.IPPROTO_TCP
+	case unix.SOCK_DGRAM:
+		socketMsg.Protocol = unix.IPPROTO_UDP
+	default:
+		return nil
+	}
+
+	msg.Socket = socketMsg
+	return nil
+}
+
+func handleAccept(tracer *Tracer, _ *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	fd := tracer.ReadArgInt32(regs, 0)
+
+	msg.Accept = &ebpfless.AcceptSyscallMsg{
+		SocketFd: fd,
+	}
+
+	return nil
+}
+
+// Handle returns
+func handleAcceptRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	addrlen, err := tracer.ReadArgInt32Ptr(process.Pid, regs, 2)
+	if err != nil {
+		return err
+	}
+
+	addr, err := parseAddrInfo(tracer, process, regs, addrlen)
+	if err != nil {
+		return err
+	}
+
+	m, ok := process.FdToSocket[msg.Accept.SocketFd]
+	if !ok {
+		return errors.New("unable to find socket")
+	}
+
+	msg.Type = ebpfless.SyscallTypeAccept
+
+	msg.Accept = &ebpfless.AcceptSyscallMsg{
+		MsgSocketInfo: ebpfless.MsgSocketInfo{
+			AddressFamily: addr.af,
+			Addr:          addr.ip,
+			Port:          m.BoundToPort,
+		},
+	}
+
+	return nil
+}
+
+func handleSocketRet(tracer *Tracer, process *Process, msg *ebpfless.SyscallMsg, regs syscall.PtraceRegs, _ bool) error {
+	ret := int32(tracer.ReadRet(regs))
+
+	if msg.Socket != nil && ret != -1 {
+		process.FdToSocket[ret] = SocketInfo{
+			AddressFamily: msg.Socket.AddressFamily,
+			Protocol:      msg.Socket.Protocol,
+		}
+	}
+
+	return nil
+}
+
+// Should send messages
+func shouldSendConnect(msg *ebpfless.SyscallMsg) bool {
+	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.ECONNREFUSED) || msg.Retval == -int64(syscall.ETIMEDOUT) || msg.Retval == -int64(syscall.EINPROGRESS)
+}
+
+func shouldSendAccept(msg *ebpfless.SyscallMsg) bool {
+	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.ECONNABORTED)
+}
+
+func shouldSendBind(msg *ebpfless.SyscallMsg) bool {
+	return msg.Retval >= 0 || msg.Retval == -int64(syscall.EACCES) || msg.Retval == -int64(syscall.EPERM) || msg.Retval == -int64(syscall.EADDRINUSE) || msg.Retval == -int64(syscall.EFAULT)
+}

--- a/pkg/security/ptracer/process.go
+++ b/pkg/security/ptracer/process.go
@@ -53,21 +53,31 @@ func (f *FSResources) clone() *FSResources {
 	}
 }
 
+// SocketInfo represents the status of an open socket
+type SocketInfo struct {
+	AddressFamily uint16
+	Protocol      uint16
+	BoundToPort   uint16
+}
+
 // Process represents a process context
 type Process struct {
-	Pid   int
-	Tgid  int
-	Nr    map[int]*ebpfless.SyscallMsg
-	FdRes *FdResources
-	FsRes *FSResources
+	Pid        int
+	Tgid       int
+	Nr         map[int]*ebpfless.SyscallMsg
+	FdRes      *FdResources
+	FsRes      *FSResources
+	FdToSocket map[int32]SocketInfo
 }
 
 // NewProcess returns a new process
 func NewProcess(pid int) *Process {
 	return &Process{
-		Pid:  pid,
-		Tgid: pid,
-		Nr:   make(map[int]*ebpfless.SyscallMsg),
+		Pid:        pid,
+		Tgid:       pid,
+		Nr:         make(map[int]*ebpfless.SyscallMsg),
+		FdToSocket: make(map[int32]SocketInfo),
+
 		FdRes: &FdResources{
 			Fd:              make(map[int32]string),
 			FileHandleCache: make(map[fileHandleKey]*fileHandleVal),

--- a/pkg/security/ptracer/ptracer.go
+++ b/pkg/security/ptracer/ptracer.go
@@ -92,7 +92,6 @@ func processVMReadv(pid int, addr uintptr, data []byte) (int, error) {
 	remoteIov := []unix.RemoteIovec{
 		{Base: addr, Len: size},
 	}
-
 	return unix.ProcessVMReadv(pid, localIov, remoteIov, 0)
 }
 

--- a/pkg/security/ptracer/syscalls_amd64.go
+++ b/pkg/security/ptracer/syscalls_amd64.go
@@ -74,8 +74,13 @@ const (
 	IoctlNr          = unix.SYS_IOCTL             // IoctlNr defines the syscall ID for amd64
 	MountNr          = unix.SYS_MOUNT             // MountNr defines the syscall ID for amd64
 	Umount2Nr        = unix.SYS_UMOUNT2           // Umount2Nr defines the syscall ID for amd64
-	PipeNr           = unix.SYS_PIPE              // PipeNr defines the syscall ID for arm64
-	Pipe2Nr          = unix.SYS_PIPE2             // Pipe2Nr defines the syscall ID for arm64
+	PipeNr           = unix.SYS_PIPE              // PipeNr defines the syscall ID for amd64
+	Pipe2Nr          = unix.SYS_PIPE2             // Pipe2Nr defines the syscall ID for amd64
+	ConnectNr        = unix.SYS_CONNECT           // ConnectNr defines the syscall ID for amd64
+	Accept4Nr        = unix.SYS_ACCEPT4           // Accept4Nr defines the syscall ID for arm64
+	AcceptNr         = unix.SYS_ACCEPT            // AcceptNr defines the syscall ID for amd64
+	BindNr           = unix.SYS_BIND              // BindNr defines the syscall ID for amd64
+	SocketNr         = unix.SYS_SOCKET            // SocketNr defines the syscall ID for amd64
 )
 
 // https://github.com/torvalds/linux/blob/v5.0/arch/x86/entry/entry_64.S#L126

--- a/pkg/security/ptracer/syscalls_arm64.go
+++ b/pkg/security/ptracer/syscalls_arm64.go
@@ -15,9 +15,9 @@ import (
 
 const (
 	OpenatNr         = unix.SYS_OPENAT            // OpenatNr defines the syscall ID for arm64
-	Openat2Nr        = unix.SYS_OPENAT2           // Openat2Nr defines the syscall ID for amd64
-	NameToHandleAtNr = unix.SYS_NAME_TO_HANDLE_AT // NameToHandleAtNr defines the syscall ID for amd64
-	OpenByHandleAtNr = unix.SYS_OPEN_BY_HANDLE_AT // OpenByHandleAtNr defines the syscall ID for amd64
+	Openat2Nr        = unix.SYS_OPENAT2           // Openat2Nr defines the syscall ID for arm64
+	NameToHandleAtNr = unix.SYS_NAME_TO_HANDLE_AT // NameToHandleAtNr defines the syscall ID for arm64
+	OpenByHandleAtNr = unix.SYS_OPEN_BY_HANDLE_AT // OpenByHandleAtNr defines the syscall ID for arm64
 	ExecveNr         = unix.SYS_EXECVE            // ExecveNr defines the syscall ID for arm64
 	ExecveatNr       = unix.SYS_EXECVEAT          // ExecveatNr defines the syscall ID for arm64
 	CloneNr          = unix.SYS_CLONE             // CloneNr defines the syscall ID for arm64
@@ -58,6 +58,11 @@ const (
 	MountNr          = unix.SYS_MOUNT             // MountNr defines the syscall ID for arm64
 	Umount2Nr        = unix.SYS_UMOUNT2           // Umount2Nr defines the syscall ID for arm64
 	Pipe2Nr          = unix.SYS_PIPE2             // Pipe2Nr defines the syscall ID for arm64
+	ConnectNr        = unix.SYS_CONNECT           // ConnectNr defines the syscall ID for arm64
+	BindNr           = unix.SYS_BIND              // BindNr defines the syscall ID for arm64
+	AcceptNr         = unix.SYS_ACCEPT            // AcceptNr defines the syscall ID for arm64
+	Accept4Nr        = unix.SYS_ACCEPT4           // Accept4Nr defines the syscall ID for arm64
+	SocketNr         = unix.SYS_SOCKET            // SocketNr defines the syscall ID for arm64
 
 	OpenNr      = -1  // OpenNr not available on arm64
 	ForkNr      = -2  // ForkNr not available on arm64

--- a/pkg/security/tests/README.md
+++ b/pkg/security/tests/README.md
@@ -1,0 +1,19 @@
+# Running tests
+
+* Running all tests:
+
+```bash
+inv -e security-agent.functional-tests --verbose --skip-linters --testflags "-test.run '.*'"
+```
+
+* Running a single test:
+
+```bash
+inv -e security-agent.functional-tests --verbose --skip-linters --testflags "-test.run 'TestConnect'"
+```
+
+* Running ebpfless tests:
+
+```bash
+inv -e security-agent.ebpfless-functional-tests --verbose --skip-linters --testflags "-test.run '.*'"
+```

--- a/pkg/security/tests/connect_test.go
+++ b/pkg/security/tests/connect_test.go
@@ -11,10 +11,10 @@ package tests
 import (
 	"context"
 	"fmt"
+	"golang.org/x/net/nettest"
 	"net"
 	"testing"
 
-	"golang.org/x/net/nettest"
 	"golang.org/x/sys/unix"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/security/tests/main_linux.go
+++ b/pkg/security/tests/main_linux.go
@@ -74,6 +74,9 @@ func SkipIfNotAvailable(t *testing.T) {
 			"~TestOsOrigin",
 			"~TestSpan",
 			"~TestChdir",
+			"~TestBindEvent",
+			"~TestAccept",
+			"~TestConnect",
 			"TestMountEvent",
 			"TestMount",
 			"TestMountPropagated",
@@ -104,7 +107,6 @@ func SkipIfNotAvailable(t *testing.T) {
 			"TestLoginUID/login-uid-exec-test",
 			"TestActionKillExcludeBinary",
 			"~TestActionKillDisarm",
-			"~TestAcceptEvent",
 		}
 
 		if disableSeccomp {

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -229,18 +229,30 @@ func (tm *testModule) validateIMDSSchema(t *testing.T, event *model.Event) bool 
 
 //nolint:deadcode,unused
 func (tm *testModule) validateAcceptSchema(t *testing.T, event *model.Event) bool {
+	if ebpfLessEnabled {
+		return true
+	}
+
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///accept.schema.json")
 }
 
 //nolint:deadcode,unused
 func (tm *testModule) validateBindSchema(t *testing.T, event *model.Event) bool {
+	if ebpfLessEnabled {
+		return true
+	}
+
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///bind.schema.json")
 }
 
 //nolint:deadcode,unused
 func (tm *testModule) validateConnectSchema(t *testing.T, event *model.Event) bool {
+	if ebpfLessEnabled {
+		return true
+	}
+
 	t.Helper()
 	return tm.validateEventSchema(t, event, "file:///connect.schema.json")
 }

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -387,17 +387,28 @@ void* connect_thread_ipv4(void *arg) {
 int test_accept_af_inet(int argc, char** argv) {
     pthread_t thread;
 
-    if (argc != 4) {
+    if (argc != 5) {
         fprintf(stderr, "%s: please specify a valid command:\n", __FUNCTION__);
         fprintf(stderr, "Arg1: IP address where the socket should bind to\n");
         fprintf(stderr, "Arg2: IP address where the socket should connect to\n");
         fprintf(stderr, "Arg3: Port to bind\n");
+        fprintf(stderr, "Arg4: Pass sockaddr_in <true/false>\n");
         return EXIT_FAILURE;
     }
 
     const char* bind_to = argv[1];
     const char* connect_to = argv[2];
     int port = atoi(argv[3]);
+
+    struct sockaddr_in *sockAddrPtr = NULL;
+    struct sockaddr_in sockAddr;
+    memset(&sockAddr, 0, sizeof(struct sockaddr_in));
+
+    socklen_t sockLen = sizeof(struct sockaddr_in);
+
+    if (strcmp(argv[4], "true") == 0) {
+        sockAddrPtr = &sockAddr;
+    }
 
     int s;
     s = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -443,13 +454,13 @@ int test_accept_af_inet(int argc, char** argv) {
         return EXIT_FAILURE;
     }
 
-    pthread_create(&thread, NULL, connect_thread_ipv4, (void*) &connectAddr);
+    pthread_create(&thread, NULL, connect_thread_ipv4, (void*)&connectAddr);
 
-    if (accept(s, NULL, NULL) < 0) {
+    if (accept(s, (struct sockaddr*)sockAddrPtr, &sockLen) < 0) {
         perror("Failed to accept");
     }
 
-    close (s);
+    close(s);
     pthread_join(thread, NULL);
     return EXIT_SUCCESS;
 }
@@ -464,17 +475,28 @@ void* connect_thread_ipv6(void *arg) {
 int test_accept_af_inet6(int argc, char** argv) {
     pthread_t thread;
 
-    if (argc != 4) {
+    if (argc != 5) {
         fprintf(stderr, "%s: please specify a valid command:\n", __FUNCTION__);
         fprintf(stderr, "Arg1: IP address where the socket should bind to\n");
         fprintf(stderr, "Arg2: IP address where the socket should connect to\n");
         fprintf(stderr, "Arg3: Port to bind\n");
+        fprintf(stderr, "Arg4: Pass sockaddr_in <true/false>\n");
         return EXIT_FAILURE;
     }
 
     const char* bind_to = argv[1];
     const char* connect_to = argv[2];
     int port = atoi(argv[3]);
+
+    struct sockaddr_in6 *sockAddrPtr = NULL;
+    struct sockaddr_in6 sockAddr;
+    memset(&sockAddr, 0, sizeof(struct sockaddr_in6));
+
+    socklen_t sockLen = sizeof(struct sockaddr_in6);
+
+    if (strcmp(argv[4], "true") == 0) {
+        sockAddrPtr = &sockAddr;
+    }
 
     int s;
     s = socket(PF_INET6, SOCK_STREAM, IPPROTO_TCP);
@@ -520,7 +542,7 @@ int test_accept_af_inet6(int argc, char** argv) {
 
     pthread_create(&thread, NULL, connect_thread_ipv6, (void*)&connectAddr);
 
-    if (accept(s, NULL, NULL) < 0) {
+    if (accept(s, (struct sockaddr*)sockAddrPtr, &sockLen) < 0) {
         perror("Failed to accept");
     }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
* Adds the following events to the ebpfless agent:
  * accept (ipv4, ipv6)
  * bind (ipv4, ipv6, domain sockets)
  * connect (ipv4, ipv6)

### Motivation

Increase network detection coverage in the ebpfless agent

### Describe how you validated your changes
* By using the integration tests present for the eBPF events and checking if the syscalls generated by the syscall tester program were being captured with the correct data.
* Instrumenting netcat locally to trigger those syscalls and verifying thtat the correct information appears in the datadog backend
* Doing the same as above on AWS fargate