### PR TITLE
remove flake from persisting integrations test

### DIFF
--- a/test/new-e2e/tests/agent-platform/persisting-integrations/persisting_integrations_test.go
+++ b/test/new-e2e/tests/agent-platform/persisting-integrations/persisting_integrations_test.go
@@ -70,7 +70,6 @@ func (is *persistingIntegrationsSuite) AfterTest(suiteName, testName string) {
 }
 
 func TestPersistingIntegrations(t *testing.T) {
-	flake.Mark(t)
 
 	platformJSON := map[string]map[string]map[string]string{}
 

--- a/test/new-e2e/tests/agent-platform/persisting-integrations/persisting_integrations_test.go
+++ b/test/new-e2e/tests/agent-platform/persisting-integrations/persisting_integrations_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the flaky mark for testing linux persisting integrations. 

### Motivation

This was added when the test was created, but does not need to be marked flaky anymore. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Looking at the tests it seems all failures where from infra flakes. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->