### PR TITLE
[EBPF] added telemetry to the sysprobe remote client

### DIFF
--- a/cmd/system-probe/api/client/client.go
+++ b/cmd/system-probe/api/client/client.go
@@ -63,6 +63,7 @@ func GetCheck[T any](client *http.Client, module types.ModuleName) (T, error) {
 	var data T
 	req, err := http.NewRequest("GET", ModuleURL(module, "/check"), nil)
 	if err != nil {
+		//we don't have a counter for this case, because this function can't really fail, since ModuleURL function constructs a safe URL
 		return data, err
 	}
 

--- a/cmd/system-probe/api/client/client.go
+++ b/cmd/system-probe/api/client/client.go
@@ -18,13 +18,28 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 )
 
 var (
 	// ErrNotImplemented is an error used when system-probe is attempted to be accessed on an unsupported OS
 	ErrNotImplemented = errors.New("system-probe unsupported")
+
+	telemetrySubsystem = "system_probe__remote_client"
 )
+
+var checkTelemetry = struct {
+	failedRequests     telemetry.Counter
+	failedResponses    telemetry.Counter
+	responseErrors     telemetry.Counter
+	malformedResponses telemetry.Counter
+}{
+	telemetry.NewCounter(telemetrySubsystem, "requests__failed", []string{"check_name"}, "Counter measuring how many system-probe check requests failed to be sent"),
+	telemetry.NewCounter(telemetrySubsystem, "responses__not_received", []string{"check_name"}, "Counter measuring how many responses from system-probe check were not read from the socket"),
+	telemetry.NewCounter(telemetrySubsystem, "responses__errors", []string{"check_name"}, "Counter measuring how many non_ok status code received from system-probe checks"),
+	telemetry.NewCounter(telemetrySubsystem, "responses__malformed", []string{"check_name"}, "Counter measuring how many malformed responses were received from system-probe checks"),
+}
 
 // Get returns a http client configured to talk to the system-probe
 var Get = funcs.MemoizeArgNoError[string, *http.Client](get)
@@ -53,19 +68,25 @@ func GetCheck[T any](client *http.Client, module types.ModuleName) (T, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
+		checkTelemetry.failedRequests.IncWithTags(map[string]string{"check_name": string(module)})
 		return data, err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
+		checkTelemetry.failedResponses.IncWithTags(map[string]string{"check_name": string(module)})
 		return data, err
 	}
 	if resp.StatusCode != http.StatusOK {
+		checkTelemetry.responseErrors.IncWithTags(map[string]string{"check_name": string(module)})
 		return data, fmt.Errorf("non-ok status code: url %s, status_code: %d, response: `%s`", req.URL, resp.StatusCode, string(body))
 	}
 
 	err = json.Unmarshal(body, &data)
+	if err != nil {
+		checkTelemetry.malformedResponses.IncWithTags(map[string]string{"check_name": string(module)})
+	}
 	return data, err
 }
 

--- a/cmd/system-probe/api/client/client_test.go
+++ b/cmd/system-probe/api/client/client_test.go
@@ -27,15 +27,31 @@ func TestConstructURL(t *testing.T) {
 	assert.Equal(t, "http://sysprobe/zzzz/asdf", u)
 }
 
+type expectedTelemetryValues struct {
+	failedRequests     float64
+	failedResponses    float64
+	responseErrors     float64
+	malformedResponses float64
+}
+
+func validateTelemetry(t *testing.T, module string, expected expectedTelemetryValues) {
+	assert.Equal(t, expected.failedRequests, checkTelemetry.failedRequests.WithValues(module).Get(), "wrong failedRequest counter value")
+	assert.Equal(t, expected.failedResponses, checkTelemetry.failedResponses.WithValues(module).Get(), "wrong failedResponses counter value")
+	assert.Equal(t, expected.responseErrors, checkTelemetry.responseErrors.WithValues(module).Get(), "wrong responseErrors counter value")
+	assert.Equal(t, expected.malformedResponses, checkTelemetry.malformedResponses.WithValues(module).Get(), "wrong malformedResponses counter value")
+}
+
 func TestGetCheck(t *testing.T) {
 	type testData struct {
-		Str string
-		Num int
+		Str string `json:"Str"`
+		Num int    `json:"Num"`
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/test/check" {
 			_, _ = w.Write([]byte(`{"Str": "asdf", "Num": 42}`))
+		} else if r.URL.Path == "/malformed/check" {
+			_, _ = w.Write([]byte("1"))
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -46,8 +62,23 @@ func TestGetCheck(t *testing.T) {
 		return net.Dial("tcp", server.Listener.Addr().String())
 	}}}
 
+	//test happy flow
 	resp, err := GetCheck[testData](client, "test")
 	require.NoError(t, err)
 	assert.Equal(t, "asdf", resp.Str)
 	assert.Equal(t, 42, resp.Num)
+	validateTelemetry(t, "test", expectedTelemetryValues{0, 0, 0, 0})
+
+	//test responseError counter
+	resp, err = GetCheck[testData](client, "foo")
+	validateTelemetry(t, "foo", expectedTelemetryValues{0, 0, 1, 0})
+
+	//test malformedResponses counter
+	resp, err = GetCheck[testData](client, "malformed")
+	validateTelemetry(t, "malformed", expectedTelemetryValues{0, 0, 0, 1})
+
+	//test failedRequests counter
+	server.Close()
+	resp, err = GetCheck[testData](client, "test")
+	validateTelemetry(t, "test", expectedTelemetryValues{1, 0, 0, 0})
 }


### PR DESCRIPTION
### What does this PR do?

Added telemetry counters to system-probe remote client

### Motivation

we want to track errors when failing to execute a check in system-probe. 
initially we introduced an explicit check in gpu-monitoring core-check when trying to run the GPU probe using the sys probe remote client ([ref PR](https://github.com/DataDog/datadog-agent/pull/32986/files#diff-5a71d9377a3c48736f8b2ce6ea4349ce6fd00dd347092e84113fafad0c443f23R151)), but it is better to have those counters available for all system-probe checks

### Describe how you validated your changes

added UTs to test the counters

### Possible Drawbacks / Trade-offs

### Additional Notes
- the new counters have just one label for the check name
- those checks are executed with a large enough interval, hence the code is not part of the hot path
- we still return errors from the `GetCheck` method to avoid breaking the API
- the explicit counter introduced in gpu core-check will be removed in a separate PR