### PR TITLE
[HA Agent] Rename to config_id and active_agent

### DIFF
--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -13,8 +13,8 @@ type Component interface {
 	// Enabled returns true if ha_agent.enabled is set to true
 	Enabled() bool
 
-	// GetGroup returns the value of ha_agent.group
-	GetGroup() string
+	// GetConfigID returns the value of config_id
+	GetConfigID() string
 
 	// GetState returns current HA agent state
 	GetState() State

--- a/comp/haagent/helpers/helpers.go
+++ b/comp/haagent/helpers/helpers.go
@@ -15,12 +15,13 @@ func IsEnabled(agentConfig model.Reader) bool {
 	return agentConfig.GetBool("ha_agent.enabled")
 }
 
-// GetGroup returns HA Agent group
-func GetGroup(agentConfig model.Reader) string {
-	return agentConfig.GetString("ha_agent.group")
+// GetConfigID returns config_id
+func GetConfigID(agentConfig model.Reader) string {
+	return agentConfig.GetString("config_id")
 }
 
 // GetHaAgentTags returns HA Agent related tags
 func GetHaAgentTags(agentConfig model.Reader) []string {
-	return []string{"agent_group:" + GetGroup(agentConfig)}
+	// TODO(alexandre.yang): Remove agent_group tag
+	return []string{"agent_group:" + GetConfigID(agentConfig)}
 }

--- a/comp/haagent/helpers/helpers.go
+++ b/comp/haagent/helpers/helpers.go
@@ -19,9 +19,3 @@ func IsEnabled(agentConfig model.Reader) bool {
 func GetConfigID(agentConfig model.Reader) string {
 	return agentConfig.GetString("config_id")
 }
-
-// GetHaAgentTags returns HA Agent related tags
-func GetHaAgentTags(agentConfig model.Reader) []string {
-	// TODO(alexandre.yang): Remove agent_group tag
-	return []string{"agent_group:" + GetConfigID(agentConfig)}
-}

--- a/comp/haagent/helpers/helpers_test.go
+++ b/comp/haagent/helpers/helpers_test.go
@@ -25,9 +25,3 @@ func TestGetConfigID(t *testing.T) {
 	cfg.SetWithoutSource("config_id", "my-config-id")
 	assert.Equal(t, "my-config-id", GetConfigID(cfg))
 }
-
-func TestGetHaAgentTags(t *testing.T) {
-	cfg := config.NewMock(t)
-	cfg.SetWithoutSource("config_id", "my-config-id")
-	assert.Equal(t, []string{"agent_group:my-config-id"}, GetHaAgentTags(cfg))
-}

--- a/comp/haagent/helpers/helpers_test.go
+++ b/comp/haagent/helpers/helpers_test.go
@@ -20,14 +20,14 @@ func TestIsEnabled(t *testing.T) {
 	assert.True(t, IsEnabled(cfg))
 }
 
-func TestGetGroup(t *testing.T) {
+func TestGetConfigID(t *testing.T) {
 	cfg := config.NewMock(t)
-	cfg.SetWithoutSource("ha_agent.group", "my-group")
-	assert.Equal(t, "my-group", GetGroup(cfg))
+	cfg.SetWithoutSource("config_id", "my-config-id")
+	assert.Equal(t, "my-config-id", GetConfigID(cfg))
 }
 
 func TestGetHaAgentTags(t *testing.T) {
 	cfg := config.NewMock(t)
-	cfg.SetWithoutSource("ha_agent.group", "my-group")
-	assert.Equal(t, []string{"agent_group:my-group"}, GetHaAgentTags(cfg))
+	cfg.SetWithoutSource("config_id", "my-config-id")
+	assert.Equal(t, []string{"agent_group:my-config-id"}, GetHaAgentTags(cfg))
 }

--- a/comp/haagent/impl/config.go
+++ b/comp/haagent/impl/config.go
@@ -25,13 +25,13 @@ var validHaIntegrations = map[string]bool{
 }
 
 type haAgentConfigs struct {
-	enabled bool
-	group   string
+	enabled  bool
+	configID string
 }
 
 func newHaAgentConfigs(agentConfig config.Component) *haAgentConfigs {
 	return &haAgentConfigs{
-		enabled: helpers.IsEnabled(agentConfig),
-		group:   helpers.GetGroup(agentConfig),
+		enabled:  helpers.IsEnabled(agentConfig),
+		configID: helpers.GetConfigID(agentConfig),
 	}
 }

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -103,9 +103,9 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 			})
 			continue
 		}
-		if haAgentMsg.Group != h.GetGroup() {
+		if haAgentMsg.ConfigID != h.GetGroup() {
 			h.log.Warnf("Skipping invalid HA_AGENT update %s: expected group %s, got %s",
-				configPath, h.GetGroup(), haAgentMsg.Group)
+				configPath, h.GetGroup(), haAgentMsg.ConfigID)
 			applyStateCallback(configPath, state.ApplyStatus{
 				State: state.ApplyStateError,
 				Error: "group does not match",
@@ -113,7 +113,7 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 			continue
 		}
 
-		h.SetLeader(haAgentMsg.Leader)
+		h.SetLeader(haAgentMsg.ActiveAgent)
 
 		h.log.Debugf("Processed config %s: %v", configPath, haAgentMsg)
 

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -34,8 +34,8 @@ func (h *haAgentImpl) Enabled() bool {
 	return h.haAgentConfigs.enabled
 }
 
-func (h *haAgentImpl) GetGroup() string {
-	return h.haAgentConfigs.group
+func (h *haAgentImpl) GetConfigID() string {
+	return h.haAgentConfigs.configID
 }
 
 func (h *haAgentImpl) GetState() haagent.State {
@@ -103,12 +103,12 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 			})
 			continue
 		}
-		if haAgentMsg.ConfigID != h.GetGroup() {
-			h.log.Warnf("Skipping invalid HA_AGENT update %s: expected group %s, got %s",
-				configPath, h.GetGroup(), haAgentMsg.ConfigID)
+		if haAgentMsg.ConfigID != h.GetConfigID() {
+			h.log.Warnf("Skipping invalid HA_AGENT update %s: expected configID %s, got %s",
+				configPath, h.GetConfigID(), haAgentMsg.ConfigID)
 			applyStateCallback(configPath, state.ApplyStatus{
 				State: state.ApplyStateError,
-				Error: "group does not match",
+				Error: "configID does not match",
 			})
 			continue
 		}

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -108,7 +108,7 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 				configPath, h.GetConfigID(), haAgentMsg.ConfigID)
 			applyStateCallback(configPath, state.ApplyStatus{
 				State: state.ApplyStateError,
-				Error: "configID does not match",
+				Error: "config_id does not match",
 			})
 			continue
 		}

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -161,7 +161,7 @@ func Test_haAgentImpl_onHaAgentUpdate(t *testing.T) {
 			expectedApplyID: testRCConfigID,
 			expectedApplyStatus: state.ApplyStatus{
 				State: state.ApplyStateError,
-				Error: "configID does not match",
+				Error: "config_id does not match",
 			},
 			expectedAgentState: haagent.Unknown,
 		},

--- a/comp/haagent/impl/rcpayload.go
+++ b/comp/haagent/impl/rcpayload.go
@@ -6,6 +6,6 @@
 package haagentimpl
 
 type haAgentConfig struct {
-	Group  string `json:"group"`
-	Leader string `json:"leader"`
+	ConfigID    string `json:"config_id"`
+	ActiveAgent string `json:"active_agent"`
 }

--- a/comp/haagent/mock/mock.go
+++ b/comp/haagent/mock/mock.go
@@ -19,13 +19,13 @@ import (
 type mockHaAgent struct {
 	Logger log.Component
 
-	group   string
-	enabled bool
-	state   haagent.State
+	configID string
+	enabled  bool
+	state    haagent.State
 }
 
-func (m *mockHaAgent) GetGroup() string {
-	return m.group
+func (m *mockHaAgent) GetConfigID() string {
+	return m.configID
 }
 
 func (m *mockHaAgent) Enabled() bool {
@@ -37,8 +37,8 @@ func (m *mockHaAgent) SetLeader(_ string) {
 
 func (m *mockHaAgent) GetState() haagent.State { return haagent.Standby }
 
-func (m *mockHaAgent) SetGroup(group string) {
-	m.group = group
+func (m *mockHaAgent) SetConfigID(configID string) {
+	m.configID = configID
 }
 
 func (m *mockHaAgent) SetEnabled(enabled bool) {
@@ -56,7 +56,7 @@ func (m *mockHaAgent) ShouldRunIntegration(_ string) bool {
 type Component interface {
 	haagent.Component
 
-	SetGroup(string)
+	SetConfigID(string)
 	SetEnabled(bool)
 	SetState(haagent.State)
 }
@@ -64,8 +64,8 @@ type Component interface {
 // NewMockHaAgent returns a new Mock
 func NewMockHaAgent() haagent.Component {
 	return &mockHaAgent{
-		enabled: false,
-		group:   "group01",
+		enabled:  false,
+		configID: "config01",
 	}
 }
 

--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	haagenthelpers "github.com/DataDog/datadog-agent/comp/haagent/helpers"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -132,10 +131,6 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 			log.Info("Adding both tags cluster_name and kube_cluster_name. You can use 'disable_cluster_name_tag_key' in the Agent config to keep the kube_cluster_name tag only")
 		}
 		hostTags = appendToHostTags(hostTags, clusterNameTags)
-	}
-
-	if haagenthelpers.IsEnabled(conf) {
-		hostTags = appendToHostTags(hostTags, haagenthelpers.GetHaAgentTags(conf))
 	}
 
 	gceTags := []string{}

--- a/comp/metadata/host/hostimpl/hosttags/tags_test.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags_test.go
@@ -137,18 +137,3 @@ func TestHostTagsCache(t *testing.T) {
 	assert.Equal(t, []string{"foo1:value1"}, hostTags.System)
 	assert.Equal(t, 2, nbCall)
 }
-
-func TestHaAgentTags(t *testing.T) {
-	mockConfig, ctx := setupTest(t)
-
-	hostTags := Get(ctx, false, mockConfig)
-	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, []string{}, hostTags.System)
-
-	mockConfig.SetWithoutSource("ha_agent.enabled", true)
-	mockConfig.SetWithoutSource("ha_agent.group", "my-group")
-
-	hostTags = Get(ctx, false, mockConfig)
-	assert.NotNil(t, hostTags.System)
-	assert.Equal(t, []string{"agent_group:my-group"}, hostTags.System)
-}

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -18,7 +18,6 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	haagenthelpers "github.com/DataDog/datadog-agent/comp/haagent/helpers"
 	"github.com/DataDog/datadog-agent/pkg/collector/externalhost"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
@@ -253,11 +252,7 @@ func (d *DeviceCheck) setDeviceHostExternalTags() {
 }
 
 func (d *DeviceCheck) buildExternalTags() []string {
-	agentTags := configUtils.GetConfiguredTags(d.agentConfig, false)
-	if haagenthelpers.IsEnabled(d.agentConfig) {
-		agentTags = append(agentTags, haagenthelpers.GetHaAgentTags(d.agentConfig)...)
-	}
-	return agentTags
+	return configUtils.GetConfiguredTags(d.agentConfig, false)
 }
 
 func (d *DeviceCheck) getValuesAndTags() (bool, []string, *valuestore.ResultValueStore, error) {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -990,8 +990,7 @@ collect_topology: false
 	assert.Nil(t, err)
 
 	cfg := agentconfig.NewMock(t)
-	cfg.SetWithoutSource("ha_agent.enabled", true)
-	cfg.SetWithoutSource("ha_agent.group", "my-group")
+	cfg.SetWithoutSource("tags", []string{"tag1:value1"})
 
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory, cfg)
 	assert.Nil(t, err)
@@ -1000,5 +999,5 @@ collect_topology: false
 	externalTags := deviceCk.buildExternalTags()
 
 	// THEN
-	assert.Equal(t, []string{"agent_group:my-group"}, externalTags)
+	assert.Equal(t, []string{"tag1:value1"}, externalTags)
 }

--- a/test/new-e2e/tests/ha-agent/haagent_test.go
+++ b/test/new-e2e/tests/ha-agent/haagent_test.go
@@ -33,7 +33,7 @@ func TestHaAgentSuite(t *testing.T) {
 	agentConfig := `
 ha_agent:
     enabled: true
-config_id: test-config01
+    group: test-group01
 log_level: debug
 `
 	e2e.Run(t, &haAgentTestSuite{}, e2e.WithProvisioner(awshost.Provisioner(
@@ -53,13 +53,8 @@ func (s *haAgentTestSuite) TestHaAgentRunningMetrics() {
 			s.T().Logf("    datadog.agent.ha_agent.running metric tags: %+v", metric.Tags)
 		}
 
-		tags := []string{"agent_state:unknown", "config_id:test-config01"}
+		tags := []string{"agent_state:unknown"}
 		metrics, err = fakeClient.FilterMetrics("datadog.agent.ha_agent.running", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
-		require.NoError(c, err)
-		assert.NotEmpty(c, metrics)
-
-		tags = []string{"config_id:test-config01"}
-		metrics, err = fakeClient.FilterMetrics("datadog.agent.running", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
 		require.NoError(c, err)
 		assert.NotEmpty(c, metrics)
 	}, 5*time.Minute, 3*time.Second)

--- a/test/new-e2e/tests/ha-agent/haagent_test.go
+++ b/test/new-e2e/tests/ha-agent/haagent_test.go
@@ -33,7 +33,7 @@ func TestHaAgentSuite(t *testing.T) {
 	agentConfig := `
 ha_agent:
     enabled: true
-    group: test-group01
+config_id: test-config01
 log_level: debug
 `
 	e2e.Run(t, &haAgentTestSuite{}, e2e.WithProvisioner(awshost.Provisioner(
@@ -53,8 +53,13 @@ func (s *haAgentTestSuite) TestHaAgentRunningMetrics() {
 			s.T().Logf("    datadog.agent.ha_agent.running metric tags: %+v", metric.Tags)
 		}
 
-		tags := []string{"agent_state:unknown"}
+		tags := []string{"agent_state:unknown", "config_id:test-config01"}
 		metrics, err = fakeClient.FilterMetrics("datadog.agent.ha_agent.running", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
+		require.NoError(c, err)
+		assert.NotEmpty(c, metrics)
+
+		tags = []string{"config_id:test-config01"}
+		metrics, err = fakeClient.FilterMetrics("datadog.agent.running", fakeintakeclient.WithTags[*aggregator.MetricSeries](tags))
 		require.NoError(c, err)
 		assert.NotEmpty(c, metrics)
 	}, 5*time.Minute, 3*time.Second)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[HA Agent] Rename group->config_id and leader->active_agent

Changes:
- Use config_id and active_agent (instead of group and leader) in HA_AGENT RC Listener
- Remove agent_group tag from host tags
- Remove agent_group tag from snmp integration external tags

### Motivation

Migration to use Fleet config_id instead of agent group

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->