### PR TITLE
Increase the `quality_gate_idle` limit to account for SMP changes

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -35,7 +35,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "356.0 MiB"
+      upper_bound: "361.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

This PR increases the `quality_gate_idle` limit to account for changes in the SMP target environment that negatively impact Agent's memory use.

### Motivation

Address the changed memory use and close out incident-34063.
