### PR TITLE
add conntrack to the base Dockerfile image

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -125,7 +125,8 @@ RUN apt full-upgrade -y \
   # this can be removed
   # Install libssl-dev as it's required by some Python checks and we rely on system version
   # Install libseccomp2 as required by `nosys-seccomp` wrapper
-  && apt install -y iproute2 libssl-dev libseccomp2 tzdata adduser
+  # Install conntrack as it's used by the network check
+  && apt install -y iproute2 libssl-dev libseccomp2 tzdata adduser conntrack
 
 # Install openjdk-11-jre-headless on jmx flavor
 RUN if [ -n "$WITH_JMX" ]; then echo "Pulling openjdk-11 from testing" \


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the `conntrack` package to the agent Dockerfile in order to support the conntrack network checks.

### Motivation

The documentation for the conntrack stats in the Network integration says "Note: You may need to install the conntrack binary in the Agent image." I would like to not have to roll a custom image in order to make this work.

### Describe how you validated your changes
N/A

### Possible Drawbacks / Trade-offs

Increased image size, additional dependencies

### Additional Notes
N/A