### PR TITLE
Yuri.lipnesh/usmon 765 http2 cont frames

### DIFF
--- a/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-defs.h
@@ -226,8 +226,8 @@ typedef struct {
 // literal_value_exceeds_frame          Count of times we couldn't retrieve the literal value due to reaching the end of the frame.
 // exceeding_max_interesting_frames		Count of times we reached the max number of frames per iteration.
 // exceeding_max_frames_to_filter		Count of times we have left with more frames to filter than the max number of frames to filter.
+// continuation_frames                  Count of occurrences where a frame of type CONTINUATION was found.
 // path_size_bucket                     Count of path sizes and divided into buckets.
-// frames_split_count                   Count of times we tried to read more data than the end of the data end.
 typedef struct {
     __u64 request_seen;
     __u64 response_seen;
@@ -236,6 +236,7 @@ typedef struct {
     __u64 literal_value_exceeds_frame;
     __u64 exceeding_max_interesting_frames;
     __u64 exceeding_max_frames_to_filter;
+    __u64 continuation_frames;
     __u64 path_size_bucket[HTTP2_TELEMETRY_PATH_BUCKETS+1];
 } http2_telemetry_t;
 

--- a/pkg/network/protocols/http2/model_linux.go
+++ b/pkg/network/protocols/http2/model_linux.go
@@ -445,6 +445,7 @@ HTTP2Telemetry{
 	"literal values exceed message count": %d,
 	"messages with more frames than we can filter": %d,
 	"messages with more interesting frames than we can process": %d,
+    "continuation frames" : %d,
 	"path headers length distribution": {
 		"in range [0, 120)": %d,
 		"in range [120, 130)": %d,
@@ -456,7 +457,7 @@ HTTP2Telemetry{
 		"in range [180, infinity)": %d
 	}
 }`, t.Request_seen, t.Response_seen, t.End_of_stream, t.End_of_stream_rst, t.Literal_value_exceeds_frame,
-		t.Exceeding_max_frames_to_filter, t.Exceeding_max_interesting_frames, t.Path_size_bucket[0], t.Path_size_bucket[1],
-		t.Path_size_bucket[2], t.Path_size_bucket[3], t.Path_size_bucket[4], t.Path_size_bucket[5], t.Path_size_bucket[6],
-		t.Path_size_bucket[7])
+		t.Exceeding_max_frames_to_filter, t.Exceeding_max_interesting_frames, t.Continuation_frames,
+		t.Path_size_bucket[0], t.Path_size_bucket[1], t.Path_size_bucket[2], t.Path_size_bucket[3],
+		t.Path_size_bucket[4], t.Path_size_bucket[5], t.Path_size_bucket[6], t.Path_size_bucket[7])
 }

--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -34,6 +34,8 @@ type kernelTelemetry struct {
 	exceedingMaxInterestingFrames *libtelemetry.TLSAwareCounter
 	// exceedingMaxFramesToFilter Count of times we have left with more frames to filter than the max number of frames to filter.
 	exceedingMaxFramesToFilter *libtelemetry.TLSAwareCounter
+	// continuationFramesCount Count of occurrences where a frame of type CONTINUATION was found.
+	continuationFramesCount *libtelemetry.TLSAwareCounter
 	// fragmentedFrameCountRST Count of times we have seen a fragmented RST frame.
 	fragmentedFrameCountRST *libtelemetry.TLSAwareCounter
 	// fragmentedHeadersFrameEOSCount Count of times we have seen a fragmented headers frame with EOS.
@@ -58,6 +60,7 @@ func newHTTP2KernelTelemetry() *kernelTelemetry {
 		literalValueExceedsFrame:       libtelemetry.NewTLSAwareCounter(metricGroup, "literal_value_exceeds_frame"),
 		exceedingMaxInterestingFrames:  libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_max_interesting_frames"),
 		exceedingMaxFramesToFilter:     libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_max_frames_to_filter"),
+		continuationFramesCount:        libtelemetry.NewTLSAwareCounter(metricGroup, "continuation_frames"),
 		fragmentedDataFrameEOSCount:    libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_data_end_data_eos"),
 		fragmentedHeadersFrameCount:    libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_data_end_headers"),
 		fragmentedHeadersFrameEOSCount: libtelemetry.NewTLSAwareCounter(metricGroup, "exceeding_data_end_headers_eos"),
@@ -81,6 +84,7 @@ func (t *kernelTelemetry) update(tel *HTTP2Telemetry, isTLS bool) {
 	t.literalValueExceedsFrame.Add(int64(telemetryDelta.Literal_value_exceeds_frame), isTLS)
 	t.exceedingMaxInterestingFrames.Add(int64(telemetryDelta.Exceeding_max_interesting_frames), isTLS)
 	t.exceedingMaxFramesToFilter.Add(int64(telemetryDelta.Exceeding_max_frames_to_filter), isTLS)
+	t.continuationFramesCount.Add(int64(telemetryDelta.Continuation_frames), isTLS)
 	for bucketIndex := range t.pathSizeBucket {
 		t.pathSizeBucket[bucketIndex].Add(int64(telemetryDelta.Path_size_bucket[bucketIndex]), isTLS)
 	}
@@ -104,6 +108,7 @@ func (t *HTTP2Telemetry) Sub(other HTTP2Telemetry) *HTTP2Telemetry {
 		Literal_value_exceeds_frame:      t.Literal_value_exceeds_frame - other.Literal_value_exceeds_frame,
 		Exceeding_max_interesting_frames: t.Exceeding_max_interesting_frames - other.Exceeding_max_interesting_frames,
 		Exceeding_max_frames_to_filter:   t.Exceeding_max_frames_to_filter - other.Exceeding_max_frames_to_filter,
+		Continuation_frames:              t.Continuation_frames - other.Continuation_frames,
 		Path_size_bucket:                 computePathSizeBucketDifferences(t.Path_size_bucket, other.Path_size_bucket),
 	}
 }

--- a/pkg/network/protocols/http2/telemetry_test.go
+++ b/pkg/network/protocols/http2/telemetry_test.go
@@ -46,6 +46,7 @@ func testKernelTelemetryUpdate(t *testing.T, isTLS bool) {
 		Literal_value_exceeds_frame:      20,
 		Exceeding_max_interesting_frames: 30,
 		Exceeding_max_frames_to_filter:   40,
+		Continuation_frames:              5,
 		Path_size_bucket:                 [8]uint64{1, 2, 3, 4, 5, 6, 7, 8},
 	}
 	kernelTelemetryGroup.update(http2Telemetry, isTLS)
@@ -61,6 +62,7 @@ func testKernelTelemetryUpdate(t *testing.T, isTLS bool) {
 	http2Telemetry.Literal_value_exceeds_frame = 26
 	http2Telemetry.Exceeding_max_interesting_frames = 32
 	http2Telemetry.Exceeding_max_frames_to_filter = 42
+	http2Telemetry.Continuation_frames = 6
 	http2Telemetry.Path_size_bucket = [8]uint64{2, 3, 4, 5, 6, 7, 8, 9}
 	kernelTelemetryGroup.update(http2Telemetry, isTLS)
 	assertTelemetryEquality(t, http2Telemetry, kernelTelemetryGroup, isTLS)
@@ -74,6 +76,8 @@ func assertTelemetryEquality(t *testing.T, http2Telemetry *HTTP2Telemetry, kerne
 	assert.Equal(t, http2Telemetry.Literal_value_exceeds_frame, uint64(kernelTelemetryGroup.literalValueExceedsFrame.Get(isTLS)))
 	assert.Equal(t, http2Telemetry.Exceeding_max_interesting_frames, uint64(kernelTelemetryGroup.exceedingMaxInterestingFrames.Get(isTLS)))
 	assert.Equal(t, http2Telemetry.Exceeding_max_frames_to_filter, uint64(kernelTelemetryGroup.exceedingMaxFramesToFilter.Get(isTLS)))
+	assert.Equal(t, http2Telemetry.Continuation_frames, uint64(kernelTelemetryGroup.continuationFramesCount.Get(isTLS)))
+
 	for i, bucket := range kernelTelemetryGroup.pathSizeBucket {
 		assert.Equal(t, http2Telemetry.Path_size_bucket[i], uint64(bucket.Get(isTLS)))
 	}

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -83,6 +83,7 @@ type HTTP2Telemetry struct {
 	Literal_value_exceeds_frame      uint64
 	Exceeding_max_interesting_frames uint64
 	Exceeding_max_frames_to_filter   uint64
+	Continuation_frames              uint64
 	Path_size_bucket                 [8]uint64
 }
 type HTTP2IncompleteFrameEntry struct {

--- a/pkg/network/usm/usm_http2_monitor_test.go
+++ b/pkg/network/usm/usm_http2_monitor_test.go
@@ -1485,10 +1485,7 @@ func (s *usmHTTP2Suite) TestContinuationFrame() {
 				telemetry, err = getHTTP2KernelTelemetry(monitor, s.isTLS)
 				require.NoError(t, err)
 
-				if telemetry.Continuation_frames != tt.expectedTelemetry.Continuation_frames {
-					return false
-				}
-				return true
+				return telemetry.Continuation_frames == tt.expectedTelemetry.Continuation_frames
 			}, time.Second*5, time.Millisecond*100)
 			if t.Failed() {
 				t.Logf("CONTINUATION frames count: %d != %d", tt.expectedTelemetry.Continuation_frames, telemetry.Continuation_frames)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds HTTP/2 CONTINUATION frames counter to kernel telemetry.

### Motivation
The basic unit of the protocol in HTTP/2 is the frame. The [CONTINUATION](https://httpwg.org/specs/rfc9113.html#CONTINUATION) frame type is used to continue a sequence of header block fragments. In order to improve the accuracy of the protocol, we would like to know how many frames of this type are encountered when processing an HTTP/2 stream in the kernel.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Add unit testing for the new telemetry counter.
Run UT locally and in pipeline.
Run http/2 load tests.
Deploy and verify system-probe on staging.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
eBPF complexity comparison of this branch with main branch on local VM:

```
| Filename/Program                         |   Stack Usage |   Instructions Processed |   Instructions Processed limit |   Max States per Instruction |   Peak States |   Total States |
|------------------------------------------|---------------|--------------------------|--------------------------------|------------------------------|---------------|----------------|
| usm/socket__http2_dynamic_table_cleaner  |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/socket__http2_eos_parser             |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/socket__http2_filter                 |            24 |                   -10898 |                              0 |                           -1 |          -791 |          -1312 |
| usm/socket__http2_handle_first_frame     |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/socket__http2_headers_parser         |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/uprobe__http2_dynamic_table_cleaner  |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/uprobe__http2_tls_eos_parser         |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/uprobe__http2_tls_filter             |            16 |                    23273 |                              0 |                           -7 |            78 |           -316 |
| usm/uprobe__http2_tls_handle_first_frame |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/uprobe__http2_tls_headers_parser     |             0 |                        0 |                              0 |                            0 |             0 |              0 |
| usm/uprobe__http2_tls_termination        |             0 |                        0 |                              0 |                            0 |             0 |              0 |
```