### PR TITLE
[gitlab] remove otel-specific tagging from release process

### DIFF
--- a/.gitlab/deploy_containers/conditions.yml
+++ b/.gitlab/deploy_containers/conditions.yml
@@ -42,30 +42,6 @@
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
-.manual_on_deploy_auto_on_rc-ot:
-  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent-dev
-      IMG_REGISTRIES: dev
-  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/ && $FORCE_MANUAL != "true"
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
-  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/ && $FORCE_MANUAL == "true"
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
-  - when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
-
 # Rule for job that are triggered on_success on RC pipelines
 .on_rc:
   - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
@@ -80,20 +56,6 @@
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
-      IMG_REGISTRIES: public
-
-# Rule for job that are triggered on_success on RC pipelines for OTel Beta
-.on_rc-ot:
-  - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
-  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
 # Rule for job that can be triggered manually on final build, deploy to prod repository on stable branch deploy, else to dev repository
@@ -114,24 +76,6 @@
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
-# Rule for job that can be triggered manually on final build, deploy to prod repository on stable branch deploy, else to dev repository
-# For OTel Beta builds
-.on_final-ot:
-  - if: $BUCKET_BRANCH == "beta"
-    when: never
-  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent-dev
-      IMG_REGISTRIES: dev
-  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: agent
-      IMG_REGISTRIES: public
-
 # Rule to deploy to our internal repository, on stable branch deploy
 .on_internal_final:
   - if: $BUCKET_BRANCH == "beta"
@@ -146,21 +90,6 @@
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
-      IMG_REGISTRIES: internal-aws-ddbuild
-
-# Rule to deploy to our internal repository, on stable branch deploy
-.on_internal_final-ot:
-  ## Jobs will be triggered on beta repo-branch so it's fine
-  ## if the "final" artifacts job is available on non-stable BUCKET_BRANCH
-  # - if: $BUCKET_BRANCH == "beta"
-  #   when: never
-  - if: $BUCKET_BRANCH != "beta" && $BUCKET_BRANCH != "stable"
-    when: never
-  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+$/
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: ci/datadog-agent/agent-release
       IMG_REGISTRIES: internal-aws-ddbuild
 
 # Rule to deploy to our internal repository on RC
@@ -181,18 +110,4 @@
       CLUSTER_AGENT_REPOSITORY: ci/datadog-agent/cluster-agent-release
       DSD_REPOSITORY: ci/datadog-agent/dogstatsd-release
       CWS_INSTRUMENTATION_REPOSITORY: ci/datadog-agent/cws-instrumentation-release
-      IMG_REGISTRIES: internal-aws-ddbuild
-
-# Rule to deploy to our internal repository on RC for OTel Agent Beta
-.on_internal_rc-ot:
-  - if: $FORCE_MANUAL == "true" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
-    when: manual
-    allow_failure: true
-    variables:
-      AGENT_REPOSITORY: ci/datadog-agent/agent-release
-      IMG_REGISTRIES: internal-aws-ddbuild
-  - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
-    when: on_success
-    variables:
-      AGENT_REPOSITORY: ci/datadog-agent/agent-release
       IMG_REGISTRIES: internal-aws-ddbuild

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -238,7 +238,7 @@ deploy_containers_latest-dogstatsd:
     IMG_SOURCES: ${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest
 
-deploy_containers_latest-a7:
+deploy_containers_latest-a7-ot:
   extends: .deploy_containers-a7-base-ot
   stage: deploy_containers
   rules:

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -92,7 +92,7 @@ deploy_containers-a7-win-only:
 deploy_containers-a7-ot:
   extends: .deploy_containers-a7-base-ot
   rules:
-    !reference [.manual_on_deploy_auto_on_rc-ot]
+    !reference [.manual_on_deploy_auto_on_rc]
   parallel:
     matrix:
       - JMX:
@@ -116,7 +116,7 @@ deploy_containers-a7-win-only-rc:
 deploy_containers-a7-ot-rc:
   extends: .deploy_containers-a7-base-ot
   rules:
-    !reference [.on_rc-ot]
+    !reference [.on_rc]
   variables:
     VERSION: 7-ot-beta-rc
   parallel:
@@ -155,14 +155,14 @@ deploy_containers-a7_internal-rc:
 deploy_containers-a7-ot_internal:
   extends: .deploy_containers-a7-base-ot
   rules:
-    !reference [.on_internal_final-ot]
+    !reference [.on_internal_final]
   variables:
     JMX: "-jmx"
 
 deploy_containers-a7-ot_internal-rc:
   extends: .deploy_containers-a7-base-ot
   rules:
-    !reference [.on_internal_rc-ot]
+    !reference [.on_internal_rc]
   variables:
     VERSION: 7-ot-beta-rc
   parallel:
@@ -238,11 +238,11 @@ deploy_containers_latest-dogstatsd:
     IMG_SOURCES: ${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest
 
-deploy_containers_latest-a7-ot:
+deploy_containers_latest-a7:
   extends: .deploy_containers-a7-base-ot
   stage: deploy_containers
   rules:
-    !reference [.on_final-ot]
+    !reference [.on_final]
   dependencies: []
   variables:
     VERSION: 7-ot-beta


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR gets rid of the `ot-beta` specific tags that trigger the pipelines for the OTel beta image releases. There is no real value add in the legacy `ot-beta` tags and simply leveraging the standard tags (for RCs and final builds) will simplify the release process and automatically align releases of the standard agent and the `ot-beta` builds, which are expected in the same cadence and on the same git commits. 

### Motivation

Address some issues releasing the `latest` images with the current out-of-band process, and aligns release schedules automatically. It also makes life easier for our internal vulnerability management process.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
None.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->