### PR TITLE
[ASCII-1994] downgrade ec2 tag warn log to debug

### DIFF
--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -101,7 +101,7 @@ func fetchEc2TagsFromAPI(ctx context.Context) ([]string, error) {
 	if err == nil {
 		return tags, nil
 	}
-	log.Warnf("unable to get tags using default credentials (falling back to instance role): %s", err)
+	log.Debugf("unable to get tags using default credentials (falling back to instance role): %s", err)
 
 	// If the above fails, for backward compatibility, fall back to our legacy
 	// behavior, where we explicitly query instance role to get credentials.


### PR DESCRIPTION
### What does this PR do?
Downgrades the following log from warn to debug: `	log.Warnf("unable to get tags using default credentials (falling back to instance role): %s", err)`

### Motivation
This is quick fix to [ASCII-1994](https://datadoghq.atlassian.net/browse/ASCII-1994). A customer is complaining that this log is being generated repeatedly and unnecessarily, which increases their log ingestion costs.

[ASCII-1994]: https://datadoghq.atlassian.net/browse/ASCII-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ