### PR TITLE
[EBPF] kmt: add dhcpd_leases to kmt flare

### DIFF
--- a/tasks/kernel_matrix_testing/kmt_os.py
+++ b/tasks/kernel_matrix_testing/kmt_os.py
@@ -225,6 +225,7 @@ class MacOS:
         ctx.run(f"brew list {' '.join(MacOS.packages)} > {flare_folder / 'brew_libvirt.txt'}", warn=True)
         ctx.run(f"netstat -an > {flare_folder / 'netstat.txt'}", warn=True)
         ctx.run(f"ifconfig -a > {flare_folder / 'ifconfig.txt'}", warn=True)
+        ctx.run(f"cp -v /var/db/dhcpd_leases {flare_folder / 'dhcpd_leases'}", warn=True)
 
 
 def flare(ctx: Context, tmp_flare_folder: Path, dest_folder: Path, keep_uncompressed_files: bool = False):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds the `/var/db/dhcpd_leases` to the `kmt.flare` command.

### Motivation

Improve debugging of local KMT issues in macOS, this file lets us know the DHCP leases given by the DHCP server and so can help us validate if a lease was given or not.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated locally by running `kmt.flare`.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->