### PR TITLE
[CWS] reduce amount of `.Info()` when updating probes

### DIFF
--- a/pkg/ebpf/mappings.go
+++ b/pkg/ebpf/mappings.go
@@ -49,9 +49,34 @@ func RemoveProgramID(progID uint32, expectedModule string) {
 	}
 }
 
+// ClearNameMappings clears all name mappings for a given module
+func ClearNameMappings(module string) {
+	mappingLock.Lock()
+	defer mappingLock.Unlock()
+
+	for progID, progModule := range progModuleMapping {
+		if progModule == module {
+			delete(progNameMapping, progID)
+			delete(progModuleMapping, progID)
+		}
+	}
+
+	for mapID, mapModule := range mapModuleMapping {
+		if mapModule == module {
+			delete(mapNameMapping, mapID)
+			delete(mapModuleMapping, mapID)
+		}
+	}
+}
+
 // AddNameMappings adds the full name mappings for ebpf maps in the manager
 func AddNameMappings(mgr *manager.Manager, module string) {
 	maps, err := mgr.GetMaps()
+	if err != nil {
+		return
+	}
+
+	progs, err := mgr.GetPrograms()
 	if err != nil {
 		return
 	}
@@ -64,10 +89,6 @@ func AddNameMappings(mgr *manager.Manager, module string) {
 		mapModuleMapping[mapid] = module
 	})
 
-	progs, err := mgr.GetPrograms()
-	if err != nil {
-		return
-	}
 	iterateProgs(progs, func(progid uint32, name string) {
 		progNameMapping[progid] = name
 		progModuleMapping[progid] = module

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1553,51 +1553,16 @@ func (p *EBPFProbe) updateProbes(ruleEventTypes []eval.EventType, needRawSyscall
 		return fmt.Errorf("failed to set enabled events: %w", err)
 	}
 
-	previousProbes := p.computeProbesIDs()
 	if err = p.Manager.UpdateActivatedProbes(activatedProbes); err != nil {
 		return err
 	}
-	newProbes := p.computeProbesIDs()
 
-	p.computeProbesDiffAndRemoveMapping(previousProbes, newProbes)
+	p.updateEBPFCheckMapping()
 	return nil
 }
 
-func (p *EBPFProbe) computeProbesIDs() map[string]lib.ProgramID {
-	out := make(map[string]lib.ProgramID)
-	progList, err := p.Manager.GetPrograms()
-	if err != nil {
-		return out
-	}
-	for funcName, prog := range progList {
-		programInfo, err := prog.Info()
-		if err != nil {
-			continue
-		}
-
-		programID, isAvailable := programInfo.ID()
-		if isAvailable {
-			out[funcName] = programID
-		}
-	}
-
-	return out
-}
-
-func (p *EBPFProbe) computeProbesDiffAndRemoveMapping(previousProbes map[string]lib.ProgramID, newProbes map[string]lib.ProgramID) {
-	// Compute the list of programs that need to be deleted from the ddebpf mapping
-	var toDelete []lib.ProgramID
-	for previousProbeFuncName, programID := range previousProbes {
-		if _, ok := newProbes[previousProbeFuncName]; !ok {
-			toDelete = append(toDelete, programID)
-		}
-	}
-
-	for _, id := range toDelete {
-		ddebpf.RemoveProgramID(uint32(id), "cws")
-	}
-
-	// new programs could have been introduced during the update, add them now
+func (p *EBPFProbe) updateEBPFCheckMapping() {
+	ddebpf.ClearNameMappings("cws")
 	ddebpf.AddNameMappings(p.Manager, "cws")
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When CWS reloads its probe today it tries to be clever and find the ones that were added and removed to update the ebpf check mapping. But calling `AddNameMappings` defeats this purpose because it will reload all the maps and programs from the given manager.

This PR simplifies this whole update process by removing all the maps and programs tagged "cws" and then reloads as before.

The main advantage of this is that we end up calling `.Info()` only once per program instead of once when doing the clever diff, and then once in `AddNameMappings`. `.Info()` is kind of expensive being a syscall, and allocating a receiving structure on the heap.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->