### PR TITLE
[CONTP-587]Workloadmeta: Add mig config to GPU collector

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -99,14 +99,11 @@ func (c *collector) getGPUdeviceInfo(device nvml.Device) (*workloadmeta.GPU, err
 		Device:     name,
 		Index:      gpuIndexID,
 		MigEnabled: false,
-		MigDevices: make([]*workloadmeta.MigDevice, 0),
+		MigDevices: nil,
 	}
 
 	migEnabled, _, ret := c.nvmlLib.DeviceGetMigMode(device)
-	if ret != nvml.SUCCESS {
-		migEnabled = nvml.DEVICE_MIG_DISABLE
-	}
-	if migEnabled == nvml.DEVICE_MIG_ENABLE {
+	if ret == nvml.SUCCESS && migEnabled == nvml.DEVICE_MIG_ENABLE {
 		// If any mid detection fails, we will return an mig disabled in config
 		migDeviceCount, ret := c.nvmlLib.DeviceGetMaxMigDeviceCount(device)
 		if ret != nvml.SUCCESS {

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1387,12 +1387,13 @@ type GPU struct {
 	MigDevices []*MigDevice
 }
 
-// MigDevice contains information about a MIG device, including the GPU instance ID, device info, attributes, and profile.
+// MigDevice contains information about a MIG device, including the GPU instance ID, device info, attributes, and profile. Nvidia MIG allows a single physical GPU to be partitioned into multiple isolated GPU instances so that multiple workloads can run on the same GPU.
 type MigDevice struct {
 	// GPUInstanceID is the ID of the GPU instance. This is a unique identifier inside the parent GPU device.
 	GPUInstanceID int
-	UUID          string
-	Name          string
+	// UUID is the device id retrieved from nvml in the format "MIG-XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX"
+	UUID string
+	Name string
 	// GPUInstanceSliceCount and MemorySizeInGb are retrieved from the profile
 	// mig 1g.10gb profile will have GPUInstanceSliceCount = 1 and MemorySizeMB = 10000
 	GPUInstanceSliceCount uint32

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1380,6 +1380,29 @@ type GPU struct {
 
 	// SMCount is the number of streaming multiprocessors in the GPU. Optional, can be empty.
 	SMCount int
+
+	// MigEnabled is true if the GPU supports MIG (Multi-Instance GPU) and it is enabled.
+	MigEnabled bool
+	// MigDevices is a list of MIG devices that are part of the GPU.
+	MigDevices []*MigDevice
+}
+
+// MigDevice contains information about a MIG device, including the GPU instance ID, device info, attributes, and profile.
+type MigDevice struct {
+	// GPUInstanceID is the ID of the GPU instance. This is a unique identifier inside the parent GPU device.
+	GPUInstanceID int
+	UUID          string
+	Name          string
+	// GPUInstanceSliceCount and MemorySizeInGb are retrieved from the profile
+	// mig 1g.10gb profile will have GPUInstanceSliceCount = 1 and MemorySizeMB = 10000
+	GPUInstanceSliceCount uint32
+	MemorySizeMB          uint64
+	// ResourceName is the resource of the profile used, e.g. "1g.10gb", "2g.20gb", etc.
+	ResourceName string
+}
+
+func (m *MigDevice) String() string {
+	return fmt.Sprintf("GPU Instance ID: %d, UUID: %s, Resource: %s", m.GPUInstanceID, m.UUID, m.ResourceName)
 }
 
 var _ Entity = &GPU{}
@@ -1427,6 +1450,13 @@ func (g GPU) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Architecture:", g.Architecture)
 	_, _ = fmt.Fprintln(&sb, "Compute Capability:", g.ComputeCapability)
 	_, _ = fmt.Fprintln(&sb, "Streaming Multiprocessor Count:", g.SMCount)
+	if g.MigEnabled {
+		_, _ = fmt.Fprintln(&sb, "----------- MIG Device -----------")
+		_, _ = fmt.Fprintln(&sb, "MIG Enabled: true")
+		for _, migDevice := range g.MigDevices {
+			_, _ = fmt.Fprintln(&sb, migDevice.String())
+		}
+	}
 
 	return sb.String()
 }

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -106,6 +106,12 @@ func GetBasicNvmlMock() *nvmlmock.Interface {
 		DeviceGetCudaComputeCapabilityFunc: func(nvml.Device) (int, int, nvml.Return) {
 			return 7, 5, nvml.SUCCESS
 		},
+		DeviceGetIndexFunc: func(nvml.Device) (int, nvml.Return) {
+			return 0, nvml.SUCCESS
+		},
+		DeviceGetMigModeFunc: func(nvml.Device) (int, int, nvml.Return) {
+			return nvml.DEVICE_MIG_DISABLE, 0, nvml.SUCCESS
+		},
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Follow up https://github.com/DataDog/datadog-agent/pull/32109
When mig config is enabled, the workloadmeta can detect the mig partitions and add them the parent gpu device

### Motivation
When nvidia-mig is **not enabled**, 
```
root@datadog-agent-linux-6997f:/# nvidia-smi -L
GPU 0: NVIDIA A100-SXM4-80GB (UUID: GPU-7fdaf0a5-179b-f636-d15d-daf243e3ff16)
root@datadog-agent-linux-6997f:/# nvidia-smi 
Mon Jan 20 01:22:29 2025       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.216.01             Driver Version: 535.216.01   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A100-SXM4-80GB          Off | 00000000:00:05.0 Off |                    0 |
| N/A   37C    P0             258W / 400W |  79527MiB / 81920MiB |     17%      Default |
|                                         |                      |             Disabled |
+-----------------------------------------+----------------------+----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0   N/A  N/A     17220      C   python                                    79518MiB |
+---------------------------------------------------------------------------------------+
```
workloadmeta result is
```
root@datadog-agent-linux-6997f:/# agent workload-list | grep "Entity gpu" -A 15
=== Entity gpu sources(merged):[runtime] id: GPU-7fdaf0a5-179b-f636-d15d-daf243e3ff16 ===
----------- Entity ID -----------
Kind: gpu ID: GPU-7fdaf0a5-179b-f636-d15d-daf243e3ff16
----------- Entity Meta -----------
Name: NVIDIA A100-SXM4-80GB
Namespace: 
Vendor: nvidia
Device: NVIDIA A100-SXM4-80GB
Active PIDs: []
Index: 0
===
```

When mig is **enabled**, run nvidia-smi, 
```
root@datadog-agent-linux-zb5fm:/# nvidia-smi -L
GPU 0: NVIDIA A100-SXM4-80GB (UUID: GPU-7fdaf0a5-179b-f636-d15d-daf243e3ff16)
  MIG 1g.10gb     Device  0: (UUID: MIG-feb88891-0321-5fef-9c87-d4af3b54259e)
  MIG 1g.10gb     Device  1: (UUID: MIG-a25704ba-3a06-5299-a795-fd7cf4d13973)
  MIG 1g.10gb     Device  2: (UUID: MIG-50f1c4c9-1508-5e8d-bb06-d08145b22e01)
  MIG 1g.10gb     Device  3: (UUID: MIG-36c795f2-5cf7-55d6-af30-e535e79b7bb6)
  MIG 1g.10gb     Device  4: (UUID: MIG-3f45d38c-8cee-503e-b806-a1f1bdceedeb)
  MIG 1g.10gb     Device  5: (UUID: MIG-96655de9-9525-58f9-a62b-0e4c1cc1c265)
  MIG 1g.10gb     Device  6: (UUID: MIG-1aae4990-b962-574e-8375-119d6d9b9687)

root@datadog-agent-linux-zb5fm:/# nvidia-smi
Mon Jan 20 01:36:56 2025       
+---------------------------------------------------------------------------------------+
| NVIDIA-SMI 535.216.01             Driver Version: 535.216.01   CUDA Version: 12.2     |
|-----------------------------------------+----------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |
|                                         |                      |               MIG M. |
|=========================================+======================+======================|
|   0  NVIDIA A100-SXM4-80GB          Off | 00000000:00:05.0 Off |                   On |
| N/A   53C    P0             302W / 400W |  24662MiB / 81920MiB |     N/A      Default |
|                                         |                      |              Enabled |
+-----------------------------------------+----------------------+----------------------+
+---------------------------------------------------------------------------------------+
| MIG devices:                                                                          |
+------------------+--------------------------------+-----------+-----------------------+
| GPU  GI  CI  MIG |                   Memory-Usage |        Vol|      Shared           |
|      ID  ID  Dev |                     BAR1-Usage | SM     Unc| CE ENC DEC OFA JPG    |
|                  |                                |        ECC|                       |
|==================+================================+===========+=======================|
|  0    7   0   0  |            8204MiB /  9728MiB  | 14      0 |  1   0    0    0    0 |
|                  |               2MiB / 16383MiB  |           |                       |
+------------------+--------------------------------+-----------+-----------------------+
|  0    8   0   1  |            8204MiB /  9728MiB  | 14      0 |  1   0    0    0    0 |
|                  |               2MiB / 16383MiB  |           |                       |
+------------------+--------------------------------+-----------+-----------------------+
|  0    9   0   2  |              12MiB /  9728MiB  | 14      0 |  1   0    0    0    0 |
|                  |               0MiB / 16383MiB  |           |                       |
+------------------+--------------------------------+-----------+-----------------------+
|  0   11   0   3  |              12MiB /  9728MiB  | 14      0 |  1   0    0    0    0 |
|                  |               0MiB / 16383MiB  |           |                       |
+------------------+--------------------------------+-----------+-----------------------+
|  0   12   0   4  |            8204MiB /  9728MiB  | 14      0 |  1   0    0    0    0 |
|                  |               2MiB / 16383MiB  |           |                       |
+------------------+--------------------------------+-----------+-----------------------+
|  0   13   0   5  |              12MiB /  9728MiB  | 14      0 |  1   0    0    0    0 |
|                  |               0MiB / 16383MiB  |           |                       |
+------------------+--------------------------------+-----------+-----------------------+
|  0   14   0   6  |              12MiB /  9728MiB  | 14      0 |  1   0    0    0    0 |
|                  |               0MiB / 16383MiB  |           |                       |
+------------------+--------------------------------+-----------+-----------------------+
                                                                                         
+---------------------------------------------------------------------------------------+
| Processes:                                                                            |
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |
|        ID   ID                                                             Usage      |
|=======================================================================================|
|    0    7    0      18068      C   python                                     8184MiB |
|    0    8    0      18069      C   python                                     8184MiB |
|    0   12    0      18067      C   python                                     8184MiB |
+---------------------------------------------------------------------------------------+

```
With this PR, we start to see mig partition and their uuid, gpu instance id and profile such as 1g.10gb. These are useful for tagging the following gpu metrics. We are adding collection on these information in workloadmeta: 
```
root@datadog-agent-linux-zb5fm:/# agent workload-list | grep "Entity gpu" -A 22
=== Entity gpu sources(merged):[runtime] id: GPU-7fdaf0a5-179b-f636-d15d-daf243e3ff16 ===
----------- Entity ID -----------
Kind: gpu ID: GPU-7fdaf0a5-179b-f636-d15d-daf243e3ff16
----------- Entity Meta -----------
Name: NVIDIA A100-SXM4-80GB
Namespace: 
Vendor: nvidia
Device: NVIDIA A100-SXM4-80GB
Active PIDs: []
Index: 0
----------- MIG Device -----------
MIG Enabled: true
GPU Instance ID: 7, UUID: MIG-feb88891-0321-5fef-9c87-d4af3b54259e, Resource: 1g.10gb
GPU Instance ID: 8, UUID: MIG-a25704ba-3a06-5299-a795-fd7cf4d13973, Resource: 1g.10gb
GPU Instance ID: 9, UUID: MIG-50f1c4c9-1508-5e8d-bb06-d08145b22e01, Resource: 1g.10gb
GPU Instance ID: 11, UUID: MIG-36c795f2-5cf7-55d6-af30-e535e79b7bb6, Resource: 1g.10gb
GPU Instance ID: 12, UUID: MIG-3f45d38c-8cee-503e-b806-a1f1bdceedeb, Resource: 1g.10gb
GPU Instance ID: 13, UUID: MIG-96655de9-9525-58f9-a62b-0e4c1cc1c265, Resource: 1g.10gb
GPU Instance ID: 14, UUID: MIG-1aae4990-b962-574e-8375-119d6d9b9687, Resource: 1g.10gb
===
```
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Deploy a cluster with nvidia GPUs that support MIG partition. The list is [here](https://docs.nvidia.com/datacenter/tesla/mig-user-guide/#id9).
Install nvidia gpu operator with mig manager
Enable MIG
```
kubectl exec -it  -n gpu-operator nvidia-mig-manager-qhqq4 --  nvidia-smi -mig 1
kubectl label node YOUR_NODE_NAME nvidia.com/mig.config="all-1g.10gb" --overwrite
kubectl get node -o json | jq '.items[].metadata.labels'
  "nvidia.com/mig.capable": "true",
  "nvidia.com/mig.config": "all-1g.10gb",
  "nvidia.com/mig.config.state": "rebooting",
  "nvidia.com/mig.strategy": "single",
```
Make sure nvidia-smi returns MIG partitions as shown above. 
Deploy datadog agent and enable gpu visible devices to agent, 
```
datadog:
  env:
    - name: NVIDIA_VISIBLE_DEVICES
      value: "all" # Exposes all accessible GPUs to the container, for testing only!
```
Run workload-list, the above info will be presented. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->