### PR TITLE
[CWS] pass the missing logs compression component to the direct sender

### DIFF
--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -19,6 +19,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -64,7 +65,7 @@ func withModule(name sysconfigtypes.ModuleName, fn func()) {
 // * Initialization using the provided Factory;
 // * Registering the HTTP endpoints of each module;
 // * Register the gRPC server;
-func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []Factory, wmeta workloadmeta.Component, tagger tagger.Component, telemetry telemetry.Component) error {
+func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []Factory, wmeta workloadmeta.Component, tagger tagger.Component, telemetry telemetry.Component, compression logscompression.Component) error {
 	var enabledModulesFactories []Factory
 	for _, factory := range factories {
 		if !cfg.ModuleIsEnabled(factory.Name) {
@@ -83,9 +84,10 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []Facto
 		var module Module
 		withModule(factory.Name, func() {
 			deps := FactoryDependencies{
-				WMeta:     wmeta,
-				Tagger:    tagger,
-				Telemetry: telemetry,
+				WMeta:       wmeta,
+				Tagger:      tagger,
+				Telemetry:   telemetry,
+				Compression: compression,
 			}
 			module, err = factory.Fn(cfg, deps)
 		})

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -25,12 +25,13 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // StartServer starts the HTTP and gRPC servers for the system-probe, which registers endpoints from all enabled modules.
-func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmeta workloadmeta.Component, tagger tagger.Component, settings settings.Component) error {
+func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmeta workloadmeta.Component, tagger tagger.Component, settings settings.Component, compression logscompression.Component) error {
 	conn, err := server.NewListener(cfg.SocketAddress)
 	if err != nil {
 		return err
@@ -38,7 +39,7 @@ func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmet
 
 	mux := gorilla.NewRouter()
 
-	err = module.Register(cfg, mux, modules.All, wmeta, tagger, telemetry)
+	err = module.Register(cfg, mux, modules.All, wmeta, tagger, telemetry, compression)
 	if err != nil {
 		return fmt.Errorf("failed to create system probe: %s", err)
 	}

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -92,7 +92,7 @@ func setupDiscoveryModule(t *testing.T) (string, *proccontainersmocks.MockContai
 			return false
 		},
 	}
-	err := module.Register(cfg, mux, []module.Factory{m}, wmeta, tagger, nil)
+	err := module.Register(cfg, mux, []module.Factory{m}, wmeta, tagger, nil, nil)
 	require.NoError(t, err)
 
 	srv := httptest.NewServer(mux)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

In direct sender mode, we found the following stack trace
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x260f1d4]
goroutine 1 [running]:
[github.com/DataDog/datadog-agent/pkg/logs/pipeline.getStrategy(0xc000b42690](http://github.com/DataDog/datadog-agent/pkg/logs/pipeline.getStrategy(0xc000b42690), 0xc000b42700, 0xc001315dc0, 0xc0040d5e60, 0x0, 0x0, {0x6805ad8, 0xc0042836e0}, {0x0, 0x0})
	/home/spi/dd/datadog-agent2/pkg/logs/pipeline/pipeline.go:175 +0x74
[github.com/DataDog/datadog-agent/pkg/logs/pipeline.NewPipeline(0xc001315ab0](http://github.com/DataDog/datadog-agent/pkg/logs/pipeline.NewPipeline(0xc001315ab0), {0x0, 0x0, 0x0}, 0xc0040d5e60, 0xc0040f8460, {0x67e04c0, 0x8af4b00}, 0x0, 0x0, ...)
	/home/spi/dd/datadog-agent2/pkg/logs/pipeline/pipeline.go:84 +0x2d2
[github.com/DataDog/datadog-agent/pkg/logs/pipeline.(*provider).Start(0xc003ff26c0)](http://github.com/DataDog/datadog-agent/pkg/logs/pipeline.(*provider).Start(0xc003ff26c0))
	/home/spi/dd/datadog-agent2/pkg/logs/pipeline/provider.go:135 +0x168
[github.com/DataDog/datadog-agent/pkg/security/reporter.newReporter({0x0](http://github.com/DataDog/datadog-agent/pkg/security/reporter.newReporter(%7B0x0), 0x0}, {0x67ee678, 0xc000c24618}, {0x3345ba2, 0x16}, {0x332a679, 0x10}, 0xc0040d5e60, 0xc0040f8460, ...)
	/home/spi/dd/datadog-agent2/pkg/security/reporter/reporter.go:57 +0x2e5
[github.com/DataDog/datadog-agent/pkg/security/reporter.NewCWSReporter(...)](http://github.com/DataDog/datadog-agent/pkg/security/reporter.NewCWSReporter(...))
	/home/spi/dd/datadog-agent2/pkg/security/reporter/reporter.go:46
[github.com/DataDog/datadog-agent/pkg/security/module.NewDirectMsgSender({0x67ee678](http://github.com/DataDog/datadog-agent/pkg/security/module.NewDirectMsgSender(%7B0x67ee678), 0xc000c24618}, {0x0, 0x0})
	/home/spi/dd/datadog-agent2/pkg/security/module/msg_sender.go:90 +0x1e7
[github.com/DataDog/datadog-agent/pkg/security/module.NewAPIServer(0xc00037a008](http://github.com/DataDog/datadog-agent/pkg/security/module.NewAPIServer(0xc00037a008), 0xc000861908, {0x0, 0x0}, {0x682a8b0, 0xc000246380}, 0xc0029a6630, {0x0, 0x0})
	/home/spi/dd/datadog-agent2/pkg/security/module/server.go:597 +0x2a7
[github.com/DataDog/datadog-agent/pkg/security/module.NewCWSConsumer(0xc00075f050](http://github.com/DataDog/datadog-agent/pkg/security/module.NewCWSConsumer(0xc00075f050), 0xc00037a008, {0x6834280, 0xc0002fbc30}, {{0x0?, 0x0?}, {0x0?, 0x0?}}, {0x0, 0x0})
	/home/spi/dd/datadog-agent2/pkg/security/module/cws.go:88 +0x2dc
[github.com/DataDog/datadog-agent/cmd/system-probe/modules.createEventMonitorModule(0x434bcb](http://github.com/DataDog/datadog-agent/cmd/system-probe/modules.createEventMonitorModule(0x434bcb)?, {{{}}, {0x6834280, 0xc0002fbc30}, {0x682c778, 0xc00051e540}, {0x6828540, 0xc000c25a70}, {0x0, 0x0}})
	/home/spi/dd/datadog-agent2/cmd/system-probe/modules/eventmonitor.go:56 +0x2ab
[github.com/DataDog/datadog-agent/cmd/system-probe/api/module.Register.func1()](http://github.com/DataDog/datadog-agent/cmd/system-probe/api/module.Register.func1())
	/home/spi/dd/datadog-agent2/cmd/system-probe/api/module/loader.go:90 +0xab
[github.com/DataDog/datadog-agent/cmd/system-probe/api/module.withModule.func1({0x6802a58](http://github.com/DataDog/datadog-agent/cmd/system-probe/api/module.withModule.func1(%7B0x6802a58)?, 0xc0009cf2f0?})
	/home/spi/dd/datadog-agent2/cmd/system-probe/api/module/loader.go:59 +0x13
runtime/pprof.Do({0x68027f0?, 0x8af4b00?}, {{0xc0010e28a0?, 0x8584300?, 0x32faa28?}}, 0xc0014068e0)
	/home/spi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.linux-amd64/src/runtime/pprof/runtime.go:51 +0x8c
[github.com/DataDog/datadog-agent/cmd/system-probe/api/module.withModule({0x331bf73](http://github.com/DataDog/datadog-agent/cmd/system-probe/api/module.withModule(%7B0x331bf73)?, 0xc000bf8f40?}, 0xc001406a88)
	/home/spi/dd/datadog-agent2/cmd/system-probe/api/module/loader.go:58 +0x1a8
[github.com/DataDog/datadog-agent/cmd/system-probe/api/module.Register(0xc0005b1480](http://github.com/DataDog/datadog-agent/cmd/system-probe/api/module.Register(0xc0005b1480), 0xc00085cb40, {0x8298980?, 0xc000bf22c8?, 0x27b9592?}, {0x6834280, 0xc0002fbc30}, {0x682c778, 0xc00051e540}, {0x6828540, ...})
	/home/spi/dd/datadog-agent2/cmd/system-probe/api/module/loader.go:84 +0x512
[github.com/DataDog/datadog-agent/cmd/system-probe/api.StartServer(0xc0005b1480](http://github.com/DataDog/datadog-agent/cmd/system-probe/api.StartServer(0xc0005b1480), {0x6828540, 0xc000c25a70}, {0x6834280, 0xc0002fbc30}, {0x682c778, 0xc00051e540}, {0x6816fb8, 0xc0007f5f40})
	/home/spi/dd/datadog-agent2/cmd/system-probe/api/server.go:41 +0x16f
[github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run.startSystemProbe({0x6821580](http://github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run.startSystemProbe(%7B0x6821580), 0xc0001334d8}, {0x6802e10, 0xc000c25a28}, {0x6828540, 0xc000c25a70}, {0x683f6c0, 0xc000a42000}, {0x67eb930, 0xc0008374d0}, ...)
	/home/spi/dd/datadog-agent2/cmd/system-probe/subcommands/run/command.go:383 +0x6a5
[github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run.run({0x6821580](http://github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run.run(%7B0x6821580), 0xc0001334d8}, {0xc000cae780?, 0xc001406f28?}, {0x6802e10, 0xc000c25a28}, {0x6828540, 0xc000c25a70}, {0x683f6c0, 0xc000a42000}, ...)
	/home/spi/dd/datadog-agent2/cmd/system-probe/subcommands/run/command.go:197 +0x2d5
reflect.Value.call({0x2f865a0?, 0x647e3c0?, 0xc0014074d0?}, {0x32f8b29, 0x4}, {0xc0010a5d40, 0xc, 0x67d7240?})
	/home/spi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.linux-amd64/src/reflect/value.go:581 +0xca6
reflect.Value.Call({0x2f865a0?, 0x647e3c0?, 0x8af4b00?}, {0xc0010a5d40?, 0x0?, 0x8c1b60?})
	/home/spi/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.5.linux-amd64/src/reflect/value.go:365 +0xb9
[github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call(0xc000000180?)](http://github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call(0xc000000180?))
	/home/spi/dd/datadog-agent2/pkg/util/fxutil/args.go:72 +0x8e
[github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot({0x2f865a0](http://github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot(%7B0x2f865a0)?, 0x647e3c0?}, {0xc0004934a0, 0x15, 0x15})
	/home/spi/dd/datadog-agent2/pkg/util/fxutil/oneshot.go:54 +0x305
[github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run.Commands.func1(0xc0006b2400](http://github.com/DataDog/datadog-agent/cmd/system-probe/subcommands/run.Commands.func1(0xc0006b2400)?, {0x32f89b1?, 0x4?, 0x32f8a9d?})
	/home/spi/dd/datadog-agent2/cmd/system-probe/subcommands/run/command.go:94 +0x1018
[github.com/spf13/cobra.(*Command).execute(0xc000313508](http://github.com/spf13/cobra.(*Command).execute(0xc000313508), {0x8af4b00, 0x0, 0x0})
	/home/spi/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:985 +0xaaa
[github.com/spf13/cobra.(*Command).ExecuteC(0xc000313208)](http://github.com/spf13/cobra.(*Command).ExecuteC(0xc000313208))
	/home/spi/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
[github.com/spf13/cobra.(*Command).Execute(...)](http://github.com/spf13/cobra.(*Command).Execute(...))
	/home/spi/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
[github.com/DataDog/datadog-agent/cmd/internal/runcmd.Run(0xc000313208)](http://github.com/DataDog/datadog-agent/cmd/internal/runcmd.Run(0xc000313208))
	/home/spi/dd/datadog-agent2/cmd/internal/runcmd/runcmd.go:26 +0x25
main.main()
	/home/spi/dd/datadog-agent2/cmd/system-probe/main.go:22 +0x85
```
caused by a nil compressor component. This was caused by https://github.com/DataDog/datadog-agent/pull/27148 that added the need for this component when talking with logs, but the compressor component was not passed down to the CWS consumer.

This PR fixes this.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->