### PR TITLE
allow KMT test regex for all or multiple packages

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -874,11 +874,10 @@ def build_run_config(run: str | None, packages: list[str]):
     c: dict[str, Any] = {}
 
     if len(packages) == 0:
-        return {"filters": {"*": {"exclude": False}}}
+        packages = ["*"]
 
     for p in packages:
-        if p[:2] == "./":
-            p = p[2:]
+        p = p.removeprefix("./")
         if run is not None:
             c["filters"] = {p: {"run-only": [run]}}
         else:
@@ -1202,15 +1201,9 @@ def test(
             info(f"[+] Preparing {component} for {arch}")
             _prepare(ctx, stack, component, arch, packages=packages, verbose=verbose, domains=domains)
 
-    if run is not None and packages is None:
-        raise Exit("Package must be provided when specifying test")
-
     pkgs = []
     if packages is not None:
         pkgs = [os.path.relpath(os.path.realpath(p)) for p in go_package_dirs(packages.split(","), [NPM_TAG, BPF_TAG])]
-
-    if run is not None and len(pkgs) > 1:
-        raise Exit("Only a single package can be specified when running specific tests")
 
     paths = KMTPaths(stack, Arch.local())  # Arch is not relevant to the test result paths, which is what we want now
     shutil.rmtree(paths.test_results, ignore_errors=True)  # Reset test-results folder

--- a/test/new-e2e/system-probe/test-runner/main.go
+++ b/test/new-e2e/system-probe/test-runner/main.go
@@ -158,7 +158,13 @@ func buildCommandArgs(pkg string, xmlpath string, jsonpath string, testArgs []st
 	if config, ok := packagesRunConfig[pkg]; ok && config.RunOnly != nil {
 		args = append(args, "-test.run", strings.Join(config.RunOnly, "|"))
 	}
+	if config, ok := packagesRunConfig[matchAllPackages]; ok && config.RunOnly != nil {
+		args = append(args, "-test.run", strings.Join(config.RunOnly, "|"))
+	}
 	if config, ok := packagesRunConfig[pkg]; ok && config.Skip != nil {
+		args = append(args, "-test.skip", strings.Join(config.Skip, "|"))
+	}
+	if config, ok := packagesRunConfig[matchAllPackages]; ok && config.Skip != nil {
 		args = append(args, "-test.skip", strings.Join(config.Skip, "|"))
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allows a KMT user to specify `--run` but apply that to multiple or all packages.

### Motivation

https://github.com/DataDog/datadog-agent/pull/32979 adds tests to many packages with the same prefix. I wanted to run all those tests in one run. There isn't a good reason to be as restrictive as we were.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Tested manually locally

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->