### PR TITLE
[CWS] use rule cache for SECL rule filter

### DIFF
--- a/pkg/security/secl/rules/filter/seclrulefilter.go
+++ b/pkg/security/secl/rules/filter/seclrulefilter.go
@@ -21,7 +21,7 @@ type SECLRuleFilter struct {
 func NewSECLRuleFilter(model eval.Model) *SECLRuleFilter {
 	return &SECLRuleFilter{
 		model:          model,
-		parsingContext: ast.NewParsingContext(false),
+		parsingContext: ast.NewParsingContext(true),
 	}
 }
 

--- a/pkg/security/secl/rules/filter/seclrulefilter.go
+++ b/pkg/security/secl/rules/filter/seclrulefilter.go
@@ -7,6 +7,8 @@
 package filter
 
 import (
+	"runtime"
+
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
@@ -45,6 +47,16 @@ func (r *SECLRuleFilter) newEvalContext() eval.Context {
 func (r *SECLRuleFilter) IsAccepted(filters []string) (bool, error) {
 	if len(filters) == 0 {
 		return true, nil
+	}
+
+	// early check for obvious and most used cases
+	if len(filters) == 1 {
+		switch filters[0] {
+		case `os == "linux"`:
+			return runtime.GOOS == "linux", nil
+		case `os == "windows"`:
+			return runtime.GOOS == "windows", nil
+		}
 	}
 
 	expression := mergeFilterExpressions(filters)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR enables the rule cache when using a parsing context for SECL rule filters. The reasoning behind that is that filters are often the same between rules ([especially in compliance rules](https://github.com/DataDog/security-agent-policies/blob/4856bfeb33ed8242ca175d04d30106465b800136/compliance/containers/cis-al2023-1.0.0.yaml#L9)) and parsing those hundreds of time is wasteful.

This PR also adds a hacky but efficient fast path for the 2 most common CWS filters that are used by nearly all rules: `os == "linux"` and `os == "windows"`.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->