### PR TITLE
Limit number of parallel queries in external metrics

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -715,6 +715,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("external_metrics_provider.chunk_size", 35)                     // Maximum number of queries to batch when querying Datadog.
 	config.BindEnvAndSetDefault("external_metrics_provider.split_batches_with_backoff", false)  // Splits batches and runs queries with errors individually with an exponential backoff
 	config.BindEnvAndSetDefault("external_metrics_provider.num_workers", 2)                     // Number of workers spawned by controller (only when CRD is used)
+	config.BindEnvAndSetDefault("external_metrics_provider.max_parallel_queries", 10)           // Maximum number of parallel queries sent to Datadog simultaneously
 	pkgconfigmodel.AddOverrideFunc(sanitizeExternalMetricsProviderChunkSize)
 	// Cluster check Autodiscovery
 	config.BindEnvAndSetDefault("cluster_checks.support_hybrid_ignore_ad_tags", false) // TODO(CINT)(Agent 7.53+) Remove this flag when hybrid ignore_ad_tags is fully deprecated

--- a/pkg/util/kubernetes/autoscalers/processor_test.go
+++ b/pkg/util/kubernetes/autoscalers/processor_test.go
@@ -17,8 +17,9 @@ import (
 
 	datadogclientmock "github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient/mock"
 	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
-
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/custommetrics"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
@@ -30,11 +31,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-var maxAge = 30 * time.Second
+const (
+	testMaxAge          = 30 * time.Second
+	testParallelQueries = 10
+)
 
 func makePoints(ts, val int) datadog.DataPoint {
 	if ts == 0 {
-		ts = (int(metav1.Now().Unix()) - int(maxAge.Seconds())) * 1000 // use ms
+		ts = (int(metav1.Now().Unix()) - int(testMaxAge.Seconds())) * 1000 // use ms
 	}
 	tsPtr := float64(ts)
 	valPtr := float64(val)
@@ -46,8 +50,28 @@ func makePartialPoints(ts int) datadog.DataPoint {
 	return datadog.DataPoint{&tsPtr, nil}
 }
 
+func TestParallelLimit(t *testing.T) {
+	cfg := configmock.New(t)
+
+	cfg.Set("external_metrics_provider.max_parallel_queries", 3000, pkgconfigmodel.SourceLocalConfigProcess)
+	p := NewProcessor(nil)
+	assert.Equal(t, maxParallelQueries, p.parallelQueries)
+
+	cfg.Set("external_metrics_provider.max_parallel_queries", 0, pkgconfigmodel.SourceLocalConfigProcess)
+	p = NewProcessor(nil)
+	assert.Equal(t, maxParallelQueries, p.parallelQueries)
+
+	cfg.Set("external_metrics_provider.max_parallel_queries", -20, pkgconfigmodel.SourceLocalConfigProcess)
+	p = NewProcessor(nil)
+	assert.Equal(t, maxParallelQueries, p.parallelQueries)
+
+	cfg.Set("external_metrics_provider.max_parallel_queries", 20, pkgconfigmodel.SourceLocalConfigProcess)
+	p = NewProcessor(nil)
+	assert.Equal(t, 20, p.parallelQueries)
+}
+
 func TestProcessor_UpdateExternalMetrics(t *testing.T) {
-	penTime := (int(time.Now().Unix()) - int(maxAge.Seconds()/2)) * 1000
+	penTime := (int(time.Now().Unix()) - int(testMaxAge.Seconds()/2)) * 1000
 	metricName := "requests_per_s"
 	tests := []struct {
 		desc     string
@@ -161,7 +185,7 @@ func TestProcessor_UpdateExternalMetrics(t *testing.T) {
 			datadogClientComp.SetQueryMetricsFunc(func(int64, int64, string) ([]datadog.Series, error) {
 				return tt.series, nil
 			})
-			hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: maxAge}
+			hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: testMaxAge, parallelQueries: testParallelQueries}
 
 			externalMetrics := hpaCl.UpdateExternalMetrics(tt.metrics)
 			fmt.Println(externalMetrics)
@@ -197,7 +221,7 @@ func TestProcessor_UpdateExternalMetrics(t *testing.T) {
 		return nil, fmt.Errorf("API error 400 Bad Request: {\"error\": [\"Rate limit of 300 requests in 3600 seconds reqchec.\"]}")
 	})
 
-	hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: maxAge}
+	hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: testMaxAge, parallelQueries: testParallelQueries}
 	invList := hpaCl.UpdateExternalMetrics(emList)
 	require.Len(t, invList, len(emList))
 	for _, i := range invList {
@@ -217,7 +241,7 @@ func randStringRune(n int) string {
 
 func TestValidateExternalMetricsBatching(t *testing.T) {
 	metricName := "foo"
-	penTime := (int(time.Now().Unix()) - int(maxAge.Seconds()/2)) * 1000
+	penTime := (int(time.Now().Unix()) - int(testMaxAge.Seconds()/2)) * 1000
 	tests := []struct {
 		desc       string
 		in         []string
@@ -344,7 +368,7 @@ func TestValidateExternalMetricsBatching(t *testing.T) {
 				}
 				return tt.out, nil
 			})
-			p := &Processor{datadogClient: datadogClientComp}
+			p := &Processor{datadogClient: datadogClientComp, parallelQueries: testParallelQueries}
 
 			_ = p.QueryExternalMetric(tt.in, GetDefaultTimeWindow())
 			assert.Equal(t, tt.batchCalls, res.bc)
@@ -470,7 +494,7 @@ func TestProcessor_ProcessHPAs(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("#%d %s", i, tt.desc), func(t *testing.T) {
 			datadogClientComp := datadogclientmock.New(t).Comp
-			hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: maxAge}
+			hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: testMaxAge, parallelQueries: testParallelQueries}
 
 			externalMetrics := hpaCl.ProcessHPAs(&tt.metrics)
 			for id, m := range externalMetrics {
@@ -597,7 +621,7 @@ func TestUpdateRateLimiting(t *testing.T) {
 			datadogClientComp.SetGetRateLimitsFunc(func() map[string]datadog.RateLimit {
 				return tt.rateLimits
 			})
-			hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: maxAge}
+			hpaCl := &Processor{datadogClient: datadogClientComp, externalMaxAge: testMaxAge, parallelQueries: testParallelQueries}
 
 			hpaCl.updateRateLimitingMetrics()
 			key := strings.Join([]string{queryEndpoint, le.JoinLeaderValue}, ",")


### PR DESCRIPTION
### What does this PR do?

Currently we're using unbounded number of parallel queries to Datadog, which can have impact on the rate limiting.

The proper solution would be to compute batches and spread them on the entire refresh period but it requires significant changes. This is a small change to improve the situation in the short term.

### Motivation

### Describe how you validated your changes

The change should be invisible to most cases. Only in case of very large usage of External Metrics, queries should be spread  more evenly due to the time it takes to execute them.

The test is then mostly non-regression in the E2E tests, and scalability testing in dogfooding.

### Possible Drawbacks / Trade-offs

### Additional Notes
