### PR TITLE
feat(language_detection): add support for PHP

### DIFF
--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -38,7 +38,7 @@ type languageFromCLI struct {
 
 var (
 	rubyPattern = regexp.MustCompile(`^ruby\d+\.\d+$`)
-	phpPattern  = regexp.MustCompile(`^php\d$`)
+	phpPattern  = regexp.MustCompile(`^php(?:-fpm)?\d(?:\.\d)?$`)
 )
 
 func matchesRubyPrefix(exe string) bool {

--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -36,34 +36,42 @@ type languageFromCLI struct {
 	validator func(exe string) bool
 }
 
-// rubyPattern is a regexp validator for the ruby prefix
-var rubyPattern = regexp.MustCompile(`^ruby\d+\.\d+$`)
+var (
+	rubyPattern = regexp.MustCompile(`^ruby\d+\.\d+$`)
+	phpPattern  = regexp.MustCompile(`^ruby\d$`)
+)
+
+func matchesRubyPrefix(exe string) bool {
+	return rubyPattern.MatchString(exe)
+}
+
+func matchesJavaPrefix(exe string) bool {
+	return exe != "javac"
+}
+
+func matchesPHPPrefix(exe string) bool {
+	return phpPattern.MatchString(exe)
+}
 
 // knownPrefixes maps languages names to their prefix
 var knownPrefixes = map[string]languageFromCLI{
 	"python": {name: languagemodels.Python},
-	"java": {name: languagemodels.Java, validator: func(exe string) bool {
-		return exe != "javac"
-	}},
-	"ruby": {name: languagemodels.Ruby, validator: func(exe string) bool {
-		return rubyPattern.MatchString(exe)
-	}},
+	"java":   {name: languagemodels.Java, validator: matchesJavaPrefix},
+	"ruby":   {name: languagemodels.Ruby, validator: matchesRubyPrefix},
+	"php":    {name: languagemodels.PHP, validator: matchesPHPPrefix},
 }
 
 // exactMatches maps an exact exe name match to a prefix
 var exactMatches = map[string]languageFromCLI{
 	"py":     {name: languagemodels.Python},
 	"python": {name: languagemodels.Python},
-
-	"java": {name: languagemodels.Java},
-
-	"npm":  {name: languagemodels.Node},
-	"node": {name: languagemodels.Node},
-
+	"java":   {name: languagemodels.Java},
+	"npm":    {name: languagemodels.Node},
+	"node":   {name: languagemodels.Node},
 	"dotnet": {name: languagemodels.Dotnet},
-
-	"ruby":  {name: languagemodels.Ruby},
-	"rubyw": {name: languagemodels.Ruby},
+	"ruby":   {name: languagemodels.Ruby},
+	"rubyw":  {name: languagemodels.Ruby},
+	"php":    {name: languagemodels.PHP},
 }
 
 // languageNameFromCmdline returns a process's language from its command.

--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -63,15 +63,16 @@ var knownPrefixes = map[string]languageFromCLI{
 
 // exactMatches maps an exact exe name match to a prefix
 var exactMatches = map[string]languageFromCLI{
-	"py":     {name: languagemodels.Python},
-	"python": {name: languagemodels.Python},
-	"java":   {name: languagemodels.Java},
-	"npm":    {name: languagemodels.Node},
-	"node":   {name: languagemodels.Node},
-	"dotnet": {name: languagemodels.Dotnet},
-	"ruby":   {name: languagemodels.Ruby},
-	"rubyw":  {name: languagemodels.Ruby},
-	"php":    {name: languagemodels.PHP},
+	"py":      {name: languagemodels.Python},
+	"python":  {name: languagemodels.Python},
+	"java":    {name: languagemodels.Java},
+	"npm":     {name: languagemodels.Node},
+	"node":    {name: languagemodels.Node},
+	"dotnet":  {name: languagemodels.Dotnet},
+	"ruby":    {name: languagemodels.Ruby},
+	"rubyw":   {name: languagemodels.Ruby},
+	"php":     {name: languagemodels.PHP},
+	"php-fpm": {name: languagemodels.PHP},
 }
 
 // languageNameFromCmdline returns a process's language from its command.

--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -38,7 +38,7 @@ type languageFromCLI struct {
 
 var (
 	rubyPattern = regexp.MustCompile(`^ruby\d+\.\d+$`)
-	phpPattern  = regexp.MustCompile(`^ruby\d$`)
+	phpPattern  = regexp.MustCompile(`^php\d$`)
 )
 
 func matchesRubyPrefix(exe string) bool {

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -121,7 +121,7 @@ func TestDetectLanguage(t *testing.T) {
 		{
 			name:     "php5",
 			cmdline:  []string{"php5", "index.php"},
-			comm:     "php",
+			comm:     "php5",
 			expected: languagemodels.PHP,
 		},
 	} {

--- a/pkg/languagedetection/detector_nix_test.go
+++ b/pkg/languagedetection/detector_nix_test.go
@@ -112,6 +112,18 @@ func TestDetectLanguage(t *testing.T) {
 			comm:     "java",
 			expected: languagemodels.Ruby,
 		},
+		{
+			name:     "php",
+			cmdline:  []string{"php", "index.php"},
+			comm:     "php",
+			expected: languagemodels.PHP,
+		},
+		{
+			name:     "php5",
+			cmdline:  []string{"php5", "index.php"},
+			comm:     "php",
+			expected: languagemodels.PHP,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			process := []languagemodels.Process{makeProcess(tc.cmdline, tc.comm)}

--- a/pkg/languagedetection/languagemodels/language.go
+++ b/pkg/languagedetection/languagemodels/language.go
@@ -9,19 +9,28 @@ package languagemodels
 type LanguageName string
 
 const (
-	//nolint:revive // TODO(PROC) Fix revive linter
+	// Go language name.
 	Go LanguageName = "go"
-	//nolint:revive // TODO(PROC) Fix revive linter
+
+	// Node language name.
 	Node LanguageName = "node"
-	//nolint:revive // TODO(PROC) Fix revive linter
+
+	// Dotnet language name.
 	Dotnet LanguageName = "dotnet"
-	//nolint:revive // TODO(PROC) Fix revive linter
+
+	// Python language name.
 	Python LanguageName = "python"
-	//nolint:revive // TODO(PROC) Fix revive linter
+
+	// Java language name.
 	Java LanguageName = "java"
-	//nolint:revive // TODO(PROC) Fix revive linter
+
+	// Ruby language name.
 	Ruby LanguageName = "ruby"
-	//nolint:revive // TODO(PROC) Fix revive linter
+
+	// PHP language name.
+	PHP LanguageName = "php"
+
+	// Unknown language name.
 	Unknown LanguageName = ""
 )
 

--- a/releasenotes/notes/language-detection-php-762044749e007343.yaml
+++ b/releasenotes/notes/language-detection-php-762044749e007343.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Language detection adds support for detecting PHP.


### PR DESCRIPTION
### What does this PR do?

This PR adds support for `PHP` as a reported language from `pkg/languagedetection`.

https://datadoghq.atlassian.net/browse/INPLAT-457

<img width="832" alt="Screenshot 2025-01-28 at 10 17 19 AM" src="https://github.com/user-attachments/assets/12db6ed9-0ea3-4446-9625-97efc690563a" />

Note: I think it matches for python for PHP here because we can detect multiple languages per container.

### Motivation

We want to use language detection to minimize the containers we load during auto-instrumentation, and one of the languages that will land eventually is PHP. 

The APM Injector does detection for the PHP language, but we can never really use that information (or any optimization) until at the base, PHP is supported.

Related POC:
- #33006 

### Describe how you validated your changes

Validated with unit tests.