### PR TITLE
feat(build): add Skaffold build process

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,9 @@
 /.run                                                @DataDog/agent-devx-loops
 /.run/docker/                                        @DataDog/container-integrations @DataDog/container-platform
 
+/skaffold.yaml                                       @DataDog/agent-devx-infra @DataDog/agent-devx-loops @DataDog/container-platform
+/.run/skaffold/                                      @DataDog/agent-devx-infra @DataDog/agent-devx-loops @DataDog/container-platform
+
 # Gitlab files
 # Files containing job contents are owned by teams in charge of the jobs + agent-devx-infra or agent-delivery
 # Files that only describe structure (eg. includes, rules) are owned by agent-devx-infra
@@ -579,6 +582,8 @@
 /tasks/update_go.py                     @DataDog/agent-runtimes
 /tasks/unit_tests/update_go_tests.py    @DataDog/agent-runtimes
 /tasks/cluster_agent_cloudfoundry.py    @DataDog/agent-integrations
+/tasks/devcontainer.py                  @DataDog/agent-devx-infra @DataDog/agent-devx-loops @DataDog/container-platform
+/tasks/skaffold.py                      @DataDog/agent-devx-infra @DataDog/agent-devx-loops @DataDog/container-platform
 /tasks/new_e2e_tests.py                 @DataDog/agent-e2e-testing @DataDog/agent-devx-loops
 /tasks/process_agent.py                 @DataDog/container-intake
 /tasks/system_probe.py                  @DataDog/ebpf-platform

--- a/.run/skaffold/Build and deploy using Skaffold.run.xml
+++ b/.run/skaffold/Build and deploy using Skaffold.run.xml
@@ -1,0 +1,33 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Build and deploy using Skaffold" type="google-container-tools-skaffold-run-config" factoryName="google-container-tools-skaffold-run-config-dev" show_console_on_std_err="false" show_console_on_std_out="false">
+    <option name="allowRunningInParallel" value="false" />
+    <option name="buildEnvironment" value="Local" />
+    <option name="cleanupDeployments" value="true" />
+    <option name="deployToCurrentContext" value="false" />
+    <option name="deployToMinikube" value="true" />
+    <option name="envVariables" />
+    <option name="imageRepositoryOverride" />
+    <option name="kubernetesContext" />
+    <option name="mappings">
+      <list />
+    </option>
+    <option name="moduleDeploymentType" value="DEPLOY_EVERYTHING" />
+    <option name="projectPathOnTarget" />
+    <option name="resourceDeletionTimeoutMins" value="2" />
+    <option name="selectedOptions">
+      <list />
+    </option>
+    <option name="skaffoldConfigurationFilePath" value="$PROJECT_DIR$/skaffold.yaml" />
+    <option name="skaffoldModules">
+      <list>
+        <option value="datadog-agent" />
+      </list>
+    </option>
+    <option name="skaffoldNamespace" />
+    <option name="skaffoldProfile" />
+    <option name="skaffoldWatchMode" value="ON_DEMAND" />
+    <option name="statusCheck" value="true" />
+    <option name="verbosity" value="WARN" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.vscode/launch.json.template
+++ b/.vscode/launch.json.template
@@ -50,5 +50,14 @@
                 }
             ]
         },
+        {
+            "name": "Build and deploy using Skaffold",
+            "type": "cloudcode.kubernetes",
+            "request": "launch",
+            "skaffoldConfig": "${workspaceFolder}/skaffold.yaml",
+            "watch": false,
+            "cleanUp": true,
+            "portForward": true
+        }
     ]
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,47 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: datadog-agent
+build:
+  platforms: [ "linux/arm64" ]
+  tagPolicy:
+    gitCommit: {
+        variant: "AbbrevCommitSha"
+    }
+  local:
+    push: false
+    concurrency: 0
+  artifacts:
+    - image: agent
+      custom:
+        buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
+          inv agent.hacky-dev-image-build --target-image=$IMAGE\""
+    - image: clusteragent
+      custom:
+        buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
+          inv cluster-agent.hacky-dev-image-build --target-image=$IMAGE\""
+deploy:
+  helm:
+    releases:
+      - name: datadog-agent
+        remoteChart: datadog/datadog
+        version: 3.88.1
+        setValueTemplates:
+          datadog:
+            apiKey: "{{cmd \"bash\" \"-c\" \"echo $DD_API_KEY\"}}"
+            appKey: "{{cmd \"bash\" \"-c\" \"echo $DD_APP_KEY\"}}"
+            kubelet:
+              tlsVerify: false
+          agents.image:
+            repository: "{{.IMAGE_REPO_agent}}"
+            tag: "{{.IMAGE_TAG_agent}}@{{.IMAGE_DIGEST_agent}}"
+            doNotCheckTag: true
+          clusterAgent:
+            image:
+              repository: "{{.IMAGE_REPO_clusteragent}}"
+              tag: "{{.IMAGE_TAG_clusteragent}}"
+              doNotCheckTag: true
+          clusterCheckRunner.image:
+            repository: "{{.IMAGE_REPO_agent}}"
+            tag: "{{.IMAGE_TAG_agent}}"
+            doNotCheckTag: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,15 +11,6 @@ build:
   local:
     push: false
     concurrency: 0
-  artifacts:
-    - image: agent
-      custom:
-        buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
-          inv agent.hacky-dev-image-build --target-image=$IMAGE\""
-    - image: clusteragent
-      custom:
-        buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
-          inv cluster-agent.hacky-dev-image-build --target-image=$IMAGE\""
 deploy:
   helm:
     releases:
@@ -45,3 +36,30 @@ deploy:
             repository: "{{.IMAGE_REPO_agent}}"
             tag: "{{.IMAGE_TAG_agent}}"
             doNotCheckTag: true
+profiles:
+  - name: kind
+    activation:
+    - kubeContext: kind
+      command: dev
+    build:
+      artifacts:
+      - image: agent
+        custom:
+          buildCommand: "inv agent.hacky-dev-image-build --target-image=$IMAGE"
+      - image: clusteragent
+        custom:
+          buildCommand: "inv cluster-agent.hacky-dev-image-build --target-image=$IMAGE"
+  - name: minikube
+    activation:
+    - kubeContext: minikube
+      command: dev
+    build:
+      artifacts:
+      - image: agent
+        custom:
+          buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
+            inv agent.hacky-dev-image-build --target-image=$IMAGE\""
+      - image: clusteragent
+        custom:
+          buildCommand: "docker exec datadog_agent_devcontainer bash -c \"
+            inv cluster-agent.hacky-dev-image-build --target-image=$IMAGE\""

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -58,6 +58,7 @@ from tasks import (
     security_agent,
     selinux,
     setup,
+    skaffold,
     system_probe,
     systray,
     testwasher,
@@ -210,6 +211,7 @@ ns.add_collection(owners)
 ns.add_collection(modules)
 ns.add_collection(pre_commit)
 ns.add_collection(devcontainer)
+ns.add_collection(skaffold)
 ns.add_collection(omnibus)
 ns.add_collection(collector)
 ns.add_collection(invoke_unit_tests)

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -9,6 +9,7 @@ import sys
 from collections import OrderedDict
 from functools import wraps
 from pathlib import Path
+from enum import Enum
 
 from invoke import task
 from invoke.exceptions import Exit
@@ -25,12 +26,18 @@ DEVCONTAINER_NAME = "datadog_agent_devcontainer"
 DEVCONTAINER_IMAGE = "registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64"
 
 
+class Skaffold_profile(Enum):
+    NONE = None
+    KIND = "kind"
+    MINIKUBE = "minikube"
+
 @task
 def setup(
     _,
     target="agent",
     build_include=None,
     build_exclude=None,
+    skaffold_profile=None,
     flavor=AgentFlavor.base.name,
     image='',
 ):
@@ -50,6 +57,7 @@ def setup(
     )
     build_exclude = [] if build_exclude is None else build_exclude.split(",")
     use_tags = get_build_tags(build_include, build_exclude)
+    use_tags.append("test") # always include the test tag for autocompletion in vscode
 
     if not os.path.exists(DEVCONTAINER_DIR):
         os.makedirs(DEVCONTAINER_DIR)
@@ -83,6 +91,7 @@ def setup(
         "--name",
         "datadog_agent_devcontainer",
     ]
+    devcontainer["features"] = {}
     devcontainer["remoteUser"] = "datadog"
     devcontainer["mounts"] = [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached",
@@ -108,16 +117,70 @@ def setup(
                 },
                 "gopls": {"formatting.local": "github.com/DataDog/datadog-agent"},
             },
-            "extensions": ["golang.Go"],
+            "extensions": ["golang.Go","ms-python.python","redhat.vscode-yaml"],
         }
     }
-    devcontainer["postStartCommand"] = (
+
+    # onCreateCommond runs the install-tools and deps tasks only when the devcontainer is created and not each time
+    # the container is started
+    devcontainer["onCreateCommand"] = (
         f"git config --global --add safe.directory {AGENT_REPOSITORY_PATH} && invoke -e install-tools && invoke -e deps"
     )
 
-    devcontainer["remoteEnv"] = {"GITLAB_TOKEN": "${localEnv:GITLAB_TOKEN}"}
+    devcontainer["containerEnv"] = {
+        "GITLAB_TOKEN": "${localEnv:GITLAB_TOKEN}",
+    }
+
+    configure_skaffold(devcontainer, Skaffold_profile(skaffold_profile))
+
     with open(fullpath, "w") as sf:
         json.dump(devcontainer, sf, indent=4, sort_keys=False, separators=(',', ': '))
+
+def configure_skaffold(devcontainer: dict, profile: Skaffold_profile):
+    if profile == Skaffold_profile.KIND:
+        devcontainer["runArgs"].append("--network=host") # to connect to the kind api-server
+        # add requires extensions
+        additional_extensions = ["GoogleCloudTools.cloudcode"]
+        devcontainer["customizations"]["vscode"]["extensions"].extend(additional_extensions)
+        
+        # Additionnal features
+        additional_features = {
+            "ghcr.io/rio/features/skaffold:2": {},
+            "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+            "ghcr.io/devcontainers-extra/features/kind:1": {},
+            "ghcr.io/dhoeric/features/google-cloud-cli:1": {},
+        }
+        devcontainer["features"].update(additional_features)
+
+        # Addionnal settings
+        additional_settings = {
+            "cloudcode.features.completion": False,
+            "cloudcode.ai.assistance.enabled": False,
+            "cloudcode.cloudsdk.checkForMissing": False,
+            "cloudcode.cloudsdk.autoInstall": False,
+            "cloudcode.autoDependencies": "off",
+            "cloudcode.enableGkeAutopilotSupport": False,
+            "cloudcode.enableMinikubeGcpAuthPlugin": False,
+            "cloudcode.enableTelemetry": False,
+            "cloudcode.updateAdcOnLogin": False,
+            "cloudcode.useGcloudAuthSkaffold": False,
+            "cloudcode.yaml.validate": False,
+        }
+        devcontainer["customizations"]["vscode"]["settings"].update(additional_settings)
+
+        # add envvars to deploy the agent
+        additional_envvars = {
+            "DD_API_KEY": "${localEnv:DD_API_KEY}",
+            "DD_APP_KEY": "${localEnv:DD_APP_KEY}",
+        }
+        devcontainer["containerEnv"].update(additional_envvars)
+
+        # add Datadog helm chart registry to the devcontainer
+        devcontainer["onCreateCommand"] += " && helm repo add datadog https://helm.datadoghq.com && helm repo update"
+
+    elif profile == Skaffold_profile.MINIKUBE:
+        # TODO: add minikube specific settings
+        pass
 
 
 @task

--- a/tasks/devcontainer.py
+++ b/tasks/devcontainer.py
@@ -17,11 +17,12 @@ from tasks.build_tags import build_tags, filter_incompatible_tags, get_build_tag
 from tasks.commands.docker import AGENT_REPOSITORY_PATH, DockerCLI
 from tasks.flavor import AgentFlavor
 from tasks.libs.common.color import Color, color_message
+from tasks.libs.common.utils import is_installed
 
 DEVCONTAINER_DIR = ".devcontainer"
 DEVCONTAINER_FILE = "devcontainer.json"
 DEVCONTAINER_NAME = "datadog_agent_devcontainer"
-DEVCONTAINER_IMAGE = "486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-devenv:1-arm64"
+DEVCONTAINER_IMAGE = "registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64"
 
 
 @task
@@ -128,7 +129,7 @@ def start(ctx, path="."):
         print(color_message("No devcontainer settings found.  Run `invoke devcontainer.setup` first.", Color.RED))
         raise Exit(code=1)
 
-    if not is_installed(ctx):
+    if not is_installed(ctx, "devcontainer"):
         print(
             color_message("Devcontainer CLI is not installed.  Run `invoke install-devcontainer-cli` first.", Color.RED)
         )
@@ -172,11 +173,6 @@ def is_up(ctx) -> bool:
     res = ctx.run("docker ps", hide=True, warn=True)
     # TODO: it's fragile to just check for the container name, but it's the best we can do for now
     return DEVCONTAINER_NAME in res.stdout
-
-
-def is_installed(ctx) -> bool:
-    res = ctx.run("which devcontainer", hide=True, warn=True)
-    return res.ok
 
 
 def run_on_devcontainer(func):

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -676,3 +676,8 @@ def is_linux():
 
 def is_windows():
     return sys.platform == 'win32'
+
+
+def is_installed(ctx, binary) -> bool:
+    res = ctx.run(f"which {binary}", hide=True, warn=True)
+    return res.ok

--- a/tasks/skaffold.py
+++ b/tasks/skaffold.py
@@ -1,0 +1,173 @@
+"""
+Skaffold related tasks
+"""
+
+from invoke import UnexpectedExit, task
+from invoke.exceptions import Exit
+
+from tasks.devcontainer import DEVCONTAINER_IMAGE, DEVCONTAINER_NAME
+from tasks.libs.common.color import Color, color_message
+from tasks.libs.common.utils import is_installed
+
+DATADOG_AGENT_MOUNT = "/home/datadog/go/src/github.com/DataDog/datadog-agent"
+
+
+@task
+def minikube_start(ctx, path: str = ".") -> None:
+    """
+    Start the Minikube Cluster
+    """
+    print(
+        color_message(
+            "Starting the Minikube cluster.",
+            Color.BLUE,
+        )
+    )
+    if not is_installed(ctx, "minikube"):
+        print(
+            color_message(
+                "Minikube CLI is not installed. Check https://minikube.sigs.k8s.io/docs/start",
+                Color.RED,
+            )
+        )
+        raise Exit(code=1)
+
+    ctx.run(f"minikube start --mount --mount-string {path}:{DATADOG_AGENT_MOUNT}")
+
+
+def is_minikube_running(ctx) -> bool:
+    """
+    Check if Minikube is running
+    """
+    try:
+        minikube_status = ctx.run("minikube status", hide=True, warn=True)
+    except UnexpectedExit:
+        if minikube_status.return_code == 130:
+            return False
+        else:
+            raise
+
+    return minikube_status.ok
+
+
+def generate_minikube_env(ctx) -> list:
+    """
+    Generate the Minikube environment variables
+    """
+    minikube_env = []
+    minikube_env_command = ctx.run("minikube docker-env", hide=True)
+    for line in minikube_env_command.stdout.split("\n"):
+        if line.startswith("export"):
+            minikube_env.append(line.replace("export ", ""))
+    return minikube_env
+
+
+@task
+def devcontainer_start(ctx) -> None:
+    """
+    Start the devcontainer
+    """
+    print(
+        color_message(
+            "Starting the devcontainer.",
+            Color.BLUE,
+        )
+    )
+    if not is_installed(ctx, "docker"):
+        print(
+            color_message(
+                "Docker CLI is not installed. Check https://docs.docker.com/desktop.",
+                Color.RED,
+            )
+        )
+        raise Exit(code=1)
+
+    print(
+        color_message(
+            "To see the running containers in Minikube, run the following command: eval $(minikube docker-env).",
+            Color.GREEN,
+        )
+    )
+
+    # Create Docker command
+    docker_command = [
+        "docker",
+        "run",
+        "-d",
+        f"-v {DATADOG_AGENT_MOUNT}:{DATADOG_AGENT_MOUNT}",
+        "-v /var/run/docker.sock:/var/run/docker.sock",
+        f"--name {DEVCONTAINER_NAME}",
+        "--pull missing",
+        f"-w {DATADOG_AGENT_MOUNT}",
+        "--user root",
+        f"{DEVCONTAINER_IMAGE}",
+        "sleep infinity",
+    ]
+
+    ctx.run(" ".join(generate_minikube_env(ctx) + docker_command))
+
+
+def is_devcontainer_running(ctx) -> bool:
+    """
+    Check if the devcontainer is running
+    """
+    command = [
+        "docker",
+        "ps",
+        "--filter",
+        f"name={DEVCONTAINER_NAME}",
+        "--format",
+        "{{.Names}}",
+    ]
+    devcontainer_status = ctx.run(" ".join(generate_minikube_env(ctx) + command), hide=True)
+    return devcontainer_status.ok and DEVCONTAINER_NAME in devcontainer_status.stdout
+
+
+@task
+def create(ctx, path=".") -> None:
+    """
+    Start the Minikube Cluster and the devcontainer
+    """
+    if not is_minikube_running(ctx):
+        minikube_start(ctx, path)
+    if not is_devcontainer_running(ctx):
+        devcontainer_start(ctx)
+
+
+@task
+def dev(ctx) -> None:
+    """
+    Start the Skaffold cluster
+    """
+    print(
+        color_message(
+            "Starting the Skaffold cluster.",
+            Color.BLUE,
+        )
+    )
+    # Check if Skaffold is installed
+    if not is_installed(ctx, "skaffold"):
+        print(
+            color_message(
+                "Skaffold is not installed. Check https://skaffold.dev/docs/install/#standalone-binary.",
+                Color.RED,
+            )
+        )
+        raise Exit(code=1)
+
+    # Create Minikube Cluster and devcontainer if they are not running.
+    create(ctx)
+
+    # Create Skaffold Dev command
+    skaffold_command = [
+        "skaffold",
+        "dev",
+        "--filename skaffold.yaml",
+        "--auto-build=false",
+        "--auto-deploy=false",
+        "--auto-sync=false",
+        "--port-forward=true",
+        "--status-check=true",
+        "--verbosity warn",
+    ]
+    ctx.run(" ".join(generate_minikube_env(ctx) + skaffold_command))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a new build and deployment process for the Agent using [Skaffold](https://skaffold.dev/). This new build process comes with both new `deva`/`invoke` tasks as well as Jetbrains run configurations to allow for IDE integration.

### Motivation

It is still complicated to build and deploy the Datadog Agent for teams that are not used to working on it. This new build and deployment process aim to solve any potential friction around dependencies and tooling by providing an automated, simple and repeatable process on building and deploying the Agent.

This new process is based of Skaffold, an open-source project from Google that allow for easy local development using Kubernetes. While based of Minikube, it is important to understand that this build process is not only for 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Built using `deva` command

```
➜  datadog-agent git:(HAD-11/wassim.dhif/improve-agent-build) deva skaffold.dev
Starting the Skaffold cluster.
Generating tags...
 - agent -> agent:a1f694ca54
 - clusteragent -> clusteragent:a1f694ca54
Checking cache...
 - agent: Not found. Building
 - clusteragent: Not found. Building
Starting build...
Found [wassim-minikube] context, using local docker daemon.
Building 2 artifacts in parallel
Building [clusteragent]...
Target platforms: [linux/arm64]
[...]
Build [clusteragent] succeeded
Building [agent]...
Target platforms: [linux/arm64]
[...]
Build [agent] succeeded
Tags used in deployment:
 - agent -> agent:77ee963253f5a0ceebda7ee7f8b26705a195e7983f2dadf80cb2594a3fb21233
 - clusteragent -> clusteragent:ba68e85842006b8bb0f588b2f779241d116476c9f72631f0edefca4354e0c3aa
Starting deploy...
Helm release datadog-agent not installed. Installing...
NAME: datadog-agent
LAST DEPLOYED: Thu Jan 16 15:44:25 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Datadog agents are spinning up on each node in your cluster. After a few
minutes, you should see your agents starting in your event stream:
    https://app.datadoghq.com/event/explorer
Waiting for deployments to stabilize...
 - deployment/datadog-agent-cluster-agent: waiting for rollout to finish: 0 of 2 updated replicas are available...
 - deployment/datadog-agent-cluster-agent is ready.
Deployments stabilized in 31.069 seconds
```

Built using Visual Studio Code debugging command

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/6faccc8d-69ae-422c-a321-7c5361023366" />

Built using Jetbrains run Configuration

<img width="1288" alt="image" src="https://github.com/user-attachments/assets/f41328eb-7d47-4aa9-9009-0fbb02b2343c" />

### Possible Drawbacks / Trade-offs

Currently the devcontainer inside Skaffold is running as root. This is considered an acceptable trade-off as the container itself is only used for development purpose and is running inside the Minikube cluster.

Another aspect that could be improved is that most of the Helm configurations in `skaffold.yaml` are hardcoded. It would be beneficial to allow for different settings based on specific use cases. [Skaffold Profiles](https://skaffold.dev/docs/environment/profiles) could offer a solution to enhance flexibility in this regard in the future.

We could also incorporate [lifecycle hooks](https://skaffold.dev/docs/lifecycle-hooks) to further automate processes, such as installing and updating the Datadog Helm chart.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->