### PR TITLE
Use docker-in-docker runner for jobs that need docker

### DIFF
--- a/.gitlab/functional_test/oracle.yml
+++ b/.gitlab/functional_test/oracle.yml
@@ -1,6 +1,6 @@
 oracle:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:docker"]
+  tags: ["docker-in-docker:amd64"]
   stage: functional_test
   needs: ["go_deps"]
   rules:

--- a/.gitlab/functional_test/serverless.yml
+++ b/.gitlab/functional_test/serverless.yml
@@ -4,7 +4,7 @@ serverless_cold_start_performance-deb_x64:
     - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:docker"]  # Still required as compute.sh is doing a container run
+  tags: ["docker-in-docker:amd64"]  # Still required as compute.sh is doing a container run
   needs: ["go_deps", "build_serverless-deb_x64"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -28,7 +28,7 @@ docker_image_build_otel:
   stage: integration_test
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   needs: ["go_deps","integration_tests_otel"]
-  tags: ["runner:docker"]  # Still required because the otel_agent_build_tests.py is doing a container run
+  tags: ["docker-in-docker:amd64"]  # Still required because the otel_agent_build_tests.py is doing a container run
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - mkdir -p /tmp/otel-ci


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Using the unmaintained `runner:docker` tag brings some flakiness in the CI, such as: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/775254318
The ci-infra recommendation is to move to the new `docker-in-docker` tag that is maintained and should offer what we need.
This tag should be stable as it is used in production in other repositories without issue.

### Motivation

Improve stability of our CI

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->