### PR TITLE
Update _dd.gcr.resource_name to remove _dd prefix

### DIFF
--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -80,7 +80,7 @@ func (c *CloudRun) GetTags() map[string]string {
 		return c.getFunctionTags(tags)
 	}
 
-	tags["_dd.gcr.resource_name"] = "projects/" + tags["project_id"] + "/locations/" + tags["location"] + "/services/" + serviceName
+	tags["gcr.resource_name"] = "projects/" + tags["project_id"] + "/locations/" + tags["location"] + "/services/" + serviceName
 	return tags
 }
 
@@ -96,7 +96,7 @@ func (c *CloudRun) getFunctionTags(tags map[string]string) map[string]string {
 		tags[c.spanNamespace+"function_signature_type"] = functionSignatureType
 	}
 
-	tags["_dd.gcrfx.resource_name"] = "projects/" + tags["project_id"] + "/locations/" + tags["location"] + "/services/" + tags["service_name"] + "/functions/" + functionTarget
+	tags["gcrfx.resource_name"] = "projects/" + tags["project_id"] + "/locations/" + tags["location"] + "/services/" + tags["service_name"] + "/functions/" + functionTarget
 	return tags
 }
 

--- a/cmd/serverless-init/cloudservice/cloudrun_test.go
+++ b/cmd/serverless-init/cloudservice/cloudrun_test.go
@@ -35,15 +35,15 @@ func TestGetCloudRunTags(t *testing.T) {
 	tags := service.GetTags()
 
 	assert.Equal(t, map[string]string{
-		"container_id":          "test_container",
-		"gcr.container_id":      "test_container",
-		"gcr.location":          "test_region",
-		"location":              "test_region",
-		"project_id":            "test_project",
-		"gcr.project_id":        "test_project",
-		"origin":                "cloudrun",
-		"_dd.origin":            "cloudrun",
-		"_dd.gcr.resource_name": "projects/test_project/locations/test_region/services/",
+		"container_id":      "test_container",
+		"gcr.container_id":  "test_container",
+		"gcr.location":      "test_region",
+		"location":          "test_region",
+		"project_id":        "test_project",
+		"gcr.project_id":    "test_project",
+		"origin":            "cloudrun",
+		"_dd.origin":        "cloudrun",
+		"gcr.resource_name": "projects/test_project/locations/test_region/services/",
 	}, tags)
 }
 
@@ -73,19 +73,19 @@ func TestGetCloudRunTagsWithEnvironmentVariables(t *testing.T) {
 	tags := service.GetTags()
 
 	assert.Equal(t, map[string]string{
-		"container_id":          "test_container",
-		"gcr.container_id":      "test_container",
-		"location":              "test_region",
-		"gcr.location":          "test_region",
-		"project_id":            "test_project",
-		"gcr.project_id":        "test_project",
-		"service_name":          "test_service",
-		"gcr.service_name":      "test_service",
-		"gcr.revision_name":     "test_revision",
-		"revision_name":         "test_revision",
-		"origin":                "cloudrun",
-		"_dd.origin":            "cloudrun",
-		"_dd.gcr.resource_name": "projects/test_project/locations/test_region/services/test_service",
+		"container_id":      "test_container",
+		"gcr.container_id":  "test_container",
+		"location":          "test_region",
+		"gcr.location":      "test_region",
+		"project_id":        "test_project",
+		"gcr.project_id":    "test_project",
+		"service_name":      "test_service",
+		"gcr.service_name":  "test_service",
+		"gcr.revision_name": "test_revision",
+		"revision_name":     "test_revision",
+		"origin":            "cloudrun",
+		"_dd.origin":        "cloudrun",
+		"gcr.resource_name": "projects/test_project/locations/test_region/services/test_service",
 	}, tags)
 }
 
@@ -134,6 +134,6 @@ func TestGetCloudRunFunctionTagsWithEnvironmentVariables(t *testing.T) {
 		"_dd.origin":                    "cloudrun",
 		"gcrfx.function_target":         "test_target",
 		"gcrfx.function_signature_type": "test_signature",
-		"_dd.gcrfx.resource_name":       "projects/test_project/locations/test_region/services/test_service/functions/test_target",
+		"gcrfx.resource_name":           "projects/test_project/locations/test_region/services/test_service/functions/test_target",
 	}, tags)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update `_dd.<gcr/gcrfx>.resource_name` to remove the `_dd` prefix and update corresponding tests. This is a nonbreaking change as the tag is already present inside of the agent this just makes the tag always visible by removing the `_dd` prefix.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->