### PR TITLE
[CONTP-586] fix unit test in cwsinstrumentation webhook

### DIFF
--- a/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/cwsinstrumentation/cws_instrumentation_test.go
@@ -225,7 +225,7 @@ func Test_injectCWSCommandInstrumentation(t *testing.T) {
 				name:     "my-pod",
 				ns:       "my-namespace",
 				userInfo: &authenticationv1.UserInfo{},
-				include:  []string{"kube_namespae:my-namespace"},
+				include:  []string{"kube_namespace:my-namespace"},
 				apiClientAnnotations: map[string]string{
 					cwsInstrumentationPodAnotationStatus: cwsInstrumentationPodAnotationReady,
 				},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

See title.

### Motivation

This unit test isn't failing before because the `NewFilter` function that creates filters based on user config treats the following two scenarios differently:
- Unrecognised filter key: no error is returned, only a warning. (so the cwsinstrumentation webhook doesn't notice the error)
- Filter key is recognised, but the regex can't be compiled: an error is returned. (so the cwsinstrumentation webhook catches the error and fails).

In principle, both cases should be treated as errors so that we avoid the following scenario:
User excludes some namespace, but makes a mistake in the filter key (i.e. `kube_namespace`, similarly to what happened in this unit test). In this case, we should be aware that there is an error and decide not to proceed to avoid exposing metrics, logs or functionality in a namespace that the user wanted to restrict.

The filter creation will be modified in a subsequent PR. This PR is only fixing the typo in the unit test to avoid unit test failure in the coming PR and to make review easier. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

The change is in unit test. No need for testing.

### Possible Drawbacks / Trade-offs
None.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

