### PR TITLE
add qualification phase for agent 6

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -108,8 +108,14 @@ jobs:
                   echo "CHANGES=$(inv -e release.check-for-changes -r "$MATRIX")" >> $GITHUB_OUTPUT
                 fi
 
+            - name: Check if agent 6 is in qualification phase
+              if: ${{ env.IS_AGENT6_RELEASE == 'true' }}
+              run: |
+                is_qualification=$(inv -e release.is-qualification --output)
+                echo "IS_QUALIFICATION=$is_qualification" >> $GITHUB_ENV
+
             - name: Create RC PR
-              if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || env.IS_AGENT6_RELEASE == 'true' }}
+              if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_AGENT6_RELEASE == 'true' && env.IS_QUALIFICATION == 'false') }}
               env:
                 MATRIX: ${{ matrix.value }}
               run: |
@@ -118,3 +124,8 @@ jobs:
                 else
                   inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }}
                 fi
+
+            - name: Rebuild agent 6 RC pipeline if no changes and in qualification phase
+              if: ${{ env.IS_AGENT6_RELEASE == 'true' && steps.check_for_changes.outputs.CHANGES == 'false' && env.IS_QUALIFICATION == 'true' }}
+              run: |
+                inv -e release.run-rc-pipeline 6.53.x

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -111,7 +111,7 @@ jobs:
             - name: Check if agent 6 is in qualification phase
               if: ${{ env.IS_AGENT6_RELEASE == 'true' }}
               run: |
-                is_qualification=$(inv -e release.is-qualification --output)
+                is_qualification=$(inv -e release.is-qualification -r 6.53.x --output)
                 echo "IS_QUALIFICATION=$is_qualification" >> $GITHUB_ENV
 
             - name: Create RC PR
@@ -128,4 +128,4 @@ jobs:
             - name: Rebuild agent 6 RC pipeline if no changes and in qualification phase
               if: ${{ env.IS_AGENT6_RELEASE == 'true' && steps.check_for_changes.outputs.CHANGES == 'false' && env.IS_QUALIFICATION == 'true' }}
               run: |
-                inv -e release.run-rc-pipeline 6.53.x
+                inv -e release.run-rc-pipeline -r 6.53.x

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -33,7 +33,7 @@ RC_VERSION_RE = re.compile(r'^\d+[.]\d+[.]\d+-rc\.\d+$')
 FINAL_VERSION_RE = re.compile(r'^\d+[.]\d+[.]\d+$')
 
 # Regex matching minor release rc version tag like x.y.0-rc.1 (semver PATCH == 0), but not x.y.1-rc.1 (semver PATCH > 0)
-MINOR_RC_VERSION_RE = re.compile(r'\d+[.]\d+[.]0-rc\.\d+')
+MINOR_RC_VERSION_RE = re.compile(r'^\d+[.]\d+[.]0-rc\.\d+$')
 
 # Regex matching the git describe output
 DESCRIBE_PATTERN = re.compile(r"^.*-(?P<commit_number>\d+)-g[0-9a-f]+$")

--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -27,7 +27,10 @@ from tasks.libs.types.version import Version
 VERSION_RE = re.compile(r'(v)?(\d+)[.](\d+)([.](\d+))?(-devel)?(-rc\.(\d+))?')
 
 # Regex matching rc version tag format like 7.50.0-rc.1
-RC_VERSION_RE = re.compile(r'\d+[.]\d+[.]\d+-rc\.\d+')
+RC_VERSION_RE = re.compile(r'^\d+[.]\d+[.]\d+-rc\.\d+$')
+
+# Regex matching final version tag format like 7.54.0
+FINAL_VERSION_RE = re.compile(r'^\d+[.]\d+[.]\d+$')
 
 # Regex matching minor release rc version tag like x.y.0-rc.1 (semver PATCH == 0), but not x.y.1-rc.1 (semver PATCH > 0)
 MINOR_RC_VERSION_RE = re.compile(r'\d+[.]\d+[.]0-rc\.\d+')

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -17,7 +17,7 @@ from datetime import date
 from time import sleep
 
 from gitlab import GitlabError
-from invoke import task
+from invoke import Failure, task
 from invoke.exceptions import Exit
 
 from tasks.libs.ciproviders.github_api import GithubAPI, create_release_pr
@@ -65,6 +65,7 @@ from tasks.libs.releasing.json import (
     update_release_json,
 )
 from tasks.libs.releasing.version import (
+    FINAL_VERSION_RE,
     MINOR_RC_VERSION_RE,
     RC_VERSION_RE,
     VERSION_RE,
@@ -85,6 +86,7 @@ GITLAB_FILES_TO_UPDATE = [
 
 BACKPORT_LABEL_COLOR = "5319e7"
 TAG_BATCH_SIZE = 3
+QUALIFICATION_TAG = "qualification"
 
 
 @task
@@ -148,10 +150,11 @@ def __get_force_option(force: bool) -> str:
     return force_option
 
 
-def __tag_single_module(ctx, module, agent_version, commit, force_option, devel):
+def __tag_single_module(ctx, module, tag_name, commit, force_option, devel):
     """Tag a given module."""
     tags = []
-    for tag in module.tag(agent_version):
+    tags_to_commit = module.tag(tag_name) if VERSION_RE.match(tag_name) else [tag_name]
+    for tag in tags_to_commit:
         if devel:
             tag += "-devel"
 
@@ -210,7 +213,15 @@ def tag_modules(
 
 @task
 def tag_version(
-    ctx, release_branch=None, commit="HEAD", push=True, force=False, devel=False, version=None, trust=False
+    ctx,
+    release_branch=None,
+    commit="HEAD",
+    push=True,
+    force=False,
+    devel=False,
+    version=None,
+    trust=False,
+    start_qual=False,
 ):
     """Create tags for a given Datadog Agent version.
 
@@ -220,6 +231,7 @@ def tag_version(
         push: Will push the tags to the origin remote (on by default).
         force: Will allow the task to overwrite existing tags. Needed to move existing tags (off by default).
         devel: Will create -devel tags (used after creation of the release branch)
+        start_qual: Will start the qualification phase for agent 6 release candidate by adding a qualification tag
 
     Examples:
         $ inv -e release.tag-version 7.27.x            # Create tags and push them to origin
@@ -235,6 +247,16 @@ def tag_version(
     force_option = __get_force_option(force)
     with agent_context(ctx, release_branch, skip_checkout=release_branch is None):
         tags = __tag_single_module(ctx, get_default_modules()["."], agent_version, commit, force_option, devel)
+
+        # create or update the qualification tag using the force option (points tag to next RC)
+        if is_agent6(ctx) and (start_qual or is_qualification(ctx)):
+            if FINAL_VERSION_RE.match(agent_version):
+                ctx.run(f"git push --delete origin {QUALIFICATION_TAG}")
+            else:
+                force_option = __get_force_option(not start_qual)
+                tags += __tag_single_module(
+                    ctx, get_default_modules()["."], QUALIFICATION_TAG, commit, force_option, False
+                )
 
     if push:
         tags_list = ' '.join(tags)
@@ -472,7 +494,20 @@ def create_rc(ctx, release_branch, patch_version=False, upstream="origin", slack
 
 
 @task
-def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False):
+def is_qualification(ctx, output=False):
+    try:
+        ctx.run(f"git tag | grep {QUALIFICATION_TAG}", hide=True)
+        if output:
+            print('true')
+        return True
+    except Failure:
+        if output:
+            print("false")
+        return False
+
+
+@task
+def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False, start_qual=False):
     """To be done after the PR created by release.create-rc is merged, with the same options
     as release.create-rc.
 
@@ -481,6 +516,7 @@ def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False):
 
     Args:
         k8s_deployments: When set to True the child pipeline deploying to subset of k8s staging clusters will be triggered.
+        start_qual: Start the qualification phase for agent 6 release candidates.
     """
 
     major_version = get_version_major(release_branch)
@@ -530,7 +566,7 @@ def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False):
         # tag_version only takes the highest version (Agent 7 currently), and creates
         # the tags for all supported versions
         # TODO: make it possible to do Agent 6-only or Agent 7-only tags?
-        tag_version(ctx, version=str(new_version), force=False)
+        tag_version(ctx, version=str(new_version), force=False, start_qual=start_qual)
         tag_modules(ctx, version=str(new_version), force=False)
 
         print(color_message(f"Waiting until the {new_version} tag appears in Gitlab", "bold"))
@@ -546,10 +582,31 @@ def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False):
         print(color_message("Creating RC pipeline", "bold"))
 
         # Step 2: Run the RC pipeline
+        run_rc_pipeline(release_branch, gitlab_tag.name, k8s_deployments)
+
+
+@task
+def run_rc_pipeline(ctx, release_branch, gitlab_tag=None, k8s_deployments=False):
+    with agent_context(ctx, release_branch):
+        if not gitlab_tag:
+            err_msg = "Error: Expected exactly one release candidate tag associated with the qualification tag commit. Tags found:"
+            try:
+                res = ctx.run(f"git tag --points-at $(git rev-list -n 1 {QUALIFICATION_TAG}) | grep 6.53")
+            except Failure as err:
+                raise Exit(message=f"{err_msg} []", code=1) from err
+
+            tags = [tag for tag in res.stdout.split("\n") if tag.strip()]
+            if len(tags) > 1:
+                raise Exit(message=f"{err_msg} {tags}", code=1)
+            if not RC_VERSION_RE.match(tags[0]):
+                raise Exit(
+                    message=f"Error: The tag '{tags[0]}' does not match expected release candidate pattern", code=1
+                )
+            gitlab_tag = tags[0]
 
         run(
             ctx,
-            git_ref=gitlab_tag.name,
+            git_ref=gitlab_tag,
             use_release_entries=True,
             repo_branch="beta",
             deploy=True,
@@ -1269,7 +1326,7 @@ def check_previous_agent6_rc(ctx):
         err_msg += agent6_prs
 
     response = get_ci_pipeline_events(
-        'ci_level:pipeline @ci.pipeline.name:"DataDog/datadog-agent" @git.tag:6.53.* -@ci.pipeline.downstream:true',
+        'ci_level:pipeline @ci.pipeline.name:"DataDog/datadog-agent" @git.tag:6.53.* -@ci.pipeline.downstream:true -@ci.partial_pipeline:retry',
         7,
     )
     if not response.data:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
add qualification phase for agent 6 by modifying the release tasks and the create rc pr workflow

#### CHANGES IN RELEASE TASKS
**1. start qualification phase** 
- added new `--start-qual` argument to `build_rc` task
- this will be manually triggered by running the build rc task with the `--start-qual` argument
- `inv release.build-rc 6.53.x --start-qual`

**2. automatically move qualification tag when RC is bumped**
- added `is_qualification()` function to check if the current state is in qualification phase
- use `git tag --force` to move qualification tag to new RC commit
- `inv release.build-rc 6.53.x` (automatically checks if in qualification phase without any extra arguments)

**3. end qualification phase**
- according to the [release coordinator guide](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/3649801154/Release+Coordinator+guide#Add-tags) we use the `tag_version` task to tag the final version
- used the same task to end the qualification phase by checking if it is agent 6 and a final version
- `inv release.tag-version --version 6.53.2`

#### CHANGES IN CREATE RC PR WORKFLOW
if current state of agent 6 is in qualification phase and there are no changes (no new commits in 6.53.x branch)
1. do not bump rc pr
2. rebuild previous rc pipeline

### Motivation
[ACIX-525](https://datadoghq.atlassian.net/browse/ACIX-525)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
ran the release tasks locally
but plan to test it fully through the next couple of agent 6 RCs

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[ACIX-525]: https://datadoghq.atlassian.net/browse/ACIX-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ