### PR TITLE
[ADXT-861] RFC - Adding Log Parsing to TestWasher (flakes.yaml)

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -23,6 +23,13 @@ test/new-e2e/tests/containers:
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
 
+# test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing:
+#   - test: TestMultiLineSuite/TestMultiLine/MultiLinePattern
+#     on-log: "Append.*to"
+
+on-log:
+  - "Append.*to"
+
 # It is possible to specify a log pattern for all tests:
 # on-log:
 #   - "I'm flaky..."

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -8,8 +8,8 @@
 
 # TODO: https://datadoghq.atlassian.net/browse/CONTINT-4143
 test/new-e2e/tests/containers:
-  - TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
-  - TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
-  - TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
-  - TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
-  - TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
+  - test: TestECSSuite/TestCPU/metric___container.cpu.usage{^ecs_container_name:stress-ng$}
+  - test: TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
+  - test: TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
+  - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
+  - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -7,6 +7,9 @@
 #    on-log: # Mark this test flaky if any of the patterns are found within its log
 #      - <log-pattern>
 #      - <log-pattern>
+# It is also possible to specify a log pattern for all tests:
+# on-log:
+#   - "I'm flaky..."
 # * For example:
 # "pkg/gohai":
 #   - test: "TestGetPayload"
@@ -22,7 +25,3 @@ test/new-e2e/tests/containers:
   - test: TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
-
-# It is possible to specify a log pattern for all tests:
-# on-log:
-#   - "I'm flaky..."

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -23,13 +23,6 @@ test/new-e2e/tests/containers:
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
 
-# test/new-e2e/tests/agent-metrics-logs/log-agent/linux-log/file-tailing:
-#   - test: TestMultiLineSuite/TestMultiLine/MultiLinePattern
-#     on-log: "Append.*to"
-
-on-log:
-  - "Append.*to"
-
 # It is possible to specify a log pattern for all tests:
 # on-log:
 #   - "I'm flaky..."

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -1,10 +1,19 @@
-# Pkg Name: Test list
-# If you mute a parent test it will ignore all the subtests as well
-# For example:
+# * Here is the file format:
+# <package-name>:
+#  - test: <test-name> # Mark this test always flaky
+#  - test: <test-name>
+#    on-log: <log-pattern> # Mark this test flaky if the pattern (regex) is found within its log
+#  - test: <test-name>
+#    on-log: # Mark this test flaky if any of the patterns are found within its log
+#      - <log-pattern>
+#      - <log-pattern>
+# * For example:
 # "pkg/gohai":
-#   - "TestGetPayload"
-# "test/new-e2e/tests/agent-platform/install-script"
-#   - "TestInstallScript/test_install_script_on_centos-79_x86_64_datadog-agent_agent_7"
+#   - test: "TestGetPayload"
+# "test/new-e2e/tests/agent-platform/install-script":
+#   - test: "TestInstallScript/test_install_script_on_centos-79_x86_64_datadog-agent_agent_7"
+# * Note:
+# If you mute a parent test it will ignore all the subtests as well.
 
 # TODO: https://datadoghq.atlassian.net/browse/CONTINT-4143
 test/new-e2e/tests/containers:

--- a/flakes.yaml
+++ b/flakes.yaml
@@ -22,3 +22,7 @@ test/new-e2e/tests/containers:
   - test: TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
+
+# It is possible to specify a log pattern for all tests:
+# on-log:
+#   - "I'm flaky..."

--- a/pkg/util/testutil/flake/parse.go
+++ b/pkg/util/testutil/flake/parse.go
@@ -63,6 +63,10 @@ func Parse(r io.Reader) (*KnownFlakyTests, error) {
 	kf := &KnownFlakyTests{packageTestList: make(map[string]map[string]struct{})}
 	for pkg, tests := range pkgToTests {
 		for _, t := range tests {
+			if _, ok := t["test"]; !ok {
+				return nil, fmt.Errorf("test field is required for %s", pkg)
+			}
+
 			// Do not include tests that have an on-log field since they are not always flaky
 			if _, hasOnLog := t["on-log"]; !hasOnLog {
 				kf.Add(pkg, t["test"])

--- a/pkg/util/testutil/flake/parse_test.go
+++ b/pkg/util/testutil/flake/parse_test.go
@@ -45,6 +45,12 @@ pkg/toto:
   - test: TestOtherTest
     on-log: "hello"`
 
+const flake_error = `pkg/gohai:
+  - test: TestGetPayload
+pkg/toto:
+  - test: TestGetPayload
+  - on-log: "hello"`
+
 func TestFlakesParse(t *testing.T) {
 	t.Run("1", func(t *testing.T) {
 		kf, err := Parse(bytes.NewBuffer([]byte(flake1)))
@@ -84,5 +90,10 @@ func TestFlakesParse(t *testing.T) {
 		if assert.Contains(t, kf.packageTestList, "pkg/toto") {
 			assert.Contains(t, kf.packageTestList["pkg/toto"], "TestGetPayload")
 		}
+	})
+
+	t.Run("5", func(t *testing.T) {
+		_, err := Parse(bytes.NewBuffer([]byte(flake_error)))
+		require.Error(t, err)
 	})
 }

--- a/pkg/util/testutil/flake/parse_test.go
+++ b/pkg/util/testutil/flake/parse_test.go
@@ -45,7 +45,7 @@ pkg/toto:
   - test: TestOtherTest
     on-log: "hello"`
 
-const flake_error = `pkg/gohai:
+const flakeError = `pkg/gohai:
   - test: TestGetPayload
 pkg/toto:
   - test: TestGetPayload
@@ -93,7 +93,7 @@ func TestFlakesParse(t *testing.T) {
 	})
 
 	t.Run("5", func(t *testing.T) {
-		_, err := Parse(bytes.NewBuffer([]byte(flake_error)))
+		_, err := Parse(bytes.NewBuffer([]byte(flakeError)))
 		require.Error(t, err)
 	})
 }

--- a/pkg/util/testutil/flake/parse_test.go
+++ b/pkg/util/testutil/flake/parse_test.go
@@ -26,17 +26,24 @@ func TestIsFlaky(t *testing.T) {
 }
 
 const flake1 = `pkg/gohai:
-  - TestGetPayload`
+  - test: TestGetPayload`
 
 const flake2 = `pkg/toto:
-  - TestGetPayload
-  - TestOtherTest`
+  - test: TestGetPayload
+  - test: TestOtherTest`
 
 const flake3 = `pkg/gohai:
-  - TestGetPayload
+  - test: TestGetPayload
 pkg/toto:
-  - TestGetPayload
-  - TestOtherTest`
+  - test: TestGetPayload
+  - test: TestOtherTest`
+
+const flake4 = `pkg/gohai:
+  - test: TestGetPayload
+pkg/toto:
+  - test: TestGetPayload
+  - test: TestOtherTest
+    on-log: "hello"`
 
 func TestFlakesParse(t *testing.T) {
 	t.Run("1", func(t *testing.T) {
@@ -65,6 +72,17 @@ func TestFlakesParse(t *testing.T) {
 		if assert.Contains(t, kf.packageTestList, "pkg/toto") {
 			assert.Contains(t, kf.packageTestList["pkg/toto"], "TestGetPayload")
 			assert.Contains(t, kf.packageTestList["pkg/toto"], "TestOtherTest")
+		}
+	})
+
+	t.Run("4", func(t *testing.T) {
+		kf, err := Parse(bytes.NewBuffer([]byte(flake4)))
+		require.NoError(t, err)
+		if assert.Contains(t, kf.packageTestList, "pkg/gohai") {
+			assert.Contains(t, kf.packageTestList["pkg/gohai"], "TestGetPayload")
+		}
+		if assert.Contains(t, kf.packageTestList, "pkg/toto") {
+			assert.Contains(t, kf.packageTestList["pkg/toto"], "TestGetPayload")
 		}
 	})
 }

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -432,10 +432,10 @@ def cc(ctx):
     washer = TestWasher(test_output_json_file=path, flakes_file_path='flakes.yaml')
     washer.parse_test_results('/tmp')
     failing_tests, marked_flaky_tests = washer.parse_test_results('/tmp')
-    all_known_flakes = washer.merge_known_flakes(marked_flaky_tests)
+    # all_known_flakes = washer.merge_known_flakes(marked_flaky_tests)
 
     print('marked', marked_flaky_tests)
-    print('known', all_known_flakes)
+    # print('known', all_known_flakes)
 
 
 @task

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -427,6 +427,18 @@ def pretty_print_logs(result_json_path, logs_per_test, max_size=250000, flakes_f
 
 
 @task
+def cc(ctx):
+    path = 'module_test_output.json'
+    washer = TestWasher(test_output_json_file=path, flakes_file_path='flakes.yaml')
+    washer.parse_test_results('/tmp')
+    failing_tests, marked_flaky_tests = washer.parse_test_results('/tmp')
+    all_known_flakes = washer.merge_known_flakes(marked_flaky_tests)
+
+    print('marked', marked_flaky_tests)
+    print('known', all_known_flakes)
+
+
+@task
 def deps(ctx, verbose=False):
     """
     Setup Go dependencies

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -427,18 +427,6 @@ def pretty_print_logs(result_json_path, logs_per_test, max_size=250000, flakes_f
 
 
 @task
-def cc(ctx):
-    path = 'module_test_output.json'
-    washer = TestWasher(test_output_json_file=path, flakes_file_path='flakes.yaml')
-    washer.parse_test_results('/tmp')
-    failing_tests, marked_flaky_tests = washer.parse_test_results('/tmp')
-    # all_known_flakes = washer.merge_known_flakes(marked_flaky_tests)
-
-    print('marked', marked_flaky_tests)
-    # print('known', all_known_flakes)
-
-
-@task
 def deps(ctx, verbose=False):
     """
     Setup Go dependencies

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -73,7 +73,9 @@ class TestWasher:
             if not flakes:
                 return
             for package, tests in flakes.items():
-                self.known_flaky_tests[f"github.com/DataDog/datadog-agent/{package}"].update(set(tests))
+                self.known_flaky_tests[f"github.com/DataDog/datadog-agent/{package}"].update(
+                    {test['test'] for test in tests}
+                )
 
     def parse_test_results(self, module_path: str) -> tuple[dict, dict]:
         failing_tests = defaultdict(set)

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -87,13 +87,14 @@ class TestWasher:
                 continue
 
             for test in tests:
-                self.known_flaky_tests[f"github.com/DataDog/datadog-agent/{package}"].add(test['test'])
-
                 if 'on-log' in test:
                     patterns = test['on-log']
                     if isinstance(patterns, str):
                         patterns = [patterns]
                     self.flaky_log_patterns[f"github.com/DataDog/datadog-agent/{package}"][test['test']] = patterns
+                else:
+                    # If there is no `on-log`, we consider it as a known flaky test right away
+                    self.known_flaky_tests[f"github.com/DataDog/datadog-agent/{package}"].add(test['test'])
 
         # on-log patterns at the top level
         self.flaky_log_main_patterns = flakes.get('on-log', [])

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 from collections import defaultdict
 
 import yaml
@@ -29,6 +30,10 @@ class TestWasher:
         self.flaky_test_indicator = flaky_test_indicator
         self.flakes_file_path = flakes_file_path
         self.known_flaky_tests = defaultdict(set)
+        # flaky_log_patterns[package][test] = [pattern1, pattern2...]
+        self.flaky_log_patterns = defaultdict(dict)
+        # Top level `on-log` used to have a pattern for every test
+        self.flaky_log_main_patterns = []
 
         self.parse_flaky_file()
 
@@ -68,14 +73,32 @@ class TestWasher:
         """
         Parse the flakes.yaml file and add the tests listed there to the kown flaky tests list
         """
+        reserved_keywords = ("on-log",)
+
         with open(self.flakes_file_path) as f:
             flakes = yaml.safe_load(f)
-            if not flakes:
-                return
-            for package, tests in flakes.items():
-                self.known_flaky_tests[f"github.com/DataDog/datadog-agent/{package}"].update(
-                    {test['test'] for test in tests}
-                )
+
+        if not flakes:
+            return
+
+        # Add the tests to the known flaky tests list
+        for package, tests in flakes.items():
+            if package in reserved_keywords:
+                continue
+
+            for test in tests:
+                self.known_flaky_tests[f"github.com/DataDog/datadog-agent/{package}"].add(test['test'])
+
+                if 'on-log' in test:
+                    patterns = test['on-log']
+                    if isinstance(patterns, str):
+                        patterns = [patterns]
+                    self.flaky_log_patterns[f"github.com/DataDog/datadog-agent/{package}"][test['test']] = patterns
+
+        # on-log patterns at the top level
+        self.flaky_log_main_patterns = flakes.get('on-log', [])
+        if isinstance(self.flaky_log_main_patterns, str):
+            self.flaky_log_main_patterns = [self.flaky_log_main_patterns]
 
     def parse_test_results(self, module_path: str) -> tuple[dict, dict]:
         failing_tests = defaultdict(set)
@@ -95,9 +118,29 @@ class TestWasher:
                 if "Output" in test_result and "panic:" in test_result["Output"]:
                     failing_tests[test_result["Package"]].add(test_result["Test"])
 
-                if "Output" in test_result and self.flaky_test_indicator in test_result["Output"]:
+                if "Output" in test_result and self.is_flaky_from_log(
+                    test_result["Package"], test_result["Test"], test_result["Output"]
+                ):
                     flaky_marked_tests[test_result["Package"]].add(test_result["Test"])
         return failing_tests, flaky_marked_tests
+
+    def is_flaky_from_log(self, package: str, test: str, log: str) -> bool:
+        """Returns whether the test is flaky based on the log output."""
+
+        if self.flaky_test_indicator in log:
+            return True
+
+        # Check if the log contains any of the flaky patterns
+        patterns = self.flaky_log_main_patterns
+
+        if test in self.flaky_log_patterns[package]:
+            patterns += self.flaky_log_patterns[package][test]
+
+        for pattern in patterns:
+            if re.search(pattern, log, re.IGNORECASE):
+                return True
+
+        return False
 
     def process_module_results(self, module_results: list[ModuleTestResult]):
         """

--- a/tasks/unit_tests/testdata/flakes_1.yaml
+++ b/tasks/unit_tests/testdata/flakes_1.yaml
@@ -1,2 +1,2 @@
 pkg/gohai:
-  - TestGetPayload
+  - test: TestGetPayload

--- a/tasks/unit_tests/testdata/flakes_2.yaml
+++ b/tasks/unit_tests/testdata/flakes_2.yaml
@@ -1,2 +1,2 @@
 pkg/toto:
-  - TestGetPayload
+  - test: TestGetPayload

--- a/tasks/unit_tests/testdata/flakes_3.yaml
+++ b/tasks/unit_tests/testdata/flakes_3.yaml
@@ -1,2 +1,2 @@
 test/new-e2e/tests/containers:
-  - TestEKSSuite/Ifail
+  - test: TestEKSSuite/Ifail

--- a/tasks/unit_tests/testdata/flakes_5.yaml
+++ b/tasks/unit_tests/testdata/flakes_5.yaml
@@ -1,2 +1,3 @@
 pkg/serverless/trace:
   - test: TestLoadConfigShouldBeFast
+    on-log: "This text won't be found in the log"

--- a/tasks/unit_tests/testdata/flakes_6.yaml
+++ b/tasks/unit_tests/testdata/flakes_6.yaml
@@ -1,2 +1,3 @@
 pkg/serverless/trace:
   - test: TestLoadConfigShouldBeFast
+    on-log: "panic.*toto"

--- a/tasks/unit_tests/testdata/flakes_7.yaml
+++ b/tasks/unit_tests/testdata/flakes_7.yaml
@@ -1,2 +1,4 @@
 pkg/serverless/trace:
   - test: TestLoadConfigShouldBeFast
+    on-log:
+      - "panic.*toto"

--- a/tasks/unit_tests/testdata/flakes_8.yaml
+++ b/tasks/unit_tests/testdata/flakes_8.yaml
@@ -1,2 +1,5 @@
 pkg/serverless/trace:
   - test: TestLoadConfigShouldBeFast
+    on-log:
+      - "panic2.*toto"
+      - "panic.*toto"

--- a/tasks/unit_tests/testdata/flakes_9.yaml
+++ b/tasks/unit_tests/testdata/flakes_9.yaml
@@ -1,0 +1,1 @@
+on-log: "panic.*toto"

--- a/tasks/unit_tests/testwasher_tests.py
+++ b/tasks/unit_tests/testwasher_tests.py
@@ -116,7 +116,8 @@ class TestUtils(unittest.TestCase):
         )
         module_path = "tasks/unit_tests/testdata"
         _, marked_flaky_tests = test_washer.parse_test_results(module_path)
-        self.assertEqual(marked_flaky_tests, {})
+        flaky_tests = test_washer.merge_known_flakes(marked_flaky_tests)
+        self.assertEqual(flaky_tests, {})
 
     def test_flaky_on_log2(self):
         test_washer = TestWasher(
@@ -125,8 +126,9 @@ class TestUtils(unittest.TestCase):
         )
         module_path = "tasks/unit_tests/testdata"
         _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        flaky_tests = test_washer.merge_known_flakes(marked_flaky_tests)
         self.assertEqual(
-            marked_flaky_tests,
+            flaky_tests,
             {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
         )
 
@@ -137,8 +139,9 @@ class TestUtils(unittest.TestCase):
         )
         module_path = "tasks/unit_tests/testdata"
         _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        flaky_tests = test_washer.merge_known_flakes(marked_flaky_tests)
         self.assertEqual(
-            marked_flaky_tests,
+            flaky_tests,
             {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
         )
 
@@ -149,8 +152,9 @@ class TestUtils(unittest.TestCase):
         )
         module_path = "tasks/unit_tests/testdata"
         _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        flaky_tests = test_washer.merge_known_flakes(marked_flaky_tests)
         self.assertEqual(
-            marked_flaky_tests,
+            flaky_tests,
             {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
         )
 
@@ -161,8 +165,9 @@ class TestUtils(unittest.TestCase):
         )
         module_path = "tasks/unit_tests/testdata"
         _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        flaky_tests = test_washer.merge_known_flakes(marked_flaky_tests)
         self.assertEqual(
-            marked_flaky_tests,
+            flaky_tests,
             {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
         )
 

--- a/tasks/unit_tests/testwasher_tests.py
+++ b/tasks/unit_tests/testwasher_tests.py
@@ -109,6 +109,63 @@ class TestUtils(unittest.TestCase):
         )
         self.assertEqual(non_flaky_failing_tests, {})
 
+    def test_flaky_on_log(self):
+        test_washer = TestWasher(
+            test_output_json_file="test_output_failure_panic.json",
+            flakes_file_path="tasks/unit_tests/testdata/flakes_5.yaml",
+        )
+        module_path = "tasks/unit_tests/testdata"
+        _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        self.assertEqual(marked_flaky_tests, {})
+
+    def test_flaky_on_log2(self):
+        test_washer = TestWasher(
+            test_output_json_file="test_output_failure_panic.json",
+            flakes_file_path="tasks/unit_tests/testdata/flakes_6.yaml",
+        )
+        module_path = "tasks/unit_tests/testdata"
+        _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        self.assertEqual(
+            marked_flaky_tests,
+            {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
+        )
+
+    def test_flaky_on_log3(self):
+        test_washer = TestWasher(
+            test_output_json_file="test_output_failure_panic.json",
+            flakes_file_path="tasks/unit_tests/testdata/flakes_7.yaml",
+        )
+        module_path = "tasks/unit_tests/testdata"
+        _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        self.assertEqual(
+            marked_flaky_tests,
+            {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
+        )
+
+    def test_flaky_on_log4(self):
+        test_washer = TestWasher(
+            test_output_json_file="test_output_failure_panic.json",
+            flakes_file_path="tasks/unit_tests/testdata/flakes_8.yaml",
+        )
+        module_path = "tasks/unit_tests/testdata"
+        _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        self.assertEqual(
+            marked_flaky_tests,
+            {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
+        )
+
+    def test_flaky_on_log5(self):
+        test_washer = TestWasher(
+            test_output_json_file="test_output_failure_panic.json",
+            flakes_file_path="tasks/unit_tests/testdata/flakes_9.yaml",
+        )
+        module_path = "tasks/unit_tests/testdata"
+        _, marked_flaky_tests = test_washer.parse_test_results(module_path)
+        self.assertEqual(
+            marked_flaky_tests,
+            {'github.com/DataDog/datadog-agent/pkg/serverless/trace': {'TestLoadConfigShouldBeFast'}},
+        )
+
 
 class TestMergeKnownFlakes(unittest.TestCase):
     def test_with_shared_keys(self):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

> [!NOTE]
> Please see this [RFC](https://docs.google.com/document/d/1BkJJOhFkKW4YLCPzUjUfBhngIDnmGhvmuytJRvu3o0k/edit?usp=sharing) for details.

RFC implementation regarding the flakes.yaml modification. Now we can specify `on-log` for tests to be able to mark them as flaky only when a pattern is found within the log.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->