### PR TITLE
[AMLII-2241] Stop Integrations Launcher from Receiving Empty Configs

### DIFF
--- a/comp/logs/integrations/impl/integrations.go
+++ b/comp/logs/integrations/impl/integrations.go
@@ -27,6 +27,10 @@ func NewLogsIntegration() *Logsintegration {
 
 // RegisterIntegration registers an integration with the integrations component
 func (li *Logsintegration) RegisterIntegration(id string, config integration.Config) {
+	if config.LogsConfig == nil || len(config.LogsConfig) == 0 {
+		return
+	}
+
 	integrationConfig := integrations.IntegrationConfig{
 		IntegrationID: id,
 		Config:        config,

--- a/comp/logs/integrations/impl/integrations.go
+++ b/comp/logs/integrations/impl/integrations.go
@@ -27,7 +27,7 @@ func NewLogsIntegration() *Logsintegration {
 
 // RegisterIntegration registers an integration with the integrations component
 func (li *Logsintegration) RegisterIntegration(id string, config integration.Config) {
-	if config.LogsConfig == nil || len(config.LogsConfig) == 0 {
+	if len(config.LogsConfig) == 0 {
 		return
 	}
 

--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -8,7 +8,6 @@ package integration
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -147,8 +146,7 @@ func (s *Launcher) run() {
 func (s *Launcher) receiveSources(cfg integrations.IntegrationConfig) {
 	sources, err := ad.CreateSources(cfg.Config)
 	if err != nil {
-		configError := fmt.Sprintf("Failed to create source for %s:", cfg.Config.Name)
-		ddLog.Error(configError, err)
+		ddLog.Errorf("Failed to create source for %q: %v", cfg.Config.Name, err)
 		return
 	}
 
@@ -162,8 +160,7 @@ func (s *Launcher) receiveSources(cfg integrations.IntegrationConfig) {
 			if !exists {
 				logFile, err = s.createFile(cfg.IntegrationID)
 				if err != nil {
-					sourceError := fmt.Sprintf("Failed to create integration log file for %s:", source.Config.IntegrationName)
-					ddLog.Error(sourceError, err)
+					ddLog.Errorf("Failed to create integration log file for %q: %v", source.Config.IntegrationName, err)
 					continue
 				}
 

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -108,18 +108,9 @@ func (suite *LauncherTestSuite) TestEmptyConfig() {
 	mockConf.Provider = "container"
 	mockConf.LogsConfig = integration.Data(``)
 
-	id := "123456789"
-
 	suite.s.Start(nil, nil, nil, nil)
-	integrationChan := suite.integrationsComp.Subscribe()
-	suite.integrationsComp.RegisterIntegration(id, *mockConf)
+	suite.integrationsComp.RegisterIntegration("12345", *mockConf)
 
-	select {
-	case msg := <-integrationChan:
-		assert.Fail(suite.T(), "Expected channel to not receive logs, instead got:", msg)
-	case <-time.After(10 * time.Millisecond):
-		assert.True(suite.T(), true, "Channel remained empty.")
-	}
 	assert.Equal(suite.T(), len(suite.s.sources.GetSources()), 0)
 }
 

--- a/pkg/logs/launchers/integration/launcher_test.go
+++ b/pkg/logs/launchers/integration/launcher_test.go
@@ -103,6 +103,26 @@ func (suite *LauncherTestSuite) TestSendLog() {
 	assert.Equal(suite.T(), expectedPath, <-filepathChan)
 }
 
+func (suite *LauncherTestSuite) TestEmptyConfig() {
+	mockConf := &integration.Config{}
+	mockConf.Provider = "container"
+	mockConf.LogsConfig = integration.Data(``)
+
+	id := "123456789"
+
+	suite.s.Start(nil, nil, nil, nil)
+	integrationChan := suite.integrationsComp.Subscribe()
+	suite.integrationsComp.RegisterIntegration(id, *mockConf)
+
+	select {
+	case msg := <-integrationChan:
+		assert.Fail(suite.T(), "Expected channel to not receive logs, instead got:", msg)
+	case <-time.After(10 * time.Millisecond):
+		assert.True(suite.T(), true, "Channel remained empty.")
+	}
+	assert.Equal(suite.T(), len(suite.s.sources.GetSources()), 0)
+}
+
 // TestNegativeCombinedUsageMax ensures errors in combinedUsageMax don't result
 // in panics from `deleteFile`
 func (suite *LauncherTestSuite) TestNegativeCombinedUsageMax() {

--- a/releasenotes/notes/fix-integration-blank-config-b9faf78986eeb737.yaml
+++ b/releasenotes/notes/fix-integration-blank-config-b9faf78986eeb737.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Bypass sending blank logs configs to the integrations launcher.

--- a/releasenotes/notes/fix-integration-blank-config-b9faf78986eeb737.yaml
+++ b/releasenotes/notes/fix-integration-blank-config-b9faf78986eeb737.yaml
@@ -8,4 +8,5 @@
 ---
 fixes:
   - |
-    Bypass sending blank logs configs to the integrations launcher.
+    Bypass sending blank logs configs to the integrations launcher to
+    prevent the launcher from sending JSON parse error logs.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes a bug where the integrations launcher received blank configurations from `RegisterIntegration`. It was causing the launcher to emit errant logs since parsing the JSON would return an error.

### Motivation

Fix known bug

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Reproduced the issue using a test case of sending the launcher an integration config with an empty logs configuration then changed the behavior of `RegisterIntegration`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

To QA, run the following docker compose:

```yaml
version: '3.8'

services:
  nginx:
    image: nginx:latest
    container_name: nginx_server
    labels:
      com.datadoghq.ad.checks: '{"nginx": {"instances": [{"nginx_status_url": "http://nginx:80/nginx_status"}]}}'
    ports:
      - "8080:80"
    environment:
      - NGINX_HOST=localhost
      - NGINX_PORT=80

  datadog:
    image: datadog/agent-dev:lucas-liseth-fix-launcher-errant-log-py3-jmx
    container_name: datadog_agent
    environment:
      - DD_API_KEY={your_api_key_here}
      - DD_HOSTNAME=nginx_monitoring
      - DD_SITE=datadoghq.com
      - DD_LOGS_ENABLED=true
      - DD_COLLECT_LOGS=true
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
```
and ensure that a log like the following doesn't appear: `CORE | ERROR | (pkg/logs/launchers/integration/launcher.go:130 in run) | Failed to create source  could not parse JSON logs config: unexpected end of JSON input`