### PR TITLE
Continue adjusting quality gate limits after SMP changes earlier this week

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -35,7 +35,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "361.0 MiB"
+      upper_bound: "365.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -51,7 +51,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "735.0 MiB"
+      upper_bound: "734.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_rss_bytes
-      upper_bound: 414MiB
+      upper_bound: 419MiB
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

This PR increases the `quality_gate_idle` and `quality_gate_logs` limits and reduces the `quality_gate_idle_all_features` limit to account for changes in the SMP target environment.

These values are 1% above the max observation from two quality gate runs: [the latest nightly](https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=false&refresh_mode=paused&tpl_var_job_id%5B0%5D=6aa61474-0e1b-449a-9bc0-041a9a333df6&tpl_var_run-id%5B0%5D=6aa61474-0e1b-449a-9bc0-041a9a333df6&view=spans&from_ts=1737616610000&to_ts=1737617210000&live=false) and [this manual run](https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=false&refresh_mode=paused&tpl_var_job_id%5B0%5D=b85a2927-da32-4797-bb55-4421b24566ee&tpl_var_run-id%5B0%5D=b85a2927-da32-4797-bb55-4421b24566ee&view=spans&from_ts=1737660286000&to_ts=1737660886000&live=false).

### Motivation

Followup from #33288