### PR TITLE
[CWS] Add security_profiles map entry deletion

### DIFF
--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -53,7 +53,6 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 		if workload, ok := t.workloads[cgce.CGroupID]; ok {
 			t.NotifyListeners(WorkloadSelectorDeleted, workload)
 			delete(t.workloads, cgce.CGroupID)
-
 		}
 	}); err != nil {
 		return err

--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -50,6 +50,7 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 	}
 
 	if err := t.cgroupResolver.RegisterListener(cgroup.CGroupDeleted, func(cgce *cgroupModel.CacheEntry) {
+		t.NotifyListeners(WorkloadSelectorDeleted, t.workloads[cgce.CGroupID])
 		delete(t.workloads, cgce.CGroupID)
 	}); err != nil {
 		return err

--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -50,7 +50,9 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 	}
 
 	if err := t.cgroupResolver.RegisterListener(cgroup.CGroupDeleted, func(cgce *cgroupModel.CacheEntry) {
-		t.NotifyListeners(WorkloadSelectorDeleted, t.workloads[cgce.CGroupID])
+		if workload, ok := t.workloads[cgce.CGroupID]; ok {
+			t.NotifyListeners(WorkloadSelectorDeleted, workload)
+		}
 		delete(t.workloads, cgce.CGroupID)
 	}); err != nil {
 		return err

--- a/pkg/security/resolvers/tags/resolver_linux.go
+++ b/pkg/security/resolvers/tags/resolver_linux.go
@@ -52,8 +52,9 @@ func (t *LinuxResolver) Start(ctx context.Context) error {
 	if err := t.cgroupResolver.RegisterListener(cgroup.CGroupDeleted, func(cgce *cgroupModel.CacheEntry) {
 		if workload, ok := t.workloads[cgce.CGroupID]; ok {
 			t.NotifyListeners(WorkloadSelectorDeleted, workload)
+			delete(t.workloads, cgce.CGroupID)
+
 		}
-		delete(t.workloads, cgce.CGroupID)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR aims to fix this bug
<img width="1112" alt="Capture d’écran 2025-01-20 à 20 17 37" src="https://github.com/user-attachments/assets/a8fa750a-414d-42c3-96a9-a720fd4e7719" />

This error is returned when the security_profiles map hits max_entry (400 by default). Recently the mechanism removing an entry from the map was deleted by mistake, making this error more frequent.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->