### PR TITLE
[ASCII-2889] Prevents the traceAgent debug to start without IPC certificate

### DIFF
--- a/comp/api/authtoken/fetchonlyimpl/authtoken.go
+++ b/comp/api/authtoken/fetchonlyimpl/authtoken.go
@@ -75,8 +75,7 @@ func (at *authToken) Get() string {
 // GetTLSClientConfig return a TLS configuration with the IPC certificate for http.Client
 func (at *authToken) GetTLSClientConfig() *tls.Config {
 	if err := at.setToken(); err != nil {
-		at.log.Debugf("%s", err.Error())
-		return nil
+		at.log.Debugf("unable to initialize authToken: %s", err.Error())
 	}
 
 	return util.GetTLSClientConfig()
@@ -85,8 +84,7 @@ func (at *authToken) GetTLSClientConfig() *tls.Config {
 // GetTLSServerConfig return a TLS configuration with the IPC certificate for http.Server
 func (at *authToken) GetTLSServerConfig() *tls.Config {
 	if err := at.setToken(); err != nil {
-		at.log.Debugf("%s", err.Error())
-		return nil
+		at.log.Debugf("unable to initialize authToken: %s", err.Error())
 	}
 
 	return util.GetTLSServerConfig()

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -33,6 +33,9 @@ import (
 
 // runAgentSidekicks is the entrypoint for running non-components that run along the agent.
 func runAgentSidekicks(ag component) error {
+	// Configure the Trace Agent Debug server to use the IPC certificate
+	ag.Agent.DebugServer.SetTLSConfig(ag.at.GetTLSServerConfig())
+
 	tracecfg := ag.config.Object()
 	err := info.InitInfo(tracecfg) // for expvar & -info option
 	if err != nil {
@@ -97,9 +100,6 @@ func runAgentSidekicks(ag component) error {
 			w.Write([]byte(res))
 		}))
 	}
-
-	// Configure the Trace Agent Debug server to use the IPC certificate
-	ag.Agent.DebugServer.SetTLSConfig(ag.at.GetTLSServerConfig())
 
 	log.Infof("Trace agent running on host %s", tracecfg.Hostname)
 	if pcfg := profilingConfig(tracecfg); pcfg != nil {

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -41,7 +41,7 @@ var (
 	clientTLSConfig = &tls.Config{
 		InsecureSkipVerify: true,
 	}
-	serverTLSConfig *tls.Config
+	serverTLSConfig = &tls.Config{}
 	initSource      source
 )
 

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1075,6 +1076,39 @@ func TestExpvar(t *testing.T) {
 			assert.NotNil(t, out["receiver"], "expvar receiver must not be nil")
 		}
 	})
+}
+
+func TestWithoutIPCCert(t *testing.T) {
+	c := newTestReceiverConfig()
+
+	// Getting an available port
+	a, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	var l *net.TCPListener
+	l, err = net.ListenTCP("tcp", a)
+	require.NoError(t, err)
+
+	availablePort := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	require.NotZero(t, availablePort)
+
+	c.DebugServerPort = availablePort
+	info.InitInfo(c)
+
+	// Starting Debug Server
+	s := NewDebugServer(c)
+
+	// Starting the Debug server
+	s.Start()
+	defer s.Stop()
+
+	// Server should not be able to connect because it didn't start
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(c.DebugServerPort)), time.Second)
+	require.Error(t, err)
+	if conn != nil {
+		conn.Close()
+	}
 }
 
 func TestNormalizeHTTPHeader(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR improve error handling around IPC cert loading:
- earlier setting of IPC cert for Debug server of traceAgent
- ensure that the server does not start if no tls.Config was provided
- improve certificate supply chain to avoid returning nil pointer

### Motivation
This PR fix some cases where the trace Agent were panicking while responding to HTTPS requests made to its Debug server because of a nil `*tls.Config` pointer.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I added a unit test to check that the Debug server does not start if not tls configuration was provided

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
There is an ongoing effort to improve the certificate supply chain in Agent codebase.