### PR TITLE
mapcleaner: Control use of batch API with batchSize argument

### DIFF
--- a/pkg/ebpf/map_cleaner.go
+++ b/pkg/ebpf/map_cleaner.go
@@ -112,10 +112,7 @@ func (mc *MapCleaner[K, V]) Clean(interval time.Duration, preClean func() bool, 
 		// required to clean the map. We use the new batch operations if they are supported (we check with a feature test instead
 		// of a version comparison because some distros have backported this API), and fallback to
 		// the old method otherwise. The new API is also more efficient because it minimizes the number of allocations.
-		cleaner := mc.cleanWithoutBatches
-		if mc.useBatchAPI {
-			cleaner = mc.cleanWithBatches
-		}
+		cleaner := mc.getCleanerFunction()
 		ticker := time.NewTicker(interval)
 		go func() {
 			defer ticker.Stop()
@@ -155,6 +152,16 @@ func (mc *MapCleaner[K, V]) Stop() {
 		mc.done <- struct{}{}
 		close(mc.done)
 	})
+}
+
+// getCleanerFunction returns the function to use for cleaning entries based on
+// whether the batch API is supported or not for this map. Separated for testing
+// purposes.
+func (mc *MapCleaner[K, V]) getCleanerFunction() func(nowTS int64, shouldClean func(nowTS int64, k K, v V) bool) {
+	if mc.useBatchAPI {
+		return mc.cleanWithBatches
+	}
+	return mc.cleanWithoutBatches
 }
 
 func (mc *MapCleaner[K, V]) cleanWithBatches(nowTS int64, shouldClean func(nowTS int64, k K, v V) bool) {

--- a/pkg/ebpf/map_cleaner_test.go
+++ b/pkg/ebpf/map_cleaner_test.go
@@ -112,10 +112,6 @@ func TestMapCleaner(t *testing.T) {
 }
 
 func TestMapCleanerBatchSize1ForcesSingleItem(t *testing.T) {
-	if !maps.BatchAPISupported() {
-		t.Skip("Cannot test if batch API is not supported")
-	}
-
 	const numMapEntries = 100
 	m, err := ebpf.NewMap(&ebpf.MapSpec{
 		Type:       ebpf.Hash,
@@ -130,15 +126,14 @@ func TestMapCleanerBatchSize1ForcesSingleItem(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, cleaner)
 		require.False(t, cleaner.useBatchAPI)
-		require.Equal(t, cleaner.cleanWithoutBatches, cleaner.getCleanerFunction())
 	})
 
 	t.Run("batch size not 1", func(t *testing.T) {
 		cleaner, err := NewMapCleaner[int64, int64](m, 100, "test", "")
 		require.NoError(t, err)
 		require.NotNil(t, cleaner)
-		require.True(t, cleaner.useBatchAPI)
-		require.Equal(t, cleaner.cleanWithBatches, cleaner.getCleanerFunction())
+
+		require.Equal(t, maps.BatchAPISupported(), cleaner.useBatchAPI)
 	})
 
 	t.Run("map does not support batches", func(t *testing.T) {
@@ -150,11 +145,10 @@ func TestMapCleanerBatchSize1ForcesSingleItem(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		cleaner, err := NewMapCleaner[int64, int64](m, 100, "test", "")
+		cleaner, err := NewMapCleaner[int64, []int64](m, 100, "test", "")
 		require.NoError(t, err)
 		require.NotNil(t, cleaner)
 		require.False(t, cleaner.useBatchAPI)
-		require.Equal(t, cleaner.cleanWithoutBatches, cleaner.getCleanerFunction())
 	})
 }
 

--- a/pkg/ebpf/map_cleaner_test.go
+++ b/pkg/ebpf/map_cleaner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -137,6 +138,12 @@ func TestMapCleanerBatchSize1ForcesSingleItem(t *testing.T) {
 	})
 
 	t.Run("map does not support batches", func(t *testing.T) {
+		kernelVersion, err := kernel.HostVersion()
+		require.NoError(t, err)
+		if kernelVersion < kernel.VersionCode(4, 6, 0) {
+			t.Skip("Kernel version does not support per-CPU maps")
+		}
+
 		m, err := ebpf.NewMap(&ebpf.MapSpec{
 			Type:       ebpf.PerCPUHash,
 			KeySize:    8,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Ensure that when setting `batchSize` to 1 when initializing the map cleaner, no batch API is used for iteration nor deletion.

### Motivation

Related to incident-34000, allowing users of the map cleaner to control whether batches are being used or not.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests included

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->