### PR TITLE
service discovery: Simplify end-service handling

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux_test.go
@@ -57,11 +57,6 @@ var (
 		env: []string{},
 		cwd: "",
 	}
-	procTestService1DifferentPID = testProc{
-		pid: 102,
-		env: []string{},
-		cwd: "",
-	}
 )
 
 var (
@@ -95,21 +90,6 @@ var (
 		APMInstrumentation:         string(apm.None),
 		RSS:                        200 * 1024 * 1024,
 		CPUCores:                   1.5,
-		CommandLine:                []string{"test-service-1"},
-		StartTimeMilli:             procLaunchedMilli,
-		ContainerID:                dummyContainerID,
-	}
-	portTCP8080DifferentPID = model.Service{
-		PID:                        procTestService1DifferentPID.pid,
-		Name:                       "test-service-1",
-		GeneratedName:              "test-service-1-generated",
-		GeneratedNameSource:        "test-service-1-generated-source",
-		ContainerServiceName:       "test-service-1-container",
-		ContainerServiceNameSource: "service",
-		DDService:                  "test-service-1",
-		DDServiceInjected:          true,
-		Ports:                      []uint16{8080},
-		APMInstrumentation:         string(apm.Injected),
 		CommandLine:                []string{"test-service-1"},
 		StartTimeMilli:             procLaunchedMilli,
 		ContainerID:                dummyContainerID,
@@ -498,91 +478,6 @@ func Test_linuxImpl(t *testing.T) {
 						APMInstrumentation:         "none",
 						RSSMemory:                  100 * 1024 * 1024,
 						CPUCores:                   1.5,
-						ContainerID:                dummyContainerID,
-					},
-				},
-			},
-		},
-		{
-			// in case we detect a service is restarted, we skip the stop event and send
-			// another start event instead.
-			name: "restart_service",
-			checkRun: []*checkRun{
-				{
-					servicesResp: &model.ServicesResponse{Services: []model.Service{
-						portTCP8080,
-					}},
-					time: calcTime(0),
-				},
-				{
-					servicesResp: &model.ServicesResponse{Services: []model.Service{
-						portTCP8080,
-					}},
-					time: calcTime(1 * time.Minute),
-				},
-				{
-					servicesResp: &model.ServicesResponse{Services: []model.Service{
-						portTCP8080DifferentPID,
-					}},
-					time: calcTime(21 * time.Minute),
-				},
-				{
-					servicesResp: &model.ServicesResponse{Services: []model.Service{
-						portTCP8080DifferentPID,
-					}},
-					time: calcTime(22 * time.Minute),
-				},
-			},
-			wantEvents: []*event{
-				{
-					RequestType: "start-service",
-					APIVersion:  "v2",
-					Payload: &eventPayload{
-						NamingSchemaVersion:        "1",
-						ServiceName:                "test-service-1",
-						GeneratedServiceName:       "test-service-1-generated",
-						GeneratedServiceNameSource: "test-service-1-generated-source",
-						ContainerServiceName:       "test-service-1-container",
-						ContainerServiceNameSource: "service",
-						DDService:                  "test-service-1",
-						ServiceNameSource:          "injected",
-						ServiceType:                "web_service",
-						HostName:                   host,
-						Env:                        "",
-						StartTime:                  calcTime(0).Unix(),
-						StartTimeMilli:             calcTime(0).UnixMilli(),
-						LastSeen:                   calcTime(1 * time.Minute).Unix(),
-						Ports:                      []uint16{8080},
-						PID:                        99,
-						CommandLine:                []string{"test-service-1"},
-						APMInstrumentation:         "none",
-						RSSMemory:                  100 * 1024 * 1024,
-						CPUCores:                   1.5,
-						ContainerID:                dummyContainerID,
-					},
-				},
-				{
-					RequestType: "start-service",
-					APIVersion:  "v2",
-					Payload: &eventPayload{
-						NamingSchemaVersion:        "1",
-						ServiceName:                "test-service-1",
-						GeneratedServiceName:       "test-service-1-generated",
-						GeneratedServiceNameSource: "test-service-1-generated-source",
-						ContainerServiceName:       "test-service-1-container",
-						ContainerServiceNameSource: "service",
-						DDService:                  "test-service-1",
-						ServiceNameSource:          "injected",
-						ServiceType:                "web_service",
-						HostName:                   host,
-						Env:                        "",
-						StartTime:                  calcTime(0).Unix(),
-						StartTimeMilli:             calcTime(0).UnixMilli(),
-						LastSeen:                   calcTime(22 * time.Minute).Unix(),
-						Ports:                      []uint16{8080},
-						PID:                        102,
-						CommandLine:                []string{"test-service-1"},
-						APMInstrumentation:         "injected",
 						ContainerID:                dummyContainerID,
 					},
 				},


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

There is some code to skip sending the end-service event in two cases:

 (1) If there is another service with the same name which is
     either has a start-service or a hearbeat event being sent
     in the same tick.

 (2) If there is another potential service (i.e. a service which
     as not yet run for 1 minute) with the same name as the one
     in the end service event, to handle service restarts.

The reason mentioned in a comment for (1) is so that the "services don't disappear in the UI" if two (unrelated) processes have the same generated service name.  However, this reason is invalid since only the row for the PID being ending would be removed in the backend, and the other row for the other PID would still exist.  Also, it's not guaranteed that the other service would even have a start-service or hearbeat event in the same tick so this check doesn't always work.

For (2), it's better to handle this in the backend where (a) the margin for the time to wait for a potential restart can be easily controlled and (b) the logic for considering two reports to be for the same service can be easily tweaked and improved (for example using more fields than just the generated name).

(Note also that as of writing the end-service event is currently ignored in the backend, so no sync is needed with changes there.)

Remove this code to simplify the implementation.

### Motivation

Noticed when reviewing https://github.com/DataDog/datadog-agent/pull/32128

### Describe how you validated your changes

Covered by unit and e2e tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->