### PR TITLE
processor: early returns if msg object is malformed for processing.

### DIFF
--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -258,6 +258,10 @@ func (p *Processor) processMessage(msg *message.Message) {
 // applyRedactingRules returns given a message if we should process it or not,
 // it applies the change directly on the Message content.
 func (p *Processor) applyRedactingRules(msg *message.Message) bool {
+	if msg == nil || msg.Origin == nil || msg.Origin.LogSource == nil || msg.Origin.LogSource.Config == nil {
+		return false
+	}
+
 	var content []byte = msg.GetContent()
 
 	// Use the internal scrubbing implementation of the Agent

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -259,6 +259,7 @@ func (p *Processor) processMessage(msg *message.Message) {
 // it applies the change directly on the Message content.
 func (p *Processor) applyRedactingRules(msg *message.Message) bool {
 	if msg == nil || msg.Origin == nil || msg.Origin.LogSource == nil || msg.Origin.LogSource.Config == nil {
+	    log.Warn("nil msg or msg with nil attribute")
 		return false
 	}
 


### PR DESCRIPTION
### What does this PR do?

Eliminate potential nil access on `applyRedactingRules` calls.

### Motivation

Do not trust the callers.
