### PR TITLE
[Backport 7.62.x] Disable batch API usage in map cleaner

### DIFF
--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -71,9 +71,6 @@ func NewMapCleaner[K any, V any](emap *ebpf.Map, defaultBatchSize uint32, name, 
 	singleTags := map[string]string{"map_name": name, "module": module, "api": "single"}
 	batchTags := map[string]string{"map_name": name, "module": module, "api": "batch"}
 	tags := singleTags
-	if m.CanUseBatchAPI() {
-		tags = batchTags
-	}
 	return &MapCleaner[K, V]{
 		emap:          m,
 		batchSize:     batchSize,
@@ -105,9 +102,6 @@ func (mc *MapCleaner[K, V]) Clean(interval time.Duration, preClean func() bool, 
 		// of a version comparison because some distros have backported this API), and fallback to
 		// the old method otherwise. The new API is also more efficient because it minimizes the number of allocations.
 		cleaner := mc.cleanWithoutBatches
-		if mc.emap.CanUseBatchAPI() {
-			cleaner = mc.cleanWithBatches
-		}
 		ticker := time.NewTicker(interval)
 		go func() {
 			defer ticker.Stop()

--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -53,7 +53,7 @@ type MapCleaner[K any, V any] struct {
 	elapsed       telemetry.SimpleHistogram
 }
 
-// NewMapCleaner instantiates a new MapCleaner
+// NewMapCleaner instantiates a new MapCleaner. Due to incident-34000, batch size is ignored and the single-item iterator is always used.
 func NewMapCleaner[K any, V any](emap *ebpf.Map, defaultBatchSize uint32, name, module string) (*MapCleaner[K, V], error) {
 	batchSize := defaultBatchSize
 	if defaultBatchSize > emap.MaxEntries() {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -890,8 +890,8 @@ func (t *Tracer) GetNetworkID(context context.Context) (string, error) {
 	return id, nil
 }
 
-const connProtoTTL = 3 * time.Minute
-const connProtoCleaningInterval = 65 * time.Second // slight jitter to avoid all maps cleaning at the same time
+var connProtoTTL = 3 * time.Minute
+var connProtoCleaningInterval = 65 * time.Second // slight jitter to avoid all maps cleaning at the same time
 
 // setupConnectionProtocolMapCleaner sets up a map cleaner for the connectionProtocolMap.
 // It will run every connProtoCleaningInterval and delete entries older than connProtoTTL.

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2813,7 +2813,13 @@ func TestMapCleanerDoesNotRemoveNewConnections(t *testing.T) {
 	currKernelVersion, err := kernel.HostVersion()
 	require.NoError(t, err)
 
-	if currKernelVersion < usmhttp2.MinimumKernelVersion {
+	cfg := testConfig()
+	cfg.ServiceMonitoringEnabled = true
+	cfg.EnableGoTLSSupport = true
+	cfg.GoTLSExcludeSelf = false
+	cfg.EnableHTTP2Monitoring = true
+
+	if currKernelVersion < usmhttp2.MinimumKernelVersion || !usmconfig.TLSSupported(cfg) {
 		t.Skipf("HTTP2 monitoring can not run on kernel before %v", usmhttp2.MinimumKernelVersion)
 	}
 
@@ -2821,12 +2827,6 @@ func TestMapCleanerDoesNotRemoveNewConnections(t *testing.T) {
 	srv, cancel := grpc.NewGRPCTLSServer(t, srvAddr, true)
 	t.Cleanup(cancel)
 	defaultCtx := context.Background()
-
-	cfg := testConfig()
-	cfg.ServiceMonitoringEnabled = true
-	cfg.EnableGoTLSSupport = true
-	cfg.GoTLSExcludeSelf = false
-	cfg.EnableHTTP2Monitoring = true
 
 	prevProtoCleaningInterval := connProtoCleaningInterval
 	prevProtoTTL := connProtoTTL

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2861,7 +2861,7 @@ func TestMapCleanerDoesNotRemoveNewConnections(t *testing.T) {
 	}
 	require.Equal(t, 2, found)
 
-	time.Sleep(2 * connProtoCleaningInterval)
+	require.Eventually(t, func() bool { return numMapCleans.Load() > 0 }, 2*connProtoCleaningInterval, 1*time.Second)
 
 	found = 0
 	iterator = connectionProtocolMap.Iterate()

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -60,6 +60,7 @@ import (
 	netlinktestutil "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	usmtestutil "github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	usmhttp2 "github.com/DataDog/datadog-agent/pkg/network/protocols/http2"
 	ddtls "github.com/DataDog/datadog-agent/pkg/network/protocols/tls"
 	"github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/connection"
@@ -2809,6 +2810,13 @@ const (
 )
 
 func TestMapCleanerDoesNotRemoveNewConnections(t *testing.T) {
+	currKernelVersion, err := kernel.HostVersion()
+	require.NoError(t, err)
+
+	if currKernelVersion < usmhttp2.MinimumKernelVersion {
+		t.Skipf("HTTP2 monitoring can not run on kernel before %v", usmhttp2.MinimumKernelVersion)
+	}
+
 	// Reproduction for incident-34000
 	srv, cancel := grpc.NewGRPCTLSServer(t, srvAddr, true)
 	t.Cleanup(cancel)

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2822,8 +2822,8 @@ func TestMapCleanerDoesNotRemoveNewConnections(t *testing.T) {
 
 	prevProtoCleaningInterval := connProtoCleaningInterval
 	prevProtoTTL := connProtoTTL
-	connProtoCleaningInterval = 10 * time.Second
-	connProtoTTL = 10 * time.Second
+	connProtoCleaningInterval = 2 * time.Second
+	connProtoTTL = 100 * time.Second // Ensure that the connection is not removed
 
 	// Restore values after test
 	t.Cleanup(func() {
@@ -2861,7 +2861,7 @@ func TestMapCleanerDoesNotRemoveNewConnections(t *testing.T) {
 	}
 	require.Equal(t, 2, found)
 
-	time.Sleep(connProtoCleaningInterval)
+	time.Sleep(2 * connProtoCleaningInterval)
 
 	found = 0
 	iterator = connectionProtocolMap.Iterate()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR disables the batch API usage in the map cleaner and adds a test to ensure that the underlying issue that caused #incident-34000 does not occurr again.

### Motivation

Fix for incident-34000

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit test reproducing the issue.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->