### PR TITLE
Set Regression Detector warmup to 0 seconds

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -107,7 +107,7 @@ single-machine-performance-regression_detector:
     - |
       RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE} \
       job submit \
-      --warmup-seconds 0
+      --warmup-seconds 0 \
       --baseline-image ${BASELINE_IMAGE} \
       --comparison-image ${COMPARISON_IMAGE} \
       --baseline-sha ${BASELINE_SHA} \

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -107,6 +107,7 @@ single-machine-performance-regression_detector:
     - |
       RUST_LOG="${RUST_LOG}" ./smp --team-id ${SMP_AGENT_TEAM_ID} --api-base ${SMP_API} --aws-named-profile ${AWS_NAMED_PROFILE} \
       job submit \
+      --warmup-seconds 0
       --baseline-image ${BASELINE_IMAGE} \
       --comparison-image ${COMPARISON_IMAGE} \
       --baseline-sha ${BASELINE_SHA} \


### PR DESCRIPTION
### What does this PR do?

The Regression Detector allows for a period of time to be elided from
results at the start of a run, the "warmup period". We set this now to
0 to enforce performance norms from the outset of the experiment runs.

It is unclear if Quality Gate limits will need to be adjusted.

### Motivation

Mirror the experience of customers. Their clocks start at 0, ours should too.

