### PR TITLE
Update zstd default release note to indicate places where this may be breaking

### DIFF
--- a/releasenotes/notes/metrics-compression-default-zstd-c786c2d28eb51b1f.yaml
+++ b/releasenotes/notes/metrics-compression-default-zstd-c786c2d28eb51b1f.yaml
@@ -6,7 +6,7 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-enhancements:
+upgrade:
   - |
     Metric payloads are compressed using `zstd` compression by default.
     This may be breaking for users who are sending metrics to systems other

--- a/releasenotes/notes/metrics-compression-default-zstd-c786c2d28eb51b1f.yaml
+++ b/releasenotes/notes/metrics-compression-default-zstd-c786c2d28eb51b1f.yaml
@@ -9,5 +9,8 @@
 enhancements:
   - |
     Metric payloads are compressed using `zstd` compression by default.
-    This can be reverted to the previous compression kind by adding
-    ``serializer_compressor_kind: zlib`` to the configuration.
+    This may be breaking for users who are sending metrics to systems other
+    than Datadog, such as Vector prior to version 0.40 or proxy servers that
+    need to decode requests. The setting can be reverted to the previous
+    compression kind by adding ``serializer_compressor_kind: zlib`` to the
+    configuration.


### PR DESCRIPTION
### What does this PR do?

Update the release note that changes the default metrics compression to `zstd` to indicate potential areas where this may cause systems to break.

### Motivation

It may help users to debug any errors that might occur on upgrading and point them to solutions.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->