### PR TITLE
[CWS] fix `TestRawPacketFilter/all-with-limit`

### DIFF
--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -143,6 +143,7 @@ func filtersToProgs(filters []Filter, opts ProgOpts, headerInsts, senderInsts as
 				asm.LoadMapPtr(asm.R2, opts.tailCallMapFd),
 				asm.Mov.Imm(asm.R3, int32(probes.TCRawPacketFilterKey+uint32(tailCalls)+1)),
 				asm.FnTailCall.Call(),
+				asm.Mov.Imm(asm.R0, 0),
 			}
 		}
 

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -225,7 +225,7 @@ func TestRawPacketFilter(t *testing.T) {
 
 	runTest := func(t *testing.T, filters []rawpacket.Filter, opts rawpacket.ProgOpts) {
 		progSpecs, err := rawpacket.FiltersToProgramSpecs(rawPacketEventMap.FD(), clsRouterMapFd.FD(), filters, opts)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.NotEmpty(t, progSpecs)
 
 		colSpec := ebpf.CollectionSpec{
@@ -236,7 +236,7 @@ func TestRawPacketFilter(t *testing.T) {
 		}
 
 		progsCol, err := ebpf.NewCollection(&colSpec)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		if err == nil {
 			progsCol.Close()
 		}

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -253,7 +253,6 @@ func TestRawPacketFilter(t *testing.T) {
 	})
 
 	t.Run("all-with-limit", func(t *testing.T) {
-		t.Skip("This test is disabled because it is too flaky")
 		opts := rawpacket.DefaultProgOpts
 		opts.MaxProgSize = 4000
 		opts.NopInstLen = 3500


### PR DESCRIPTION
### What does this PR do?

In the `all-with-limit` test we generate a lot of nops to test the tail call behavior. This result in some programs that are filled with nops, and thus R0 is never affected which trips the verifier when checking the exit instruction -> R0 has no value.

To fix this this PR initialize R0 to 0 after the tail call (so it's unreachable).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->