### PR TITLE
Auto multiline V2 - reuse cached message. Fixes panic in journald with processing rules. 

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -74,7 +74,9 @@ func (b *bucket) flush() *message.Message {
 		content = append(content, message.TruncatedFlag...)
 	}
 
-	msg := message.NewRawMessage(content, b.message.Status, b.originalDataLen, b.message.ParsingExtra.Timestamp)
+	msg := b.message
+	b.message.SetContent(content)
+	b.message.RawDataLen = b.originalDataLen
 	tlmTags := []string{"false", "single_line"}
 
 	if b.lineCount > 1 {

--- a/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/aggregator.go
@@ -75,8 +75,8 @@ func (b *bucket) flush() *message.Message {
 	}
 
 	msg := b.message
-	b.message.SetContent(content)
-	b.message.RawDataLen = b.originalDataLen
+	msg.SetContent(content)
+	msg.RawDataLen = b.originalDataLen
 	tlmTags := []string{"false", "single_line"}
 
 	if b.lineCount > 1 {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes a panic caused by the interaction of this feature with journald logs. 
The journald tailer does not rebuild the message after the decoder processes it (unlike the file tailer). As a result, the auto multiline aggregator was stripping the `origin` field, causing a panic downstream when [we tried to query the processing rules. ](https://github.com/DataDog/datadog-agent/blob/a5b71bd1c4183b6da7417093f4774bd16d019a4e/pkg/logs/processor/processor.go#L266)

### Motivation

Fix panic

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

1. Create a journald logs integration
```
logs:

  - type: journald
    log_processing_rules:
    - type: mask_sequences 
      name: test 
      pattern: message
      replace_placeholder: "not-a-message"
```

2. in datadog.yaml 
```
logs_config:
    experimental_auto_multi_line_detection: true
```

3. collect some journald logs (systemd-cat is helpful)
4. Agent should not panic, processing rules should work. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->