### PR TITLE
[CWS] Remove container_id from kernel context

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/activity_dump.h
+++ b/pkg/security/ebpf/c/include/helpers/activity_dump.h
@@ -46,12 +46,7 @@ __attribute__((always_inline)) struct activity_dump_config *lookup_or_delete_tra
 
 __attribute__((always_inline)) struct cgroup_tracing_event_t *get_cgroup_tracing_event() {
     u32 key = bpf_get_current_pid_tgid() % EVENT_GEN_SIZE;
-    struct cgroup_tracing_event_t *evt = bpf_map_lookup_elem(&cgroup_tracing_event_gen, &key);
-    if (evt == NULL) {
-        return 0;
-    }
-    evt->container.container_id[0] = 0;
-    return evt;
+    return bpf_map_lookup_elem(&cgroup_tracing_event_gen, &key);
 }
 
 __attribute__((always_inline)) u32 is_cgroup_activity_dumps_supported(struct cgroup_context_t *cgroup) {
@@ -113,11 +108,6 @@ __attribute__((always_inline)) u64 trace_new_cgroup(void *ctx, u64 now, struct c
         return 0;
     }
 
-    if ((container->cgroup_context.cgroup_flags&CGROUP_MANAGER_MASK) != CGROUP_MANAGER_SYSTEMD) {
-        copy_container_id(container->container_id, evt->container.container_id);
-    } else {
-        evt->container.container_id[0] = '\0';
-    }
     evt->container.cgroup_context = container->cgroup_context;
     evt->cookie = cookie;
     evt->config = config;

--- a/pkg/security/ebpf/c/include/helpers/container.h
+++ b/pkg/security/ebpf/c/include/helpers/container.h
@@ -13,8 +13,6 @@ static __attribute__((always_inline)) void copy_container_id(const container_id_
 static void __attribute__((always_inline)) fill_container_context(struct proc_cache_t *entry, struct container_context_t *context) {
     if (entry) {
         context->cgroup_context = entry->container.cgroup_context;
-    } else {
-        context->container_id[0] = 0;
     }
 }
 

--- a/pkg/security/ebpf/c/include/helpers/container.h
+++ b/pkg/security/ebpf/c/include/helpers/container.h
@@ -12,7 +12,6 @@ static __attribute__((always_inline)) void copy_container_id(const container_id_
 
 static void __attribute__((always_inline)) fill_container_context(struct proc_cache_t *entry, struct container_context_t *context) {
     if (entry) {
-        copy_container_id(entry->container.container_id, context->container_id);
         context->cgroup_context = entry->container.cgroup_context;
     } else {
         context->container_id[0] = 0;

--- a/pkg/security/ebpf/c/include/helpers/container.h
+++ b/pkg/security/ebpf/c/include/helpers/container.h
@@ -10,9 +10,18 @@ static __attribute__((always_inline)) void copy_container_id(const container_id_
 
 #define copy_container_id_no_tracing(src, dst) __builtin_memmove(dst, src, CONTAINER_ID_LEN)
 
+static void __attribute__((always_inline)) reset_cgroup_context(struct container_context_t *context) {
+    context->cgroup_context.cgroup_file.ino = 0;
+    context->cgroup_context.cgroup_file.mount_id = 0;
+    context->cgroup_context.cgroup_file.path_id = 0;
+    context->cgroup_context.cgroup_flags = 0;
+}
+
 static void __attribute__((always_inline)) fill_container_context(struct proc_cache_t *entry, struct container_context_t *context) {
     if (entry) {
         context->cgroup_context = entry->container.cgroup_context;
+    } else {
+        reset_cgroup_context(context);
     }
 }
 

--- a/pkg/security/ebpf/c/include/helpers/network/dns.h
+++ b/pkg/security/ebpf/c/include/helpers/network/dns.h
@@ -34,10 +34,7 @@ __attribute__((always_inline)) struct dns_event_t *reset_dns_event(struct __sk_b
     fill_network_context(&evt->network, skb, pkt);
 
     struct proc_cache_t *entry = get_proc_cache(evt->process.pid);
-    if (entry == NULL) {
-        evt->container.container_id[0] = 0;
-    } else {
-        copy_container_id_no_tracing(entry->container.container_id, &evt->container.container_id);
+    if (entry != NULL) {
         evt->container.cgroup_context = entry->container.cgroup_context;
     }
 

--- a/pkg/security/ebpf/c/include/helpers/network/imds.h
+++ b/pkg/security/ebpf/c/include/helpers/network/imds.h
@@ -29,13 +29,6 @@ __attribute__((always_inline)) struct imds_event_t *reset_imds_event(struct __sk
     // network context
     fill_network_context(&evt->network, skb, pkt);
 
-    struct proc_cache_t *entry = get_proc_cache(evt->process.pid);
-    if (entry == NULL) {
-        evt->container.container_id[0] = 0;
-    } else {
-        copy_container_id_no_tracing(entry->container.container_id, &evt->container.container_id);
-    }
-
     // should we sample this event for activity dumps ?
     struct activity_dump_config *config = lookup_or_delete_traced_pid(evt->process.pid, bpf_ktime_get_ns(), NULL);
     if (config) {

--- a/pkg/security/ebpf/c/include/helpers/network/stats.h
+++ b/pkg/security/ebpf/c/include/helpers/network/stats.h
@@ -53,10 +53,7 @@ __attribute__((always_inline)) int flush_network_stats(u32 pid, struct active_fl
     fill_network_device_context(&evt->device, entry->netns, entry->ifindex);
 
     struct proc_cache_t *proc_cache_entry = get_proc_cache(pid);
-    if (proc_cache_entry == NULL) {
-        evt->container.container_id[0] = 0;
-    } else {
-        copy_container_id_no_tracing(proc_cache_entry->container.container_id, &evt->container.container_id);
+    if (proc_cache_entry != NULL) {
         evt->container.cgroup_context = proc_cache_entry->container.cgroup_context;
     }
 

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -39,7 +39,6 @@ void __attribute__((always_inline)) copy_proc_entry(struct process_entry_t *src,
 }
 
 void __attribute__((always_inline)) copy_proc_cache(struct proc_cache_t *src, struct proc_cache_t *dst) {
-    copy_container_id(src->container.container_id, dst->container.container_id);
     dst->container.cgroup_context.cgroup_flags = src->container.cgroup_context.cgroup_flags;
     copy_proc_entry(&src->entry, &dst->entry);
 }

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -72,10 +72,6 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         // Select the old cache entry
         old_entry = get_proc_from_cookie(cookie);
         if (old_entry) {
-            if ((old_entry->container.container_id[0] != '\0') && old_entry->container.cgroup_context.cgroup_flags && (old_entry->container.cgroup_context.cgroup_flags != CGROUP_MANAGER_SYSTEMD)) {
-                return 0;
-            }
-
             // copy cache data
             copy_proc_cache(old_entry, &new_entry);
         }
@@ -188,8 +184,6 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         } else if (length >= 7 && (*prefix)[length-7] == '.'  && (*prefix)[length-6] == 's' && (*prefix)[length-5] == 'c' && (*prefix)[length-4] == 'o' && (*prefix)[length-3] == 'p' && (*prefix)[length-2] == 'e') {
             cgroup_flags = CGROUP_MANAGER_SYSTEMD | CGROUP_SYSTEMD_SCOPE;
         }
-    } else {
-        bpf_probe_read(&new_entry.container.container_id, sizeof(new_entry.container.container_id), container_id);
     }
 
     new_entry.container.cgroup_context.cgroup_flags = cgroup_flags;

--- a/pkg/security/ebpf/c/include/hooks/network/raw.h
+++ b/pkg/security/ebpf/c/include/hooks/network/raw.h
@@ -22,13 +22,6 @@ int classifier_raw_packet_sender(struct __sk_buff *skb) {
     // process context
     fill_network_process_context_from_pkt(&evt->process, pkt);
 
-    struct proc_cache_t *entry = get_proc_cache(evt->process.pid);
-    if (entry == NULL) {
-        evt->container.container_id[0] = 0;
-    } else {
-        copy_container_id_no_tracing(entry->container.container_id, &evt->container.container_id);
-    }
-
     fill_network_device_context_from_pkt(&evt->device, skb, pkt);
 
     u32 len = evt->len;

--- a/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
+++ b/pkg/security/ebpf/c/include/hooks/raw_syscalls.h
@@ -20,7 +20,7 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     fill_container_context(proc_cache_entry, &event.container);
 
     // check if this event should trigger a syscall drift event
-    if (is_anomaly_syscalls_enabled() && event.container.container_id[0] != 0) {
+    if (is_anomaly_syscalls_enabled() && (event.container.cgroup_context.cgroup_flags != 0)) {
         // fetch the profile for the current container
         struct security_profile_t *profile = bpf_map_lookup_elem(&security_profiles, &event.container);
         if (profile) {

--- a/pkg/security/ebpf/c/include/structs/events_context.h
+++ b/pkg/security/ebpf/c/include/structs/events_context.h
@@ -65,7 +65,6 @@ struct cgroup_context_t {
 };
 
 struct container_context_t {
-    container_id_t container_id;
     struct cgroup_context_t cgroup_context;
 };
 

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -67,7 +67,7 @@ func testRawPacketFilter(t *testing.T, filters []rawpacket.Filter, expRetCode in
 	if expRetCode != -1 {
 		assert.Nil(t, err, "program execution error")
 	}
-	assert.Equal(t, expRetCode, code, "return code error: %v", err)
+	assert.Equal(t, expRetCode, code, "return code error: %v, check the `struct raw_packet_event_t` and adapt the `structRawPacketEventData*` const", err)
 }
 
 func TestRawPacketTailCalls(t *testing.T) {

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -203,11 +203,10 @@ func (fh *EBPFFieldHandlers) ResolveContainerContext(ev *model.Event) (*model.Co
 
 // ResolveContainerRuntime retrieves the container runtime managing the container
 func (fh *EBPFFieldHandlers) ResolveContainerRuntime(ev *model.Event, _ *model.ContainerContext) string {
-	if ev.CGroupContext.CGroupFlags != 0 && ev.ContainerContext.ContainerID != "" {
-		return getContainerRuntime(ev.CGroupContext.CGroupFlags)
+	if ev.ContainerContext.Runtime == "" && ev.CGroupContext.CGroupFlags != 0 {
+		ev.ContainerContext.Runtime = getContainerRuntime(ev.CGroupContext.CGroupFlags)
 	}
-
-	return ""
+	return ev.ContainerContext.Runtime
 }
 
 // getContainerRuntime returns the container runtime managing the cgroup

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -737,7 +737,7 @@ func (p *EBPFProbe) EventMarshallerCtor(event *model.Event) func() events.EventM
 }
 
 func (p *EBPFProbe) unmarshalContexts(data []byte, event *model.Event) (int, error) {
-	read, err := model.UnmarshalBinary(data, &event.PIDContext, &event.SpanContext, &event.CGroupContext)
+	read, err := model.UnmarshalBinary(data, &event.PIDContext, &event.SpanContext, event.CGroupContext)
 	if err != nil {
 		return 0, err
 	}
@@ -804,6 +804,7 @@ func (p *EBPFProbe) setProcessContext(eventType model.EventType, event *model.Ev
 
 	// do the same with cgroup context
 	event.CGroupContext = &event.ProcessCacheEntry.CGroup
+	event.ContainerContext.ContainerID = event.ProcessContext.ContainerID
 
 	if process.IsKThread(event.ProcessContext.PPid, event.ProcessContext.Pid) {
 		return false
@@ -831,17 +832,16 @@ func (p *EBPFProbe) zeroEvent() *model.Event {
 	return p.event
 }
 
-func (p *EBPFProbe) resolveCGroup(pid uint32, cgroupPathKey model.PathKey, cgroupFlags containerutils.CGroupFlags, newEntryCb func(entry *model.ProcessCacheEntry, err error)) (*model.CGroupContext, error) {
+func (p *EBPFProbe) resolveCGroupAndContainer(pid uint32, cgroupPathKey model.PathKey, cgroupFlags containerutils.CGroupFlags, newEntryCb func(entry *model.ProcessCacheEntry, err error)) (*model.CGroupContext, containerutils.ContainerID, error) {
 	cgroupContext, _, err := p.Resolvers.ResolveCGroupContext(cgroupPathKey, cgroupFlags)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve cgroup for pid %d: %w", pid, err)
+		return nil, "", fmt.Errorf("failed to resolve cgroup for pid %d: %w", pid, err)
 	}
-	updated := p.Resolvers.ProcessResolver.UpdateProcessCGroupContext(pid, cgroupContext, newEntryCb)
-	if !updated {
-		return nil, fmt.Errorf("failed to update cgroup for pid %d", pid)
+	pce := p.Resolvers.ProcessResolver.UpdateProcessCGroupContext(pid, cgroupContext, newEntryCb)
+	if pce == nil {
+		return nil, "", fmt.Errorf("failed to update cgroup for pid %d", pid)
 	}
-
-	return cgroupContext, nil
+	return cgroupContext, pce.ContainerID, nil
 }
 
 func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
@@ -927,16 +927,12 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode cgroup tracing event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
-		if cgroupContext, err := p.resolveCGroup(event.CgroupTracing.Pid, event.CgroupTracing.CGroupContext.CGroupFile, event.CgroupTracing.CGroupContext.CGroupFlags, newEntryCb); err != nil {
+		if cgroupContext, containerID, err := p.resolveCGroupAndContainer(event.CgroupTracing.Pid, event.CgroupTracing.CGroupContext.CGroupFile, event.CgroupTracing.CGroupContext.CGroupFlags, newEntryCb); err != nil {
 			seclog.Debugf("Failed to resolve cgroup: %s", err.Error())
 		} else {
 			event.CgroupTracing.CGroupContext = *cgroupContext
-			if cgroupContext.CGroupFlags.IsContainer() {
-				containerID, _ := containerutils.FindContainerID(cgroupContext.CGroupID)
-				event.CgroupTracing.ContainerContext.ContainerID = containerID
-			}
-
 			event.CGroupContext = cgroupContext
+			event.CgroupTracing.ContainerContext.ContainerID = containerID
 			p.profileManagers.activityDumpManager.HandleCGroupTracingEvent(&event.CgroupTracing)
 		}
 		return
@@ -945,7 +941,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			seclog.Errorf("failed to decode cgroup write event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
-		if _, err := p.resolveCGroup(event.CgroupWrite.Pid, event.CgroupWrite.File.PathKey, containerutils.CGroupFlags(event.CgroupWrite.CGroupFlags), newEntryCb); err != nil {
+		if _, _, err := p.resolveCGroupAndContainer(event.CgroupWrite.Pid, event.CgroupWrite.File.PathKey, containerutils.CGroupFlags(event.CgroupWrite.CGroupFlags), newEntryCb); err != nil {
 			seclog.Debugf("Failed to resolve cgroup: %s", err.Error())
 		}
 		return
@@ -998,7 +994,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		}
 	default:
 		if !event.CGroupContext.CGroupFile.IsNull() {
-			cgroupContext, err := p.resolveCGroup(event.PIDContext.Pid, event.CGroupContext.CGroupFile, event.CGroupContext.CGroupFlags, newEntryCb)
+			cgroupContext, _, err := p.resolveCGroupAndContainer(event.PIDContext.Pid, event.CGroupContext.CGroupFile, event.CGroupContext.CGroupFlags, newEntryCb)
 			if err != nil {
 				seclog.Debugf("failed to resolve cgroup context for event %s: %s", err, eventType.String())
 			} else {
@@ -1010,6 +1006,9 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 	if !p.setProcessContext(eventType, event, newEntryCb) {
 		return
 	}
+
+	// resolve the container context
+	event.ContainerContext, _ = p.fieldHandlers.ResolveContainerContext(event)
 
 	switch eventType {
 
@@ -1362,9 +1361,6 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			return
 		}
 	}
-
-	// resolve the container context
-	event.ContainerContext, _ = p.fieldHandlers.ResolveContainerContext(event)
 
 	// send related events
 	for _, relatedEvent := range relatedEvents {

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -892,17 +892,12 @@ func (p *EBPFResolver) resolveFromKernelMaps(pid, tid uint32, inode uint64, newE
 	entry := p.NewProcessCacheEntry(model.PIDContext{Pid: pid, Tid: tid, ExecInode: inode})
 
 	var ctrCtx model.ContainerContext
-	read, err := ctrCtx.UnmarshalBinary(procCache)
-	if err != nil {
-		return nil
-	}
-
 	cgroupRead, err := entry.CGroup.UnmarshalBinary(procCache)
 	if err != nil {
 		return nil
 	}
 
-	if _, err := entry.UnmarshalProcEntryBinary(procCache[read+cgroupRead:]); err != nil {
+	if _, err := entry.UnmarshalProcEntryBinary(procCache[cgroupRead:]); err != nil {
 		return nil
 	}
 
@@ -1330,7 +1325,7 @@ func (p *EBPFResolver) newEntryFromProcfsAndSyncKernelMaps(proc *process.Process
 	bootTime := p.timeResolver.GetBootTime()
 
 	// insert new entry in kernel maps
-	procCacheEntryB := make([]byte, 248)
+	procCacheEntryB := make([]byte, 184)
 	_, err := entry.Process.MarshalProcCache(procCacheEntryB, bootTime)
 	if err != nil {
 		seclog.Errorf("couldn't marshal proc_cache entry: %s", err)

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1496,13 +1496,13 @@ func (p *EBPFResolver) Walk(callback func(entry *model.ProcessCacheEntry)) {
 }
 
 // UpdateProcessCGroupContext updates the cgroup context and container ID of the process matching the provided PID
-func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext *model.CGroupContext, newEntryCb func(entry *model.ProcessCacheEntry, err error)) bool {
+func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext *model.CGroupContext, newEntryCb func(entry *model.ProcessCacheEntry, err error)) *model.ProcessCacheEntry {
 	p.Lock()
 	defer p.Unlock()
 
 	pce := p.resolve(pid, pid, 0, false, newEntryCb)
 	if pce == nil {
-		return false
+		return nil
 	}
 
 	pce.Process.CGroup = *cgroupContext
@@ -1512,7 +1512,7 @@ func (p *EBPFResolver) UpdateProcessCGroupContext(pid uint32, cgroupContext *mod
 		pce.ContainerID = containerID
 		pce.Process.ContainerID = containerID
 	}
-	return true
+	return pce
 }
 
 // NewEBPFResolver returns a new process resolver

--- a/pkg/security/secl/model/marshallers_linux.go
+++ b/pkg/security/secl/model/marshallers_linux.go
@@ -73,14 +73,12 @@ func (e *FileFields) MarshalBinary(data []byte) (int, error) {
 // MarshalProcCache marshals a binary representation of itself
 func (e *Process) MarshalProcCache(data []byte, bootTime time.Time) (int, error) {
 	// Marshal proc_cache_t
-	if len(data) < ContainerIDLen {
+	if len(data) < 8 {
 		return 0, ErrNotEnoughSpace
 	}
 
-	copy(data[0:ContainerIDLen], []byte(e.ContainerID))
-	binary.NativeEndian.PutUint64(data[ContainerIDLen:ContainerIDLen+8], uint64(e.CGroup.CGroupFlags))
-
-	written := ContainerIDLen + 8
+	binary.NativeEndian.PutUint64(data[0:8], uint64(e.CGroup.CGroupFlags))
+	written := 8
 
 	// process without cgroup should be mainly pid 1
 	if !e.CGroup.CGroupFile.IsNull() {

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -57,18 +57,6 @@ func (e *CGroupContext) UnmarshalBinary(data []byte) (int, error) {
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself
-func (e *ContainerContext) UnmarshalBinary(data []byte) (int, error) {
-	id, err := UnmarshalString(data, ContainerIDLen)
-	if err != nil {
-		return 0, err
-	}
-
-	e.ContainerID = containerutils.ContainerID(id)
-
-	return ContainerIDLen, nil
-}
-
-// UnmarshalBinary unmarshalls a binary representation of itself
 func (e *ChmodEvent) UnmarshalBinary(data []byte) (int, error) {
 	n, err := UnmarshalBinary(data, &e.SyscallEvent, &e.SyscallContext, &e.File)
 	if err != nil {
@@ -967,17 +955,11 @@ func (e *SpliceEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *CgroupTracingEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := UnmarshalBinary(data, &e.ContainerContext)
+	read, err := UnmarshalBinary(data, &e.CGroupContext)
 	if err != nil {
 		return 0, err
 	}
 	cursor := read
-
-	read, err = UnmarshalBinary(data[cursor:], &e.CGroupContext)
-	if err != nil {
-		return 0, err
-	}
-	cursor += read
 
 	read, err = e.Config.EventUnmarshalBinary(data[cursor:])
 	if err != nil {

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -178,7 +178,7 @@ func newDockerCmdWrapper(mountSrc, mountDest string, kind string, runtimeCommand
 	cmd := exec.Command(executable, "version")
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to retrieve Docker version: %w (%s)", err, string(output))
 	}
 
 	for _, line := range strings.Split(strings.ToLower(string(output)), "\n") {

--- a/pkg/security/tests/container_test.go
+++ b/pkg/security/tests/container_test.go
@@ -31,11 +31,11 @@ func TestContainerCreatedAt(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_container_created_at",
-			Expression: `container.id != "" && container.created_at < 3s && open.file.path == "{{.Root}}/test-open"`,
+			Expression: `container.id != "" && container.created_at < 1s && open.file.path == "{{.Root}}/test-open"`,
 		},
 		{
 			ID:         "test_container_created_at_delay",
-			Expression: `container.id != "" && container.created_at > 3s && open.file.path == "{{.Root}}/test-open-delay"`,
+			Expression: `container.id != "" && container.created_at > 1s && open.file.path in [ "{{.Root}}/test-open-delay1", "{{.Root}}/test-open-delay2" ]`,
 		},
 	}
 	test, err := newTestModule(t, nil, ruleDefs)
@@ -49,7 +49,12 @@ func TestContainerCreatedAt(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	testFileDelay, _, err := test.Path("test-open-delay")
+	testFileDelay1, _, err := test.Path("test-open-delay1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testFileDelay2, _, err := test.Path("test-open-delay2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,22 +80,29 @@ func TestContainerCreatedAt(t *testing.T) {
 	})
 
 	dockerWrapper.Run(t, "container-created-at-delay", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		cmd := cmdFunc("touch", []string{testFileDelay1}, nil) // shouldn't trigger an event
+		if err := cmd.Run(); err != nil {
+			t.Fatal(err)
+		}
+
+		time.Sleep((1 * time.Second) + (500 * time.Millisecond))
+
 		test.WaitSignal(t, func() error {
-			cmd := cmdFunc("touch", []string{testFileDelay}, nil) // shouldn't trigger an event
-			if err := cmd.Run(); err != nil {
-				return err
+			for i := 0; i < 3; i++ {
+				cmd = cmdFunc("touch", []string{testFileDelay2}, nil)
+				if err := cmd.Run(); err != nil {
+					return err
+				}
 			}
-			time.Sleep(3 * time.Second)
-			cmd = cmdFunc("touch", []string{testFileDelay}, nil)
-			return cmd.Run()
+			return nil
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_container_created_at_delay")
-			assertFieldEqual(t, event, "open.file.path", testFileDelay)
+			assertFieldEqual(t, event, "open.file.path", testFileDelay2)
 			assertFieldNotEmpty(t, event, "container.id", "container id shouldn't be empty")
 			assert.Equal(t, event.CGroupContext.CGroupFlags, containerutils.CGroupFlags(containerutils.CGroupManagerDocker))
 			createdAtNano, _ := event.GetFieldValue("container.created_at")
 			createdAt := time.Unix(0, int64(createdAtNano.(int)))
-			assert.True(t, time.Since(createdAt) > 3*time.Second)
+			assert.True(t, time.Since(createdAt) > time.Second)
 
 			test.validateOpenSchema(t, event)
 		})

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -248,7 +248,7 @@ func (tm *testModule) waitSignal(tb testing.TB, action func() error, cb func(*mo
 		if _, ok := err.(ErrSkipTest); ok {
 			tb.Skip(err)
 		} else {
-			tb.Fatal(err)
+			tb.Fatalf("error while waiting for signal: %s", err)
 		}
 	}
 }

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -1285,8 +1285,11 @@ func (tm *testModule) StartADockerGetDump() (*dockerCmdWrapper, *activityDumpIde
 	if err != nil {
 		return nil, nil, err
 	}
-	dump, err := tm.GetDumpFromDocker(dockerInstance)
-	if err != nil {
+	var dump *activityDumpIdentifier
+	if err := retry.Do(func() error {
+		dump, err = tm.GetDumpFromDocker(dockerInstance)
+		return nil
+	}); err != nil {
 		_, _ = dockerInstance.stop()
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Do not store the container_id kernel side.

### Motivation

Now that we have a way to identify a cgroup (using its path key), we do not need
to store the container id kernel side, saving 64 bytes per proc_cache entry which
can amount to 8 MB on some hosts. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->