### PR TITLE
[AMLII-2236] Enable Http/2 for log agent when using a proxy

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -397,12 +397,6 @@ func httpClientFactory(timeout time.Duration, cfg pkgconfigmodel.Reader) func() 
 
 	transportConfig := cfg.Get("logs_config.http_protocol")
 
-	// If any proxy is set, use http1
-	// This will be removed in a future version
-	if cfg.GetProxies() != nil {
-		transportConfig = "http1"
-	}
-
 	// Configure transport based on user setting
 	switch transportConfig {
 	case "http1":

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -495,7 +495,7 @@ func TestTransportProtocol_HTTP1FallBack(t *testing.T) {
 	assert.Equal(t, "HTTP/1.1", resp.Proto)
 }
 
-func TestTransportProtocol_HTTP1WhenUsingProxy(t *testing.T) {
+func TestTransportProtocol_HTTP2WhenUsingProxy(t *testing.T) {
 	c := configmock.New(t)
 
 	// Force client to use ALNP
@@ -503,10 +503,42 @@ func TestTransportProtocol_HTTP1WhenUsingProxy(t *testing.T) {
 	c.SetWithoutSource("skip_ssl_validation", true)
 
 	// The test server uses TLS, so if we set the http proxy (not https), it still makes
-	// a request to the test server, but disable HTTP/2 since a proxy is configured.
+	// a request to the test server
 	c.SetWithoutSource("proxy.http", "http://foo.bar")
 
 	server := NewTestHTTPSServer(false)
+	defer server.Close()
+
+	timeout := 5 * time.Second
+	client := httpClientFactory(timeout, c)()
+
+	req, err := http.NewRequest("POST", server.URL, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Assert that the server chose HTTP/2.0 because a proxy was configured
+	assert.Equal(t, "HTTP/2.0", resp.Proto)
+}
+
+func TestTransportProtocol_HTTP1FallBackWhenUsingProxy(t *testing.T) {
+	c := configmock.New(t)
+
+	// Force client to use ALNP
+	c.SetWithoutSource("logs_config.http_protocol", "auto")
+	c.SetWithoutSource("skip_ssl_validation", true)
+
+	// The test server uses TLS, so if we set the http proxy (not https), it still makes
+	// a request to the test server
+	c.SetWithoutSource("proxy.http", "http://foo.bar")
+
+	// Start the test server that only support HTTP/1.1
+	server := NewTestHTTPSServer(true)
 	defer server.Close()
 
 	timeout := 5 * time.Second

--- a/releasenotes/notes/enable-http2-for-log-agent-proxy-2fc186ff7688473c.yaml
+++ b/releasenotes/notes/enable-http2-for-log-agent-proxy-2fc186ff7688473c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Log agent now officially support http2 transport to proxy.

--- a/releasenotes/notes/enable-http2-for-log-agent-proxy-2fc186ff7688473c.yaml
+++ b/releasenotes/notes/enable-http2-for-log-agent-proxy-2fc186ff7688473c.yaml
@@ -8,4 +8,4 @@
 ---
 features:
   - |
-    Log agent now officially support http2 transport to proxy.
+    Log Agent now officially supports http2 transport to proxy.


### PR DESCRIPTION
### What does this PR do?
[Previously](https://github.com/DataDog/datadog-agent/pull/32308), out of an abundance of caution, we disabled HTTP/2 negotiation for the logs agent when a proxy is configured. However, recent testings confirmed that http/2 is safe to be used for proxy and can be auto negotiated to http1 if negotiate fails 

### Motivation
Logs agent transport improvements.

### Describe how you validated your changes
QA covered by unit test (as it spins up a real server/client)

### Possible Drawbacks / Trade-offs
### Additional Notes
Validations can be found via each card's comment here
https://datadoghq.atlassian.net/browse/AMLII-2236