### PR TITLE
[DJM] Add Databricks workspace name as tag

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -121,6 +121,7 @@ func setupCommonHostTags(s *common.Setup) {
 		return clusterNameRegex.ReplaceAllString(v, "_")
 	})
 	setIfExists(s, "DB_CLUSTER_ID", "databricks_cluster_id", nil)
+	setIfExists(s, "DATABRICKS_WORKSPACE", "databricks_workspace", nil)
 
 	// dupes for backward compatibility
 	setIfExists(s, "DB_CLUSTER_ID", "cluster_id", nil)

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -27,12 +27,13 @@ func TestSetupCommonHostTags(t *testing.T) {
 		{
 			name: "basic fields with formatting",
 			env: map[string]string{
-				"DB_DRIVER_IP":      "192.168.1.100",
-				"DB_INSTANCE_TYPE":  "m4.xlarge",
-				"DB_IS_JOB_CLUSTER": "true",
-				"DD_JOB_NAME":       "example,'job,name",
-				"DB_CLUSTER_NAME":   "example[,'job]name",
-				"DB_CLUSTER_ID":     "cluster123",
+				"DB_DRIVER_IP":         "192.168.1.100",
+				"DB_INSTANCE_TYPE":     "m4.xlarge",
+				"DB_IS_JOB_CLUSTER":    "true",
+				"DD_JOB_NAME":          "example,'job,name",
+				"DB_CLUSTER_NAME":      "example[,'job]name",
+				"DB_CLUSTER_ID":        "cluster123",
+				"DATABRICKS_WORKSPACE": "example_workspace",
 			},
 			wantTags: []string{
 				"spark_host_ip:192.168.1.100",
@@ -43,6 +44,7 @@ func TestSetupCommonHostTags(t *testing.T) {
 				"databricks_cluster_id:cluster123",
 				"cluster_id:cluster123",
 				"cluster_name:example___job_name",
+				"databricks_workspace:example_workspace",
 			},
 		},
 		{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the workspace name as tag (host and installer span tags) if the env var `DATABRICKS_WORKSPACE` exists.

### Motivation

With the current Databricks init script, the workspace name is surfaced in our dashboard because we add it as tag during the install. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->