### PR TITLE
[CWS] fix needs statement for `.deploy_containers-cws-instrumentation-base`

### DIFF
--- a/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
+++ b/.gitlab/deploy_cws_instrumentation/deploy_cws_instrumentation.yml
@@ -9,7 +9,11 @@ include:
 .deploy_containers-cws-instrumentation-base:
   extends: .docker_publish_job_definition
   stage: deploy_cws_instrumentation
-  dependencies: []
+  needs:
+    - job: "docker_build_cws_instrumentation_amd64"
+      artifacts: false
+    - job: "docker_build_cws_instrumentation_arm64"
+      artifacts: false
   before_script:
     - if [[ "$VERSION" == "" ]]; then VERSION="$(inv agent.version --url-safe)" || exit $?; fi
     - if [[ "$CWS_INSTRUMENTATION_REPOSITORY" == "" ]]; then export CWS_INSTRUMENTATION_REPOSITORY="cws-instrumentation"; fi


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Similarly to what is being done for the DCA in https://github.com/DataDog/datadog-agent/blob/2953a65044d13e52f31b8146b079cc3d9cca1fc1/.gitlab/deploy_dca/deploy_dca.yml#L9, this PR fixes the `needs` clause of the cws-instrumentation deploy jobs. The main goal of this is to be able to trigger this job even if some unrelated job failed earlier in the pipeline.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->