### PR TITLE
APM: Reduce number of allocs from sampler metrics

### DIFF
--- a/pkg/trace/sampler/metrics.go
+++ b/pkg/trace/sampler/metrics.go
@@ -24,28 +24,33 @@ type metrics struct {
 	value      map[metricsKey]metricsValue
 }
 
-type metricsKey [3]string
+type metricsKey struct {
+	targetService    string
+	targetEnv        string
+	samplingPriority string
+}
 
 func newMetricsKey(service, env string, samplingPriority *SamplingPriority) metricsKey {
-	var key metricsKey
-	if service != "" {
-		key[0] = "target_service:" + service
-	}
-	if env != "" {
-		key[1] = "target_env:" + env
+	mk := metricsKey{
+		targetService: service,
+		targetEnv:     env,
 	}
 	if samplingPriority != nil {
-		key[2] = samplingPriority.tag()
+		mk.samplingPriority = samplingPriority.tagValue()
 	}
-	return key
+	return mk
 }
 
 func (k metricsKey) tags() []string {
-	tags := make([]string, 0, len(k))
-	for _, v := range k {
-		if v != "" {
-			tags = append(tags, v)
-		}
+	tags := make([]string, 0, 3) // Pre-allocate number of fields for efficiency
+	if k.targetService != "" {
+		tags = append(tags, "target_service:"+k.targetService)
+	}
+	if k.targetEnv != "" {
+		tags = append(tags, "target_env:"+k.targetEnv)
+	}
+	if k.samplingPriority != "" {
+		tags = append(tags, "sampling_priority:"+k.samplingPriority)
 	}
 	return tags
 }

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -10,13 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
+
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-go/v5/statsd"
 	mockStatsd "github.com/DataDog/datadog-go/v5/statsd/mocks"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 )
 
 func randomTraceID() uint64 {
@@ -89,7 +90,7 @@ func TestPrioritySample(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.priority.tag(), func(t *testing.T) {
+		t.Run(tt.priority.tagValue(), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			statsdClient := mockStatsd.NewMockClientInterface(ctrl)
@@ -107,7 +108,7 @@ func TestPrioritySample(t *testing.T) {
 			if tt.priority == PriorityNone {
 				expectedTagsA = append(expectedTagsA, "sampling_priority:auto_drop")
 			} else {
-				expectedTagsA = append(expectedTagsA, tt.priority.tag())
+				expectedTagsA = append(expectedTagsA, "sampling_priority:"+tt.priority.tagValue())
 			}
 			chunkA, rootA := getTestTraceWithService("service-a", s)
 			chunkA.Priority = int32(tt.priority)
@@ -121,7 +122,7 @@ func TestPrioritySample(t *testing.T) {
 			if tt.priority == PriorityNone {
 				expectedTagsB = append(expectedTagsB, "sampling_priority:auto_drop")
 			} else {
-				expectedTagsB = append(expectedTagsB, tt.priority.tag())
+				expectedTagsB = append(expectedTagsB, "sampling_priority:"+tt.priority.tagValue())
 			}
 			chunkB, rootB := getTestTraceWithService("service-b", s)
 			chunkB.Priority = int32(tt.priority)

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -68,21 +68,19 @@ const (
 	samplerHasher = uint64(1111111111111111111)
 )
 
-func (s SamplingPriority) tag() string {
-	var v string
+func (s SamplingPriority) tagValue() string {
 	switch s {
 	case PriorityUserDrop:
-		v = "manual_drop"
+		return "manual_drop"
 	case PriorityAutoDrop:
-		v = "auto_drop"
+		return "auto_drop"
 	case PriorityAutoKeep:
-		v = "auto_keep"
+		return "auto_keep"
 	case PriorityUserKeep:
-		v = "manual_keep"
+		return "manual_keep"
 	default:
-		v = "none"
+		return "none"
 	}
-	return "sampling_priority:" + v
 }
 
 // SampleByRate returns whether to keep a trace, based on its ID and a sampling rate.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Reduce the number of allocations associated with metrics emitted by the trace samplers.

### Motivation
In our nightly benchmarks I noticed a CPU + Allocations regression. Looking at the profiles at least some of that was due to increased GC pressure from allocations made from these new metrics tags.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This area is well covered by unit tests. I validated the performance changes using the trace-agent-testbed against the nightly build. Allocations are reduced 4% in the agent process function and the Sample function no longer appears in the flame chart thanks to the much reduced allocations.

### Possible Drawbacks / Trade-offs
Changes can always introduce bugs but this seems like a worthy change to me and to my eyes doesn't increase the complexity.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->