### PR TITLE
[CWS] do not copy macros out of the macro store when creating a state

### DIFF
--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -71,7 +71,7 @@ func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.
 	}
 
 	if state.macros != nil {
-		if macro, ok := state.macros[*obj.Ident]; ok {
+		if macro, ok := state.macros.GetMacroEvaluator(*obj.Ident); ok {
 			return macro.Value, obj.Pos, nil
 		}
 	}
@@ -129,7 +129,7 @@ func arrayToEvaluator(array *ast.Array, opts *Opts, state *State) (interface{}, 
 		return &evaluator, array.Pos, nil
 	} else if array.Ident != nil {
 		if state.macros != nil {
-			if macro, ok := state.macros[*array.Ident]; ok {
+			if macro, ok := state.macros.GetMacroEvaluator(*array.Ident); ok {
 				return macro.Value, array.Pos, nil
 			}
 		}

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -95,11 +95,7 @@ func (m *Macro) Parse(parsingContext *ast.ParsingContext, expression string) err
 }
 
 func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*MacroEvaluator, error) {
-	macros := make(map[MacroID]*MacroEvaluator)
-	for _, macro := range opts.MacroStore.List() {
-		macros[macro.ID] = macro.evaluator
-	}
-	state := NewState(model, field, macros)
+	state := NewState(model, field, opts.MacroStore)
 
 	var eval interface{}
 	var err error

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -27,7 +27,7 @@ func (s *MacroStore) List() []*Macro {
 }
 
 // Get returns the marcro
-func (s *MacroStore) Get(id string) *Macro {
+func (s *MacroStore) Get(id MacroID) *Macro {
 	if s == nil {
 		return nil
 	}
@@ -38,6 +38,15 @@ func (s *MacroStore) Get(id string) *Macro {
 		}
 	}
 	return nil
+}
+
+// GetMacroEvaluator returns the macro evaluator associated with the macro ID
+func (s *MacroStore) GetMacroEvaluator(id MacroID) (*MacroEvaluator, bool) {
+	macro := s.Get(id)
+	if macro == nil {
+		return nil, false
+	}
+	return macro.evaluator, true
 }
 
 // Contains returns returns true is there is already a macro with this ID in the store

--- a/pkg/security/secl/compiler/eval/rule.go
+++ b/pkg/security/secl/compiler/eval/rule.go
@@ -202,11 +202,7 @@ func (r *Rule) Parse(parsingContext *ast.ParsingContext) error {
 
 // NewRuleEvaluator returns a new evaluator for a rule
 func NewRuleEvaluator(rule *ast.Rule, model Model, opts *Opts) (*RuleEvaluator, error) {
-	macros := make(map[MacroID]*MacroEvaluator)
-	for _, macro := range opts.MacroStore.List() {
-		macros[macro.ID] = macro.evaluator
-	}
-	state := NewState(model, "", macros)
+	state := NewState(model, "", opts.MacroStore)
 
 	eval, _, err := nodeToEvaluator(rule.BooleanExpression, opts, state)
 	if err != nil {
@@ -331,7 +327,7 @@ func (r *Rule) genPartials(field Field) error {
 		return err
 	}
 
-	state := NewState(r.Model, field, macroPartial)
+	state := NewState(r.Model, field, partialMacroEvaluatorGetter(macroPartial))
 	pEval, _, err := nodeToEvaluator(r.ast.BooleanExpression, r.Opts, state)
 	if err != nil {
 		return fmt.Errorf("couldn't generate partial for field %s and rule %s: %w", field, r.ID, err)
@@ -351,4 +347,11 @@ func (r *Rule) genPartials(field Field) error {
 	r.evaluator.setPartial(field, pEvalBool.EvalFnc)
 
 	return nil
+}
+
+type partialMacroEvaluatorGetter map[MacroID]*MacroEvaluator
+
+func (p partialMacroEvaluatorGetter) GetMacroEvaluator(macroID string) (*MacroEvaluator, bool) {
+	v, ok := p[macroID]
+	return v, ok
 }

--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -21,7 +21,7 @@ type State struct {
 	model       Model
 	field       Field
 	fieldValues map[Field][]FieldValue
-	macros      map[MacroID]*MacroEvaluator
+	macros      MacroEvaluatorGetter
 	regexpCache StateRegexpCache
 	registers   []Register
 }
@@ -52,14 +52,16 @@ func (s *State) UpdateFieldValues(field Field, value FieldValue) error {
 }
 
 // NewState returns a new State
-func NewState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *State {
-	if macros == nil {
-		macros = make(map[MacroID]*MacroEvaluator)
-	}
+func NewState(model Model, field Field, macros MacroEvaluatorGetter) *State {
 	return &State{
 		field:       field,
 		macros:      macros,
 		model:       model,
 		fieldValues: make(map[Field][]FieldValue),
 	}
+}
+
+// MacroEvaluatorGetter is an interface to get a MacroEvaluator
+type MacroEvaluatorGetter interface {
+	GetMacroEvaluator(macroID string) (*MacroEvaluator, bool)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When creating an evaluation state we need to provide a map from ID to the macro evaluator. We currently copy the macro out of the macro store when doing this but this is not needed.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->