### PR TITLE
bininspect: makes `want` take a byte slice to skip allocations

### DIFF
--- a/pkg/network/go/bininspect/pclntab.go
+++ b/pkg/network/go/bininspect/pclntab.go
@@ -269,7 +269,7 @@ func (p *pclntanSymbolParser) funcName(data sectionAccess) string {
 		return ""
 	}
 
-	if p.symbolFilter.want(string(p.funcNameHelper[:idxToNull])) {
+	if p.symbolFilter.want(p.funcNameHelper[:idxToNull]) {
 		return string(p.funcNameHelper[:idxToNull])
 	}
 	return ""

--- a/pkg/network/go/bininspect/symbol_filter.go
+++ b/pkg/network/go/bininspect/symbol_filter.go
@@ -21,7 +21,7 @@ type symbolFilter interface {
 	// getMinMaxLength returns the minimum and maximum name lengths of the symbols wanted by the filter.
 	getMinMaxLength() (int, int)
 	// want returns true if the filter want the symbol.
-	want(symbol string) bool
+	want(symbol []byte) bool
 	// findMissing returns the list of symbol names which the filter wanted but were not found in the
 	// symbol map. This is only used for error messages.
 	findMissing(map[string]safeelf.Symbol) []string
@@ -52,8 +52,8 @@ func (f stringSetSymbolFilter) getNumWanted() int {
 	return len(f.symbolSet)
 }
 
-func (f stringSetSymbolFilter) want(symbol string) bool {
-	_, ok := f.symbolSet[symbol]
+func (f stringSetSymbolFilter) want(symbol []byte) bool {
+	_, ok := f.symbolSet[string(symbol)]
 	return ok
 }
 
@@ -93,8 +93,8 @@ func (f infixSymbolFilter) getNumWanted() int {
 	return 1
 }
 
-func (f infixSymbolFilter) want(symbol string) bool {
-	return strings.Contains(symbol, f.infix)
+func (f infixSymbolFilter) want(symbol []byte) bool {
+	return strings.Contains(string(symbol), f.infix)
 }
 
 // findMissing gets the list of symbols which were missing. Only used for error

--- a/pkg/network/go/bininspect/symbols.go
+++ b/pkg/network/go/bininspect/symbols.go
@@ -183,7 +183,7 @@ func getSymbolsUnified(f *safeelf.File, typ safeelf.SectionType, filter symbolFi
 		}
 
 		// Checking the symbol is relevant for us.
-		if !filter.want(string(symbolNameBuf[:symbolNameSize])) {
+		if !filter.want(symbolNameBuf[:symbolNameSize]) {
 			continue
 		}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`.want` is often called through the `symbolFilter` interface. As such it's rarely inlined and thus calling it like `.want(string(bytes))` does not end up triggering the optimization where the "bytes to string" allocation/copy is skipped when used to access a map and we end up seeing the copy in [SMP profiles](https://app.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20language%3Ago%20experiment%3Aquality_gate_idle_all_features%20version%3A7.64.0-devel_git.42.78000ed&agg_m=count&agg_m_source=base&agg_t=count&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZSd94ofJ1UsqwAAABhBWlNkOTQxQ0FBRFZHc2RSTGFMU3p3QUEAAAAkMDE5NDlkZmEtMTU3Yy00N2Q0LThhODMtMzFlMjg5YmE0YjhjAAbtcg&fromUser=true&my_code=disabled&profile_type=alloc-size&profileId=AZSd941CAADVGsdRLaLSzwAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1737810041799&to_ts=1737824441799&live=false).

This PR changes `.want` to take a byte slice instead, allowing to do the "bytes to string" cast in its body, and the optimization to triggers every time.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->