### PR TITLE
Lazy obfuscator for Oracle

### DIFF
--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle/common"
-	"github.com/DataDog/datadog-agent/pkg/obfuscate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -157,8 +156,7 @@ AND status = 'ACTIVE'`)
 		return fmt.Errorf("failed to collect session sampling activity: %w \n%s", err, activityQuery)
 	}
 
-	o := obfuscate.NewObfuscator(obfuscate.Config{SQL: c.config.ObfuscatorOptions})
-	defer o.Stop()
+	o := c.LazyInitObfuscator()
 	var payloadSent bool
 	var lastNow string
 	for _, sample := range sessionSamples {

--- a/pkg/collector/corechecks/oracle/obfuscate.go
+++ b/pkg/collector/corechecks/oracle/obfuscate.go
@@ -20,6 +20,7 @@ var (
 	obfuscatorLock sync.Mutex
 )
 
+// Inits an obfuscator a single time the first time it is called
 func (c *Check) LazyInitObfuscator() *obfuscate.Obfuscator {
 	// Ensure thread safe initialization
 	obfuscatorLock.Lock()

--- a/pkg/collector/corechecks/oracle/obfuscate.go
+++ b/pkg/collector/corechecks/oracle/obfuscate.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build oracle
+
+package oracle
+
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/obfuscate"
+)
+
+var (
+	obfuscatorLock sync.Mutex
+)
+
+func (c *Check) LazyInitObfuscator() *obfuscate.Obfuscator {
+	// Ensure thread safe initialization
+	obfuscatorLock.Lock()
+	defer obfuscatorLock.Unlock()
+
+	if c.obfuscator == nil {
+		c.obfuscator = obfuscate.NewObfuscator(obfuscate.Config{SQL: c.config.ObfuscatorOptions})
+	}
+
+	return c.obfuscator
+}

--- a/pkg/collector/corechecks/oracle/obfuscate.go
+++ b/pkg/collector/corechecks/oracle/obfuscate.go
@@ -20,7 +20,7 @@ var (
 	obfuscatorLock sync.Mutex
 )
 
-// Inits an obfuscator a single time the first time it is called
+// LazyInitObfuscator inits an obfuscator a single time the first time it is called
 func (c *Check) LazyInitObfuscator() *obfuscate.Obfuscator {
 	// Ensure thread safe initialization
 	obfuscatorLock.Lock()

--- a/pkg/collector/corechecks/oracle/oracle.go
+++ b/pkg/collector/corechecks/oracle/oracle.go
@@ -114,6 +114,7 @@ type Check struct {
 	legacyIntegrationCompatibilityMode      bool
 	clock                                   clock.Clock
 	lastSampleID                            uint64
+	obfuscator                              *obfuscate.Obfuscator
 }
 
 type vDatabase struct {

--- a/pkg/collector/corechecks/oracle/statements.go
+++ b/pkg/collector/corechecks/oracle/statements.go
@@ -423,8 +423,7 @@ func (c *Check) StatementMetrics() (int, error) {
 			return 0, nil
 		}
 
-		o := obfuscate.NewObfuscator(obfuscate.Config{SQL: c.config.ObfuscatorOptions})
-		defer o.Stop()
+		o := c.LazyInitObfuscator()
 		var diff OracleRowMonotonicCount
 		planErrors = 0
 		sendPlan := true

--- a/releasenotes/notes/oracle-obfuscator-lazy-init-ce7c237bb52ee72f.yaml
+++ b/releasenotes/notes/oracle-obfuscator-lazy-init-ce7c237bb52ee72f.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Updated Oracle check to lazily initialize the obfuscator. This should
+    improve performance each time the Oracle check runs and collects SQL
+    statements.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Uses a lazy initer to create a single obfuscator to be used by the Oracle check during its lifetime.

### Motivation
Creating the obfuscator each time we need it is expensive, and prevents the cache from working.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->