### PR TITLE
[CWS] lazy load btfhub data

### DIFF
--- a/pkg/security/probe/constantfetch/fetcher.go
+++ b/pkg/security/probe/constantfetch/fetcher.go
@@ -108,11 +108,13 @@ func (f *ComposeConstantFetcher) fillConstantCacheIfNeeded() {
 			seclog.Errorf("failed to run constant fetcher: %v", err)
 		}
 
-		for _, req := range f.requests {
-			if req.value == ErrorSentinel {
-				if newValue, present := res[req.id]; present {
-					req.value = newValue
-					req.fetcherName = fetcher.String()
+		if len(res) != 0 {
+			for _, req := range f.requests {
+				if req.value == ErrorSentinel {
+					if newValue, present := res[req.id]; present {
+						req.value = newValue
+						req.fetcherName = fetcher.String()
+					}
 				}
 			}
 		}

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -60,9 +60,6 @@ func TestOctogonConstants(t *testing.T) {
 		if err != nil {
 			t.Skipf("btfhub constant fetcher is not available: %v", err)
 		}
-		if !btfhubFetcher.HasConstantsInStore() {
-			t.Skip("btfhub has no constant for this OS")
-		}
 
 		fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reduces the impact of initializing the BTFHub constant fetcher and moves the cost to the fetching of constants. The goal of this is that if all constants are found before the need for btfhub the unmarshalling of the constants file is not needed, and with this PR not done anymore.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->