### PR TITLE
[CWS] make sure constant editors are all defined once in the same spot

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2033,7 +2033,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 		PathResolutionEnabled:     probe.Opts.PathResolutionEnabled,
 		SecurityProfileMaxCount:   config.RuntimeSecurity.SecurityProfileMaxCount,
 		NetworkFlowMonitorEnabled: config.Probe.NetworkFlowMonitorEnabled,
-	})
+	}, p.kernelVersion)
 
 	if config.RuntimeSecurity.ActivityDumpEnabled {
 		for _, e := range config.RuntimeSecurity.ActivityDumpTracedEventTypes {
@@ -2231,37 +2231,6 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 	// prevent some helpers from loading
 	if !p.kernelVersion.HasBPFForEachMapElemHelper() {
 		p.managerOptions.ExcludedFunctions = append(p.managerOptions.ExcludedFunctions, probes.AllBPFForEachMapElemProgramFunctions()...)
-	}
-
-	if !p.kernelVersion.HasSKStorage() {
-		// Edit each SK_Storage map and transform them to a basic hash maps so they can be loaded by older kernels.
-		// We need this so that the eBPF manager can link the SK_Storage maps in our eBPF programs, even if deadcode
-		// elimination will clean up the piece of code that work with them prior to running the verifier.
-		if p.managerOptions.MapSpecEditors == nil {
-			p.managerOptions.MapSpecEditors = make(map[string]manager.MapSpecEditor, len(probes.AllSKStorageMaps()))
-		}
-		for _, skMapName := range probes.AllSKStorageMaps() {
-			p.managerOptions.MapSpecEditors[skMapName] = manager.MapSpecEditor{
-				Type:       lib.Hash,
-				KeySize:    1,
-				ValueSize:  1,
-				MaxEntries: 1,
-				EditorFlag: manager.EditKeyValue | manager.EditType | manager.EditMaxEntries,
-			}
-		}
-	}
-
-	if !p.kernelVersion.HasNoPreallocMapsInPerfEvent() {
-		// Edit maps used in perf_event programs with BPF_F_NO_PREALLOC flag so that they are pre-allocated
-		if p.managerOptions.MapSpecEditors == nil {
-			p.managerOptions.MapSpecEditors = make(map[string]manager.MapSpecEditor, len(probes.AllSKStorageMaps()))
-		}
-		for _, noPreallocMapName := range probes.AllNoPreallocMapsInPerfEventPrograms() {
-			p.managerOptions.MapSpecEditors[noPreallocMapName] = manager.MapSpecEditor{
-				Flags:      unix.BPF_ANY,
-				EditorFlag: manager.EditFlags,
-			}
-		}
 	}
 
 	if p.useFentry {


### PR DESCRIPTION
### What does this PR do?

We currently have 2 map spec editor for `active_flows`: the one expanding the size if network flows are enabled, and the one removing the prealloc flag on old kernels. The way we defined those overrides the first one when the second is defined. This PR fixes this issue by merging all spec editors in the same function.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->