### PR TITLE
exclude `.git` from copyright linter

### DIFF
--- a/tasks/libs/types/copyright.py
+++ b/tasks/libs/types/copyright.py
@@ -24,6 +24,8 @@ COPYRIGHT_REGEX = [
 
 # These path patterns are excluded from checks
 PATH_EXCLUSION_REGEX = [
+    # Git internal folder
+    '/.git/',
     # These are auto-generated files but without headers to indicate it
     '/vendor/',
     '/pkg/clusteragent/autoscaling/custommetrics/api/generated/',


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When doing the copyright linting we collect all files matching `*.go`. If a branch is named with a name ending with `.go`, like `NDMII-3313-integration-metric-stats.go` you end up with a file `.git/logs/refs/remotes/origin/NDMII-3313-integration-metric-stats.go` that we are trying to lint. This PR exclude the `.git` folder from the linter. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->