### PR TITLE
Treat false-like values as false on boolean typed headers (APMSP-1734)

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -576,7 +576,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	case <-time.After(time.Duration(r.conf.DecoderTimeout) * time.Millisecond):
 		// this payload can not be accepted
 		io.Copy(io.Discard, req.Body) //nolint:errcheck
-		if h := req.Header.Get(header.SendRealHTTPStatus); h != "" {
+		if isHeaderTrue(header.SendRealHTTPStatus, req.Header.Get(header.SendRealHTTPStatus)) {
 			w.WriteHeader(http.StatusTooManyRequests)
 		} else {
 			w.WriteHeader(r.rateLimiterResponse)
@@ -643,11 +643,25 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	payload := &Payload{
 		Source:                 ts,
 		TracerPayload:          tp,
-		ClientComputedTopLevel: req.Header.Get(header.ComputedTopLevel) != "",
-		ClientComputedStats:    req.Header.Get(header.ComputedStats) != "",
+		ClientComputedTopLevel: isHeaderTrue(header.ComputedTopLevel, req.Header.Get(header.ComputedTopLevel)),
+		ClientComputedStats:    isHeaderTrue(header.ComputedStats, req.Header.Get(header.ComputedStats)),
 		ClientDroppedP0s:       droppedTracesFromHeader(req.Header, ts),
 	}
 	r.out <- payload
+}
+
+// isHeaderTrue returns true if value is non-empty and not a "false"-like value as defined by strconv.ParseBool
+// e.g. (0, f, F, FALSE, False, false) will be considered false while all other values will be true.
+func isHeaderTrue(key, value string) bool {
+	if len(value) == 0 {
+		return false
+	}
+	bval, err := strconv.ParseBool(value)
+	if err != nil {
+		log.Debug("Non-boolean value %s found in header %s, defaulting to true", value, key)
+		return true
+	}
+	return bval
 }
 
 func droppedTracesFromHeader(h http.Header, ts *info.TagStats) int64 {

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -719,6 +719,8 @@ func TestClientComputedStatsHeader(t *testing.T) {
 			req.Header.Set(header.Lang, "lang1")
 			if on {
 				req.Header.Set(header.ComputedStats, "yes")
+			} else {
+				req.Header.Set(header.ComputedStats, "false")
 			}
 			var wg sync.WaitGroup
 			wg.Add(1)

--- a/pkg/trace/api/internal/header/headers.go
+++ b/pkg/trace/api/internal/header/headers.go
@@ -56,11 +56,12 @@ const (
 	TracerVersion = "Datadog-Meta-Tracer-Version"
 
 	// ComputedTopLevel specifies that the client has marked top-level spans, when set.
-	// Any non-empty value will mean 'yes'.
+	// Any value other than 0, f, F, FALSE, False, false will mean 'yes'.
 	ComputedTopLevel = "Datadog-Client-Computed-Top-Level"
 
 	// ComputedStats specifies whether the client has computed stats so that the agent
 	// doesn't have to.
+	// Any value other than 0, f, F, FALSE, False, false will mean 'yes'.
 	ComputedStats = "Datadog-Client-Computed-Stats"
 
 	// DroppedP0Traces contains the number of P0 trace chunks dropped by the client.
@@ -79,7 +80,7 @@ const (
 	// it wants to receive the "real" status in the response. By default, the agent
 	// will send a 200 OK response for every payload, even those dropped due to
 	// intake limits.
-	// Any value set in this header will cause the agent to send a 429 code to a client
+	// Any value other than 0, f, F, FALSE, False, false set in this header will cause the agent to send a 429 code to a client
 	// when the payload cannot be submitted.
 	SendRealHTTPStatus = "Datadog-Send-Real-Http-Status"
 )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Change the following "boolean" header values:
- Datadog-Client-Computed-Top-Level
- Datadog-Send-Real-Http-Status
- Datadog-Client-Computed-Stats

To now treat the following values as `false`:
- 0
- f
- F
- FALSE
- False
- false 

Previously _any_ non-empty value would be treated as "true".

### Motivation
Given the boolean nature of these headers it was expected that it was possible to set these to `false`, this led to an implementation issue that was difficult to immediately detect.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

I've updated our unit tests to cover this change

### Possible Drawbacks / Trade-offs
Hypothetically there may be a tracer sending one of these new "false" values already and unexpectedly get a change in behavior. This is extremely unlikely, and if there are any applications sending "false" or similar today it is almost certainly a bug that just hasn't been discovered yet and this change will resolve it.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->