### PR TITLE
[EBPF] gpu: fixes for GPU flaky e2e tests

### DIFF
--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -160,7 +160,7 @@ func (v *gpuSuite) TestNvmlMetricsPresent() {
 }
 
 func (v *gpuSuite) TestWorkloadmetaHasGPUs() {
-	out, err := v.Env().RemoteHost.Execute("agent workload-list")
+	out, err := v.Env().RemoteHost.Execute("sudo /opt/datadog-agent/bin/agent/agent workload-list")
 	v.Require().NoError(err)
 	v.Contains(out, "=== Entity gpu sources(merged):[runtime] id: ")
 	if v.T().Failed() {

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -128,7 +128,7 @@ func gpuInstanceProvisioner(params *provisionerParams) provisioners.Provisioner 
 		}
 
 		// Validate GPU devices
-		validateGPUDevicesCmd, err := validateGPUDevices(awsEnv, host)
+		validateGPUDevicesCmd, err := validateGPUDevices(&awsEnv, host)
 		if err != nil {
 			return err
 		}
@@ -140,14 +140,14 @@ func gpuInstanceProvisioner(params *provisionerParams) provisioners.Provisioner 
 		}
 
 		// Pull all the docker images required for the tests
-		dockerPullCmds, err := downloadDockerImages(awsEnv, host, params.dockerImages, dockerManager)
+		dockerPullCmds, err := downloadDockerImages(&awsEnv, host, params.dockerImages, dockerManager)
 		if err != nil {
 			return err
 		}
 
 		// Validate that Docker can run CUDA samples
 		dockerCudaDeps := append(dockerPullCmds, validateGPUDevicesCmd...)
-		dockerCudaValidateCmd, err := validateDockerCuda(awsEnv, host, dockerCudaDeps...)
+		dockerCudaValidateCmd, err := validateDockerCuda(&awsEnv, host, dockerCudaDeps...)
 		if err != nil {
 			return fmt.Errorf("validateDockerCuda failed: %w", err)
 		}
@@ -169,7 +169,7 @@ func gpuInstanceProvisioner(params *provisionerParams) provisioners.Provisioner 
 		// Combine agent options from the parameters with the fakeintake and docker dependencies
 		params.agentOptions = append(params.agentOptions,
 			agentparams.WithFakeintake(fakeIntake),
-			agentparams.WithPulumiResourceOptions(utils.PulumiDependsOn(dockerManager, dockerCudaValidateCmd)), // Depend on Docker to avoid apt lock issues
+			agentparams.WithPulumiResourceOptions(utils.PulumiDependsOn(dockerCudaValidateCmd)), // Depend on Docker to avoid apt lock issues
 		)
 
 		// Set updater to nil as we're not using it
@@ -191,7 +191,7 @@ func gpuInstanceProvisioner(params *provisionerParams) provisioners.Provisioner 
 }
 
 // validateGPUDevices checks that there are GPU devices present and accesible
-func validateGPUDevices(e aws.Environment, vm *componentsremote.Host) ([]pulumi.Resource, error) {
+func validateGPUDevices(e *aws.Environment, vm *componentsremote.Host) ([]pulumi.Resource, error) {
 	commands := map[string]string{
 		"pci":    fmt.Sprintf("lspci -d %s:: | grep NVIDIA", nvidiaPCIVendorID),
 		"driver": "lsmod | grep nvidia",
@@ -217,7 +217,7 @@ func validateGPUDevices(e aws.Environment, vm *componentsremote.Host) ([]pulumi.
 	return cmds, nil
 }
 
-func downloadDockerImages(e aws.Environment, vm *componentsremote.Host, images []string, dependsOn ...pulumi.Resource) ([]pulumi.Resource, error) {
+func downloadDockerImages(e *aws.Environment, vm *componentsremote.Host, images []string, dependsOn ...pulumi.Resource) ([]pulumi.Resource, error) {
 	var cmds []pulumi.Resource
 
 	for i, image := range images {
@@ -238,7 +238,7 @@ func downloadDockerImages(e aws.Environment, vm *componentsremote.Host, images [
 	return cmds, nil
 }
 
-func validateDockerCuda(e aws.Environment, vm *componentsremote.Host, dependsOn ...pulumi.Resource) (command.Command, error) {
+func validateDockerCuda(e *aws.Environment, vm *componentsremote.Host, dependsOn ...pulumi.Resource) (command.Command, error) {
 	return vm.OS.Runner().Command(
 		e.CommonNamer().ResourceName("docker-cuda-validate"),
 		&command.Args{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR contains fixes for the GPU e2e tests, that are marked as flaky as part of #incident-33572. 

- A fix for the agent binary path when calling `workload-list` 
- Some tentative fixes where the `aws.Environment` was being copied and now they're being passed as a pointer. While it shouldn't have an effect, considering we don't know where the error is coming from it's a fix with no cost to try.
- Changing the dependencies of the agent, to depend only on the last command and not on intermediate ones.

### Motivation

Fixing the behavior of the GPU e2e test.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

e2e test run manually, as it's marked as flaky and doesn't run on PRs.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->