### PR TITLE
[ASCII-2668] Increase the e2e fips cipher server startup timeout to 60s

### DIFF
--- a/test/new-e2e/tests/fips-compliance/fips_ciphers_nix_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_ciphers_nix_test.go
@@ -134,7 +134,7 @@ func runFipsServer(v *fipsServerSuite, tc cipherTestCase, composeFiles string) {
 		serverLogs, _ := v.Env().RemoteHost.Execute("docker logs dd-fips-server")
 		assert.Contains(t, serverLogs, "Server Starting...", "Server should start")
 		assert.Equal(t, 1, strings.Count(serverLogs, "Server Starting..."), "Server should start only once, logs from previous runs should not be present")
-	}, 10*time.Second, 2*time.Second)
+	}, 60*time.Second, 5*time.Second)
 }
 
 func runAgentDiagnose(v *fipsServerSuite, composeFiles string) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[Failing CI test](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/770048933) as we checked logs before the fips-server started with the rsa generated cert

This PR increases that assertion timeout to 60s instead of 10s

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->