### PR TITLE
Update Quality Gates memory allotments

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -9,7 +9,7 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 500MiB
+  memory_allotment: 250 MiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -9,7 +9,7 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 1GiB
+  memory_allotment: 850 MiB
 
   environment:
     DD_API_KEY: 00000001

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -4,7 +4,7 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 500MiB
+  memory_allotment: 350 MiB
 
   environment:
     DD_API_KEY: 00000001


### PR DESCRIPTION
### What does this PR do?

This commit updates the memory allotments to more tightly bound the allocation as indicated by previous Quality Gate runs: Agent simply needs less memory than it did.

