### PR TITLE
check_pkg_size should not run on release branch anymore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -620,6 +620,10 @@ workflow:
   - <<: *if_main_branch
   - <<: *if_release_branch
 
+.not_on_release_branch:
+  - <<: *if_release_branch
+    when: never
+
 .only_main:
   - <<: *if_not_main_branch
     when: never

--- a/.gitlab/pkg_metrics/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics/pkg_metrics.yml
@@ -85,9 +85,7 @@ check_pkg_size:
     - if: $CI_COMMIT_BRANCH == "main"
       when: on_success
       allow_failure: true
-    - if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
-      when: on_success
-      allow_failure: true
+    - !reference [.not_on_release_branch]
     - !reference [.except_mergequeue]
     - when: on_success
   needs:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Change `check_pkg_size` to not run on release branch anymore

### Motivation

`check_pkg_size` is missbehaving comparing release branch to main commits

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->