### PR TITLE
Introduce intake connection count check

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -37,6 +37,12 @@ checks:
       series: total_rss_bytes
       upper_bound: "356.0 MiB"
 
+  - name: intake_connections
+    description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."
+    bounds:
+      series: "connection.current"
+      upper_bound: 3
+
 report_links:
   - text: "bounds checks dashboard"
     link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&tpl_var_run-id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -48,6 +48,12 @@ checks:
       series: total_rss_bytes
       upper_bound: "735.0 MiB"
 
+  - name: intake_connections
+    description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."
+    bounds:
+      series: "connection.current"
+      upper_bound: 3
+
 report_links:
   - text: "bounds checks dashboard"
     link: "https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=true&refresh_mode=paused&tpl_var_experiment%5B0%5D={{ experiment }}&tpl_var_job_id%5B0%5D={{ job_id }}&tpl_var_run-id%5B0%5D={{ job_id }}&view=spans&from_ts={{ start_time_ms }}&to_ts={{ end_time_ms }}&live=false"

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -35,3 +35,9 @@ checks:
     bounds:
       series: lost_bytes
       upper_bound: 0KiB
+
+  - name: intake_connections
+    description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."
+    bounds:
+      series: "connection.current"
+      upper_bound: 6


### PR DESCRIPTION
### What does this PR do?

This commit introduces a new check to all quality gate experiments bounding above the connections established by Agent to the Datadog intake. Here the intake is our in-rig endpoint and not the actual Datadog API intake, so we have perfect knowledge.

This check is intended to preserve status quo and is intentionally generous.

