### PR TITLE
Add config option to disable cache hit miss metrics

### DIFF
--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -638,6 +638,7 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.True(t, o.CreditCards.Luhn)
 	assert.True(t, o.Cache.Enabled)
 	assert.Equal(t, int64(5555555), o.Cache.MaxSize)
+	assert.True(t, o.Cache.Metrics)
 
 	assert.True(t, cfg.InstallSignature.Found)
 	assert.Equal(t, traceconfig.InstallSignatureConfig{
@@ -1799,6 +1800,20 @@ func TestLoadEnv(t *testing.T) {
 		actualParsed := cfg.Obfuscation.Cache.MaxSize
 		assert.Equal(t, "1234567", actualConfig)
 		assert.Equal(t, int64(1234567), actualParsed)
+	})
+
+	env = "DD_APM_OBFUSCATION_CACHE_METRICS"
+	t.Run(env, func(t *testing.T) {
+		t.Setenv(env, "false")
+
+		c := buildConfigComponent(t, true, fx.Replace(corecomp.MockParams{
+			Params: corecomp.Params{ConfFilePath: "./testdata/full.yaml"},
+		}))
+		cfg := c.Object()
+
+		assert.NotNil(t, cfg)
+		assert.False(t, pkgconfigsetup.Datadog().GetBool("apm_config.obfuscation.cache.metrics"))
+		assert.False(t, cfg.Obfuscation.Cache.Metrics)
 	})
 
 	env = "DD_APM_PROFILING_ADDITIONAL_ENDPOINTS"

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -446,6 +446,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	c.Obfuscation.CreditCards.KeepValues = pkgconfigsetup.Datadog().GetStringSlice("apm_config.obfuscation.credit_cards.keep_values")
 	c.Obfuscation.Cache.Enabled = pkgconfigsetup.Datadog().GetBool("apm_config.obfuscation.cache.enabled")
 	c.Obfuscation.Cache.MaxSize = pkgconfigsetup.Datadog().GetInt64("apm_config.obfuscation.cache.max_size")
+	c.Obfuscation.Cache.Metrics = pkgconfigsetup.Datadog().GetBool("apm_config.obfuscation.cache.metrics")
 
 	if core.IsSet("apm_config.filter_tags.require") {
 		tags := core.GetStringSlice("apm_config.filter_tags.require")

--- a/comp/trace/config/testdata/full.yaml
+++ b/comp/trace/config/testdata/full.yaml
@@ -93,3 +93,4 @@ apm_config:
     cache:
       enabled: true
       max_size: 5555555
+      metrics: true

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -45,6 +45,7 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.obfuscation.memcached.keep_command", false, "DD_APM_OBFUSCATION_MEMCACHED_KEEP_COMMAND")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.cache.enabled", true, "DD_APM_OBFUSCATION_CACHE_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.obfuscation.cache.max_size", 5000000, "DD_APM_OBFUSCATION_CACHE_MAX_SIZE")
+	config.BindEnvAndSetDefault("apm_config.obfuscation.cache.metrics", true, "DD_APM_OBFUSCATION_CACHE_METRICS")
 	config.SetKnown("apm_config.filter_tags.require")
 	config.SetKnown("apm_config.filter_tags.reject")
 	config.SetKnown("apm_config.filter_tags_regex.require")

--- a/pkg/obfuscate/cache.go
+++ b/pkg/obfuscate/cache.go
@@ -54,6 +54,7 @@ type cacheOptions struct {
 	On      bool
 	Statsd  StatsClient
 	MaxSize int64
+	Metrics bool
 }
 
 // newMeasuredCache returns a new measuredCache.
@@ -68,8 +69,8 @@ func newMeasuredCache(opts cacheOptions) *measuredCache {
 		// that can be stored is calculated as opts.MaxSize / 10.
 		// Multiplying this maximum number by 10 (opts.MaxSize / 10 * 10) as per the ristretto documentation.
 		NumCounters: opts.MaxSize,
-		BufferItems: 64,   // default recommended value
-		Metrics:     true, // enable hit/miss counters
+		BufferItems: 64,           // default recommended value
+		Metrics:     opts.Metrics, // enable hit/miss counters
 	}
 	cache, err := ristretto.NewCache(cfg)
 	if err != nil {

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -280,6 +280,9 @@ type CacheConfig struct {
 
 	// MaxSize is the maximum size of the cache in bytes.
 	MaxSize int64 `mapstructure:"max_size"`
+
+	// Metrics specifies whether to emit hit/miss metrics for the cache.
+	Metrics bool `mapstructure:"metrics"`
 }
 
 // NewObfuscator creates a new obfuscator
@@ -289,7 +292,7 @@ func NewObfuscator(cfg Config) *Obfuscator {
 	}
 	o := Obfuscator{
 		opts:              &cfg,
-		queryCache:        newMeasuredCache(cacheOptions{On: cfg.Cache.Enabled, Statsd: cfg.Statsd, MaxSize: cfg.Cache.MaxSize}),
+		queryCache:        newMeasuredCache(cacheOptions{On: cfg.Cache.Enabled, Statsd: cfg.Statsd, MaxSize: cfg.Cache.MaxSize, Metrics: cfg.Cache.Metrics}),
 		sqlLiteralEscapes: atomic.NewBool(false),
 		log:               cfg.Logger,
 	}

--- a/releasenotes/notes/obfuscate-cache-metrics-option-to-disable-1167a979541ecc63.yaml
+++ b/releasenotes/notes/obfuscate-cache-metrics-option-to-disable-1167a979541ecc63.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add config option `apm.obfuscation.cache.metrics` to enable or disable obfuscation cache hit miss metrics. This option is enabled by default.

--- a/releasenotes/notes/obfuscate-cache-metrics-option-to-disable-1167a979541ecc63.yaml
+++ b/releasenotes/notes/obfuscate-cache-metrics-option-to-disable-1167a979541ecc63.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add config option `apm.obfuscation.cache.metrics` to enable or disable obfuscation cache hit miss metrics. This option is enabled by default.
+    Add config option `apm_config.obfuscation.cache.metrics` to enable or disable obfuscation cache hit miss metrics. This option is enabled by default.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds config option `apm_config.obfuscation.cache.metrics` to enable or disable obfuscation cache hit miss metrics. This option is enabled by default.

### Motivation
Enabling cache statistics metrics comes with performance [overhead](https://github.com/outcaste-io/ristretto/blob/v0.2.3/cache.go#L109-L113). The option allows user to disable the cache hit/miss metrics. 
From a simple performance comparison, metrics on vs. off has small CPU difference. RSS memory usage is almost identical.
<img width="1841" alt="image" src="https://github.com/user-attachments/assets/cc30c2c4-c215-44a9-b70e-5f48b2a8bdbf" />
<img width="1856" alt="image" src="https://github.com/user-attachments/assets/0f185e7c-3cb2-4e12-a48c-ec23b7cddf1a" />

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->