### PR TITLE
Migrate to `go.etcd.io/etcd/client/v3`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -2348,13 +2348,10 @@ core,go.etcd.io/etcd/api/v3/version,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/api/v3/versionpb,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/pkg/v3/fileutil,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/pkg/v3/logutil,Apache-2.0,Copyright 2016 The etcd Authors
-core,go.etcd.io/etcd/client/pkg/v3/pathutil,Apache-2.0,Copyright 2016 The etcd Authors
-core,go.etcd.io/etcd/client/pkg/v3/srv,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/pkg/v3/systemd,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/pkg/v3/tlsutil,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/pkg/v3/transport,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/pkg/v3/types,Apache-2.0,Copyright 2016 The etcd Authors
-core,go.etcd.io/etcd/client/v2,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/v3,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/v3/credentials,Apache-2.0,Copyright 2016 The etcd Authors
 core,go.etcd.io/etcd/client/v3/internal/endpoint,Apache-2.0,Copyright 2016 The etcd Authors

--- a/comp/core/autodiscovery/providers/etcd.go
+++ b/comp/core/autodiscovery/providers/etcd.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"go.etcd.io/etcd/client/v2"
+	"go.etcd.io/etcd/client/v3"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"

--- a/comp/core/autodiscovery/providers/etcd_test.go
+++ b/comp/core/autodiscovery/providers/etcd_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"go.etcd.io/etcd/client/v2"
+	"go.etcd.io/etcd/client/v3"
 )
 
 type etcdTest struct {

--- a/go.mod
+++ b/go.mod
@@ -297,7 +297,6 @@ require (
 	github.com/wI2L/jsondiff v0.6.1
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.etcd.io/bbolt v1.3.11
-	go.etcd.io/etcd/client/v2 v2.306.0-alpha.0
 	go.mongodb.org/mongo-driver v1.15.1
 	go.opentelemetry.io/collector v0.118.0 // indirect
 	go.opentelemetry.io/collector/component v0.118.0
@@ -526,7 +525,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4
 	go.etcd.io/etcd/api/v3 v3.6.0-alpha.0 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.0-alpha.0.0.20220522111935-c3bc4116dcd1 // indirect
-	go.etcd.io/etcd/client/v3 v3.6.0-alpha.0 // indirect
+	go.etcd.io/etcd/client/v3 v3.6.0-alpha.0
 	go.etcd.io/etcd/server/v3 v3.6.0-alpha.0.0.20220522111935-c3bc4116dcd1 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.24.0 // indirect

--- a/test/integration/config_providers/etcd/etcd_provider_test.go
+++ b/test/integration/config_providers/etcd/etcd_provider_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	etcd_client "go.etcd.io/etcd/client/v2"
+	etcd_client "go.etcd.io/etcd/client/v3"
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"


### PR DESCRIPTION
### What does this PR do?

Migrate from `go.etcd.io/etcd/client/v2` to `go.etcd.io/etcd/client/v3`.

### Motivation

`go.etcd.io/etcd/client/v3` was already indirectly used.
So, we can remove one dependency.

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
