### PR TITLE
[CWS] reduce the amount of allocations linked to smaps parsing during snapshot

### DIFF
--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -129,7 +129,7 @@ func (pn *ProcessNode) addFiles(files []string, stats *Stats, newEvent func() *m
 		}
 
 		evt := newEvent()
-		fullPath := filepath.Join(utils.ProcRootPath(pn.Process.Pid), f)
+		fullPath := utils.ProcRootFilePath(pn.Process.Pid, f)
 		if evt.ProcessContext == nil {
 			evt.ProcessContext = &model.ProcessContext{}
 		}

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot.go
@@ -216,20 +216,55 @@ func getMemoryMappedFiles(pid int32, processEventPath string) (files []string, _
 	scanner := bufio.NewScanner(smapsFile)
 
 	for scanner.Scan() && len(files) < MaxMmapedFiles {
-		line := scanner.Text()
-		fields := strings.Fields(line)
+		line := scanner.Bytes()
 
-		if len(fields) < 6 || strings.HasSuffix(fields[0], ":") {
+		path, ok := extractPathFromSmapsLine(line)
+		if !ok {
 			continue
 		}
 
-		path := strings.Join(fields[5:], " ")
-		if len(path) != 0 && path != processEventPath {
-			files = append(files, path)
+		if len(path) == 0 {
+			continue
 		}
+
+		if path == processEventPath {
+			continue
+		}
+
+		// skip [vdso], [stack], [heap] and similar mappings
+		if strings.HasPrefix(path, "[") {
+			continue
+		}
+
+		files = append(files, path)
 	}
 
 	return files, scanner.Err()
+}
+
+func extractPathFromSmapsLine(line []byte) (string, bool) {
+	inSpace := false
+	spaceCount := 0
+	for i, c := range line {
+		if c == ' ' || c == '\t' {
+			// check for fields separator
+			if !inSpace && spaceCount == 0 && i > 0 {
+				if line[i-1] == ':' {
+					return "", false
+				}
+			}
+
+			if !inSpace {
+				inSpace = true
+				spaceCount++
+			}
+		} else if spaceCount == 5 {
+			return string(line[i:]), true
+		} else {
+			inSpace = false
+		}
+	}
+	return "", false
 }
 
 func (pn *ProcessNode) snapshotBoundSockets(p *process.Process, stats *Stats, newEvent func() *model.Event) {

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
@@ -37,6 +37,9 @@ func TestSnapshotMemoryMappedFiles(t *testing.T) {
 		if len(smap.Path) == 0 {
 			continue
 		}
+		if smap.Path[0] == '[' {
+			continue
+		}
 		gopsutilFiles = append(gopsutilFiles, smap.Path)
 	}
 

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
@@ -72,6 +72,12 @@ func TestExtractPathFromSmapsLine(t *testing.T) {
 			ok:   true,
 		},
 		{
+			name: "regular with space",
+			line: "e1cc8924f000-e1cc89251000 rw-p 00030000 fd:00 6259                       /usr/lib/aarch64-linux-gnu/ld linux aarch64.so.1",
+			path: "/usr/lib/aarch64-linux-gnu/ld linux aarch64.so.1",
+			ok:   true,
+		},
+		{
 			name: "field",
 			line: "KernelPageSize:        4 kB",
 			path: "",

--- a/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
+++ b/pkg/security/security_profile/activity_tree/process_node_snapshot_test.go
@@ -48,3 +48,59 @@ func TestSnapshotMemoryMappedFiles(t *testing.T) {
 
 	assert.Equal(t, gopsutilFiles, ownImplemFiles)
 }
+
+func TestExtractPathFromSmapsLine(t *testing.T) {
+	entries := []struct {
+		name string
+		line string
+		path string
+		ok   bool
+	}{
+		{
+			name: "stack",
+			line: "fffe33c3000-ffffe33e4000 rw-p 00000000 00:00 0                          [stack]",
+			path: "[stack]",
+			ok:   true,
+		},
+		{
+			name: "regular",
+			line: "e1cc8924f000-e1cc89251000 rw-p 00030000 fd:00 6259                       /usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1",
+			path: "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1",
+			ok:   true,
+		},
+		{
+			name: "field",
+			line: "KernelPageSize:        4 kB",
+			path: "",
+			ok:   false,
+		},
+		{
+			name: "vmflags",
+			line: "VmFlags: rd wr mr mw me ac",
+			path: "",
+			ok:   false,
+		},
+		// this one is not found today in actual smaps but
+		// if for some reason a new flags is added then the
+		// number of spaces matches the number of spaces in
+		// a file line, so it's best to test it
+		{
+			name: "vmflags future",
+			line: "VmFlags: rd wr mr mw me ac abc",
+			path: "",
+			ok:   false,
+		},
+	}
+
+	for _, entry := range entries {
+		t.Run(entry.name, func(t *testing.T) {
+			path, ok := extractPathFromSmapsLine([]byte(entry.line))
+			if ok != entry.ok {
+				t.Errorf("expected ok=%t, got %t", entry.ok, ok)
+			}
+			if path != entry.path {
+				t.Errorf("expected %s, got %s", entry.path, path)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR:
- skips the `[vdso]`, `[stack]` etc meta files when reading smaps files during snapshot (no need to insert them in the dumps)
- reduces drastically the amount of allocation linked to this parsing (no `.Text()`, no `strings.Field`, no `strings.Join`)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->