### PR TITLE
Use embedded version in the unverified client

### DIFF
--- a/pkg/config/remote/meta/staging.director.json
+++ b/pkg/config/remote/meta/staging.director.json
@@ -2,17 +2,17 @@
   "signatures": [
     {
       "keyid": "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6",
-      "sig": "c926bd33ae30267ddf141b8b8fb2f6338b6f1451cbc2b1b704082080c337272b35d599272843a66a720a601d4e08209f87747beb5f000663d851c7b6a13bf901"
+      "sig": "6d7ddf4bcbd1ce223b5352cae4671ef42800d79f0c94dda905cf0dd8a6198ba69795a19201dc7230e4bd872cf109e827233678bf76389910933472417488320e"
     },
     {
       "keyid": "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1",
-      "sig": "d4baf2506a736be2ede3dd488d45a11de68a3987f661452853a23d21de943dfaa033e3a099051db8669f1a3837cb07375685b4fd89e226ce83c28d66aeab700a"
+      "sig": "a1236d12903e1c4024fc6340c50a0f2fe9972e967eb2bace8d6594e156f0466f772bfc0c9f30e07067904073c0d7ba7d48ad00341405312daf0d7bc502ccc50f"
     }
   ],
   "signed": {
     "_type": "root",
     "consistent_snapshot": true,
-    "expires": "2025-12-01T17:00:00Z",
+    "expires": "1970-01-01T00:00:00Z",
     "keys": {
       "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6": {
         "keyid_hash_algorithms": ["sha256", "sha512"],
@@ -34,34 +34,34 @@
     "roles": {
       "root": {
         "keyids": [
-          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6",
-          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1"
+          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1",
+          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"
         ],
         "threshold": 2
       },
       "snapshot": {
         "keyids": [
-          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6",
-          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1"
+          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1",
+          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"
         ],
         "threshold": 2
       },
       "targets": {
         "keyids": [
-          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6",
-          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1"
+          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1",
+          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"
         ],
         "threshold": 2
       },
       "timestamp": {
         "keyids": [
-          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6",
-          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1"
+          "6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1",
+          "233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"
         ],
         "threshold": 2
       }
     },
     "spec_version": "1.0",
-    "version": 25
+    "version": 1
   }
 }


### PR DESCRIPTION
This change currently breaks go unverified clients as they hardcoded the director root to version 1 instead of accepting an arbitrary one (there's no TUF verification).
We'll work on this, but for the moment we must revert the director root update