### PR TITLE
poc(ssi): workload selection

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -98,6 +98,7 @@ type Webhook interface {
 // doesn't always work on Fargate (one of the envs where we use an agent sidecar), and
 // the agent sidecar webhook needs to remove it.
 func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workload.PodPatcher, datadogConfig config.Component, demultiplexer demultiplexer.Component) []Webhook {
+	log.Info("ahhhhh its really my build")
 	// Note: the auto_instrumentation pod injection filter is used across
 	// multiple mutating webhooks, so we add it as a hard dependency to each
 	// of the components that use it via the injectionFilter parameter.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -311,13 +311,13 @@ func (w *Webhook) getLibrariesLanguageDetection(pod *corev1.Pod) *libInfoLanguag
 
 // getAllLatestDefaultLibraries returns all supported by APM Instrumentation tracing libraries
 // that should be enabled by default
-func (w *Webhook) getAllLatestDefaultLibraries() []libInfo {
+func getAllLatestDefaultLibraries(containerRegistry string) []libInfo {
 	var libsToInject []libInfo
 	for _, lang := range supportedLanguages {
 		if !lang.isEnabledByDefault() {
 			continue
 		}
-		libsToInject = append(libsToInject, lang.defaultLibInfo(w.config.containerRegistry, ""))
+		libsToInject = append(libsToInject, lang.defaultLibInfo(containerRegistry, ""))
 	}
 
 	return libsToInject
@@ -400,6 +400,7 @@ func (e extractedPodLibInfo) useLanguageDetectionLibs() (extractedPodLibInfo, bo
 	return e, false
 }
 
+// TODO (mspicer) Update this method with target filter.
 func (w *Webhook) initExtractedLibInfo(pod *corev1.Pod) extractedPodLibInfo {
 	// it's possible to get here without single step being enabled, and the pod having
 	// annotations on it to opt it into pod mutation, we disambiguate those two cases.
@@ -444,7 +445,7 @@ func (w *Webhook) extractLibInfo(pod *corev1.Pod) extractedPodLibInfo {
 	}
 
 	if extracted.source.isSingleStep() {
-		return extracted.withLibs(w.getAllLatestDefaultLibraries())
+		return extracted.withLibs(getAllLatestDefaultLibraries(w.config.containerRegistry))
 	}
 
 	// Get libraries to inject for Remote Instrumentation
@@ -458,7 +459,7 @@ func (w *Webhook) extractLibInfo(pod *corev1.Pod) extractedPodLibInfo {
 			log.Warnf("Ignoring version %q. To inject all libs, the only supported version is latest for now", version)
 		}
 
-		return extracted.withLibs(w.getAllLatestDefaultLibraries())
+		return extracted.withLibs(getAllLatestDefaultLibraries(w.config.containerRegistry))
 	}
 
 	return extractedPodLibInfo{}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// TODO(mspicer): Maybe take this over?
 // NewInjectionFilter constructs an injection filter using the autoinstrumentation
 // GetNamespaceInjectionFilter.
 func NewInjectionFilter(datadogConfig config.Component) (mutatecommon.InjectionFilter, error) {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injection_filter.go
@@ -89,6 +89,8 @@ func (f *injectionFilter) Err() error {
 //     are not one of the ones disabled by default.
 //   - Enabled and disabled namespaces: return error.
 func makeAPMSSINamespaceFilter(apmEnabledNamespaces, apmDisabledNamespaces []string) (*containers.Filter, error) {
+	log.Infof("APM SSI enabled namespaces: %v", apmEnabledNamespaces)
+	log.Infof("APM SSI disabled namespaces: %v", apmDisabledNamespaces)
 	if len(apmEnabledNamespaces) > 0 && len(apmDisabledNamespaces) > 0 {
 		return nil, fmt.Errorf("apm.instrumentation.enabled_namespaces and apm.instrumentation.disabled_namespaces configuration cannot be set together")
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
@@ -1,0 +1,184 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package autoinstrumentation
+
+import (
+	"fmt"
+
+	"github.com/go-viper/mapstructure/v2"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type TargetFilter struct {
+	targets               []Target
+	containerRegistry     string
+	disabledNamespaces    map[string]bool
+	defaultTracerVersions []libInfo
+}
+
+func NewTargetFilter(datadogConfig config.Component) (*TargetFilter, error) {
+	targets, err := ParseConfig(datadogConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing targets from config: %w", err)
+	}
+
+	disabledNamespacesCfg := datadogConfig.GetStringSlice("apm_config.instrumentation.disabled_namespaces")
+	disabledNamespaces := make(map[string]bool, len(disabledNamespacesCfg))
+	for _, ns := range disabledNamespacesCfg {
+		disabledNamespaces[ns] = true
+	}
+
+	// TODO: pass this in as a parameter.
+	containerRegistry := mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.auto_instrumentation.container_registry")
+	defaultTracerVersions := getAllLatestDefaultLibraries(containerRegistry)
+
+	return &TargetFilter{
+		targets:               targets,
+		disabledNamespaces:    disabledNamespaces,
+		containerRegistry:     containerRegistry,
+		defaultTracerVersions: defaultTracerVersions,
+	}, nil
+}
+
+func (f *TargetFilter) Filter(pod *corev1.Pod) []libInfo {
+	// If the namespace is disabled, we don't need to check the targets.
+	if _, ok := f.disabledNamespaces[pod.Namespace]; ok {
+		return nil
+	}
+
+	// Check if the pod matches any of the targets. The first match wins.
+	for _, target := range f.targets {
+		// Check the pod namespace against the namespace selector.
+		if !matchesNamespaceSelector(pod, target.NamespaceSelector) {
+			log.Debugf("Pod ns %s does not match namespace selector %v", pod.Namespace, target.NamespaceSelector)
+			continue
+		}
+
+		// Check the pod labels against the pod selector.
+		if !target.Selector.podSelector.Matches(labels.Set(pod.Labels)) {
+			continue
+		}
+
+		// If no tracer versions are specified, use the default.
+		if len(target.TracerVersions) == 0 {
+			return f.defaultTracerVersions
+		}
+
+		// Otherwise, use the configured tracers.
+		return target.tracerVersions
+	}
+
+	// No target matched.
+	return nil
+}
+
+func matchesNamespaceSelector(pod *corev1.Pod, selector NamespaceSelector) bool {
+	// If there are no match names, the selector matches all namespaces.
+	if len(selector.MatchNames) == 0 {
+		return true
+	}
+
+	// Check if the pod namespace is in the match names.
+	_, ok := selector.matchNamesMapped[pod.Namespace]
+	return ok
+}
+
+func ParseConfig(datadogConfig config.Component) ([]Target, error) {
+	containerRegistry := mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.auto_instrumentation.container_registry")
+
+	data := datadogConfig.Get("apm_config.instrumentation.targets")
+	if data == nil {
+		return nil, nil
+	}
+
+	targets := []Target{}
+	err := mapstructure.Decode(data, &targets)
+	if err != nil {
+		return nil, err
+	}
+
+	// Preprocess config for faster filtering, which happens on every pod.
+	for i := range targets {
+		// Preprocess the namespace selector.
+		targets[i].NamespaceSelector.matchNamesMapped = make(map[string]bool, len(targets[i].NamespaceSelector.MatchNames))
+		for _, ns := range targets[i].NamespaceSelector.MatchNames {
+			targets[i].NamespaceSelector.matchNamesMapped[ns] = true
+		}
+
+		// Preprocess the pod selector.
+		podSelector, err := targets[i].Selector.AsLabelSelector()
+		if err != nil {
+			return nil, fmt.Errorf("error parsing pod selector for target %s: %w", targets[i].Name, err)
+		}
+		targets[i].Selector.podSelector = podSelector
+
+		tracers := []libInfo{}
+		for lang, version := range targets[i].TracerVersions {
+			l := language(lang)
+			if !l.isSupported() {
+				log.Warnf("APM Instrumentation detected configuration for unsupported language: %s. Tracing library for %s will not be injected", lang, lang)
+				continue
+			}
+
+			log.Infof("Library version %s is specified for language %s", version, lang)
+			tracers = append(tracers, l.libInfo("", l.libImageName(containerRegistry, version)))
+		}
+		targets[i].tracerVersions = tracers
+	}
+
+	return targets, nil
+}
+
+type Target struct {
+	Name              string            `mapstructure:"name"`
+	Selector          PodSelector       `mapstructure:"selector"`
+	NamespaceSelector NamespaceSelector `mapstructure:"namespaceSelector"`
+	TracerVersions    map[string]string `mapstructure:"ddTraceVersions"`
+	tracerVersions    []libInfo
+}
+
+type PodSelector struct {
+	// metav1.LabelSelector
+	MatchLabels      map[string]string            `mapstructure:"matchLabels"`
+	MatchExpressions []PodSelectorMatchExpression `mapstructure:"matchExpressions"`
+	podSelector      labels.Selector
+}
+
+func (p PodSelector) AsLabelSelector() (labels.Selector, error) {
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels:      p.MatchLabels,
+		MatchExpressions: make([]metav1.LabelSelectorRequirement, len(p.MatchExpressions)),
+	}
+	for i, expr := range p.MatchExpressions {
+		labelSelector.MatchExpressions[i] = metav1.LabelSelectorRequirement{
+			Key:      expr.Key,
+			Operator: expr.Operator,
+			Values:   expr.Values,
+		}
+	}
+
+	return metav1.LabelSelectorAsSelector(labelSelector)
+}
+
+type PodSelectorMatchExpression struct {
+	// metav1.LabelSelectorRequirement
+	Key      string                       `mapstructure:"key"`
+	Operator metav1.LabelSelectorOperator `mapstructure:"operator"`
+	Values   []string                     `mapstructure:"values"`
+}
+
+type NamespaceSelector struct {
+	MatchNames []string `mapstructure:"matchNames"`
+
+	matchNamesMapped map[string]bool
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
@@ -6,6 +6,7 @@
 package autoinstrumentation
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -30,6 +31,12 @@ func NewTargetFilter(datadogConfig config.Component) (*TargetFilter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error parsing targets from config: %w", err)
 	}
+
+	data, err := json.Marshal(targets)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling targets: %w", err)
+	}
+	log.Infof("Parsed targets: %s", data)
 
 	disabledNamespacesCfg := datadogConfig.GetStringSlice("apm_config.instrumentation.disabled_namespaces")
 	disabledNamespaces := make(map[string]bool, len(disabledNamespacesCfg))

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets.go
@@ -21,7 +21,6 @@ import (
 
 type TargetFilter struct {
 	targets               []Target
-	containerRegistry     string
 	disabledNamespaces    map[string]bool
 	defaultTracerVersions []libInfo
 }
@@ -45,7 +44,6 @@ func NewTargetFilter(datadogConfig config.Component) (*TargetFilter, error) {
 	return &TargetFilter{
 		targets:               targets,
 		disabledNamespaces:    disabledNamespaces,
-		containerRegistry:     containerRegistry,
 		defaultTracerVersions: defaultTracerVersions,
 	}, nil
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
@@ -1,0 +1,175 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+func TestParseConfig(t *testing.T) {
+	mockConfig := configmock.NewFromFile(t, "testdata/targets.yaml")
+	targets, err := ParseConfig(mockConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Ensure there is exactly one target.
+	require.Len(t, targets, 1)
+	target := targets[0]
+
+	// Check the name.
+	require.Equal(t, "Billing Service", target.Name)
+
+	// Check the pod selector.
+	require.Len(t, target.Selector.MatchLabels, 1)
+	require.Equal(t, "billing-service", target.Selector.MatchLabels["app"])
+	require.Len(t, target.Selector.MatchExpressions, 1)
+	require.Equal(t, "env", target.Selector.MatchExpressions[0].Key)
+	require.Equal(t, metav1.LabelSelectorOpIn, target.Selector.MatchExpressions[0].Operator)
+	require.Len(t, target.Selector.MatchExpressions[0].Values, 1)
+	require.Equal(t, "prod", target.Selector.MatchExpressions[0].Values[0])
+
+	// Check the namespace selector.
+	require.Len(t, target.NamespaceSelector.MatchNames, 1)
+	require.Equal(t, "billing", target.NamespaceSelector.MatchNames[0])
+
+	// Check the tracer versions.
+	require.Len(t, target.TracerVersions, 1)
+	require.Equal(t, "default", target.TracerVersions["java"])
+}
+
+func TestFilter(t *testing.T) {
+	libVersions := map[string]libInfo{
+		"java": {
+			ctrName: "",
+			lang:    java,
+			image:   "gcr.io/datadoghq/dd-lib-java-init:default",
+		},
+		"python": {
+			ctrName: "",
+			lang:    python,
+			image:   "gcr.io/datadoghq/dd-lib-python-init:default",
+		},
+		"ruby": {
+			ctrName: "",
+			lang:    ruby,
+			image:   "gcr.io/datadoghq/dd-lib-ruby-init:default",
+		},
+		"php": {
+			ctrName: "",
+			lang:    php,
+			image:   "gcr.io/datadoghq/dd-lib-php-init:default",
+		},
+		"js": {
+			ctrName: "",
+			lang:    js,
+			image:   "gcr.io/datadoghq/dd-lib-js-init:default",
+		},
+		"dotnet": {
+			ctrName: "",
+			lang:    dotnet,
+			image:   "gcr.io/datadoghq/dd-lib-dotnet-init:default",
+		},
+	}
+
+	tests := map[string]struct {
+		configPath string
+		in         *corev1.Pod
+		out        []libInfo
+	}{
+		"a rule without selectors applies as a default": {
+			configPath: "testdata/filter.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Labels: map[string]string{
+						"app": "frontend",
+					},
+				},
+			},
+			out: []libInfo{
+				libVersions["js"],
+			},
+		},
+		"a single service example matches rule": {
+			configPath: "testdata/filter.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "billing-service",
+					Labels: map[string]string{
+						"app": "billing-service",
+					},
+				},
+			},
+			out: []libInfo{
+				libVersions["python"],
+			},
+		},
+		"a java microservice service matches rule": {
+			configPath: "testdata/filter.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "application",
+					Labels: map[string]string{
+						"language": "java",
+					},
+				},
+			},
+			out: []libInfo{
+				libVersions["java"],
+			},
+		},
+		"a disabled namespace gets no tracers": {
+			configPath: "testdata/filter.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "infra",
+					Labels: map[string]string{
+						"language": "java",
+					},
+				},
+			},
+			out: nil,
+		},
+		"unset tracer versions applies all tracers": {
+			configPath: "testdata/filter.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "application",
+					Labels: map[string]string{
+						"language": "unknown",
+					},
+				},
+			},
+			out: []libInfo{
+				libVersions["java"],
+				libVersions["python"],
+				libVersions["ruby"],
+				libVersions["php"],
+				libVersions["js"],
+				libVersions["dotnet"],
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockConfig := configmock.NewFromFile(t, test.configPath)
+			f, err := NewTargetFilter(mockConfig)
+			require.NoError(t, err)
+
+			libList := f.Filter(test.in)
+			require.Equal(t, test.out, libList)
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
@@ -49,38 +49,10 @@ func TestParseConfig(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	libVersions := map[string]libInfo{
-		"java": {
-			ctrName: "",
-			lang:    java,
-			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
-		},
-		"python": {
-			ctrName: "",
-			lang:    python,
-			image:   "gcr.io/datadoghq/dd-lib-python-init:v2",
-		},
-		"ruby": {
-			ctrName: "",
-			lang:    ruby,
-			image:   "gcr.io/datadoghq/dd-lib-ruby-init:v2",
-		},
-		"js": {
-			ctrName: "",
-			lang:    js,
-			image:   "gcr.io/datadoghq/dd-lib-js-init:v5",
-		},
-		"dotnet": {
-			ctrName: "",
-			lang:    dotnet,
-			image:   "gcr.io/datadoghq/dd-lib-dotnet-init:v3",
-		},
-	}
-
 	tests := map[string]struct {
 		configPath string
 		in         *corev1.Pod
-		out        []libInfo
+		out        []language
 	}{
 		"a rule without selectors applies as a default": {
 			configPath: "testdata/filter.yaml",
@@ -92,9 +64,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 			},
-			out: []libInfo{
-				libVersions["js"],
-			},
+			out: []language{js},
 		},
 		"a single service example matches rule": {
 			configPath: "testdata/filter.yaml",
@@ -106,9 +76,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 			},
-			out: []libInfo{
-				libVersions["python"],
-			},
+			out: []language{python},
 		},
 		"a java microservice service matches rule": {
 			configPath: "testdata/filter.yaml",
@@ -120,9 +88,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 			},
-			out: []libInfo{
-				libVersions["java"],
-			},
+			out: []language{java},
 		},
 		"a disabled namespace gets no tracers": {
 			configPath: "testdata/filter.yaml",
@@ -146,13 +112,7 @@ func TestFilter(t *testing.T) {
 					},
 				},
 			},
-			out: []libInfo{
-				libVersions["java"],
-				libVersions["js"],
-				libVersions["python"],
-				libVersions["dotnet"],
-				libVersions["ruby"],
-			},
+			out: []language{java, js, python, dotnet, ruby},
 		},
 	}
 
@@ -163,7 +123,11 @@ func TestFilter(t *testing.T) {
 			require.NoError(t, err)
 
 			libList := f.Filter(test.in)
-			require.Equal(t, test.out, libList)
+			languages := make([]language, 0, len(libList))
+			for _, lib := range libList {
+				languages = append(languages, lib.lang)
+			}
+			require.Equal(t, test.out, languages)
 		})
 	}
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/targets_test.go
@@ -53,32 +53,27 @@ func TestFilter(t *testing.T) {
 		"java": {
 			ctrName: "",
 			lang:    java,
-			image:   "gcr.io/datadoghq/dd-lib-java-init:default",
+			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
 		},
 		"python": {
 			ctrName: "",
 			lang:    python,
-			image:   "gcr.io/datadoghq/dd-lib-python-init:default",
+			image:   "gcr.io/datadoghq/dd-lib-python-init:v2",
 		},
 		"ruby": {
 			ctrName: "",
 			lang:    ruby,
-			image:   "gcr.io/datadoghq/dd-lib-ruby-init:default",
-		},
-		"php": {
-			ctrName: "",
-			lang:    php,
-			image:   "gcr.io/datadoghq/dd-lib-php-init:default",
+			image:   "gcr.io/datadoghq/dd-lib-ruby-init:v2",
 		},
 		"js": {
 			ctrName: "",
 			lang:    js,
-			image:   "gcr.io/datadoghq/dd-lib-js-init:default",
+			image:   "gcr.io/datadoghq/dd-lib-js-init:v5",
 		},
 		"dotnet": {
 			ctrName: "",
 			lang:    dotnet,
-			image:   "gcr.io/datadoghq/dd-lib-dotnet-init:default",
+			image:   "gcr.io/datadoghq/dd-lib-dotnet-init:v3",
 		},
 	}
 
@@ -153,11 +148,10 @@ func TestFilter(t *testing.T) {
 			},
 			out: []libInfo{
 				libVersions["java"],
-				libVersions["python"],
-				libVersions["ruby"],
-				libVersions["php"],
 				libVersions["js"],
+				libVersions["python"],
 				libVersions["dotnet"],
+				libVersions["ruby"],
 			},
 		},
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter.yaml
@@ -1,0 +1,30 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    disabled_namespaces:
+      - "infra"
+      - "system"
+    targets:
+      - name: "Billing Service"
+        selector:
+          matchLabels:
+            app: "billing-service"
+        namespaceSelector:
+          matchNames:
+          - "billing-service"
+        ddTraceVersions:
+          python: "default"
+      - name: "Microservices"
+        selector:
+          matchLabels:
+            language: "java"
+        ddTraceVersions:
+          java: "default"
+      - name: "Unknown Language"
+        selector:
+          matchLabels:
+            language: "unknown"
+      - name: "Default"
+        ddTraceVersions:
+          js: "default"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/targets.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/targets.yaml
@@ -1,0 +1,21 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    disabled_namespaces:
+      - "kube-system"
+    targets:
+      - name: "Billing Service"
+        selector:
+          matchLabels:
+            app: "billing-service"
+          matchExpressions:
+            - key: "env"
+              operator: "In"
+              values:
+                - "prod"
+        namespaceSelector:
+          matchNames:
+          - "billing"
+        ddTraceVersions:
+          java: "default"

--- a/pkg/clusteragent/admission/mutate/common/ns_injection_filter.go
+++ b/pkg/clusteragent/admission/mutate/common/ns_injection_filter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// TODO(mspicer) Mabybe implment this interface?
 // InjectionFilter is an interface to determine if a pod should be mutated.
 type InjectionFilter interface {
 	// ShouldMutatePod checks if a pod is mutable per explicit rules and


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR creates a proof of concept implementation for the [Kubernetes SSI | Workload Selection](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing) RFC.

### Motivation
This change is not to be merged or formally reviewed, but simply to be used as a discussion point for a proper implementation.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Here is the datadog helm chart config used for this test:
```
datadog:
  apiKeyExistingSecret: datadog-secret
  apm:
    instrumentation:
      enabled: true
    disabled_namespace:
      - "infra"
  env:
    - name: DD_HOSTNAME
      valueFrom:
        fieldRef:
          fieldPath: spec.nodeName

clusterAgent:
  enabled: true
  image:
    doNotCheckTag: true
  datadog_cluster_yaml:
    apm_config:
      instrumentation:
        enabled: true
        targets:
          - name: "Billing Service"
            selector:
              matchLabels:
                app: "billing-service"
            namespaceSelector:
              matchNames:
              - "billing-service"
            ddTraceVersions:
              java: "default"
          - name: "Microservices"
            selector:
              matchLabels:
                language: "python"
            ddTraceVersions:
              python: "default"
```