### PR TITLE
[CWS/CSPM] remove unneeded build tags from security agent

### DIFF
--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !windows && kubeapiserver
+//go:build !windows
 
 // Package check holds check related files
 package check
@@ -14,12 +14,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/dynamic"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
@@ -37,10 +34,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/k8sconfig"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
 	"github.com/DataDog/datadog-agent/pkg/security/utils/hostnameutils"
-	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
 // CliParams needs to be exported because the compliance subcommand is tightly coupled to this subcommand and tests need to be able to access this type.
@@ -140,20 +135,13 @@ func RunCheck(log log.Component, config config.Component, _ secrets.Component, s
 	var resolver compliance.Resolver
 	if checkArgs.overrideRegoInput != "" {
 		resolver = newFakeResolver(checkArgs.overrideRegoInput)
-	} else if flavor.GetFlavor() == flavor.ClusterAgent {
-		resolver = compliance.NewResolver(context.Background(), compliance.ResolverOptions{
-			Hostname:           hname,
-			DockerProvider:     compliance.DefaultDockerProvider,
-			LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
-			KubernetesProvider: complianceKubernetesProvider,
-			StatsdClient:       statsdClient,
-		})
 	} else {
 		resolver = compliance.NewResolver(context.Background(), compliance.ResolverOptions{
 			Hostname:           hname,
 			HostRoot:           os.Getenv("HOST_ROOT"),
 			DockerProvider:     compliance.DefaultDockerProvider,
 			LinuxAuditProvider: compliance.DefaultLinuxAuditProvider,
+			KubernetesProvider: complianceKubernetesProvider,
 			StatsdClient:       statsdClient,
 		})
 	}
@@ -259,16 +247,6 @@ func reportComplianceEvents(log log.Component, events []*compliance.CheckEvent, 
 		reporter.ReportEvent(event)
 	}
 	return nil
-}
-
-func complianceKubernetesProvider(_ctx context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
-	ctx, cancel := context.WithTimeout(_ctx, 2*time.Second)
-	defer cancel()
-	apiCl, err := apiserver.WaitForAPIClient(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	return apiCl.DynamicCl, apiCl.Cl.Discovery(), nil
 }
 
 type fakeResolver struct {

--- a/cmd/security-agent/subcommands/check/command_unsupported.go
+++ b/cmd/security-agent/subcommands/check/command_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build windows || !kubeapiserver
+//go:build windows
 
 // Package check holds check related files
 package check

--- a/cmd/security-agent/subcommands/check/resolver_cluster_agent.go
+++ b/cmd/security-agent/subcommands/check/resolver_cluster_agent.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows && kubeapiserver
+
+// Package check holds check related files
+package check
+
+import (
+	"context"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+)
+
+func complianceKubernetesProvider(_ctx context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
+	ctx, cancel := context.WithTimeout(_ctx, 2*time.Second)
+	defer cancel()
+	apiCl, err := apiserver.WaitForAPIClient(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return apiCl.DynamicCl, apiCl.Cl.Discovery(), nil
+}

--- a/cmd/security-agent/subcommands/check/resolver_security_agent.go
+++ b/cmd/security-agent/subcommands/check/resolver_security_agent.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows && !kubeapiserver
+
+// Package check holds check related files
+package check
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/compliance"
+)
+
+var complianceKubernetesProvider compliance.KubernetesProvider

--- a/cmd/security-agent/subcommands/compliance/command_test.go
+++ b/cmd/security-agent/subcommands/compliance/command_test.go
@@ -8,8 +8,10 @@
 package compliance
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"runtime"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 
 	"github.com/stretchr/testify/require"
 
@@ -45,7 +47,11 @@ func TestEventCommands(t *testing.T) {
 			subcommandNames = append(subcommandNames, subcommand.Use)
 		}
 
-		require.Equal(t, []string{"event", "load <conf-type>"}, subcommandNames, "subcommand missing")
+		if runtime.GOOS == "windows" {
+			require.Equal(t, []string{"event", "load <conf-type>"}, subcommandNames, "subcommand missing")
+		} else {
+			require.Equal(t, []string{"check", "event", "load <conf-type>"}, subcommandNames, "subcommand missing")
+		}
 
 		fxutil.TestOneShotSubcommand(t,
 			Commands(&command.GlobalParams{}),

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -151,8 +151,6 @@ SECURITY_AGENT_TAGS = {
     "netcgo",
     "datadog.no_waf",
     "docker",
-    "kubeapiserver",
-    "kubelet",
     "zlib",
     "zstd",
     "ec2",

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -151,8 +151,6 @@ SECURITY_AGENT_TAGS = {
     "netcgo",
     "datadog.no_waf",
     "docker",
-    "containerd",
-    "no_dynamic_plugins",
     "kubeapiserver",
     "kubelet",
     "zlib",

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -155,7 +155,6 @@ SECURITY_AGENT_TAGS = {
     "no_dynamic_plugins",
     "kubeapiserver",
     "kubelet",
-    "podman",
     "zlib",
     "zstd",
     "ec2",


### PR DESCRIPTION
### What does this PR do?

This PR removes some unneeded build tags from the security agent build. Especially only the docker build tag is needed from all the containers related build tags because of compliance's usage of `pkg/util/docker`. The k8s benchmarks are executed on data collected from processes and as such doesn't require any kubelet/kubeapiserver related build tags.

### Motivation

### Describe how you validated your changes

This code is tested by unit and e2e tests.
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->