### PR TITLE
[CONTP-589] DCA local failover store: call close on a reader

### DIFF
--- a/cmd/cluster-agent/api/v2/series/series.go
+++ b/cmd/cluster-agent/api/v2/series/series.go
@@ -76,6 +76,7 @@ func (h *seriesHandler) handle(w http.ResponseWriter, r *http.Request) {
 	default:
 		rc = r.Body
 	}
+	defer rc.Close()
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
rc.Close() statement ensures that the Close method is called on the reader when the function returns. This releases any resources associated with the reader.

### Motivation
There are memory Leaks without properly closing reader: 
It was observed after this [PR](https://github.com/DataDog/datadog-agent/pull/33206) is merged
<img width="842" alt="Screenshot 2025-01-22 at 4 20 49 PM" src="https://github.com/user-attachments/assets/56bb3b58-577f-4ac7-a5b0-968308a65b4e" />


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Test on nightly cluster

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->