### PR TITLE
fix(fleet): Use E2E_PIPELINE_ID in install script tests

### DIFF
--- a/.gitlab/deploy_packages/e2e.yml
+++ b/.gitlab/deploy_packages/e2e.yml
@@ -13,3 +13,4 @@ qa_installer_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "install*.sh" "$OMNIBUS_PACKAGE_DIR" "s3://${INSTALLER_TESTING_S3_BUCKET}/${CI_COMMIT_SHA}/scripts/"
+    - $S3_CP_CMD --recursive --exclude "*" --include "install*.sh" "$OMNIBUS_PACKAGE_DIR" "s3://${INSTALLER_TESTING_S3_BUCKET}/pipeline-${CI_PIPELINE_ID}/scripts/"

--- a/test/new-e2e/tests/installer/script/databricks_test.go
+++ b/test/new-e2e/tests/installer/script/databricks_test.go
@@ -28,7 +28,7 @@ func testDatabricksScript(os e2eos.Descriptor, arch e2eos.Architecture) installe
 	s := &installScriptDatabricksSuite{
 		installerScriptBaseSuite: newInstallerScriptSuite("installer-databricks", os, arch, awshost.WithoutFakeIntake(), awshost.WithoutAgent()),
 	}
-	s.url = fmt.Sprintf("https://installtesting.datad0g.com/%s/scripts/install-databricks.sh", s.commitHash)
+	s.url = s.scriptURLPrefix + "install-databricks.sh"
 
 	return s
 }

--- a/test/new-e2e/tests/installer/script/default_script_test.go
+++ b/test/new-e2e/tests/installer/script/default_script_test.go
@@ -26,7 +26,7 @@ func testDefaultScript(os e2eos.Descriptor, arch e2eos.Architecture) installerSc
 	s := &installScriptDefaultSuite{
 		installerScriptBaseSuite: newInstallerScriptSuite("installer-default", os, arch, awshost.WithoutFakeIntake(), awshost.WithoutAgent()),
 	}
-	s.url = fmt.Sprintf("https://installtesting.datad0g.com/%s/scripts/install.sh", s.commitHash)
+	s.url = s.scriptURLPrefix + "install.sh"
 
 	return s
 }


### PR DESCRIPTION
### What does this PR do?
Uses `E2E_PIPELINE_ID` to fetch install scripts. Due to CloudFront invalidation; when running a second pipeline on the same commit, it's the first pipeline install script that is used on the second pipeline. This can break; because the first pipeline script hardcodes the first pipeline OCI link. If there was an issue with the first pipeline regarding OCI deployment; the second pipepline will break as well.

Example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/774531448

### Motivation
We don't like broken tests around here

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
