### PR TITLE
[HA Agent] Add datadog.agent.ha_agent.integration_runs v2

### DIFF
--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -25,4 +25,7 @@ type Component interface {
 
 	// ShouldRunIntegration returns true if the integration should be run
 	ShouldRunIntegration(integrationName string) bool
+
+	// IsHaIntegration return true if it's an HA integration.
+	IsHaIntegration(integrationName string) bool
 }

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -79,6 +79,11 @@ func (h *haAgentImpl) ShouldRunIntegration(integrationName string) bool {
 	return true
 }
 
+// IsHaIntegration return true if it's an HA integration.
+func (h *haAgentImpl) IsHaIntegration(integrationName string) bool {
+	return validHaIntegrations[integrationName]
+}
+
 func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 	h.log.Debugf("Updates received: count=%d", len(updates))
 

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -283,6 +283,43 @@ func Test_haAgentImpl_ShouldRunIntegration(t *testing.T) {
 	}
 }
 
+func Test_haAgentImpl_IsIntegration(t *testing.T) {
+	testAgentHostname := "my-agent-hostname"
+	tests := []struct {
+		name                  string
+		leader                string
+		agentConfigs          map[string]interface{}
+		expectIsHaIntegration map[string]bool
+	}{
+		{
+			name: "base case",
+			// should run HA-integrations
+			// should run "non HA integrations"
+			agentConfigs: map[string]interface{}{
+				"hostname": testAgentHostname,
+			},
+			leader: testAgentHostname,
+			expectIsHaIntegration: map[string]bool{
+				"snmp":                true,
+				"cisco_aci":           true,
+				"cisco_sdwan":         true,
+				"network_path":        true,
+				"unknown_integration": false,
+				"cpu":                 false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			haAgent := newTestHaAgentComponent(t, tt.agentConfigs)
+
+			for integrationName, shouldRun := range tt.expectIsHaIntegration {
+				assert.Equalf(t, shouldRun, haAgent.Comp.IsHaIntegration(integrationName), "fail for integration: "+integrationName)
+			}
+		})
+	}
+}
+
 func Test_haAgentImpl_resetAgentState(t *testing.T) {
 	// GIVEN
 	haAgent := newTestHaAgentComponent(t, nil)

--- a/comp/haagent/mock/mock.go
+++ b/comp/haagent/mock/mock.go
@@ -52,6 +52,10 @@ func (m *mockHaAgent) ShouldRunIntegration(_ string) bool {
 	return true
 }
 
+func (m *mockHaAgent) IsHaIntegration(_ string) bool {
+	return true
+}
+
 // Component is the component type.
 type Component interface {
 	haagent.Component

--- a/pkg/collector/runner/expvars/expvars.go
+++ b/pkg/collector/runner/expvars/expvars.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
 	"github.com/mohae/deepcopy"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -105,12 +106,12 @@ func GetCheckStats() map[string]map[checkid.ID]*checkstats.Stats {
 }
 
 // AddCheckStats adds runtime stats to the check's expvars
-func AddCheckStats(
-	c check.Check,
+func AddCheckStats(c check.Check,
 	execTime time.Duration,
 	err error,
 	warnings []error,
 	mStats checkstats.SenderStats,
+	haagent haagent.Component,
 ) {
 
 	var s *checkstats.Stats
@@ -133,7 +134,7 @@ func AddCheckStats(
 		stats[c.ID()] = s
 	}
 
-	s.Add(execTime, err, warnings, mStats)
+	s.Add(execTime, err, warnings, mStats, haagent)
 }
 
 // RemoveCheckStats removes a check from the check stats map

--- a/pkg/collector/runner/expvars/expvars_test.go
+++ b/pkg/collector/runner/expvars/expvars_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -171,7 +172,7 @@ func TestExpvarsReset(t *testing.T) {
 			testCheck := newTestCheck(checkID)
 
 			for runIdx := 0; runIdx < numCheckRuns; runIdx++ {
-				AddCheckStats(testCheck, 12345, nil, []error{}, stats.SenderStats{})
+				AddCheckStats(testCheck, 12345, nil, []error{}, stats.SenderStats{}, haagentmock.NewMockHaAgent())
 			}
 		}
 	}
@@ -243,7 +244,7 @@ func TestExpvarsCheckStats(t *testing.T) {
 
 					<-start
 
-					AddCheckStats(testCheck, duration, err, warnings, expectedStats)
+					AddCheckStats(testCheck, duration, err, warnings, expectedStats, haagentmock.NewMockHaAgent())
 
 					actualStats, found := CheckStats(testCheck.ID())
 					require.True(t, found)
@@ -319,7 +320,7 @@ func TestExpvarsGetChecksStatsClone(t *testing.T) {
 			testCheck := newTestCheck(checkID)
 
 			for runIdx := 0; runIdx < numCheckRuns; runIdx++ {
-				AddCheckStats(testCheck, 12345, nil, []error{}, stats.SenderStats{})
+				AddCheckStats(testCheck, 12345, nil, []error{}, stats.SenderStats{}, haagentmock.NewMockHaAgent())
 			}
 		}
 	}
@@ -424,7 +425,7 @@ func TestGetCheckStatsRace(t *testing.T) {
 
 					warnings := []error{errors.New("error1"), errors.New("error2"), errors.New("error3")}
 					for runIdx := 0; runIdx < numCheckRuns; runIdx++ {
-						AddCheckStats(testCheck, 12345, nil, warnings, stats.SenderStats{})
+						AddCheckStats(testCheck, 12345, nil, warnings, stats.SenderStats{}, haagentmock.NewMockHaAgent())
 					}
 				}
 			}

--- a/pkg/collector/worker/check_logger_test.go
+++ b/pkg/collector/worker/check_logger_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"testing"
 
+	haagentmock "github.com/DataDog/datadog-agent/comp/haagent/mock"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -32,7 +33,7 @@ func newTestCheck(id string) *stubCheck {
 }
 
 func addExpvarsCheckStats(c check.Check) {
-	expvars.AddCheckStats(c, 0, nil, nil, stats.SenderStats{})
+	expvars.AddCheckStats(c, 0, nil, nil, stats.SenderStats{}, haagentmock.NewMockHaAgent())
 }
 
 func setUp() {

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -563,6 +563,61 @@ func TestWorkerServiceCheckSending(t *testing.T) {
 	mockSender.AssertNumberOfCalls(t, "ServiceCheck", 3)
 }
 
+func TestWorkerHaAgentIntegrationMetric(t *testing.T) {
+	// GIVEN
+	expvars.Reset()
+	pkgconfigsetup.Datadog().SetWithoutSource("hostname", "myhost")
+	pkgconfigsetup.Datadog().SetWithoutSource("integration_check_status_enabled", "false")
+
+	var wg sync.WaitGroup
+
+	checksTracker := tracker.NewRunningChecksTracker()
+	pendingChecksChan := make(chan check.Check, 10)
+	mockShouldAddStatsFunc := func(checkid.ID) bool { return true }
+
+	goodCheck := newCheck(t, "snmp:111", false, nil)
+	anotherCheck := newCheck(t, "network_path:222", true, nil)
+
+	pendingChecksChan <- goodCheck
+	pendingChecksChan <- anotherCheck
+	close(pendingChecksChan)
+
+	mockSender := mocksender.NewMockSender("")
+	haAgentMock := haagentmock.NewMockHaAgent().(haagentmock.Component)
+	haAgentMock.SetEnabled(true)
+	worker, err := newWorkerWithOptions(
+		100,
+		200,
+		pendingChecksChan,
+		checksTracker,
+		mockShouldAddStatsFunc,
+		func() (sender.Sender, error) {
+			return mockSender, nil
+		},
+		haAgentMock,
+		pollingInterval,
+	)
+	require.Nil(t, err)
+
+	// EXPECT
+	mockSender.On("Commit").Return().Times(2)
+	mockSender.On("Count", "datadog.agent.ha_agent.integration_runs", float64(1), "", []string{"integration:snmp"}).Return().Times(1)
+	mockSender.On("Count", "datadog.agent.ha_agent.integration_runs", float64(1), "", []string{"integration:network_path"}).Return().Times(1)
+
+	// WHEN
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		worker.Run()
+	}()
+	wg.Wait()
+
+	// THEN
+	assert.Equal(t, 2, int(expvars.GetRunsCount())) // Quick sanity check
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Commit", 2)
+}
+
 func TestWorkerSenderNil(t *testing.T) {
 	expvars.Reset()
 	pkgconfigsetup.Datadog().SetWithoutSource("hostname", "myhost")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[HA Agent] Add datadog.agent.ha_agent.integration_runs

### Motivation

`datadog.agent.ha_agent.integration_runs` for HA Agent feature OOTB dashboard, see example below.

It helps know which agent is running which integrations over time.

![image](https://github.com/user-attachments/assets/d9d71485-8fb3-4f85-865d-8ed1ac4f51a2)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->