### PR TITLE
emit obfuscation cache cost added and evicted metrics

### DIFF
--- a/pkg/obfuscate/cache.go
+++ b/pkg/obfuscate/cache.go
@@ -41,8 +41,10 @@ func (c *measuredCache) statsLoop() {
 	for {
 		select {
 		case <-tick.C:
-			_ = c.statsd.Gauge("datadog.trace_agent.obfuscation.sql_cache.hits", float64(mx.Hits()), nil, 1)     //nolint:errcheck
-			_ = c.statsd.Gauge("datadog.trace_agent.obfuscation.sql_cache.misses", float64(mx.Misses()), nil, 1) //nolint:errcheck
+			_ = c.statsd.Gauge("datadog.trace_agent.obfuscation.sql_cache.hits", float64(mx.Hits()), nil, 1)                //nolint:errcheck
+			_ = c.statsd.Gauge("datadog.trace_agent.obfuscation.sql_cache.misses", float64(mx.Misses()), nil, 1)            //nolint:errcheck
+			_ = c.statsd.Gauge("datadog.trace_agent.obfuscation.sql_cache.cost_added", float64(mx.CostAdded()), nil, 1)     //nolint:errcheck
+			_ = c.statsd.Gauge("datadog.trace_agent.obfuscation.sql_cache.cost_evicted", float64(mx.CostEvicted()), nil, 1) //nolint:errcheck
 		case <-c.close:
 			c.Cache.Close()
 			return

--- a/releasenotes/notes/obfuscate-cache-metrics-cost-added-evicted-eca0b1212b457767.yaml
+++ b/releasenotes/notes/obfuscate-cache-metrics-cost-added-evicted-eca0b1212b457767.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add new metrics for obfuscation cache
+    - ``datadog.trace_agent.obfuscation.sql_cache.cost_added`` tracks the cumulative cost of entries successfully added to the obfuscation cache (Set calls).
+    - ``datadog.trace_agent.obfuscation.sql_cache.cost_evicted`` tracks the cumulative cost of entries evicted from the obfuscation cache.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR emits 2 new metrics for the obfuscation cache. 
- `datadog.trace_agent.obfuscation.sql_cache.cost_added` - measures the sum of costs that have been added (successful Set calls).
- `datadog.trace_agent.obfuscation.sql_cache.cost_evicted` - measures the sum of all costs that have been evicted.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->