### PR TITLE
[HA Agent] Add ha_agent_enabled to datadog.agent.running

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -876,6 +876,9 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 			tags = append(tags, "package_version:"+version.AgentPackageVersion)
 		}
 	}
+	if agg.haAgent.Enabled() {
+		tags = append(tags, "ha_agent_enabled")
+	}
 	// nil to empty string
 	// This is expected by other components/tests
 	if tags == nil {

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -877,7 +877,7 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 		}
 	}
 	if agg.haAgent.Enabled() {
-		tags = append(tags, "ha_agent_enabled")
+		tags = append(tags, "ha_agent_enabled:true")
 	}
 	// nil to empty string
 	// This is expected by other components/tests

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -296,7 +296,7 @@ func TestDefaultSeries(t *testing.T) {
 		require.Equal(t, 1, len(m))
 		require.Equal(t, "datadog.agent.up", m[0].CheckName)
 		require.Equal(t, servicecheck.ServiceCheckOK, m[0].Status)
-		require.Equal(t, []string{"ha_agent_enabled"}, m[0].Tags)
+		require.Equal(t, []string{"ha_agent_enabled:true"}, m[0].Tags)
 		require.Equal(t, agg.hostname, m[0].Host)
 
 		return true
@@ -306,14 +306,14 @@ func TestDefaultSeries(t *testing.T) {
 	expectedSeries := metrics.Series{&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion, "ha_agent_enabled"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion, "ha_agent_enabled:true"}),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 	}, &metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.ha_agent.running", agg.agentName),
 		Points:         []metrics.Point{{Value: float64(1), Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"ha_agent_enabled", "agent_state:standby"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"ha_agent_enabled:true", "agent_state:standby"}),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -321,7 +321,7 @@ func TestDefaultSeries(t *testing.T) {
 		Name:           fmt.Sprintf("n_o_i_n_d_e_x.datadog.%s.payload.dropped", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 0, Ts: float64(start.Unix())}},
 		Host:           agg.hostname,
-		Tags:           tagset.CompositeTagsFromSlice([]string{"ha_agent_enabled"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"ha_agent_enabled:true"}),
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 		NoIndex:        true,
@@ -653,7 +653,7 @@ func TestTags(t *testing.T) {
 			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
 			withVersion:             false,
 			haAgentEnabled:          true,
-			want:                    []string{"ha_agent_enabled"},
+			want:                    []string{"ha_agent_enabled:true"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -296,7 +296,7 @@ func TestDefaultSeries(t *testing.T) {
 		require.Equal(t, 1, len(m))
 		require.Equal(t, "datadog.agent.up", m[0].CheckName)
 		require.Equal(t, servicecheck.ServiceCheckOK, m[0].Status)
-		require.Equal(t, []string{}, m[0].Tags)
+		require.Equal(t, []string{"ha_agent_enabled"}, m[0].Tags)
 		require.Equal(t, agg.hostname, m[0].Host)
 
 		return true
@@ -306,14 +306,14 @@ func TestDefaultSeries(t *testing.T) {
 	expectedSeries := metrics.Series{&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion, "ha_agent_enabled"}),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 	}, &metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.ha_agent.running", agg.agentName),
 		Points:         []metrics.Point{{Value: float64(1), Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"agent_state:standby"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"ha_agent_enabled", "agent_state:standby"}),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -321,7 +321,7 @@ func TestDefaultSeries(t *testing.T) {
 		Name:           fmt.Sprintf("n_o_i_n_d_e_x.datadog.%s.payload.dropped", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 0, Ts: float64(start.Unix())}},
 		Host:           agg.hostname,
-		Tags:           tagset.CompositeTagsFromSlice([]string{}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"ha_agent_enabled"}),
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 		NoIndex:        true,
@@ -644,6 +644,16 @@ func TestTags(t *testing.T) {
 			globalTags:              func(types.TagCardinality) ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
 			withVersion:             true,
 			want:                    []string{"container_name:agent", "version:" + version.AgentVersion, "kube_cluster_name:foo"},
+		},
+		{
+			name:                    "tags disabled, without version, ha agent enabled",
+			hostname:                "hostname",
+			tlmContainerTagsEnabled: false,
+			agentTags:               func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
+			globalTags:              func(types.TagCardinality) ([]string, error) { return nil, errors.New("disabled") },
+			withVersion:             false,
+			haAgentEnabled:          true,
+			want:                    []string{"ha_agent_enabled"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[HA Agent] Add ha_agent_enabled to datadog.agent.running

### Motivation

1/ HA feature will migrate toward using `config_id` instead of `agent_group` (related PR https://github.com/DataDog/datadog-agent/pull/33068).

Currently, HA Agent backend is querying `datadog.agent.running{agent_group:*} by {host,agent_group}`, as you can see we filter by `agent_group:*` to only return results if HA Agent is enabled (agent_group present only if HA Agent is enabled). This filter is important for backend only process when needed (HA Enabled).

We will transition to using `config_id` instead, but `config_id` will be present all the time (not dependent on HA Agent enabled or not), meaning we can't filter like `config_id:*` when querying the metric. 

So, by adding `ha_agent_enabled:true`, we will be able to query like this:
```
datadog.agent.running{ha_agent_enabled:true} by {host,config_id}
```

2/ Can be useful for users to know how many agents are HA, and create monitors.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->