### PR TITLE
Fix: prevent dlopen calls when compiled statically

### DIFF
--- a/pkg/util/system/dlopen_linux.go
+++ b/pkg/util/system/dlopen_linux.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && cgo
+//go:build linux && cgo && !static
 
 package system
 

--- a/pkg/util/system/dlopen_other.go
+++ b/pkg/util/system/dlopen_other.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux || !cgo
+//go:build !linux || !cgo || static
 
 package system
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -762,7 +762,7 @@ def build_sysprobe_binary(
         ldflags += ' -s -w'
 
     if static:
-        build_tags.extend(["osusergo", "netgo"])
+        build_tags.extend(["osusergo", "netgo", "static"])
         build_tags = list(set(build_tags).difference({"netcgo"}))
 
     if not is_windows and "pcap" in build_tags:


### PR DESCRIPTION
### What does this PR do?

Otherwise system-probe's startup hangs in `detectNVML(features)`

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->