### PR TITLE
Fix obfuscation cache cost calculation to include struct overhead

### DIFF
--- a/pkg/obfuscate/cache.go
+++ b/pkg/obfuscate/cache.go
@@ -64,10 +64,11 @@ func newMeasuredCache(opts cacheOptions) *measuredCache {
 	}
 	cfg := &ristretto.Config{
 		MaxCost: opts.MaxSize,
-		// Assuming the minimum query size is 10 bytes, the maximum number of queries
-		// that can be stored is calculated as opts.MaxSize / 10.
-		// Multiplying this maximum number by 10 (opts.MaxSize / 10 * 10) as per the ristretto documentation.
-		NumCounters: opts.MaxSize,
+		// Assuming the minimum query size is 10 bytes , the maximum number of queries
+		// that can be stored is calculated as opts.MaxSize / (10 + 320).
+		// The 320 bytes is the fixed size of the ObfuscatedQuery struct which is stored in the cache.
+		// Multiplying this maximum number by 10 (opts.MaxSize / 330 * 10) as per the ristretto documentation.
+		NumCounters: int64(opts.MaxSize / 330 * 10),
 		BufferItems: 64,   // default recommended value
 		Metrics:     true, // enable hit/miss counters
 	}

--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -354,7 +354,16 @@ type ObfuscatedQuery struct {
 // Cost returns the number of bytes needed to store all the fields
 // of this ObfuscatedQuery.
 func (oq *ObfuscatedQuery) Cost() int64 {
-	return int64(len(oq.Query)) + oq.Metadata.Size
+	// The cost of the ObfuscatedQuery struct is the sum of the length of the query string,
+	// the size of the metadata content, and the size of the struct itself and its fields headers.
+	// 320 bytes come from
+	// - 112 bytes for the ObfuscatedQuery struct itself, measured by unsafe.Sizeof(ObfuscatedQuery{})
+	// - 96 bytes for the Metadata struct itself, measured by unsafe.Sizeof(SQLMetadata{})
+	// - 16 bytes for the Query string header
+	// - 16 bytes for the TablesCSV string header
+	// - 24 * 3 bytes for the Comments, Commands, and Procedures slices headers
+	// - 8 bytes for the Size int64 field
+	return int64(len(oq.Query)) + oq.Metadata.Size + 320
 }
 
 // attemptObfuscation attempts to obfuscate the SQL query loaded into the tokenizer, using the given set of filters.

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -380,8 +380,8 @@ TABLE T4 UNION CORRESPONDING TABLE T3`,
 			assert.Equal(tt.metadata.TablesCSV, oq.Metadata.TablesCSV)
 			assert.Equal(tt.metadata.Commands, oq.Metadata.Commands)
 			assert.Equal(tt.metadata.Comments, oq.Metadata.Comments)
-			// Cost() includes the query text size, exclude it to see if it matches the size the metadata filter collected.
-			assert.Equal(oq.Cost()-int64(len(oq.Query)), oq.Metadata.Size)
+			// Cost() includes the query text size, metadata size and struct overhead
+			assert.Equal(oq.Cost()-int64(len(oq.Query))-oq.Metadata.Size, 320)
 		})
 	}
 }

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -381,7 +381,7 @@ TABLE T4 UNION CORRESPONDING TABLE T3`,
 			assert.Equal(tt.metadata.Commands, oq.Metadata.Commands)
 			assert.Equal(tt.metadata.Comments, oq.Metadata.Comments)
 			// Cost() includes the query text size, metadata size and struct overhead
-			assert.Equal(oq.Cost()-int64(len(oq.Query))-oq.Metadata.Size, 320)
+			assert.Equal(oq.Cost()-int64(len(oq.Query))-oq.Metadata.Size, int64(320))
 		})
 	}
 }

--- a/releasenotes/notes/obfuscate-cache-item-cost-fix-5d3c9b57564d5f3b.yaml
+++ b/releasenotes/notes/obfuscate-cache-item-cost-fix-5d3c9b57564d5f3b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Obfuscation Cache Size Calculation:
+    Resolved an issue where the cache item size was underestimated by not accounting for the Go struct overhead (including struct fields and headers for strings and slices).
+    This fix ensures a more accurate calculation of cache item memory usage, leading to better memory efficiency and preventing over-allocation of NumCounters in cache configurations.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR corrects the calculation of cache item size for obfuscation by including the Go struct overhead in the total cost. The struct overhead accounts for the memory consumed by the struct itself, as well as the headers for strings and slices within the struct.

Previously, the cost calculation only included the length of the obfuscated query and the size of the metadata. This approach underestimated the actual memory usage of a cache item. As a result, the `NumCounters` configuration (which determines the maximum count of cache items) was over-allocated. This caused higher-than-expected memory usage due to the larger-than-needed `Count-Min Sketch` and `Bloom filter` used to manage the cache.

With this fix, the cache cost calculation now reflects the true memory footprint of each cache item, leading to a more accurate `NumCounters` estimation and improved memory usage.

### Motivation
https://datadoghq.atlassian.net/browse/DBMON-4921
The configuration option `apm_config.obfuscation.cache.max_size` is designed to set the maximum size of the [cache in bytes](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L1268-L1271). An accurate cost calculation ensures that the cache is correctly capped at the desired maximum size. Underestimating the cache item size not only impacts internal memory usage but also results in “over-caching,” where the total size of cached items exceeds the configured maximum size in bytes.

**Heap live size before vs. after**
Before:
<img width="1110" alt="image" src="https://github.com/user-attachments/assets/1ffbaaa0-9453-4fcb-a05c-802a876f64b9" />
After:
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/fef23c92-08f0-45c4-bd38-8c9423f67013" />

**RSS Memory before vs. after**
<img width="1348" alt="image" src="https://github.com/user-attachments/assets/6b24714e-7576-47cc-89bd-de2595497eeb" />

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->