### PR TITLE
fix(release): Move the prelude creation with the changelog update

### DIFF
--- a/tasks/notes.py
+++ b/tasks/notes.py
@@ -72,8 +72,28 @@ def update_changelog(ctx, release_branch, target="all", upstream="origin"):
     branch = get_default_branch(major=new_version_int[0])
 
     with agent_context(ctx, branch):
-        # Step 1 - generate the changelogs
+        # Step 1: Add release changelog preludes
+        update_branch = f"changelog-update-{new_version}"
+        base_branch = get_current_branch(ctx)
+        print(color_message(f"Branching out to {update_branch}", "bold"))
+        ctx.run(f"git switch -c {update_branch}")
 
+        print(color_message("Adding Agent release changelog prelude", "bold"))
+        _add_prelude(ctx, str(new_version))
+
+        print(color_message("Adding DCA release changelog prelude", "bold"))
+        _add_dca_prelude(ctx, str(new_version))
+
+        ok = try_git_command(ctx, f"git commit -m 'Add preludes for {new_version} release'")
+        if not ok:
+            raise Exit(
+                color_message(
+                    f"Could not create commit. Please commit manually, push the {update_branch} branch and then open a PR against {release_branch}.",
+                    "red",
+                ),
+                code=1,
+            )
+        # Step 2 - generate the changelogs
         generate_agent = target in ["all", "agent"]
         generate_cluster_agent = target in ["all", "cluster-agent"]
 
@@ -96,14 +116,7 @@ def update_changelog(ctx, release_branch, target="all", upstream="origin"):
         if generate_cluster_agent:
             update_changelog_generic(ctx, new_version, "releasenotes-dca", "CHANGELOG-DCA.rst")
 
-        # Step 2 - commit changes
-
-        update_branch = f"changelog-update-{new_version}"
-        base_branch = get_current_branch(ctx)
-
-        print(color_message(f"Branching out to {update_branch}", "bold"))
-        ctx.run(f"git checkout -b {update_branch}")
-
+        # Step 3 - commit changes
         print(color_message("Committing CHANGELOG.rst and CHANGELOG-DCA.rst", "bold"))
         print(
             color_message(
@@ -124,8 +137,7 @@ def update_changelog(ctx, release_branch, target="all", upstream="origin"):
                 code=1,
             )
 
-        # Step 3 - Push and create PR
-
+        # Step 4 - Push and create PR
         print(color_message("Pushing new branch to the upstream repository", "bold"))
         res = ctx.run(f"git push --set-upstream {upstream} {update_branch}", warn=True)
         if res.exited is None or res.exited > 0:

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -64,7 +64,6 @@ from tasks.libs.releasing.json import (
     set_new_release_branch,
     update_release_json,
 )
-from tasks.libs.releasing.notes import _add_dca_prelude, _add_prelude
 from tasks.libs.releasing.version import (
     MINOR_RC_VERSION_RE,
     RC_VERSION_RE,
@@ -309,24 +308,7 @@ def finish(ctx, release_branch, upstream="origin"):
                 code=1,
             )
 
-        # Step 4: Add release changelog preludes
-        print(color_message("Adding Agent release changelog prelude", "bold"))
-        _add_prelude(ctx, str(new_version))
-
-        print(color_message("Adding DCA release changelog prelude", "bold"))
-        _add_dca_prelude(ctx, str(new_version))
-
-        ok = try_git_command(ctx, f"git commit -m 'Add preludes for {new_version} release'")
-        if not ok:
-            raise Exit(
-                color_message(
-                    f"Could not create commit. Please commit manually, push the {final_branch} branch and then open a PR against {final_branch}.",
-                    "red",
-                ),
-                code=1,
-            )
-
-        # Step 5: Push branch and create PR
+        # Step 4: Push branch and create PR
         print(color_message("Pushing new branch to the upstream repository", "bold"))
         res = ctx.run(f"git push --set-upstream {upstream} {final_branch}", warn=True)
         if res.exited is None or res.exited > 0:
@@ -339,7 +321,7 @@ def finish(ctx, release_branch, upstream="origin"):
             )
 
         create_release_pr(
-            f"Final updates for release.json and Go modules for {new_version} release + preludes",
+            f"Final updates for release.json and Go modules for {new_version} release",
             release_branch,
             final_branch,
             new_version,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Move the prelude creation with the changelog update

### Motivation
The prelude were initially created in the `final` PR. As such:
- they were pointing to a non-existing changlog file
- it creates a dependency on `documentation` team to review the PR, it could slow down the releasing process.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->