### PR TITLE
do not abort installation if lanmanserver is not available

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -52,6 +52,7 @@
       - E2E_MSI_TEST: TestInstallExistingAltDir
       - E2E_MSI_TEST: TestInstallAltDirAndCorruptForUninstall
       - E2E_MSI_TEST: TestInstallFail
+      - E2E_MSI_TEST: TestInstallWithLanmanServerDisabled
       # These tests are v7 only
       - E2E_MSI_TEST: TestNPMUpgradeToNPM
       - E2E_MSI_TEST: TestNPMUpgradeNPMToNPM

--- a/releasenotes/notes/msi-lanmanserver-6b8f1bf993efb5c3.yaml
+++ b/releasenotes/notes/msi-lanmanserver-6b8f1bf993efb5c3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Windows installer will not abort if the LanmanServer (Server) service is not running, regression introduced in 7.47.0.

--- a/releasenotes/notes/msi-lanmanserver-6b8f1bf993efb5c3.yaml
+++ b/releasenotes/notes/msi-lanmanserver-6b8f1bf993efb5c3.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Windows installer will not abort if the LanmanServer (Server) service is not running, regression introduced in 7.47.0.
+    Windows installer will not abort if the LanmanServer (Server) service is not running (regression introduced in 7.47.0).

--- a/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions.Tests/ProcessUserCustomActions/UserCustomActionsTests.cs
@@ -179,5 +179,18 @@ namespace CustomActions.Tests.ProcessUserCustomActions
                 .Should()
                 .Be(ActionResult.Failure);
         }
+
+        [Fact]
+        public void ProcessDdAgentUserCredentials_Handles_Lanmanserver_Not_Availabile()
+        {
+            // IsDomainController throws an exception if the Lanmanserver service is not available
+            Test.NativeMethods
+                .Setup(n => n.IsDomainController()).Throws<Exception>();
+
+            Test.Create()
+                .ProcessDdAgentUserCredentials()
+                .Should()
+                .Be(ActionResult.Success);
+        }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -90,7 +90,6 @@ namespace Datadog.CustomActions
         /// </summary>
         private void ConfigureUserGroups()
         {
-            // Host is a domain controller, fetch additional info
             try
             {
                 if (_nativeMethods.IsReadOnlyDomainController())

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ConfigureUserCustomActions.cs
@@ -90,11 +90,22 @@ namespace Datadog.CustomActions
         /// </summary>
         private void ConfigureUserGroups()
         {
-            if (_nativeMethods.IsReadOnlyDomainController())
+            // Host is a domain controller, fetch additional info
+            try
             {
-                _session.Log("Host is a Read-Only Domain controller, user cannot be added to groups by the installer." +
-                             " Install will continue, agent may not function properly if user has not been added to these groups.");
-                return;
+                if (_nativeMethods.IsReadOnlyDomainController())
+                {
+                    _session.Log("Host is a Read-Only Domain controller, user cannot be added to groups by the installer." +
+                                 " Install will continue, agent may not function properly if user has not been added to these groups.");
+                    return;
+                }
+            }
+            catch (Exception e)
+            {
+                // On error assume the host is not a read-only domain controller
+                // If the host is actually a read-only domain controller then the following operations will fail
+                _session.Log($"Error determining if host is a read-only domain controller, continuing assuming it is not: {e}");
+                _session.Log("If the host is actually a read-only domain controller, ensure the LanmanServer/Server service is running.");
             }
 
             _nativeMethods.AddToGroup(_ddAgentUserSID, WellKnownSidType.BuiltinPerformanceMonitoringUsersSid);

--- a/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/ProcessUserCustomActions.cs
@@ -277,7 +277,7 @@ namespace Datadog.CustomActions
         /// <summary>
         /// Throws an exception if the password is required but not provided.
         /// </summary>
-        private void TestIfPasswordIsRequiredAndProvidedForExistingAccount(string ddAgentUserName, string ddAgentUserPassword, bool isDomainController,
+        private void TestIfPasswordIsRequiredAndProvidedForExistingAccount(string ddAgentUserName, string ddAgentUserPassword,
             bool isServiceAccount, bool isDomainAccount, bool datadogAgentServiceExists)
         {
             var passwordProvided = !string.IsNullOrEmpty(ddAgentUserPassword);
@@ -298,7 +298,7 @@ namespace Datadog.CustomActions
             // Only look for $ at the end of the account name if it's a domain account, because
             // normal account names can end with $. In the case of a domain account that ends
             // in $ that is NOT intended to be a gMSA account, the user must provide a password.
-            if (isDomainController || isDomainAccount)
+            if (_isDomainController || isDomainAccount)
             {
                 if (ddAgentUserName.EndsWith("$") && !isServiceAccount)
                 {
@@ -307,7 +307,7 @@ namespace Datadog.CustomActions
                 }
             }
 
-            if (isDomainController)
+            if (_isDomainController)
             {
                 // We choose not to create/manage the account/password on domain controllers because
                 // the account can be replicated/used across the domain/forest.
@@ -442,7 +442,7 @@ namespace Datadog.CustomActions
                         $"\"{domain}\\{userName}\" ({securityIdentifier.Value}, {nameUse}) is a {(isDomainAccount ? "domain" : "local")} {(isServiceAccount ? "service " : string.Empty)}account");
 
                     TestAgentUserIsNotCurrentUser(securityIdentifier, isServiceAccount);
-                    TestIfPasswordIsRequiredAndProvidedForExistingAccount(userName, ddAgentUserPassword, _isDomainController, isServiceAccount, isDomainAccount, datadogAgentServiceExists);
+                    TestIfPasswordIsRequiredAndProvidedForExistingAccount(userName, ddAgentUserPassword, isServiceAccount, isDomainAccount, datadogAgentServiceExists);
                 }
                 else
                 {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix regression introduced in 7.47.0 that fails the install if `LanmanServer` service is not available.

originally fixed in 7.28.0: https://github.com/DataDog/datadog-agent/pull/7655
 
### Motivation
https://datadoghq.atlassian.net/browse/WINA-252
https://datadoghq.atlassian.net/browse/WINA-507
https://datadoghq.atlassian.net/browse/FRAGENT-2624

Fix regression.

Make possible to attempt tests in containers.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
disable+stop `LanmanServer` service and install the Agent

install the Agent in a container

unit test and e2e test added

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
`LanmanServer` service is required for the Windows APIs ([NetServerGetInfo](https://learn.microsoft.com/en-us/windows/win32/api/lmserver/nf-lmserver-netservergetinfo)) used by the installer to determine if the host is a domain controller. If this API fails the installer will now assume the host is a workstation/client, as it did before 7.47.0.

This will also allow the installer to succeed in a container, though we don't officially support that method. We separately provide containers with the Agent pre-installed, refer to [our documentation](https://docs.datadoghq.com/containers/docker/?tab=windows) for details.