### PR TITLE
[GPU] removed redundant internal telemetry counter

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -77,12 +77,11 @@ func newCheck(tagger tagger.Component, telemetry telemetry.Component) check.Chec
 }
 
 func newCheckTelemetry(tm telemetry.Component) *checkTelemetry {
-	subsystem := CheckName
 	return &checkTelemetry{
-		nvmlMetricsSent:     tm.NewCounter(subsystem, "nvml_metrics_sent", []string{"collector"}, "Number of NVML metrics sent"),
-		collectorErrors:     tm.NewCounter(subsystem, "collector_errors", []string{"collector"}, "Number of errors from NVML collectors"),
-		activeMetrics:       tm.NewGauge(subsystem, "active_metrics", nil, "Number of active metrics"),
-		sysprobeMetricsSent: tm.NewCounter(subsystem, "sysprobe_metrics_sent", nil, "Number of metrics sent based on system probe data"),
+		nvmlMetricsSent:     tm.NewCounter(CheckName, "nvml_metrics_sent", []string{"collector"}, "Number of NVML metrics sent"),
+		collectorErrors:     tm.NewCounter(CheckName, "collector_errors", []string{"collector"}, "Number of errors from NVML collectors"),
+		activeMetrics:       tm.NewGauge(CheckName, "active_metrics", nil, "Number of active metrics"),
+		sysprobeMetricsSent: tm.NewCounter(CheckName, "sysprobe_metrics_sent", nil, "Number of metrics sent based on system probe data"),
 	}
 }
 

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -81,7 +81,6 @@ func newCheckTelemetry(tm telemetry.Component) *checkTelemetry {
 	return &checkTelemetry{
 		nvmlMetricsSent:     tm.NewCounter(subsystem, "nvml_metrics_sent", []string{"collector"}, "Number of NVML metrics sent"),
 		collectorErrors:     tm.NewCounter(subsystem, "collector_errors", []string{"collector"}, "Number of errors from NVML collectors"),
-		sysprobeChecks:      tm.NewCounter(subsystem, "sysprobe_checks", []string{"status"}, "Number of sysprobe checks, by status"),
 		activeMetrics:       tm.NewGauge(subsystem, "active_metrics", nil, "Number of active metrics"),
 		sysprobeMetricsSent: tm.NewCounter(subsystem, "sysprobe_metrics_sent", nil, "Number of metrics sent based on system probe data"),
 	}
@@ -148,10 +147,8 @@ func (c *Check) Run() error {
 func (c *Check) emitSysprobeMetrics(snd sender.Sender) error {
 	stats, err := sysprobeclient.GetCheck[model.GPUStats](c.sysProbeClient, sysconfig.GPUMonitoringModule)
 	if err != nil {
-		c.telemetry.sysprobeChecks.Add(1, "error")
 		return fmt.Errorf("cannot get data from system-probe: %w", err)
 	}
-	c.telemetry.sysprobeChecks.Add(1, "success")
 
 	// Set all metrics to inactive, so we can remove the ones that we don't see
 	// and send the final metrics

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -54,7 +54,6 @@ type Check struct {
 type checkTelemetry struct {
 	nvmlMetricsSent     telemetry.Counter
 	collectorErrors     telemetry.Counter
-	sysprobeChecks      telemetry.Counter
 	activeMetrics       telemetry.Gauge
 	sysprobeMetricsSent telemetry.Counter
 }


### PR DESCRIPTION
### What does this PR do?

removed the counter to measure failures and success of  running system-probe check.

### Motivation

This is redundant due to newly introduced internal telemetry counters in systemprobe remote client
[PR](https://github.com/DataDog/datadog-agent/pull/33308)

### Describe how you validated your changes
All existing tests should pass
### Possible Drawbacks / Trade-offs

### Additional Notes