### PR TITLE
[CWS] Reduce max entries of unused maps

### DIFF
--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -162,13 +162,14 @@ func getMaxEntries(numCPU int, min int, max int) uint32 {
 
 // MapSpecEditorOpts defines some options of the map spec editor
 type MapSpecEditorOpts struct {
-	TracedCgroupSize        int
-	UseMmapableMaps         bool
-	UseRingBuffers          bool
-	RingBufferSize          uint32
-	PathResolutionEnabled   bool
-	SecurityProfileMaxCount int
-	ReducedProcPidCacheSize bool
+	TracedCgroupSize          int
+	UseMmapableMaps           bool
+	UseRingBuffers            bool
+	RingBufferSize            uint32
+	PathResolutionEnabled     bool
+	SecurityProfileMaxCount   int
+	ReducedProcPidCacheSize   bool
+	NetworkFlowMonitorEnabled bool
 }
 
 // AllMapSpecEditors returns the list of map editors
@@ -178,6 +179,15 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.Ma
 		procPidCacheMaxEntries = getMaxEntries(numCPU, minProcEntries, maxProcEntries/2)
 	} else {
 		procPidCacheMaxEntries = getMaxEntries(numCPU, minProcEntries, maxProcEntries)
+	}
+
+	var activeFlowsMaxEntries, nsFlowToNetworkStats uint32
+	if opts.NetworkFlowMonitorEnabled {
+		activeFlowsMaxEntries = procPidCacheMaxEntries
+		nsFlowToNetworkStats = 4096
+	} else {
+		activeFlowsMaxEntries = 1
+		nsFlowToNetworkStats = 1
 	}
 
 	editors := map[string]manager.MapSpecEditor{
@@ -199,11 +209,15 @@ func AllMapSpecEditors(numCPU int, opts MapSpecEditorOpts) map[string]manager.Ma
 		},
 
 		"active_flows": {
-			MaxEntries: procPidCacheMaxEntries,
+			MaxEntries: activeFlowsMaxEntries,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"active_flows_spin_locks": {
-			MaxEntries: procPidCacheMaxEntries,
+			MaxEntries: activeFlowsMaxEntries,
+			EditorFlag: manager.EditMaxEntries,
+		},
+		"ns_flow_to_network_stats": {
+			MaxEntries: nsFlowToNetworkStats,
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"inet_bind_args": {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2029,12 +2029,13 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 	}
 
 	p.managerOptions.MapSpecEditors = probes.AllMapSpecEditors(p.numCPU, probes.MapSpecEditorOpts{
-		TracedCgroupSize:        config.RuntimeSecurity.ActivityDumpTracedCgroupsCount,
-		UseRingBuffers:          useRingBuffers,
-		UseMmapableMaps:         useMmapableMaps,
-		RingBufferSize:          uint32(config.Probe.EventStreamBufferSize),
-		PathResolutionEnabled:   probe.Opts.PathResolutionEnabled,
-		SecurityProfileMaxCount: config.RuntimeSecurity.SecurityProfileMaxCount,
+		TracedCgroupSize:          config.RuntimeSecurity.ActivityDumpTracedCgroupsCount,
+		UseRingBuffers:            useRingBuffers,
+		UseMmapableMaps:           useMmapableMaps,
+		RingBufferSize:            uint32(config.Probe.EventStreamBufferSize),
+		PathResolutionEnabled:     probe.Opts.PathResolutionEnabled,
+		SecurityProfileMaxCount:   config.RuntimeSecurity.SecurityProfileMaxCount,
+		NetworkFlowMonitorEnabled: config.Probe.NetworkFlowMonitorEnabled,
 	})
 
 	if config.RuntimeSecurity.ActivityDumpEnabled {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reduces the size of unused maps.

### Motivation

This reduces the total kernel memory size when `network_flow_monitor` is disabled.