### PR TITLE
service discovery: Reduce container status cache time

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/comm_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/comm_test.go
@@ -31,7 +31,7 @@ const (
 func TestIgnoreComm(t *testing.T) {
 	serverDir := buildFakeServer(t)
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -41,6 +41,11 @@ import (
 
 const (
 	pathServices = "/services"
+
+	// Use a low cache validity to ensure that we refresh information every time
+	// the check is run if needed. This is the same as cacheValidityNoRT in
+	// pkg/process/checks/container.go.
+	containerCacheValidatity = 2 * time.Second
 )
 
 // Ensure discovery implements the module.Module interface.
@@ -695,7 +700,7 @@ func (s *discovery) getServices() (*[]model.Service, error) {
 
 	var services []model.Service
 	alivePids := make(map[int32]struct{}, len(pids))
-	containers, _, pidToCid, err := s.containerProvider.GetContainers(1*time.Minute, nil)
+	containers, _, pidToCid, err := s.containerProvider.GetContainers(containerCacheValidatity, nil)
 	if err != nil {
 		log.Errorf("could not get containers: %s", err)
 	}

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -200,7 +200,7 @@ func startProcessWithFile(t *testing.T, f *os.File) *exec.Cmd {
 // Check that we get (only) listening processes for all expected protocols.
 func TestBasic(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	var expectedPIDs []int
 	var unexpectedPIDs []int
@@ -254,7 +254,7 @@ func TestBasic(t *testing.T) {
 // Check that we get all listening ports for a process
 func TestPorts(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	var expectedPorts []uint16
 	var unexpectedPorts []uint16
@@ -311,7 +311,7 @@ func TestPorts(t *testing.T) {
 
 func TestPortsLimits(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	var expectedPorts []int
 
@@ -346,7 +346,7 @@ func TestPortsLimits(t *testing.T) {
 
 func TestServiceName(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	listener, err := net.Listen("tcp", "")
 	require.NoError(t, err)
@@ -387,7 +387,7 @@ func TestServiceName(t *testing.T) {
 
 func TestInjectedServiceName(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	createEnvsMemfd(t, []string{
 		"OTHER_ENV=test",
@@ -415,7 +415,7 @@ func TestInjectedServiceName(t *testing.T) {
 
 func TestAPMInstrumentationInjected(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	createEnvsMemfd(t, []string{
 		"DD_INJECTION_ENABLED=service_name,tracer",
@@ -512,7 +512,7 @@ func testCaptureWrappedCommands(t *testing.T, script string, commandWrapper []st
 	t.Cleanup(func() { _ = proc.Kill() })
 
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 	pid := int(proc.Pid)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		svcMap := getServicesMap(collect, url)
@@ -553,7 +553,7 @@ func TestAPMInstrumentationProvided(t *testing.T) {
 
 	serverDir := buildFakeServer(t)
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -635,7 +635,7 @@ func assertCPU(t require.TestingT, url string, pid int) {
 func TestCommandLineSanitization(t *testing.T) {
 	serverDir := buildFakeServer(t)
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })
@@ -667,7 +667,7 @@ func TestNodeDocker(t *testing.T) {
 	require.NoError(t, err)
 
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 	pid := int(nodeJSPID)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -726,7 +726,7 @@ func TestAPMInstrumentationProvidedWithMaps(t *testing.T) {
 			require.NoError(t, err)
 
 			url, mockContainerProvider := setupDiscoveryModule(t)
-			mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+			mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 			pid := cmd.Process.Pid
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -743,7 +743,7 @@ func TestAPMInstrumentationProvidedWithMaps(t *testing.T) {
 // Check that we can get listening processes in other namespaces.
 func TestNamespaces(t *testing.T) {
 	url, mockContainerProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).AnyTimes()
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).AnyTimes()
 
 	// Needed when changing namespaces
 	runtime.LockOSThread()
@@ -832,7 +832,7 @@ func TestDocker(t *testing.T) {
 				pid1111 = process.PID
 				mockContainerProvider.
 					EXPECT().
-					GetContainers(1*time.Minute, nil).
+					GetContainers(containerCacheValidatity, nil).
 					Return(
 						[]*agentPayload.Container{
 							{Id: "dummyCID", Tags: []string{
@@ -870,7 +870,7 @@ func TestCache(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	mockContainerProvider := proccontainersmocks.NewMockContainerProvider(mockCtrl)
-	mockContainerProvider.EXPECT().GetContainers(1*time.Minute, nil).MinTimes(1)
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidatity, nil).MinTimes(1)
 	discovery := newDiscovery(mockContainerProvider)
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The GetContainers() call currently uses a cache validity time of 1 minute for the container information (the information which is scraped from system-probe, not for the information from workloadmeta).  This is problematic, since due to jitter, even though the agent check is called once every minute, the time between the calls to GetContainers() is not guaranteed to be larger than one minute, so the container information may not get refreshed when needed, leading to temporarily missing container information for new containers.

For example, in the log below, the second call is about a half a millisecond shy of one minute:

 now: 2025-01-17 11:01:35.453556101 +0100 CET m=+164.914910536
 now: 2025-01-17 11:02:35.453245896 +0100 CET m=+224.914600324

Furthermore, since there is a per-container ID cache in collector_cache.go which also caches errors, and another collector-wide refresh time (in RefreshCgroups() in collector_linux.go), it's possible for the the cached "unable to find container ID" error to take two calls to go away, but the potential->running transaction only takes one call (1 minute) to happen so the start-service event could be emitted without the container information.

Also, during testing or debugging when the endpoint is accessed directly as a debugging aid, the problem is aggravated since the intermediate calls always happen less than 1 minute apart.

Reduce the time to a couple of seconds similar to the code in the container check.

### Motivation

Failures in e2e tests and manual test.

### Describe how you validated your changes

Manually tested by starting/stopping containerized services and hitting the debug endpoint and checking the start-service events in the logs.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->