### PR TITLE
Multiple settings can be associated with the same env var

### DIFF
--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -369,6 +369,23 @@ func TestIsConfigured(t *testing.T) {
 	assert.False(t, cfg.IsConfigured("unknown"))
 }
 
+func TestEnvVarMultipleSettings(t *testing.T) {
+	cfg := NewConfig("test", "TEST", nil)
+	cfg.SetDefault("a", 0)
+	cfg.SetDefault("b", 0)
+	cfg.SetDefault("c", 0)
+	cfg.BindEnv("a", "TEST_MY_ENVVAR")
+	cfg.BindEnv("b", "TEST_MY_ENVVAR")
+
+	t.Setenv("TEST_MY_ENVVAR", "123")
+
+	cfg.BuildSchema()
+
+	assert.Equal(t, 123, cfg.GetInt("a"))
+	assert.Equal(t, 123, cfg.GetInt("b"))
+	assert.Equal(t, 0, cfg.GetInt("c"))
+}
+
 func TestAllKeysLowercased(t *testing.T) {
 	cfg := NewConfig("test", "TEST", nil)
 	cfg.SetDefault("a", 0)


### PR DESCRIPTION
### What does this PR do?

Allow multiple settings to associate with the same env var using `BindEnv`. The value of that env var is then assigned to all bound settings.

### Motivation

Noticed while testing teeconfig that `DD_API_KEY` was not being assigned to the `api_key`. This was because `security_agent.internal_profiling.api_key` also binds to this envvar. The binding should work for multiple settings at once, as it did with viper: https://github.com/DataDog/viper/blob/23b76a0698669ac4e62cca8dc70a666c1f877b99/viper.go#L196C2-L196C36.

### Describe how you validated your changes

Behavior change covered by a unit test, which fails without this change.

### Possible Drawbacks / Trade-offs

### Additional Notes
