### PR TITLE
Add kube_cronjob tag to kubernetes_state.job.duration and fix existing unit tests

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -89,7 +89,6 @@ func defaultMetricNamesMapper() map[string]string {
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed":             "vpa.spec_container_minallowed",
 		"kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed":             "vpa.spec_container_maxallowed",
 		"kube_cronjob_spec_suspend":                                                                "cronjob.spec_suspend",
-		"kube_job_duration":                                                                        "job.duration",
 		"kube_ingress_path":                                                                        "ingress.path",
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -101,6 +101,7 @@ func defaultMetricTransformers() map[string]metricTransformerFunc {
 		"kube_cronjob_next_schedule_time":               cronJobNextScheduleTransformer,
 		"kube_cronjob_status_last_schedule_time":        cronJobLastScheduleTransformer,
 		"kube_job_complete":                             jobCompleteTransformer,
+		"kube_job_duration":                             jobDurationTransformer,
 		"kube_job_failed":                               jobFailedTransformer,
 		"kube_job_status_failed":                        jobStatusFailedTransformer,
 		"kube_job_status_succeeded":                     jobStatusSucceededTransformer,
@@ -370,6 +371,10 @@ func jobCompleteTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric,
 	jobMetric(s, metric, ksmMetricPrefix+"job.completion.succeeded", hostname, tagsCopy)
 
 	jobServiceCheck(s, metric, servicecheck.ServiceCheckOK, hostname, tags)
+}
+
+func jobDurationTransformer(s sender.Sender, _ string, metric ksmstore.DDMetric, hostname string, tags []string, _ time.Time) {
+	jobMetric(s, metric, ksmMetricPrefix+"job.duration", hostname, tags)
 }
 
 // jobFailedTransformer sends a metric and a service check based on kube_job_failed

--- a/releasenotes/notes/[agent]-add-kube_cronjob-tag-to-job-duration-add9616702d61668.yaml
+++ b/releasenotes/notes/[agent]-add-kube_cronjob-tag-to-job-duration-add9616702d61668.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds a kube_cronjob tag to kubernetes_state.job.duration metric.
+fixes:
+  - |
+    Fixes some existing metric transformer unit tests by correcting their assertions.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
* Adds the `kube_cronjob` tag to the `kubernetes_state.job.duration`
* Fixes some small existing unit test bugs where the `AssertServiceCheck` and `AssertMetric` functions were incorrectly being supplied the _input_ tags, not the _expected_ tags.

### Motivation
Feature request

### Describe how you validated your changes
I deployed a cronjob onto a test cluster and observed that it is now properly tagged with `kube_cronjob`
<img width="1048" alt="Screenshot 2025-01-21 at 5 31 09 PM" src="https://github.com/user-attachments/assets/d42cbe40-a6c0-4e38-acc6-d57598f5183f" />


<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->