### PR TITLE
[ebpfless] Cancel packet capture loop via Close()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1112,7 +1112,7 @@ replace github.com/ProtonMail/go-crypto => github.com/ProtonMail/go-crypto v1.0.
 // Prevent a false-positive detection by the Google and Ikarus security vendors on VirusTotal
 exclude go.opentelemetry.io/proto/otlp v1.1.0
 
-replace github.com/google/gopacket v1.1.19 => github.com/DataDog/gopacket v0.0.0-20250117045428-fe4bae19ab92
+replace github.com/google/gopacket v1.1.19 => github.com/DataDog/gopacket v0.0.0-20250121143817-e1e3480abefb
 
 // Remove once https://github.com/kubernetes/kube-state-metrics/pull/2553 is merged
 replace k8s.io/kube-state-metrics/v2 v2.13.1-0.20241025121156-110f03d7331f => github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20241108192007-8859a4289d92

--- a/go.mod
+++ b/go.mod
@@ -1112,7 +1112,7 @@ replace github.com/ProtonMail/go-crypto => github.com/ProtonMail/go-crypto v1.0.
 // Prevent a false-positive detection by the Google and Ikarus security vendors on VirusTotal
 exclude go.opentelemetry.io/proto/otlp v1.1.0
 
-replace github.com/google/gopacket v1.1.19 => github.com/DataDog/gopacket v0.0.0-20240626205202-4ac4cee31f14
+replace github.com/google/gopacket v1.1.19 => github.com/DataDog/gopacket v0.0.0-20250117045428-fe4bae19ab92
 
 // Remove once https://github.com/kubernetes/kube-state-metrics/pull/2553 is merged
 replace k8s.io/kube-state-metrics/v2 v2.13.1-0.20241025121156-110f03d7331f => github.com/L3n41c/kube-state-metrics/v2 v2.13.1-0.20241108192007-8859a4289d92

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4ti
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee/go.mod h1:nTot/Iy0kW16bXgXr6blEc8gFeAS7vTqYlhAxh+dbc0=
-github.com/DataDog/gopacket v0.0.0-20250117045428-fe4bae19ab92 h1:AR3OBtrZtXHScahYvkk4FQU3Eb81Lis8jvV3DaAPlUA=
-github.com/DataDog/gopacket v0.0.0-20250117045428-fe4bae19ab92/go.mod h1:riddUzxTSBpJXk3qBHtYr4qOhFhT6k/1c0E3qkQjQpA=
+github.com/DataDog/gopacket v0.0.0-20250121143817-e1e3480abefb h1:DWP0inw/CyCUdBh/913y3B2NK+Suu1VDC90Hrm9qtxE=
+github.com/DataDog/gopacket v0.0.0-20250121143817-e1e3480abefb/go.mod h1:riddUzxTSBpJXk3qBHtYr4qOhFhT6k/1c0E3qkQjQpA=
 github.com/DataDog/gopsutil v1.2.2 h1:8lmthwyyCXa1NKiYcHlrtl9AAFdfbNI2gPcioCJcBPU=
 github.com/DataDog/gopsutil v1.2.2/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=

--- a/go.sum
+++ b/go.sum
@@ -180,8 +180,8 @@ github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4ti
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee/go.mod h1:nTot/Iy0kW16bXgXr6blEc8gFeAS7vTqYlhAxh+dbc0=
-github.com/DataDog/gopacket v0.0.0-20240626205202-4ac4cee31f14 h1:t34NfJA77KgFZsh8kcNFW57LZLa0kW2YSUs4MvLKRxU=
-github.com/DataDog/gopacket v0.0.0-20240626205202-4ac4cee31f14/go.mod h1:riddUzxTSBpJXk3qBHtYr4qOhFhT6k/1c0E3qkQjQpA=
+github.com/DataDog/gopacket v0.0.0-20250117045428-fe4bae19ab92 h1:AR3OBtrZtXHScahYvkk4FQU3Eb81Lis8jvV3DaAPlUA=
+github.com/DataDog/gopacket v0.0.0-20250117045428-fe4bae19ab92/go.mod h1:riddUzxTSBpJXk3qBHtYr4qOhFhT6k/1c0E3qkQjQpA=
 github.com/DataDog/gopsutil v1.2.2 h1:8lmthwyyCXa1NKiYcHlrtl9AAFdfbNI2gPcioCJcBPU=
 github.com/DataDog/gopsutil v1.2.2/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=

--- a/pkg/network/dns/packet_source_windows.go
+++ b/pkg/network/dns/packet_source_windows.go
@@ -39,8 +39,8 @@ func newWindowsPacketSource(telemetrycomp telemetry.Component) (filter.PacketSou
 }
 
 func (p *windowsPacketSource) VisitPackets(visit func([]byte, filter.PacketInfo, time.Time) error) error {
-	mu.Lock()
-	defer mu.Unlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	for {
 		// break out of loop if exit is closed
 		select {
@@ -67,7 +67,7 @@ func (p *windowsPacketSource) Close() {
 	close(p.exit)
 
 	// wait for the VisitPackets loop to finish, then close
-	mu.Lock()
-	defer mu.Unlock()
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	_ = p.di.Close()
 }

--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -122,8 +122,10 @@ func (s *socketFilterSnooper) Start() error {
 func (s *socketFilterSnooper) Close() {
 	s.once.Do(func() {
 		close(s.exit)
-		s.wg.Wait()
+		// stop the packet capture loop
 		s.source.Close()
+		// wait for the packet capture loop to finish
+		s.wg.Wait()
 		s.cache.Close()
 		if s.statKeeper != nil {
 			s.statKeeper.Close()
@@ -170,7 +172,7 @@ func (s *socketFilterSnooper) processPacket(data []byte, _ filter.PacketInfo, ts
 
 func (s *socketFilterSnooper) pollPackets() {
 	for {
-		err := s.source.VisitPackets(s.exit, s.processPacket)
+		err := s.source.VisitPackets(s.processPacket)
 
 		if err != nil {
 			log.Warnf("error reading packet: %s", err)

--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -122,9 +122,8 @@ func (s *socketFilterSnooper) Start() error {
 func (s *socketFilterSnooper) Close() {
 	s.once.Do(func() {
 		close(s.exit)
-		// stop the packet capture loop
+		// close the packet capture loop and wait for it to finish
 		s.source.Close()
-		// wait for the packet capture loop to finish
 		s.wg.Wait()
 		s.cache.Close()
 		if s.statKeeper != nil {

--- a/pkg/network/filter/packet_source.go
+++ b/pkg/network/filter/packet_source.go
@@ -22,12 +22,13 @@ type PacketSource interface {
 	// If no packet is available, VisitPacket blocks until OptPollTimeout and returns.
 	// The format of the packet is dependent on the implementation of PacketSource -- i.e. it may be an ethernet frame, or a IP frame.
 	// The data buffer is reused between invocations of VisitPacket and thus should not be pointed to.
-	// If the cancel channel is closed, VisitPackets will stop reading.
-	VisitPackets(cancel <-chan struct{}, visitor func(data []byte, info PacketInfo, timestamp time.Time) error) error
+	// If the PacketSource is closed, VisitPackets will stop reading.
+	VisitPackets(visitor func(data []byte, info PacketInfo, timestamp time.Time) error) error
 
 	// LayerType returns the type of packet this source reads
 	LayerType() gopacket.LayerType
 
-	// Close closes the packet source
+	// Close closes the packet source. This will cancel VisitPackets if it is currently polling.
+	// Close() will not return until after VisitPackets has been canceled/returned.
 	Close()
 }

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -138,7 +138,7 @@ func (p *AFPacketSource) SetBPF(filter []bpf.RawInstruction) error {
 }
 
 type zeroCopyPacketReader interface {
-	ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error)
+	ZeroCopyReadPacketDataWithExit(exit <-chan struct{}) (data []byte, ci gopacket.CaptureInfo, err error)
 	// GetPacketInfoBuffer returns a pointer to AFPacketInfo which is reused between calls
 	GetPacketInfoBuffer() *AFPacketInfo
 }
@@ -157,7 +157,7 @@ func visitPackets(p zeroCopyPacketReader, exit <-chan struct{}, visit AFPacketVi
 		default:
 		}
 
-		data, stats, err := p.ZeroCopyReadPacketData()
+		data, stats, err := p.ZeroCopyReadPacketDataWithExit(exit)
 
 		// Immediately retry for EAGAIN
 		if err == syscall.EAGAIN {

--- a/pkg/network/filter/packet_source_linux_test.go
+++ b/pkg/network/filter/packet_source_linux_test.go
@@ -24,7 +24,7 @@ type mockPacketReader struct {
 	err  error
 }
 
-func (m *mockPacketReader) ZeroCopyReadPacketData() (data []byte, ci gopacket.CaptureInfo, err error) {
+func (m *mockPacketReader) ZeroCopyReadPacketDataWithExit(_ <-chan struct{}) (data []byte, ci gopacket.CaptureInfo, err error) {
 	return m.data, m.ci, m.err
 }
 func (m *mockPacketReader) GetPacketInfoBuffer() *AFPacketInfo {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Uses https://github.com/DataDog/gopacket/pull/3 which makes Close() cancel ZeroCopyReadPacketData.

### Motivation
Improves the performance of existing tests a fair bit, and greatly improves ebpfless test performance

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Existing test suite should pass, and run 24% faster, `577.173s` -> `466.346s` (because it incidentally speeds up the DNS snooper):
```
DD_REMOTE_CONFIGURATION_ENABLED=false sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite
```
Ebpfless test suite should pass, and run 3x faster, `69.357s` -> `22.789s`:
```
DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless
```

In the CI job `new-e2e-npm-packages`, the `TestEC2VMWKitSuite` should pass which tests windows

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->