### PR TITLE
Investigate permissions settings in SMP environment

### DIFF
--- a/pkg/util/filesystem/permission_nowindows.go
+++ b/pkg/util/filesystem/permission_nowindows.go
@@ -31,10 +31,11 @@ func NewPermission() (*Permission, error) {
 func (p *Permission) RestrictAccessToUser(path string) error {
 	usr, err := user.Lookup("dd-agent")
 	if err != nil {
+		log.Infof("SMP Env Testing: Failed to look up user dd-agent")
 		return nil
 	}
-
 	usrID, err := strconv.Atoi(usr.Uid)
+	log.Infof("SMP Env Testing: Uid for user dd-agent is %d", usrID)
 	if err != nil {
 		return fmt.Errorf("couldn't parse UID (%s): %w", usr.Uid, err)
 	}

--- a/pkg/util/filesystem/permission_nowindows.go
+++ b/pkg/util/filesystem/permission_nowindows.go
@@ -31,14 +31,14 @@ func NewPermission() (*Permission, error) {
 func (p *Permission) RestrictAccessToUser(path string) error {
 	usr, err := user.Lookup("dd-agent")
 	if err != nil {
-		log.Infof("SMP Env Testing: Failed to look up user dd-agent")
+		log.Infof("SMP Env Testing: Failed to look up user dd-agent for '%s' ", path)
 		return nil
 	}
 	usrID, err := strconv.Atoi(usr.Uid)
-	log.Infof("SMP Env Testing: Uid for user dd-agent is %d", usrID)
 	if err != nil {
 		return fmt.Errorf("couldn't parse UID (%s): %w", usr.Uid, err)
 	}
+	log.Infof("SMP Env Testing: Uid for user dd-agent is %d when setting perms for '%s' ", usrID, path)
 
 	grpID, err := strconv.Atoi(usr.Gid)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Adds temporary log lines to get more insight as to the permissions set in agent

### Motivation

Determine if ownership is being set properly for the auth token in the SMP environment. Motivation covered in this [notebook](https://app.datadoghq.com/notebook/11187612/caleb-deep-dive-into-users-and-permissions?notebookType=rte)

### Possible Drawbacks / Trade-offs

### Additional Notes

This does not require review as it will not be merged. Using this PR as a shortcut to get custom agent build into SMP environment

[SMPTNG-588](https://datadoghq.atlassian.net/browse/SMPTNG-588)

[SMPTNG-588]: https://datadoghq.atlassian.net/browse/SMPTNG-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ