### PR TITLE
Add ddprocmon service status to flare

### DIFF
--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -312,16 +312,19 @@ func getDDServices(manager *mgr.Mgr) ([]serviceInfo, error) {
 		}
 	}
 
-	// Getting ddnpm service info separately
-	ddnpm, err := winutil.OpenService(manager, "ddnpm", windows.GENERIC_READ)
-	if err != nil {
-		log.Warnf("Error Opening Service ddnpm %v", err)
-	} else {
-		ddnpmConf, err := getServiceInfo(ddnpm)
+	// Getting driver service info separately, since it's not included in the list of running services
+	drivers := []string{"ddnpm", "ddprocmon"}
+	for _, driverName := range drivers {
+		service, err := winutil.OpenService(manager, driverName, windows.GENERIC_READ)
 		if err != nil {
-			log.Warnf("Error getting info for ddnpm: %v", err)
+			log.Warnf("Error Opening Service %s %v", driverName, err)
+		} else {
+			serviceInfo, err := getServiceInfo(service)
+			if err != nil {
+				log.Warnf("Error getting info for %s: %v", driverName, err)
+			}
+			ddServices = append(ddServices, serviceInfo)
 		}
-		ddServices = append(ddServices, ddnpmConf)
 	}
 
 	return ddServices, nil

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -8,7 +8,6 @@
 package flare
 
 import (
-	"slices"
 	"strings"
 	"syscall"
 	"time"

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -311,8 +311,8 @@ func getDDServices(manager *mgr.Mgr) ([]serviceInfo, error) {
 				log.Warnf("Error getting info for %s: %v", serviceName, err)
 			}
 			ddServices = append(ddServices, conf2)
+			srvc.Close()
 		}
-		srvc.Close()
 	}
 
 	return ddServices, nil

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -319,11 +319,10 @@ func getDDServices(manager *mgr.Mgr) ([]serviceInfo, error) {
 	return ddServices, nil
 }
 
-// filterDatadogServices returns a list of the Datadog services from the input list
+// filterDatadogServices returns the services that start with "datadog" (case insensitive)
 func filterDatadogServices(services []string) []string {
 	ddServices := []string{}
 
-	// Include all services that start with "datadog" (case insensitive)
 	for _, serviceName := range services {
 		// "The service control manager database preserves the case of the characters, but service name comparisons are always case insensitive."
 		// https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-openservicew

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -313,6 +313,7 @@ func getDDServices(manager *mgr.Mgr) ([]serviceInfo, error) {
 			}
 			ddServices = append(ddServices, conf2)
 		}
+		srvc.Close()
 	}
 
 	return ddServices, nil

--- a/pkg/flare/service_windows.go
+++ b/pkg/flare/service_windows.go
@@ -298,7 +298,7 @@ func getDDServices(manager *mgr.Mgr) ([]serviceInfo, error) {
 	}
 
 	for _, serviceName := range list {
-		if strings.HasPrefix(serviceName, "datadog") {
+		if strings.HasPrefix(strings.ToLower(serviceName), "datadog") {
 			srvc, err := winutil.OpenService(manager, serviceName, windows.GENERIC_READ)
 			if err != nil {
 				log.Warnf("Error Opening Service %s: %v", serviceName, err)

--- a/pkg/flare/service_windows_test.go
+++ b/pkg/flare/service_windows_test.go
@@ -48,3 +48,15 @@ func TestWindowsService(t *testing.T) {
 	}
 
 }
+
+func TestListDatadogServices(t *testing.T) {
+	inServices := []string{"datadog-agent", "Datadog Installer", "not-datadog"}
+	outServices := listDatadogServices(inServices)
+	assert.Contains(t, outServices, "Datadog Installer", "prefix match should be case insensitive")
+	assert.NotContains(t, outServices, "not-datadog", "non-datadog services should not be included")
+
+	inServices = []string{"ddprocmon"}
+	expected := []string{"ddnpm", "ddprocmon"}
+	outServices = listDatadogServices(inServices)
+	assert.Equal(t, expected, outServices, "list should contain one instance of each driver")
+}

--- a/pkg/flare/service_windows_test.go
+++ b/pkg/flare/service_windows_test.go
@@ -49,14 +49,10 @@ func TestWindowsService(t *testing.T) {
 
 }
 
-func TestListDatadogServices(t *testing.T) {
+func TestFilterDatadogServices(t *testing.T) {
 	inServices := []string{"datadog-agent", "Datadog Installer", "not-datadog"}
-	outServices := listDatadogServices(inServices)
+	outServices := filterDatadogServices(inServices)
+	assert.Contains(t, outServices, "datadog-agent")
 	assert.Contains(t, outServices, "Datadog Installer", "prefix match should be case insensitive")
 	assert.NotContains(t, outServices, "not-datadog", "non-datadog services should not be included")
-
-	inServices = []string{"ddprocmon"}
-	expected := []string{"ddnpm", "ddprocmon"}
-	outServices = listDatadogServices(inServices)
-	assert.Equal(t, expected, outServices, "list should contain one instance of each driver")
 }

--- a/releasenotes/notes/ddprocmon-servicestatus-flare-1769b34ffbfa8b2f.yaml
+++ b/releasenotes/notes/ddprocmon-servicestatus-flare-1769b34ffbfa8b2f.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Include Datadog Process Monitor (``ddprocmon``) service status in flare on Windows
+fixes:
+  - |
+    Agent flare service status search for ``datadog`` services is now case insensitive on Windows


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add `ddprocmon` service status to flare

Make user-mode service match case insensitive, so it finds fleet automation service `Datadog Installer`.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1267

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Generate flare, ensure that `servicestatus.json` includes `ddprocmon`

with fleet automation isntalled, ensure it included `Datadog Installer`

unit test added

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
windows treats service names case insensitively, too
> The service control manager database preserves the case of the characters, but service name comparisons are always case insensitive.

https://learn.microsoft.com/en-us/windows/win32/api/winsvc/nf-winsvc-openservicea