### PR TITLE
[ebpfless] Lifecycle bugfixes

### DIFF
--- a/pkg/network/filter/packet_source.go
+++ b/pkg/network/filter/packet_source.go
@@ -19,7 +19,7 @@ type PacketInfo interface{}
 // PacketSource reads raw packet data
 type PacketSource interface {
 	// VisitPackets reads all new raw packets that are available, invoking the given callback for each packet.
-	// If no packet is available, VisitPacket returns immediately.
+	// If no packet is available, VisitPacket blocks until OptPollTimeout and returns.
 	// The format of the packet is dependent on the implementation of PacketSource -- i.e. it may be an ethernet frame, or a IP frame.
 	// The data buffer is reused between invocations of VisitPacket and thus should not be pointed to.
 	// If the cancel channel is closed, VisitPackets will stop reading.

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -47,6 +47,8 @@ var packetSourceTelemetry = struct {
 // AFPacketSource provides a RAW_SOCKET attached to an eBPF SOCKET_FILTER
 type AFPacketSource struct {
 	*afpacket.TPacket
+	// store AFPacketInfo used to visit packets to avoid malloc on a per-packet basis
+	afPacketInfo *AFPacketInfo
 
 	exit chan struct{}
 }
@@ -57,6 +59,11 @@ type AFPacketInfo struct {
 	// sockaddr_ll struct; see packet(7)
 	// https://man7.org/linux/man-pages/man7/packet.7.html
 	PktType uint8
+}
+
+// GetPacketInfoBuffer returns a pointer to AFPacketInfo which is reused between calls
+func (p *AFPacketSource) GetPacketInfoBuffer() *AFPacketInfo {
+	return p.afPacketInfo
 }
 
 // OptSnapLen specifies the maximum length of the packet to read
@@ -98,8 +105,9 @@ func NewAFPacketSource(size int, opts ...interface{}) (*AFPacketSource, error) {
 	}
 
 	ps := &AFPacketSource{
-		TPacket: rawSocket,
-		exit:    make(chan struct{}),
+		TPacket:      rawSocket,
+		afPacketInfo: &AFPacketInfo{},
+		exit:         make(chan struct{}),
 	}
 	go ps.pollStats()
 
@@ -131,6 +139,8 @@ func (p *AFPacketSource) SetBPF(filter []bpf.RawInstruction) error {
 
 type zeroCopyPacketReader interface {
 	ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error)
+	// GetPacketInfoBuffer returns a pointer to AFPacketInfo which is reused between calls
+	GetPacketInfoBuffer() *AFPacketInfo
 }
 
 // AFPacketVisitor is the callback that AFPacketSource will trigger for packets
@@ -138,7 +148,7 @@ type zeroCopyPacketReader interface {
 type AFPacketVisitor = func(data []byte, info PacketInfo, t time.Time) error
 
 func visitPackets(p zeroCopyPacketReader, exit <-chan struct{}, visit AFPacketVisitor) error {
-	pktInfo := &AFPacketInfo{}
+	pktInfo := p.GetPacketInfoBuffer()
 	for {
 		// allow the read loop to be prematurely interrupted
 		select {

--- a/pkg/network/filter/packet_source_linux_test.go
+++ b/pkg/network/filter/packet_source_linux_test.go
@@ -8,13 +8,14 @@
 package filter
 
 import (
+	"testing"
+	"time"
+
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/afpacket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
-	"testing"
-	"time"
 )
 
 type mockPacketReader struct {
@@ -25,6 +26,9 @@ type mockPacketReader struct {
 
 func (m *mockPacketReader) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
 	return m.data, m.ci, m.err
+}
+func (m *mockPacketReader) GetPacketInfoBuffer() *AFPacketInfo {
+	return &AFPacketInfo{}
 }
 
 func mockCaptureInfo(ancillaryData []interface{}) gopacket.CaptureInfo {

--- a/pkg/network/tracer/connection/ebpfless_tracer.go
+++ b/pkg/network/tracer/connection/ebpfless_tracer.go
@@ -148,9 +148,6 @@ func (t *ebpfLessTracer) Start(closeCallback func(*network.ConnectionStats)) err
 				return
 			default:
 			}
-
-			// Sleep briefly and try again
-			time.Sleep(5 * time.Millisecond)
 		}
 	}()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes three lifecycle issues related to ebpfless packet capture:
1. [main fix] Call `t.packetSrc.Close()` when closing the ebpfless tracer
2. Cancel the packet capture loop based on `t.exit`
3. Reuse `*AFPacketInfo` to avoid malloc on a per-packet basis

### Motivation
Noticed CPU issues while running ebpfless tests.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Fixes CPU usage for the ebpfless test suite:
```
DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->