### PR TITLE
[CONTP-573] Implement pod cooldown period for lang detection

### DIFF
--- a/comp/languagedetection/client/clientimpl/client.go
+++ b/comp/languagedetection/client/clientimpl/client.go
@@ -36,6 +36,9 @@ const (
 
 	// defaultprocessesWithoutPodCleanupPeriod defines the period to clean up process events from the map
 	defaultprocessesWithoutPodCleanupPeriod = time.Hour
+
+	// podCooldownPeriod defines the period to wait before sending fresh updates
+	podCooldownPeriod = 20 * time.Second
 )
 
 // Module defines the fx options for this component.
@@ -127,6 +130,7 @@ func newClient(
 		processesWithoutPodCleanupPeriod: defaultprocessesWithoutPodCleanupPeriod,
 		freshlyUpdatedPods:               make(map[string]time.Time),
 		periodicalFlushPeriod:            deps.Config.GetDuration("language_detection.reporting.refresh_period"),
+		podCooldownPeriod:                podCooldownPeriod,
 		timeProvider:                     time.Now,
 	}
 	deps.Lc.Append(fx.Hook{

--- a/comp/languagedetection/client/clientimpl/client.go
+++ b/comp/languagedetection/client/clientimpl/client.go
@@ -38,7 +38,7 @@ const (
 	defaultprocessesWithoutPodCleanupPeriod = time.Hour
 
 	// podCooldownPeriod defines the period to wait before sending fresh updates
-	podCooldownPeriod = 20 * time.Second
+	podCooldownPeriod = 10 * 20 * time.Second
 )
 
 // Module defines the fx options for this component.
@@ -87,8 +87,9 @@ type client struct {
 	freshDataPeriod    time.Duration
 	freshlyUpdatedPods map[string]time.Time
 
-	// Additionally, we want to gaurantee the pod has been fully synced before sending
-	// the data to the cluster-agent. This is to avoid sending partial data.
+	// Additionally, we want to guarantee the pod has been fully synced with proccess info
+	// before sending the data to the cluster-agent. Thus we wait for 'podCooldownPeriod'
+	// before allowing a fresh update to be sent.
 	podCooldownPeriod time.Duration
 
 	// There is a race between the process check and the kubelet. If the process check detects a language

--- a/comp/languagedetection/client/clientimpl/client.go
+++ b/comp/languagedetection/client/clientimpl/client.go
@@ -87,7 +87,7 @@ type client struct {
 	freshDataPeriod    time.Duration
 	freshlyUpdatedPods map[string]time.Time
 
-	// Additionally, we want to guarantee the pod has been fully synced with proccess info
+	// Additionally, we want to guarantee the pod has been fully synced with process info
 	// before sending the data to the cluster-agent. Thus we wait for 'podCooldownPeriod'
 	// before allowing a fresh update to be sent.
 	podCooldownPeriod time.Duration

--- a/comp/languagedetection/client/clientimpl/util.go
+++ b/comp/languagedetection/client/clientimpl/util.go
@@ -20,6 +20,8 @@ type eventsToRetry struct {
 	events         []workloadmeta.Event
 }
 
+type TimeProvider func() time.Time
+
 type batch map[string]*podInfo
 
 func (b batch) getOrAddPodInfo(podName, podnamespace string, ownerRef *workloadmeta.KubernetesPodOwner) *podInfo {

--- a/comp/languagedetection/client/clientimpl/util.go
+++ b/comp/languagedetection/client/clientimpl/util.go
@@ -20,6 +20,7 @@ type eventsToRetry struct {
 	events         []workloadmeta.Event
 }
 
+// TimeProvider is a function that returns the current time
 type TimeProvider func() time.Time
 
 type batch map[string]*podInfo


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Implements a cooling down period for new pods in the language detection client. 

### Motivation

Provide better guarantee of a full picture all of the processes and all of the languages running on a pod for tracing library injection.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

This new coolDown period is well tested by unit tests through a timeProvider mock. We are able to verify that once the coolDownPeriod has passed, the client will then consider the podInfo as part of the data to send to the DCA.

### Possible Drawbacks / Trade-offs

Detected languages will take approximately "podCooldownPeriod" time longer to reach the DCA.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->