### PR TITLE
fix bundle arg check when building the agent

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -99,7 +99,7 @@ build do
     command "inv -e rtloader.clean"
     command "inv -e rtloader.make --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER -DPython3_EXECUTABLE=#{install_dir}/embedded/bin/python3'", :env => env
     command "inv -e rtloader.install"
-    bundle_arg = bundled_agents ? bundled_agents.map { |k| "--bundle #{k}" }.join(" ") : "--bundle agent"
+    bundle_arg = bundled_agents.map { |k| "--bundle #{k}" }.join(" ")
 
     include_sds = ""
     if linux_target?


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When we investigated the impact of the single agent binary and the bundle system we found out that this `bundle_arg` is wrong because `[]` is truth-y in ruby. This PR fixes the check to make sure the bundling is done as expected.

This PR makes no change to the actual artifact, it's done just to not have a known bug in the code.

### Motivation

### Describe how you validated your changes

This PR was validate manually (and using the size checks) but during QA week you should:
- make sure the shipped agent is not a single agent binary: especially running `DD_BUNDLED_AGENT=trace-agent agent --help` should not print the help message of the trace agent
- make sure the shipped agents for heroku are still working as expected: there should be one regular core agent at the usual path, and one bundled agent at `bin/agent/core-agent` including both the core agent and the process agent

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->