### PR TITLE
Prevent leaking received dogstatsd metrics on agent shutdown

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -197,7 +197,6 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 	l.telemetryStore.tlmUDSConnections.Inc(tlmListenerID, l.transport)
 	defer func() {
 		_ = closeFunc(conn)
-		packetsBuffer.Flush()
 		packetsBuffer.Close()
 		if telemetryWithFullListenerID {
 			l.clearTelemetry(tlmListenerID)

--- a/comp/dogstatsd/packets/buffer_test.go
+++ b/comp/dogstatsd/packets/buffer_test.go
@@ -144,6 +144,6 @@ func TestBufferFlush(t *testing.T) {
 	}
 
 	buffer.Append(packet)
-	buffer.Flush()
+	buffer.Close()
 	assert.Equal(t, 1, len(packetChannel))
 }

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -484,10 +484,11 @@ func (s *server) stop(context.Context) error {
 	if !s.IsRunning() {
 		return nil
 	}
-	close(s.stopChan)
 	for _, l := range s.listeners {
 		l.Stop()
 	}
+	close(s.stopChan)
+
 	if s.Statistics != nil {
 		s.Statistics.Stop()
 	}

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -77,6 +77,11 @@ type trigger struct {
 	// service checks and such have to be waited for before returning
 	// from Flush()
 	waitForSerializer bool
+
+	// used to flush all available data during a flush procedure, event data belonging to
+	// incomplete buckets. Is generally only appropriate to set during shutdown, since
+	// subsequent transmissions of the same bucket will override earlier entries in the backend.
+	forceFlushAll bool
 }
 
 // flushTrigger is a trigger used to flush data, results is expected to be written

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -98,7 +98,8 @@ func (d *ServerlessDemultiplexer) Run() {
 // Stop stops the wrapped aggregator and the forwarder.
 func (d *ServerlessDemultiplexer) Stop(flush bool) {
 	if flush {
-		d.ForceFlushToSerializer(time.Now(), true)
+		forceFlushAll := pkgconfigsetup.Datadog().GetBool("dogstatsd_flush_incomplete_buckets")
+		d.forceFlushToSerializer(time.Now(), true, forceFlushAll)
 	}
 
 	d.statsdWorker.stop()
@@ -110,6 +111,10 @@ func (d *ServerlessDemultiplexer) Stop(flush bool) {
 
 // ForceFlushToSerializer flushes all data from the time sampler to the serializer.
 func (d *ServerlessDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
+	d.forceFlushToSerializer(start, waitForSerializer, false)
+}
+
+func (d *ServerlessDemultiplexer) forceFlushToSerializer(start time.Time, waitForSerializer bool, forceFlushAll bool) {
 	d.flushLock.Lock()
 	defer d.flushLock.Unlock()
 
@@ -125,6 +130,7 @@ func (d *ServerlessDemultiplexer) ForceFlushToSerializer(start time.Time, waitFo
 					time:              start,
 					blockChan:         make(chan struct{}),
 					waitForSerializer: waitForSerializer,
+					forceFlushAll:     forceFlushAll,
 				},
 				sketchesSink: sketchesSink,
 				seriesSink:   seriesSink,

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -691,6 +691,6 @@ func flushSerieWithBlocklist(sampler *TimeSampler, timestamp float64, bl *utilst
 	var series metrics.Series
 	var sketches metrics.SketchSeriesList
 
-	sampler.flush(timestamp, &series, &sketches, bl, forceFlushAll	)
+	sampler.flush(timestamp, &series, &sketches, bl, forceFlushAll)
 	return series, sketches
 }

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -61,7 +61,7 @@ func testBucketSampling(t *testing.T, store *tags.Store) {
 	sampler.sample(&mSample, 12355.0)
 	sampler.sample(&mSample, 12365.0)
 
-	series, _ := flushSerie(sampler, 12360.0)
+	series, _ := flushSerie(sampler, 12360.0, false)
 
 	expectedSerie := &metrics.Serie{
 		Name:       "my.metric.name",
@@ -111,7 +111,7 @@ func testContextSampling(t *testing.T, store *tags.Store) {
 	sampler.sample(&mSample2, 12346.0)
 	sampler.sample(&mSample3, 12346.0)
 
-	series, _ := flushSerie(sampler, 12360.0)
+	series, _ := flushSerie(sampler, 12360.0, false)
 
 	expectedSerie1 := &metrics.Serie{
 		Name:     "my.metric.name1",
@@ -180,7 +180,7 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 	sampler.sample(sampleCounter2, 1002.0)
 	sampler.sample(sampleGauge3, 1003.0)
 
-	series, _ := flushSerie(sampler, 1010.0)
+	series, _ := flushSerie(sampler, 1010.0, false)
 
 	expectedSerie1 := &metrics.Serie{
 		Name:       "my.counter1",
@@ -227,7 +227,7 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 	sampler.sample(sampleCounter1, 1010.0)
 	sampler.sample(sampleCounter2, 1020.0)
 
-	series, _ = flushSerie(sampler, 1040.0)
+	series, _ = flushSerie(sampler, 1040.0, false)
 
 	expectedSerie1 = &metrics.Serie{
 		Name:       "my.counter1",
@@ -253,20 +253,20 @@ func testCounterExpirySeconds(t *testing.T, store *tags.Store) {
 	metrics.AssertSeriesEqual(t, expectedSeries, series)
 
 	// We shouldn't get any empty counter since the last flushSeries was during the same interval
-	series, _ = flushSerie(sampler, 1045.0)
+	series, _ = flushSerie(sampler, 1045.0, false)
 	assert.Equal(t, 0, len(series))
 
 	// Now we should get the empty counters
-	series, _ = flushSerie(sampler, 1050.0)
+	series, _ = flushSerie(sampler, 1050.0, false)
 	assert.Equal(t, 2, len(series))
 
-	series, _ = flushSerie(sampler, 1329.0)
+	series, _ = flushSerie(sampler, 1329.0, false)
 	// Counter1 should have stopped reporting but the context is not expired yet
 	// Counter2 should still report
 	assert.Equal(t, 1, len(series))
 	assert.Equal(t, 2, len(sampler.contextResolver.resolver.contextsByKey))
 
-	series, _ = flushSerie(sampler, 1800.0)
+	series, _ = flushSerie(sampler, 1800.0, false)
 	// Everything stopped reporting and is expired
 	assert.Equal(t, 0, len(series))
 	assert.Equal(t, 0, len(sampler.contextResolver.resolver.contextsByKey))
@@ -302,7 +302,7 @@ func testSketch(t *testing.T, store *tags.Store) {
 		"interval should default to 10")
 
 	t.Run("empty flush", func(t *testing.T) {
-		_, flushed := flushSerie(sampler, timeNowNano())
+		_, flushed := flushSerie(sampler, timeNowNano(), false)
 		require.Len(t, flushed, 0)
 	})
 
@@ -324,7 +324,7 @@ func testSketch(t *testing.T, store *tags.Store) {
 			now++
 		}
 
-		_, flushed := flushSerie(sampler, now)
+		_, flushed := flushSerie(sampler, now, false)
 		metrics.AssertSketchSeriesEqual(t, &metrics.SketchSeries{
 			Name:     name,
 			Tags:     tagset.CompositeTagsFromSlice(tags),
@@ -339,7 +339,7 @@ func testSketch(t *testing.T, store *tags.Store) {
 			ContextKey: keyGen.Generate(name, host, tagset.NewHashingTagsAccumulatorWithTags(tags)),
 		}, flushed[0])
 
-		_, flushed = flushSerie(sampler, now)
+		_, flushed = flushSerie(sampler, now, false)
 		require.Len(t, flushed, 0, "these points have already been flushed")
 	})
 
@@ -371,7 +371,7 @@ func testSketchBucketSampling(t *testing.T, store *tags.Store) {
 	sampler.sample(&mSample2, 10012)
 	sampler.sample(&mSample1, 10021)
 
-	_, flushed := flushSerie(sampler, 10020.0)
+	_, flushed := flushSerie(sampler, 10020.0, false)
 	expSketch := &quantile.Sketch{}
 	expSketch.Insert(quantile.Default(), 1, 2)
 
@@ -414,7 +414,7 @@ func testSketchContextSampling(t *testing.T, store *tags.Store) {
 	sampler.sample(&mSample1, 10011)
 	sampler.sample(&mSample2, 10011)
 
-	_, flushed := flushSerie(sampler, 10020)
+	_, flushed := flushSerie(sampler, 10020, false)
 	expSketch := &quantile.Sketch{}
 	expSketch.Insert(quantile.Default(), 1)
 
@@ -472,7 +472,7 @@ func testBucketSamplingWithSketchAndSeries(t *testing.T, store *tags.Store) {
 	sampler.sample(&mSample, 12355.0)
 	sampler.sample(&mSample, 12365.0)
 
-	series, sketches := flushSerie(sampler, 12360.0)
+	series, sketches := flushSerie(sampler, 12360.0, false)
 
 	expectedSerie := &metrics.Serie{
 		Name:       "my.metric.name",
@@ -526,7 +526,7 @@ func testFlushMissingContext(t *testing.T, store *tags.Store) {
 
 	assert.Len(t, sampler.contextResolver.resolver.contextsByKey, 0)
 
-	metrics, sketches := flushSerie(sampler, 1100)
+	metrics, sketches := flushSerie(sampler, 1100, false)
 
 	assert.Len(t, metrics, 0)
 	assert.Len(t, sketches, 0)
@@ -559,7 +559,7 @@ func testFlushBlocklist(t *testing.T, store *tags.Store) {
 		"test.histogram.count",
 	}, false)
 
-	metrics, sketches := flushSerieWithBlocklist(sampler, 1100, &bl)
+	metrics, sketches := flushSerieWithBlocklist(sampler, 1100, &bl, false)
 
 	assert.Len(t, metrics, 4)
 	assert.Len(t, sketches, 1)
@@ -579,9 +579,87 @@ func testFlushBlocklist(t *testing.T, store *tags.Store) {
 		"test.sketch",
 	})
 }
+
 func TestFlushBlocklist(t *testing.T) {
 	testWithTagsStore(t, testFlushBlocklist)
 }
+
+func TestForcedFlush(t *testing.T) {
+	sampler := testTimeSampler(tags.NewStore(false, "test"))
+	testMetric1 := &metrics.MetricSample{
+		Name:       "test.count1",
+		Value:      1,
+		Mtype:      metrics.CountType,
+		SampleRate: 1,
+	}
+	testMetric2 := &metrics.MetricSample{
+		Name:       "test.count2",
+		Value:      1,
+		Mtype:      metrics.CountType,
+		SampleRate: 1,
+	}
+	testSketch := &metrics.MetricSample{
+		Name:       "test.sketch",
+		Value:      1,
+		Mtype:      metrics.DistributionType,
+		SampleRate: 1,
+	}
+
+	sampler.sample(testMetric1, 999)
+	sampler.sample(testMetric2, 1010)
+	sampler.sample(testMetric2, 1022)
+
+	sampler.sample(testSketch, 999)
+	sampler.sample(testSketch, 1010)
+	sampler.sample(testSketch, 1021)
+
+	mSerie, sSerie := flushSerie(sampler, 1000, true)
+
+	expMetric1 := &metrics.Serie{
+		Name:     testMetric1.Name,
+		Points:   []metrics.Point{{Ts: 990.0, Value: float64(1)}},
+		Tags:     tagset.CompositeTags{},
+		Host:     "",
+		MType:    metrics.APICountType,
+		Interval: 10,
+	}
+
+	expMetric2 := &metrics.Serie{
+		Name: testMetric2.Name,
+		Points: []metrics.Point{
+			{Ts: 1010.0, Value: float64(1)},
+			{Ts: 1020.0, Value: float64(1)},
+		},
+		Tags:     tagset.CompositeTags{},
+		Host:     "",
+		MType:    metrics.APICountType,
+		Interval: 10,
+	}
+
+	require.Len(t, mSerie, 2)
+	if mSerie[0].Name == testMetric1.Name {
+		metrics.AssertSerieEqual(t, expMetric1, mSerie[0])
+		metrics.AssertSerieEqual(t, expMetric2, mSerie[1])
+	} else {
+		metrics.AssertSerieEqual(t, expMetric1, mSerie[1])
+		metrics.AssertSerieEqual(t, expMetric2, mSerie[0])
+	}
+
+	expSketch := &quantile.Sketch{}
+	expSketch.Insert(quantile.Default(), 1)
+	metrics.AssertSketchSeriesEqual(t, &metrics.SketchSeries{
+		Name:     testSketch.Name,
+		Tags:     tagset.CompositeTags{},
+		Interval: 10,
+		Points: []metrics.SketchPoint{
+			{Ts: 990.0, Sketch: expSketch},
+			{Ts: 1010.0, Sketch: expSketch},
+			{Ts: 1020.0, Sketch: expSketch},
+		},
+		ContextKey: generateContextKey(testSketch),
+	}, sSerie[0])
+}
+
 func benchmarkTimeSampler(b *testing.B, store *tags.Store) {
 	sampler := NewTimeSampler(TimeSamplerID(0), 10, store, nooptagger.NewComponent(), "host")
 
@@ -601,18 +679,18 @@ func BenchmarkTimeSampler(b *testing.B) {
 	benchWithTagsStore(b, benchmarkTimeSampler)
 }
 
-func flushSerie(sampler *TimeSampler, timestamp float64) (metrics.Series, metrics.SketchSeriesList) {
+func flushSerie(sampler *TimeSampler, timestamp float64, forceFlushAll bool) (metrics.Series, metrics.SketchSeriesList) {
 	var series metrics.Series
 	var sketches metrics.SketchSeriesList
 
-	sampler.flush(timestamp, &series, &sketches, nil)
+	sampler.flush(timestamp, &series, &sketches, nil, forceFlushAll)
 	return series, sketches
 }
 
-func flushSerieWithBlocklist(sampler *TimeSampler, timestamp float64, bl *utilstrings.Blocklist) (metrics.Series, metrics.SketchSeriesList) {
+func flushSerieWithBlocklist(sampler *TimeSampler, timestamp float64, bl *utilstrings.Blocklist, forceFlushAll bool) (metrics.Series, metrics.SketchSeriesList) {
 	var series metrics.Series
 	var sketches metrics.SketchSeriesList
 
-	sampler.flush(timestamp, &series, &sketches, bl)
+	sampler.flush(timestamp, &series, &sketches, bl, forceFlushAll	)
 	return series, sketches
 }

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -116,7 +116,7 @@ func (w *timeSamplerWorker) stop() {
 }
 
 func (w *timeSamplerWorker) triggerFlush(trigger flushTrigger) {
-	w.sampler.flush(float64(trigger.time.Unix()), trigger.seriesSink, trigger.sketchesSink, w.flushBlocklist)
+	w.sampler.flush(float64(trigger.time.Unix()), trigger.seriesSink, trigger.sketchesSink, w.flushBlocklist, trigger.forceFlushAll)
 	trigger.blockChan <- struct{}{}
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1478,6 +1478,8 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("dogstatsd_log_file_max_size", "10Mb")
 	// Control for how long counter would be sampled to 0 if not received
 	config.BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
+	// Control dogstatsd shutdown behaviors
+	config.BindEnvAndSetDefault("dogstatsd_flush_incomplete_buckets", false, "DD_DOGSTATSD_FLUSH_INCOMPLETE_BUCKETS")
 	// Control how long we keep dogstatsd contexts in memory.
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1479,7 +1479,7 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	// Control for how long counter would be sampled to 0 if not received
 	config.BindEnvAndSetDefault("dogstatsd_expiry_seconds", 300)
 	// Control dogstatsd shutdown behaviors
-	config.BindEnvAndSetDefault("dogstatsd_flush_incomplete_buckets", false, "DD_DOGSTATSD_FLUSH_INCOMPLETE_BUCKETS")
+	config.BindEnvAndSetDefault("dogstatsd_flush_incomplete_buckets", false)
 	// Control how long we keep dogstatsd contexts in memory.
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 20)
 	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic

--- a/releasenotes/notes/incomplete-bucket-flush-97ba1890548de400.yaml
+++ b/releasenotes/notes/incomplete-bucket-flush-97ba1890548de400.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    Added new dogstatsd configuration option "dogstatsd_flush_incomplete_buckets". 
-    When enabled, dogstatsd will flush all received metrics during shutdown irregardless
-    of which time-interval based bucket they belong to.  
+    Added new DogStatsD configuration option "dogstatsd_flush_incomplete_buckets". 
+    When enabled, DogStatsD will flush all received metrics during shutdown, regardless
+    of which time-interval based bucket they belong to.

--- a/releasenotes/notes/incomplete-bucket-flush-97ba1890548de400.yaml
+++ b/releasenotes/notes/incomplete-bucket-flush-97ba1890548de400.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added new dogstatsd configuration option "dogstatsd_flush_incomplete_buckets". 
+    When enabled, dogstatsd will flush all received metrics during shutdown irregardless
+    of which time-interval based bucket they belong to.  


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Currently, Dogstatsd will bucket metrics into 10 second intervals and will only push buckets up to intake if said buckets are complete (aka the end of their interval is in the past). This behavior is true even on agent shutdown, meaning the final set of metrics dogstatsd received are generally dropped during shutdown. This PR introduces a new flag that will force Dogstatsd to persist all received metrics on shutdown irregardless of their bucket state, and it also provides stronger guarantees that the dogstatsd data pipeline will flush in the correct order on shutdown.

### Motivation
This change was made primarily to support short-lived systems, such as agents running in Fargate. The [Datadog Fargate](https://docs.datadoghq.com/integrations/ecs_fargate) page will need to be updated with information about the new configuration option.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Setting up a client that emits a single count metric a second to the dogstatsd server provides an excellent visualization into the dogstatsd flush behavior. With the new flag disabled (current behavior), shutting down this dogstatsd server at any time will always result in the final metric reading in the UI being pegged to 10 for each 10 second interval recorded. Enabling the flag and shutting down at different times will result in the final metric read representing the actual second of shutdown. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
REF: https://datadoghq.atlassian.net/browse/AGTMETRICS-284