### PR TITLE
[NPM-4140] Fix test failures that appear in KMT

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2322,7 +2322,7 @@ func TestConntrackerFallback(t *testing.T) {
 
 func testConfig() *config.Config {
 	cfg := config.New()
-	if env.IsECSFargate() {
+	if env.IsECSFargate() || cfg.EnableEbpfless {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -181,11 +181,8 @@ func (s *TracerSuite) TestTCPRetransmit() {
 		// Iterate through active connections until we find connection created above, and confirm send + recv counts
 		connections := getConnections(ct, tr)
 
-		ok := false
-		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		if !assert.True(ct, ok) {
-			return
-		}
+		conn, _ = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		require.NotNil(ct, conn)
 
 		assert.Equal(ct, 100*clientMessageSize, int(conn.Monotonic.SentBytes))
 		assert.Equal(ct, serverMessageSize, int(conn.Monotonic.RecvBytes))
@@ -1292,12 +1289,12 @@ func testUDPPeekCount(t *testing.T, udpnet, ip string) {
 	var outgoing *network.ConnectionStats
 	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
 		conns := getConnections(collect, tr)
-		newOutgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		if ok {
+		newOutgoing, _ := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		if newOutgoing != nil {
 			outgoing = newOutgoing
 		}
-		newIncoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), conns)
-		if ok {
+		newIncoming, _ := findConnection(c.RemoteAddr(), c.LocalAddr(), conns)
+		if newIncoming != nil {
 			incoming = newIncoming
 		}
 		require.NotNil(collect, outgoing)
@@ -1360,12 +1357,12 @@ func testUDPPacketSumming(t *testing.T, udpnet, ip string) {
 	var outgoing *network.ConnectionStats
 	require.EventuallyWithTf(t, func(collect *assert.CollectT) {
 		conns := getConnections(collect, tr)
-		newOutgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		if ok {
+		newOutgoing, _ := findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
+		if newOutgoing != nil {
 			outgoing = newOutgoing
 		}
-		newIncoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), conns)
-		if ok {
+		newIncoming, _ := findConnection(c.RemoteAddr(), c.LocalAddr(), conns)
+		if newIncoming != nil {
 			incoming = newIncoming
 		}
 
@@ -2048,12 +2045,12 @@ func (s *TracerSuite) TestPreexistingConnectionDirection() {
 	var incoming, outgoing *network.ConnectionStats
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		connections := getConnections(collect, tr)
-		newOutgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		if ok {
+		newOutgoing, _ := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		if newOutgoing != nil {
 			outgoing = newOutgoing
 		}
-		newIncoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
-		if ok {
+		newIncoming, _ := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		if newIncoming != nil {
 			incoming = newIncoming
 		}
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1903,7 +1903,7 @@ func (s *TracerSuite) TestShortWrite() {
 	f := os.NewFile(uintptr(sk), "")
 	c, err := net.FileConn(f)
 	require.NoError(t, err)
-	defer c.Close()
+	t.Cleanup(func() { c.Close() })
 
 	unix.Shutdown(sk, unix.SHUT_WR)
 	close(read)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -402,13 +402,15 @@ func (s *TracerSuite) TestTCPConnsReported() {
 		// Test
 		connections := getConnections(collect, tr)
 
-		if forward == nil {
-			// Server-side
-			forward, _ = findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		// Server-side
+		newForward, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		if ok {
+			forward = newForward
 		}
-		if reverse == nil {
-			// Client-side
-			reverse, _ = findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		// Client-side
+		newReverse, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		if ok {
+			reverse = newReverse
 		}
 
 		require.NotNil(collect, forward)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -403,13 +403,13 @@ func (s *TracerSuite) TestTCPConnsReported() {
 		connections := getConnections(collect, tr)
 
 		// Server-side
-		newForward, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
-		if ok {
+		newForward, _ := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
+		if newForward != nil {
 			forward = newForward
 		}
 		// Client-side
-		newReverse, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-		if ok {
+		newReverse, _ := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
+		if newReverse != nil {
 			reverse = newReverse
 		}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes test failures that only appeared once I turned on KMT:
1. Disables `ProtocolClassificationEnabled` in ebpfless (since the same global config is used by all tests, and it seems some config currently "leaks" between tests... we should look into that later)
2. Changes the query pattern for `findConnection` -- previously it would take the first connection it found and keep that forever. For ebpfless, it needs to replace that connection if it gets newer data.
3. Changes to `TestShortWrite` -- something strange happened with this one. After setting `SO_SNDBUF` to 5000, you would expect it to buffer that much writes (the kernel actually sets `SO_SNDBUF` to 10k, so you would expect 10KB of buffer). But that depends on the kernel apparently. I was only able to fix it by draining the read-end at the final phase of the test. If that's not the right thing to do let me know - we should probably do a quick call since this is hard to explain.
    * In ubuntu 22.04 (kernel 5.15.0), it lets you write 42741 bytes before it's full. And it will really send all that over the wire.
    * But in ubuntu 24.04 (kernel 6.8.0), it still lets you write 42741 bytes, but only 10KB travels over the wire and then it stops progressing until you read from the other end.

### Motivation
Turning on kernel matrix testing

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ebpfless test suite should still passs:
```
DD_REMOTE_CONFIGURATION_ENABLED=false TEST_EBPFLESS_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless
```
KMT should pass in this stacked PR: [\[NPM-4140\] Enable ebpfless tests in CI/KMT](https://github.com/DataDog/datadog-agent/pull/33379)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[NPM-4140]: https://datadoghq.atlassian.net/browse/NPM-4140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ