### PR TITLE
Change receive resource spans v2 to opt out

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -182,7 +182,7 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	}
 
 	if pkgconfig.Get("apm_config.features") == nil {
-		apmConfigFeatures := []string{"enable_receive_resource_spans_v2"}
+		apmConfigFeatures := []string{}
 		if pkgdatadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
 			apmConfigFeatures = append(apmConfigFeatures, "enable_operation_and_resource_name_logic_v2")
 		}

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -80,7 +80,7 @@ func (suite *ConfigTestSuite) TestAgentConfigDefaults() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, false, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_receive_resource_spans_v2", "enable_otlp_compute_top_level_by_span_kind"},
+	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"},
 		c.Get("apm_config.features"))
 }
 
@@ -104,7 +104,7 @@ func (suite *ConfigTestSuite) TestOperationAndResourceNameV2FeatureGate() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, false, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"},
+	assert.Equal(t, []string{"enable_operation_and_resource_name_logic_v2", "enable_otlp_compute_top_level_by_span_kind"},
 		c.Get("apm_config.features"))
 }
 

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -58,7 +58,7 @@ func (suite *ConfigTestSuite) TestAgentConfig() {
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, 10, c.Get("apm_config.trace_buffer"))
 	assert.Equal(t, false, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_receive_resource_spans_v2"}, c.Get("apm_config.features"))
+	assert.Equal(t, []string{}, c.Get("apm_config.features"))
 }
 
 func (suite *ConfigTestSuite) TestAgentConfigDefaults() {
@@ -104,7 +104,7 @@ func (suite *ConfigTestSuite) TestOperationAndResourceNameV2FeatureGate() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, false, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_receive_resource_spans_v2", "enable_operation_and_resource_name_logic_v2", "enable_otlp_compute_top_level_by_span_kind"},
+	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"},
 		c.Get("apm_config.features"))
 }
 
@@ -152,7 +152,7 @@ func (suite *ConfigTestSuite) TestAgentConfigWithDatadogYamlDefaults() {
 	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 	assert.Equal(t, false, c.Get("apm_config.receiver_enabled"))
 	assert.Equal(t, false, c.Get("otlp_config.traces.span_name_as_resource_name"))
-	assert.Equal(t, []string{"enable_receive_resource_spans_v2", "enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
+	assert.Equal(t, []string{"enable_otlp_compute_top_level_by_span_kind"}, c.Get("apm_config.features"))
 
 	// log_level from datadog.yaml takes precedence -> more verbose
 	assert.Equal(t, "debug", c.Get("log_level"))

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/traces_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/traces_exporter_test.go
@@ -90,8 +90,8 @@ func testTraceExporter(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	tcfg.TraceWriter.FlushPeriodSeconds = 0.1
 	tcfg.Endpoints[0].APIKey = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	tcfg.Endpoints[0].Host = server.URL
-	if enableReceiveResourceSpansV2 {
-		tcfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		tcfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	ctx := context.Background()
 	traceagent := pkgagent.NewAgent(ctx, tcfg, telemetry.NewNoopCollector(), &ddgostatsd.NoOpClient{}, gzip.NewComponent())
@@ -132,8 +132,8 @@ func testNewTracesExporter(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	tcfg.Endpoints[0].APIKey = "ddog_32_characters_long_api_key1"
 	ctx := context.Background()
 	tcfg.ReceiverEnabled = false
-	if enableReceiveResourceSpansV2 {
-		tcfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		tcfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	traceagent := pkgagent.NewAgent(ctx, tcfg, telemetry.NewNoopCollector(), &ddgostatsd.NoOpClient{}, gzip.NewComponent())
 

--- a/comp/otelcol/otlp/components/statsprocessor/agent_test.go
+++ b/comp/otelcol/otlp/components/statsprocessor/agent_test.go
@@ -59,8 +59,8 @@ func testTraceAgent(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	require.NoError(t, err)
 	cfg.OTLPReceiver.AttributesTranslator = attributesTranslator
 	cfg.BucketInterval = 50 * time.Millisecond
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	cfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 	out := make(chan *pb.StatsPayload, 10)

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -165,8 +165,8 @@ func TestOTLPMetrics(t *testing.T) {
 func testOTLPMetrics(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	assert := assert.New(t)
 	cfg := NewTestConfig(t)
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	stats := &teststatsd.Client{}
 
@@ -231,8 +231,8 @@ func testOTLPNameRemapping(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	// Verify that while EnableOperationAndResourceNamesV2 is in alpha, SpanNameRemappings overrides it
 	cfg := NewTestConfig(t)
 	cfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	cfg.OTLPReceiver.SpanNameRemappings = map[string]string{"libname.unspecified": "new"}
 	out := make(chan *Payload, 1)
@@ -269,8 +269,8 @@ func TestOTLPSpanNameV2(t *testing.T) {
 func testOTLPSpanNameV2(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	cfg := NewTestConfig(t)
 	cfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	out := make(chan *Payload, 1)
 	rcv := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
@@ -708,8 +708,8 @@ func TestCreateChunks(t *testing.T) {
 
 func testCreateChunk(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	cfg := NewTestConfig(t)
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	cfg.OTLPReceiver.ProbabilisticSampling = 50
 	o := NewOTLPReceiver(nil, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
@@ -763,8 +763,8 @@ func TestOTLPReceiveResourceSpans(t *testing.T) {
 
 func testOTLPReceiveResourceSpans(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	cfg := NewTestConfig(t)
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	out := make(chan *Payload, 1)
 	rcv := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
@@ -1260,8 +1260,8 @@ func testOTLPHostname(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	}
 	for _, tt := range testcases {
 		cfg := NewTestConfig(t)
-		if enableReceiveResourceSpansV2 {
-			cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+		if !enableReceiveResourceSpansV2 {
+			cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 		}
 		cfg.Hostname = tt.config
 		out := make(chan *Payload, 1)
@@ -1296,7 +1296,6 @@ func testOTLPHostname(enableReceiveResourceSpansV2 bool, t *testing.T) {
 
 func TestResourceRelatedSpanAttributesAreIgnored_ReceiveResourceSpansV2(t *testing.T) {
 	cfg := NewTestConfig(t)
-	cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
 	out := make(chan *Payload, 1)
 	rcv := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
 	rattr := map[string]interface{}{}
@@ -1343,16 +1342,16 @@ func TestOTLPReceiver(t *testing.T) {
 func testOTLPReceiver(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	t.Run("New", func(t *testing.T) {
 		cfg := NewTestConfig(t)
-		if enableReceiveResourceSpansV2 {
-			cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+		if !enableReceiveResourceSpansV2 {
+			cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 		}
 		assert.NotNil(t, NewOTLPReceiver(nil, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{}).conf)
 	})
 
 	t.Run("Start/nil", func(t *testing.T) {
 		cfg := NewTestConfig(t)
-		if enableReceiveResourceSpansV2 {
-			cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+		if !enableReceiveResourceSpansV2 {
+			cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 		}
 		o := NewOTLPReceiver(nil, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
 		o.Start()
@@ -1363,8 +1362,8 @@ func testOTLPReceiver(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	t.Run("Start/grpc", func(t *testing.T) {
 		port := testutil.FreeTCPPort(t)
 		cfg := NewTestConfig(t)
-		if enableReceiveResourceSpansV2 {
-			cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+		if !enableReceiveResourceSpansV2 {
+			cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 		}
 		cfg.OTLPReceiver = &config.OTLP{
 			BindHost: "localhost",
@@ -1384,8 +1383,8 @@ func testOTLPReceiver(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	t.Run("processRequest", func(t *testing.T) {
 		out := make(chan *Payload, 5)
 		cfg := NewTestConfig(t)
-		if enableReceiveResourceSpansV2 {
-			cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+		if !enableReceiveResourceSpansV2 {
+			cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 		}
 		o := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
 		o.processRequest(context.Background(), http.Header(map[string][]string{
@@ -1627,7 +1626,6 @@ func TestOTelSpanToDDSpan(t *testing.T) {
 func testOTelSpanToDDSpan(enableOperationAndResourceNameV2 bool, t *testing.T) {
 	cfg := NewTestConfig(t)
 	now := uint64(otlpTestSpan.StartTimestamp())
-	cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
 	if enableOperationAndResourceNameV2 {
 		cfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 	}
@@ -3410,7 +3408,6 @@ func testOTLPConvertSpanSetPeerService(enableOperationAndResourceNameV2 bool, t 
 func testOTelSpanToDDSpanSetPeerService(enableOperationAndResourceNameV2 bool, t *testing.T) {
 	now := uint64(otlpTestSpan.StartTimestamp())
 	cfg := NewTestConfig(t)
-	cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
 	if enableOperationAndResourceNameV2 {
 		cfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 	}
@@ -3795,8 +3792,8 @@ func testResourceAttributesMap(enableReceiveResourceSpansV2 bool, t *testing.T) 
 	lib := pcommon.NewInstrumentationScope()
 	span := testutil.NewOTLPSpan(&testutil.OTLPSpan{})
 	cfg := NewTestConfig(t)
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	NewOTLPReceiver(nil, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{}).convertSpan(rattr, lib, span)
 	assert.Len(t, rattr, 1) // ensure "rattr" has no new entries
@@ -4273,8 +4270,8 @@ func benchmarkProcessRequest(enableReceiveResourceSpansV2 bool, b *testing.B) {
 	}()
 
 	cfg := NewBenchmarkTestConfig(b)
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	r := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})
 	b.ReportAllocs()
@@ -4316,8 +4313,8 @@ func benchmarkProcessRequestTopLevel(enableReceiveResourceSpansV2 bool, b *testi
 	}()
 
 	cfg := NewBenchmarkTestConfig(b)
-	if enableReceiveResourceSpansV2 {
-		cfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		cfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	cfg.Features["enable_otlp_compute_top_level_by_span_kind"] = struct{}{}
 	r := NewOTLPReceiver(out, cfg, &statsd.NoOpClient{}, &timing.NoopReporter{})

--- a/pkg/trace/stats/otel_benckmark_test.go
+++ b/pkg/trace/stats/otel_benckmark_test.go
@@ -45,37 +45,37 @@ func benchmarkOTelObfuscation(b *testing.B, enableObfuscation bool) {
 		semconv.AttributeDeploymentEnvironment: "tracer_env",
 		semconv.AttributeDBSystem:              "mysql",
 		semconv.AttributeDBStatement: `
-		SELECT 
-    	u.id, 
-			u.name, 
-			u.email, 
-			o.order_id, 
-			o.total_amount, 
-			p.product_name, 
-			p.price 
-		FROM 
-				users u 
-		JOIN 
-				orders o ON u.id = o.user_id 
-		JOIN 
-				order_items oi ON o.order_id = oi.order_id 
-		JOIN 
-				products p ON oi.product_id = p.product_id 
-		WHERE 
-				u.status = 'active' 
-				AND o.order_date BETWEEN '2023-01-01' AND '2023-12-31' 
-				AND p.category IN ('electronics', 'books') 
-		GROUP BY 
-				u.id, 
-				u.name, 
-				u.email, 
-				o.order_id, 
-				o.total_amount, 
-				p.product_name, 
-				p.price 
-		ORDER BY 
-				o.order_date DESC, 
-				p.price ASC 
+		SELECT
+    	u.id,
+			u.name,
+			u.email,
+			o.order_id,
+			o.total_amount,
+			p.product_name,
+			p.price
+		FROM
+				users u
+		JOIN
+				orders o ON u.id = o.user_id
+		JOIN
+				order_items oi ON o.order_id = oi.order_id
+		JOIN
+				products p ON oi.product_id = p.product_id
+		WHERE
+				u.status = 'active'
+				AND o.order_date BETWEEN '2023-01-01' AND '2023-12-31'
+				AND p.category IN ('electronics', 'books')
+		GROUP BY
+				u.id,
+				u.name,
+				u.email,
+				o.order_id,
+				o.total_amount,
+				p.product_name,
+				p.price
+		ORDER BY
+				o.order_date DESC,
+				p.price ASC
 		LIMIT 100;
 		`,
 	} {
@@ -94,7 +94,6 @@ func benchmarkOTelObfuscation(b *testing.B, enableObfuscation bool) {
 	conf.Hostname = "agent_host"
 	conf.DefaultEnv = "agent_env"
 	conf.Obfuscation.Redis.Enabled = true
-	conf.Features["enable_receive_resource_spans_v2"] = struct{}{}
 	conf.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}
 	conf.OTLPReceiver.AttributesTranslator = attributesTranslator
 

--- a/pkg/trace/stats/otel_util_test.go
+++ b/pkg/trace/stats/otel_util_test.go
@@ -236,8 +236,8 @@ func TestProcessOTLPTraces(t *testing.T) {
 			conf.Hostname = agentHost
 			conf.DefaultEnv = agentEnv
 			conf.Features["enable_cid_stats"] = struct{}{}
-			if tt.enableReceiveResourceSpansV2 {
-				conf.Features["enable_receive_resource_spans_v2"] = struct{}{}
+			if !tt.enableReceiveResourceSpansV2 {
+				conf.Features["disable_receive_resource_spans_v2"] = struct{}{}
 			}
 			conf.PeerTagsAggregation = tt.peerTagsAggr
 			conf.OTLPReceiver.AttributesTranslator = attributesTranslator

--- a/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
+++ b/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
@@ -50,8 +50,8 @@ func testOTelAPMStatsMatch(enableReceiveResourceSpansV2 bool, t *testing.T) {
 	require.NoError(t, err)
 	tcfg := getTraceAgentCfg(attributesTranslator)
 	peerTagKeys := tcfg.ConfiguredPeerTags()
-	if enableReceiveResourceSpansV2 {
-		tcfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !enableReceiveResourceSpansV2 {
+		tcfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 
 	metricsClient := &statsd.NoOpClient{}

--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -53,13 +53,13 @@ func OtelSpanToDDSpanMinimal(
 
 	// correct span type logic if using new resource receiver, keep same if on v1. separate from OperationAndResourceNameV2Enabled.
 	var spanType string
-	if conf.HasFeature("enable_receive_resource_spans_v2") {
-		spanType = traceutil.GetOTelSpanType(otelspan, otelres)
-	} else {
+	if conf.HasFeature("disable_receive_resource_spans_v2") {
 		spanType = traceutil.GetOTelAttrValInResAndSpanAttrs(otelspan, otelres, true, "span.type")
 		if spanType == "" {
 			spanType = traceutil.SpanKind2Type(otelspan, otelres)
 		}
+	} else {
+		spanType = traceutil.GetOTelSpanType(otelspan, otelres)
 	}
 
 	ddspan := &pb.Span{

--- a/releasenotes/notes/change-receive-resource-spans-v2-to-opt-out-e3fb3c8ead6138c0.yaml
+++ b/releasenotes/notes/change-receive-resource-spans-v2-to-opt-out-e3fb3c8ead6138c0.yaml
@@ -1,0 +1,5 @@
+
+---
+enhancements:
+  - |
+    Added a new feature flag `disable_receive_resource_spans_v2` in DD_APM_FEATURES that replaces `enable_receive_resource_spans_v2` - the refactored implementation of ReceiveResourceSpans for OTLP is now opt-out instead of opt-in.

--- a/test/new-e2e/tests/otel/otel-agent/complete_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/complete_test.go
@@ -37,6 +37,8 @@ agents:
       env:
         - name: DD_OTELCOLLECTOR_CONVERTER_ENABLED
           value: 'false'
+        - name: DD_APM_FEATURES
+          value: 'disable_receive_resource_spans_v2'
 `
 	t.Parallel()
 	e2e.Run(t, &completeTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(completeConfig)))))

--- a/test/new-e2e/tests/otel/otel-agent/receive_resource_spans_v2_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/receive_resource_spans_v2_test.go
@@ -30,8 +30,6 @@ agents:
   containers:
     otelAgent:
       env:
-        - name: DD_APM_FEATURES
-          value: 'enable_receive_resource_spans_v2'
         - name: DD_OTLP_CONFIG_TRACES_SPAN_NAME_AS_RESOURCE_NAME
           value: 'false'
 `

--- a/test/new-e2e/tests/otel/otlp-ingest/operation_and_resource_name_logic_v2_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/operation_and_resource_name_logic_v2_test.go
@@ -75,7 +75,7 @@ agents:
     traceAgent:
       env:
         - name: DD_APM_FEATURES
-          value: 'enable_operation_and_resource_name_logic_v2,enable_receive_resource_spans_v2'
+          value: 'enable_operation_and_resource_name_logic_v2'
 `
 	t.Parallel()
 	e2e.Run(t, &otlpIngestOpNameV2RecvrV2TestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values)))))

--- a/test/new-e2e/tests/otel/otlp-ingest/receive_resource_spans_v2_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/receive_resource_spans_v2_test.go
@@ -33,12 +33,6 @@ datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-agents:
-  containers:
-    traceAgent:
-      env:
-        - name: DD_APM_FEATURES
-          value: 'enable_receive_resource_spans_v2'
 `
 	t.Parallel()
 	e2e.Run(t, &otlpIngestSpanReceiverV2TestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values)))))

--- a/test/new-e2e/tests/otel/otlp-ingest/receive_resource_spans_v2_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/receive_resource_spans_v2_test.go
@@ -6,13 +6,13 @@
 package otlpingest
 
 import (
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
 	"testing"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
-	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/otel/utils"
 )
 
@@ -33,6 +33,12 @@ datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
+agents:
+  containers:
+    traceAgent:
+      env:
+        - name: DD_APM_FEATURES
+          value: 'enable_operation_and_resource_name_logic_v2'
 `
 	t.Parallel()
 	e2e.Run(t, &otlpIngestSpanReceiverV2TestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values)))))

--- a/test/new-e2e/tests/otel/utils/pipelines_utils.go
+++ b/test/new-e2e/tests/otel/utils/pipelines_utils.go
@@ -170,13 +170,13 @@ func TestTracesWithSpanReceiverV2(s OTelTestSuite) {
 		assert.Equal(s.T(), version, sp.Meta["version"])
 		assert.Equal(s.T(), customAttributeValue, sp.Meta[customAttribute])
 		if sp.Meta["span.kind"] == "client" {
-			assert.Equal(s.T(), "telemetrygen.client", sp.Name)
+			assert.Equal(s.T(), "client.request", sp.Name)
 			assert.Equal(s.T(), "lets-go", sp.Resource)
 			assert.Equal(s.T(), "http", sp.Type)
 			assert.Zero(s.T(), sp.ParentID)
 		} else {
 			assert.Equal(s.T(), "server", sp.Meta["span.kind"])
-			assert.Equal(s.T(), "telemetrygen.server", sp.Name)
+			assert.Equal(s.T(), "server.request", sp.Name)
 			assert.Equal(s.T(), "okey-dokey-0", sp.Resource)
 			assert.Equal(s.T(), "web", sp.Type)
 			assert.IsType(s.T(), uint64(0), sp.ParentID)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Added a new feature flag `` in DD_APM_FEATURES that replaces `enable_receive_resource_spans_v2` - the refactored implementation of ReceiveResourceSpans for OTLP is now opt-out instead of opt-in.

Waiting for https://github.com/DataDog/datadog-agent/pull/33322 to be merged into main.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Run agent locally; verify that when no flag is specified, the v2 logic is active, and when `disable_receive_resource_spans_v2` is added (in either yaml or env), v1 is active.
