### PR TITLE
[RC] Fix PAR JWT casing conflict

### DIFF
--- a/pkg/config/remote/api/http.go
+++ b/pkg/config/remote/api/http.go
@@ -234,7 +234,7 @@ func (c *HTTPClient) FetchOrgStatus(ctx context.Context) (*pbgo.OrgStatusRespons
 // Token for authentication to the RC backend.
 func (c *HTTPClient) UpdatePARJWT(jwt string) {
 	c.headerLock.Lock()
-	c.header.Set("DD-PAR-JWT", jwt)
+	c.header["DD-PAR-JWT"] = []string{jwt}
 	c.headerLock.Unlock()
 }
 


### PR DESCRIPTION
### What does this PR do?

Fix invalid case of the PAR-JWT header when using the `UpdatePARJWT` method

The header configured on startup is using an ALL-UPPERCASE case while when using `UpdatePARJWT` we have a different case.
<img width="272" alt="image" src="https://github.com/user-attachments/assets/ca562e85-637f-4cf4-ba90-0ca67c2ce93f" />

This is because the first is using map assignment while the second uses the `Set` method which canonicalizes the key name

```go
// Set sets the header entries associated with key to the
// single element value. It replaces any existing values
// associated with key. The key is case insensitive; it is
// canonicalized by [textproto.CanonicalMIMEHeaderKey].
// To use non-canonical keys, assign to the map directly.
func (h Header) Set(key, value string) {
	textproto.MIMEHeader(h).Set(key, value)
}
```

### Motivation

Because of this if the JWT is both specified at startup and updated after, the first value won't be cleared and it looks like the backend is picking up the first one because we get expired JWTs on our side.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Tested in a local PAR with this commit `go get github.com/DataDog/datadog-agent/pkg/config/remote@c9c53a69c5d45f39bb3c15844846d1f4862800b6`,  provided a fake jwt through `rcservice.WithPARJWT` and then correct ones through `UpdatePARJWT` and I retrieved the keys successfully

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is not a problem if we only use `UpdatePARJWT`