### PR TITLE
Remove manual trigger of Go mod tidy Action

### DIFF
--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -3,16 +3,10 @@ on:
   pull_request:
     types:
       - labeled
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number"
-        required: true
-        type: number
 
 jobs:
   mod_tidy_and_generate_licenses:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go')) }}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,13 +14,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
-      - name: Checkout PR
-        # run only if triggered manually, otherwise we are already on the right branch and we won't have `pr_number`
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: gh pr checkout "$PR_NUMBER"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
       - name: Install go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
@@ -41,12 +28,12 @@ jobs:
       - name: Go mod tidy
         run: inv -e tidy
       - name: Update LICENSE-3rdparty.csv
-        if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
         run: |
           inv -e install-tools
           inv -e generate-licenses
       - name: Update mocks
-        if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
         run: inv -e security-agent.gen-mocks # generate both security agent and process mocks
       - uses: stefanzweifel/git-auto-commit-action@8621497c8c39c72f3e2a999a26b4ca1b5058a842 # v5.0.1
         id: autocommit

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   mod_tidy_and_generate_licenses:
-    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   mod_tidy_and_generate_licenses:
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
+    if: ${{ github.repository == 'DataDog/datadog-agent' && github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Disable manual trigger that is almost not used and eventually vulnerable

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->