### PR TITLE
Throw Error if Not admin

### DIFF
--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -193,12 +193,7 @@ try {
    $adminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
    if (-not $myWindowsPrincipal.IsInRole($adminRole)) {
       # We are not running "as Administrator"
-      $newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
-      $newProcess.Arguments = $myInvocation.MyCommand.Definition;
-      $newProcess.Verb = "runas";
-      $proc = [System.Diagnostics.Process]::Start($newProcess);
-      $proc.WaitForExit()
-      return $proc.ExitCode
+      throw "This script must be run with administrative privileges."
    }
 
    # First thing to do is to stop the services if they are started


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Changes Install Script to throw an error if not admin. 

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1138

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Tested manually with following steps:
- run script in non admin powershell, assert it fails with the not admin error
- Run script in admin powershell and assert that it runs without problem. 

### Possible Drawbacks / Trade-offs
Removes elevating to admin. Meaning users need to run in admin powershell. `runas` verb appears to not pass through environment variables. This leads to installing latest version of agent and potential not setting the `remote_updates`, and `api_key` settings. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->