### PR TITLE
fix(prometheus): [agent6] Deactivate prometheus test which is not supported with python2

### DIFF
--- a/test/new-e2e/tests/containers/ecs_test.go
+++ b/test/new-e2e/tests/containers/ecs_test.go
@@ -528,37 +528,6 @@ func (suite *ecsSuite) testDogstatsd(taskName string) {
 	})
 }
 
-func (suite *ecsSuite) TestPrometheus() {
-	// Test Prometheus check
-	suite.testMetric(&testMetricArgs{
-		Filter: testMetricFilterArgs{
-			Name: "prometheus.prom_gauge",
-		},
-		Expect: testMetricExpectArgs{
-			Tags: &[]string{
-				`^cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
-				`^container_id:`,
-				`^container_name:ecs-.*-prometheus-ec2-`,
-				`^docker_image:ghcr.io/datadog/apps-prometheus:main$`,
-				`^ecs_cluster_name:` + regexp.QuoteMeta(suite.ecsClusterName) + `$`,
-				`^ecs_container_name:prometheus$`,
-				`^endpoint:http://.*:8080/metrics$`,
-				`^git.commit.sha:`,                                                       // org.opencontainers.image.revision docker image label
-				`^git.repository_url:https://github.com/DataDog/test-infra-definitions$`, // org.opencontainers.image.source   docker image label
-				`^image_id:sha256:`,
-				`^image_name:ghcr.io/datadog/apps-prometheus$`,
-				`^image_tag:main$`,
-				`^series:`,
-				`^short_image:apps-prometheus$`,
-				`^task_arn:`,
-				`^task_family:.*-prometheus-ec2$`,
-				`^task_name:.*-prometheus-ec2$`,
-				`^task_version:[[:digit:]]+$`,
-			},
-		},
-	})
-}
-
 func (suite *ecsSuite) TestTraceUDS() {
 	suite.testTrace(taskNameTracegenUDS)
 }

--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -834,43 +834,6 @@ func (suite *k8sSuite) testDogstatsdContainerID(kubeNamespace, kubeDeployment st
 	})
 }
 
-func (suite *k8sSuite) TestPrometheus() {
-	// Test Prometheus check
-	suite.testMetric(&testMetricArgs{
-		Filter: testMetricFilterArgs{
-			Name: "prom_gauge",
-			Tags: []string{
-				"^kube_deployment:prometheus$",
-				"^kube_namespace:workload-prometheus$",
-			},
-		},
-		Expect: testMetricExpectArgs{
-			Tags: &[]string{
-				`^container_id:`,
-				`^container_name:prometheus$`,
-				`^display_container_name:prometheus`,
-				`^endpoint:http://.*:8080/metrics$`,
-				`^git.commit.sha:`, // org.opencontainers.image.revision docker image label
-				`^git.repository_url:https://github.com/DataDog/test-infra-definitions$`, // org.opencontainers.image.source   docker image label
-				`^image_id:ghcr.io/datadog/apps-prometheus@sha256:`,
-				`^image_name:ghcr.io/datadog/apps-prometheus$`,
-				`^image_tag:main$`,
-				`^kube_container_name:prometheus$`,
-				`^kube_deployment:prometheus$`,
-				`^kube_namespace:workload-prometheus$`,
-				`^kube_ownerref_kind:replicaset$`,
-				`^kube_ownerref_name:prometheus-[[:alnum:]]+$`,
-				`^kube_qos:Burstable$`,
-				`^kube_replica_set:prometheus-[[:alnum:]]+$`,
-				`^pod_name:prometheus-[[:alnum:]]+-[[:alnum:]]+$`,
-				`^pod_phase:running$`,
-				`^series:`,
-				`^short_image:apps-prometheus$`,
-			},
-		},
-	})
-}
-
 func (suite *k8sSuite) TestAdmissionController() {
 	ctx := context.Background()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Deactivate the failing `TestPrometheus` from the containers test suites as it's checking the openmetrics v2 check [not enabled in python2](https://github.com/DataDog/integrations-core/blob/052a2ee6820d3dc120b66f2a91d9eb22b00af01b/openmetrics/datadog_checks/openmetrics/openmetrics.py#L13-L14)

### Motivation
Have a greener pipeline

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->