### PR TITLE
[backport 7.62.x] [corechecks/cluster/ksm] Add new collector name mappings for apiservices/crds

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -70,6 +70,8 @@ var extendedCollectors = map[string]string{
 // collectorNameReplacement contains a mapping of collector names as they would appear in the KSM config to what
 // their new collector name would be. For backwards compatibility.
 var collectorNameReplacement = map[string]string{
+	"apiservices":               "apiregistration.k8s.io/v1, Resource=apiservices",
+	"customresourcedefinitions": "apiextensions.k8s.io/v1, Resource=customresourcedefinitions",
 	// verticalpodautoscalers were removed from the built-in KSM metrics in KSM 2.9, and the changes made to
 	// the KSM builder in KSM 2.9 result in the detected custom resource store name being different.
 	"verticalpodautoscalers": "autoscaling.k8s.io/v1beta2, Resource=verticalpodautoscalers",

--- a/releasenotes-dca/notes/ksm-add-collector-mapping-apiservices-crds-828e899f4ed551f0.yaml
+++ b/releasenotes-dca/notes/ksm-add-collector-mapping-apiservices-crds-828e899f4ed551f0.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add mapping for apiservices and customresourcedefinitions to KSM check to
+    prevent errors on startup with discovering resources.


### PR DESCRIPTION
Backport https://github.com/DataDog/datadog-agent/commit/cc0f026313a12205511fec7e3a6ba8a6a71a9536 from https://github.com/DataDog/datadog-agent/pull/33271.

---
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add collector name replacement mapping for:
`customresourcedefinitions` -> `apiextensions.k8s.io/v1, Resource=customresourcedefinitions`
`apiservices` -> `apiregistration.k8s.io/v1, Resource=apiservices`

### Motivation

Naming conventions seem to have changed for the ksm stores, causing issues when the ksm check starts e.g.: `Could not configure check kubernetes_state_core: resource customresourcedefinitions does not exist.`

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Checked that error logs on startup disappear with change and setting:
```
datadog:
  ...
  kubeStateMetricsCore:
    enabled: true
    collectCrdMetrics: true
    collectApiServicesMetrics: true
```

`kubernetes_state_core` check is scheduled properly after the change:
<img width="667" alt="image" src="https://github.com/user-attachments/assets/133a86c7-0eaa-4de9-a9ab-29c3824528a7" />


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->