### PR TITLE
sbom: allow collector to scan library packages and any relationships

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ require (
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/alecthomas/participle v0.7.1 // indirect
 	github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30
-	github.com/aquasecurity/trivy-db v0.0.0-20240910133327-7e0f4d2ed4c1
+	github.com/aquasecurity/trivy-db v0.0.0-20240910133327-7e0f4d2ed4c1 // indirect
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/aws/aws-lambda-go v1.37.0
 	github.com/aws/aws-sdk-go v1.55.6 // indirect

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -328,11 +328,9 @@ func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applie
 
 	trivyReport, err := s.ScanArtifact(ctx, types.ScanOptions{
 		ScanRemovedPackages: false,
-		PkgTypes:            []types.PkgType{types.PkgTypeOS},
-		PkgRelationships: []ftypes.Relationship{
-			ftypes.RelationshipUnknown,
-		},
-		Scanners: types.Scanners{types.SBOMScanner},
+		PkgTypes:            []types.PkgType{types.PkgTypeOS, types.PkgTypeLibrary},
+		PkgRelationships:    ftypes.Relationships,
+		Scanners:            types.Scanners{types.SBOMScanner},
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
-	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -33,10 +32,7 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 	"github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 	"github.com/aquasecurity/trivy/pkg/scanner"
-	"github.com/aquasecurity/trivy/pkg/scanner/langpkg"
-	"github.com/aquasecurity/trivy/pkg/scanner/ospkg"
 	"github.com/aquasecurity/trivy/pkg/types"
-	"github.com/aquasecurity/trivy/pkg/vulnerability"
 
 	// This is required to load sqlite based RPM databases
 	_ "modernc.org/sqlite"
@@ -64,9 +60,6 @@ type Collector struct {
 	config           collectorConfig
 	cacheInitialized sync.Once
 	persistentCache  CacheWithCleaner
-	osScanner        ospkg.Scanner
-	langScanner      langpkg.Scanner
-	vulnClient       vulnerability.Client
 	marshaler        cyclonedx.Marshaler
 	wmeta            option.Option[workloadmeta.Component]
 }
@@ -158,11 +151,8 @@ func NewCollector(cfg config.Component, wmeta option.Option[workloadmeta.Compone
 			maxCacheSize:      cfg.GetInt("sbom.cache.max_disk_size"),
 			overlayFSSupport:  cfg.GetBool("sbom.container_image.overlayfs_direct_scan"),
 		},
-		osScanner:   ospkg.NewScanner(),
-		langScanner: langpkg.NewScanner(),
-		vulnClient:  vulnerability.NewClient(db.Config{}),
-		marshaler:   cyclonedx.NewMarshaler(""),
-		wmeta:       wmeta,
+		marshaler: cyclonedx.NewMarshaler(""),
+		wmeta:     wmeta,
 	}, nil
 }
 

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -284,21 +284,18 @@ func (d *driver) Scan(_ context.Context, target, artifactKey string, blobKeys []
 		return nil, ftypes.OS{}, xerrors.Errorf("failed to apply layers: %w", err)
 	}
 
-	scanTarget := types.ScanTarget{
-		Name:       target,
-		OS:         detail.OS,
-		Repository: detail.Repository,
-		Packages:   detail.Packages,
-	}
-
 	result := types.Result{
 		Target: fmt.Sprintf("%s (%s %s)", target, detail.OS.Family, detail.OS.Name),
 		Class:  types.ClassOSPkg,
-		Type:   scanTarget.OS.Family,
+		Type:   detail.OS.Family,
 	}
 
-	sort.Sort(scanTarget.Packages)
-	result.Packages = scanTarget.Packages
+	sort.Sort(detail.Packages)
+	result.Packages = detail.Packages
+	for _, app := range detail.Applications {
+		sort.Sort(app.Packages)
+		result.Packages = append(result.Packages, app.Packages...)
+	}
 
 	return []types.Result{result}, detail.OS, nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR:
- cleans up the unused variables `osScanner`, `langScanner` and `vulnClient` that are not used since the last trivy bump
- do not filter out lib packages when collecting the results
- collect the application packages in addition to OS ones

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->