### PR TITLE
[CWS] stop variables when releasing them

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -505,6 +505,13 @@ func (v *Variables) Set(name string, value interface{}) bool {
 	return !existed
 }
 
+// Stop the underlying ttl lru
+func (v *Variables) Stop() {
+	if v.lru != nil {
+		v.lru.Stop()
+	}
+}
+
 // ScopedVariables holds a set of scoped variables
 type ScopedVariables struct {
 	scoper Scoper
@@ -584,7 +591,10 @@ func (v *ScopedVariables) GetVariable(name string, value interface{}, _ Variable
 
 // ReleaseVariable releases a scoped variable
 func (v *ScopedVariables) ReleaseVariable(key ScopedVariable) {
-	delete(v.vars, key)
+	if variables, ok := v.vars[key]; ok {
+		variables.Stop()
+		delete(v.vars, key)
+	}
 }
 
 // NewScopedVariables returns a new set of scope variables


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

TTL caches need a goroutine to do the periodic cleanup. Currently this goroutine is leaking. This PR fixes this issue by stopping it when releasing the variable.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->