### PR TITLE
Improve kept/seen metrics for trace sampler

### DIFF
--- a/pkg/trace/sampler/catalog_test.go
+++ b/pkg/trace/sampler/catalog_test.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -60,7 +61,7 @@ func TestNewServiceLookup(t *testing.T) {
 
 func TestServiceKeyCatalogRegister(t *testing.T) {
 	cat := newServiceLookup(0)
-	s := getTestPrioritySampler()
+	s := getTestPrioritySampler(&statsd.NoOpClient{})
 
 	_, root1 := getTestTraceWithService("service1", s)
 	sig1 := cat.register(ServiceSignature{root1.Service, defaultEnv})
@@ -168,7 +169,7 @@ func TestServiceKeyCatalogRatesByService(t *testing.T) {
 	assert := assert.New(t)
 
 	cat := newServiceLookup(0)
-	s := getTestPrioritySampler()
+	s := getTestPrioritySampler(&statsd.NoOpClient{})
 
 	_, root1 := getTestTraceWithService("service1", s)
 	sig1 := cat.register(ServiceSignature{root1.Service, defaultEnv})

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -52,9 +52,7 @@ type Sampler struct {
 	// extraRate is an extra raw sampling rate to apply on top of the sampler rate
 	extraRate float64
 
-	totalSeen float32
-	totalKept *atomic.Int64
-
+	metrics metrics
 	tags    []string
 	exit    chan struct{}
 	stopped chan struct{}
@@ -64,14 +62,14 @@ type Sampler struct {
 // newSampler returns an initialized Sampler
 func newSampler(extraRate float64, targetTPS float64, tags []string, statsd statsd.ClientInterface) *Sampler {
 	s := &Sampler{
-		seen: make(map[Signature][numBuckets]float32),
-
+		seen:      make(map[Signature][numBuckets]float32),
 		extraRate: extraRate,
 		targetTPS: atomic.NewFloat64(targetTPS),
 		tags:      tags,
-
-		totalKept: atomic.NewInt64(0),
-
+		metrics: metrics{
+			tags:   tags,
+			statsd: statsd,
+		},
 		exit:    make(chan struct{}),
 		stopped: make(chan struct{}),
 		statsd:  statsd,
@@ -140,7 +138,6 @@ func (s *Sampler) countWeightedSig(now time.Time, signature Signature, n float32
 	buckets[bucketID%numBuckets] += n
 	s.seen[signature] = buckets
 
-	s.totalSeen += n
 	s.muSeen.Unlock()
 	return updateRates
 }
@@ -248,11 +245,6 @@ func zeroAndGetMax(buckets [numBuckets]float32, previousBucket, newBucket int64)
 	return maxBucket, buckets
 }
 
-// countSample counts a trace sampled by the sampler.
-func (s *Sampler) countSample() {
-	s.totalKept.Inc()
-}
-
 // getSignatureSampleRate returns the sampling rate to apply to a signature
 func (s *Sampler) getSignatureSampleRate(sig Signature) float64 {
 	s.muRates.RLock()
@@ -311,14 +303,8 @@ func (s *Sampler) size() int64 {
 }
 
 func (s *Sampler) report() {
-	s.muSeen.Lock()
-	seen := int64(s.totalSeen)
-	s.totalSeen = 0
-	s.muSeen.Unlock()
-	kept := s.totalKept.Swap(0)
-	_ = s.statsd.Count("datadog.trace_agent.sampler.kept", kept, s.tags, 1)
-	_ = s.statsd.Count("datadog.trace_agent.sampler.seen", seen, s.tags, 1)
-	_ = s.statsd.Gauge("datadog.trace_agent.sampler.size", float64(s.size()), s.tags, 1)
+	s.metrics.report()
+	_ = s.statsd.Gauge(metricSamplerSize, float64(s.size()), s.tags, 1)
 }
 
 // Stop stops the main Run loop

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -69,6 +69,7 @@ func newSampler(extraRate float64, targetTPS float64, tags []string, statsd stat
 		metrics: metrics{
 			tags:   tags,
 			statsd: statsd,
+			value:  make(map[metricsKey]metricsValue),
 		},
 		exit:    make(chan struct{}),
 		stopped: make(chan struct{}),

--- a/pkg/trace/sampler/metrics.go
+++ b/pkg/trace/sampler/metrics.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package sampler
+
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-go/v5/statsd"
+)
+
+const (
+	metricSamplerSeen = "datadog.trace_agent.sampler.seen"
+	metricSamplerKept = "datadog.trace_agent.sampler.kept"
+	metricSamplerSize = "datadog.trace_agent.sampler.size"
+)
+
+type metrics struct {
+	statsd statsd.ClientInterface
+	tags   []string
+	value  sync.Map
+}
+
+type metricsKey [3]string
+
+func newMetricsKey(service, env string, samplingPriority *SamplingPriority) metricsKey {
+	var key metricsKey
+	if service != "" {
+		key[0] = "target_service:" + service
+	}
+	if env != "" {
+		key[1] = "target_env:" + env
+	}
+	if samplingPriority != nil {
+		key[2] = samplingPriority.tag()
+	}
+	return key
+}
+
+func (k metricsKey) tags() []string {
+	tags := make([]string, 0, len(k))
+	for _, v := range k {
+		if v != "" {
+			tags = append(tags, v)
+		}
+	}
+	return tags
+}
+
+type metricsValue struct {
+	seen int64
+	kept int64
+}
+
+func (m *metrics) record(sampled bool, metricsKey metricsKey) {
+	initialValue := metricsValue{seen: 1}
+	if sampled {
+		initialValue.kept = 1
+	}
+	if v, load := m.value.LoadOrStore(metricsKey, initialValue); load {
+		loadedMetricsValue := v.(metricsValue)
+		loadedMetricsValue.seen++
+		if sampled {
+			loadedMetricsValue.kept++
+		}
+		m.value.Store(metricsKey, loadedMetricsValue)
+	}
+}
+
+func (m *metrics) report() {
+	m.value.Range(func(key, value any) bool {
+		metricsKey := key.(metricsKey)
+		metricsValue := value.(metricsValue)
+		tags := append(m.tags, metricsKey.tags()...)
+		if metricsValue.seen > 0 {
+			_ = m.statsd.Count(metricSamplerSeen, metricsValue.seen, tags, 1)
+		}
+		if metricsValue.kept > 0 {
+			_ = m.statsd.Count(metricSamplerKept, metricsValue.kept, tags, 1)
+		}
+		m.value.Delete(metricsKey) // reset counters
+		return true
+	})
+}

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -13,6 +13,8 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-go/v5/statsd"
+	mockStatsd "github.com/DataDog/datadog-go/v5/statsd/mocks"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
 )
@@ -21,14 +23,14 @@ func randomTraceID() uint64 {
 	return uint64(rand.Int63())
 }
 
-func getTestPrioritySampler() *PrioritySampler {
+func getTestPrioritySampler(statsd statsd.ClientInterface) *PrioritySampler {
 	// No extra fixed sampling, no maximum TPS
 	conf := &config.AgentConfig{
 		ExtraSampleRate: 1.0,
 		TargetTPS:       0.0,
 	}
 
-	return NewPrioritySampler(conf, &DynamicConfig{}, &statsd.NoOpClient{})
+	return NewPrioritySampler(conf, &DynamicConfig{}, statsd)
 }
 
 func getTestTraceWithService(service string, s *PrioritySampler) (*pb.TraceChunk, *pb.Span) {
@@ -61,64 +63,103 @@ func getTestTraceWithService(service string, s *PrioritySampler) (*pb.TraceChunk
 }
 
 func TestPrioritySample(t *testing.T) {
-	// Simple sample unit test
-	assert := assert.New(t)
+	tests := []struct {
+		priority        SamplingPriority
+		expectedSampled bool
+	}{
+		{
+			priority:        PriorityNone,
+			expectedSampled: false,
+		},
+		{
+			priority:        PriorityUserDrop,
+			expectedSampled: false,
+		},
+		{
+			priority:        PriorityAutoDrop,
+			expectedSampled: false,
+		},
+		{
+			priority:        PriorityAutoKeep,
+			expectedSampled: true,
+		},
+		{
+			priority:        PriorityUserKeep,
+			expectedSampled: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.priority.tag(), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			statsdClient := mockStatsd.NewMockClientInterface(ctrl)
 
-	env := defaultEnv
+			s := getTestPrioritySampler(statsdClient)
 
-	s := getTestPrioritySampler()
+			// make sure
+			// - we report the right metrics per service and env.
+			// - we aggregate metric values before calling statsd.
+			expectedTagsA := []string{
+				"sampler:priority",
+				"target_service:service-a",
+				"target_env:testEnv",
+			}
+			if tt.priority == PriorityNone {
+				expectedTagsA = append(expectedTagsA, "sampling_priority:auto_drop")
+			} else {
+				expectedTagsA = append(expectedTagsA, tt.priority.tag())
+			}
+			chunkA, rootA := getTestTraceWithService("service-a", s)
+			chunkA.Priority = int32(tt.priority)
+			assert.Equal(t, tt.expectedSampled, s.Sample(time.Now(), chunkA, rootA, defaultEnv, 0))
+			assert.Equal(t, tt.expectedSampled, s.Sample(time.Now(), chunkA, rootA, defaultEnv, 0))
+			expectedTagsB := []string{
+				"sampler:priority",
+				"target_service:service-b",
+				"target_env:testEnv",
+			}
+			if tt.priority == PriorityNone {
+				expectedTagsB = append(expectedTagsB, "sampling_priority:auto_drop")
+			} else {
+				expectedTagsB = append(expectedTagsB, tt.priority.tag())
+			}
+			chunkB, rootB := getTestTraceWithService("service-b", s)
+			chunkB.Priority = int32(tt.priority)
+			assert.Equal(t, tt.expectedSampled, s.Sample(time.Now(), chunkB, rootB, defaultEnv, 0))
+			assert.Equal(t, tt.expectedSampled, s.Sample(time.Now(), chunkB, rootB, defaultEnv, 0))
+			if tt.expectedSampled {
+				statsdClient.EXPECT().Count(metricSamplerSeen, int64(2), expectedTagsA, float64(1)).Times(1)
+				statsdClient.EXPECT().Count(metricSamplerKept, int64(2), expectedTagsA, float64(1)).Times(1)
+				statsdClient.EXPECT().Count(metricSamplerSeen, int64(2), expectedTagsB, float64(1)).Times(1)
+				statsdClient.EXPECT().Count(metricSamplerKept, int64(2), expectedTagsB, float64(1)).Times(1)
+			} else {
+				statsdClient.EXPECT().Count(metricSamplerSeen, int64(2), expectedTagsA, float64(1)).Times(1)
+				statsdClient.EXPECT().Count(metricSamplerSeen, int64(2), expectedTagsB, float64(1)).Times(1)
+				statsdClient.EXPECT().Count(metricSamplerKept, gomock.Any(), gomock.Any(), float64(1)).Times(0)
+			}
+			statsdClient.EXPECT().Gauge(metricSamplerSize, gomock.Any(), []string{"sampler:priority"}, float64(1)).Times(1)
+			s.sampler.report()
 
-	assert.Equal(float32(0), s.sampler.totalSeen, "checking fresh backend total score is 0")
-	assert.Equal(int64(0), s.sampler.totalKept.Load(), "checking fresh backend sampled score is 0")
+			// make sure we reset the counters
+			statsdClient.EXPECT().Count(metricSamplerKept, gomock.Any(), gomock.Any(), float64(1)).Times(0)
+			statsdClient.EXPECT().Count(metricSamplerSeen, gomock.Any(), gomock.Any(), float64(1)).Times(0)
+			statsdClient.EXPECT().Gauge(metricSamplerSize, gomock.Any(), []string{"sampler:priority"}, float64(1)).Times(1)
+			s.sampler.report()
 
-	s = getTestPrioritySampler()
-	chunk, root := getTestTraceWithService("my-service", s)
-
-	chunk.Priority = -1
-	sampled := s.Sample(time.Now(), chunk, root, env, 0)
-	assert.False(sampled, "trace with negative priority is dropped")
-	assert.Equal(float32(0), s.sampler.totalSeen, "sampling a priority -1 trace should *NOT* impact sampler backend")
-	assert.Equal(int64(0), s.sampler.totalKept.Load(), "sampling a priority -1 trace should *NOT* impact sampler backend")
-
-	s = getTestPrioritySampler()
-	chunk, root = getTestTraceWithService("my-service", s)
-
-	chunk.Priority = 0
-	sampled = s.Sample(time.Now(), chunk, root, env, 0)
-	assert.False(sampled, "trace with priority 0 is dropped")
-	assert.True(float32(0) < s.sampler.totalSeen, "sampling a priority 0 trace should increase total score")
-	assert.Equal(int64(0), s.sampler.totalKept.Load(), "sampling a priority 0 trace should *NOT* increase sampled score")
-
-	s = getTestPrioritySampler()
-	chunk, root = getTestTraceWithService("my-service", s)
-
-	chunk.Priority = 1
-	sampled = s.Sample(time.Now(), chunk, root, env, 0)
-	assert.True(sampled, "trace with priority 1 is kept")
-	assert.True(float32(0) < s.sampler.totalSeen, "sampling a priority 0 trace should increase total score")
-	assert.True(int64(0) < s.sampler.totalKept.Load(), "sampling a priority 0 trace should increase sampled score")
-
-	s = getTestPrioritySampler()
-	chunk, root = getTestTraceWithService("my-service", s)
-
-	chunk.Priority = 2
-	sampled = s.Sample(time.Now(), chunk, root, env, 0)
-	assert.True(sampled, "trace with priority 2 is kept")
-	assert.Equal(float32(0), s.sampler.totalSeen, "sampling a priority 2 trace should *NOT* increase total score")
-	assert.Equal(int64(0), s.sampler.totalKept.Load(), "sampling a priority 2 trace should *NOT* increase sampled score")
-
-	s = getTestPrioritySampler()
-	chunk, root = getTestTraceWithService("my-service", s)
-
-	chunk.Priority = int32(PriorityUserKeep)
-	sampled = s.Sample(time.Now(), chunk, root, env, 0)
-	assert.True(sampled, "trace with high priority is kept")
-	assert.Equal(float32(0), s.sampler.totalSeen, "sampling a high priority trace should *NOT* increase total score")
-	assert.Equal(int64(0), s.sampler.totalKept.Load(), "sampling a high priority trace should *NOT* increase sampled score")
-
-	chunk.Priority = int32(PriorityNone)
-	sampled = s.Sample(time.Now(), chunk, root, env, 0)
-	assert.False(sampled, "this should not happen but a trace without priority sampling set should be dropped")
+			// make sure we report the metrics only for service-a.
+			assert.Equal(t, tt.expectedSampled, s.Sample(time.Now(), chunkB, rootB, defaultEnv, 0))
+			statsdClient.EXPECT().Count(metricSamplerKept, gomock.Any(), expectedTagsA, float64(1)).Times(0)
+			statsdClient.EXPECT().Count(metricSamplerSeen, gomock.Any(), expectedTagsA, float64(1)).Times(0)
+			if tt.expectedSampled {
+				statsdClient.EXPECT().Count(metricSamplerKept, int64(1), expectedTagsB, float64(1)).Times(1)
+			} else {
+				statsdClient.EXPECT().Count(metricSamplerKept, gomock.Any(), expectedTagsB, float64(1)).Times(0)
+			}
+			statsdClient.EXPECT().Count(metricSamplerSeen, int64(1), expectedTagsB, float64(1)).Times(1)
+			statsdClient.EXPECT().Gauge(metricSamplerSize, gomock.Any(), []string{"sampler:priority"}, float64(1)).Times(1)
+			s.sampler.report()
+		})
+	}
 }
 
 func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
@@ -153,7 +194,7 @@ func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 
 	for _, tc := range testCases {
 		rand.Seed(3)
-		s := getTestPrioritySampler()
+		s := getTestPrioritySampler(&statsd.NoOpClient{})
 
 		t.Logf("testing targetTPS=%0.1f generatedTPS=%0.1f clientDrop=%v", tc.targetTPS, tc.generatedTPS, tc.clientDrop)
 		s.sampler.targetTPS = atomic.NewFloat64(tc.targetTPS)

--- a/pkg/trace/sampler/probabilistic.go
+++ b/pkg/trace/sampler/probabilistic.go
@@ -67,6 +67,7 @@ func NewProbabilisticSampler(conf *config.AgentConfig, statsd statsd.ClientInter
 		metrics: metrics{
 			statsd: statsd,
 			tags:   []string{"sampler:probabilistic"},
+			value:  make(map[metricsKey]metricsValue),
 		},
 		stop:            make(chan struct{}),
 		stopped:         make(chan struct{}),

--- a/pkg/trace/sampler/probabilistic.go
+++ b/pkg/trace/sampler/probabilistic.go
@@ -18,8 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-agent/pkg/trace/watchdog"
 
-	"go.uber.org/atomic"
-
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
@@ -41,17 +39,13 @@ type ProbabilisticSampler struct {
 	hashSeed                 []byte
 	scaledSamplingPercentage uint32
 	samplingPercentage       float64
+	metrics                  metrics
 	// fullTraceIDMode looks at the full 128-bit trace ID to make the sampling decision
 	// This can be useful when trying to run this probabilistic sampler alongside the
 	// OTEL probabilistic sampler processor which always looks at the full 128-bit trace id.
 	// This is disabled by default to ensure compatibility in distributed systems where legacy applications may
 	// drop the top 64 bits of the trace ID.
 	fullTraceIDMode bool
-
-	statsd     statsd.ClientInterface
-	tracesSeen *atomic.Int64
-	tracesKept *atomic.Int64
-	tags       []string
 
 	// start/stop synchronization
 	stopOnce sync.Once
@@ -70,13 +64,13 @@ func NewProbabilisticSampler(conf *config.AgentConfig, statsd statsd.ClientInter
 		hashSeed:                 hashSeedBytes,
 		scaledSamplingPercentage: uint32(conf.ProbabilisticSamplerSamplingPercentage * percentageScaleFactor),
 		samplingPercentage:       float64(conf.ProbabilisticSamplerSamplingPercentage) / 100.,
-		statsd:                   statsd,
-		tracesSeen:               atomic.NewInt64(0),
-		tracesKept:               atomic.NewInt64(0),
-		tags:                     []string{"sampler:probabilistic"},
-		stop:                     make(chan struct{}),
-		stopped:                  make(chan struct{}),
-		fullTraceIDMode:          fullTraceIDMode,
+		metrics: metrics{
+			statsd: statsd,
+			tags:   []string{"sampler:probabilistic"},
+		},
+		stop:            make(chan struct{}),
+		stopped:         make(chan struct{}),
+		fullTraceIDMode: fullTraceIDMode,
 	}
 }
 
@@ -87,15 +81,15 @@ func (ps *ProbabilisticSampler) Start() {
 		return
 	}
 	go func() {
-		defer watchdog.LogOnPanic(ps.statsd)
+		defer watchdog.LogOnPanic(ps.metrics.statsd)
 		statsTicker := time.NewTicker(10 * time.Second)
 		defer statsTicker.Stop()
 		for {
 			select {
 			case <-statsTicker.C:
-				ps.report()
+				ps.metrics.report()
 			case <-ps.stop:
-				ps.report()
+				ps.metrics.report()
 				close(ps.stopped)
 				return
 			}
@@ -116,11 +110,14 @@ func (ps *ProbabilisticSampler) Stop() {
 }
 
 // Sample a trace given the chunk's root span, returns true if the trace should be kept
-func (ps *ProbabilisticSampler) Sample(root *trace.Span) bool {
+func (ps *ProbabilisticSampler) Sample(root *trace.Span) (sampled bool) {
 	if !ps.enabled {
 		return false
 	}
-	ps.tracesSeen.Add(1)
+
+	defer func() {
+		ps.metrics.record(sampled, newMetricsKey(root.Service, "", nil))
+	}()
 
 	tid := make([]byte, 16)
 	var err error
@@ -140,17 +137,10 @@ func (ps *ProbabilisticSampler) Sample(root *trace.Span) bool {
 	hash := hasher.Sum32()
 	keep := hash&bitMaskHashBuckets < ps.scaledSamplingPercentage
 	if keep {
-		ps.tracesKept.Add(1)
+		sampled = true
 		setMetric(root, probRateKey, ps.samplingPercentage)
 	}
-	return keep
-}
-
-func (ps *ProbabilisticSampler) report() {
-	seen := ps.tracesSeen.Swap(0)
-	kept := ps.tracesKept.Swap(0)
-	_ = ps.statsd.Count("datadog.trace_agent.sampler.kept", kept, ps.tags, 1)
-	_ = ps.statsd.Count("datadog.trace_agent.sampler.seen", seen, ps.tags, 1)
+	return
 }
 
 func get128BitTraceID(span *trace.Span) ([]byte, error) {

--- a/pkg/trace/sampler/probabilistic_test.go
+++ b/pkg/trace/sampler/probabilistic_test.go
@@ -11,6 +11,8 @@ import (
 	"encoding/hex"
 	"testing"
 
+	mockStatsd "github.com/DataDog/datadog-go/v5/statsd/mocks"
+	"github.com/golang/mock/gomock"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,6 +86,52 @@ func TestProbabilisticSampler(t *testing.T) {
 			Meta:    map[string]string{"_dd.p.tid": hex.EncodeToString(tid[:8])},
 		})
 		assert.False(t, sampled)
+	})
+	t.Run("keep-dd-metrics", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		statsdClient := mockStatsd.NewMockClientInterface(ctrl)
+
+		tid := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+		conf := &config.AgentConfig{
+			ProbabilisticSamplerEnabled:            true,
+			ProbabilisticSamplerHashSeed:           0,
+			ProbabilisticSamplerSamplingPercentage: 41,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
+		}
+		sampler := NewProbabilisticSampler(conf, statsdClient)
+		sampled := sampler.Sample(&trace.Span{
+			TraceID: binary.BigEndian.Uint64(tid[8:]),
+			Meta:    map[string]string{"_dd.p.tid": hex.EncodeToString(tid[:8])},
+		})
+		assert.True(t, sampled)
+
+		statsdClient.EXPECT().Count(metricSamplerKept, int64(1), []string{"sampler:probabilistic"}, float64(1)).Times(1)
+		statsdClient.EXPECT().Count(metricSamplerSeen, int64(1), []string{"sampler:probabilistic"}, float64(1)).Times(1)
+		sampler.metrics.report()
+	})
+	t.Run("drop-dd-metrics", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		statsdClient := mockStatsd.NewMockClientInterface(ctrl)
+
+		tid := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+		conf := &config.AgentConfig{
+			ProbabilisticSamplerEnabled:            true,
+			ProbabilisticSamplerHashSeed:           0,
+			ProbabilisticSamplerSamplingPercentage: 40,
+			Features:                               map[string]struct{}{"probabilistic_sampler_full_trace_id": {}},
+		}
+		sampler := NewProbabilisticSampler(conf, statsdClient)
+		sampled := sampler.Sample(&trace.Span{
+			TraceID: 555,
+			Meta:    map[string]string{"_dd.p.tid": hex.EncodeToString(tid[:8])},
+		})
+		assert.False(t, sampled)
+
+		statsdClient.EXPECT().Count(metricSamplerKept, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+		statsdClient.EXPECT().Count(metricSamplerSeen, int64(1), []string{"sampler:probabilistic"}, float64(1)).Times(1)
+		sampler.metrics.report()
 	})
 	t.Run("keep-dd-64-full", func(t *testing.T) {
 		conf := &config.AgentConfig{

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -68,6 +68,23 @@ const (
 	samplerHasher = uint64(1111111111111111111)
 )
 
+func (s SamplingPriority) tag() string {
+	var v string
+	switch s {
+	case PriorityUserDrop:
+		v = "manual_drop"
+	case PriorityAutoDrop:
+		v = "auto_drop"
+	case PriorityAutoKeep:
+		v = "auto_keep"
+	case PriorityUserKeep:
+		v = "manual_keep"
+	default:
+		v = "none"
+	}
+	return "sampling_priority:" + v
+}
+
 // SampleByRate returns whether to keep a trace, based on its ID and a sampling rate.
 // This assumes that trace IDs are nearly uniformly distributed.
 func SampleByRate(traceID uint64, rate float64) bool {

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -71,7 +71,9 @@ func (s *ScoreSampler) Sample(now time.Time, trace pb.Trace, root *pb.Span, env 
 
 	rate := s.getSignatureSampleRate(signature)
 
-	return s.applySampleRate(root, rate)
+	sampled := s.applySampleRate(root, rate)
+	s.metrics.record(sampled, newMetricsKey(root.Service, env, nil))
+	return sampled
 }
 
 // UpdateTargetTPS updates the target tps
@@ -90,7 +92,6 @@ func (s *ScoreSampler) applySampleRate(root *pb.Span, rate float64) bool {
 	traceID := root.TraceID
 	sampled := SampleByRate(traceID, newRate)
 	if sampled {
-		s.countSample()
 		setMetric(root, s.samplingRateKey, rate)
 	}
 	return sampled


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Add `target_service`, `target_env` and `sampling_priority` to Priority sampler.
- Add `target_service` and `target_env` to Error sampler.
- Add `target_service` to Probabilistic sampler.
- The timing of the following metrics have been changed.
  - `datadog.trace_agent.sampler.kept`
  - `datadog.trace_agent.sampler.seen`

### Motivation

Same as #33091.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

#### Priority sampler

1. `DD_TRACE_SAMPLING_RULES` was unset in a tracing library.
2. `DD_TRACE_SAMPLING_RULES=[{"resource":"*","service":"note-client","sample_rate":1}]` was set.
3. `DD_TRACE_SAMPLING_RULES=[{"resource":"*","service":"note-client","sample_rate":0.5}]` was set.
4. `DD_TRACE_SAMPLING_RULES` was unset in the tracing library.

![2025-01-23_17-57-31](https://github.com/user-attachments/assets/eadec824-dbcd-4087-afba-bab7e87576b0)

#### Error sampler

When `value > 0`, I didn't set `DD_TRACE_SAMPLING_RULES`.
When `value == 0`, I set `DD_TRACE_SAMPLING_RULES` in a tracing library.

![2025-01-23_17-58-03](https://github.com/user-attachments/assets/0a62411a-9789-4ce4-84b7-cf66c658fbb9)

#### Probabilistic sampler

Set `DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE` to 50, 75 and 100.

![2025-01-22_13-20-31](https://github.com/user-attachments/assets/caf4635b-b486-4dd0-93b0-d2a429157984)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Closed #33091 since it didn't have metrics aggregation on the client side(trace-agent). See https://github.com/DataDog/datadog-agent/pull/33091#issuecomment-2606171656.