### PR TITLE
[CWS] delay netns path resolution to after cache miss

### DIFF
--- a/pkg/security/resolvers/netns/resolver.go
+++ b/pkg/security/resolvers/netns/resolver.go
@@ -249,16 +249,16 @@ func (nr *Resolver) SaveNetworkNamespaceHandleLazy(nsID uint32, nsPathFunc func(
 		return nil, false
 	}
 
-	nsPath := nsPathFunc()
-	if nsPath == nil {
-		return nil, false
-	}
-
 	nr.Lock()
 	defer nr.Unlock()
 
 	netns, found := nr.networkNamespaces.Get(nsID)
 	if !found {
+		nsPath := nsPathFunc()
+		if nsPath == nil {
+			return nil, false
+		}
+
 		var err error
 		netns, err = NewNetworkNamespaceWithPath(nsID, nsPath)
 		if err != nil {
@@ -271,6 +271,12 @@ func (nr *Resolver) SaveNetworkNamespaceHandleLazy(nsID uint32, nsPathFunc func(
 			// we already have a handle for this network namespace, ignore
 			return netns, false
 		}
+
+		nsPath := nsPathFunc()
+		if nsPath == nil {
+			return nil, false
+		}
+
 		if err := netns.openHandle(nsPath); err != nil {
 			// we'll get this namespace another time, ignore
 			return nil, false


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

If there is a hit in the network namespace cache, we don't need the netns path so calling the callback is not necessary. This PR moves the callback call down to where it's going to be used in order to cut the amount of useless calls.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->