### PR TITLE
Auto multiline V2 - Perform JSON detection after user submitted patterns have been evaluated

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
@@ -19,7 +19,7 @@ func NewJSONDetector() *JSONDetector {
 }
 
 // ProcessAndContinue checks if a message is a JSON message.
-// This implements the Herustic interface - so we should stop processing if we detect a JSON message by returning false.
+// This implements the Heuristic interface - so we should stop processing if we detect a JSON message by returning false.
 func (j *JSONDetector) ProcessAndContinue(context *messageContext) bool {
 	if context.labelAssignedBy == defaultLabelSource && jsonRegexp.Match(context.rawMessage) {
 		context.label = noAggregate

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector.go
@@ -21,7 +21,7 @@ func NewJSONDetector() *JSONDetector {
 // ProcessAndContinue checks if a message is a JSON message.
 // This implements the Herustic interface - so we should stop processing if we detect a JSON message by returning false.
 func (j *JSONDetector) ProcessAndContinue(context *messageContext) bool {
-	if jsonRegexp.Match(context.rawMessage) {
+	if context.labelAssignedBy == defaultLabelSource && jsonRegexp.Match(context.rawMessage) {
 		context.label = noAggregate
 		context.labelAssignedBy = "JSON_detector"
 		return false

--- a/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/json_detector_test.go
@@ -40,11 +40,23 @@ func TestJsonDetector(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(string(tc.rawMessage), func(t *testing.T) {
 			messageContext := &messageContext{
-				rawMessage: []byte(tc.rawMessage),
-				label:      aggregate,
+				rawMessage:      []byte(tc.rawMessage),
+				label:           aggregate,
+				labelAssignedBy: defaultLabelSource,
 			}
 			assert.Equal(t, tc.expectedResult, jsonDetector.ProcessAndContinue(messageContext))
 			assert.Equal(t, tc.expectedLabel, messageContext.label)
 		})
 	}
+}
+
+func TestJsonDetectorDoesntOverrideAssignedLabel(t *testing.T) {
+	jsonDetector := NewJSONDetector()
+	messageContext := &messageContext{
+		rawMessage:      []byte(`{"key": "value"}`),
+		label:           aggregate,
+		labelAssignedBy: "Not default!",
+	}
+	assert.Equal(t, true, jsonDetector.ProcessAndContinue(messageContext))
+	assert.Equal(t, aggregate, messageContext.label)
 }

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
@@ -15,6 +15,8 @@ const (
 	startGroup Label = iota
 	noAggregate
 	aggregate
+
+	defaultLabelSource = "default"
 )
 
 type messageContext struct {
@@ -59,7 +61,7 @@ func (l *Labeler) Label(rawMessage []byte) Label {
 		rawMessage:      rawMessage,
 		tokens:          nil,
 		label:           aggregate,
-		labelAssignedBy: "default",
+		labelAssignedBy: defaultLabelSource,
 	}
 	for _, h := range l.lablerHeuristics {
 		if !h.ProcessAndContinue(context) {

--- a/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/labeler.go
@@ -38,7 +38,7 @@ type Heuristic interface {
 
 // Labeler labels log messages based on a set of heuristics.
 // Each Heuristic operates on the output of the previous heuristic - mutating the message context.
-// A label is chosen when a herusitc signals the labeler to stop or when all herustics have been processed.
+// A label is chosen when a herusitc signals the labeler to stop or when all Heuristics have been processed.
 type Labeler struct {
 	lablerHeuristics    []Heuristic
 	analyticsHeuristics []Heuristic

--- a/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/pattern_table.go
@@ -142,7 +142,7 @@ func (p *PatternTable) DumpTable() []DiagnosticRow {
 }
 
 // ProcessAndContinue adds a pattern to the table and updates its label based on it's frequency.
-// This implements the Herustic interface - so we should stop processing if the label was changed
+// This implements the Heuristic interface - so we should stop processing if the label was changed
 // due to pattern detection.
 func (p *PatternTable) ProcessAndContinue(context *messageContext) bool {
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/tokenizer.go
@@ -38,7 +38,7 @@ func NewTokenizer(maxEvalBytes int) *Tokenizer {
 }
 
 // ProcessAndContinue enriches the message context with tokens.
-// This implements the Herustic interface - this heuristic does not stop processing.
+// This implements the Heuristic interface - this heuristic does not stop processing.
 func (t *Tokenizer) ProcessAndContinue(context *messageContext) bool {
 	maxBytes := len(context.rawMessage)
 	if maxBytes > t.maxEvalBytes {

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
@@ -117,7 +117,7 @@ func NewUserSamples(config model.Reader) *UserSamples {
 }
 
 // ProcessAndContinue applies a user sample to a log message. If it matches, a label is assigned.
-// This implements the Herustic interface - so we should stop processing if we detect a user pattern by returning false.
+// This implements the Heuristic interface - so we should stop processing if we detect a user pattern by returning false.
 func (j *UserSamples) ProcessAndContinue(context *messageContext) bool {
 	if context.tokens == nil {
 		log.Error("Tokens are required to process user samples")

--- a/pkg/logs/internal/decoder/auto_multiline_handler.go
+++ b/pkg/logs/internal/decoder/auto_multiline_handler.go
@@ -27,12 +27,11 @@ func NewAutoMultilineHandler(outputFn func(m *message.Message), maxContentSize i
 	heuristics := []automultilinedetection.Heuristic{}
 
 	heuristics = append(heuristics, automultilinedetection.NewTokenizer(pkgconfigsetup.Datadog().GetInt("logs_config.auto_multi_line.tokenizer_max_input_bytes")))
+	heuristics = append(heuristics, automultilinedetection.NewUserSamples(pkgconfigsetup.Datadog()))
 
 	if pkgconfigsetup.Datadog().GetBool("logs_config.auto_multi_line.enable_json_detection") {
 		heuristics = append(heuristics, automultilinedetection.NewJSONDetector())
 	}
-
-	heuristics = append(heuristics, automultilinedetection.NewUserSamples(pkgconfigsetup.Datadog()))
 
 	if pkgconfigsetup.Datadog().GetBool("logs_config.auto_multi_line.enable_datetime_detection") {
 		heuristics = append(heuristics, automultilinedetection.NewTimestampDetector(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Previously - if a log was detected to be JSON, all future heuristics would be skipped. There may be cases where this is not ideal (such as JSON being split onto multiple lines). This PR adjusts JSON detection to occur after user patterns have been evaluated. JSON detection is skipped if a user pattern matched the log. This allows users to override the JSON detection behavior with a well crafted regex/sample if desired. This avoids needing to disable json detection globally in these cases. 

### Motivation

User feedback on Auto multiline V2. 

### Describe how you validated your changes

1. In Datadog.yaml

```yaml
logs_config:
    experimental_auto_multi_line_detection: true
    auto_multi_line_detection_custom_samples:
    - regex: ".*1234.*"
```

2. Submit the following log: 

```
2024-08-14 18:06:06 INFO Main main Some log line 169
{"id": "Foo", "timestmap": "1234", "message": "test", "level": "info"}
{"id": "Foo", "timestmap": "1234", "message": "test", "level": "info"}
2024-08-14 18:06:06 INFO Main main Some log line 169
2024-08-14 18:06:06 INFO Main main Some log line 169
{"id": "Foo", "timestmap": "1234", "message": "test", "level": "info"}
2024-08-14 18:06:06 INFO Main main Some log line 169
{"id": "Foo", "timestmap": "1234", 
"message": "test", "level": "info"}
2024-08-14 18:06:06 INFO Main main Some log line 169
{"id": "Foo", "timestmap": "1234", 
"message": "test", "level": "info"}
{"id": "Foo", "timestmap": "1234", 
"message": "test", "level": "info"}
{"id": "Foo", "timestmap": "1234", 
"message": "test", "level": "info"}
2024-08-14 18:06:06 INFO Main main Some log line 169
2024-08-14 18:06:06 INFO Main main Some log line 169
2024-08-14 18:06:06 INFO Main main Some log line 169
2024-08-14 18:06:06 INFO Main main Some log line 169
{"id": "Foo", "timestmap": "1234", 
"message": "test", "level": "info"}
```

3. In the log explorer check that the logs look like the screenshot below. Note that:
- Single line JSON logs are NOT aggregated. This shows that JSON detection is still working. 
- Multiline JSON logs are aggregated. This shows that JSON detection is bypassed by the configured pattern. 
- single line non JSON logs are not aggregated.

<img width="831" alt="Screenshot 2025-01-15 at 12 41 23 PM" src="https://github.com/user-attachments/assets/efd2e416-c745-4878-9c25-d607ff504173" />

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->