### PR TITLE
chore(origindetection): add ProcessID to OriginInfo for DogStatsD

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -328,6 +328,7 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 				udsOriginDetectionErrors.Add(1)
 				l.telemetryStore.tlmUDSOriginDetectionError.Inc(tlmListenerID, l.transport)
 			} else {
+				packet.ProcessID = uint32(pid)
 				packet.Origin = container
 				if capBuff != nil {
 					capBuff.ContainerID = container

--- a/comp/dogstatsd/packets/buffer_test.go
+++ b/comp/dogstatsd/packets/buffer_test.go
@@ -32,6 +32,7 @@ func TestBufferTelemetry(t *testing.T) {
 		Contents:   []byte("test"),
 		Buffer:     []byte("test read"),
 		Origin:     "test origin",
+		ProcessID:  uint32(1234),
 		ListenerID: "1",
 		Source:     0,
 	}
@@ -56,7 +57,7 @@ func TestBufferTelemetry(t *testing.T) {
 
 	bufferSizeBytesMetricLabel := bufferSizeBytesMetrics[0].Tags()
 	assert.Equal(t, bufferSizeBytesMetricLabel["listener_id"], "test_buffer")
-	assert.Equal(t, float64(246), bufferSizeBytesMetrics[0].Value())
+	assert.Equal(t, float64(262), bufferSizeBytesMetrics[0].Value())
 }
 
 func TestBufferTelemetryFull(t *testing.T) {
@@ -123,7 +124,7 @@ func TestBufferTelemetryFull(t *testing.T) {
 
 	channelPacketsBytesMetricLabel := channelPacketsBytesMetrics[0].Tags()
 	assert.Equal(t, channelPacketsBytesMetricLabel["listener_id"], "test_buffer")
-	assert.Equal(t, float64(123), channelPacketsBytesMetrics[0].Value())
+	assert.Equal(t, float64(131), channelPacketsBytesMetrics[0].Value())
 
 	assert.Equal(t, float64(1), channelSizeMetrics[0].Value())
 }

--- a/comp/dogstatsd/packets/types.go
+++ b/comp/dogstatsd/packets/types.go
@@ -33,6 +33,7 @@ type Packet struct {
 	Contents   []byte     // Contents, might contain several messages
 	Buffer     []byte     // Underlying buffer for data read
 	Origin     string     // Origin container if identified
+	ProcessID  uint32     // ProcessID that sent the packet
 	ListenerID string     // Listener ID
 	Source     SourceType // Type of listener that produced the packet
 }

--- a/comp/dogstatsd/server/convert_bench_test.go
+++ b/comp/dogstatsd/server/convert_bench_test.go
@@ -61,7 +61,7 @@ func runParseMetricBenchmark(b *testing.B, multipleValues bool) {
 					continue
 				}
 
-				benchSamples = enrichMetricSample(samples, parsed, "", "", conf)
+				benchSamples = enrichMetricSample(samples, parsed, "", 0, "", conf)
 			}
 		})
 	}

--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -37,15 +37,18 @@ type enrichConfig struct {
 }
 
 // extractTagsMetadata returns tags (client tags + host tag) and information needed to query tagger (origins, cardinality).
-func extractTagsMetadata(tags []string, originFromUDS string, localData origindetection.LocalData, externalData origindetection.ExternalData, conf enrichConfig) ([]string, string, taggertypes.OriginInfo, metrics.MetricSource) {
+func extractTagsMetadata(tags []string, originFromUDS string, processID uint32, localData origindetection.LocalData, externalData origindetection.ExternalData, conf enrichConfig) ([]string, string, taggertypes.OriginInfo, metrics.MetricSource) {
 	host := conf.defaultHostname
 	metricSource := metrics.MetricSourceDogstatsd
+
+	// Add Origin Detection metadata
 	origin := taggertypes.OriginInfo{
 		ContainerIDFromSocket: originFromUDS,
 		LocalData:             localData,
 		ExternalData:          externalData,
 		ProductOrigin:         origindetection.ProductOriginDogStatsD,
 	}
+	origin.LocalData.ProcessID = processID
 
 	n := 0
 	for _, tag := range tags {
@@ -110,9 +113,9 @@ func tsToFloatForSamples(ts time.Time) float64 {
 	return float64(ts.Unix())
 }
 
-func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSample, origin string, listenerID string, conf enrichConfig) []metrics.MetricSample {
+func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSample, origin string, processID uint32, listenerID string, conf enrichConfig) []metrics.MetricSample {
 	metricName := ddSample.name
-	tags, hostnameFromTags, extractedOrigin, metricSource := extractTagsMetadata(ddSample.tags, origin, ddSample.localData, ddSample.externalData, conf)
+	tags, hostnameFromTags, extractedOrigin, metricSource := extractTagsMetadata(ddSample.tags, origin, processID, ddSample.localData, ddSample.externalData, conf)
 
 	if !isExcluded(metricName, conf.metricPrefix, conf.metricPrefixBlacklist) {
 		metricName = conf.metricPrefix + metricName
@@ -191,8 +194,8 @@ func enrichEventAlertType(dogstatsdAlertType alertType) metricsevent.AlertType {
 	return metricsevent.AlertTypeSuccess
 }
 
-func enrichEvent(event dogstatsdEvent, origin string, conf enrichConfig) *metricsevent.Event {
-	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(event.tags, origin, event.localData, event.externalData, conf)
+func enrichEvent(event dogstatsdEvent, origin string, processID uint32, conf enrichConfig) *metricsevent.Event {
+	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(event.tags, origin, processID, event.localData, event.externalData, conf)
 
 	enrichedEvent := &metricsevent.Event{
 		Title:          event.title,
@@ -228,8 +231,8 @@ func enrichServiceCheckStatus(status serviceCheckStatus) servicecheck.ServiceChe
 	return servicecheck.ServiceCheckUnknown
 }
 
-func enrichServiceCheck(serviceCheck dogstatsdServiceCheck, origin string, conf enrichConfig) *servicecheck.ServiceCheck {
-	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(serviceCheck.tags, origin, serviceCheck.localData, serviceCheck.externalData, conf)
+func enrichServiceCheck(serviceCheck dogstatsdServiceCheck, origin string, processID uint32, conf enrichConfig) *servicecheck.ServiceCheck {
+	tags, hostnameFromTags, extractedOrigin, _ := extractTagsMetadata(serviceCheck.tags, origin, processID, serviceCheck.localData, serviceCheck.externalData, conf)
 
 	enrichedServiceCheck := &servicecheck.ServiceCheck{
 		CheckName:  serviceCheck.name,

--- a/comp/dogstatsd/server/enrich_bench_test.go
+++ b/comp/dogstatsd/server/enrich_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkExtractTagsMetadata(b *testing.B) {
 			sb.ResetTimer()
 
 			for n := 0; n < sb.N; n++ {
-				tags, _, _, _ = extractTagsMetadata(baseTags, "", origindetection.LocalData{}, origindetection.ExternalData{}, conf)
+				tags, _, _, _ = extractTagsMetadata(baseTags, "", 0, origindetection.LocalData{}, origindetection.ExternalData{}, conf)
 			}
 		})
 	}
@@ -52,7 +52,7 @@ func BenchmarkMetricsExclusion(b *testing.B) {
 
 	b.Run("none", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			enrichMetricSample(out, sample, "", "", conf)
+			enrichMetricSample(out, sample, "", 0, "", conf)
 		}
 	})
 
@@ -66,7 +66,7 @@ func BenchmarkMetricsExclusion(b *testing.B) {
 		b.Run(fmt.Sprintf("%d-exact", i),
 			func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
-					enrichMetricSample(out, sample, "", "", conf)
+					enrichMetricSample(out, sample, "", 0, "", conf)
 				}
 			})
 	}

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -41,7 +41,7 @@ func parseAndEnrichSingleMetricMessage(t *testing.T, message []byte, conf enrich
 	}
 
 	samples := []metrics.MetricSample{}
-	samples = enrichMetricSample(samples, parsed, "", "", conf)
+	samples = enrichMetricSample(samples, parsed, "", 0, "", conf)
 	if len(samples) != 1 {
 		return metrics.MetricSample{}, fmt.Errorf("wrong number of metrics parsed")
 	}
@@ -58,7 +58,7 @@ func parseAndEnrichMultipleMetricMessage(t *testing.T, message []byte, conf enri
 	}
 
 	samples := []metrics.MetricSample{}
-	return enrichMetricSample(samples, parsed, "", "", conf), nil
+	return enrichMetricSample(samples, parsed, "", 0, "", conf), nil
 }
 
 func parseAndEnrichServiceCheckMessage(t *testing.T, message []byte, conf enrichConfig) (*servicecheck.ServiceCheck, error) {
@@ -69,7 +69,7 @@ func parseAndEnrichServiceCheckMessage(t *testing.T, message []byte, conf enrich
 	if err != nil {
 		return nil, err
 	}
-	return enrichServiceCheck(parsed, "", conf), nil
+	return enrichServiceCheck(parsed, "", 0, conf), nil
 }
 
 func parseAndEnrichEventMessage(t *testing.T, message []byte, conf enrichConfig) (*event.Event, error) {
@@ -80,7 +80,7 @@ func parseAndEnrichEventMessage(t *testing.T, message []byte, conf enrichConfig)
 	if err != nil {
 		return nil, err
 	}
-	return enrichEvent(parsed, "", conf), nil
+	return enrichEvent(parsed, "", 0, conf), nil
 }
 
 func TestConvertParseMultiple(t *testing.T) {
@@ -1005,7 +1005,7 @@ func TestMetricBlocklistShouldBlock(t *testing.T) {
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}
-	samples = enrichMetricSample(samples, parsed, "", "", conf)
+	samples = enrichMetricSample(samples, parsed, "", 0, "", conf)
 
 	assert.Equal(t, 0, len(samples))
 }
@@ -1023,7 +1023,7 @@ func TestServerlessModeShouldSetEmptyHostname(t *testing.T) {
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}
-	samples = enrichMetricSample(samples, parsed, "", "", conf)
+	samples = enrichMetricSample(samples, parsed, "", 0, "", conf)
 
 	assert.Equal(t, 1, len(samples))
 	assert.Equal(t, "", samples[0].Host)
@@ -1044,7 +1044,7 @@ func TestMetricBlocklistShouldNotBlock(t *testing.T) {
 	parsed, err := parser.parseMetricSample(message)
 	assert.NoError(t, err)
 	samples := []metrics.MetricSample{}
-	samples = enrichMetricSample(samples, parsed, "", "", conf)
+	samples = enrichMetricSample(samples, parsed, "", 0, "", conf)
 
 	assert.Equal(t, 1, len(samples))
 }
@@ -1468,7 +1468,7 @@ func TestEnrichTags(t *testing.T) {
 		tt.wantedOrigin.ProductOrigin = origindetection.ProductOriginDogStatsD
 
 		t.Run(tt.name, func(t *testing.T) {
-			tags, host, origin, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, tt.args.localData, tt.args.externalData, tt.args.conf)
+			tags, host, origin, metricSource := extractTagsMetadata(tt.args.tags, tt.args.originFromUDS, 0, tt.args.localData, tt.args.externalData, tt.args.conf)
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedHost, host)
 			assert.Equal(t, tt.wantedOrigin, origin)
@@ -1516,7 +1516,7 @@ func TestEnrichTagsWithJMXCheckName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", origindetection.LocalData{}, origindetection.ExternalData{}, enrichConfig{})
+			tags, _, _, metricSource := extractTagsMetadata(tt.tags, "", 0, origindetection.LocalData{}, origindetection.ExternalData{}, enrichConfig{})
 			assert.Equal(t, tt.wantedTags, tags)
 			assert.Equal(t, tt.wantedMetricSource, metricSource)
 			assert.NotContains(t, tags, tt.jmxCheckName)

--- a/comp/dogstatsd/server/server_bench_test.go
+++ b/comp/dogstatsd/server/server_bench_test.go
@@ -108,7 +108,7 @@ func BenchmarkPbarseMetricMessage(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		samplesBench = make([]metrics.MetricSample, 0, 512)
 		for pb.Next() {
-			s.parseMetricMessage(samplesBench, parser, message, "", "", false)
+			s.parseMetricMessage(samplesBench, parser, message, "", 0, "", false)
 			samplesBench = samplesBench[0:0]
 		}
 	})

--- a/comp/dogstatsd/server/server_test.go
+++ b/comp/dogstatsd/server/server_test.go
@@ -75,7 +75,7 @@ func TestNoMappingsConfig(t *testing.T) {
 	assert.Nil(t, s.mapper)
 
 	parser := newParser(deps.Config, s.sharedFloat64List, 1, deps.WMeta, s.stringInternerTelemetry)
-	samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", "", false)
+	samples, err := s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", 0, "", false)
 	assert.NoError(t, err)
 	assert.Len(t, samples, 1)
 }
@@ -133,19 +133,19 @@ func testContainerIDParsing(t *testing.T, cfg map[string]interface{}) {
 	parser.dsdOriginEnabled = true
 
 	// Metric
-	metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container"), "", "", false)
+	metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container"), "", 0, "", false)
 	assert.NoError(err)
 	assert.Len(metrics, 1)
 	assert.Equal("metric-container", metrics[0].OriginInfo.LocalData.ContainerID)
 
 	// Event
-	event, err := s.parseEventMessage(parser, []byte("_e{10,10}:event title|test\\ntext|c:event-container"), "")
+	event, err := s.parseEventMessage(parser, []byte("_e{10,10}:event title|test\\ntext|c:event-container"), "", 0)
 	assert.NoError(err)
 	assert.NotNil(event)
 	assert.Equal("event-container", event.OriginInfo.LocalData.ContainerID)
 
 	// Service check
-	serviceCheck, err := s.parseServiceCheckMessage(parser, []byte("_sc|service-check.name|0|c:service-check-container"), "")
+	serviceCheck, err := s.parseServiceCheckMessage(parser, []byte("_sc|service-check.name|0|c:service-check-container"), "", 0)
 	assert.NoError(err)
 	assert.NotNil(serviceCheck)
 	assert.Equal("service-check-container", serviceCheck.OriginInfo.LocalData.ContainerID)
@@ -177,22 +177,25 @@ func TestOrigin(t *testing.T) {
 		parser.dsdOriginEnabled = true
 
 		// Metric
-		metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container|#dd.internal.card:none"), "", "", false)
+		metrics, err := s.parseMetricMessage(nil, parser, []byte("metric.name:123|g|c:metric-container|#dd.internal.card:none"), "", 1234, "", false)
 		assert.NoError(err)
 		assert.Len(metrics, 1)
 		assert.Equal("metric-container", metrics[0].OriginInfo.LocalData.ContainerID)
+		assert.Equal(uint32(1234), metrics[0].OriginInfo.LocalData.ProcessID)
 
 		// Event
-		event, err := s.parseEventMessage(parser, []byte("_e{10,10}:event title|test\\ntext|c:event-container|#dd.internal.card:none"), "")
+		event, err := s.parseEventMessage(parser, []byte("_e{10,10}:event title|test\\ntext|c:event-container|#dd.internal.card:none"), "", 1234)
 		assert.NoError(err)
 		assert.NotNil(event)
 		assert.Equal("event-container", event.OriginInfo.LocalData.ContainerID)
+		assert.Equal(uint32(1234), event.OriginInfo.LocalData.ProcessID)
 
 		// Service check
-		serviceCheck, err := s.parseServiceCheckMessage(parser, []byte("_sc|service-check.name|0|c:service-check-container|#dd.internal.card:none"), "")
+		serviceCheck, err := s.parseServiceCheckMessage(parser, []byte("_sc|service-check.name|0|c:service-check-container|#dd.internal.card:none"), "", 1234)
 		assert.NoError(err)
 		assert.NotNil(serviceCheck)
 		assert.Equal("service-check-container", serviceCheck.OriginInfo.LocalData.ContainerID)
+		assert.Equal(uint32(1234), serviceCheck.OriginInfo.LocalData.ProcessID)
 	})
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add the `ProcessID` in DogStatsD's `OriginInfo` struct.

### Motivation

This is done to allow to switch from `taggertypes` to `origindetection` modules.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by both unit tests and E2E tests.

### Possible Drawbacks / Trade-offs

When we will want to remove the `origin` that is being resolved from the PID in the DogStatsD server to have it being resolved inside the Tagger, we will need to be careful about `server.getOriginCounter()` as the cache key is the origin. A solution could be to either use the PID, or the metric name.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A