### PR TITLE
[EBPF] GPU monitoring: removed unused field in GPU context

### DIFF
--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -27,9 +27,6 @@ const nvidiaResourceName = "nvidia.com/gpu"
 
 // systemContext holds certain attributes about the system that are used by the GPU probe.
 type systemContext struct {
-	// maxGpuThreadsPerDevice maps each device index to the maximum number of threads it can run in parallel
-	maxGpuThreadsPerDevice map[int]int
-
 	// timeResolver allows to resolve kernel-time timestamps
 	timeResolver *ktime.Resolver
 
@@ -83,7 +80,6 @@ func (e *symbolsEntry) updateLastUsedTime() {
 
 func getSystemContext(nvmlLib nvml.Interface, procRoot string, wmeta workloadmeta.Component) (*systemContext, error) {
 	ctx := &systemContext{
-		maxGpuThreadsPerDevice:    make(map[int]int),
 		deviceSmVersions:          make(map[int]int),
 		cudaSymbols:               make(map[string]*symbolsEntry),
 		pidMaps:                   make(map[int][]*procfs.ProcMap),
@@ -136,13 +132,6 @@ func (ctx *systemContext) fillDeviceInfo() error {
 			return err
 		}
 		ctx.deviceSmVersions[i] = smVersion
-
-		maxThreads, ret := dev.GetNumGpuCores()
-		if ret != nvml.SUCCESS {
-			return fmt.Errorf("error getting max threads for device %s: %s", dev, nvml.ErrorString(ret))
-		}
-
-		ctx.maxGpuThreadsPerDevice[i] = maxThreads
 
 		ctx.gpuDevices = append(ctx.gpuDevices, dev)
 	}


### PR DESCRIPTION
### What does this PR do?
removed redundant `maxGpuThreadsPerDevice` cache map, as it is no longer used. The aggregators are querying the device cache directly using the UUID as the key, as opposed to the old way of using the device ID.

### Motivation

unused code

### Describe how you validated your changes
All existing UTs should still pass

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->