### PR TITLE
[DRAFT] Enable operation name v2 by default in OTel agent statsprocessor

### DIFF
--- a/comp/otelcol/otlp/components/statsprocessor/agent.go
+++ b/comp/otelcol/otlp/components/statsprocessor/agent.go
@@ -95,6 +95,7 @@ func NewAgentWithConfig(ctx context.Context, cfg *traceconfig.AgentConfig, out c
 	a.ClientStatsAggregator = stats.NewClientStatsAggregator(cfg, statsWriter, metricsClient)
 	// lastly, start the OTLP receiver, which will be used to introduce ResourceSpans into the traceagent,
 	// so that we can transform them to Datadog spans and receive stats.
+	cfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 	a.OTLPReceiver = api.NewOTLPReceiver(pchan, cfg, metricsClient, timingReporter)
 	// we want to discard all traces that would be written out so replace traceWriter with noop
 	a.TraceWriter = &noopTraceWriter{}

--- a/comp/otelcol/otlp/components/statsprocessor/agent_test.go
+++ b/comp/otelcol/otlp/components/statsprocessor/agent_test.go
@@ -109,6 +109,7 @@ func testTraceAgent(enableReceiveResourceSpansV2 bool, t *testing.T) {
 					assert.Greater(t, len(bucket.Stats), 0)
 					actual = append(actual, bucket.Stats...)
 				}
+				assert.Equal(t, "Internal", cspayload.Stats[0].Stats[0].Name)
 			}
 		case <-timeout:
 			t.Fatal("timed out")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->