### PR TITLE
cleanup deprecation warnings in mockery config

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -3,6 +3,7 @@ dir: "{{.InterfaceDir}}/mocks"
 outpkg: "mocks"
 mockname: "{{.InterfaceName}}"
 filename: "{{.InterfaceNameSnake}}.go"
+issue-845-fix: true
 
 packages:
   # security agent

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,4 +1,4 @@
-with-expecter: false
+with-expecter: true
 dir: "{{.InterfaceDir}}/mocks"
 outpkg: "mocks"
 mockname: "{{.InterfaceName}}"

--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -4,6 +4,7 @@ outpkg: "mocks"
 mockname: "{{.InterfaceName}}"
 filename: "{{.InterfaceNameSnake}}.go"
 issue-845-fix: true
+resolve-type-alias: false
 
 packages:
   # security agent

--- a/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_client.go
+++ b/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_client.go
@@ -89,12 +89,12 @@ func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) Run(run func(ctx co
 	return _c
 }
 
-func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) Return(_a0 api.EventMonitoringModule_GetProcessEventsClient, _a1 error) *EventMonitoringModuleClient_GetProcessEvents_Call {
+func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) Return(_a0 grpc.ServerStreamingClient[api.ProcessEventMessage], _a1 error) *EventMonitoringModuleClient_GetProcessEvents_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) RunAndReturn(run func(context.Context, *api.GetProcessEventParams, ...grpc.CallOption) (api.EventMonitoringModule_GetProcessEventsClient, error)) *EventMonitoringModuleClient_GetProcessEvents_Call {
+func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) RunAndReturn(run func(context.Context, *api.GetProcessEventParams, ...grpc.CallOption) (grpc.ServerStreamingClient[api.ProcessEventMessage], error)) *EventMonitoringModuleClient_GetProcessEvents_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_client.go
+++ b/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_client.go
@@ -17,6 +17,14 @@ type EventMonitoringModuleClient struct {
 	mock.Mock
 }
 
+type EventMonitoringModuleClient_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *EventMonitoringModuleClient) EXPECT() *EventMonitoringModuleClient_Expecter {
+	return &EventMonitoringModuleClient_Expecter{mock: &_m.Mock}
+}
+
 // GetProcessEvents provides a mock function with given fields: ctx, in, opts
 func (_m *EventMonitoringModuleClient) GetProcessEvents(ctx context.Context, in *api.GetProcessEventParams, opts ...grpc.CallOption) (grpc.ServerStreamingClient[api.ProcessEventMessage], error) {
 	_va := make([]interface{}, len(opts))
@@ -52,6 +60,43 @@ func (_m *EventMonitoringModuleClient) GetProcessEvents(ctx context.Context, in 
 	}
 
 	return r0, r1
+}
+
+// EventMonitoringModuleClient_GetProcessEvents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetProcessEvents'
+type EventMonitoringModuleClient_GetProcessEvents_Call struct {
+	*mock.Call
+}
+
+// GetProcessEvents is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.GetProcessEventParams
+//   - opts ...grpc.CallOption
+func (_e *EventMonitoringModuleClient_Expecter) GetProcessEvents(ctx interface{}, in interface{}, opts ...interface{}) *EventMonitoringModuleClient_GetProcessEvents_Call {
+	return &EventMonitoringModuleClient_GetProcessEvents_Call{Call: _e.mock.On("GetProcessEvents",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) Run(run func(ctx context.Context, in *api.GetProcessEventParams, opts ...grpc.CallOption)) *EventMonitoringModuleClient_GetProcessEvents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.GetProcessEventParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) Return(_a0 api.EventMonitoringModule_GetProcessEventsClient, _a1 error) *EventMonitoringModuleClient_GetProcessEvents_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *EventMonitoringModuleClient_GetProcessEvents_Call) RunAndReturn(run func(context.Context, *api.GetProcessEventParams, ...grpc.CallOption) (api.EventMonitoringModule_GetProcessEventsClient, error)) *EventMonitoringModuleClient_GetProcessEvents_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewEventMonitoringModuleClient creates a new instance of EventMonitoringModuleClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_get_process_events_client.go
+++ b/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_get_process_events_client.go
@@ -17,6 +17,14 @@ type EventMonitoringModule_GetProcessEventsClient struct {
 	mock.Mock
 }
 
+type EventMonitoringModule_GetProcessEventsClient_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *EventMonitoringModule_GetProcessEventsClient) EXPECT() *EventMonitoringModule_GetProcessEventsClient_Expecter {
+	return &EventMonitoringModule_GetProcessEventsClient_Expecter{mock: &_m.Mock}
+}
+
 // CloseSend provides a mock function with no fields
 func (_m *EventMonitoringModule_GetProcessEventsClient) CloseSend() error {
 	ret := _m.Called()
@@ -33,6 +41,33 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) CloseSend() error {
 	}
 
 	return r0
+}
+
+// EventMonitoringModule_GetProcessEventsClient_CloseSend_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CloseSend'
+type EventMonitoringModule_GetProcessEventsClient_CloseSend_Call struct {
+	*mock.Call
+}
+
+// CloseSend is a helper method to define mock.On call
+func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) CloseSend() *EventMonitoringModule_GetProcessEventsClient_CloseSend_Call {
+	return &EventMonitoringModule_GetProcessEventsClient_CloseSend_Call{Call: _e.mock.On("CloseSend")}
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_CloseSend_Call) Run(run func()) *EventMonitoringModule_GetProcessEventsClient_CloseSend_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_CloseSend_Call) Return(_a0 error) *EventMonitoringModule_GetProcessEventsClient_CloseSend_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_CloseSend_Call) RunAndReturn(run func() error) *EventMonitoringModule_GetProcessEventsClient_CloseSend_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Context provides a mock function with no fields
@@ -53,6 +88,33 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) Context() context.Contex
 	}
 
 	return r0
+}
+
+// EventMonitoringModule_GetProcessEventsClient_Context_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Context'
+type EventMonitoringModule_GetProcessEventsClient_Context_Call struct {
+	*mock.Call
+}
+
+// Context is a helper method to define mock.On call
+func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) Context() *EventMonitoringModule_GetProcessEventsClient_Context_Call {
+	return &EventMonitoringModule_GetProcessEventsClient_Context_Call{Call: _e.mock.On("Context")}
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Context_Call) Run(run func()) *EventMonitoringModule_GetProcessEventsClient_Context_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Context_Call) Return(_a0 context.Context) *EventMonitoringModule_GetProcessEventsClient_Context_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Context_Call) RunAndReturn(run func() context.Context) *EventMonitoringModule_GetProcessEventsClient_Context_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Header provides a mock function with no fields
@@ -85,6 +147,33 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) Header() (metadata.MD, e
 	return r0, r1
 }
 
+// EventMonitoringModule_GetProcessEventsClient_Header_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Header'
+type EventMonitoringModule_GetProcessEventsClient_Header_Call struct {
+	*mock.Call
+}
+
+// Header is a helper method to define mock.On call
+func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) Header() *EventMonitoringModule_GetProcessEventsClient_Header_Call {
+	return &EventMonitoringModule_GetProcessEventsClient_Header_Call{Call: _e.mock.On("Header")}
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Header_Call) Run(run func()) *EventMonitoringModule_GetProcessEventsClient_Header_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Header_Call) Return(_a0 metadata.MD, _a1 error) *EventMonitoringModule_GetProcessEventsClient_Header_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Header_Call) RunAndReturn(run func() (metadata.MD, error)) *EventMonitoringModule_GetProcessEventsClient_Header_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Recv provides a mock function with no fields
 func (_m *EventMonitoringModule_GetProcessEventsClient) Recv() (*api.ProcessEventMessage, error) {
 	ret := _m.Called()
@@ -115,6 +204,33 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) Recv() (*api.ProcessEven
 	return r0, r1
 }
 
+// EventMonitoringModule_GetProcessEventsClient_Recv_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Recv'
+type EventMonitoringModule_GetProcessEventsClient_Recv_Call struct {
+	*mock.Call
+}
+
+// Recv is a helper method to define mock.On call
+func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) Recv() *EventMonitoringModule_GetProcessEventsClient_Recv_Call {
+	return &EventMonitoringModule_GetProcessEventsClient_Recv_Call{Call: _e.mock.On("Recv")}
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Recv_Call) Run(run func()) *EventMonitoringModule_GetProcessEventsClient_Recv_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Recv_Call) Return(_a0 *api.ProcessEventMessage, _a1 error) *EventMonitoringModule_GetProcessEventsClient_Recv_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Recv_Call) RunAndReturn(run func() (*api.ProcessEventMessage, error)) *EventMonitoringModule_GetProcessEventsClient_Recv_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RecvMsg provides a mock function with given fields: m
 func (_m *EventMonitoringModule_GetProcessEventsClient) RecvMsg(m interface{}) error {
 	ret := _m.Called(m)
@@ -131,6 +247,34 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) RecvMsg(m interface{}) e
 	}
 
 	return r0
+}
+
+// EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RecvMsg'
+type EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call struct {
+	*mock.Call
+}
+
+// RecvMsg is a helper method to define mock.On call
+//   - m interface{}
+func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) RecvMsg(m interface{}) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
+	return &EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call{Call: _e.mock.On("RecvMsg", m)}
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) Run(run func(m interface{})) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(interface{}))
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) Return(_a0 error) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) RunAndReturn(run func(interface{}) error) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SendMsg provides a mock function with given fields: m
@@ -151,6 +295,34 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) SendMsg(m interface{}) e
 	return r0
 }
 
+// EventMonitoringModule_GetProcessEventsClient_SendMsg_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendMsg'
+type EventMonitoringModule_GetProcessEventsClient_SendMsg_Call struct {
+	*mock.Call
+}
+
+// SendMsg is a helper method to define mock.On call
+//   - m interface{}
+func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) SendMsg(m interface{}) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
+	return &EventMonitoringModule_GetProcessEventsClient_SendMsg_Call{Call: _e.mock.On("SendMsg", m)}
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) Run(run func(m interface{})) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(interface{}))
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) Return(_a0 error) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) RunAndReturn(run func(interface{}) error) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Trailer provides a mock function with no fields
 func (_m *EventMonitoringModule_GetProcessEventsClient) Trailer() metadata.MD {
 	ret := _m.Called()
@@ -169,6 +341,33 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) Trailer() metadata.MD {
 	}
 
 	return r0
+}
+
+// EventMonitoringModule_GetProcessEventsClient_Trailer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Trailer'
+type EventMonitoringModule_GetProcessEventsClient_Trailer_Call struct {
+	*mock.Call
+}
+
+// Trailer is a helper method to define mock.On call
+func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) Trailer() *EventMonitoringModule_GetProcessEventsClient_Trailer_Call {
+	return &EventMonitoringModule_GetProcessEventsClient_Trailer_Call{Call: _e.mock.On("Trailer")}
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Trailer_Call) Run(run func()) *EventMonitoringModule_GetProcessEventsClient_Trailer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Trailer_Call) Return(_a0 metadata.MD) *EventMonitoringModule_GetProcessEventsClient_Trailer_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventMonitoringModule_GetProcessEventsClient_Trailer_Call) RunAndReturn(run func() metadata.MD) *EventMonitoringModule_GetProcessEventsClient_Trailer_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewEventMonitoringModule_GetProcessEventsClient creates a new instance of EventMonitoringModule_GetProcessEventsClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_get_process_events_client.go
+++ b/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_get_process_events_client.go
@@ -232,7 +232,7 @@ func (_c *EventMonitoringModule_GetProcessEventsClient_Recv_Call) RunAndReturn(r
 }
 
 // RecvMsg provides a mock function with given fields: m
-func (_m *EventMonitoringModule_GetProcessEventsClient) RecvMsg(m interface{}) error {
+func (_m *EventMonitoringModule_GetProcessEventsClient) RecvMsg(m any) error {
 	ret := _m.Called(m)
 
 	if len(ret) == 0 {
@@ -240,7 +240,7 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) RecvMsg(m interface{}) e
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(interface{}) error); ok {
+	if rf, ok := ret.Get(0).(func(any) error); ok {
 		r0 = rf(m)
 	} else {
 		r0 = ret.Error(0)
@@ -255,14 +255,14 @@ type EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call struct {
 }
 
 // RecvMsg is a helper method to define mock.On call
-//   - m interface{}
+//   - m any
 func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) RecvMsg(m interface{}) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
 	return &EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call{Call: _e.mock.On("RecvMsg", m)}
 }
 
-func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) Run(run func(m interface{})) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
+func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) Run(run func(m any)) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(interface{}))
+		run(args[0].(any))
 	})
 	return _c
 }
@@ -272,13 +272,13 @@ func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) Return(_a0 
 	return _c
 }
 
-func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) RunAndReturn(run func(interface{}) error) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
+func (_c *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call) RunAndReturn(run func(any) error) *EventMonitoringModule_GetProcessEventsClient_RecvMsg_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // SendMsg provides a mock function with given fields: m
-func (_m *EventMonitoringModule_GetProcessEventsClient) SendMsg(m interface{}) error {
+func (_m *EventMonitoringModule_GetProcessEventsClient) SendMsg(m any) error {
 	ret := _m.Called(m)
 
 	if len(ret) == 0 {
@@ -286,7 +286,7 @@ func (_m *EventMonitoringModule_GetProcessEventsClient) SendMsg(m interface{}) e
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(interface{}) error); ok {
+	if rf, ok := ret.Get(0).(func(any) error); ok {
 		r0 = rf(m)
 	} else {
 		r0 = ret.Error(0)
@@ -301,14 +301,14 @@ type EventMonitoringModule_GetProcessEventsClient_SendMsg_Call struct {
 }
 
 // SendMsg is a helper method to define mock.On call
-//   - m interface{}
+//   - m any
 func (_e *EventMonitoringModule_GetProcessEventsClient_Expecter) SendMsg(m interface{}) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
 	return &EventMonitoringModule_GetProcessEventsClient_SendMsg_Call{Call: _e.mock.On("SendMsg", m)}
 }
 
-func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) Run(run func(m interface{})) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
+func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) Run(run func(m any)) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(interface{}))
+		run(args[0].(any))
 	})
 	return _c
 }
@@ -318,7 +318,7 @@ func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) Return(_a0 
 	return _c
 }
 
-func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) RunAndReturn(run func(interface{}) error) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
+func (_c *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call) RunAndReturn(run func(any) error) *EventMonitoringModule_GetProcessEventsClient_SendMsg_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_server.go
+++ b/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_server.go
@@ -14,6 +14,14 @@ type EventMonitoringModuleServer struct {
 	mock.Mock
 }
 
+type EventMonitoringModuleServer_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *EventMonitoringModuleServer) EXPECT() *EventMonitoringModuleServer_Expecter {
+	return &EventMonitoringModuleServer_Expecter{mock: &_m.Mock}
+}
+
 // GetProcessEvents provides a mock function with given fields: _a0, _a1
 func (_m *EventMonitoringModuleServer) GetProcessEvents(_a0 *api.GetProcessEventParams, _a1 grpc.ServerStreamingServer[api.ProcessEventMessage]) error {
 	ret := _m.Called(_a0, _a1)
@@ -32,9 +40,65 @@ func (_m *EventMonitoringModuleServer) GetProcessEvents(_a0 *api.GetProcessEvent
 	return r0
 }
 
+// EventMonitoringModuleServer_GetProcessEvents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetProcessEvents'
+type EventMonitoringModuleServer_GetProcessEvents_Call struct {
+	*mock.Call
+}
+
+// GetProcessEvents is a helper method to define mock.On call
+//   - _a0 *api.GetProcessEventParams
+//   - _a1 api.EventMonitoringModule_GetProcessEventsServer
+func (_e *EventMonitoringModuleServer_Expecter) GetProcessEvents(_a0 interface{}, _a1 interface{}) *EventMonitoringModuleServer_GetProcessEvents_Call {
+	return &EventMonitoringModuleServer_GetProcessEvents_Call{Call: _e.mock.On("GetProcessEvents", _a0, _a1)}
+}
+
+func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) Run(run func(_a0 *api.GetProcessEventParams, _a1 api.EventMonitoringModule_GetProcessEventsServer)) *EventMonitoringModuleServer_GetProcessEvents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*api.GetProcessEventParams), args[1].(api.EventMonitoringModule_GetProcessEventsServer))
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) Return(_a0 error) *EventMonitoringModuleServer_GetProcessEvents_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) RunAndReturn(run func(*api.GetProcessEventParams, api.EventMonitoringModule_GetProcessEventsServer) error) *EventMonitoringModuleServer_GetProcessEvents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // mustEmbedUnimplementedEventMonitoringModuleServer provides a mock function with no fields
 func (_m *EventMonitoringModuleServer) mustEmbedUnimplementedEventMonitoringModuleServer() {
 	_m.Called()
+}
+
+// EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'mustEmbedUnimplementedEventMonitoringModuleServer'
+type EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call struct {
+	*mock.Call
+}
+
+// mustEmbedUnimplementedEventMonitoringModuleServer is a helper method to define mock.On call
+func (_e *EventMonitoringModuleServer_Expecter) mustEmbedUnimplementedEventMonitoringModuleServer() *EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call {
+	return &EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call{Call: _e.mock.On("mustEmbedUnimplementedEventMonitoringModuleServer")}
+}
+
+func (_c *EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call) Run(run func()) *EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call) Return() *EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call) RunAndReturn(run func()) *EventMonitoringModuleServer_mustEmbedUnimplementedEventMonitoringModuleServer_Call {
+	_c.Run(run)
+	return _c
 }
 
 // NewEventMonitoringModuleServer creates a new instance of EventMonitoringModuleServer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_server.go
+++ b/pkg/eventmonitor/proto/api/mocks/event_monitoring_module_server.go
@@ -47,14 +47,14 @@ type EventMonitoringModuleServer_GetProcessEvents_Call struct {
 
 // GetProcessEvents is a helper method to define mock.On call
 //   - _a0 *api.GetProcessEventParams
-//   - _a1 api.EventMonitoringModule_GetProcessEventsServer
+//   - _a1 grpc.ServerStreamingServer[api.ProcessEventMessage]
 func (_e *EventMonitoringModuleServer_Expecter) GetProcessEvents(_a0 interface{}, _a1 interface{}) *EventMonitoringModuleServer_GetProcessEvents_Call {
 	return &EventMonitoringModuleServer_GetProcessEvents_Call{Call: _e.mock.On("GetProcessEvents", _a0, _a1)}
 }
 
-func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) Run(run func(_a0 *api.GetProcessEventParams, _a1 api.EventMonitoringModule_GetProcessEventsServer)) *EventMonitoringModuleServer_GetProcessEvents_Call {
+func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) Run(run func(_a0 *api.GetProcessEventParams, _a1 grpc.ServerStreamingServer[api.ProcessEventMessage])) *EventMonitoringModuleServer_GetProcessEvents_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*api.GetProcessEventParams), args[1].(api.EventMonitoringModule_GetProcessEventsServer))
+		run(args[0].(*api.GetProcessEventParams), args[1].(grpc.ServerStreamingServer[api.ProcessEventMessage]))
 	})
 	return _c
 }
@@ -64,7 +64,7 @@ func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) Return(_a0 error) *
 	return _c
 }
 
-func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) RunAndReturn(run func(*api.GetProcessEventParams, api.EventMonitoringModule_GetProcessEventsServer) error) *EventMonitoringModuleServer_GetProcessEvents_Call {
+func (_c *EventMonitoringModuleServer_GetProcessEvents_Call) RunAndReturn(run func(*api.GetProcessEventParams, grpc.ServerStreamingServer[api.ProcessEventMessage]) error) *EventMonitoringModuleServer_GetProcessEvents_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/process/checks/mocks/check.go
+++ b/pkg/process/checks/mocks/check.go
@@ -12,9 +12,44 @@ type Check struct {
 	mock.Mock
 }
 
+type Check_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Check) EXPECT() *Check_Expecter {
+	return &Check_Expecter{mock: &_m.Mock}
+}
+
 // Cleanup provides a mock function with no fields
 func (_m *Check) Cleanup() {
 	_m.Called()
+}
+
+// Check_Cleanup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Cleanup'
+type Check_Cleanup_Call struct {
+	*mock.Call
+}
+
+// Cleanup is a helper method to define mock.On call
+func (_e *Check_Expecter) Cleanup() *Check_Cleanup_Call {
+	return &Check_Cleanup_Call{Call: _e.mock.On("Cleanup")}
+}
+
+func (_c *Check_Cleanup_Call) Run(run func()) *Check_Cleanup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Check_Cleanup_Call) Return() *Check_Cleanup_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Check_Cleanup_Call) RunAndReturn(run func()) *Check_Cleanup_Call {
+	_c.Run(run)
+	return _c
 }
 
 // Init provides a mock function with given fields: syscfg, info, oneShot
@@ -35,6 +70,36 @@ func (_m *Check) Init(syscfg *checks.SysProbeConfig, info *checks.HostInfo, oneS
 	return r0
 }
 
+// Check_Init_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Init'
+type Check_Init_Call struct {
+	*mock.Call
+}
+
+// Init is a helper method to define mock.On call
+//   - syscfg *checks.SysProbeConfig
+//   - info *checks.HostInfo
+//   - oneShot bool
+func (_e *Check_Expecter) Init(syscfg interface{}, info interface{}, oneShot interface{}) *Check_Init_Call {
+	return &Check_Init_Call{Call: _e.mock.On("Init", syscfg, info, oneShot)}
+}
+
+func (_c *Check_Init_Call) Run(run func(syscfg *checks.SysProbeConfig, info *checks.HostInfo, oneShot bool)) *Check_Init_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*checks.SysProbeConfig), args[1].(*checks.HostInfo), args[2].(bool))
+	})
+	return _c
+}
+
+func (_c *Check_Init_Call) Return(_a0 error) *Check_Init_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Check_Init_Call) RunAndReturn(run func(*checks.SysProbeConfig, *checks.HostInfo, bool) error) *Check_Init_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsEnabled provides a mock function with no fields
 func (_m *Check) IsEnabled() bool {
 	ret := _m.Called()
@@ -51,6 +116,33 @@ func (_m *Check) IsEnabled() bool {
 	}
 
 	return r0
+}
+
+// Check_IsEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsEnabled'
+type Check_IsEnabled_Call struct {
+	*mock.Call
+}
+
+// IsEnabled is a helper method to define mock.On call
+func (_e *Check_Expecter) IsEnabled() *Check_IsEnabled_Call {
+	return &Check_IsEnabled_Call{Call: _e.mock.On("IsEnabled")}
+}
+
+func (_c *Check_IsEnabled_Call) Run(run func()) *Check_IsEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Check_IsEnabled_Call) Return(_a0 bool) *Check_IsEnabled_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Check_IsEnabled_Call) RunAndReturn(run func() bool) *Check_IsEnabled_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Name provides a mock function with no fields
@@ -71,6 +163,33 @@ func (_m *Check) Name() string {
 	return r0
 }
 
+// Check_Name_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Name'
+type Check_Name_Call struct {
+	*mock.Call
+}
+
+// Name is a helper method to define mock.On call
+func (_e *Check_Expecter) Name() *Check_Name_Call {
+	return &Check_Name_Call{Call: _e.mock.On("Name")}
+}
+
+func (_c *Check_Name_Call) Run(run func()) *Check_Name_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Check_Name_Call) Return(_a0 string) *Check_Name_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Check_Name_Call) RunAndReturn(run func() string) *Check_Name_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Realtime provides a mock function with no fields
 func (_m *Check) Realtime() bool {
 	ret := _m.Called()
@@ -87,6 +206,33 @@ func (_m *Check) Realtime() bool {
 	}
 
 	return r0
+}
+
+// Check_Realtime_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Realtime'
+type Check_Realtime_Call struct {
+	*mock.Call
+}
+
+// Realtime is a helper method to define mock.On call
+func (_e *Check_Expecter) Realtime() *Check_Realtime_Call {
+	return &Check_Realtime_Call{Call: _e.mock.On("Realtime")}
+}
+
+func (_c *Check_Realtime_Call) Run(run func()) *Check_Realtime_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Check_Realtime_Call) Return(_a0 bool) *Check_Realtime_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Check_Realtime_Call) RunAndReturn(run func() bool) *Check_Realtime_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Run provides a mock function with given fields: nextGroupID, options
@@ -119,6 +265,35 @@ func (_m *Check) Run(nextGroupID func() int32, options *checks.RunOptions) (chec
 	return r0, r1
 }
 
+// Check_Run_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Run'
+type Check_Run_Call struct {
+	*mock.Call
+}
+
+// Run is a helper method to define mock.On call
+//   - nextGroupID func() int32
+//   - options *checks.RunOptions
+func (_e *Check_Expecter) Run(nextGroupID interface{}, options interface{}) *Check_Run_Call {
+	return &Check_Run_Call{Call: _e.mock.On("Run", nextGroupID, options)}
+}
+
+func (_c *Check_Run_Call) Run(run func(nextGroupID func() int32, options *checks.RunOptions)) *Check_Run_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(func() int32), args[1].(*checks.RunOptions))
+	})
+	return _c
+}
+
+func (_c *Check_Run_Call) Return(_a0 checks.RunResult, _a1 error) *Check_Run_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Check_Run_Call) RunAndReturn(run func(func() int32, *checks.RunOptions) (checks.RunResult, error)) *Check_Run_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ShouldSaveLastRun provides a mock function with no fields
 func (_m *Check) ShouldSaveLastRun() bool {
 	ret := _m.Called()
@@ -137,6 +312,33 @@ func (_m *Check) ShouldSaveLastRun() bool {
 	return r0
 }
 
+// Check_ShouldSaveLastRun_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ShouldSaveLastRun'
+type Check_ShouldSaveLastRun_Call struct {
+	*mock.Call
+}
+
+// ShouldSaveLastRun is a helper method to define mock.On call
+func (_e *Check_Expecter) ShouldSaveLastRun() *Check_ShouldSaveLastRun_Call {
+	return &Check_ShouldSaveLastRun_Call{Call: _e.mock.On("ShouldSaveLastRun")}
+}
+
+func (_c *Check_ShouldSaveLastRun_Call) Run(run func()) *Check_ShouldSaveLastRun_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Check_ShouldSaveLastRun_Call) Return(_a0 bool) *Check_ShouldSaveLastRun_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Check_ShouldSaveLastRun_Call) RunAndReturn(run func() bool) *Check_ShouldSaveLastRun_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SupportsRunOptions provides a mock function with no fields
 func (_m *Check) SupportsRunOptions() bool {
 	ret := _m.Called()
@@ -153,6 +355,33 @@ func (_m *Check) SupportsRunOptions() bool {
 	}
 
 	return r0
+}
+
+// Check_SupportsRunOptions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SupportsRunOptions'
+type Check_SupportsRunOptions_Call struct {
+	*mock.Call
+}
+
+// SupportsRunOptions is a helper method to define mock.On call
+func (_e *Check_Expecter) SupportsRunOptions() *Check_SupportsRunOptions_Call {
+	return &Check_SupportsRunOptions_Call{Call: _e.mock.On("SupportsRunOptions")}
+}
+
+func (_c *Check_SupportsRunOptions_Call) Run(run func()) *Check_SupportsRunOptions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Check_SupportsRunOptions_Call) Return(_a0 bool) *Check_SupportsRunOptions_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Check_SupportsRunOptions_Call) RunAndReturn(run func() bool) *Check_SupportsRunOptions_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewCheck creates a new instance of Check. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/process/procutil/mocks/probe.go
+++ b/pkg/process/procutil/mocks/probe.go
@@ -14,9 +14,44 @@ type Probe struct {
 	mock.Mock
 }
 
+type Probe_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Probe) EXPECT() *Probe_Expecter {
+	return &Probe_Expecter{mock: &_m.Mock}
+}
+
 // Close provides a mock function with no fields
 func (_m *Probe) Close() {
 	_m.Called()
+}
+
+// Probe_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type Probe_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *Probe_Expecter) Close() *Probe_Close_Call {
+	return &Probe_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *Probe_Close_Call) Run(run func()) *Probe_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *Probe_Close_Call) Return() *Probe_Close_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Probe_Close_Call) RunAndReturn(run func()) *Probe_Close_Call {
+	_c.Run(run)
+	return _c
 }
 
 // ProcessesByPID provides a mock function with given fields: now, collectStats
@@ -49,6 +84,35 @@ func (_m *Probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*pr
 	return r0, r1
 }
 
+// Probe_ProcessesByPID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ProcessesByPID'
+type Probe_ProcessesByPID_Call struct {
+	*mock.Call
+}
+
+// ProcessesByPID is a helper method to define mock.On call
+//   - now time.Time
+//   - collectStats bool
+func (_e *Probe_Expecter) ProcessesByPID(now interface{}, collectStats interface{}) *Probe_ProcessesByPID_Call {
+	return &Probe_ProcessesByPID_Call{Call: _e.mock.On("ProcessesByPID", now, collectStats)}
+}
+
+func (_c *Probe_ProcessesByPID_Call) Run(run func(now time.Time, collectStats bool)) *Probe_ProcessesByPID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(time.Time), args[1].(bool))
+	})
+	return _c
+}
+
+func (_c *Probe_ProcessesByPID_Call) Return(_a0 map[int32]*procutil.Process, _a1 error) *Probe_ProcessesByPID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Probe_ProcessesByPID_Call) RunAndReturn(run func(time.Time, bool) (map[int32]*procutil.Process, error)) *Probe_ProcessesByPID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StatsForPIDs provides a mock function with given fields: pids, now
 func (_m *Probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*procutil.Stats, error) {
 	ret := _m.Called(pids, now)
@@ -79,6 +143,35 @@ func (_m *Probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*procutil.
 	return r0, r1
 }
 
+// Probe_StatsForPIDs_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StatsForPIDs'
+type Probe_StatsForPIDs_Call struct {
+	*mock.Call
+}
+
+// StatsForPIDs is a helper method to define mock.On call
+//   - pids []int32
+//   - now time.Time
+func (_e *Probe_Expecter) StatsForPIDs(pids interface{}, now interface{}) *Probe_StatsForPIDs_Call {
+	return &Probe_StatsForPIDs_Call{Call: _e.mock.On("StatsForPIDs", pids, now)}
+}
+
+func (_c *Probe_StatsForPIDs_Call) Run(run func(pids []int32, now time.Time)) *Probe_StatsForPIDs_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]int32), args[1].(time.Time))
+	})
+	return _c
+}
+
+func (_c *Probe_StatsForPIDs_Call) Return(_a0 map[int32]*procutil.Stats, _a1 error) *Probe_StatsForPIDs_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Probe_StatsForPIDs_Call) RunAndReturn(run func([]int32, time.Time) (map[int32]*procutil.Stats, error)) *Probe_StatsForPIDs_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StatsWithPermByPID provides a mock function with given fields: pids
 func (_m *Probe) StatsWithPermByPID(pids []int32) (map[int32]*procutil.StatsWithPerm, error) {
 	ret := _m.Called(pids)
@@ -107,6 +200,34 @@ func (_m *Probe) StatsWithPermByPID(pids []int32) (map[int32]*procutil.StatsWith
 	}
 
 	return r0, r1
+}
+
+// Probe_StatsWithPermByPID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StatsWithPermByPID'
+type Probe_StatsWithPermByPID_Call struct {
+	*mock.Call
+}
+
+// StatsWithPermByPID is a helper method to define mock.On call
+//   - pids []int32
+func (_e *Probe_Expecter) StatsWithPermByPID(pids interface{}) *Probe_StatsWithPermByPID_Call {
+	return &Probe_StatsWithPermByPID_Call{Call: _e.mock.On("StatsWithPermByPID", pids)}
+}
+
+func (_c *Probe_StatsWithPermByPID_Call) Run(run func(pids []int32)) *Probe_StatsWithPermByPID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]int32))
+	})
+	return _c
+}
+
+func (_c *Probe_StatsWithPermByPID_Call) Return(_a0 map[int32]*procutil.StatsWithPerm, _a1 error) *Probe_StatsWithPermByPID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Probe_StatsWithPermByPID_Call) RunAndReturn(run func([]int32) (map[int32]*procutil.StatsWithPerm, error)) *Probe_StatsWithPermByPID_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewProbe creates a new instance of Probe. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/process/runner/mocks/submitter.go
+++ b/pkg/process/runner/mocks/submitter.go
@@ -15,9 +15,47 @@ type Submitter struct {
 	mock.Mock
 }
 
+type Submitter_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *Submitter) EXPECT() *Submitter_Expecter {
+	return &Submitter_Expecter{mock: &_m.Mock}
+}
+
 // Submit provides a mock function with given fields: start, name, messages
 func (_m *Submitter) Submit(start time.Time, name string, messages *types.Payload) {
 	_m.Called(start, name, messages)
+}
+
+// Submitter_Submit_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Submit'
+type Submitter_Submit_Call struct {
+	*mock.Call
+}
+
+// Submit is a helper method to define mock.On call
+//   - start time.Time
+//   - name string
+//   - messages *types.Payload
+func (_e *Submitter_Expecter) Submit(start interface{}, name interface{}, messages interface{}) *Submitter_Submit_Call {
+	return &Submitter_Submit_Call{Call: _e.mock.On("Submit", start, name, messages)}
+}
+
+func (_c *Submitter_Submit_Call) Run(run func(start time.Time, name string, messages *types.Payload)) *Submitter_Submit_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(time.Time), args[1].(string), args[2].(*types.Payload))
+	})
+	return _c
+}
+
+func (_c *Submitter_Submit_Call) Return() *Submitter_Submit_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *Submitter_Submit_Call) RunAndReturn(run func(time.Time, string, *types.Payload)) *Submitter_Submit_Call {
+	_c.Run(run)
+	return _c
 }
 
 // NewSubmitter creates a new instance of Submitter. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/security/agent/mocks/security_module_client_wrapper.go
+++ b/pkg/security/agent/mocks/security_module_client_wrapper.go
@@ -4,8 +4,6 @@ package mocks
 
 import (
 	api "github.com/DataDog/datadog-agent/pkg/security/proto/api"
-	grpc "google.golang.org/grpc"
-
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -341,23 +339,23 @@ func (_c *SecurityModuleClientWrapper_GenerateEncoding_Call) RunAndReturn(run fu
 }
 
 // GetActivityDumpStream provides a mock function with no fields
-func (_m *SecurityModuleClientWrapper) GetActivityDumpStream() (grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], error) {
+func (_m *SecurityModuleClientWrapper) GetActivityDumpStream() (api.SecurityModule_GetActivityDumpStreamClient, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetActivityDumpStream")
 	}
 
-	var r0 grpc.ServerStreamingClient[api.ActivityDumpStreamMessage]
+	var r0 api.SecurityModule_GetActivityDumpStreamClient
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], error)); ok {
+	if rf, ok := ret.Get(0).(func() (api.SecurityModule_GetActivityDumpStreamClient, error)); ok {
 		return rf()
 	}
-	if rf, ok := ret.Get(0).(func() grpc.ServerStreamingClient[api.ActivityDumpStreamMessage]); ok {
+	if rf, ok := ret.Get(0).(func() api.SecurityModule_GetActivityDumpStreamClient); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(grpc.ServerStreamingClient[api.ActivityDumpStreamMessage])
+			r0 = ret.Get(0).(api.SecurityModule_GetActivityDumpStreamClient)
 		}
 	}
 
@@ -387,12 +385,12 @@ func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) Run(run func()
 	return _c
 }
 
-func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) Return(_a0 grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], _a1 error) *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
+func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) Return(_a0 api.SecurityModule_GetActivityDumpStreamClient, _a1 error) *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) RunAndReturn(run func() (grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], error)) *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
+func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) RunAndReturn(run func() (api.SecurityModule_GetActivityDumpStreamClient, error)) *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -455,23 +453,23 @@ func (_c *SecurityModuleClientWrapper_GetConfig_Call) RunAndReturn(run func() (*
 }
 
 // GetEvents provides a mock function with no fields
-func (_m *SecurityModuleClientWrapper) GetEvents() (grpc.ServerStreamingClient[api.SecurityEventMessage], error) {
+func (_m *SecurityModuleClientWrapper) GetEvents() (api.SecurityModule_GetEventsClient, error) {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetEvents")
 	}
 
-	var r0 grpc.ServerStreamingClient[api.SecurityEventMessage]
+	var r0 api.SecurityModule_GetEventsClient
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (grpc.ServerStreamingClient[api.SecurityEventMessage], error)); ok {
+	if rf, ok := ret.Get(0).(func() (api.SecurityModule_GetEventsClient, error)); ok {
 		return rf()
 	}
-	if rf, ok := ret.Get(0).(func() grpc.ServerStreamingClient[api.SecurityEventMessage]); ok {
+	if rf, ok := ret.Get(0).(func() api.SecurityModule_GetEventsClient); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(grpc.ServerStreamingClient[api.SecurityEventMessage])
+			r0 = ret.Get(0).(api.SecurityModule_GetEventsClient)
 		}
 	}
 
@@ -501,12 +499,12 @@ func (_c *SecurityModuleClientWrapper_GetEvents_Call) Run(run func()) *SecurityM
 	return _c
 }
 
-func (_c *SecurityModuleClientWrapper_GetEvents_Call) Return(_a0 grpc.ServerStreamingClient[api.SecurityEventMessage], _a1 error) *SecurityModuleClientWrapper_GetEvents_Call {
+func (_c *SecurityModuleClientWrapper_GetEvents_Call) Return(_a0 api.SecurityModule_GetEventsClient, _a1 error) *SecurityModuleClientWrapper_GetEvents_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *SecurityModuleClientWrapper_GetEvents_Call) RunAndReturn(run func() (grpc.ServerStreamingClient[api.SecurityEventMessage], error)) *SecurityModuleClientWrapper_GetEvents_Call {
+func (_c *SecurityModuleClientWrapper_GetEvents_Call) RunAndReturn(run func() (api.SecurityModule_GetEventsClient, error)) *SecurityModuleClientWrapper_GetEvents_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/security/agent/mocks/security_module_client_wrapper.go
+++ b/pkg/security/agent/mocks/security_module_client_wrapper.go
@@ -14,9 +14,44 @@ type SecurityModuleClientWrapper struct {
 	mock.Mock
 }
 
+type SecurityModuleClientWrapper_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *SecurityModuleClientWrapper) EXPECT() *SecurityModuleClientWrapper_Expecter {
+	return &SecurityModuleClientWrapper_Expecter{mock: &_m.Mock}
+}
+
 // Close provides a mock function with no fields
 func (_m *SecurityModuleClientWrapper) Close() {
 	_m.Called()
+}
+
+// SecurityModuleClientWrapper_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type SecurityModuleClientWrapper_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) Close() *SecurityModuleClientWrapper_Close_Call {
+	return &SecurityModuleClientWrapper_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *SecurityModuleClientWrapper_Close_Call) Run(run func()) *SecurityModuleClientWrapper_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_Close_Call) Return() *SecurityModuleClientWrapper_Close_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_Close_Call) RunAndReturn(run func()) *SecurityModuleClientWrapper_Close_Call {
+	_c.Run(run)
+	return _c
 }
 
 // DumpDiscarders provides a mock function with no fields
@@ -45,6 +80,33 @@ func (_m *SecurityModuleClientWrapper) DumpDiscarders() (string, error) {
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_DumpDiscarders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpDiscarders'
+type SecurityModuleClientWrapper_DumpDiscarders_Call struct {
+	*mock.Call
+}
+
+// DumpDiscarders is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) DumpDiscarders() *SecurityModuleClientWrapper_DumpDiscarders_Call {
+	return &SecurityModuleClientWrapper_DumpDiscarders_Call{Call: _e.mock.On("DumpDiscarders")}
+}
+
+func (_c *SecurityModuleClientWrapper_DumpDiscarders_Call) Run(run func()) *SecurityModuleClientWrapper_DumpDiscarders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_DumpDiscarders_Call) Return(_a0 string, _a1 error) *SecurityModuleClientWrapper_DumpDiscarders_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_DumpDiscarders_Call) RunAndReturn(run func() (string, error)) *SecurityModuleClientWrapper_DumpDiscarders_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // DumpNetworkNamespace provides a mock function with given fields: snapshotInterfaces
@@ -77,6 +139,34 @@ func (_m *SecurityModuleClientWrapper) DumpNetworkNamespace(snapshotInterfaces b
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_DumpNetworkNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpNetworkNamespace'
+type SecurityModuleClientWrapper_DumpNetworkNamespace_Call struct {
+	*mock.Call
+}
+
+// DumpNetworkNamespace is a helper method to define mock.On call
+//   - snapshotInterfaces bool
+func (_e *SecurityModuleClientWrapper_Expecter) DumpNetworkNamespace(snapshotInterfaces interface{}) *SecurityModuleClientWrapper_DumpNetworkNamespace_Call {
+	return &SecurityModuleClientWrapper_DumpNetworkNamespace_Call{Call: _e.mock.On("DumpNetworkNamespace", snapshotInterfaces)}
+}
+
+func (_c *SecurityModuleClientWrapper_DumpNetworkNamespace_Call) Run(run func(snapshotInterfaces bool)) *SecurityModuleClientWrapper_DumpNetworkNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(bool))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_DumpNetworkNamespace_Call) Return(_a0 *api.DumpNetworkNamespaceMessage, _a1 error) *SecurityModuleClientWrapper_DumpNetworkNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_DumpNetworkNamespace_Call) RunAndReturn(run func(bool) (*api.DumpNetworkNamespaceMessage, error)) *SecurityModuleClientWrapper_DumpNetworkNamespace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DumpProcessCache provides a mock function with given fields: withArgs, format
 func (_m *SecurityModuleClientWrapper) DumpProcessCache(withArgs bool, format string) (string, error) {
 	ret := _m.Called(withArgs, format)
@@ -103,6 +193,35 @@ func (_m *SecurityModuleClientWrapper) DumpProcessCache(withArgs bool, format st
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_DumpProcessCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpProcessCache'
+type SecurityModuleClientWrapper_DumpProcessCache_Call struct {
+	*mock.Call
+}
+
+// DumpProcessCache is a helper method to define mock.On call
+//   - withArgs bool
+//   - format string
+func (_e *SecurityModuleClientWrapper_Expecter) DumpProcessCache(withArgs interface{}, format interface{}) *SecurityModuleClientWrapper_DumpProcessCache_Call {
+	return &SecurityModuleClientWrapper_DumpProcessCache_Call{Call: _e.mock.On("DumpProcessCache", withArgs, format)}
+}
+
+func (_c *SecurityModuleClientWrapper_DumpProcessCache_Call) Run(run func(withArgs bool, format string)) *SecurityModuleClientWrapper_DumpProcessCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(bool), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_DumpProcessCache_Call) Return(_a0 string, _a1 error) *SecurityModuleClientWrapper_DumpProcessCache_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_DumpProcessCache_Call) RunAndReturn(run func(bool, string) (string, error)) *SecurityModuleClientWrapper_DumpProcessCache_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GenerateActivityDump provides a mock function with given fields: request
@@ -135,6 +254,34 @@ func (_m *SecurityModuleClientWrapper) GenerateActivityDump(request *api.Activit
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_GenerateActivityDump_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GenerateActivityDump'
+type SecurityModuleClientWrapper_GenerateActivityDump_Call struct {
+	*mock.Call
+}
+
+// GenerateActivityDump is a helper method to define mock.On call
+//   - request *api.ActivityDumpParams
+func (_e *SecurityModuleClientWrapper_Expecter) GenerateActivityDump(request interface{}) *SecurityModuleClientWrapper_GenerateActivityDump_Call {
+	return &SecurityModuleClientWrapper_GenerateActivityDump_Call{Call: _e.mock.On("GenerateActivityDump", request)}
+}
+
+func (_c *SecurityModuleClientWrapper_GenerateActivityDump_Call) Run(run func(request *api.ActivityDumpParams)) *SecurityModuleClientWrapper_GenerateActivityDump_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*api.ActivityDumpParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GenerateActivityDump_Call) Return(_a0 *api.ActivityDumpMessage, _a1 error) *SecurityModuleClientWrapper_GenerateActivityDump_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GenerateActivityDump_Call) RunAndReturn(run func(*api.ActivityDumpParams) (*api.ActivityDumpMessage, error)) *SecurityModuleClientWrapper_GenerateActivityDump_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GenerateEncoding provides a mock function with given fields: request
 func (_m *SecurityModuleClientWrapper) GenerateEncoding(request *api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error) {
 	ret := _m.Called(request)
@@ -163,6 +310,34 @@ func (_m *SecurityModuleClientWrapper) GenerateEncoding(request *api.Transcoding
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_GenerateEncoding_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GenerateEncoding'
+type SecurityModuleClientWrapper_GenerateEncoding_Call struct {
+	*mock.Call
+}
+
+// GenerateEncoding is a helper method to define mock.On call
+//   - request *api.TranscodingRequestParams
+func (_e *SecurityModuleClientWrapper_Expecter) GenerateEncoding(request interface{}) *SecurityModuleClientWrapper_GenerateEncoding_Call {
+	return &SecurityModuleClientWrapper_GenerateEncoding_Call{Call: _e.mock.On("GenerateEncoding", request)}
+}
+
+func (_c *SecurityModuleClientWrapper_GenerateEncoding_Call) Run(run func(request *api.TranscodingRequestParams)) *SecurityModuleClientWrapper_GenerateEncoding_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*api.TranscodingRequestParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GenerateEncoding_Call) Return(_a0 *api.TranscodingRequestMessage, _a1 error) *SecurityModuleClientWrapper_GenerateEncoding_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GenerateEncoding_Call) RunAndReturn(run func(*api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error)) *SecurityModuleClientWrapper_GenerateEncoding_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GetActivityDumpStream provides a mock function with no fields
@@ -195,6 +370,33 @@ func (_m *SecurityModuleClientWrapper) GetActivityDumpStream() (grpc.ServerStrea
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_GetActivityDumpStream_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActivityDumpStream'
+type SecurityModuleClientWrapper_GetActivityDumpStream_Call struct {
+	*mock.Call
+}
+
+// GetActivityDumpStream is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) GetActivityDumpStream() *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
+	return &SecurityModuleClientWrapper_GetActivityDumpStream_Call{Call: _e.mock.On("GetActivityDumpStream")}
+}
+
+func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) Run(run func()) *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) Return(_a0 grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], _a1 error) *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetActivityDumpStream_Call) RunAndReturn(run func() (grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], error)) *SecurityModuleClientWrapper_GetActivityDumpStream_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetConfig provides a mock function with no fields
 func (_m *SecurityModuleClientWrapper) GetConfig() (*api.SecurityConfigMessage, error) {
 	ret := _m.Called()
@@ -223,6 +425,33 @@ func (_m *SecurityModuleClientWrapper) GetConfig() (*api.SecurityConfigMessage, 
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_GetConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfig'
+type SecurityModuleClientWrapper_GetConfig_Call struct {
+	*mock.Call
+}
+
+// GetConfig is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) GetConfig() *SecurityModuleClientWrapper_GetConfig_Call {
+	return &SecurityModuleClientWrapper_GetConfig_Call{Call: _e.mock.On("GetConfig")}
+}
+
+func (_c *SecurityModuleClientWrapper_GetConfig_Call) Run(run func()) *SecurityModuleClientWrapper_GetConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetConfig_Call) Return(_a0 *api.SecurityConfigMessage, _a1 error) *SecurityModuleClientWrapper_GetConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetConfig_Call) RunAndReturn(run func() (*api.SecurityConfigMessage, error)) *SecurityModuleClientWrapper_GetConfig_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GetEvents provides a mock function with no fields
@@ -255,6 +484,33 @@ func (_m *SecurityModuleClientWrapper) GetEvents() (grpc.ServerStreamingClient[a
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_GetEvents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEvents'
+type SecurityModuleClientWrapper_GetEvents_Call struct {
+	*mock.Call
+}
+
+// GetEvents is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) GetEvents() *SecurityModuleClientWrapper_GetEvents_Call {
+	return &SecurityModuleClientWrapper_GetEvents_Call{Call: _e.mock.On("GetEvents")}
+}
+
+func (_c *SecurityModuleClientWrapper_GetEvents_Call) Run(run func()) *SecurityModuleClientWrapper_GetEvents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetEvents_Call) Return(_a0 grpc.ServerStreamingClient[api.SecurityEventMessage], _a1 error) *SecurityModuleClientWrapper_GetEvents_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetEvents_Call) RunAndReturn(run func() (grpc.ServerStreamingClient[api.SecurityEventMessage], error)) *SecurityModuleClientWrapper_GetEvents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRuleSetReport provides a mock function with no fields
 func (_m *SecurityModuleClientWrapper) GetRuleSetReport() (*api.GetRuleSetReportResultMessage, error) {
 	ret := _m.Called()
@@ -283,6 +539,33 @@ func (_m *SecurityModuleClientWrapper) GetRuleSetReport() (*api.GetRuleSetReport
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_GetRuleSetReport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRuleSetReport'
+type SecurityModuleClientWrapper_GetRuleSetReport_Call struct {
+	*mock.Call
+}
+
+// GetRuleSetReport is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) GetRuleSetReport() *SecurityModuleClientWrapper_GetRuleSetReport_Call {
+	return &SecurityModuleClientWrapper_GetRuleSetReport_Call{Call: _e.mock.On("GetRuleSetReport")}
+}
+
+func (_c *SecurityModuleClientWrapper_GetRuleSetReport_Call) Run(run func()) *SecurityModuleClientWrapper_GetRuleSetReport_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetRuleSetReport_Call) Return(_a0 *api.GetRuleSetReportResultMessage, _a1 error) *SecurityModuleClientWrapper_GetRuleSetReport_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetRuleSetReport_Call) RunAndReturn(run func() (*api.GetRuleSetReportResultMessage, error)) *SecurityModuleClientWrapper_GetRuleSetReport_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GetStatus provides a mock function with no fields
@@ -315,6 +598,33 @@ func (_m *SecurityModuleClientWrapper) GetStatus() (*api.Status, error) {
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_GetStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStatus'
+type SecurityModuleClientWrapper_GetStatus_Call struct {
+	*mock.Call
+}
+
+// GetStatus is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) GetStatus() *SecurityModuleClientWrapper_GetStatus_Call {
+	return &SecurityModuleClientWrapper_GetStatus_Call{Call: _e.mock.On("GetStatus")}
+}
+
+func (_c *SecurityModuleClientWrapper_GetStatus_Call) Run(run func()) *SecurityModuleClientWrapper_GetStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetStatus_Call) Return(_a0 *api.Status, _a1 error) *SecurityModuleClientWrapper_GetStatus_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_GetStatus_Call) RunAndReturn(run func() (*api.Status, error)) *SecurityModuleClientWrapper_GetStatus_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListActivityDumps provides a mock function with no fields
 func (_m *SecurityModuleClientWrapper) ListActivityDumps() (*api.ActivityDumpListMessage, error) {
 	ret := _m.Called()
@@ -343,6 +653,33 @@ func (_m *SecurityModuleClientWrapper) ListActivityDumps() (*api.ActivityDumpLis
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_ListActivityDumps_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListActivityDumps'
+type SecurityModuleClientWrapper_ListActivityDumps_Call struct {
+	*mock.Call
+}
+
+// ListActivityDumps is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) ListActivityDumps() *SecurityModuleClientWrapper_ListActivityDumps_Call {
+	return &SecurityModuleClientWrapper_ListActivityDumps_Call{Call: _e.mock.On("ListActivityDumps")}
+}
+
+func (_c *SecurityModuleClientWrapper_ListActivityDumps_Call) Run(run func()) *SecurityModuleClientWrapper_ListActivityDumps_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_ListActivityDumps_Call) Return(_a0 *api.ActivityDumpListMessage, _a1 error) *SecurityModuleClientWrapper_ListActivityDumps_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_ListActivityDumps_Call) RunAndReturn(run func() (*api.ActivityDumpListMessage, error)) *SecurityModuleClientWrapper_ListActivityDumps_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ListSecurityProfiles provides a mock function with given fields: includeCache
@@ -375,6 +712,34 @@ func (_m *SecurityModuleClientWrapper) ListSecurityProfiles(includeCache bool) (
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_ListSecurityProfiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSecurityProfiles'
+type SecurityModuleClientWrapper_ListSecurityProfiles_Call struct {
+	*mock.Call
+}
+
+// ListSecurityProfiles is a helper method to define mock.On call
+//   - includeCache bool
+func (_e *SecurityModuleClientWrapper_Expecter) ListSecurityProfiles(includeCache interface{}) *SecurityModuleClientWrapper_ListSecurityProfiles_Call {
+	return &SecurityModuleClientWrapper_ListSecurityProfiles_Call{Call: _e.mock.On("ListSecurityProfiles", includeCache)}
+}
+
+func (_c *SecurityModuleClientWrapper_ListSecurityProfiles_Call) Run(run func(includeCache bool)) *SecurityModuleClientWrapper_ListSecurityProfiles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(bool))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_ListSecurityProfiles_Call) Return(_a0 *api.SecurityProfileListMessage, _a1 error) *SecurityModuleClientWrapper_ListSecurityProfiles_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_ListSecurityProfiles_Call) RunAndReturn(run func(bool) (*api.SecurityProfileListMessage, error)) *SecurityModuleClientWrapper_ListSecurityProfiles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ReloadPolicies provides a mock function with no fields
 func (_m *SecurityModuleClientWrapper) ReloadPolicies() (*api.ReloadPoliciesResultMessage, error) {
 	ret := _m.Called()
@@ -403,6 +768,33 @@ func (_m *SecurityModuleClientWrapper) ReloadPolicies() (*api.ReloadPoliciesResu
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_ReloadPolicies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReloadPolicies'
+type SecurityModuleClientWrapper_ReloadPolicies_Call struct {
+	*mock.Call
+}
+
+// ReloadPolicies is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) ReloadPolicies() *SecurityModuleClientWrapper_ReloadPolicies_Call {
+	return &SecurityModuleClientWrapper_ReloadPolicies_Call{Call: _e.mock.On("ReloadPolicies")}
+}
+
+func (_c *SecurityModuleClientWrapper_ReloadPolicies_Call) Run(run func()) *SecurityModuleClientWrapper_ReloadPolicies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_ReloadPolicies_Call) Return(_a0 *api.ReloadPoliciesResultMessage, _a1 error) *SecurityModuleClientWrapper_ReloadPolicies_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_ReloadPolicies_Call) RunAndReturn(run func() (*api.ReloadPoliciesResultMessage, error)) *SecurityModuleClientWrapper_ReloadPolicies_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // RunSelfTest provides a mock function with no fields
@@ -435,6 +827,33 @@ func (_m *SecurityModuleClientWrapper) RunSelfTest() (*api.SecuritySelfTestResul
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_RunSelfTest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RunSelfTest'
+type SecurityModuleClientWrapper_RunSelfTest_Call struct {
+	*mock.Call
+}
+
+// RunSelfTest is a helper method to define mock.On call
+func (_e *SecurityModuleClientWrapper_Expecter) RunSelfTest() *SecurityModuleClientWrapper_RunSelfTest_Call {
+	return &SecurityModuleClientWrapper_RunSelfTest_Call{Call: _e.mock.On("RunSelfTest")}
+}
+
+func (_c *SecurityModuleClientWrapper_RunSelfTest_Call) Run(run func()) *SecurityModuleClientWrapper_RunSelfTest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_RunSelfTest_Call) Return(_a0 *api.SecuritySelfTestResultMessage, _a1 error) *SecurityModuleClientWrapper_RunSelfTest_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_RunSelfTest_Call) RunAndReturn(run func() (*api.SecuritySelfTestResultMessage, error)) *SecurityModuleClientWrapper_RunSelfTest_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SaveSecurityProfile provides a mock function with given fields: name, tag
 func (_m *SecurityModuleClientWrapper) SaveSecurityProfile(name string, tag string) (*api.SecurityProfileSaveMessage, error) {
 	ret := _m.Called(name, tag)
@@ -465,6 +884,35 @@ func (_m *SecurityModuleClientWrapper) SaveSecurityProfile(name string, tag stri
 	return r0, r1
 }
 
+// SecurityModuleClientWrapper_SaveSecurityProfile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveSecurityProfile'
+type SecurityModuleClientWrapper_SaveSecurityProfile_Call struct {
+	*mock.Call
+}
+
+// SaveSecurityProfile is a helper method to define mock.On call
+//   - name string
+//   - tag string
+func (_e *SecurityModuleClientWrapper_Expecter) SaveSecurityProfile(name interface{}, tag interface{}) *SecurityModuleClientWrapper_SaveSecurityProfile_Call {
+	return &SecurityModuleClientWrapper_SaveSecurityProfile_Call{Call: _e.mock.On("SaveSecurityProfile", name, tag)}
+}
+
+func (_c *SecurityModuleClientWrapper_SaveSecurityProfile_Call) Run(run func(name string, tag string)) *SecurityModuleClientWrapper_SaveSecurityProfile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_SaveSecurityProfile_Call) Return(_a0 *api.SecurityProfileSaveMessage, _a1 error) *SecurityModuleClientWrapper_SaveSecurityProfile_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_SaveSecurityProfile_Call) RunAndReturn(run func(string, string) (*api.SecurityProfileSaveMessage, error)) *SecurityModuleClientWrapper_SaveSecurityProfile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StopActivityDump provides a mock function with given fields: name, container, cgroup
 func (_m *SecurityModuleClientWrapper) StopActivityDump(name string, container string, cgroup string) (*api.ActivityDumpStopMessage, error) {
 	ret := _m.Called(name, container, cgroup)
@@ -493,6 +941,36 @@ func (_m *SecurityModuleClientWrapper) StopActivityDump(name string, container s
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClientWrapper_StopActivityDump_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StopActivityDump'
+type SecurityModuleClientWrapper_StopActivityDump_Call struct {
+	*mock.Call
+}
+
+// StopActivityDump is a helper method to define mock.On call
+//   - name string
+//   - container string
+//   - cgroup string
+func (_e *SecurityModuleClientWrapper_Expecter) StopActivityDump(name interface{}, container interface{}, cgroup interface{}) *SecurityModuleClientWrapper_StopActivityDump_Call {
+	return &SecurityModuleClientWrapper_StopActivityDump_Call{Call: _e.mock.On("StopActivityDump", name, container, cgroup)}
+}
+
+func (_c *SecurityModuleClientWrapper_StopActivityDump_Call) Run(run func(name string, container string, cgroup string)) *SecurityModuleClientWrapper_StopActivityDump_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_StopActivityDump_Call) Return(_a0 *api.ActivityDumpStopMessage, _a1 error) *SecurityModuleClientWrapper_StopActivityDump_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClientWrapper_StopActivityDump_Call) RunAndReturn(run func(string, string, string) (*api.ActivityDumpStopMessage, error)) *SecurityModuleClientWrapper_StopActivityDump_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewSecurityModuleClientWrapper creates a new instance of SecurityModuleClientWrapper. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/security/proto/api/mocks/security_module_client.go
+++ b/pkg/security/proto/api/mocks/security_module_client.go
@@ -17,6 +17,14 @@ type SecurityModuleClient struct {
 	mock.Mock
 }
 
+type SecurityModuleClient_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *SecurityModuleClient) EXPECT() *SecurityModuleClient_Expecter {
+	return &SecurityModuleClient_Expecter{mock: &_m.Mock}
+}
+
 // DumpActivity provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) DumpActivity(ctx context.Context, in *api.ActivityDumpParams, opts ...grpc.CallOption) (*api.ActivityDumpMessage, error) {
 	_va := make([]interface{}, len(opts))
@@ -52,6 +60,43 @@ func (_m *SecurityModuleClient) DumpActivity(ctx context.Context, in *api.Activi
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_DumpActivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpActivity'
+type SecurityModuleClient_DumpActivity_Call struct {
+	*mock.Call
+}
+
+// DumpActivity is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.ActivityDumpParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) DumpActivity(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_DumpActivity_Call {
+	return &SecurityModuleClient_DumpActivity_Call{Call: _e.mock.On("DumpActivity",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_DumpActivity_Call) Run(run func(ctx context.Context, in *api.ActivityDumpParams, opts ...grpc.CallOption)) *SecurityModuleClient_DumpActivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.ActivityDumpParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpActivity_Call) Return(_a0 *api.ActivityDumpMessage, _a1 error) *SecurityModuleClient_DumpActivity_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpActivity_Call) RunAndReturn(run func(context.Context, *api.ActivityDumpParams, ...grpc.CallOption) (*api.ActivityDumpMessage, error)) *SecurityModuleClient_DumpActivity_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // DumpDiscarders provides a mock function with given fields: ctx, in, opts
@@ -91,6 +136,43 @@ func (_m *SecurityModuleClient) DumpDiscarders(ctx context.Context, in *api.Dump
 	return r0, r1
 }
 
+// SecurityModuleClient_DumpDiscarders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpDiscarders'
+type SecurityModuleClient_DumpDiscarders_Call struct {
+	*mock.Call
+}
+
+// DumpDiscarders is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.DumpDiscardersParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) DumpDiscarders(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_DumpDiscarders_Call {
+	return &SecurityModuleClient_DumpDiscarders_Call{Call: _e.mock.On("DumpDiscarders",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_DumpDiscarders_Call) Run(run func(ctx context.Context, in *api.DumpDiscardersParams, opts ...grpc.CallOption)) *SecurityModuleClient_DumpDiscarders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.DumpDiscardersParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpDiscarders_Call) Return(_a0 *api.DumpDiscardersMessage, _a1 error) *SecurityModuleClient_DumpDiscarders_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpDiscarders_Call) RunAndReturn(run func(context.Context, *api.DumpDiscardersParams, ...grpc.CallOption) (*api.DumpDiscardersMessage, error)) *SecurityModuleClient_DumpDiscarders_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DumpNetworkNamespace provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) DumpNetworkNamespace(ctx context.Context, in *api.DumpNetworkNamespaceParams, opts ...grpc.CallOption) (*api.DumpNetworkNamespaceMessage, error) {
 	_va := make([]interface{}, len(opts))
@@ -126,6 +208,43 @@ func (_m *SecurityModuleClient) DumpNetworkNamespace(ctx context.Context, in *ap
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_DumpNetworkNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpNetworkNamespace'
+type SecurityModuleClient_DumpNetworkNamespace_Call struct {
+	*mock.Call
+}
+
+// DumpNetworkNamespace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.DumpNetworkNamespaceParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) DumpNetworkNamespace(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_DumpNetworkNamespace_Call {
+	return &SecurityModuleClient_DumpNetworkNamespace_Call{Call: _e.mock.On("DumpNetworkNamespace",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_DumpNetworkNamespace_Call) Run(run func(ctx context.Context, in *api.DumpNetworkNamespaceParams, opts ...grpc.CallOption)) *SecurityModuleClient_DumpNetworkNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.DumpNetworkNamespaceParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpNetworkNamespace_Call) Return(_a0 *api.DumpNetworkNamespaceMessage, _a1 error) *SecurityModuleClient_DumpNetworkNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpNetworkNamespace_Call) RunAndReturn(run func(context.Context, *api.DumpNetworkNamespaceParams, ...grpc.CallOption) (*api.DumpNetworkNamespaceMessage, error)) *SecurityModuleClient_DumpNetworkNamespace_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // DumpProcessCache provides a mock function with given fields: ctx, in, opts
@@ -165,6 +284,43 @@ func (_m *SecurityModuleClient) DumpProcessCache(ctx context.Context, in *api.Du
 	return r0, r1
 }
 
+// SecurityModuleClient_DumpProcessCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpProcessCache'
+type SecurityModuleClient_DumpProcessCache_Call struct {
+	*mock.Call
+}
+
+// DumpProcessCache is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.DumpProcessCacheParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) DumpProcessCache(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_DumpProcessCache_Call {
+	return &SecurityModuleClient_DumpProcessCache_Call{Call: _e.mock.On("DumpProcessCache",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_DumpProcessCache_Call) Run(run func(ctx context.Context, in *api.DumpProcessCacheParams, opts ...grpc.CallOption)) *SecurityModuleClient_DumpProcessCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.DumpProcessCacheParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpProcessCache_Call) Return(_a0 *api.SecurityDumpProcessCacheMessage, _a1 error) *SecurityModuleClient_DumpProcessCache_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_DumpProcessCache_Call) RunAndReturn(run func(context.Context, *api.DumpProcessCacheParams, ...grpc.CallOption) (*api.SecurityDumpProcessCacheMessage, error)) *SecurityModuleClient_DumpProcessCache_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetActivityDumpStream provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) GetActivityDumpStream(ctx context.Context, in *api.ActivityDumpStreamParams, opts ...grpc.CallOption) (grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], error) {
 	_va := make([]interface{}, len(opts))
@@ -200,6 +356,43 @@ func (_m *SecurityModuleClient) GetActivityDumpStream(ctx context.Context, in *a
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_GetActivityDumpStream_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActivityDumpStream'
+type SecurityModuleClient_GetActivityDumpStream_Call struct {
+	*mock.Call
+}
+
+// GetActivityDumpStream is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.ActivityDumpStreamParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) GetActivityDumpStream(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_GetActivityDumpStream_Call {
+	return &SecurityModuleClient_GetActivityDumpStream_Call{Call: _e.mock.On("GetActivityDumpStream",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_GetActivityDumpStream_Call) Run(run func(ctx context.Context, in *api.ActivityDumpStreamParams, opts ...grpc.CallOption)) *SecurityModuleClient_GetActivityDumpStream_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.ActivityDumpStreamParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetActivityDumpStream_Call) Return(_a0 grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], _a1 error) *SecurityModuleClient_GetActivityDumpStream_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetActivityDumpStream_Call) RunAndReturn(run func(context.Context, *api.ActivityDumpStreamParams, ...grpc.CallOption) (grpc.ServerStreamingClient[api.ActivityDumpStreamMessage], error)) *SecurityModuleClient_GetActivityDumpStream_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GetConfig provides a mock function with given fields: ctx, in, opts
@@ -239,6 +432,43 @@ func (_m *SecurityModuleClient) GetConfig(ctx context.Context, in *api.GetConfig
 	return r0, r1
 }
 
+// SecurityModuleClient_GetConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfig'
+type SecurityModuleClient_GetConfig_Call struct {
+	*mock.Call
+}
+
+// GetConfig is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.GetConfigParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) GetConfig(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_GetConfig_Call {
+	return &SecurityModuleClient_GetConfig_Call{Call: _e.mock.On("GetConfig",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_GetConfig_Call) Run(run func(ctx context.Context, in *api.GetConfigParams, opts ...grpc.CallOption)) *SecurityModuleClient_GetConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.GetConfigParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetConfig_Call) Return(_a0 *api.SecurityConfigMessage, _a1 error) *SecurityModuleClient_GetConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetConfig_Call) RunAndReturn(run func(context.Context, *api.GetConfigParams, ...grpc.CallOption) (*api.SecurityConfigMessage, error)) *SecurityModuleClient_GetConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetEvents provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) GetEvents(ctx context.Context, in *api.GetEventParams, opts ...grpc.CallOption) (grpc.ServerStreamingClient[api.SecurityEventMessage], error) {
 	_va := make([]interface{}, len(opts))
@@ -274,6 +504,43 @@ func (_m *SecurityModuleClient) GetEvents(ctx context.Context, in *api.GetEventP
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_GetEvents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEvents'
+type SecurityModuleClient_GetEvents_Call struct {
+	*mock.Call
+}
+
+// GetEvents is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.GetEventParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) GetEvents(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_GetEvents_Call {
+	return &SecurityModuleClient_GetEvents_Call{Call: _e.mock.On("GetEvents",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_GetEvents_Call) Run(run func(ctx context.Context, in *api.GetEventParams, opts ...grpc.CallOption)) *SecurityModuleClient_GetEvents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.GetEventParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetEvents_Call) Return(_a0 grpc.ServerStreamingClient[api.SecurityEventMessage], _a1 error) *SecurityModuleClient_GetEvents_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetEvents_Call) RunAndReturn(run func(context.Context, *api.GetEventParams, ...grpc.CallOption) (grpc.ServerStreamingClient[api.SecurityEventMessage], error)) *SecurityModuleClient_GetEvents_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GetRuleSetReport provides a mock function with given fields: ctx, in, opts
@@ -313,6 +580,43 @@ func (_m *SecurityModuleClient) GetRuleSetReport(ctx context.Context, in *api.Ge
 	return r0, r1
 }
 
+// SecurityModuleClient_GetRuleSetReport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRuleSetReport'
+type SecurityModuleClient_GetRuleSetReport_Call struct {
+	*mock.Call
+}
+
+// GetRuleSetReport is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.GetRuleSetReportParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) GetRuleSetReport(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_GetRuleSetReport_Call {
+	return &SecurityModuleClient_GetRuleSetReport_Call{Call: _e.mock.On("GetRuleSetReport",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_GetRuleSetReport_Call) Run(run func(ctx context.Context, in *api.GetRuleSetReportParams, opts ...grpc.CallOption)) *SecurityModuleClient_GetRuleSetReport_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.GetRuleSetReportParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetRuleSetReport_Call) Return(_a0 *api.GetRuleSetReportResultMessage, _a1 error) *SecurityModuleClient_GetRuleSetReport_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetRuleSetReport_Call) RunAndReturn(run func(context.Context, *api.GetRuleSetReportParams, ...grpc.CallOption) (*api.GetRuleSetReportResultMessage, error)) *SecurityModuleClient_GetRuleSetReport_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStatus provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) GetStatus(ctx context.Context, in *api.GetStatusParams, opts ...grpc.CallOption) (*api.Status, error) {
 	_va := make([]interface{}, len(opts))
@@ -348,6 +652,43 @@ func (_m *SecurityModuleClient) GetStatus(ctx context.Context, in *api.GetStatus
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_GetStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStatus'
+type SecurityModuleClient_GetStatus_Call struct {
+	*mock.Call
+}
+
+// GetStatus is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.GetStatusParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) GetStatus(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_GetStatus_Call {
+	return &SecurityModuleClient_GetStatus_Call{Call: _e.mock.On("GetStatus",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_GetStatus_Call) Run(run func(ctx context.Context, in *api.GetStatusParams, opts ...grpc.CallOption)) *SecurityModuleClient_GetStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.GetStatusParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetStatus_Call) Return(_a0 *api.Status, _a1 error) *SecurityModuleClient_GetStatus_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_GetStatus_Call) RunAndReturn(run func(context.Context, *api.GetStatusParams, ...grpc.CallOption) (*api.Status, error)) *SecurityModuleClient_GetStatus_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ListActivityDumps provides a mock function with given fields: ctx, in, opts
@@ -387,6 +728,43 @@ func (_m *SecurityModuleClient) ListActivityDumps(ctx context.Context, in *api.A
 	return r0, r1
 }
 
+// SecurityModuleClient_ListActivityDumps_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListActivityDumps'
+type SecurityModuleClient_ListActivityDumps_Call struct {
+	*mock.Call
+}
+
+// ListActivityDumps is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.ActivityDumpListParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) ListActivityDumps(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_ListActivityDumps_Call {
+	return &SecurityModuleClient_ListActivityDumps_Call{Call: _e.mock.On("ListActivityDumps",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_ListActivityDumps_Call) Run(run func(ctx context.Context, in *api.ActivityDumpListParams, opts ...grpc.CallOption)) *SecurityModuleClient_ListActivityDumps_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.ActivityDumpListParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_ListActivityDumps_Call) Return(_a0 *api.ActivityDumpListMessage, _a1 error) *SecurityModuleClient_ListActivityDumps_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_ListActivityDumps_Call) RunAndReturn(run func(context.Context, *api.ActivityDumpListParams, ...grpc.CallOption) (*api.ActivityDumpListMessage, error)) *SecurityModuleClient_ListActivityDumps_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListSecurityProfiles provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) ListSecurityProfiles(ctx context.Context, in *api.SecurityProfileListParams, opts ...grpc.CallOption) (*api.SecurityProfileListMessage, error) {
 	_va := make([]interface{}, len(opts))
@@ -422,6 +800,43 @@ func (_m *SecurityModuleClient) ListSecurityProfiles(ctx context.Context, in *ap
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_ListSecurityProfiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSecurityProfiles'
+type SecurityModuleClient_ListSecurityProfiles_Call struct {
+	*mock.Call
+}
+
+// ListSecurityProfiles is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.SecurityProfileListParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) ListSecurityProfiles(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_ListSecurityProfiles_Call {
+	return &SecurityModuleClient_ListSecurityProfiles_Call{Call: _e.mock.On("ListSecurityProfiles",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_ListSecurityProfiles_Call) Run(run func(ctx context.Context, in *api.SecurityProfileListParams, opts ...grpc.CallOption)) *SecurityModuleClient_ListSecurityProfiles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.SecurityProfileListParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_ListSecurityProfiles_Call) Return(_a0 *api.SecurityProfileListMessage, _a1 error) *SecurityModuleClient_ListSecurityProfiles_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_ListSecurityProfiles_Call) RunAndReturn(run func(context.Context, *api.SecurityProfileListParams, ...grpc.CallOption) (*api.SecurityProfileListMessage, error)) *SecurityModuleClient_ListSecurityProfiles_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ReloadPolicies provides a mock function with given fields: ctx, in, opts
@@ -461,6 +876,43 @@ func (_m *SecurityModuleClient) ReloadPolicies(ctx context.Context, in *api.Relo
 	return r0, r1
 }
 
+// SecurityModuleClient_ReloadPolicies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReloadPolicies'
+type SecurityModuleClient_ReloadPolicies_Call struct {
+	*mock.Call
+}
+
+// ReloadPolicies is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.ReloadPoliciesParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) ReloadPolicies(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_ReloadPolicies_Call {
+	return &SecurityModuleClient_ReloadPolicies_Call{Call: _e.mock.On("ReloadPolicies",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_ReloadPolicies_Call) Run(run func(ctx context.Context, in *api.ReloadPoliciesParams, opts ...grpc.CallOption)) *SecurityModuleClient_ReloadPolicies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.ReloadPoliciesParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_ReloadPolicies_Call) Return(_a0 *api.ReloadPoliciesResultMessage, _a1 error) *SecurityModuleClient_ReloadPolicies_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_ReloadPolicies_Call) RunAndReturn(run func(context.Context, *api.ReloadPoliciesParams, ...grpc.CallOption) (*api.ReloadPoliciesResultMessage, error)) *SecurityModuleClient_ReloadPolicies_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RunSelfTest provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) RunSelfTest(ctx context.Context, in *api.RunSelfTestParams, opts ...grpc.CallOption) (*api.SecuritySelfTestResultMessage, error) {
 	_va := make([]interface{}, len(opts))
@@ -496,6 +948,43 @@ func (_m *SecurityModuleClient) RunSelfTest(ctx context.Context, in *api.RunSelf
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_RunSelfTest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RunSelfTest'
+type SecurityModuleClient_RunSelfTest_Call struct {
+	*mock.Call
+}
+
+// RunSelfTest is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.RunSelfTestParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) RunSelfTest(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_RunSelfTest_Call {
+	return &SecurityModuleClient_RunSelfTest_Call{Call: _e.mock.On("RunSelfTest",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_RunSelfTest_Call) Run(run func(ctx context.Context, in *api.RunSelfTestParams, opts ...grpc.CallOption)) *SecurityModuleClient_RunSelfTest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.RunSelfTestParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_RunSelfTest_Call) Return(_a0 *api.SecuritySelfTestResultMessage, _a1 error) *SecurityModuleClient_RunSelfTest_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_RunSelfTest_Call) RunAndReturn(run func(context.Context, *api.RunSelfTestParams, ...grpc.CallOption) (*api.SecuritySelfTestResultMessage, error)) *SecurityModuleClient_RunSelfTest_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SaveSecurityProfile provides a mock function with given fields: ctx, in, opts
@@ -535,6 +1024,43 @@ func (_m *SecurityModuleClient) SaveSecurityProfile(ctx context.Context, in *api
 	return r0, r1
 }
 
+// SecurityModuleClient_SaveSecurityProfile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveSecurityProfile'
+type SecurityModuleClient_SaveSecurityProfile_Call struct {
+	*mock.Call
+}
+
+// SaveSecurityProfile is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.SecurityProfileSaveParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) SaveSecurityProfile(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_SaveSecurityProfile_Call {
+	return &SecurityModuleClient_SaveSecurityProfile_Call{Call: _e.mock.On("SaveSecurityProfile",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_SaveSecurityProfile_Call) Run(run func(ctx context.Context, in *api.SecurityProfileSaveParams, opts ...grpc.CallOption)) *SecurityModuleClient_SaveSecurityProfile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.SecurityProfileSaveParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_SaveSecurityProfile_Call) Return(_a0 *api.SecurityProfileSaveMessage, _a1 error) *SecurityModuleClient_SaveSecurityProfile_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_SaveSecurityProfile_Call) RunAndReturn(run func(context.Context, *api.SecurityProfileSaveParams, ...grpc.CallOption) (*api.SecurityProfileSaveMessage, error)) *SecurityModuleClient_SaveSecurityProfile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StopActivityDump provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) StopActivityDump(ctx context.Context, in *api.ActivityDumpStopParams, opts ...grpc.CallOption) (*api.ActivityDumpStopMessage, error) {
 	_va := make([]interface{}, len(opts))
@@ -572,6 +1098,43 @@ func (_m *SecurityModuleClient) StopActivityDump(ctx context.Context, in *api.Ac
 	return r0, r1
 }
 
+// SecurityModuleClient_StopActivityDump_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StopActivityDump'
+type SecurityModuleClient_StopActivityDump_Call struct {
+	*mock.Call
+}
+
+// StopActivityDump is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.ActivityDumpStopParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) StopActivityDump(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_StopActivityDump_Call {
+	return &SecurityModuleClient_StopActivityDump_Call{Call: _e.mock.On("StopActivityDump",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_StopActivityDump_Call) Run(run func(ctx context.Context, in *api.ActivityDumpStopParams, opts ...grpc.CallOption)) *SecurityModuleClient_StopActivityDump_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.ActivityDumpStopParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_StopActivityDump_Call) Return(_a0 *api.ActivityDumpStopMessage, _a1 error) *SecurityModuleClient_StopActivityDump_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_StopActivityDump_Call) RunAndReturn(run func(context.Context, *api.ActivityDumpStopParams, ...grpc.CallOption) (*api.ActivityDumpStopMessage, error)) *SecurityModuleClient_StopActivityDump_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // TranscodingRequest provides a mock function with given fields: ctx, in, opts
 func (_m *SecurityModuleClient) TranscodingRequest(ctx context.Context, in *api.TranscodingRequestParams, opts ...grpc.CallOption) (*api.TranscodingRequestMessage, error) {
 	_va := make([]interface{}, len(opts))
@@ -607,6 +1170,43 @@ func (_m *SecurityModuleClient) TranscodingRequest(ctx context.Context, in *api.
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleClient_TranscodingRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TranscodingRequest'
+type SecurityModuleClient_TranscodingRequest_Call struct {
+	*mock.Call
+}
+
+// TranscodingRequest is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *api.TranscodingRequestParams
+//   - opts ...grpc.CallOption
+func (_e *SecurityModuleClient_Expecter) TranscodingRequest(ctx interface{}, in interface{}, opts ...interface{}) *SecurityModuleClient_TranscodingRequest_Call {
+	return &SecurityModuleClient_TranscodingRequest_Call{Call: _e.mock.On("TranscodingRequest",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *SecurityModuleClient_TranscodingRequest_Call) Run(run func(ctx context.Context, in *api.TranscodingRequestParams, opts ...grpc.CallOption)) *SecurityModuleClient_TranscodingRequest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*api.TranscodingRequestParams), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *SecurityModuleClient_TranscodingRequest_Call) Return(_a0 *api.TranscodingRequestMessage, _a1 error) *SecurityModuleClient_TranscodingRequest_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleClient_TranscodingRequest_Call) RunAndReturn(run func(context.Context, *api.TranscodingRequestParams, ...grpc.CallOption) (*api.TranscodingRequestMessage, error)) *SecurityModuleClient_TranscodingRequest_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewSecurityModuleClient creates a new instance of SecurityModuleClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/security/proto/api/mocks/security_module_server.go
+++ b/pkg/security/proto/api/mocks/security_module_server.go
@@ -17,6 +17,14 @@ type SecurityModuleServer struct {
 	mock.Mock
 }
 
+type SecurityModuleServer_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *SecurityModuleServer) EXPECT() *SecurityModuleServer_Expecter {
+	return &SecurityModuleServer_Expecter{mock: &_m.Mock}
+}
+
 // DumpActivity provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) DumpActivity(_a0 context.Context, _a1 *api.ActivityDumpParams) (*api.ActivityDumpMessage, error) {
 	ret := _m.Called(_a0, _a1)
@@ -45,6 +53,35 @@ func (_m *SecurityModuleServer) DumpActivity(_a0 context.Context, _a1 *api.Activ
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleServer_DumpActivity_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpActivity'
+type SecurityModuleServer_DumpActivity_Call struct {
+	*mock.Call
+}
+
+// DumpActivity is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.ActivityDumpParams
+func (_e *SecurityModuleServer_Expecter) DumpActivity(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_DumpActivity_Call {
+	return &SecurityModuleServer_DumpActivity_Call{Call: _e.mock.On("DumpActivity", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_DumpActivity_Call) Run(run func(_a0 context.Context, _a1 *api.ActivityDumpParams)) *SecurityModuleServer_DumpActivity_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.ActivityDumpParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpActivity_Call) Return(_a0 *api.ActivityDumpMessage, _a1 error) *SecurityModuleServer_DumpActivity_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpActivity_Call) RunAndReturn(run func(context.Context, *api.ActivityDumpParams) (*api.ActivityDumpMessage, error)) *SecurityModuleServer_DumpActivity_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // DumpDiscarders provides a mock function with given fields: _a0, _a1
@@ -77,6 +114,35 @@ func (_m *SecurityModuleServer) DumpDiscarders(_a0 context.Context, _a1 *api.Dum
 	return r0, r1
 }
 
+// SecurityModuleServer_DumpDiscarders_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpDiscarders'
+type SecurityModuleServer_DumpDiscarders_Call struct {
+	*mock.Call
+}
+
+// DumpDiscarders is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.DumpDiscardersParams
+func (_e *SecurityModuleServer_Expecter) DumpDiscarders(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_DumpDiscarders_Call {
+	return &SecurityModuleServer_DumpDiscarders_Call{Call: _e.mock.On("DumpDiscarders", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_DumpDiscarders_Call) Run(run func(_a0 context.Context, _a1 *api.DumpDiscardersParams)) *SecurityModuleServer_DumpDiscarders_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.DumpDiscardersParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpDiscarders_Call) Return(_a0 *api.DumpDiscardersMessage, _a1 error) *SecurityModuleServer_DumpDiscarders_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpDiscarders_Call) RunAndReturn(run func(context.Context, *api.DumpDiscardersParams) (*api.DumpDiscardersMessage, error)) *SecurityModuleServer_DumpDiscarders_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DumpNetworkNamespace provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) DumpNetworkNamespace(_a0 context.Context, _a1 *api.DumpNetworkNamespaceParams) (*api.DumpNetworkNamespaceMessage, error) {
 	ret := _m.Called(_a0, _a1)
@@ -105,6 +171,35 @@ func (_m *SecurityModuleServer) DumpNetworkNamespace(_a0 context.Context, _a1 *a
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleServer_DumpNetworkNamespace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpNetworkNamespace'
+type SecurityModuleServer_DumpNetworkNamespace_Call struct {
+	*mock.Call
+}
+
+// DumpNetworkNamespace is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.DumpNetworkNamespaceParams
+func (_e *SecurityModuleServer_Expecter) DumpNetworkNamespace(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_DumpNetworkNamespace_Call {
+	return &SecurityModuleServer_DumpNetworkNamespace_Call{Call: _e.mock.On("DumpNetworkNamespace", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_DumpNetworkNamespace_Call) Run(run func(_a0 context.Context, _a1 *api.DumpNetworkNamespaceParams)) *SecurityModuleServer_DumpNetworkNamespace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.DumpNetworkNamespaceParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpNetworkNamespace_Call) Return(_a0 *api.DumpNetworkNamespaceMessage, _a1 error) *SecurityModuleServer_DumpNetworkNamespace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpNetworkNamespace_Call) RunAndReturn(run func(context.Context, *api.DumpNetworkNamespaceParams) (*api.DumpNetworkNamespaceMessage, error)) *SecurityModuleServer_DumpNetworkNamespace_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // DumpProcessCache provides a mock function with given fields: _a0, _a1
@@ -137,6 +232,35 @@ func (_m *SecurityModuleServer) DumpProcessCache(_a0 context.Context, _a1 *api.D
 	return r0, r1
 }
 
+// SecurityModuleServer_DumpProcessCache_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DumpProcessCache'
+type SecurityModuleServer_DumpProcessCache_Call struct {
+	*mock.Call
+}
+
+// DumpProcessCache is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.DumpProcessCacheParams
+func (_e *SecurityModuleServer_Expecter) DumpProcessCache(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_DumpProcessCache_Call {
+	return &SecurityModuleServer_DumpProcessCache_Call{Call: _e.mock.On("DumpProcessCache", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_DumpProcessCache_Call) Run(run func(_a0 context.Context, _a1 *api.DumpProcessCacheParams)) *SecurityModuleServer_DumpProcessCache_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.DumpProcessCacheParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpProcessCache_Call) Return(_a0 *api.SecurityDumpProcessCacheMessage, _a1 error) *SecurityModuleServer_DumpProcessCache_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_DumpProcessCache_Call) RunAndReturn(run func(context.Context, *api.DumpProcessCacheParams) (*api.SecurityDumpProcessCacheMessage, error)) *SecurityModuleServer_DumpProcessCache_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetActivityDumpStream provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) GetActivityDumpStream(_a0 *api.ActivityDumpStreamParams, _a1 grpc.ServerStreamingServer[api.ActivityDumpStreamMessage]) error {
 	ret := _m.Called(_a0, _a1)
@@ -153,6 +277,35 @@ func (_m *SecurityModuleServer) GetActivityDumpStream(_a0 *api.ActivityDumpStrea
 	}
 
 	return r0
+}
+
+// SecurityModuleServer_GetActivityDumpStream_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetActivityDumpStream'
+type SecurityModuleServer_GetActivityDumpStream_Call struct {
+	*mock.Call
+}
+
+// GetActivityDumpStream is a helper method to define mock.On call
+//   - _a0 *api.ActivityDumpStreamParams
+//   - _a1 grpc.ServerStreamingServer[api.ActivityDumpStreamMessage]
+func (_e *SecurityModuleServer_Expecter) GetActivityDumpStream(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_GetActivityDumpStream_Call {
+	return &SecurityModuleServer_GetActivityDumpStream_Call{Call: _e.mock.On("GetActivityDumpStream", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_GetActivityDumpStream_Call) Run(run func(_a0 *api.ActivityDumpStreamParams, _a1 grpc.ServerStreamingServer[api.ActivityDumpStreamMessage])) *SecurityModuleServer_GetActivityDumpStream_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*api.ActivityDumpStreamParams), args[1].(grpc.ServerStreamingServer[api.ActivityDumpStreamMessage]))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetActivityDumpStream_Call) Return(_a0 error) *SecurityModuleServer_GetActivityDumpStream_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetActivityDumpStream_Call) RunAndReturn(run func(*api.ActivityDumpStreamParams, grpc.ServerStreamingServer[api.ActivityDumpStreamMessage]) error) *SecurityModuleServer_GetActivityDumpStream_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GetConfig provides a mock function with given fields: _a0, _a1
@@ -185,6 +338,35 @@ func (_m *SecurityModuleServer) GetConfig(_a0 context.Context, _a1 *api.GetConfi
 	return r0, r1
 }
 
+// SecurityModuleServer_GetConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetConfig'
+type SecurityModuleServer_GetConfig_Call struct {
+	*mock.Call
+}
+
+// GetConfig is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.GetConfigParams
+func (_e *SecurityModuleServer_Expecter) GetConfig(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_GetConfig_Call {
+	return &SecurityModuleServer_GetConfig_Call{Call: _e.mock.On("GetConfig", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_GetConfig_Call) Run(run func(_a0 context.Context, _a1 *api.GetConfigParams)) *SecurityModuleServer_GetConfig_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.GetConfigParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetConfig_Call) Return(_a0 *api.SecurityConfigMessage, _a1 error) *SecurityModuleServer_GetConfig_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetConfig_Call) RunAndReturn(run func(context.Context, *api.GetConfigParams) (*api.SecurityConfigMessage, error)) *SecurityModuleServer_GetConfig_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetEvents provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) GetEvents(_a0 *api.GetEventParams, _a1 grpc.ServerStreamingServer[api.SecurityEventMessage]) error {
 	ret := _m.Called(_a0, _a1)
@@ -201,6 +383,35 @@ func (_m *SecurityModuleServer) GetEvents(_a0 *api.GetEventParams, _a1 grpc.Serv
 	}
 
 	return r0
+}
+
+// SecurityModuleServer_GetEvents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetEvents'
+type SecurityModuleServer_GetEvents_Call struct {
+	*mock.Call
+}
+
+// GetEvents is a helper method to define mock.On call
+//   - _a0 *api.GetEventParams
+//   - _a1 grpc.ServerStreamingServer[api.SecurityEventMessage]
+func (_e *SecurityModuleServer_Expecter) GetEvents(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_GetEvents_Call {
+	return &SecurityModuleServer_GetEvents_Call{Call: _e.mock.On("GetEvents", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_GetEvents_Call) Run(run func(_a0 *api.GetEventParams, _a1 grpc.ServerStreamingServer[api.SecurityEventMessage])) *SecurityModuleServer_GetEvents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*api.GetEventParams), args[1].(grpc.ServerStreamingServer[api.SecurityEventMessage]))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetEvents_Call) Return(_a0 error) *SecurityModuleServer_GetEvents_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetEvents_Call) RunAndReturn(run func(*api.GetEventParams, grpc.ServerStreamingServer[api.SecurityEventMessage]) error) *SecurityModuleServer_GetEvents_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // GetRuleSetReport provides a mock function with given fields: _a0, _a1
@@ -233,6 +444,35 @@ func (_m *SecurityModuleServer) GetRuleSetReport(_a0 context.Context, _a1 *api.G
 	return r0, r1
 }
 
+// SecurityModuleServer_GetRuleSetReport_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRuleSetReport'
+type SecurityModuleServer_GetRuleSetReport_Call struct {
+	*mock.Call
+}
+
+// GetRuleSetReport is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.GetRuleSetReportParams
+func (_e *SecurityModuleServer_Expecter) GetRuleSetReport(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_GetRuleSetReport_Call {
+	return &SecurityModuleServer_GetRuleSetReport_Call{Call: _e.mock.On("GetRuleSetReport", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_GetRuleSetReport_Call) Run(run func(_a0 context.Context, _a1 *api.GetRuleSetReportParams)) *SecurityModuleServer_GetRuleSetReport_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.GetRuleSetReportParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetRuleSetReport_Call) Return(_a0 *api.GetRuleSetReportResultMessage, _a1 error) *SecurityModuleServer_GetRuleSetReport_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetRuleSetReport_Call) RunAndReturn(run func(context.Context, *api.GetRuleSetReportParams) (*api.GetRuleSetReportResultMessage, error)) *SecurityModuleServer_GetRuleSetReport_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetStatus provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) GetStatus(_a0 context.Context, _a1 *api.GetStatusParams) (*api.Status, error) {
 	ret := _m.Called(_a0, _a1)
@@ -261,6 +501,35 @@ func (_m *SecurityModuleServer) GetStatus(_a0 context.Context, _a1 *api.GetStatu
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleServer_GetStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetStatus'
+type SecurityModuleServer_GetStatus_Call struct {
+	*mock.Call
+}
+
+// GetStatus is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.GetStatusParams
+func (_e *SecurityModuleServer_Expecter) GetStatus(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_GetStatus_Call {
+	return &SecurityModuleServer_GetStatus_Call{Call: _e.mock.On("GetStatus", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_GetStatus_Call) Run(run func(_a0 context.Context, _a1 *api.GetStatusParams)) *SecurityModuleServer_GetStatus_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.GetStatusParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetStatus_Call) Return(_a0 *api.Status, _a1 error) *SecurityModuleServer_GetStatus_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_GetStatus_Call) RunAndReturn(run func(context.Context, *api.GetStatusParams) (*api.Status, error)) *SecurityModuleServer_GetStatus_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ListActivityDumps provides a mock function with given fields: _a0, _a1
@@ -293,6 +562,35 @@ func (_m *SecurityModuleServer) ListActivityDumps(_a0 context.Context, _a1 *api.
 	return r0, r1
 }
 
+// SecurityModuleServer_ListActivityDumps_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListActivityDumps'
+type SecurityModuleServer_ListActivityDumps_Call struct {
+	*mock.Call
+}
+
+// ListActivityDumps is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.ActivityDumpListParams
+func (_e *SecurityModuleServer_Expecter) ListActivityDumps(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_ListActivityDumps_Call {
+	return &SecurityModuleServer_ListActivityDumps_Call{Call: _e.mock.On("ListActivityDumps", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_ListActivityDumps_Call) Run(run func(_a0 context.Context, _a1 *api.ActivityDumpListParams)) *SecurityModuleServer_ListActivityDumps_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.ActivityDumpListParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_ListActivityDumps_Call) Return(_a0 *api.ActivityDumpListMessage, _a1 error) *SecurityModuleServer_ListActivityDumps_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_ListActivityDumps_Call) RunAndReturn(run func(context.Context, *api.ActivityDumpListParams) (*api.ActivityDumpListMessage, error)) *SecurityModuleServer_ListActivityDumps_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListSecurityProfiles provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) ListSecurityProfiles(_a0 context.Context, _a1 *api.SecurityProfileListParams) (*api.SecurityProfileListMessage, error) {
 	ret := _m.Called(_a0, _a1)
@@ -321,6 +619,35 @@ func (_m *SecurityModuleServer) ListSecurityProfiles(_a0 context.Context, _a1 *a
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleServer_ListSecurityProfiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListSecurityProfiles'
+type SecurityModuleServer_ListSecurityProfiles_Call struct {
+	*mock.Call
+}
+
+// ListSecurityProfiles is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.SecurityProfileListParams
+func (_e *SecurityModuleServer_Expecter) ListSecurityProfiles(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_ListSecurityProfiles_Call {
+	return &SecurityModuleServer_ListSecurityProfiles_Call{Call: _e.mock.On("ListSecurityProfiles", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_ListSecurityProfiles_Call) Run(run func(_a0 context.Context, _a1 *api.SecurityProfileListParams)) *SecurityModuleServer_ListSecurityProfiles_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.SecurityProfileListParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_ListSecurityProfiles_Call) Return(_a0 *api.SecurityProfileListMessage, _a1 error) *SecurityModuleServer_ListSecurityProfiles_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_ListSecurityProfiles_Call) RunAndReturn(run func(context.Context, *api.SecurityProfileListParams) (*api.SecurityProfileListMessage, error)) *SecurityModuleServer_ListSecurityProfiles_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // ReloadPolicies provides a mock function with given fields: _a0, _a1
@@ -353,6 +680,35 @@ func (_m *SecurityModuleServer) ReloadPolicies(_a0 context.Context, _a1 *api.Rel
 	return r0, r1
 }
 
+// SecurityModuleServer_ReloadPolicies_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReloadPolicies'
+type SecurityModuleServer_ReloadPolicies_Call struct {
+	*mock.Call
+}
+
+// ReloadPolicies is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.ReloadPoliciesParams
+func (_e *SecurityModuleServer_Expecter) ReloadPolicies(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_ReloadPolicies_Call {
+	return &SecurityModuleServer_ReloadPolicies_Call{Call: _e.mock.On("ReloadPolicies", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_ReloadPolicies_Call) Run(run func(_a0 context.Context, _a1 *api.ReloadPoliciesParams)) *SecurityModuleServer_ReloadPolicies_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.ReloadPoliciesParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_ReloadPolicies_Call) Return(_a0 *api.ReloadPoliciesResultMessage, _a1 error) *SecurityModuleServer_ReloadPolicies_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_ReloadPolicies_Call) RunAndReturn(run func(context.Context, *api.ReloadPoliciesParams) (*api.ReloadPoliciesResultMessage, error)) *SecurityModuleServer_ReloadPolicies_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RunSelfTest provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) RunSelfTest(_a0 context.Context, _a1 *api.RunSelfTestParams) (*api.SecuritySelfTestResultMessage, error) {
 	ret := _m.Called(_a0, _a1)
@@ -381,6 +737,35 @@ func (_m *SecurityModuleServer) RunSelfTest(_a0 context.Context, _a1 *api.RunSel
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleServer_RunSelfTest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RunSelfTest'
+type SecurityModuleServer_RunSelfTest_Call struct {
+	*mock.Call
+}
+
+// RunSelfTest is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.RunSelfTestParams
+func (_e *SecurityModuleServer_Expecter) RunSelfTest(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_RunSelfTest_Call {
+	return &SecurityModuleServer_RunSelfTest_Call{Call: _e.mock.On("RunSelfTest", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_RunSelfTest_Call) Run(run func(_a0 context.Context, _a1 *api.RunSelfTestParams)) *SecurityModuleServer_RunSelfTest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.RunSelfTestParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_RunSelfTest_Call) Return(_a0 *api.SecuritySelfTestResultMessage, _a1 error) *SecurityModuleServer_RunSelfTest_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_RunSelfTest_Call) RunAndReturn(run func(context.Context, *api.RunSelfTestParams) (*api.SecuritySelfTestResultMessage, error)) *SecurityModuleServer_RunSelfTest_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SaveSecurityProfile provides a mock function with given fields: _a0, _a1
@@ -413,6 +798,35 @@ func (_m *SecurityModuleServer) SaveSecurityProfile(_a0 context.Context, _a1 *ap
 	return r0, r1
 }
 
+// SecurityModuleServer_SaveSecurityProfile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SaveSecurityProfile'
+type SecurityModuleServer_SaveSecurityProfile_Call struct {
+	*mock.Call
+}
+
+// SaveSecurityProfile is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.SecurityProfileSaveParams
+func (_e *SecurityModuleServer_Expecter) SaveSecurityProfile(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_SaveSecurityProfile_Call {
+	return &SecurityModuleServer_SaveSecurityProfile_Call{Call: _e.mock.On("SaveSecurityProfile", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_SaveSecurityProfile_Call) Run(run func(_a0 context.Context, _a1 *api.SecurityProfileSaveParams)) *SecurityModuleServer_SaveSecurityProfile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.SecurityProfileSaveParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_SaveSecurityProfile_Call) Return(_a0 *api.SecurityProfileSaveMessage, _a1 error) *SecurityModuleServer_SaveSecurityProfile_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_SaveSecurityProfile_Call) RunAndReturn(run func(context.Context, *api.SecurityProfileSaveParams) (*api.SecurityProfileSaveMessage, error)) *SecurityModuleServer_SaveSecurityProfile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // StopActivityDump provides a mock function with given fields: _a0, _a1
 func (_m *SecurityModuleServer) StopActivityDump(_a0 context.Context, _a1 *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error) {
 	ret := _m.Called(_a0, _a1)
@@ -441,6 +855,35 @@ func (_m *SecurityModuleServer) StopActivityDump(_a0 context.Context, _a1 *api.A
 	}
 
 	return r0, r1
+}
+
+// SecurityModuleServer_StopActivityDump_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'StopActivityDump'
+type SecurityModuleServer_StopActivityDump_Call struct {
+	*mock.Call
+}
+
+// StopActivityDump is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.ActivityDumpStopParams
+func (_e *SecurityModuleServer_Expecter) StopActivityDump(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_StopActivityDump_Call {
+	return &SecurityModuleServer_StopActivityDump_Call{Call: _e.mock.On("StopActivityDump", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_StopActivityDump_Call) Run(run func(_a0 context.Context, _a1 *api.ActivityDumpStopParams)) *SecurityModuleServer_StopActivityDump_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.ActivityDumpStopParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_StopActivityDump_Call) Return(_a0 *api.ActivityDumpStopMessage, _a1 error) *SecurityModuleServer_StopActivityDump_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_StopActivityDump_Call) RunAndReturn(run func(context.Context, *api.ActivityDumpStopParams) (*api.ActivityDumpStopMessage, error)) *SecurityModuleServer_StopActivityDump_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // TranscodingRequest provides a mock function with given fields: _a0, _a1
@@ -473,9 +916,65 @@ func (_m *SecurityModuleServer) TranscodingRequest(_a0 context.Context, _a1 *api
 	return r0, r1
 }
 
+// SecurityModuleServer_TranscodingRequest_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'TranscodingRequest'
+type SecurityModuleServer_TranscodingRequest_Call struct {
+	*mock.Call
+}
+
+// TranscodingRequest is a helper method to define mock.On call
+//   - _a0 context.Context
+//   - _a1 *api.TranscodingRequestParams
+func (_e *SecurityModuleServer_Expecter) TranscodingRequest(_a0 interface{}, _a1 interface{}) *SecurityModuleServer_TranscodingRequest_Call {
+	return &SecurityModuleServer_TranscodingRequest_Call{Call: _e.mock.On("TranscodingRequest", _a0, _a1)}
+}
+
+func (_c *SecurityModuleServer_TranscodingRequest_Call) Run(run func(_a0 context.Context, _a1 *api.TranscodingRequestParams)) *SecurityModuleServer_TranscodingRequest_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*api.TranscodingRequestParams))
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_TranscodingRequest_Call) Return(_a0 *api.TranscodingRequestMessage, _a1 error) *SecurityModuleServer_TranscodingRequest_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *SecurityModuleServer_TranscodingRequest_Call) RunAndReturn(run func(context.Context, *api.TranscodingRequestParams) (*api.TranscodingRequestMessage, error)) *SecurityModuleServer_TranscodingRequest_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // mustEmbedUnimplementedSecurityModuleServer provides a mock function with no fields
 func (_m *SecurityModuleServer) mustEmbedUnimplementedSecurityModuleServer() {
 	_m.Called()
+}
+
+// SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'mustEmbedUnimplementedSecurityModuleServer'
+type SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call struct {
+	*mock.Call
+}
+
+// mustEmbedUnimplementedSecurityModuleServer is a helper method to define mock.On call
+func (_e *SecurityModuleServer_Expecter) mustEmbedUnimplementedSecurityModuleServer() *SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call {
+	return &SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call{Call: _e.mock.On("mustEmbedUnimplementedSecurityModuleServer")}
+}
+
+func (_c *SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call) Run(run func()) *SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call) Return() *SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call) RunAndReturn(run func()) *SecurityModuleServer_mustEmbedUnimplementedSecurityModuleServer_Call {
+	_c.Run(run)
+	return _c
 }
 
 // NewSecurityModuleServer creates a new instance of SecurityModuleServer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/pkg/serializer/mocks/metric_serializer.go
+++ b/pkg/serializer/mocks/metric_serializer.go
@@ -22,6 +22,14 @@ type MetricSerializer struct {
 	mock.Mock
 }
 
+type MetricSerializer_Expecter struct {
+	mock *mock.Mock
+}
+
+func (_m *MetricSerializer) EXPECT() *MetricSerializer_Expecter {
+	return &MetricSerializer_Expecter{mock: &_m.Mock}
+}
+
 // AreSeriesEnabled provides a mock function with no fields
 func (_m *MetricSerializer) AreSeriesEnabled() bool {
 	ret := _m.Called()
@@ -38,6 +46,33 @@ func (_m *MetricSerializer) AreSeriesEnabled() bool {
 	}
 
 	return r0
+}
+
+// MetricSerializer_AreSeriesEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AreSeriesEnabled'
+type MetricSerializer_AreSeriesEnabled_Call struct {
+	*mock.Call
+}
+
+// AreSeriesEnabled is a helper method to define mock.On call
+func (_e *MetricSerializer_Expecter) AreSeriesEnabled() *MetricSerializer_AreSeriesEnabled_Call {
+	return &MetricSerializer_AreSeriesEnabled_Call{Call: _e.mock.On("AreSeriesEnabled")}
+}
+
+func (_c *MetricSerializer_AreSeriesEnabled_Call) Run(run func()) *MetricSerializer_AreSeriesEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_AreSeriesEnabled_Call) Return(_a0 bool) *MetricSerializer_AreSeriesEnabled_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_AreSeriesEnabled_Call) RunAndReturn(run func() bool) *MetricSerializer_AreSeriesEnabled_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // AreSketchesEnabled provides a mock function with no fields
@@ -58,6 +93,33 @@ func (_m *MetricSerializer) AreSketchesEnabled() bool {
 	return r0
 }
 
+// MetricSerializer_AreSketchesEnabled_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AreSketchesEnabled'
+type MetricSerializer_AreSketchesEnabled_Call struct {
+	*mock.Call
+}
+
+// AreSketchesEnabled is a helper method to define mock.On call
+func (_e *MetricSerializer_Expecter) AreSketchesEnabled() *MetricSerializer_AreSketchesEnabled_Call {
+	return &MetricSerializer_AreSketchesEnabled_Call{Call: _e.mock.On("AreSketchesEnabled")}
+}
+
+func (_c *MetricSerializer_AreSketchesEnabled_Call) Run(run func()) *MetricSerializer_AreSketchesEnabled_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_AreSketchesEnabled_Call) Return(_a0 bool) *MetricSerializer_AreSketchesEnabled_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_AreSketchesEnabled_Call) RunAndReturn(run func() bool) *MetricSerializer_AreSketchesEnabled_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SendAgentchecksMetadata provides a mock function with given fields: m
 func (_m *MetricSerializer) SendAgentchecksMetadata(m marshaler.JSONMarshaler) error {
 	ret := _m.Called(m)
@@ -74,6 +136,34 @@ func (_m *MetricSerializer) SendAgentchecksMetadata(m marshaler.JSONMarshaler) e
 	}
 
 	return r0
+}
+
+// MetricSerializer_SendAgentchecksMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendAgentchecksMetadata'
+type MetricSerializer_SendAgentchecksMetadata_Call struct {
+	*mock.Call
+}
+
+// SendAgentchecksMetadata is a helper method to define mock.On call
+//   - m marshaler.JSONMarshaler
+func (_e *MetricSerializer_Expecter) SendAgentchecksMetadata(m interface{}) *MetricSerializer_SendAgentchecksMetadata_Call {
+	return &MetricSerializer_SendAgentchecksMetadata_Call{Call: _e.mock.On("SendAgentchecksMetadata", m)}
+}
+
+func (_c *MetricSerializer_SendAgentchecksMetadata_Call) Run(run func(m marshaler.JSONMarshaler)) *MetricSerializer_SendAgentchecksMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(marshaler.JSONMarshaler))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendAgentchecksMetadata_Call) Return(_a0 error) *MetricSerializer_SendAgentchecksMetadata_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendAgentchecksMetadata_Call) RunAndReturn(run func(marshaler.JSONMarshaler) error) *MetricSerializer_SendAgentchecksMetadata_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SendEvents provides a mock function with given fields: e
@@ -94,6 +184,34 @@ func (_m *MetricSerializer) SendEvents(e event.Events) error {
 	return r0
 }
 
+// MetricSerializer_SendEvents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendEvents'
+type MetricSerializer_SendEvents_Call struct {
+	*mock.Call
+}
+
+// SendEvents is a helper method to define mock.On call
+//   - e event.Events
+func (_e *MetricSerializer_Expecter) SendEvents(e interface{}) *MetricSerializer_SendEvents_Call {
+	return &MetricSerializer_SendEvents_Call{Call: _e.mock.On("SendEvents", e)}
+}
+
+func (_c *MetricSerializer_SendEvents_Call) Run(run func(e event.Events)) *MetricSerializer_SendEvents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(event.Events))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendEvents_Call) Return(_a0 error) *MetricSerializer_SendEvents_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendEvents_Call) RunAndReturn(run func(event.Events) error) *MetricSerializer_SendEvents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SendHostMetadata provides a mock function with given fields: m
 func (_m *MetricSerializer) SendHostMetadata(m marshaler.JSONMarshaler) error {
 	ret := _m.Called(m)
@@ -110,6 +228,34 @@ func (_m *MetricSerializer) SendHostMetadata(m marshaler.JSONMarshaler) error {
 	}
 
 	return r0
+}
+
+// MetricSerializer_SendHostMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendHostMetadata'
+type MetricSerializer_SendHostMetadata_Call struct {
+	*mock.Call
+}
+
+// SendHostMetadata is a helper method to define mock.On call
+//   - m marshaler.JSONMarshaler
+func (_e *MetricSerializer_Expecter) SendHostMetadata(m interface{}) *MetricSerializer_SendHostMetadata_Call {
+	return &MetricSerializer_SendHostMetadata_Call{Call: _e.mock.On("SendHostMetadata", m)}
+}
+
+func (_c *MetricSerializer_SendHostMetadata_Call) Run(run func(m marshaler.JSONMarshaler)) *MetricSerializer_SendHostMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(marshaler.JSONMarshaler))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendHostMetadata_Call) Return(_a0 error) *MetricSerializer_SendHostMetadata_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendHostMetadata_Call) RunAndReturn(run func(marshaler.JSONMarshaler) error) *MetricSerializer_SendHostMetadata_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SendIterableSeries provides a mock function with given fields: serieSource
@@ -130,6 +276,34 @@ func (_m *MetricSerializer) SendIterableSeries(serieSource metrics.SerieSource) 
 	return r0
 }
 
+// MetricSerializer_SendIterableSeries_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendIterableSeries'
+type MetricSerializer_SendIterableSeries_Call struct {
+	*mock.Call
+}
+
+// SendIterableSeries is a helper method to define mock.On call
+//   - serieSource metrics.SerieSource
+func (_e *MetricSerializer_Expecter) SendIterableSeries(serieSource interface{}) *MetricSerializer_SendIterableSeries_Call {
+	return &MetricSerializer_SendIterableSeries_Call{Call: _e.mock.On("SendIterableSeries", serieSource)}
+}
+
+func (_c *MetricSerializer_SendIterableSeries_Call) Run(run func(serieSource metrics.SerieSource)) *MetricSerializer_SendIterableSeries_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(metrics.SerieSource))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendIterableSeries_Call) Return(_a0 error) *MetricSerializer_SendIterableSeries_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendIterableSeries_Call) RunAndReturn(run func(metrics.SerieSource) error) *MetricSerializer_SendIterableSeries_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SendMetadata provides a mock function with given fields: m
 func (_m *MetricSerializer) SendMetadata(m marshaler.JSONMarshaler) error {
 	ret := _m.Called(m)
@@ -146,6 +320,34 @@ func (_m *MetricSerializer) SendMetadata(m marshaler.JSONMarshaler) error {
 	}
 
 	return r0
+}
+
+// MetricSerializer_SendMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendMetadata'
+type MetricSerializer_SendMetadata_Call struct {
+	*mock.Call
+}
+
+// SendMetadata is a helper method to define mock.On call
+//   - m marshaler.JSONMarshaler
+func (_e *MetricSerializer_Expecter) SendMetadata(m interface{}) *MetricSerializer_SendMetadata_Call {
+	return &MetricSerializer_SendMetadata_Call{Call: _e.mock.On("SendMetadata", m)}
+}
+
+func (_c *MetricSerializer_SendMetadata_Call) Run(run func(m marshaler.JSONMarshaler)) *MetricSerializer_SendMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(marshaler.JSONMarshaler))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendMetadata_Call) Return(_a0 error) *MetricSerializer_SendMetadata_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendMetadata_Call) RunAndReturn(run func(marshaler.JSONMarshaler) error) *MetricSerializer_SendMetadata_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SendOrchestratorManifests provides a mock function with given fields: msgs, hostName, clusterID
@@ -166,6 +368,36 @@ func (_m *MetricSerializer) SendOrchestratorManifests(msgs []types.ProcessMessag
 	return r0
 }
 
+// MetricSerializer_SendOrchestratorManifests_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendOrchestratorManifests'
+type MetricSerializer_SendOrchestratorManifests_Call struct {
+	*mock.Call
+}
+
+// SendOrchestratorManifests is a helper method to define mock.On call
+//   - msgs []types.ProcessMessageBody
+//   - hostName string
+//   - clusterID string
+func (_e *MetricSerializer_Expecter) SendOrchestratorManifests(msgs interface{}, hostName interface{}, clusterID interface{}) *MetricSerializer_SendOrchestratorManifests_Call {
+	return &MetricSerializer_SendOrchestratorManifests_Call{Call: _e.mock.On("SendOrchestratorManifests", msgs, hostName, clusterID)}
+}
+
+func (_c *MetricSerializer_SendOrchestratorManifests_Call) Run(run func(msgs []types.ProcessMessageBody, hostName string, clusterID string)) *MetricSerializer_SendOrchestratorManifests_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]types.ProcessMessageBody), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendOrchestratorManifests_Call) Return(_a0 error) *MetricSerializer_SendOrchestratorManifests_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendOrchestratorManifests_Call) RunAndReturn(run func([]types.ProcessMessageBody, string, string) error) *MetricSerializer_SendOrchestratorManifests_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SendOrchestratorMetadata provides a mock function with given fields: msgs, hostName, clusterID, payloadType
 func (_m *MetricSerializer) SendOrchestratorMetadata(msgs []types.ProcessMessageBody, hostName string, clusterID string, payloadType int) error {
 	ret := _m.Called(msgs, hostName, clusterID, payloadType)
@@ -182,6 +414,37 @@ func (_m *MetricSerializer) SendOrchestratorMetadata(msgs []types.ProcessMessage
 	}
 
 	return r0
+}
+
+// MetricSerializer_SendOrchestratorMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendOrchestratorMetadata'
+type MetricSerializer_SendOrchestratorMetadata_Call struct {
+	*mock.Call
+}
+
+// SendOrchestratorMetadata is a helper method to define mock.On call
+//   - msgs []types.ProcessMessageBody
+//   - hostName string
+//   - clusterID string
+//   - payloadType int
+func (_e *MetricSerializer_Expecter) SendOrchestratorMetadata(msgs interface{}, hostName interface{}, clusterID interface{}, payloadType interface{}) *MetricSerializer_SendOrchestratorMetadata_Call {
+	return &MetricSerializer_SendOrchestratorMetadata_Call{Call: _e.mock.On("SendOrchestratorMetadata", msgs, hostName, clusterID, payloadType)}
+}
+
+func (_c *MetricSerializer_SendOrchestratorMetadata_Call) Run(run func(msgs []types.ProcessMessageBody, hostName string, clusterID string, payloadType int)) *MetricSerializer_SendOrchestratorMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]types.ProcessMessageBody), args[1].(string), args[2].(string), args[3].(int))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendOrchestratorMetadata_Call) Return(_a0 error) *MetricSerializer_SendOrchestratorMetadata_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendOrchestratorMetadata_Call) RunAndReturn(run func([]types.ProcessMessageBody, string, string, int) error) *MetricSerializer_SendOrchestratorMetadata_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // SendProcessesMetadata provides a mock function with given fields: data
@@ -202,6 +465,34 @@ func (_m *MetricSerializer) SendProcessesMetadata(data interface{}) error {
 	return r0
 }
 
+// MetricSerializer_SendProcessesMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendProcessesMetadata'
+type MetricSerializer_SendProcessesMetadata_Call struct {
+	*mock.Call
+}
+
+// SendProcessesMetadata is a helper method to define mock.On call
+//   - data interface{}
+func (_e *MetricSerializer_Expecter) SendProcessesMetadata(data interface{}) *MetricSerializer_SendProcessesMetadata_Call {
+	return &MetricSerializer_SendProcessesMetadata_Call{Call: _e.mock.On("SendProcessesMetadata", data)}
+}
+
+func (_c *MetricSerializer_SendProcessesMetadata_Call) Run(run func(data interface{})) *MetricSerializer_SendProcessesMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(interface{}))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendProcessesMetadata_Call) Return(_a0 error) *MetricSerializer_SendProcessesMetadata_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendProcessesMetadata_Call) RunAndReturn(run func(interface{}) error) *MetricSerializer_SendProcessesMetadata_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SendServiceChecks provides a mock function with given fields: serviceChecks
 func (_m *MetricSerializer) SendServiceChecks(serviceChecks servicecheck.ServiceChecks) error {
 	ret := _m.Called(serviceChecks)
@@ -220,6 +511,34 @@ func (_m *MetricSerializer) SendServiceChecks(serviceChecks servicecheck.Service
 	return r0
 }
 
+// MetricSerializer_SendServiceChecks_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendServiceChecks'
+type MetricSerializer_SendServiceChecks_Call struct {
+	*mock.Call
+}
+
+// SendServiceChecks is a helper method to define mock.On call
+//   - serviceChecks servicecheck.ServiceChecks
+func (_e *MetricSerializer_Expecter) SendServiceChecks(serviceChecks interface{}) *MetricSerializer_SendServiceChecks_Call {
+	return &MetricSerializer_SendServiceChecks_Call{Call: _e.mock.On("SendServiceChecks", serviceChecks)}
+}
+
+func (_c *MetricSerializer_SendServiceChecks_Call) Run(run func(serviceChecks servicecheck.ServiceChecks)) *MetricSerializer_SendServiceChecks_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(servicecheck.ServiceChecks))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendServiceChecks_Call) Return(_a0 error) *MetricSerializer_SendServiceChecks_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendServiceChecks_Call) RunAndReturn(run func(servicecheck.ServiceChecks) error) *MetricSerializer_SendServiceChecks_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SendSketch provides a mock function with given fields: sketches
 func (_m *MetricSerializer) SendSketch(sketches metrics.SketchesSource) error {
 	ret := _m.Called(sketches)
@@ -236,6 +555,34 @@ func (_m *MetricSerializer) SendSketch(sketches metrics.SketchesSource) error {
 	}
 
 	return r0
+}
+
+// MetricSerializer_SendSketch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SendSketch'
+type MetricSerializer_SendSketch_Call struct {
+	*mock.Call
+}
+
+// SendSketch is a helper method to define mock.On call
+//   - sketches metrics.SketchesSource
+func (_e *MetricSerializer_Expecter) SendSketch(sketches interface{}) *MetricSerializer_SendSketch_Call {
+	return &MetricSerializer_SendSketch_Call{Call: _e.mock.On("SendSketch", sketches)}
+}
+
+func (_c *MetricSerializer_SendSketch_Call) Run(run func(sketches metrics.SketchesSource)) *MetricSerializer_SendSketch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(metrics.SketchesSource))
+	})
+	return _c
+}
+
+func (_c *MetricSerializer_SendSketch_Call) Return(_a0 error) *MetricSerializer_SendSketch_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MetricSerializer_SendSketch_Call) RunAndReturn(run func(metrics.SketchesSource) error) *MetricSerializer_SendSketch_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // NewMetricSerializer creates a new instance of MetricSerializer. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When we generate mocks today, we get a lot of deprecation warnings from mockery:
```
11 Feb 25 15:10 CET WRN DEPRECATION: with-expecter will be permanently set to True in v3 dry-run=false url=https://vektra.github.io/mockery/v2.49/deprecations/#with-expecter version=v2.49.2
11 Feb 25 15:10 CET WRN DEPRECATION: issue-845-fix must be set to True to remove this warning. Visit the link for more details. dry-run=false interface=Check qualified-name=github.com/DataDog/datadog-agent/pkg/process/checks url=https://vektra.github.io/mockery/v2.49/deprecations/#issue-845-fix version=v2.49.2
11 Feb 25 15:10 CET WRN DEPRECATION: resolve-type-alias will be permanently set to False in v3. Please modify your config to set the parameter to False. dry-run=false interface=MetricSerializer qualified-name=github.com/DataDog/datadog-agent/pkg/serializer url=https://vektra.github.io/mockery/v2.49/deprecations/#resolve-type-alias version=v2.49.2
```

This PR fixes some deprecation warnings, and re-generate the mocks with this new config.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

To generate mocks:
```
inv -e security-agent.gen-mocks
```
or 
```
inv -e process-agent.gen-mocks
```

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->