### PR TITLE
collect terminated pods

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
@@ -55,6 +55,7 @@ func NewCollectorInventory(cfg config.Component, store workloadmeta.Component, t
 			k8sCollectors.NewStatefulSetCollectorVersions(metadataAsTags),
 			k8sCollectors.NewStorageClassCollectorVersions(metadataAsTags),
 			k8sCollectors.NewUnassignedPodCollectorVersions(cfg, store, tagger, metadataAsTags),
+			k8sCollectors.NewTerminatedPodCollectorVersions(cfg, store, tagger, metadataAsTags),
 			k8sCollectors.NewVerticalPodAutoscalerCollectorVersions(metadataAsTags),
 		},
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_terminated.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_terminated.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && orchestrator
+
+package k8s
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	k8sProcessors "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/config/utils"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
+
+	corev1Informers "k8s.io/client-go/informers/core/v1"
+	corev1Listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewTerminatedPodCollectorVersions builds the group of collector versions.
+func NewTerminatedPodCollectorVersions(cfg config.Component, store workloadmeta.Component, tagger tagger.Component, metadataAsTags utils.MetadataAsTags) collectors.CollectorVersions {
+	return collectors.NewCollectorVersions(
+		NewTerminatedPodCollector(cfg, store, tagger, metadataAsTags),
+	)
+}
+
+// TerminatedPodCollector is a collector for Kubernetes Pods that are not
+// assigned to a node yet.
+type TerminatedPodCollector struct {
+	informer  corev1Informers.PodInformer
+	lister    corev1Listers.PodLister
+	metadata  *collectors.CollectorMetadata
+	processor *processors.Processor
+}
+
+// NewTerminatedPodCollector creates a new collector for the Kubernetes Pod
+// resource that is not assigned to any node.
+func NewTerminatedPodCollector(cfg config.Component, store workloadmeta.Component, tagger tagger.Component, metadataAsTags utils.MetadataAsTags) *TerminatedPodCollector {
+	resourceType := getResourceType(podName, podVersion)
+	labelsAsTags := metadataAsTags.GetResourcesLabelsAsTags()[resourceType]
+	annotationsAsTags := metadataAsTags.GetResourcesAnnotationsAsTags()[resourceType]
+
+	return &TerminatedPodCollector{
+		metadata: &collectors.CollectorMetadata{
+			IsDefaultVersion:                     true,
+			IsStable:                             pkgconfigsetup.Datadog().GetBool("orchestrator_explorer.terminated_pods.enabled"),
+			IsMetadataProducer:                   true,
+			IsManifestProducer:                   true,
+			SupportsManifestBuffering:            true,
+			Name:                                 "terminated-pods",
+			NodeType:                             orchestrator.K8sPod,
+			Version:                              "v1",
+			LabelsAsTags:                         labelsAsTags,
+			AnnotationsAsTags:                    annotationsAsTags,
+			SupportsTerminatedResourceCollection: true,
+		},
+		processor: processors.NewProcessor(k8sProcessors.NewPodHandlers(cfg, store, tagger)),
+	}
+}
+
+// Informer returns the shared informer.
+func (c *TerminatedPodCollector) Informer() cache.SharedInformer {
+	return c.informer.Informer()
+}
+
+// Init is used to initialize the collector.
+func (c *TerminatedPodCollector) Init(rcfg *collectors.CollectorRunConfig) {
+	c.informer = rcfg.OrchestratorInformerFactory.TerminatedPodInformerFactory.Core().V1().Pods()
+	c.lister = c.informer.Lister()
+}
+
+// Metadata is used to access information about the collector.
+func (c *TerminatedPodCollector) Metadata() *collectors.CollectorMetadata {
+	return c.metadata
+}
+
+// Run triggers the collection process.
+func (c *TerminatedPodCollector) Run(rcfg *collectors.CollectorRunConfig) (*collectors.CollectorRunResult, error) {
+	// TerminatedPodCollector does not process any resources as it is only used to collect terminated pods by deletion handler.
+	return c.Process(rcfg, []*v1.Pod{})
+}
+
+// Process is used to process the list of resources and return the result.
+func (c *TerminatedPodCollector) Process(rcfg *collectors.CollectorRunConfig, list interface{}) (*collectors.CollectorRunResult, error) {
+	ctx := collectors.NewK8sProcessorContext(rcfg, c.metadata)
+
+	processResult, processed := c.processor.Process(ctx, list)
+
+	if processed == -1 {
+		return nil, collectors.ErrProcessingPanic
+	}
+
+	result := &collectors.CollectorRunResult{
+		Result:             processResult,
+		ResourcesListed:    len(c.processor.Handlers().ResourceList(ctx, list)),
+		ResourcesProcessed: processed,
+	}
+
+	return result, nil
+}

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
@@ -55,6 +55,7 @@ func (cv *CollectorVersions) CollectorForVersion(version string) (K8sCollector, 
 type OrchestratorInformerFactory struct {
 	InformerFactory              informers.SharedInformerFactory
 	UnassignedPodInformerFactory informers.SharedInformerFactory
+	TerminatedPodInformerFactory informers.SharedInformerFactory
 	DynamicInformerFactory       dynamicinformer.DynamicSharedInformerFactory
 	CRDInformerFactory           externalversions.SharedInformerFactory
 	VPAInformerFactory           vpai.SharedInformerFactory

--- a/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/discovery/collector_discovery_crd.go
@@ -116,6 +116,9 @@ func (d *DiscoveryCollector) DiscoverRegularResource(resource string, groupVersi
 	if resource == "clusters" {
 		return d.isSupportClusterCollector(collector, collectorInventory)
 	}
+	if resource == "terminated-pods" {
+		return d.isSupportTerminatedPodCollector(collector, collectorInventory)
+	}
 
 	return d.isSupportCollector(collector)
 }
@@ -136,6 +139,19 @@ func (d *DiscoveryCollector) isSupportClusterCollector(collector collectors.K8sC
 		return nil, fmt.Errorf("failed to discover cluster resource %w", err)
 	}
 	_, err = d.isSupportCollector(nodeCollector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover resource %s", collector.Metadata().Name)
+	}
+	return collector, nil
+
+}
+
+func (d *DiscoveryCollector) isSupportTerminatedPodCollector(collector collectors.K8sCollector, collectorInventory *inventory.CollectorInventory) (collectors.K8sCollector, error) {
+	podCollector, err := collectorInventory.CollectorForDefaultVersion("pods")
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover pod resource %w", err)
+	}
+	_, err = d.isSupportCollector(podCollector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to discover resource %s", collector.Metadata().Name)
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -223,8 +223,17 @@ func (o *OrchestratorCheck) Cancel() {
 }
 
 func getOrchestratorInformerFactory(apiClient *apiserver.APIClient) *collectors.OrchestratorInformerFactory {
-	tweakListOptions := func(options *metav1.ListOptions) {
+	unassignedPodsTweakListOptions := func(options *metav1.ListOptions) {
 		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "").String()
+	}
+
+	// Only collect pods that are in a terminated state: Succeeded or Failed
+	terminatedPodsTweakListOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.AndSelectors(
+			fields.OneTermNotEqualSelector("status.phase", "Running"),
+			fields.OneTermNotEqualSelector("status.phase", "Pending"),
+			fields.OneTermNotEqualSelector("status.phase", "Unknown"),
+		).String()
 	}
 
 	of := &collectors.OrchestratorInformerFactory{
@@ -232,7 +241,8 @@ func getOrchestratorInformerFactory(apiClient *apiserver.APIClient) *collectors.
 		CRDInformerFactory:           externalversions.NewSharedInformerFactory(apiClient.CRDInformerClient, defaultResyncInterval),
 		DynamicInformerFactory:       dynamicinformer.NewDynamicSharedInformerFactory(apiClient.DynamicInformerCl, defaultResyncInterval),
 		VPAInformerFactory:           vpai.NewSharedInformerFactory(apiClient.VPAInformerClient, defaultResyncInterval),
-		UnassignedPodInformerFactory: informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval, informers.WithTweakListOptions(tweakListOptions)),
+		UnassignedPodInformerFactory: informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval, informers.WithTweakListOptions(unassignedPodsTweakListOptions)),
+		TerminatedPodInformerFactory: informers.NewSharedInformerFactoryWithOptions(apiClient.InformerCl, defaultResyncInterval, informers.WithTweakListOptions(terminatedPodsTweakListOptions)),
 	}
 
 	return of

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -227,11 +227,10 @@ func getOrchestratorInformerFactory(apiClient *apiserver.APIClient) *collectors.
 		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "").String()
 	}
 
-	// Only collect pods that are in a terminated state: Succeeded or Failed
+	// Only collect pods that are in a terminated state: Succeeded, Failed, or Pending.
 	terminatedPodsTweakListOptions := func(options *metav1.ListOptions) {
 		options.FieldSelector = fields.AndSelectors(
 			fields.OneTermNotEqualSelector("status.phase", "Running"),
-			fields.OneTermNotEqualSelector("status.phase", "Pending"),
 			fields.OneTermNotEqualSelector("status.phase", "Unknown"),
 		).String()
 	}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -842,6 +842,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_manifest", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.manifest_collection.buffer_flush_interval", 20*time.Second)
 	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_resources.enabled", false)
+	config.BindEnvAndSetDefault("orchestrator_explorer.terminated_pods.enabled", false)
 
 	// Container lifecycle configuration
 	config.BindEnvAndSetDefault("container_lifecycle.enabled", true)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Collecting terminated pods by adding a new terminated pod collector. 
The new collector uses `informer.AddEventHandler` to collect only terminated pod data. https://github.com/DataDog/datadog-agent/blob/55f7c9ecbd91758df3070115a93cfa12f16998f9/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go#L297

Unlike other collectors, It won't send data during each run as we have node agent to send pod payloads  https://github.com/DataDog/datadog-agent/blob/55f7c9ecbd91758df3070115a93cfa12f16998f9/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/pod_terminated.go#L86-L89

Feature flag: `DD_ORCHESTRATOR_EXPLORER_TERMINATED_RESOURCES_ENABLED` and `DD_ORCHESTRATOR_EXPLORER_TERMINATED_PODS_ENABLED`

Related PR: https://github.com/DataDog/datadog-agent/pull/33131

### QA
Delete a pod, check its manifest in k8s explorer