### PR TITLE
fix(reno): Update the release_tag_re for agent6

### DIFF
--- a/releasenotes-dca/config.yaml
+++ b/releasenotes-dca/config.yaml
@@ -2,7 +2,7 @@
 default_branch: main
 collapse_pre_releases: true
 no_show_source: true
-release_tag_re: '^7\.([\d.-]|rc|devel)+$'
+release_tag_re: '^6\.([\d.-]|rc|devel)+$'
 pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
 template: |
           # Each section from every release note are combined when the

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -2,7 +2,7 @@
 default_branch: main
 collapse_pre_releases: true
 no_show_source: true
-release_tag_re: '^7\.([\d.-]|rc|devel)+$'
+release_tag_re: '^6\.([\d.-]|rc|devel)+$'
 pre_release_tag_re: '(?P<pre_release>-rc\.\d+)$'
 template: |
           # Each section from every release note are combined when the


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update the release_tag_re for agent6

### Motivation
Currently `reno` is unable to generate a release note on agent6 branch because it only shows the `7.y.z` tags

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->