### PR TITLE
[CWS] early check for any field in `eventTypeFromFields`

### DIFF
--- a/pkg/security/secl/compiler/eval/event.go
+++ b/pkg/security/secl/compiler/eval/event.go
@@ -32,6 +32,12 @@ type Event interface {
 func eventTypeFromFields(model Model, state *State) (EventType, error) {
 	var eventType EventType
 
+	// if there are no fields, we can't determine the event type
+	// this is not uncommon, especially in macros
+	if len(state.fieldValues) == 0 {
+		return eventType, nil
+	}
+
 	ev := model.NewEvent()
 	for field := range state.fieldValues {
 		evt, _, err := ev.GetFieldMetadata(field)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Most macros have no field in them, as such when this function is called on a macro the creation of the event is not necessary since it will never be used. This PR optimizes this by returning early if there is no field.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->