### PR TITLE
[CTK-4731] Add logging for flaking API server test

### DIFF
--- a/comp/process/apiserver/apiserver_test.go
+++ b/comp/process/apiserver/apiserver_test.go
@@ -28,6 +28,7 @@ import (
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func TestLifecycle(t *testing.T) {
@@ -97,16 +98,20 @@ func TestPostAuthentication(t *testing.T) {
 		url := fmt.Sprintf("https://localhost:%d/config/log_level?value=debug", port)
 		req, err := http.NewRequest("POST", url, nil)
 		require.NoError(c, err)
+		log.Info("Issuing unauthenticated test request to url: %s", url)
 		res, err := util.GetClient(false).Do(req)
 		require.NoError(c, err)
 		defer res.Body.Close()
+		log.Info("Received unauthenticated test response")
 		assert.Equal(c, http.StatusUnauthorized, res.StatusCode)
 
 		// With authentication
 		req.Header.Set("Authorization", "Bearer "+util.GetAuthToken())
+		log.Info("Issuing authenticated test request to url: %s", url)
 		res, err = util.GetClient(false).Do(req)
 		require.NoError(c, err)
 		defer res.Body.Close()
+		log.Info("Received authenticated test response")
 		assert.Equal(c, http.StatusOK, res.StatusCode)
 	}, 5*time.Second, time.Second)
 }

--- a/comp/process/apiserver/apiserver_test.go
+++ b/comp/process/apiserver/apiserver_test.go
@@ -98,7 +98,7 @@ func TestPostAuthentication(t *testing.T) {
 		url := fmt.Sprintf("https://localhost:%d/config/log_level?value=debug", port)
 		req, err := http.NewRequest("POST", url, nil)
 		require.NoError(c, err)
-		log.Info("Issuing unauthenticated test request to url: %s", url)
+		log.Infof("Issuing unauthenticated test request to url: %s", url)
 		res, err := util.GetClient(false).Do(req)
 		require.NoError(c, err)
 		defer res.Body.Close()
@@ -107,7 +107,7 @@ func TestPostAuthentication(t *testing.T) {
 
 		// With authentication
 		req.Header.Set("Authorization", "Bearer "+util.GetAuthToken())
-		log.Info("Issuing authenticated test request to url: %s", url)
+		log.Infof("Issuing authenticated test request to url: %s", url)
 		res, err = util.GetClient(false).Do(req)
 		require.NoError(c, err)
 		defer res.Body.Close()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds logging to a test that is currently flaking in CI.

### Motivation
Help with debugging flakes in the test. Currently the only output when the test fails is as follows, so it's not clear where the test is failing:
```
mock.go:31: 2025-01-23 18:18:23 UTC | INFO | (comp/core/tagger/impl/tagger.go:107 in NewComponent) | TaggerClient is created, defaultTagger type:  *mock.FakeTagger
    mock.go:31: 2025-01-23 18:18:23 UTC | INFO | (comp/process/apiserver/apiserver.go:55 in newApiServer) | API server listening on localhost:59425
    mock.go:31: 2025-01-23 18:18:23 UTC | INFO | (comp/core/workloadmeta/impl/store.go:100 in start) | workloadmeta store initialized successfully
    apiserver_test.go:95: 
        	Error Trace:	C:/buildroot/datadog-agent/comp/process/apiserver/apiserver_test.go:95
        	Error:      	Condition never satisfied
        	Test:       	TestPostAuthentication
```

### Describe how you validated your changes
Validated that the new logging is present in CI job logs:
```
2025-01-24T16:46:33.990001Z 01O     mock.go:31: 2025-01-24 16:46:14 UTC | INFO | (comp/process/apiserver/apiserver.go:55 in newApiServer) | API server listening on localhost:43609
2025-01-24T16:46:33.990009Z 01O     mock.go:31: 2025-01-24 16:46:14 UTC | INFO | (comp/core/workloadmeta/impl/store.go:100 in start) | workloadmeta store initialized successfully
2025-01-24T16:46:33.990014Z 01O     mock.go:31: 2025-01-24 16:46:15 UTC | INFO | (comp/process/apiserver/apiserver_test.go:101 in func2) | Issuing unauthenticated test request to url: https://localhost:43609/config/log_level?value=debug
2025-01-24T16:46:33.990020Z 01O     mock.go:31: 2025-01-24 16:46:15 UTC | WARN | (comp/process/apiserver/apiserver.go:100 in func1) | invalid auth token for POST request to /config/log_level?value=debug: no session token provided
2025-01-24T16:46:33.990041Z 01O     mock.go:31: 2025-01-24 16:46:15 UTC | INFO | (comp/process/apiserver/apiserver_test.go:105 in func2) | Received unauthenticated test response
2025-01-24T16:46:33.990052Z 01O     mock.go:31: 2025-01-24 16:46:15 UTC | INFO | (comp/process/apiserver/apiserver_test.go:110 in func2) | Issuing authenticated test request to url: https://localhost:43609/config/log_level?value=debug
2025-01-24T16:46:33.990058Z 01O     mock.go:31: 2025-01-24 16:46:15 UTC | INFO | (comp/process/apiserver/apiserver_test.go:114 in func2) | Received authenticated test response
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->