### PR TITLE
Update Regression Detector lading to 0.25.4

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.3
+  version: 0.25.4
 
 target:
 


### PR DESCRIPTION
Release notes here: https://github.com/DataDog/lading/releases/tag/v0.25.4
