### PR TITLE
usm: sharedlibraries: Ensure path does not exceed path->len.

### DIFF
--- a/pkg/network/ebpf/c/shared-libraries/probes.h
+++ b/pkg/network/ebpf/c/shared-libraries/probes.h
@@ -74,7 +74,9 @@ static __always_inline void push_event_if_relevant(void *ctx, lib_path_t *path, 
     if (!is_shared_library) {
         return;
     }
-
+    if (i + LIB_SO_SUFFIX_SIZE > path->len) {
+        return;
+    }
     u64 crypto_libset_enabled = 0;
     LOAD_CONSTANT("crypto_libset_enabled", crypto_libset_enabled);
 

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -611,7 +611,7 @@ func (s *SharedLibrarySuite) TestValidPathExistsInTheMemory() {
 			// Paths are written consecutively in memory, at the end of a page.
 			name: "end of a page",
 			writePaths: func(data []byte, textFilePath, soPath string) int {
-				offset := os.Getpagesize() - len(textFilePath) - 1 - len(soPath) - 1
+				offset := 2*os.Getpagesize() - len(textFilePath) - 1 - len(soPath) - 1
 				copy(data[offset:], textFilePath)
 				data[offset+len(textFilePath)] = 0 // Null-terminate the first path
 				copy(data[offset+len(textFilePath)+1:], soPath)

--- a/pkg/network/usm/sharedlibraries/watcher_test.go
+++ b/pkg/network/usm/sharedlibraries/watcher_test.go
@@ -608,6 +608,19 @@ func (s *SharedLibrarySuite) TestValidPathExistsInTheMemory() {
 			},
 		},
 		{
+			// Paths are written consecutively in memory, at the end of a page.
+			name: "end of a page",
+			writePaths: func(data []byte, textFilePath, soPath string) int {
+				offset := os.Getpagesize() - len(textFilePath) - 1 - len(soPath) - 1
+				copy(data[offset:], textFilePath)
+				data[offset+len(textFilePath)] = 0 // Null-terminate the first path
+				copy(data[offset+len(textFilePath)+1:], soPath)
+				data[offset+len(textFilePath)+1+len(soPath)] = 0 // Null-terminate the second path
+
+				return offset
+			},
+		},
+		{
 			// The first path is written at the end of the first page, and the second path is written at the beginning
 			// of the second page.
 			name: "cross pages",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Ensuring we do not send to user mode a path, just because later in the memory we have seen a matching .so file.

For instance, having the following memory '<path 1>\0libssl.so', would have caused us to send to the user mode '<path 1>', even if it wasn't matching our filtering.

That was caused as we never verified we're not exceeding path->len, so we scanned the entire 220 characters we read from the memory. And if it contains a matching pattern the first path would have been considered as a valid match

### Motivation

* Fixing flakiness identified in the CI
* Reducing the amount of events sent from the kernel to the user mode

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

* UT were added
* Deployed to staging
    * [Link](https://ddstaging.datadoghq.com/dashboard/kfn-zy2-t98/agent-system-probe-overview?fromUser=true&refresh_mode=paused&tpl_var_kube_cluster_name%5B0%5D=victini&from_ts=1737444528884&to_ts=1737453014000&live=false) to deployment
    * USM Pulse [dashboard](https://ddstaging.datadoghq.com/dashboard/eb3-euv-gu4/usm-pulse?fromUser=true&refresh_mode=paused&tpl_var_kube_cluster_name%5B0%5D=victini&from_ts=1737444480000&to_ts=1737453000000&live=false)
    * Key metrics - [shared libraries](https://ddstaging.datadoghq.com/s/c894ecec5/qer-9xv-pk7)
    * The change is negligible and was verified using a custom version and a log that was gone after introducing the fix
* Load test
    * [link](https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=usmon1404-base&tpl_var_client-service%5B0%5D=python-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=usmon1404-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm3&tpl_var_server-service%5B0%5D=python-httpbin-tls&tpl_var_tls.library%5B0%5D=openssl&from_ts=1737445200000&to_ts=1737447240000&live=false)
    * No performance impact
    * No accuracy impact

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->