### PR TITLE
Reapply "[ASCII-2587] Migrating TraceAgent to use IPC cert"

### DIFF
--- a/cmd/agent/subcommands/flare/command.go
+++ b/cmd/agent/subcommands/flare/command.go
@@ -177,10 +177,18 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 
 	type pprofGetter func(path string) ([]byte, error)
 
-	tcpGet := func(portConfig string) pprofGetter {
-		pprofURL := fmt.Sprintf("http://127.0.0.1:%d/debug/pprof", pkgconfigsetup.Datadog().GetInt(portConfig))
+	tcpGet := func(portConfig string, onHTTPS bool) pprofGetter {
+		endpoint := url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(pkgconfigsetup.Datadog().GetInt(portConfig))),
+			Path:   "/debug/pprof",
+		}
+		if onHTTPS {
+			endpoint.Scheme = "https"
+		}
+
 		return func(path string) ([]byte, error) {
-			return util.DoGet(c, pprofURL+path, util.LeaveConnectionOpen)
+			return util.DoGet(c, endpoint.String()+path, util.LeaveConnectionOpen)
 		}
 	}
 
@@ -230,15 +238,15 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 	}
 
 	agentCollectors := map[string]agentProfileCollector{
-		"core":           serviceProfileCollector(tcpGet("expvar_port"), seconds),
-		"security-agent": serviceProfileCollector(tcpGet("security_agent.expvar_port"), seconds),
+		"core":           serviceProfileCollector(tcpGet("expvar_port", false), seconds),
+		"security-agent": serviceProfileCollector(tcpGet("security_agent.expvar_port", false), seconds),
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("process_config.enabled") ||
 		pkgconfigsetup.Datadog().GetBool("process_config.container_collection.enabled") ||
 		pkgconfigsetup.Datadog().GetBool("process_config.process_collection.enabled") {
 
-		agentCollectors["process"] = serviceProfileCollector(tcpGet("process_config.expvar_port"), seconds)
+		agentCollectors["process"] = serviceProfileCollector(tcpGet("process_config.expvar_port", false), seconds)
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("apm_config.enabled") {
@@ -251,7 +259,7 @@ func readProfileData(seconds int) (flare.ProfileData, error) {
 			traceCpusec = 4
 		}
 
-		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port"), traceCpusec)
+		agentCollectors["trace"] = serviceProfileCollector(tcpGet("apm_config.debug.port", true), traceCpusec)
 	}
 
 	if pkgconfigsetup.SystemProbe().GetBool("system_probe_config.enabled") {

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -29,6 +29,7 @@ type commandTestSuite struct {
 	suite.Suite
 	sysprobeSocketPath string
 	tcpServer          *httptest.Server
+	tcpTLSServer       *httptest.Server
 	unixServer         *httptest.Server
 	systemProbeServer  *httptest.Server
 }
@@ -42,12 +43,16 @@ func (c *commandTestSuite) SetupSuite() {
 // This should be called by each test that requires them.
 func (c *commandTestSuite) startTestServers() {
 	t := c.T()
-	c.tcpServer, c.unixServer, c.systemProbeServer = c.getPprofTestServer()
+	c.tcpServer, c.tcpTLSServer, c.unixServer, c.systemProbeServer = c.getPprofTestServer()
 
 	t.Cleanup(func() {
 		if c.tcpServer != nil {
 			c.tcpServer.Close()
 			c.tcpServer = nil
+		}
+		if c.tcpTLSServer != nil {
+			c.tcpTLSServer.Close()
+			c.tcpTLSServer = nil
 		}
 		if c.unixServer != nil {
 			c.unixServer.Close()
@@ -82,12 +87,13 @@ func newMockHandler() http.HandlerFunc {
 	})
 }
 
-func (c *commandTestSuite) getPprofTestServer() (tcpServer *httptest.Server, unixServer *httptest.Server, sysProbeServer *httptest.Server) {
+func (c *commandTestSuite) getPprofTestServer() (tcpServer *httptest.Server, tcpTLSServer *httptest.Server, unixServer *httptest.Server, sysProbeServer *httptest.Server) {
 	var err error
 	t := c.T()
 
 	handler := newMockHandler()
 	tcpServer = httptest.NewServer(handler)
+	tcpTLSServer = httptest.NewTLSServer(handler)
 	if runtime.GOOS == "linux" {
 		unixServer = httptest.NewUnstartedServer(handler)
 		unixServer.Listener, err = net.Listen("unix", c.sysprobeSocketPath)
@@ -101,7 +107,7 @@ func (c *commandTestSuite) getPprofTestServer() (tcpServer *httptest.Server, uni
 		sysProbeServer.Start()
 	}
 
-	return tcpServer, unixServer, sysProbeServer
+	return tcpServer, tcpTLSServer, unixServer, sysProbeServer
 }
 
 func TestCommandTestSuite(t *testing.T) {
@@ -116,10 +122,14 @@ func (c *commandTestSuite) TestReadProfileData() {
 	require.NoError(t, err)
 	port := u.Port()
 
+	u, err = url.Parse(c.tcpTLSServer.URL)
+	require.NoError(t, err)
+	httpsPort := u.Port()
+
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource("expvar_port", port)
 	mockConfig.SetWithoutSource("apm_config.enabled", true)
-	mockConfig.SetWithoutSource("apm_config.debug.port", port)
+	mockConfig.SetWithoutSource("apm_config.debug.port", httpsPort)
 	mockConfig.SetWithoutSource("apm_config.receiver_timeout", "10")
 	mockConfig.SetWithoutSource("process_config.expvar_port", port)
 	mockConfig.SetWithoutSource("security_agent.expvar_port", port)

--- a/cmd/agent/subcommands/secret/command.go
+++ b/cmd/agent/subcommands/secret/command.go
@@ -114,7 +114,7 @@ func commonSubAgentSecretRefresh(conf config.Component, agentName, portConfigNam
 	c := apiutil.GetClient(false)
 	c.Timeout = conf.GetDuration("server_timeout") * time.Second
 
-	url := fmt.Sprintf("http://127.0.0.1:%d/secret/refresh", port)
+	url := fmt.Sprintf("https://127.0.0.1:%d/secret/refresh", port)
 	res, err := apiutil.DoGet(c, url, apiutil.CloseConnection)
 	if err != nil {
 		return nil, fmt.Errorf("could not contact %s: %s", agentName, err)

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
@@ -68,6 +69,7 @@ type dependencies struct {
 	Statsd             statsd.Component
 	Tagger             tagger.Component
 	Compressor         compression.Component
+	At                 authtoken.Component
 }
 
 var _ traceagent.Component = (*component)(nil)
@@ -93,6 +95,7 @@ type component struct {
 	params             *Params
 	tagger             tagger.Component
 	telemetryCollector telemetry.TelemetryCollector
+	at                 authtoken.Component
 	wg                 *sync.WaitGroup
 }
 
@@ -115,6 +118,7 @@ func NewAgent(deps dependencies) (traceagent.Component, error) {
 		params:             deps.Params,
 		telemetryCollector: deps.TelemetryCollector,
 		tagger:             deps.Tagger,
+		at:                 deps.At,
 		wg:                 &sync.WaitGroup{},
 	}
 	statsdCl, err := setupMetrics(deps.Statsd, c.config, c.telemetryCollector)

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -98,6 +98,9 @@ func runAgentSidekicks(ag component) error {
 		}))
 	}
 
+	// Configure the Trace Agent Debug server to use the IPC certificate
+	ag.Agent.DebugServer.SetTLSConfig(ag.at.GetTLSServerConfig())
+
 	log.Infof("Trace agent running on host %s", tracecfg.Hostname)
 	if pcfg := profilingConfig(tracecfg); pcfg != nil {
 		if err := profiling.Start(*pcfg); err != nil {

--- a/comp/trace/agent/impl/run.go
+++ b/comp/trace/agent/impl/run.go
@@ -33,6 +33,9 @@ import (
 
 // runAgentSidekicks is the entrypoint for running non-components that run along the agent.
 func runAgentSidekicks(ag component) error {
+	// Configure the Trace Agent Debug server to use the IPC certificate
+	ag.Agent.DebugServer.SetTLSConfig(ag.at.GetTLSServerConfig())
+
 	tracecfg := ag.config.Object()
 	err := info.InitInfo(tracecfg) // for expvar & -info option
 	if err != nil {
@@ -97,9 +100,6 @@ func runAgentSidekicks(ag component) error {
 			w.Write([]byte(res))
 		}))
 	}
-
-	// Configure the Trace Agent Debug server to use the IPC certificate
-	ag.Agent.DebugServer.SetTLSConfig(ag.at.GetTLSServerConfig())
 
 	log.Infof("Trace agent running on host %s", tracecfg.Hostname)
 	if pcfg := profilingConfig(tracecfg); pcfg != nil {

--- a/comp/trace/bundle_test.go
+++ b/comp/trace/bundle_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/api/authtoken/createandfetchimpl"
+	"github.com/DataDog/datadog-agent/comp/api/authtoken/fetchonlyimpl"
 	"github.com/DataDog/datadog-agent/comp/core"
 	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -45,6 +47,7 @@ func TestBundleDependencies(t *testing.T) {
 		zstdfx.Module(),
 		taggerfx.Module(tagger.Params{}),
 		fx.Supply(&traceagentimpl.Params{}),
+		createandfetchimpl.Module(),
 	)
 }
 
@@ -75,6 +78,7 @@ func TestMockBundleDependencies(t *testing.T) {
 		fx.Invoke(func(_ traceagent.Component) {}),
 		MockBundle(),
 		taggerfx.Module(tagger.Params{}),
+		fetchonlyimpl.MockModule(),
 	))
 
 	require.NotNil(t, cfg.Object())

--- a/comp/trace/status/statusimpl/status.go
+++ b/comp/trace/status/statusimpl/status.go
@@ -95,7 +95,7 @@ func (s statusProvider) populateStatus() map[string]interface{} {
 	port := s.Config.GetInt("apm_config.debug.port")
 
 	c := client()
-	url := fmt.Sprintf("http://localhost:%d/debug/vars", port)
+	url := fmt.Sprintf("https://localhost:%d/debug/vars", port)
 	resp, err := apiutil.DoGet(c, url, apiutil.CloseConnection)
 	if err != nil {
 		return map[string]interface{}{

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -71,7 +71,7 @@ func TraceAgentConfig(config config.Reader) (string, error) {
 	c := util.GetClient(false)
 	c.Timeout = config.GetDuration("server_timeout") * time.Second
 
-	ipcAddressWithPort := fmt.Sprintf("http://127.0.0.1:%d/config", port)
+	ipcAddressWithPort := fmt.Sprintf("https://127.0.0.1:%d/config", port)
 
 	client := settingshttp.NewClient(c, ipcAddressWithPort, "trace-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
 	return client.FullConfig()

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -216,7 +216,7 @@ func GetExpVar(fb flaretypes.FlareBuilder) error {
 
 	apmDebugPort := pkgconfigsetup.Datadog().GetInt("apm_config.debug.port")
 	f := filepath.Join("expvar", "trace-agent")
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/vars", apmDebugPort))
+	resp, err := http.Get(fmt.Sprintf("https://127.0.0.1:%d/debug/vars", apmDebugPort))
 	if err != nil {
 		return fb.AddFile(f, []byte(fmt.Sprintf("Error retrieving vars: %v", err)))
 	}

--- a/pkg/trace/api/debug_server.go
+++ b/pkg/trace/api/debug_server.go
@@ -50,26 +50,23 @@ func (ds *DebugServer) Start() {
 		log.Debug("Debug server is disabled by config (apm_config.debug.port: 0).")
 		return
 	}
-	ds.server = &http.Server{
-		ReadTimeout:  defaultTimeout,
-		WriteTimeout: defaultTimeout,
-		Handler:      ds.setupMux(),
-	}
 
 	// TODO: Improve certificate delivery
 	if ds.tlsConfig == nil {
 		log.Warnf("Debug server wasn't able to start: uninitialized IPC certificate")
-		// Removing server to avoid blocking on shutdown step
-		ds.server = nil
 		return
 	}
 
 	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(ds.conf.DebugServerPort)))
 	if err != nil {
 		log.Errorf("Error creating debug server listener: %s", err)
-		// Removing server to avoid blocking on shutdown step
-		ds.server = nil
 		return
+	}
+
+	ds.server = &http.Server{
+		ReadTimeout:  defaultTimeout,
+		WriteTimeout: defaultTimeout,
+		Handler:      ds.setupMux(),
 	}
 
 	tlsListener := tls.NewListener(listener, ds.tlsConfig)

--- a/pkg/trace/info/info.go
+++ b/pkg/trace/info/info.go
@@ -8,6 +8,7 @@ package info
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"expvar" // automatically publish `/debug/vars` on HTTP port
 	"fmt"
@@ -236,8 +237,9 @@ func getProgramBanner(version string) (string, string) {
 // If error is nil, means the program is running.
 // If not, it displays a pretty-printed message anyway (for support)
 func Info(w io.Writer, conf *config.AgentConfig) error {
-	url := fmt.Sprintf("http://127.0.0.1:%d/debug/vars", conf.DebugServerPort)
-	client := http.Client{Timeout: 3 * time.Second}
+	url := fmt.Sprintf("https://127.0.0.1:%d/debug/vars", conf.DebugServerPort)
+	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	client := http.Client{Timeout: 3 * time.Second, Transport: tr}
 	resp, err := client.Get(url)
 	if err != nil {
 		// OK, here, we can't even make an http call on the agent port,

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -63,7 +63,7 @@ func (h *testServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func testServer(t *testing.T, testFile string) *httptest.Server {
 	t.Helper()
-	server := httptest.NewServer(&testServerHandler{t: t, testFile: testFile})
+	server := httptest.NewTLSServer(&testServerHandler{t: t, testFile: testFile})
 	t.Logf("test server (serving fake yet valid data) listening on %s", server.URL)
 	return server
 }
@@ -94,7 +94,7 @@ func (h *testServerWarningHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 }
 
 func testServerWarning(t *testing.T) *httptest.Server {
-	server := httptest.NewServer(&testServerWarningHandler{t: t})
+	server := httptest.NewTLSServer(&testServerWarningHandler{t: t})
 	t.Logf("test server (serving data containing worrying values) listening on %s", server.URL)
 	return server
 }
@@ -119,7 +119,7 @@ func (h *testServerErrorHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 }
 
 func testServerError(t *testing.T) *httptest.Server {
-	server := httptest.NewServer(&testServerErrorHandler{t: t})
+	server := httptest.NewTLSServer(&testServerErrorHandler{t: t})
 	t.Logf("test server (serving bad data to trigger errors) listening on %s", server.URL)
 	return server
 }
@@ -331,7 +331,7 @@ func TestError(t *testing.T) {
 	assert.Equal(len(lines[1]), len(lines[2]))
 	assert.Equal("", lines[3])
 	assert.Regexp(regexp.MustCompile(`^  Error: .*$`), lines[4])
-	assert.Equal(fmt.Sprintf("  URL: http://127.0.0.1:%d/debug/vars", port), lines[5])
+	assert.Equal(fmt.Sprintf("  URL: https://127.0.0.1:%d/debug/vars", port), lines[5])
 	assert.Equal("", lines[6])
 	assert.Equal("", lines[7])
 }

--- a/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
+++ b/test/new-e2e/tests/agent-shared-components/config-refresh/config_endpoint.go
@@ -20,7 +20,7 @@ type agentConfigEndpointInfo struct {
 }
 
 func traceConfigEndpoint(port int) agentConfigEndpointInfo {
-	return agentConfigEndpointInfo{"trace-agent", "http", port, "/config"}
+	return agentConfigEndpointInfo{"trace-agent", "https", port, "/config"}
 }
 
 func processConfigEndpoint(port int) agentConfigEndpointInfo {


### PR DESCRIPTION
### What does this PR do?
This PR reapply a PR that was migrating traceAgent Debug server to HTTPS. It was reverted several time for different reasons. Here is the history of this change:
1. -#31847 : the original PR is merged
2. #32320 reverts #31847 due to error in agent-shared-component e2e test
3. #32355 reapply #31847 by fixing breaking e2e test
4. #33261 reverts #32355 due to panics occurring when rare race conditions happened, which was leading to uninitialized 		auth components
5. #33358 fix the panicking behaviour by providing default TLS configurations in the case they could not be initialized

This PR finally reapplied #32355 

### Describe how you validated your changes
Changes have been manually validated by preventing a traceAgent to initialize its auth_token component and fetching its Debug API, checking that it's not leading to panic.

### Additional Notes
This solution will be soon replaced by another mechanism where every process is able to create the auth artifacts, which will prevent from inconsistent behaviors.