### PR TITLE
[NPM-4140] Enable ebpfless tests in KMT

### DIFF
--- a/pkg/ebpf/ebpftest/buildmode_linux.go
+++ b/pkg/ebpf/ebpftest/buildmode_linux.go
@@ -26,16 +26,13 @@ func init() {
 
 // SupportedBuildModes returns the build modes supported on the current host
 func SupportedBuildModes() []BuildMode {
-	modes := []BuildMode{RuntimeCompiled, CORE}
+	modes := []BuildMode{RuntimeCompiled, CORE, Ebpfless}
 	if !prebuilt.IsDeprecated() || os.Getenv("TEST_PREBUILT_OVERRIDE") == "true" {
 		modes = append(modes, Prebuilt)
 	}
 	if os.Getenv("TEST_FENTRY_OVERRIDE") == "true" ||
 		(runtime.GOARCH == "amd64" && (hostPlatform == "amazon" || hostPlatform == "amzn") && kv.Major() == 5 && kv.Minor() == 10) {
 		modes = append(modes, Fentry)
-	}
-	if os.Getenv("TEST_EBPFLESS_OVERRIDE") == "true" {
-		modes = append(modes, Ebpfless)
 	}
 
 	return modes

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1894,10 +1894,13 @@ func (s *TracerSuite) TestShortWrite() {
 	c, err := net.FileConn(f)
 	require.NoError(t, err)
 
+	var conn *network.ConnectionStats
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		conns := getConnections(collect, tr)
-		conn, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		require.True(collect, ok)
+		if conn == nil {
+			conn, _ = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		}
+		require.NotNil(collect, conn)
 		require.Equal(collect, sent, conn.Monotonic.SentBytes)
 	}, 3*time.Second, 100*time.Millisecond, "couldn't find connection used by short write")
 }

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2322,7 +2322,7 @@ func TestConntrackerFallback(t *testing.T) {
 
 func testConfig() *config.Config {
 	cfg := config.New()
-	if env.IsECSFargate() {
+	if env.IsECSFargate() || cfg.EnableEbpfless {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Unconditionally enables KMT testing for ebpfless
### Motivation
We want to routinely check for regressions in ebpfless.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
`TEST_EBPFLESS_OVERRIDE` is not required anymore:
```
DD_REMOTE_CONFIGURATION_ENABLED=false sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless/TestTCPConnsReported
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->