### PR TITLE
[CWS] switch testOpts compare to reflect.DeepEqual

### DIFF
--- a/pkg/security/tests/testopts.go
+++ b/pkg/security/tests/testopts.go
@@ -10,7 +10,6 @@ package tests
 
 import (
 	"reflect"
-	"slices"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
@@ -111,57 +110,5 @@ func withForceReload() optFunc {
 }
 
 func (to testOpts) Equal(opts testOpts) bool {
-	return to.disableApprovers == opts.disableApprovers &&
-		to.disableEnvVarsResolution == opts.disableEnvVarsResolution &&
-		to.enableActivityDump == opts.enableActivityDump &&
-		to.activityDumpRateLimiter == opts.activityDumpRateLimiter &&
-		to.activityDumpTagRules == opts.activityDumpTagRules &&
-		to.activityDumpDuration == opts.activityDumpDuration &&
-		to.activityDumpLoadControllerPeriod == opts.activityDumpLoadControllerPeriod &&
-		to.activityDumpTracedCgroupsCount == opts.activityDumpTracedCgroupsCount &&
-		to.activityDumpCgroupDifferentiateArgs == opts.activityDumpCgroupDifferentiateArgs &&
-		to.activityDumpAutoSuppressionEnabled == opts.activityDumpAutoSuppressionEnabled &&
-		to.activityDumpLoadControllerTimeout == opts.activityDumpLoadControllerTimeout &&
-		to.activityDumpSyscallMonitorPeriod == opts.activityDumpSyscallMonitorPeriod &&
-		reflect.DeepEqual(to.activityDumpTracedEventTypes, opts.activityDumpTracedEventTypes) &&
-		to.activityDumpLocalStorageDirectory == opts.activityDumpLocalStorageDirectory &&
-		to.activityDumpLocalStorageCompression == opts.activityDumpLocalStorageCompression &&
-		reflect.DeepEqual(to.activityDumpLocalStorageFormats, opts.activityDumpLocalStorageFormats) &&
-		to.enableSecurityProfile == opts.enableSecurityProfile &&
-		to.securityProfileMaxImageTags == opts.securityProfileMaxImageTags &&
-		to.securityProfileDir == opts.securityProfileDir &&
-		to.securityProfileWatchDir == opts.securityProfileWatchDir &&
-		to.enableAutoSuppression == opts.enableAutoSuppression &&
-		slices.Equal(to.autoSuppressionEventTypes, opts.autoSuppressionEventTypes) &&
-		to.enableAnomalyDetection == opts.enableAnomalyDetection &&
-		slices.Equal(to.anomalyDetectionEventTypes, opts.anomalyDetectionEventTypes) &&
-		to.anomalyDetectionDefaultMinimumStablePeriod == opts.anomalyDetectionDefaultMinimumStablePeriod &&
-		to.anomalyDetectionMinimumStablePeriodExec == opts.anomalyDetectionMinimumStablePeriodExec &&
-		to.anomalyDetectionMinimumStablePeriodDNS == opts.anomalyDetectionMinimumStablePeriodDNS &&
-		to.anomalyDetectionWarmupPeriod == opts.anomalyDetectionWarmupPeriod &&
-		to.disableDiscarders == opts.disableDiscarders &&
-		to.disableFilters == opts.disableFilters &&
-		to.disableERPCDentryResolution == opts.disableERPCDentryResolution &&
-		to.disableMapDentryResolution == opts.disableMapDentryResolution &&
-		reflect.DeepEqual(to.envsWithValue, opts.envsWithValue) &&
-		to.disableRuntimeSecurity == opts.disableRuntimeSecurity &&
-		to.enableSBOM == opts.enableSBOM &&
-		to.enableHostSBOM == opts.enableHostSBOM &&
-		to.snapshotRuleMatchHandler == nil && opts.snapshotRuleMatchHandler == nil &&
-		to.preStartCallback == nil && opts.preStartCallback == nil &&
-		to.networkIngressEnabled == opts.networkIngressEnabled &&
-		to.networkRawPacketEnabled == opts.networkRawPacketEnabled &&
-		to.disableOnDemandRateLimiter == opts.disableOnDemandRateLimiter &&
-		to.ebpfLessEnabled == opts.ebpfLessEnabled &&
-		to.enforcementExcludeBinary == opts.enforcementExcludeBinary &&
-		to.enforcementDisarmerContainerEnabled == opts.enforcementDisarmerContainerEnabled &&
-		to.enforcementDisarmerContainerMaxAllowed == opts.enforcementDisarmerContainerMaxAllowed &&
-		to.enforcementDisarmerContainerPeriod == opts.enforcementDisarmerContainerPeriod &&
-		to.enforcementDisarmerExecutableEnabled == opts.enforcementDisarmerExecutableEnabled &&
-		to.enforcementDisarmerExecutableMaxAllowed == opts.enforcementDisarmerExecutableMaxAllowed &&
-		to.enforcementDisarmerExecutablePeriod == opts.enforcementDisarmerExecutablePeriod &&
-		to.eventServerRetention == opts.eventServerRetention &&
-		to.discardRuntime == opts.discardRuntime &&
-		to.networkFlowMonitorEnabled == opts.networkFlowMonitorEnabled &&
-		to.enableSelfTests == opts.enableSelfTests
+	return reflect.DeepEqual(to, opts)
 }


### PR DESCRIPTION
### What does this PR do?

We currently implement this manually which is error prone, let's switch to the stdlib function instead.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->