### PR TITLE
wmeta: Add architecture and compute capability to GPU entity

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -89,6 +89,16 @@ func (c *collector) Pull(_ context.Context) error {
 			return fmt.Errorf("failed to get device name for index %d: %v", i, nvml.ErrorString(ret))
 		}
 
+		arch, ret := dev.GetArchitecture()
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to get architecture for device index %d: %v", i, nvml.ErrorString(ret))
+		}
+
+		major, minor, ret := dev.GetCudaComputeCapability()
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to get CUDA compute capability for device index %d: %v", i, nvml.ErrorString(ret))
+		}
+
 		gpu := &workloadmeta.GPU{
 			EntityID: workloadmeta.EntityID{
 				Kind: workloadmeta.KindGPU,
@@ -97,9 +107,14 @@ func (c *collector) Pull(_ context.Context) error {
 			EntityMeta: workloadmeta.EntityMeta{
 				Name: name,
 			},
-			Vendor: nvidiaVendor,
-			Device: name,
-			Index:  i,
+			Vendor:       nvidiaVendor,
+			Device:       name,
+			Index:        i,
+			Architecture: gpuArchToString(arch),
+			ComputeCapability: workloadmeta.GPUComputeCapability{
+				Major: major,
+				Minor: minor,
+			},
 		}
 
 		event := workloadmeta.CollectorEvent{
@@ -121,4 +136,31 @@ func (c *collector) GetID() string {
 
 func (c *collector) GetTargetCatalog() workloadmeta.AgentType {
 	return c.catalog
+}
+
+func gpuArchToString(nvmlArch nvml.DeviceArchitecture) string {
+	switch nvmlArch {
+	case nvml.DEVICE_ARCH_KEPLER:
+		return "kepler"
+	case nvml.DEVICE_ARCH_PASCAL:
+		return "pascal"
+	case nvml.DEVICE_ARCH_VOLTA:
+		return "volta"
+	case nvml.DEVICE_ARCH_TURING:
+		return "turing"
+	case nvml.DEVICE_ARCH_AMPERE:
+		return "ampere"
+	case nvml.DEVICE_ARCH_ADA:
+		return "ada"
+	case nvml.DEVICE_ARCH_HOPPER:
+		return "hopper"
+	case nvml.DEVICE_ARCH_UNKNOWN:
+		return "unknown"
+	default:
+		// Distinguish invalid and unknown, NVML can return unknown but we should always
+		// be able to process the return value of NVML. If we reach this part, we forgot
+		// to add a new case for a new architecture.
+		return "invalid"
+	}
+
 }

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -99,6 +99,11 @@ func (c *collector) Pull(_ context.Context) error {
 			return fmt.Errorf("failed to get CUDA compute capability for device index %d: %v", i, nvml.ErrorString(ret))
 		}
 
+		devAttr, ret := dev.GetAttributes()
+		if ret != nvml.SUCCESS {
+			return fmt.Errorf("failed to get device attributes for device index %d: %v", i, nvml.ErrorString(ret))
+		}
+
 		gpu := &workloadmeta.GPU{
 			EntityID: workloadmeta.EntityID{
 				Kind: workloadmeta.KindGPU,
@@ -115,6 +120,7 @@ func (c *collector) Pull(_ context.Context) error {
 				Major: major,
 				Minor: minor,
 			},
+			SMCount: int(devAttr.MultiprocessorCount),
 		}
 
 		event := workloadmeta.CollectorEvent{

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -44,7 +44,7 @@ func TestPull(t *testing.T) {
 		require.Equal(t, "hopper", gpu.Architecture)
 		require.Equal(t, testutil.DefaultGPUComputeCapMajor, gpu.ComputeCapability.Major)
 		require.Equal(t, testutil.DefaultGPUComputeCapMinor, gpu.ComputeCapability.Minor)
-		require.Equal(t, testutil.DefaultGPUAttributes.MultiprocessorCount, gpu.SMCount)
+		require.Equal(t, int(testutil.DefaultGPUAttributes.MultiprocessorCount), gpu.SMCount)
 	}
 
 	for _, uuid := range testutil.GPUUUIDs {

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -47,5 +48,22 @@ func TestPull(t *testing.T) {
 
 	for _, uuid := range testutil.GPUUUIDs {
 		require.True(t, foundIDs[uuid], "GPU with UUID %s not found", uuid)
+	}
+}
+
+func TestGpuArchToString(t *testing.T) {
+	tests := []struct {
+		arch     nvml.DeviceArchitecture
+		expected string
+	}{
+		{nvml.DEVICE_ARCH_KEPLER, "kepler"},
+		{nvml.DEVICE_ARCH_UNKNOWN, "unknown"},
+		{nvml.DeviceArchitecture(3751), "invalid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			require.Equal(t, tt.expected, gpuArchToString(tt.arch))
+		})
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -40,6 +40,9 @@ func TestPull(t *testing.T) {
 		require.Equal(t, nvidiaVendor, gpu.Vendor)
 		require.Equal(t, testutil.DefaultGPUName, gpu.Name)
 		require.Equal(t, testutil.DefaultGPUName, gpu.Device)
+		require.Equal(t, "hopper", gpu.Architecture)
+		require.Equal(t, testutil.DefaultGPUComputeCapMajor, gpu.ComputeCapability.Major)
+		require.Equal(t, testutil.DefaultGPUComputeCapMinor, gpu.ComputeCapability.Minor)
 	}
 
 	for _, uuid := range testutil.GPUUUIDs {

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -44,6 +44,7 @@ func TestPull(t *testing.T) {
 		require.Equal(t, "hopper", gpu.Architecture)
 		require.Equal(t, testutil.DefaultGPUComputeCapMajor, gpu.ComputeCapability.Major)
 		require.Equal(t, testutil.DefaultGPUComputeCapMinor, gpu.ComputeCapability.Minor)
+		require.Equal(t, testutil.DefaultGPUAttributes.MultiprocessorCount, gpu.SMCount)
 	}
 
 	for _, uuid := range testutil.GPUUUIDs {

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1377,6 +1377,9 @@ type GPU struct {
 
 	// ComputeCapability contains the compute capability version of the GPU.
 	ComputeCapability GPUComputeCapability
+
+	// SMCount is the number of streaming multiprocessors in the GPU.
+	SMCount int
 }
 
 var _ Entity = &GPU{}
@@ -1423,6 +1426,7 @@ func (g GPU) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Index:", g.Index)
 	_, _ = fmt.Fprintln(&sb, "Architecture:", g.Architecture)
 	_, _ = fmt.Fprintln(&sb, "Compute Capability:", g.ComputeCapability)
+	_, _ = fmt.Fprintln(&sb, "Streaming Multiprocessor Count:", g.SMCount)
 
 	return sb.String()
 }

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1372,13 +1372,13 @@ type GPU struct {
 	// of containers.
 	Index int
 
-	// Architecture contains the architecture of the GPU (e.g., Pascal, Volta, etc.)
+	// Architecture contains the architecture of the GPU (e.g., Pascal, Volta, etc.). Optional, can be empty.
 	Architecture string
 
-	// ComputeCapability contains the compute capability version of the GPU.
+	// ComputeCapability contains the compute capability version of the GPU. Optional, can be 0/0
 	ComputeCapability GPUComputeCapability
 
-	// SMCount is the number of streaming multiprocessors in the GPU.
+	// SMCount is the number of streaming multiprocessors in the GPU. Optional, can be empty.
 	SMCount int
 }
 

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1371,6 +1371,12 @@ type GPU struct {
 	// is not guaranteed to be stable across reboots, nor is necessarily the same inside
 	// of containers.
 	Index int
+
+	// Architecture contains the architecture of the GPU (e.g., Pascal, Volta, etc.)
+	Architecture string
+
+	// ComputeCapability contains the compute capability version of the GPU.
+	ComputeCapability GPUComputeCapability
 }
 
 var _ Entity = &GPU{}
@@ -1415,6 +1421,21 @@ func (g GPU) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Device:", g.Device)
 	_, _ = fmt.Fprintln(&sb, "Active PIDs:", g.ActivePIDs)
 	_, _ = fmt.Fprintln(&sb, "Index:", g.Index)
+	_, _ = fmt.Fprintln(&sb, "Architecture:", g.Architecture)
+	_, _ = fmt.Fprintln(&sb, "Compute Capability:", g.ComputeCapability)
 
 	return sb.String()
+}
+
+// GPUComputeCapability represents the compute capability version of a GPU.
+type GPUComputeCapability struct {
+	// Major represents the major version of the compute capability.
+	Major int
+
+	// Minor represents the minor version of the compute capability.
+	Minor int
+}
+
+func (gcc GPUComputeCapability) String() string {
+	return fmt.Sprintf("%d.%d", gcc.Major, gcc.Minor)
 }

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -48,6 +48,15 @@ var DefaultGpuUUID = GPUUUIDs[0]
 // DefaultGPUName is the name for the default device returned by the mock
 var DefaultGPUName = "Tesla T4"
 
+// DefaultGPUComputeCapMajor is the major number for the compute capabilities for the default device returned by the mock
+var DefaultGPUComputeCapMajor = 7
+
+// DefaultGPUComputeCapMinor is the minor number for the compute capabilities for the default device returned by the mock
+var DefaultGPUComputeCapMinor = 5
+
+// DefaultGPUArch is the architecture for the default device returned by the mock
+var DefaultGPUArch = nvml.DeviceArchitecture(nvml.DEVICE_ARCH_HOPPER)
+
 // GetDeviceMock returns a mock of the nvml.Device with the given UUID.
 func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 	return &nvmlmock.Device{
@@ -62,6 +71,9 @@ func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 		},
 		GetNameFunc: func() (string, nvml.Return) {
 			return DefaultGPUName, nvml.SUCCESS
+		},
+		GetArchitectureFunc: func() (nvml.DeviceArchitecture, nvml.Return) {
+			return DefaultGPUArch, nvml.SUCCESS
 		},
 	}
 }

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -57,6 +57,10 @@ var DefaultGPUComputeCapMinor = 5
 // DefaultGPUArch is the architecture for the default device returned by the mock
 var DefaultGPUArch = nvml.DeviceArchitecture(nvml.DEVICE_ARCH_HOPPER)
 
+var DefaultGPUAttributes = nvml.DeviceAttributes{
+	MultiprocessorCount: 10,
+}
+
 // GetDeviceMock returns a mock of the nvml.Device with the given UUID.
 func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 	return &nvmlmock.Device{
@@ -75,6 +79,9 @@ func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 		GetArchitectureFunc: func() (nvml.DeviceArchitecture, nvml.Return) {
 			return DefaultGPUArch, nvml.SUCCESS
 		},
+		GetAttributesFunc: func() (nvml.DeviceAttributes, nvml.Return) {
+			return DefaultGPUAttributes, nvml.SUCCESS
+		}
 	}
 }
 

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -81,7 +81,7 @@ func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 		},
 		GetAttributesFunc: func() (nvml.DeviceAttributes, nvml.Return) {
 			return DefaultGPUAttributes, nvml.SUCCESS
-		}
+		},
 	}
 }
 

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -57,6 +57,7 @@ var DefaultGPUComputeCapMinor = 5
 // DefaultGPUArch is the architecture for the default device returned by the mock
 var DefaultGPUArch = nvml.DeviceArchitecture(nvml.DEVICE_ARCH_HOPPER)
 
+// DefaultGPUAttributes is the attributes for the default device returned by the mock
 var DefaultGPUAttributes = nvml.DeviceAttributes{
 	MultiprocessorCount: 10,
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds both the GPU architecture and the compute capability to the workloadmeta GPU entity.

### Motivation

Storing extra data to be used in the tagger and other parts of the code using GPUs.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests include the new function, validated also with a `workload-list` query in a node with GPUs.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->