### PR TITLE
[CWS] Reduce some logs level

### DIFF
--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -855,7 +855,7 @@ func (adm *ActivityDumpManager) SnapshotTracedCgroups() {
 
 		if err = adm.activityDumpsConfigMap.Lookup(&event.ConfigCookie, &event.Config); err != nil {
 			// this config doesn't exist anymore, remove expired entries
-			seclog.Infof("config not found for (%v): %v", cgroupFile, err)
+			seclog.Warnf("config not found for (%v): %v", cgroupFile, err)
 			_ = adm.tracedCgroupsMap.Delete(cgroupFile)
 			continue
 		}
@@ -864,7 +864,7 @@ func (adm *ActivityDumpManager) SnapshotTracedCgroups() {
 	}
 
 	if err = iterator.Err(); err != nil {
-		seclog.Infof("couldn't iterate over the map traced_cgroups: %v", err)
+		seclog.Warnf("couldn't iterate over the map traced_cgroups: %v", err)
 	}
 }
 

--- a/pkg/security/security_profile/dump/manager.go
+++ b/pkg/security/security_profile/dump/manager.go
@@ -855,7 +855,7 @@ func (adm *ActivityDumpManager) SnapshotTracedCgroups() {
 
 		if err = adm.activityDumpsConfigMap.Lookup(&event.ConfigCookie, &event.Config); err != nil {
 			// this config doesn't exist anymore, remove expired entries
-			seclog.Errorf("config not found for (%v): %v", cgroupFile, err)
+			seclog.Infof("config not found for (%v): %v", cgroupFile, err)
 			_ = adm.tracedCgroupsMap.Delete(cgroupFile)
 			continue
 		}
@@ -864,7 +864,7 @@ func (adm *ActivityDumpManager) SnapshotTracedCgroups() {
 	}
 
 	if err = iterator.Err(); err != nil {
-		seclog.Errorf("couldn't iterate over the map traced_cgroups: %v", err)
+		seclog.Infof("couldn't iterate over the map traced_cgroups: %v", err)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Reduce the log level of SnapshotTracedCgroups errors, which happens one third of time:

![image](https://github.com/user-attachments/assets/78327a10-498e-4942-bbf3-14885829d784)

Those errors are related to the iteration of the tracedCgroupsMap eBPF map, which can still be accessed both in userspace and kernel space concurrently, leading to those errors.

This may put in light some corner cases design issues regarding the way cgroups are being traced, which should be addressed later on on a separate rework.

### Motivation

Reduce the errors logs

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->