### PR TITLE
[ASCII-2698] Provide a default self-signed certificate if the IPC certificate cannot be load

### DIFF
--- a/comp/api/authtoken/fetchonlyimpl/authtoken.go
+++ b/comp/api/authtoken/fetchonlyimpl/authtoken.go
@@ -76,7 +76,6 @@ func (at *authToken) Get() string {
 func (at *authToken) GetTLSClientConfig() *tls.Config {
 	if err := at.setToken(); err != nil {
 		at.log.Debugf("%s", err.Error())
-		return nil
 	}
 
 	return util.GetTLSClientConfig()
@@ -86,7 +85,6 @@ func (at *authToken) GetTLSClientConfig() *tls.Config {
 func (at *authToken) GetTLSServerConfig() *tls.Config {
 	if err := at.setToken(); err != nil {
 		at.log.Debugf("%s", err.Error())
-		return nil
 	}
 
 	return util.GetTLSServerConfig()

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -282,7 +282,7 @@ func init() {
 	hosts := []string{"127.0.0.1", "localhost"}
 	_, rootCertPEM, rootKey, err := pkgtoken.GenerateRootCert(hosts, 2048)
 	if err != nil {
-		log.Errorf("unable to start TLS server")
+		log.Errorf("unable to generate a self-signed certificate: %v", err)
 		return
 	}
 
@@ -294,12 +294,11 @@ func init() {
 	// Create a TLS cert using the private key and certificate
 	rootTLSCert, err := tls.X509KeyPair(rootCertPEM, rootKeyPEM)
 	if err != nil {
-		log.Errorf("invalid key pair: %v", err)
+		log.Errorf("unable to generate a self-signed certificate: %v", err)
 		return
 	}
 
 	serverTLSConfig = &tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
-		MinVersion:   tls.VersionTLS13,
 	}
 }

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -165,7 +165,12 @@ func GetTLSServerConfig() *tls.Config {
 	tokenLock.RLock()
 	defer tokenLock.RUnlock()
 	if initSource == uninitialized {
-		log.Errorf("GetTLSServerConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function)")
+		log.Errorf("GetTLSServerConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function), generating a self-signed certificate")
+		config, err := generateSelfSignedCert()
+		if err != nil {
+			log.Error(err.Error())
+		}
+		serverTLSConfig = &config
 	}
 	return serverTLSConfig.Clone()
 }
@@ -300,15 +305,4 @@ func generateSelfSignedCert() (tls.Config, error) {
 	return tls.Config{
 		Certificates: []tls.Certificate{rootTLSCert},
 	}, nil
-}
-
-func init() {
-	tokenLock.Lock()
-	defer tokenLock.Unlock()
-
-	config, err := generateSelfSignedCert()
-	if err != nil {
-		log.Errorf("unable to initialize the tls server configuration: %v", err)
-	}
-	serverTLSConfig = &config
 }

--- a/pkg/api/util/util_test.go
+++ b/pkg/api/util/util_test.go
@@ -61,9 +61,6 @@ func TestStartingServerClientWithUninitializedTLS(t *testing.T) {
 	clientTLSConfig = &tls.Config{
 		InsecureSkipVerify: true,
 	}
-	config, err := generateSelfSignedCert()
-	require.NoError(t, err)
-	serverTLSConfig = &config
 
 	// create a server with the provided tls server config
 	l, err := net.Listen("tcp", ":0")

--- a/pkg/api/util/util_test.go
+++ b/pkg/api/util/util_test.go
@@ -56,6 +56,16 @@ func TestIsIPv6(t *testing.T) {
 }
 
 func TestStartingServerClientWithUninitializedTLS(t *testing.T) {
+	// re initialize the client and server tls config
+	initSource = uninitialized
+	clientTLSConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	config, err := generateSelfSignedCert()
+	require.NoError(t, err)
+	serverTLSConfig = &config
+
+	// create a server with the provided tls server config
 	l, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 

--- a/pkg/api/util/util_test.go
+++ b/pkg/api/util/util_test.go
@@ -6,9 +6,13 @@
 package util
 
 import (
+	"crypto/tls"
+	"net"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsIPv6(t *testing.T) {
@@ -49,4 +53,36 @@ func TestIsIPv6(t *testing.T) {
 			assert.Equal(t, IsIPv6(tt.input), tt.expectedOutput)
 		})
 	}
+}
+
+func TestStartingServerClientWithUninitializedTLS(t *testing.T) {
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+
+	tlsListener := tls.NewListener(l, GetTLSServerConfig())
+
+	go server.Serve(tlsListener) //nolint:errcheck
+	defer server.Close()
+
+	// create a http client with the provided tls client config
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	require.NoError(t, err)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: GetTLSClientConfig(),
+		},
+	}
+
+	// make a request to the server
+	resp, err := client.Get("https://localhost:" + port)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR update `pkg/api/util` which is used by almost all Agent IPC server, to provide a self-signed certificate if the shared IPC certificate artifact could not be loaded on time.

### Motivation
This will solve #incident-34271 by avoiding the IPC server to panic when IPC certificate is missing.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I added a unit-test to assert that servers are able to start with the default certificate value.