### PR TITLE
[CONTP-547] assert detected language in agent workloadmeta in e2e test

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -348,11 +348,18 @@ func (suite *k8sSuite) testAgentCLI() {
 	})
 
 	suite.Run("agent workload-list", func() {
-		stdout, stderr, err := suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "workload-list", "-v"})
-		suite.Require().NoError(err)
-		suite.Empty(stderr, "Standard error of `agent workload-list` should be empty")
-		suite.Contains(stdout, "=== Entity container sources(merged):[node_orchestrator runtime] id: ")
-		suite.Contains(stdout, "=== Entity kubernetes_pod sources(merged):[cluster_orchestrator node_orchestrator] id: ")
+		var stdout string
+		var stderr string
+		suite.EventuallyWithT(func(c *assert.CollectT) {
+			stdout, stderr, err = suite.podExec("datadog", pod.Items[0].Name, "agent", []string{"agent", "workload-list", "-v"})
+			if !assert.NoError(c, err) {
+				return
+			}
+			assert.Empty(c, stderr, "Standard error of `agent workload-list` should be empty")
+			assert.Contains(c, stdout, "=== Entity container sources(merged):[node_orchestrator runtime] id: ")
+			assert.Contains(c, stdout, "=== Entity kubernetes_pod sources(merged):[cluster_orchestrator node_orchestrator] id: ")
+			assert.Contains(c, stdout, "Language: python") // Added temporarily to investigate flaky e2e test
+		}, 2*time.Minute, 1*time.Second)
 		if suite.T().Failed() {
 			suite.T().Log(stdout)
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Related to [this](https://github.com/DataDog/datadog-agent/pull/32841).

### Motivation

Determine if the issue causing e2e failure for APM SSI is coming from the node agent side or the dca side.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

QA already implemented.

### Possible Drawbacks / Trade-offs
None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->