### PR TITLE
Prevent panic during the shutdown of the journald and windows event tailers

### DIFF
--- a/pkg/logs/tailers/journald/tailer.go
+++ b/pkg/logs/tailers/journald/tailer.go
@@ -193,6 +193,11 @@ func (t *Tailer) setup() error {
 }
 
 func (t *Tailer) forwardMessages() {
+	defer func() {
+		// the decoder has successfully been flushed
+		close(t.done)
+	}()
+
 	for decodedMessage := range t.decoder.OutputChan {
 		if len(decodedMessage.GetContent()) > 0 {
 			t.outputChan <- decodedMessage
@@ -250,7 +255,6 @@ func (t *Tailer) tail() {
 	defer func() {
 		t.journal.Close()
 		t.decoder.Stop()
-		t.done <- struct{}{}
 	}()
 	for {
 		select {

--- a/releasenotes/notes/panic-on-tailer-close-ee1ce3603e006428.yaml
+++ b/releasenotes/notes/panic-on-tailer-close-ee1ce3603e006428.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Fix potential panic in journald and windows event tailers during system shutdown
+    Fix potential panic in journald and Windows event tailers during system shutdown

--- a/releasenotes/notes/panic-on-tailer-close-ee1ce3603e006428.yaml
+++ b/releasenotes/notes/panic-on-tailer-close-ee1ce3603e006428.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix potential panic in journald and windows event tailers during system shutdown


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Both the journald and windows event tailer possess a forwarding routine, wherein they pull data from their decoder to a pipeline channel in a loop. On process teardown, these tailers don't wait for their forwarding routines to complete before signaling other agent processes to begin their own teardowns, leading the possibility of the forwarding routines panic-ing as they attempt to write to a closed pipeline channel.  
### Motivation

### Describe how you validated your changes
Sleeps placed in forwarding routine and the logs/processor's Stop function can reliably force the identified panic on shutdown. Introducing the new code results in a shutdown behavior as expected (no panics), with and without the sleeps.
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->