### PR TITLE
Change default return type for Get

### DIFF
--- a/pkg/config/nodetreemodel/getter_test.go
+++ b/pkg/config/nodetreemodel/getter_test.go
@@ -50,6 +50,40 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, 1111, cfg.Get("a"))
 }
 
+func TestGetDefaultType(t *testing.T) {
+	cfg := NewConfig("test", "", nil)
+	cfg.SetKnown("a")
+	cfg.SetKnown("b")
+	cfg.BuildSchema()
+
+	cfg.ReadConfig(strings.NewReader(`---
+a:
+  "url1":
+   - apikey2
+   - apikey3
+  "url2":
+   - apikey4
+b:
+  1:
+   - a
+   - b
+  2:
+   - c
+`))
+
+	expected := map[string]interface{}{
+		"url1": []interface{}{"apikey2", "apikey3"},
+		"url2": []interface{}{"apikey4"},
+	}
+	assert.Equal(t, expected, cfg.Get("a"))
+
+	expected2 := map[interface{}]interface{}{
+		1: []interface{}{"a", "b"},
+		2: []interface{}{"c"},
+	}
+	assert.Equal(t, expected2, cfg.Get("b"))
+}
+
 func TestGetInnerNode(t *testing.T) {
 	cfg := NewConfig("test", "", nil)
 	cfg.SetDefault("a.b.c", 1234)


### PR DESCRIPTION
### What does this PR do?

Viper default to `map[string]interface{}` when getting settings without default values.  This mimic the behavior from viper.

Once all settings in the config have a default value we can remove this logic

### Describe how you validated your changes
Local QA and unit tests.