### PR TITLE
Cached deletions are not treated as not present data

### DIFF
--- a/pkg/config/remote/uptane/transactional_store.go
+++ b/pkg/config/remote/uptane/transactional_store.go
@@ -6,6 +6,7 @@
 package uptane
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -213,6 +214,10 @@ func (t *transaction) get(bucketName string, path string) ([]byte, error) {
 	// check if it's present in the in-memory cache
 	data, ok := bucket[path]
 	if ok {
+		if data == nil {
+			err := fmt.Errorf("File empty or not found: %s in bucket %s", path, bucketName)
+			return nil, err
+		}
 		return data, nil
 	}
 


### PR DESCRIPTION
If the element is only in the storage we have
- present: data, nil
- missing:  nil, error


If the element is added in the cache we have

- present: data, nil
- missing: look in local storage (the ones above)

But this is different as data could also be nil and mean that the file is not present at all and should return the same error.