### PR TITLE
remove kmod BTF load func

### DIFF
--- a/pkg/ebpf/btf.go
+++ b/pkg/ebpf/btf.go
@@ -86,11 +86,8 @@ func FlushBTF() {
 	}
 }
 
-type kernelModuleBTFLoadFunc func(string) (*btf.Spec, error)
-
 type returnBTF struct {
-	vmlinux        *btf.Spec
-	moduleLoadFunc kernelModuleBTFLoadFunc
+	vmlinux *btf.Spec
 }
 
 type BTFResultMetadata struct { //nolint:revive // TODO
@@ -195,8 +192,7 @@ func (b *orderedBTFLoader) loadKernel() (*returnBTF, error) {
 	}
 	b.resultMetadata.filepathUsed = "<unknown, internal to cilium ebpf>"
 	return &returnBTF{
-		vmlinux:        spec,
-		moduleLoadFunc: nil,
+		vmlinux: spec,
 	}, nil
 }
 
@@ -210,8 +206,7 @@ func (b *orderedBTFLoader) loadUser() (*returnBTF, error) {
 	}
 	b.resultMetadata.filepathUsed = b.userBTFPath
 	return &returnBTF{
-		vmlinux:        spec,
-		moduleLoadFunc: nil,
+		vmlinux: spec,
 	}, nil
 }
 
@@ -226,19 +221,13 @@ func (b *orderedBTFLoader) checkForMinimizedBTF(extractDir string) (*returnBTF, 
 		}
 		b.resultMetadata.filepathUsed = extractedBtfPath
 		return &returnBTF{
-			vmlinux:        spec,
-			moduleLoadFunc: nil,
+			vmlinux: spec,
 		}, nil
 	}
 	return nil, nil
 }
 
 func (b *orderedBTFLoader) checkForUnminimizedBTF(extractDir string) (*returnBTF, error) {
-	absExtractDir := filepath.Join(b.embeddedDir, extractDir)
-	modLoadFunc := func(mod string) (*btf.Spec, error) {
-		b.delayedFlusher.Reset(btfFlushDelay)
-		return loadBTFFrom(filepath.Join(absExtractDir, mod))
-	}
 	btfRelativePath := filepath.Join(extractDir, "vmlinux")
 	extractedBtfPath := filepath.Join(b.embeddedDir, btfRelativePath)
 	if _, err := os.Stat(extractedBtfPath); err == nil {
@@ -248,8 +237,7 @@ func (b *orderedBTFLoader) checkForUnminimizedBTF(extractDir string) (*returnBTF
 		}
 		b.resultMetadata.filepathUsed = extractedBtfPath
 		return &returnBTF{
-			vmlinux:        spec,
-			moduleLoadFunc: modLoadFunc,
+			vmlinux: spec,
 		}, nil
 	}
 	return nil, nil

--- a/pkg/ebpf/co_re.go
+++ b/pkg/ebpf/co_re.go
@@ -76,7 +76,6 @@ func (c *coreAssetLoader) loadCOREAsset(filename string, startFn func(bytecode.A
 	defer buf.Close()
 
 	opts := manager.Options{
-		KernelModuleBTFLoadFunc: ret.moduleLoadFunc,
 		VerifierOptions: bpflib.CollectionOptions{
 			Programs: bpflib.ProgramOptions{
 				KernelTypes: ret.vmlinux,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes usage of `KernelModuleBTFLoadFunc`

### Motivation

We no longer deal with custom kernel module BTF that is separate from the kernel BTF. It is merged into a single file. The only kmod BTF in separate files is the default BTF exposed by newer kernels, which is handled by `cilium/ebpf` automatically.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Automated tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->