### PR TITLE
chore(apm): use origindetection Local Data resolution

### DIFF
--- a/comp/core/tagger/origindetection/origindetection.go
+++ b/comp/core/tagger/origindetection/origindetection.go
@@ -32,6 +32,8 @@ const (
 
 	// LocalDataContainerIDPrefix is the prefix used for the Container ID sent in the Local Data list.
 	LocalDataContainerIDPrefix = "ci-"
+	// LocalDataLegacyContainerIDPrefix is the Legacy prefix used by APM for the Container ID sent in the Local Data list.
+	LocalDataLegacyContainerIDPrefix = "cid-"
 	// LocalDataInodePrefix is the prefix used for the Inode sent in the Local Data list.
 	LocalDataInodePrefix = "in-"
 
@@ -107,13 +109,16 @@ func ParseLocalData(rawLocalData string) (LocalData, error) {
 			}
 		}
 	} else {
-		// The Local Data can contain a single value.
-		if strings.HasPrefix(rawLocalData, LocalDataContainerIDPrefix) {
+		switch {
+		case strings.HasPrefix(rawLocalData, LocalDataContainerIDPrefix):
 			localData.ContainerID = rawLocalData[len(LocalDataContainerIDPrefix):]
-		} else if strings.HasPrefix(rawLocalData, LocalDataInodePrefix) {
+		case strings.HasPrefix(rawLocalData, LocalDataInodePrefix):
 			localData.Inode, parsingError = strconv.ParseUint(rawLocalData[len(LocalDataInodePrefix):], 10, 64)
-		} else {
-			// Container ID with old format: <container-id>
+		case strings.HasPrefix(rawLocalData, LocalDataLegacyContainerIDPrefix):
+			// Container ID with old APM format: cid:<container-id>. Kept for backward compatibility.
+			localData.ContainerID = rawLocalData[len(LocalDataLegacyContainerIDPrefix):]
+		default:
+			// Container ID with old DogStatsD format: <container-id>. Kept for backward compatibility.
 			localData.ContainerID = rawLocalData
 		}
 	}

--- a/comp/core/tagger/origindetection/origindetection_test.go
+++ b/comp/core/tagger/origindetection/origindetection_test.go
@@ -44,13 +44,25 @@ func TestParseLocalData(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			name:         "Multiple values in reverse order",
+			rawLocalData: "in-12345,ci-abc123",
+			expected:     LocalData{ContainerID: "abc123", Inode: 12345},
+			expectError:  false,
+		},
+		{
 			name:         "Invalid inode",
 			rawLocalData: "in-invalid",
 			expected:     LocalData{},
 			expectError:  true,
 		},
 		{
-			name:         "Old container format",
+			name:         "Old APM container format",
+			rawLocalData: "cid-abc123",
+			expected:     LocalData{ContainerID: "abc123"},
+			expectError:  false,
+		},
+		{
+			name:         "Old DogStatsD container format",
 			rawLocalData: "abc123",
 			expected:     LocalData{ContainerID: "abc123"},
 			expectError:  false,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Migrate the Local Data resolution for APM to the `origindetection` module.

### Motivation

This is done to ensure consistency in Origin Detection behavior across Datadog Products.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by unit and E2E tests but I also checked manually
* With a modified library that only send Local Data:
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/7f7c923a-9af6-433f-9bff-860baf18acb4" />

* With a modified library that only send External Data:
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/33f24b7d-2d3a-43a4-925c-7282f9773bbe" />

### Possible Drawbacks / Trade-offs

None.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A