### PR TITLE
service discovery: Remove ignore_process config in check

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
@@ -52,11 +52,6 @@ var (
 		env: []string{},
 		cwd: "",
 	}
-	procIgnoreService1 = testProc{
-		pid: 100,
-		env: nil,
-		cwd: "",
-	}
 	procTestService1Repeat = testProc{
 		pid: 101,
 		env: []string{},
@@ -118,14 +113,6 @@ var (
 		CommandLine:                []string{"test-service-1"},
 		StartTimeMilli:             procLaunchedMilli,
 		ContainerID:                dummyContainerID,
-	}
-	portTCP8081 = model.Service{
-		PID:            procIgnoreService1.pid,
-		Name:           "ignore-1",
-		GeneratedName:  "ignore-1",
-		Ports:          []uint16{8081},
-		StartTimeMilli: procLaunchedMilli,
-		ContainerID:    dummyContainerID,
 	}
 	portTCP5000 = model.Service{
 		PID:                        procPythonService.pid,
@@ -189,7 +176,6 @@ func cmpEvents(a, b *event) bool {
 
 func Test_linuxImpl(t *testing.T) {
 	host := "test-host"
-	cfgYaml := `ignore_processes: ["ignore-1", "ignore-2"]`
 	t.Setenv("DD_DISCOVERY_ENABLED", "true")
 
 	type checkRun struct {
@@ -209,7 +195,6 @@ func Test_linuxImpl(t *testing.T) {
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP5000,
 						portTCP8080,
-						portTCP8081,
 					}},
 					time: calcTime(0),
 				},
@@ -217,7 +202,6 @@ func Test_linuxImpl(t *testing.T) {
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP5000,
 						portTCP8080,
-						portTCP8081,
 					}},
 					time: calcTime(1 * time.Minute),
 				},
@@ -225,7 +209,6 @@ func Test_linuxImpl(t *testing.T) {
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP5000,
 						portTCP8080UpdatedRSS,
-						portTCP8081,
 					}},
 					time: calcTime(20 * time.Minute),
 				},
@@ -372,7 +355,6 @@ func Test_linuxImpl(t *testing.T) {
 				{
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP8080,
-						portTCP8081,
 						portTCP5432,
 					}},
 					time: calcTime(0),
@@ -380,7 +362,6 @@ func Test_linuxImpl(t *testing.T) {
 				{
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP8080,
-						portTCP8081,
 						portTCP5432,
 					}},
 					time: calcTime(1 * time.Minute),
@@ -388,7 +369,6 @@ func Test_linuxImpl(t *testing.T) {
 				{
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP8080,
-						portTCP8081,
 						portTCP5432,
 					}},
 					time: calcTime(20 * time.Minute),
@@ -531,14 +511,12 @@ func Test_linuxImpl(t *testing.T) {
 				{
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP8080,
-						portTCP8081,
 					}},
 					time: calcTime(0),
 				},
 				{
 					servicesResp: &model.ServicesResponse{Services: []model.Service{
 						portTCP8080,
-						portTCP8081,
 					}},
 					time: calcTime(1 * time.Minute),
 				},
@@ -626,7 +604,7 @@ func Test_linuxImpl(t *testing.T) {
 			err := check.Configure(
 				mSender.GetSenderManager(),
 				integration.FakeConfigHash,
-				integration.Data(cfgYaml),
+				integration.Data{},
 				nil,
 				"test",
 			)


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

There is another ignore process config which is handled in the system probe so earlier in the processing.  The ignore_process in the check has never been used nor documented, so remove it to simplify the code.

### Motivation

Noticed while reviewing https://github.com/DataDog/datadog-agent/pull/32128.

### Describe how you validated your changes

Covered by unit and E2E tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->