### PR TITLE
[CONTP-589] Add ztsd as a decompressor in DCA failover store

### DIFF
--- a/cmd/cluster-agent/api/v2/series/series.go
+++ b/cmd/cluster-agent/api/v2/series/series.go
@@ -18,12 +18,14 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/api"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/zstd"
 	"github.com/gorilla/mux"
 )
 
 const (
 	encodingGzip           = "gzip"
 	encodingDeflate        = "deflate"
+	encodingZstd           = "zstd"
 	loadMetricsHandlerName = "load-metrics-handler"
 )
 
@@ -69,6 +71,8 @@ func (h *seriesHandler) handle(w http.ResponseWriter, r *http.Request) {
 		rc, err = gzip.NewReader(r.Body)
 	case encodingDeflate:
 		rc, err = zlib.NewReader(r.Body)
+	case encodingZstd:
+		rc = zstd.NewReader(r.Body)
 	default:
 		rc = r.Body
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- An in-memory store has been added to DCA in https://github.com/DataDog/datadog-agent/pull/30562. 
- The store is to collect workload metrics from local cluster node agent. However the default compression method has been updated in 7.62 which is changed from zlib to ztsd. https://github.com/DataDog/datadog-agent/pull/32087
- This results in a series payload decompression failure on the DCA side. This PR introduces the ztsd method to align with the changes made in the node agent.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This feature is still in development. QA done locally. However a unit test should be added to prevent similar error happening again. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->