### PR TITLE
feat(renovate): Add a renovate configuration for auto-bump of buildimage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@
 
 /mkdocs.yml                             @DataDog/agent-devx-infra
 /release.json                           @DataDog/agent-delivery @DataDog/agent-metrics-logs @DataDog/windows-kernel-integrations @DataDog/agent-security
+/renovate.json                          @DataDog/agent-devx-infra
 /requirements.txt                       @DataDog/agent-devx-infra
 /pyproject.toml                         @DataDog/agent-devx-infra @DataDog/agent-devx-loops
 /repository.datadog.yml                 @DataDog/agent-devx-infra

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+      "config:recommended"
+    ],
+    "customManagers" : [
+      {
+        "customType": "regex",
+        "fileMatch": [".gitlab-ci.yml"],
+        "matchStrings": [
+          "  DATADOG_AGENT_[^:]*: (?<currentValue>v.*)",
+          "  CI_IMAGE_[^:]*: (?<currentValue>v.*)"
+        ],
+        "depNameTemplate": "buildimages",
+        "versioningTemplate": "loose",
+        "datasourceTemplate": "custom.buildimages"
+      }
+    ],
+    "customDatasources": {
+      "buildimages": {
+        "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-deb_x64/tags",
+        "transformTemplates": [
+          "{\"releases\": $map(results, function($v) { {\"version\": $v.name, \"releaseTimestamp\": $v.last_updated } }) }"
+        ]
+      }
+    }
+  }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add a renovate configuration for auto-bump of buildimage

### Motivation
Have a regular PR bumping the `buildimages`

### Describe how you validated your changes
[Configuration](https://github.com/chouetz/psychic-guacamole/blob/main/renovate.json) tested on a personal repository: generated [PR](https://github.com/chouetz/psychic-guacamole/pull/43/files)
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->