### PR TITLE
[NPM-4140] Enable ebpfless tests in CI/KMT

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -317,7 +317,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// connection aggregation with port rollups
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_connection_rollup"), false)
 
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_ebpfless"), false)
+	cfg.BindEnvAndSetDefault(join(netNS, "enable_ebpfless"), false, "DD_ENABLE_EBPFLESS", "DD_NETWORK_CONFIG_ENABLE_EBPFLESS")
 
 	// windows config
 	cfg.BindEnvAndSetDefault(join(spNS, "windows.enable_monotonic_count"), false)

--- a/pkg/ebpf/ebpftest/buildmode.go
+++ b/pkg/ebpf/ebpftest/buildmode.go
@@ -46,7 +46,7 @@ func (p prebuiltMode) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
-		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
+		"DD_ENABLE_EBPFLESS":                 "false",
 	}
 }
 
@@ -63,7 +63,7 @@ func (r runtimeCompiled) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
-		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
+		"DD_ENABLE_EBPFLESS":                 "false",
 	}
 }
 
@@ -80,7 +80,7 @@ func (c core) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "true",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
-		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
+		"DD_ENABLE_EBPFLESS":                 "false",
 	}
 }
 
@@ -97,7 +97,7 @@ func (f fentry) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "true",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
-		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
+		"DD_ENABLE_EBPFLESS":                 "false",
 	}
 }
 
@@ -114,7 +114,7 @@ func (e ebpfless) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
-		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "true",
+		"DD_ENABLE_EBPFLESS":                 "true",
 	}
 }
 

--- a/pkg/ebpf/ebpftest/buildmode.go
+++ b/pkg/ebpf/ebpftest/buildmode.go
@@ -46,6 +46,7 @@ func (p prebuiltMode) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
+		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
 	}
 }
 
@@ -62,6 +63,7 @@ func (r runtimeCompiled) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
+		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
 	}
 }
 
@@ -78,6 +80,7 @@ func (c core) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "true",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
+		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
 	}
 }
 
@@ -94,6 +97,7 @@ func (f fentry) Env() map[string]string {
 		"DD_ENABLE_CO_RE":                    "true",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
 		"DD_ALLOW_PREBUILT_FALLBACK":         "false",
+		"DD_NETWORK_CONFIG_ENABLE_EBPFLESS":  "false",
 	}
 }
 
@@ -116,7 +120,7 @@ func (e ebpfless) Env() map[string]string {
 
 // GetBuildMode returns which build mode the current environment matches, if any
 func GetBuildMode() BuildMode {
-	for _, mode := range []BuildMode{Prebuilt, RuntimeCompiled, CORE, Fentry} {
+	for _, mode := range []BuildMode{Prebuilt, RuntimeCompiled, CORE, Fentry, Ebpfless} {
 		if hasBuildModeEnv(mode) {
 			return mode
 		}

--- a/pkg/ebpf/ebpftest/buildmode_linux.go
+++ b/pkg/ebpf/ebpftest/buildmode_linux.go
@@ -26,13 +26,16 @@ func init() {
 
 // SupportedBuildModes returns the build modes supported on the current host
 func SupportedBuildModes() []BuildMode {
-	modes := []BuildMode{RuntimeCompiled, CORE, Ebpfless}
+	modes := []BuildMode{RuntimeCompiled, CORE}
 	if !prebuilt.IsDeprecated() || os.Getenv("TEST_PREBUILT_OVERRIDE") == "true" {
 		modes = append(modes, Prebuilt)
 	}
 	if os.Getenv("TEST_FENTRY_OVERRIDE") == "true" ||
 		(runtime.GOARCH == "amd64" && (hostPlatform == "amazon" || hostPlatform == "amzn") && kv.Major() == 5 && kv.Minor() == 10) {
 		modes = append(modes, Fentry)
+	}
+	if os.Getenv("TEST_EBPFLESS_OVERRIDE") == "true" {
+		modes = append(modes, Ebpfless)
 	}
 
 	return modes

--- a/pkg/ebpf/ebpftest/buildmode_linux.go
+++ b/pkg/ebpf/ebpftest/buildmode_linux.go
@@ -26,16 +26,13 @@ func init() {
 
 // SupportedBuildModes returns the build modes supported on the current host
 func SupportedBuildModes() []BuildMode {
-	modes := []BuildMode{RuntimeCompiled, CORE}
+	modes := []BuildMode{RuntimeCompiled, CORE, Ebpfless}
 	if !prebuilt.IsDeprecated() || os.Getenv("TEST_PREBUILT_OVERRIDE") == "true" {
 		modes = append(modes, Prebuilt)
 	}
 	if os.Getenv("TEST_FENTRY_OVERRIDE") == "true" ||
 		(runtime.GOARCH == "amd64" && (hostPlatform == "amazon" || hostPlatform == "amzn") && kv.Major() == 5 && kv.Minor() == 10) {
 		modes = append(modes, Fentry)
-	}
-	if os.Getenv("TEST_EBPFLESS_OVERRIDE") == "true" {
-		modes = append(modes, Ebpfless)
 	}
 
 	return modes

--- a/pkg/ebpf/ebpftest/buildmode_test.go
+++ b/pkg/ebpf/ebpftest/buildmode_test.go
@@ -24,6 +24,9 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+
+		assert.Equal(t, Prebuilt, GetBuildMode())
 	})
 	TestBuildMode(t, RuntimeCompiled, "", func(t *testing.T) {
 		cfg := ebpf.NewConfig()
@@ -32,6 +35,9 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+
+		assert.Equal(t, RuntimeCompiled, GetBuildMode())
 	})
 	TestBuildMode(t, CORE, "", func(t *testing.T) {
 		cfg := ebpf.NewConfig()
@@ -40,6 +46,9 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+
+		assert.Equal(t, CORE, GetBuildMode())
 	})
 	TestBuildMode(t, Fentry, "", func(t *testing.T) {
 		cfg := ebpf.NewConfig()
@@ -48,5 +57,19 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "true", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+
+		assert.Equal(t, Fentry, GetBuildMode())
+	})
+	TestBuildMode(t, Ebpfless, "", func(t *testing.T) {
+		cfg := ebpf.NewConfig()
+		assert.False(t, cfg.EnableRuntimeCompiler)
+		assert.False(t, cfg.EnableCORE)
+		assert.False(t, cfg.AllowPrebuiltFallback)
+		assert.False(t, cfg.AllowRuntimeCompiledFallback)
+		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "true", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+
+		assert.Equal(t, Ebpfless, GetBuildMode())
 	})
 }

--- a/pkg/ebpf/ebpftest/buildmode_test.go
+++ b/pkg/ebpf/ebpftest/buildmode_test.go
@@ -24,7 +24,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
-		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, Prebuilt, GetBuildMode())
 	})
@@ -35,7 +35,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
-		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, RuntimeCompiled, GetBuildMode())
 	})
@@ -46,7 +46,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
-		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, CORE, GetBuildMode())
 	})
@@ -57,7 +57,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "true", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
-		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, Fentry, GetBuildMode())
 	})
@@ -68,7 +68,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
 		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
-		assert.Equal(t, "true", os.Getenv("DD_NETWORK_CONFIG_ENABLE_EBPFLESS"))
+		assert.Equal(t, "true", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, Ebpfless, GetBuildMode())
 	})

--- a/pkg/network/tracer/testutil/config_linux.go
+++ b/pkg/network/tracer/testutil/config_linux.go
@@ -18,7 +18,7 @@ var kv = kernel.MustHostVersion()
 // Config returns a network.Config setup for test purposes
 func Config() *config.Config {
 	cfg := config.New()
-	if env.IsECSFargate() {
+	if env.IsECSFargate() || cfg.EnableEbpfless {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -41,7 +41,6 @@ import (
 	"go4.org/intern"
 	"golang.org/x/sys/unix"
 
-	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
@@ -2341,7 +2340,7 @@ func TestConntrackerFallback(t *testing.T) {
 
 func testConfig() *config.Config {
 	cfg := config.New()
-	if env.IsECSFargate() || cfg.EnableEbpfless {
+	if ebpftest.GetBuildMode() == ebpftest.Ebpfless {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -2344,6 +2344,10 @@ func testConfig() *config.Config {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}
+	if ebpftest.GetBuildMode() == ebpftest.Fentry {
+		cfg.ProtocolClassificationEnabled = false
+	}
+
 	// prebuilt on 5.18+ does not support UDPv6
 	if isPrebuilt(cfg) && kv >= kernel.VersionCode(5, 18, 0) {
 		cfg.CollectUDPv6Conns = false

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -21,6 +21,7 @@ import (
 	"net/netip"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -63,8 +64,16 @@ type TracerSuite struct {
 	suite.Suite
 }
 
+func SupportedNetworkBuildModes() []ebpftest.BuildMode {
+	modes := ebpftest.SupportedBuildModes()
+	if !slices.Contains(modes, ebpftest.Ebpfless) {
+		modes = append(modes, ebpftest.Ebpfless)
+	}
+	return modes
+}
+
 func TestTracerSuite(t *testing.T) {
-	ebpftest.TestBuildModes(t, ebpftest.SupportedBuildModes(), "", func(t *testing.T) {
+	ebpftest.TestBuildModes(t, SupportedNetworkBuildModes(), "", func(t *testing.T) {
 		suite.Run(t, new(TracerSuite))
 	})
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -75,6 +75,9 @@ func setupTracer(t testing.TB, cfg *config.Config) *Tracer {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}
+	if ebpftest.GetBuildMode() == ebpftest.Fentry {
+		cfg.ProtocolClassificationEnabled = false
+	}
 
 	tr, err := NewTracer(cfg, nil)
 	require.NoError(t, err)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -74,7 +74,7 @@ func isFentry() bool {
 }
 
 func setupTracer(t testing.TB, cfg *config.Config) *Tracer {
-	if isFentry() {
+	if ebpftest.GetBuildMode() == ebpftest.Ebpfless {
 		env.SetFeatures(t, env.ECSFargate)
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -69,10 +69,6 @@ func TestTracerSuite(t *testing.T) {
 	})
 }
 
-func isFentry() bool {
-	return ebpftest.GetBuildMode() == ebpftest.Fentry
-}
-
 func setupTracer(t testing.TB, cfg *config.Config) *Tracer {
 	if ebpftest.GetBuildMode() == ebpftest.Ebpfless {
 		env.SetFeatures(t, env.ECSFargate)

--- a/pkg/network/usm/tests/tracer_classification_test.go
+++ b/pkg/network/usm/tests/tracer_classification_test.go
@@ -54,6 +54,9 @@ func setupTracer(t testing.TB, cfg *config.Config) *tracer.Tracer {
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false
 	}
+	if ebpftest.GetBuildMode() == ebpftest.Fentry {
+		cfg.ProtocolClassificationEnabled = false
+	}
 
 	tr, err := tracer.NewTracer(cfg, nil)
 	require.NoError(t, err)

--- a/pkg/network/usm/tests/tracer_classification_test.go
+++ b/pkg/network/usm/tests/tracer_classification_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 }
 
 func setupTracer(t testing.TB, cfg *config.Config) *tracer.Tracer {
-	if ebpftest.GetBuildMode() == ebpftest.Fentry {
+	if ebpftest.GetBuildMode() == ebpftest.Ebpfless {
 		env.SetFeatures(t, env.ECSFargate)
 		// protocol classification not yet supported on fargate
 		cfg.ProtocolClassificationEnabled = false


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Enables KMT testing for ebpfless/fargate
### Motivation
Want to catch regressions in ebpfless

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Running the tracer suite should now include the eBPFless suite:
```
DD_REMOTE_CONFIGURATION_ENABLED=false  sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite
```
CI should pass, and the KMT jobs should include eBPFless tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->