### PR TITLE
[OTEL-2318] support config subcmd in otel-agent

### DIFF
--- a/cmd/otel-agent/command/command.go
+++ b/cmd/otel-agent/command/command.go
@@ -100,7 +100,7 @@ func newSettingsClient() (settings.Client, error) {
 	agentIPCHost := pkgconfigsetup.Datadog().GetString("agent_ipc.host")
 	agentIPCPort := pkgconfigsetup.Datadog().GetInt("agent_ipc.host")
 	// use the same url as configsync
-	apiConfigURL := fmt.Sprintf("https://%v:%v/config/v1",agentIPCHost, agentIPCPort)
+	apiConfigURL := fmt.Sprintf("https://%v:%v/config/v1", agentIPCHost, agentIPCPort)
 	return settingshttp.NewClient(c, apiConfigURL, "otel-agent", settingshttp.NewHTTPClientOptions(util.LeaveConnectionOpen)), nil
 }
 

--- a/test/new-e2e/tests/otel/otel-agent/minimal_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/minimal_test.go
@@ -92,3 +92,7 @@ func (s *minimalTestSuite) TestOTelFlareFiles() {
 func (s *minimalTestSuite) TestOTelRemoteConfigPayload() {
 	utils.TestOTelRemoteConfigPayload(s, minimalProvidedConfig, minimalFullConfig)
 }
+
+func (s *minimalTestSuite) TestConfigSubcommand() {
+	utils.TestConfigSubcommand(s)
+}

--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -237,8 +237,12 @@ func TestConfigSubcommand(s OTelTestSuite) {
 	timeout := time.Now().Add(5 * time.Minute)
 	for i := 1; time.Now().Before(timeout); i++ {
 		stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agent.Name, "otel-agent", []string{"otel-agent", "config"})
-		require.NoError(s.T(), err, "Failed to execute otel-agent config")
-		s.T().Logf("otel-agent config returns:\nstderr: %s\nstdout: %s\n", stderr, stdout)
-		time.Sleep(30 * time.Second)
+		if err != nil {
+			s.T().Logf("otel-agent config err %v", err)
+			time.Sleep(30 * time.Second)
+		} else {
+			s.T().Logf("otel-agent config returns:\nstderr: %s\nstdout: %s\n", stderr, stdout)
+			break
+		}
 	}
 }

--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -227,3 +227,18 @@ func validateConfigs(t *testing.T, expectedCfg string, actualCfg string) {
 
 	assert.YAMLEq(t, expectedCfg, actualCfg)
 }
+
+// TestConfigSubcommand tests config subcommand in otel-agent container
+func TestConfigSubcommand(s OTelTestSuite) {
+	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(s.T(), err)
+	agent := getAgentPod(s)
+
+	timeout := time.Now().Add(5 * time.Minute)
+	for i := 1; time.Now().Before(timeout); i++ {
+		stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agent.Name, "otel-agent", []string{"otel-agent", "config"})
+		require.NoError(s.T(), err, "Failed to execute otel-agent config")
+		s.T().Logf("otel-agent config returns:\nstderr: %s\nstdout: %s\n", stderr, stdout)
+		time.Sleep(30 * time.Second)
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Support `config` subcommand in otel-agent

### Motivation
Provides a way to get runtime agent config in otel-agent.

### Describe how you validated your changes
New otel e2e test