### PR TITLE
rollback support for persisting integrations on windows

### DIFF
--- a/.gitlab/e2e_install_packages/windows.yml
+++ b/.gitlab/e2e_install_packages/windows.yml
@@ -38,6 +38,7 @@
       - E2E_MSI_TEST: TestUpgradeFromLatest
       - E2E_MSI_TEST: TestPersistingIntegrations
       - E2E_MSI_TEST: TestIntegrationFolderPermissions
+      - E2E_MSI_TEST: TestIntegrationRollback
       - E2E_MSI_TEST: TestUpgradeRollback
       - E2E_MSI_TEST: TestUpgradeRollbackWithoutCWS
       - E2E_MSI_TEST: TestUpgradeChangeUser

--- a/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
+++ b/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
@@ -242,7 +242,7 @@ func TestIntegrationRollback(t *testing.T) {
 	upgradeAgentPackge, err := windowsAgent.GetUpgradeTestPackageFromEnv()
 	require.NoError(t, err, "should get upgrade test package")
 	s.upgradeAgentPackge = upgradeAgentPackge
-	run(t, s)
+	Run(t, s)
 }
 
 type testIntegrationRollback struct {

--- a/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
+++ b/test/new-e2e/tests/windows/install-test/persisting_integrations_test.go
@@ -270,8 +270,7 @@ func (s *testIntegrationRollback) TestIntegrationRollback() {
 	err := s.installThirdPartyIntegration(vm, "datadog-ping==1.0.2")
 	s.Require().NoError(err, "should install third party integration")
 
-	// add package to .post_python_installed_packages.txt (this will be still there on rollback)
-
+	// add package to .post_python_installed_packages.txt to check for(this will be still there on rollback)
 	folderPath := "C:\\ProgramData\\Datadog\\protected"
 	filePath := filepath.Join(folderPath, ".post_python_installed_packages.txt")
 	_, err = vm.AppendFile("windows", filePath, []byte("test==1.0.0\n"))

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -94,6 +94,12 @@ namespace Datadog.AgentCustomActions
         {
             return Datadog.CustomActions.PythonDistributionCustomAction.RunPostInstPythonScript(session);
         }
+        
+        [CustomAction]
+        public static ActionResult RunPreRemovePythonScriptRollback(Session session)
+        {
+            return Datadog.CustomActions.PythonDistributionCustomAction.RunPreRemovePythonScriptRollback(session);
+        }
 
         [CustomAction]
         public static ActionResult RunPreRemovePythonScript(Session session)

--- a/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/AgentCustomActions/CustomAction.cs
@@ -94,7 +94,7 @@ namespace Datadog.AgentCustomActions
         {
             return Datadog.CustomActions.PythonDistributionCustomAction.RunPostInstPythonScript(session);
         }
-        
+
         [CustomAction]
         public static ActionResult RunPreRemovePythonScriptRollback(Session session)
         {

--- a/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/CustomActions.csproj
@@ -89,6 +89,7 @@
     <Compile Include="Rollback\ServicePermissionRollbackData.cs" />
     <Compile Include="Rollback\RestoreDaclRollbackCustomAction.cs" />
     <Compile Include="Rollback\FilePermissionRollbackData.cs" />
+    <Compile Include="Rollback\FileStorageRollbackData.cs" />
     <Compile Include="Rollback\RollbackDataStore.cs" />
     <Compile Include="ServiceCustomAction.cs" />
     <Compile Include="PatchInstallerCustomAction.cs" />

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
@@ -271,6 +271,8 @@ namespace Datadog.CustomActions
         private ActionResult RunPreRemovePythonScript()
         {
             // add the .post_python_installed_packages.txt to the rollback data store
+            // This means the file can be restored on failure and still used to create a diff file for next retry
+            // Helps prevents silent failure of third party integration feature. Where there is no post file so it silenly continues.
             var pythonPackagesFile = Path.Combine(_session.Property("APPLICATIONDATADIRECTORY"), "protected", ".post_python_installed_packages.txt");
             // check that file path exists
             if (!System.IO.File.Exists(pythonPackagesFile))

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
@@ -282,13 +282,13 @@ namespace Datadog.CustomActions
                 _rollbackDataStore.Add(new FileStorageRollbackData(pythonPackagesFile));
             }
 
-            var result =  RunPythonScript(_session, "pre.py");
+            var result = RunPythonScript(_session, "pre.py");
             _rollbackDataStore.Store();
             return result;
         }
         private void RunRollbackDataRestore()
         {
-             try
+            try
             {
                 _rollbackDataStore.Restore();
             }
@@ -303,7 +303,7 @@ namespace Datadog.CustomActions
             RunRollbackDataRestore();
             return ActionResult.Success;
         }
-        
+
         public static ActionResult RunPostInstPythonScript(Session session)
         {
             return new PythonDistributionCustomAction(new SessionWrapper(session), "pythonDistribution").RunPostInstPythonScript();

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
@@ -284,9 +284,12 @@ namespace Datadog.CustomActions
                 _rollbackDataStore.Add(new FileStorageRollbackData(pythonPackagesFile));
             }
 
-            var result = RunPythonScript(_session, "pre.py");
-            _rollbackDataStore.Store();
-            return result;
+            try {
+                return RunPythonScript(_session, "pre.py");
+            }
+            finally{
+                _rollbackDataStore.Store();
+            }
         }
         private void RunRollbackDataRestore()
         {
@@ -308,7 +311,7 @@ namespace Datadog.CustomActions
 
         public static ActionResult RunPostInstPythonScript(Session session)
         {
-            return new PythonDistributionCustomAction(new SessionWrapper(session), "pythonDistribution").RunPostInstPythonScript();
+            return new PythonDistributionCustomAction(new SessionWrapper(session), "pythonPostDistribution").RunPostInstPythonScript();
         }
 
         public static ActionResult RunPreRemovePythonScript(Session session)

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
@@ -1,5 +1,7 @@
 using Datadog.CustomActions.Extensions;
 using Datadog.CustomActions.Interfaces;
+using Datadog.CustomActions.Native;
+using Datadog.CustomActions.Rollback;
 using Microsoft.Deployment.WindowsInstaller;
 using System;
 using System.Diagnostics;
@@ -8,8 +10,13 @@ using System.Text;
 
 namespace Datadog.CustomActions
 {
+
     public class PythonDistributionCustomAction
     {
+        private readonly ISession _session;
+        private readonly IFileSystemServices _fileSystemServices;
+        private readonly IServiceController _serviceController;
+        private readonly RollbackDataStore _rollbackDataStore;
         public static class MessageRecordFields
         {
             /// <summary>
@@ -31,6 +38,29 @@ namespace Datadog.CustomActions
             /// Enables an action (such as CustomAction) to add ticks to the expected total number of progress of the progress bar.
             /// </summary>
             public const int ProgressAddition = 1;
+        }
+
+        public PythonDistributionCustomAction(
+            ISession session,
+            string rollbackDataName,
+            IFileSystemServices fileSystemServices,
+            IServiceController serviceController)
+        {
+            _session = session;
+            _fileSystemServices = fileSystemServices;
+            _serviceController = serviceController;
+
+            _rollbackDataStore = new RollbackDataStore(session, rollbackDataName, _fileSystemServices, _serviceController);
+        }
+
+        public PythonDistributionCustomAction(ISession session, string rollbackDataName)
+            : this(
+                session,
+                rollbackDataName,
+                new FileSystemServices(),
+                new ServiceController()
+            )
+        {
         }
 
         private static ActionResult DecompressPythonDistribution(
@@ -225,23 +255,68 @@ namespace Datadog.CustomActions
             return ActionResult.Success;
         }
 
-        public static ActionResult RunPostInstPythonScript(Session session)
+        private ActionResult RunPostInstPythonScript()
         {
-            ISession sessionWrapper = new SessionWrapper(session);
             // check if INSTALL_PYTHON_THIRD_PARTY_DEPS property is set
-            var installPythonThirdPartyDeps = sessionWrapper.Property("INSTALL_PYTHON_THIRD_PARTY_DEPS");
+            var installPythonThirdPartyDeps = _session.Property("INSTALL_PYTHON_THIRD_PARTY_DEPS");
             if (string.IsNullOrEmpty(installPythonThirdPartyDeps) || installPythonThirdPartyDeps != "1")
             {
-                sessionWrapper.Log("Skipping installation of third-party Python deps. Set INSTALL_PYTHON_THIRD_PARTY_DEPS=1 to enable this feature.");
+                _session.Log("Skipping installation of third-party Python deps. Set INSTALL_PYTHON_THIRD_PARTY_DEPS=1 to enable this feature.");
                 return ActionResult.Success;
             }
+            return RunPythonScript(_session, "post.py");
 
-            return RunPythonScript(sessionWrapper, "post.py");
+        }
+
+        private ActionResult RunPreRemovePythonScript()
+        {
+            // add the .post_python_installed_packages.txt to the rollback data store
+            var pythonPackagesFile = Path.Combine(_session.Property("APPLICATIONDATADIRECTORY"), "protected", ".post_python_installed_packages.txt");
+            // check that file path exists
+            if (!System.IO.File.Exists(pythonPackagesFile))
+            {
+                _session.Log($"File {pythonPackagesFile} does not exist, skipping rollback data store addition.");
+            }
+            else
+            {
+                _rollbackDataStore.Add(new FileStorageRollbackData(pythonPackagesFile));
+            }
+
+            var result =  RunPythonScript(_session, "pre.py");
+            _rollbackDataStore.Store();
+            return result;
+        }
+        private void RunRollbackDataRestore()
+        {
+             try
+            {
+                _rollbackDataStore.Restore();
+            }
+            catch (Exception e)
+            {
+                _session.Log($"Error while restoring rollback post install file: {e}");
+            }
+        }
+
+        private ActionResult RunPreRemovePythonScriptRollback()
+        {
+            RunRollbackDataRestore();
+            return ActionResult.Success;
+        }
+        
+        public static ActionResult RunPostInstPythonScript(Session session)
+        {
+            return new PythonDistributionCustomAction(new SessionWrapper(session), "pythonDistribution").RunPostInstPythonScript();
         }
 
         public static ActionResult RunPreRemovePythonScript(Session session)
         {
-            return RunPythonScript(new SessionWrapper(session), "pre.py");
+            return new PythonDistributionCustomAction(new SessionWrapper(session), "pythonDistribution").RunPreRemovePythonScript();
+        }
+
+        public static ActionResult RunPreRemovePythonScriptRollback(Session session)
+        {
+            return new PythonDistributionCustomAction(new SessionWrapper(session), "pythonDistribution").RunPreRemovePythonScriptRollback();
         }
     }
 }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
@@ -284,10 +284,12 @@ namespace Datadog.CustomActions
                 _rollbackDataStore.Add(new FileStorageRollbackData(pythonPackagesFile));
             }
 
-            try {
+            try
+            {
                 return RunPythonScript(_session, "pre.py");
             }
-            finally{
+            finally
+            {
                 _rollbackDataStore.Store();
             }
         }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FileStorageRollbackData.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FileStorageRollbackData.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Security.AccessControl;
+using Datadog.CustomActions.Interfaces;
+using Newtonsoft.Json;
+
+namespace Datadog.CustomActions.Rollback
+{
+    class FileStorageRollbackData : IRollbackAction
+    {
+        [JsonProperty("FilePath")] private string _filePath;
+        [JsonProperty("Content")] private string _content;
+
+        [JsonConstructor]
+        public FileStorageRollbackData()
+        {
+        }
+
+        public FileStorageRollbackData(string filePath)
+        {
+            _filePath = filePath;
+            
+            // check that file path exists
+            if (!System.IO.File.Exists(filePath))
+            {
+                _content = null;
+            }
+            else
+            {
+                // read the content and base64 encode it
+                byte[] fileContent = System.IO.File.ReadAllBytes(filePath);
+                _content = Convert.ToBase64String(fileContent);
+            }
+            
+        }
+
+        /// <summary>
+        /// Write fileContent to the @FilePath for restore purposes.
+        /// </summary>
+        /// <remarks>
+        /// Files with no content will still be created.
+        /// </remarks>
+        public void Restore(ISession session, IFileSystemServices _, IServiceController __)
+        {
+            // restore the file content
+            if (_content == null)
+            {
+                session.Log($"File {_filePath} has no content");
+                // create an empty file
+                System.IO.File.Create(_filePath).Close();
+                return;
+            }
+            byte[] fileContent = Convert.FromBase64String(_content);
+            System.IO.File.WriteAllBytes(_filePath, fileContent);
+            session.Log($"Restored file {_filePath}");
+        }
+    }
+}

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FileStorageRollbackData.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FileStorageRollbackData.cs
@@ -18,7 +18,7 @@ namespace Datadog.CustomActions.Rollback
         public FileStorageRollbackData(string filePath)
         {
             _filePath = filePath;
-            
+
             // check that file path exists
             if (!System.IO.File.Exists(filePath))
             {
@@ -27,10 +27,10 @@ namespace Datadog.CustomActions.Rollback
             else
             {
                 // read the content and base64 encode it
-                byte[] fileContent = System.IO.File.ReadAllBytes(filePath);
+                var fileContent = System.IO.File.ReadAllBytes(filePath);
                 _content = Convert.ToBase64String(fileContent);
             }
-            
+
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Datadog.CustomActions.Rollback
                 System.IO.File.Create(_filePath).Close();
                 return;
             }
-            byte[] fileContent = Convert.FromBase64String(_content);
+            var fileContent = Convert.FromBase64String(_content);
             System.IO.File.WriteAllBytes(_filePath, fileContent);
             session.Log($"Restored file {_filePath}");
         }

--- a/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FileStorageRollbackData.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/Rollback/FileStorageRollbackData.cs
@@ -37,7 +37,7 @@ namespace Datadog.CustomActions.Rollback
         /// Write fileContent to the @FilePath for restore purposes.
         /// </summary>
         /// <remarks>
-        /// Files with no content will still be created.
+        /// Files with no content will not be created.
         /// </remarks>
         public void Restore(ISession session, IFileSystemServices _, IServiceController __)
         {
@@ -45,8 +45,6 @@ namespace Datadog.CustomActions.Rollback
             if (_content == null)
             {
                 session.Log($"File {_filePath} has no content");
-                // create an empty file
-                System.IO.File.Create(_filePath).Close();
                 return;
             }
             var fileContent = Convert.FromBase64String(_content);

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -33,6 +33,8 @@ namespace WixSetup.Datadog_Agent
         public ManagedAction PrepareDecompressPythonDistributions { get; }
 
         public ManagedAction RunPostInstPythonScript { get; }
+        
+        public ManagedAction RunPreRemovePythonScriptRollback { get; }
 
         public ManagedAction RunPreRemovePythonScript { get; }
 
@@ -307,6 +309,19 @@ namespace WixSetup.Datadog_Agent
             }
                 .SetProperties(
                     "PROJECTLOCATION=[PROJECTLOCATION], APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
+            
+            RunPreRemovePythonScriptRollback = new CustomAction<CustomActions>(
+                    new Id(nameof(RunPreRemovePythonScriptRollback)),
+                    CustomActions.RunPreRemovePythonScriptRollback,
+                    Return.check,
+                    When.Before,
+                    new Step(RunPreRemovePythonScript.Id),
+                    Conditions.FirstInstall | Conditions.Upgrading | Conditions.Maintenance
+                )
+            {
+                Execute = Execute.rollback,
+                Impersonate = false
+            };
 
             ConfigureUser = new CustomAction<CustomActions>(
                     new Id(nameof(ConfigureUser)),

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -33,7 +33,7 @@ namespace WixSetup.Datadog_Agent
         public ManagedAction PrepareDecompressPythonDistributions { get; }
 
         public ManagedAction RunPostInstPythonScript { get; }
-        
+
         public ManagedAction RunPreRemovePythonScriptRollback { get; }
 
         public ManagedAction RunPreRemovePythonScript { get; }
@@ -309,7 +309,7 @@ namespace WixSetup.Datadog_Agent
             }
                 .SetProperties(
                     "PROJECTLOCATION=[PROJECTLOCATION], APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY]");
-            
+
             RunPreRemovePythonScriptRollback = new CustomAction<CustomActions>(
                     new Id(nameof(RunPreRemovePythonScriptRollback)),
                     CustomActions.RunPreRemovePythonScriptRollback,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add support for rollback on failure in Third Party Integrations persistence. Creates a new rollback data store to add the `.post_python_install.txt` file.  

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1265

This fixes the issues that could arise from upgrade failing. As we could end up in a state with no post install file, and no way to create a new diff file on the next install. Could lead to the feature silently failing and not installing integrations. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Tested by added e2e tests. They test roll back and assure the file is correctly restored.

### Possible Drawbacks / Trade-offs

Right now this uses base64 to encode the file in our `RollbackDataStore` other approaches could be more efficient. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Change log covered by: [Persisting Third Party Integrations On Windows](https://github.com/DataDog/datadog-agent/pull/32528)