### PR TITLE
fix(tag_version): Push tags by batch, again

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -17,6 +17,8 @@ from tasks.libs.common.user_interactions import yes_no_question
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+TAG_BATCH_SIZE = 3
+
 
 @contextmanager
 def clone(ctx, repo, branch, options=""):
@@ -310,3 +312,11 @@ def revert_git_config(original_config):
             subprocess.run(['git', 'config', '--unset', key])
         else:
             subprocess.run(['git', 'config', key, value])
+
+
+def push_tags_by_batch(ctx, tags, force_option, batch_size=TAG_BATCH_SIZE):
+    tags_list = ' '.join(tags)
+    for idx in range(0, len(tags), batch_size):
+        batch_tags = tags[idx : idx + batch_size]
+        ctx.run(f"git push origin {' '.join(batch_tags)}{force_option}")
+    print(f"Pushed tag {tags_list}")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -35,6 +35,7 @@ from tasks.libs.common.git import (
     get_last_commit,
     get_last_release_tag,
     is_agent6,
+    push_tags_by_batch,
     set_git_config,
     try_git_command,
 )
@@ -85,7 +86,6 @@ GITLAB_FILES_TO_UPDATE = [
 ]
 
 BACKPORT_LABEL_COLOR = "5319e7"
-TAG_BATCH_SIZE = 3
 
 
 @task
@@ -201,11 +201,7 @@ def tag_modules(
                 tags.extend(new_tags)
 
         if push:
-            tags_list = ' '.join(tags)
-            for idx in range(0, len(tags), TAG_BATCH_SIZE):
-                batch_tags = tags[idx : idx + TAG_BATCH_SIZE]
-                ctx.run(f"git push origin {' '.join(batch_tags)}{force_option}")
-            print(f"Pushed tag {tags_list}")
+            push_tags_by_batch(ctx, tags, force_option)
         print(f"Created module tags for version {agent_version}")
 
 
@@ -238,9 +234,7 @@ def tag_version(
         tags = __tag_single_module(ctx, get_default_modules()["."], agent_version, commit, force_option, devel)
 
     if push:
-        tags_list = ' '.join(tags)
-        ctx.run(f"git push origin {tags_list}{force_option}")
-        print(f"Pushed tag {tags_list}")
+        push_tags_by_batch(ctx, tags, force_option)
     print(f"Created tags for version {agent_version}")
 
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Follow-up of #32983
Push tags by batch, on the `tag_version` task now.

### Motivation
As per [this comment](https://github.com/DataDog/datadog-agent/pull/32983/files#r1916272378) there was another usage of the push by batch I missed

### Describe how you validated your changes
Already covered by the tests introduced in #32983
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->