### PR TITLE
Improve kept/seen metrics for trace sampler

### DIFF
--- a/pkg/trace/sampler/catalog_test.go
+++ b/pkg/trace/sampler/catalog_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +61,7 @@ func TestNewServiceLookup(t *testing.T) {
 
 func TestServiceKeyCatalogRegister(t *testing.T) {
 	cat := newServiceLookup(0)
-	s := getTestPrioritySampler()
+	s := getTestPrioritySampler(&statsd.NoOpClient{})
 
 	_, root1 := getTestTraceWithService("service1", s)
 	sig1 := cat.register(ServiceSignature{root1.Service, defaultEnv})
@@ -168,7 +169,7 @@ func TestServiceKeyCatalogRatesByService(t *testing.T) {
 	assert := assert.New(t)
 
 	cat := newServiceLookup(0)
-	s := getTestPrioritySampler()
+	s := getTestPrioritySampler(&statsd.NoOpClient{})
 
 	_, root1 := getTestTraceWithService("service1", s)
 	sig1 := cat.register(ServiceSignature{root1.Service, defaultEnv})

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -108,6 +108,7 @@ func (s *PrioritySampler) Sample(now time.Time, trace *pb.TraceChunk, root *pb.S
 	// by the client library. Which, is turn, is based on agent hints,
 	// but the rule of thumb is: respect client choice.
 	sampled := samplingPriority > 0
+	s.sampler.countSample(sampled, root.Service, toSamplerEnv(tracerEnv, s.agentEnv))
 
 	// Short-circuit and return without counting the trace in the sampling rate logic
 	// if its value has not been set automatically by the client lib.
@@ -126,7 +127,6 @@ func (s *PrioritySampler) Sample(now time.Time, trace *pb.TraceChunk, root *pb.S
 
 	if sampled {
 		s.applyRate(root, signature)
-		s.sampler.countSample()
 	}
 	return sampled
 }

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -71,7 +71,9 @@ func (s *ScoreSampler) Sample(now time.Time, trace pb.Trace, root *pb.Span, env 
 
 	rate := s.getSignatureSampleRate(signature)
 
-	return s.applySampleRate(root, rate)
+	sampled := s.applySampleRate(root, rate)
+	s.countSample(sampled, root.Service, env)
+	return sampled
 }
 
 // UpdateTargetTPS updates the target tps
@@ -90,7 +92,6 @@ func (s *ScoreSampler) applySampleRate(root *pb.Span, rate float64) bool {
 	traceID := root.TraceID
 	sampled := SampleByRate(traceID, newRate)
 	if sampled {
-		s.countSample()
 		setMetric(root, s.samplingRateKey, rate)
 	}
 	return sampled


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Add tags such as `sample_service` and `sample_env`.
- The timing of the following metrics have been changed.
  - `datadog.trace_agent.sampler.kept`
  - `datadog.trace_agent.sampler.seen`

### Motivation

To get more insights during troubleshooting of sampler behavior.

> The timing of the following metrics have been changed.

Before this PR, when short-circuit(L112-L120) gets hit, `datadog.trace_agent.sampler.kept` and `datadog.trace_agent.sampler.seen` were not counted.
Even in this case, trace agent "sees" a trace and determins whether to "keep" a trace based on `sampled` from `GetSamplingPriority(trace)`.

https://github.com/DataDog/datadog-agent/blob/cb0d65b6920ecd830901149a319119d0b1b190a4/pkg/trace/sampler/prioritysampler.go#L99-L132


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Using `datadog/agent-dev:keisku-sampler-metrics-py3`.

#### Priority / Error Sampler

Now we can confirm `DD_TRACE_SAMPLING_RULES=[{"resource":"*","service":"note-client","sample_rate":1}]` is applied with this metric.

![2025-01-21_14-46-03](https://github.com/user-attachments/assets/8e0873b5-ac07-4cbc-885a-bad237f37110)

Applied the config to tracers through Manage Ingestion Rate.

![2025-01-21_14-43-33](https://github.com/user-attachments/assets/0bedd726-d78c-42a8-b118-2b527ae51804)

#### Probabilistic Sampler

Update `DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE` from 100 to 50.

![2025-01-21_15-02-10](https://github.com/user-attachments/assets/fc4fbd6a-7792-4f1f-9474-b1b33c254981)


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->