### PR TITLE
fix(installer): Synchronously terminate the installer experiment

### DIFF
--- a/pkg/fleet/installer/packages/embedded/datadog-installer-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-installer-exp.service
@@ -10,6 +10,7 @@ Type=oneshot
 PIDFile=/opt/datadog-packages/run/installer-exp.pid
 ExecStart=/opt/datadog-packages/datadog-installer/experiment/bin/installer/installer run -p /opt/datadog-packages/run/installer-exp.pid
 ExecStart=/bin/false
+ExecStop=/usr/bin/tail --pid $MAINPID -f /dev/null
 ExecStop=/bin/false
 
 [Install]


### PR DESCRIPTION
### What does this PR do?
The [systemd documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#Conflicts=) is very clear that the `Conflicts` keyword does not imply a start/stop ordering. The installer-exp & installer units are conflicting but there is no start/stop ordering, meaning that the exp can start while the main is starting or vice versa. 

As the RC DB can only have one writer at a time, this makes the unit that starts flakily exit; which we definitely don't want.
 
### Motivation

### Describe how you validated your changes
E2Es

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->