### PR TITLE
[CWS] reduce size of rate limiters

### DIFF
--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -9,6 +9,7 @@ package config
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"net"
 	"strings"
 	"time"
@@ -111,7 +112,7 @@ type RuntimeSecurityConfig struct {
 	// ActivityDumpCgroupDumpTimeout defines the cgroup activity dumps timeout.
 	ActivityDumpCgroupDumpTimeout time.Duration
 	// ActivityDumpRateLimiter defines the kernel rate of max events per sec for activity dumps.
-	ActivityDumpRateLimiter int
+	ActivityDumpRateLimiter uint16
 	// ActivityDumpCgroupWaitListTimeout defines the time to wait before a cgroup can be dumped again.
 	ActivityDumpCgroupWaitListTimeout time.Duration
 	// ActivityDumpCgroupDifferentiateArgs defines if system-probe should differentiate process nodes using process
@@ -377,7 +378,6 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		ActivityDumpCgroupsManagers:           pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.cgroup_managers"),
 		ActivityDumpTracedEventTypes:          parseEventTypeStringSlice(pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.activity_dump.traced_event_types")),
 		ActivityDumpCgroupDumpTimeout:         pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.dump_duration"),
-		ActivityDumpRateLimiter:               pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.rate_limiter"),
 		ActivityDumpCgroupWaitListTimeout:     pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.activity_dump.cgroup_wait_list_timeout"),
 		ActivityDumpCgroupDifferentiateArgs:   pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.activity_dump.cgroup_differentiate_args"),
 		ActivityDumpLocalStorageDirectory:     pkgconfigsetup.SystemProbe().GetString("runtime_security_config.activity_dump.local_storage.output_directory"),
@@ -465,6 +465,12 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		// direct sender
 		SendEventFromSystemProbe: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.direct_send_from_system_probe"),
 	}
+
+	activityDumpRateLimiter := pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.rate_limiter")
+	if activityDumpRateLimiter < 0 || activityDumpRateLimiter > math.MaxUint16 {
+		return nil, fmt.Errorf("invalid value for runtime_security_config.activity_dump.rate_limiter: %d, must be in uint16 range", activityDumpRateLimiter)
+	}
+	rsConfig.ActivityDumpRateLimiter = uint16(activityDumpRateLimiter)
 
 	if err := rsConfig.sanitize(); err != nil {
 		return nil, err

--- a/pkg/security/ebpf/c/include/structs/activity_dump.h
+++ b/pkg/security/ebpf/c/include/structs/activity_dump.h
@@ -7,7 +7,8 @@ struct activity_dump_config {
     u64 wait_list_timestamp;
     u64 start_timestamp;
     u64 end_timestamp;
-    u32 events_rate;
+    u16 events_rate;
+    u16 padding;
     u32 paused;
 };
 

--- a/pkg/security/ebpf/c/include/structs/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/structs/rate_limiter.h
@@ -25,8 +25,10 @@ u8 __attribute__((always_inline)) get_counter(struct rate_limiter_ctx *r) {
 }
 
 void __attribute__((always_inline)) inc_counter(struct rate_limiter_ctx *r, u8 delta) {
-    u8 new_counter = get_counter(r) + delta;
-    r->data = (r->data & ~0xff) | new_counter;
+    // this is an horrible hack, to keep the atomic property
+    // we do an atomic add on the full data, worse case scenario
+    // the current_period is increased by 256 nanoseconds
+    __sync_fetch_and_add(&r->data, delta);
 }
 
 #endif /* _STRUCTS_RATE_LIMITER_H_ */

--- a/pkg/security/ebpf/c/include/structs/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/structs/rate_limiter.h
@@ -1,30 +1,32 @@
 #ifndef _STRUCTS_RATE_LIMITER_H_
 #define _STRUCTS_RATE_LIMITER_H_
 
+#define RATE_LIMITER_COUNTER_MASK 0xffffllu
+
 struct rate_limiter_ctx {
     /*
         data is representing both the `current_period` start
-        in the first 7 bytes (basically current_period & ~0xff)
-        and the counter in the last byte
+        in the first 6 bytes (basically current_period & ~0xff)
+        and the counter in the last 2 bytes
     */
     u64 data;
 };
 
-struct rate_limiter_ctx __attribute__((always_inline)) new_rate_limiter(u64 now, u8 counter) {
+struct rate_limiter_ctx __attribute__((always_inline)) new_rate_limiter(u64 now, u16 counter) {
     return (struct rate_limiter_ctx) {
-        .data = (now & ~((u64)0xff)) | counter,
+        .data = (now & ~RATE_LIMITER_COUNTER_MASK) | counter,
     };
 }
 
 u64 __attribute__((always_inline)) get_current_period(struct rate_limiter_ctx *r) {
-    return r->data & ~((u64)0xff);
+    return r->data & ~RATE_LIMITER_COUNTER_MASK;
 }
 
-u8 __attribute__((always_inline)) get_counter(struct rate_limiter_ctx *r) {
-    return r->data & 0xff;
+u16 __attribute__((always_inline)) get_counter(struct rate_limiter_ctx *r) {
+    return r->data & RATE_LIMITER_COUNTER_MASK;
 }
 
-void __attribute__((always_inline)) inc_counter(struct rate_limiter_ctx *r, u8 delta) {
+void __attribute__((always_inline)) inc_counter(struct rate_limiter_ctx *r, u16 delta) {
     // this is an horrible hack, to keep the atomic property
     // we do an atomic add on the full data, worse case scenario
     // the current_period is increased by 256 nanoseconds

--- a/pkg/security/ebpf/c/include/structs/rate_limiter.h
+++ b/pkg/security/ebpf/c/include/structs/rate_limiter.h
@@ -2,10 +2,31 @@
 #define _STRUCTS_RATE_LIMITER_H_
 
 struct rate_limiter_ctx {
-    u64 current_period;
-    u32 counter;
-    u32 padding;
+    /*
+        data is representing both the `current_period` start
+        in the first 7 bytes (basically current_period & ~0xff)
+        and the counter in the last byte
+    */
+    u64 data;
 };
 
+struct rate_limiter_ctx __attribute__((always_inline)) new_rate_limiter(u64 now, u8 counter) {
+    return (struct rate_limiter_ctx) {
+        .data = (now & ~((u64)0xff)) | counter,
+    };
+}
+
+u64 __attribute__((always_inline)) get_current_period(struct rate_limiter_ctx *r) {
+    return r->data & ~((u64)0xff);
+}
+
+u8 __attribute__((always_inline)) get_counter(struct rate_limiter_ctx *r) {
+    return r->data & 0xff;
+}
+
+void __attribute__((always_inline)) inc_counter(struct rate_limiter_ctx *r, u8 delta) {
+    u8 new_counter = get_counter(r) + delta;
+    r->data = (r->data & ~0xff) | new_counter;
+}
 
 #endif /* _STRUCTS_RATE_LIMITER_H_ */

--- a/pkg/security/ebpf/c/include/tests/activity_dump_ratelimiter_test.h
+++ b/pkg/security/ebpf/c/include/tests/activity_dump_ratelimiter_test.h
@@ -14,9 +14,7 @@ int test_ad_ratelimiter() {
 
     u32 rate = AD_RL_TEST_RATE;
 
-    struct rate_limiter_ctx ctx;
-    ctx.counter = 0;
-    ctx.current_period = now;
+    struct rate_limiter_ctx ctx = new_rate_limiter(now, 0);
     u64 cookie = 0;
     bpf_map_update_elem(&activity_dump_rate_limiters, &cookie, &ctx, BPF_ANY);
 

--- a/pkg/security/secl/model/marshallers_linux.go
+++ b/pkg/security/secl/model/marshallers_linux.go
@@ -171,7 +171,8 @@ func (adlc *ActivityDumpLoadConfig) MarshalBinary() ([]byte, error) {
 	binary.NativeEndian.PutUint64(raw[16:24], adlc.WaitListTimestampRaw)
 	binary.NativeEndian.PutUint64(raw[24:32], adlc.StartTimestampRaw)
 	binary.NativeEndian.PutUint64(raw[32:40], adlc.EndTimestampRaw)
-	binary.NativeEndian.PutUint32(raw[40:44], adlc.Rate)
+	binary.NativeEndian.PutUint16(raw[40:42], adlc.Rate)
+	binary.NativeEndian.PutUint16(raw[42:44], 0)
 	binary.NativeEndian.PutUint32(raw[44:48], adlc.Paused)
 
 	return raw, nil

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -654,7 +654,7 @@ type ActivityDumpLoadConfig struct {
 	WaitListTimestampRaw uint64
 	StartTimestampRaw    uint64
 	EndTimestampRaw      uint64
-	Rate                 uint32 // max number of events per sec
+	Rate                 uint16 // max number of events per sec
 	Paused               uint32
 }
 

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -1030,7 +1030,8 @@ func (adlc *ActivityDumpLoadConfig) EventUnmarshalBinary(data []byte) (int, erro
 	adlc.WaitListTimestampRaw = binary.NativeEndian.Uint64(data[16:24])
 	adlc.StartTimestampRaw = binary.NativeEndian.Uint64(data[24:32])
 	adlc.EndTimestampRaw = binary.NativeEndian.Uint64(data[32:40])
-	adlc.Rate = binary.NativeEndian.Uint32(data[40:44])
+	adlc.Rate = binary.NativeEndian.Uint16(data[40:42])
+	// 2 bytes of padding
 	adlc.Paused = binary.NativeEndian.Uint32(data[44:48])
 	return 48, nil
 }

--- a/pkg/security/security_profile/dump/activity_dump.go
+++ b/pkg/security/security_profile/dump/activity_dump.go
@@ -128,11 +128,11 @@ type SyscallPolicy struct {
 }
 
 // NewActivityDumpLoadConfig returns a new instance of ActivityDumpLoadConfig
-func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, waitListTimeout time.Duration, rate int, start time.Time, resolver *stime.Resolver) *model.ActivityDumpLoadConfig {
+func NewActivityDumpLoadConfig(evt []model.EventType, timeout time.Duration, waitListTimeout time.Duration, rate uint16, start time.Time, resolver *stime.Resolver) *model.ActivityDumpLoadConfig {
 	adlc := &model.ActivityDumpLoadConfig{
 		TracedEventTypes: evt,
 		Timeout:          timeout,
-		Rate:             uint32(rate),
+		Rate:             uint16(rate),
 	}
 	if resolver != nil {
 		adlc.StartTimestampRaw = uint64(resolver.ComputeMonotonicTimestamp(start))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reduces the kernel size of the structure `struct rate_limiter_ctx` allowing to reclaim half of the memory used by the `activity_dump_rate_limiters` and `rate_limiters` maps. Especially this results in a win of ~5MiB just for the `rate_limiters` maps on staging.

The main idea here is to pack the counter and the previous "now" in the same u64 by re-using the lower bits of the time field. We lose a bit of precision (in the order of 256 nanoseconds) at the great value of reducing the kernel size used by CWS. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->