### PR TITLE
[CSPM] re-add the kubelet build tag, needed for local hostname resolution

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -153,6 +153,7 @@ SECURITY_AGENT_TAGS = {
     "docker",
     "zlib",
     "zstd",
+    "kubelet",
     "ec2",
 }
 


### PR DESCRIPTION

### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/33427 removed the kubelet build tag from the security agent build, but this tag is needed for local hostname resolution when the communication with the core agent fails.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->