### PR TITLE
fix(fleet): Add journalctl logs on systemd events order assert failure

### DIFF
--- a/test/new-e2e/tests/installer/host/systemd.go
+++ b/test/new-e2e/tests/installer/host/systemd.go
@@ -113,6 +113,19 @@ func (h *Host) AssertSystemdEvents(since JournaldTimestamp, events SystemdEventS
 		h.t.Logf("Blocked on validating: %v", lastSearchedEvents)
 		h.t.Logf("Expected events: %v", events.Events)
 		h.t.Logf("Actual events: %v", logs)
+
+		// Display all journalctl logs from units in the events
+		units := map[string]struct{}{}
+		for _, events := range events.Events {
+			for _, event := range events {
+				units[event.Unit] = struct{}{}
+			}
+		}
+
+		for unit := range units {
+			h.t.Logf("--- Logs for unit %s:", unit)
+			h.remote.MustExecute(fmt.Sprintf("sudo journalctl -xeu %s", unit))
+		}
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Adds journalctl unit logs when the systemd events order assertion fails

### Motivation

### Describe how you validated your changes
Test changes only

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->