### PR TITLE
[CONTP-586] parsefilters still returns the built filters even in case of error

### DIFF
--- a/comp/core/autodiscovery/listeners/common.go
+++ b/comp/core/autodiscovery/listeners/common.go
@@ -67,7 +67,8 @@ func standardTagsDigest(labels map[string]string) string {
 }
 
 // newContainerFilters instantiates the required container filters for AD listeners
-func newContainerFilters() (*containerFilters, error) {
+// The returned filter will never be nil
+func newContainerFilters() *containerFilters {
 	global := containers.NewAutodiscoveryFilter(containers.GlobalFilter)
 	metrics := containers.NewAutodiscoveryFilter(containers.MetricsFilter)
 	logs := containers.NewAutodiscoveryFilter(containers.LogsFilter)
@@ -75,7 +76,7 @@ func newContainerFilters() (*containerFilters, error) {
 		global:  global,
 		metrics: metrics,
 		logs:    logs,
-	}, nil
+	}
 }
 
 func (f *containerFilters) IsExcluded(filter containers.FilterType, annotations map[string]string, name, image, ns string) bool {

--- a/comp/core/autodiscovery/listeners/common.go
+++ b/comp/core/autodiscovery/listeners/common.go
@@ -68,18 +68,9 @@ func standardTagsDigest(labels map[string]string) string {
 
 // newContainerFilters instantiates the required container filters for AD listeners
 func newContainerFilters() (*containerFilters, error) {
-	global, err := containers.NewAutodiscoveryFilter(containers.GlobalFilter)
-	if err != nil {
-		return nil, err
-	}
-	metrics, err := containers.NewAutodiscoveryFilter(containers.MetricsFilter)
-	if err != nil {
-		return nil, err
-	}
-	logs, err := containers.NewAutodiscoveryFilter(containers.LogsFilter)
-	if err != nil {
-		return nil, err
-	}
+	global := containers.NewAutodiscoveryFilter(containers.GlobalFilter)
+	metrics := containers.NewAutodiscoveryFilter(containers.MetricsFilter)
+	logs := containers.NewAutodiscoveryFilter(containers.LogsFilter)
 	return &containerFilters{
 		global:  global,
 		metrics: metrics,

--- a/comp/core/autodiscovery/listeners/kube_endpoints.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints.go
@@ -83,10 +83,7 @@ func NewKubeEndpointsListener(options ServiceListernerDeps) (ServiceListener, er
 		return nil, fmt.Errorf("cannot get service informer: %s", err)
 	}
 
-	containerFilters, err := newContainerFilters()
-	if err != nil {
-		return nil, err
-	}
+	containerFilters := newContainerFilters()
 
 	return &KubeEndpointsListener{
 		endpoints:          make(map[k8stypes.UID][]*KubeEndpointService),

--- a/comp/core/autodiscovery/listeners/kube_services.go
+++ b/comp/core/autodiscovery/listeners/kube_services.go
@@ -93,10 +93,7 @@ func NewKubeServiceListener(options ServiceListernerDeps) (ServiceListener, erro
 		return nil, fmt.Errorf("cannot get service informer: %s", err)
 	}
 
-	containerFilters, err := newContainerFilters()
-	if err != nil {
-		return nil, err
-	}
+	containerFilters := newContainerFilters()
 
 	return &KubeServiceListener{
 		services:          make(map[k8stypes.UID]Service),

--- a/comp/core/autodiscovery/listeners/workloadmeta.go
+++ b/comp/core/autodiscovery/listeners/workloadmeta.go
@@ -73,10 +73,7 @@ func newWorkloadmetaListener(
 	wmeta workloadmeta.Component,
 	telemetryStore *telemetry.Store,
 ) (workloadmetaListener, error) {
-	containerFilters, err := newContainerFilters()
-	if err != nil {
-		return nil, err
-	}
+	containerFilters := newContainerFilters()
 
 	return &workloadmetaListenerImpl{
 		name: name,

--- a/comp/core/autodiscovery/listeners/workloadmeta_test.go
+++ b/comp/core/autodiscovery/listeners/workloadmeta_test.go
@@ -83,9 +83,9 @@ func (l *testWorkloadmetaListener) assertServices(expectedServices map[string]wl
 }
 
 func newTestWorkloadmetaListener(t *testing.T) *testWorkloadmetaListener {
-	filters, err := newContainerFilters()
-	if err != nil {
-		t.Fatalf("cannot initialize container filters: %s", err)
+	filters := newContainerFilters()
+	if filters == nil {
+		t.Fatal("got nil containers filter")
 	}
 
 	w := fxutil.Test[workloadmetamock.Mock](t, fx.Options(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
# Please Read the Motivation and Possible Drawbacks / Trade-offs sections Carefully

### What does this PR do?

Fixes bug in parseFilters function that parses input filters as regex.

### Motivation

The NewFilter function that creates filters based on user config suffers from 2 issues:

####  It treats the following two scenarios differently:
* Unrecognised filter key: no error is returned, only a warning.
* Filter key is recognised, but the regex can't be compiled: an error is returned.

In principle, both cases should be treated as errors so that we avoid the following scenario:
User excludes some namespace, but makes a mistake in the filter key (i.e. `kube_namespace`). In this case, we should be aware that there is an error and decide not to proceed to avoid exposing metrics, logs or functionality in a namespace that the user wanted to restrict.

Interestingly, there is a unit test in the CWS INstrumentation webhook which miss-spells the `kube_namespace` filter key as `kube_namespae`. The webhook is still created nonetheless since the filter parsers don't return an error, but just a warning. As a result, the webhook is unaware of the mistake in the filter, and will inject stuff in namespaces that the user wanted to exclude. (See [this](https://github.com/DataDog/datadog-agent/pull/33348) PR).

The same issue can happen with pretty much any other component (other webhooks, autodiscovery, etc.).

#### If few regex filters failed to compile, and others succeeded, no filters are returned at all
 
If the user has configured multiple filters, among which some are correctly formatted and others are not, parseFilters will only return an error, without including the correctly parsed filters.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

E2E tests already in place.

Manual QA for validation:

Deploy the agent with an filter regex, and ensure that autodiscovery continues to work for the properly configured filters.
Also ensure that you can see the regex error in the autodiscovery section in `agent status`

Example:

```
datadog:
  kubelet:
    tlsVerify: false
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  containerExcludeLogs: "kube_namespace:* name:prometheus weird"
  logs:
    enabled: true
    containerCollectAll: true
```

Deploy the following app:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: prometheus
  labels:
    app: prometheus
    purpose: example
spec:
  replicas: 1
  selector:
    matchLabels:
      app: prometheus
      purpose: example
  template:
    metadata:
      labels:
        app: prometheus
        purpose: example
      annotations:
        ad.datadoghq.com/prometheus.checks: |
          {
            "openmetrics": {
              "init_config": {},
              "instances": [
                {
                  "openmetrics_endpoint": "http://%%host%%:9090/metrics"
                }
              ]
            }
          }
    spec:
      containers:
        - name: prometheus
          image: prom/prometheus
          ports:
            - containerPort: 9090
              name: promport
```

Wait for a moment, and then run `agent status` command on the agent.
You should expect to see openmetrics check scheduled, and to see a regex error in autodiscovery section:
```
    openmetrics (6.0.0)
    -------------------
      Instance ID: openmetrics:535ad87b366e7874 [OK]
      Configuration Source: container:containerd://6791206495c34ee6c20490e05b7c282198620e2fed7c72c2b18d88811adf0208
      Total Runs: 2
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 2
      Average Execution Time : 6ms
      Last Execution Date : 2025-01-27 10:09:54 UTC (1737972594000)
      Last Successful Execution Date : 2025-01-27 10:09:54 UTC (1737972594000)
```


```
=============
Autodiscovery
=============

  Enabled Features
  ================
    containerd
    cri
    kube_orchestratorexplorer
    kubernetes

  Container Inclusion/Exclusion Errors
  ====================================
    Container filter "weird" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'
    invalid regex '*': error parsing regexp: missing argument to repetition operator: `*`
```

Previously, in such scenarios, the behaviour was to not have any check scheduled by autodiscovery.


### Possible Drawbacks / Trade-offs

For autodiscovery, it makes sense to proceed even when the parse filter returns errors as long as successfully compiled filters are still returned by the filter. 

The error logs will be useful for debugging.

For other cases, it depends, it might be ok to proceed despite the error, or it might be dangerous to do so (like the case of CWS instrumentation webhook or auto instrumentation webhook).

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->