### PR TITLE
fix(installer): Wait on installer to avoid flaky test

### DIFF
--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -172,7 +172,7 @@ func (h *Host) WaitForUnitActivating(t *testing.T, units ...string) {
 			h.t.Logf("installer exp logs:\n%s", h.remote.MustExecute("sudo journalctl -xeu datadog-installer-exp"))
 			h.t.Logf("unit %s logs:\n%s", unit, h.remote.MustExecute("sudo journalctl -xeu "+unit))
 		}
-		require.NoError(t, err, "unit %s did not become activating")
+		require.NoError(t, err, "unit %s did not become activating", unit)
 	}
 }
 

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -386,6 +386,8 @@ func (s *upgradeScenarioSuite) TestInstallerAgentFailure() {
 	s.stopExperiment(datadogInstaller) // Can't check error
 	s.assertSuccessfulInstallerStopExperiment(timestamp)
 
+	s.host.WaitForUnitActive(installerUnit)
+
 	// Retry the golden path to check if everything fine
 	s.setCatalog(testCatalog)
 	s.executeInstallerGoldenPath()


### PR DESCRIPTION
### What does this PR do?
The Installer requires use of a boltdb. Boltdb has a lock on write so if another process has opened the db no other can use it until that process released the db. This happened here somehow; and the installer was in crashloop trying to get hold of the DB.  In the meantime, an order was sent to start an expriment in the test & the installer missed it.

This PR fixes it by waiting on the installer to be ready before sending the experiment order.

### Motivation

### Describe how you validated your changes
E2E change only
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->