### PR TITLE
[CWS] Do not pre-allocate active_flows

### DIFF
--- a/pkg/ebpf/c/map-defs.h
+++ b/pkg/ebpf/c/map-defs.h
@@ -34,6 +34,9 @@
 #define BPF_HASH_MAP(name, key_type, value_type, max_entries) \
     BPF_MAP(name, BPF_MAP_TYPE_HASH, key_type, value_type, max_entries, 0, 0, INCLUDE_KEY_TYPE)
 
+#define BPF_HASH_MAP_FLAGS(name, key_type, value_type, max_entries, map_flags) \
+    BPF_MAP(name, BPF_MAP_TYPE_HASH, key_type, value_type, max_entries, 0, map_flags, INCLUDE_KEY_TYPE)
+
 #define BPF_PROG_ARRAY(name, max_entries) \
     BPF_MAP(name, BPF_MAP_TYPE_PROG_ARRAY, u32, u32, max_entries, 0, 0, INCLUDE_KEY_TYPE)
 

--- a/pkg/security/ebpf/c/include/hooks/network/flow.h
+++ b/pkg/security/ebpf/c/include/hooks/network/flow.h
@@ -332,18 +332,21 @@ int hook_inet_bind(ctx_t *ctx) {
 
 HOOK_EXIT("inet_bind")
 int rethook_inet_bind(ctx_t *ctx) {
-    int ret = CTX_PARMRET(ctx);
-    if (ret < 0) {
-        // we only care about successful bind operations
-        return 0;
-    }
-
     // fetch inet_bind arguments
     u64 id = bpf_get_current_pid_tgid();
     u32 tid = (u32)id;
     struct inet_bind_args_t *args = bpf_map_lookup_elem(&inet_bind_args, &id);
     if (args == NULL) {
         // should never happen, ignore
+        return 0;
+    }
+
+    // delete the entry in inet_bind_args to make sure we always cleanup inet_bind_args and we don't leak entries
+    bpf_map_delete_elem(&inet_bind_args, &id);
+
+    int ret = CTX_PARMRET(ctx);
+    if (ret < 0) {
+        // we only care about successful bind operations
         return 0;
     }
 

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -50,6 +50,9 @@ BPF_HASH_MAP(auid_approvers, u32, struct event_mask_filter_t, 128)
 BPF_HASH_MAP(auid_range_approvers, u32, struct u32_range_filter_t, EVENT_MAX)
 BPF_HASH_MAP(active_flows_spin_locks, u32, struct active_flows_spin_lock_t, 1) // max entry will be overridden at runtime
 
+BPF_HASH_MAP_FLAGS(active_flows, u32, struct active_flows_t, 1, BPF_F_NO_PREALLOC) // max entry will be overridden at runtime
+BPF_HASH_MAP_FLAGS(inet_bind_args, u64, struct inet_bind_args_t, 1, BPF_F_NO_PREALLOC) // max entries will be overridden at runtime
+
 BPF_LRU_MAP(activity_dump_rate_limiters, u64, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(rate_limiters, u32, struct rate_limiter_ctx, 1) // max entries will be overridden at runtime
 BPF_LRU_MAP(mount_ref, u32, struct mount_ref_t, 64000)
@@ -76,8 +79,6 @@ BPF_LRU_MAP(kill_list, u32, u32, 32)
 BPF_LRU_MAP(user_sessions, struct user_session_key_t, struct user_session_t, 1024)
 BPF_LRU_MAP(dentry_resolver_inputs, u64, struct dentry_resolver_input_t, 256)
 BPF_LRU_MAP(ns_flow_to_network_stats, struct namespaced_flow_t, struct network_stats_t, 4096) // TODO: size should be updated dynamically with "nf_conntrack_max"
-BPF_LRU_MAP(active_flows, u32, struct active_flows_t, 1) // max entries will be overridden at runtime
-BPF_LRU_MAP(inet_bind_args, u64, struct inet_bind_args_t, 1) // max entries will be overridden at runtime
 
 BPF_LRU_MAP_FLAGS(tasks_in_coredump, u64, u8, 64, BPF_F_NO_COMMON_LRU)
 BPF_LRU_MAP_FLAGS(syscalls, u64, struct syscall_cache_t, 1, BPF_F_NO_COMMON_LRU) // max entries will be overridden at runtime

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -333,7 +333,7 @@ func (k *Version) HaveRingBuffers() bool {
 // HasNoPreallocMapsInPerfEvent returns true if the kernel supports using non-preallocated maps in perf_event programs
 // See https://github.com/torvalds/linux/commit/274052a2b0ab9f380ce22b19ff80a99b99ecb198
 func (k *Version) HasNoPreallocMapsInPerfEvent() bool {
-	return k.Code != 0 && k.Code >= Kernel6_1
+	return k.Code >= Kernel6_1
 }
 
 // HasSKStorage returns true if the kernel supports SK_STORAGE maps

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -330,6 +330,12 @@ func (k *Version) HaveRingBuffers() bool {
 	return features.HaveMapType(ebpf.RingBuf) == nil
 }
 
+// HasNoPreallocMapsInPerfEvent returns true if the kernel supports using non-preallocated maps in perf_event programs
+// See https://github.com/torvalds/linux/commit/274052a2b0ab9f380ce22b19ff80a99b99ecb198
+func (k *Version) HasNoPreallocMapsInPerfEvent() bool {
+	return k.Code != 0 && k.Code >= Kernel6_1
+}
+
 // HasSKStorage returns true if the kernel supports SK_STORAGE maps
 // See https://github.com/torvalds/linux/commit/6ac99e8f23d4b10258406ca0dd7bffca5f31da9d
 func (k *Version) HasSKStorage() bool {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -144,6 +144,14 @@ func AllSKStorageMaps() []string {
 	}
 }
 
+// AllNoPreallocMapsInPerfEventPrograms returns the list of maps with the BPF_F_NO_PREALLOC flag that are used in
+// perf_event programs
+func AllNoPreallocMapsInPerfEventPrograms() []string {
+	return []string{
+		"active_flows",
+	}
+}
+
 // AllBPFForEachMapElemProgramFunctions returns the list of programs that leverage the bpf_for_each_map_elem helper
 func AllBPFForEachMapElemProgramFunctions() []string {
 	return []string{

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2254,6 +2254,19 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 		}
 	}
 
+	if !p.kernelVersion.HasNoPreallocMapsInPerfEvent() {
+		// Edit maps used in perf_event programs with BPF_F_NO_PREALLOC flag so that they are pre-allocated
+		if p.managerOptions.MapSpecEditors == nil {
+			p.managerOptions.MapSpecEditors = make(map[string]manager.MapSpecEditor, len(probes.AllSKStorageMaps()))
+		}
+		for _, noPreallocMapName := range probes.AllNoPreallocMapsInPerfEventPrograms() {
+			p.managerOptions.MapSpecEditors[noPreallocMapName] = manager.MapSpecEditor{
+				Flags:      unix.BPF_ANY,
+				EditorFlag: manager.EditFlags,
+			}
+		}
+	}
+
 	if p.useFentry {
 		afBasedExcluder, err := newAvailableFunctionsBasedExcluder()
 		if err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `active_flows` map was introduced in https://github.com/DataDog/datadog-agent/pull/32350 to track the list of active flows per process. This map was initially an LRU hashmap, which means that all its entries were pre-allocated on map creation. This PR changes the map type to a normal hashmap with the `BPF_F_NO_PREALLOC` flag to make sure it isn't preallocated.

### Motivation

Pre-allocating the `active_flows` map is completely overkill for the use case and uses too much memory. Note that:
- there cannot be more entries than the count of running processes on the machine
- entries are automatically flushed every 10 secondes

### Note

We're still exploring how to make this feature work in staging, it is disabled by default for now. This is an iterative improvement, not the final fix for "how to use a huge map in prod".