### PR TITLE
fix %s to %w in IsUserAnAdmin

### DIFF
--- a/pkg/util/winutil/users.go
+++ b/pkg/util/winutil/users.go
@@ -56,7 +56,7 @@ func IsUserAnAdmin() (bool, error) {
 		0, 0, 0, 0, 0, 0,
 		&administratorsGroup)
 	if err != nil {
-		return false, fmt.Errorf("could not get local system SID: %s", err)
+		return false, fmt.Errorf("could not get local system SID: %w", err)
 	}
 	defer windows.FreeSid(administratorsGroup)
 
@@ -64,7 +64,7 @@ func IsUserAnAdmin() (bool, error) {
 	var isAdmin bool
 	err = CheckTokenMembership(0, administratorsGroup, &isAdmin)
 	if err != nil {
-		return false, fmt.Errorf("could not check token membership: %s", err)
+		return false, fmt.Errorf("could not check token membership: %w", err)
 	}
 
 	return isAdmin, nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix the %s to a %w to correctly wrap the error in `IsUserAnAdmin` function.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-1233
Fixes the error wrapping in new `IsUserAnAdmin` code.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Validated by: [fix is user admin](https://github.com/DataDog/datadog-agent/pull/32925)

Change log covered by: [fix is user admin](https://github.com/DataDog/datadog-agent/pull/32925)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->