### PR TITLE
chore(ssi): refactor instrumentation config

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -19,6 +19,50 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// InstrumentationConfig is a struct to store the configuration for the autoinstrumentation logic. It can be populated
+// using the datadog config through NewInstrumentationConfig.
+type InstrumentationConfig struct {
+	// Enabled is a flag to enable the auto instrumentation. If false, the auto instrumentation is disabled with the
+	// caveat of the annotation based instrumentation. Full config
+	// key: apm_config.instrumentation.enabled
+	Enabled bool `mapstructure:"enabled"`
+	// EnabledNamespaces is a list of namespaces where the autoinstrumentation is enabled. If empty, it is enabled in
+	// all namespaces. EnabledNamespace and DisabledNamespaces are mutually exclusive and cannot be set together. Full
+	// config key: apm_config.instrumentation.enabled_namespaces
+	EnabledNamespaces []string `mapstructure:"enabled_namespaces"`
+	// DisabledNamespaces is a list of namespaces where the autoinstrumentation is disabled. If empty, it is enabled in
+	// all namespaces. EnabledNamespace and DisabledNamespaces are mutually exclusive and cannot be set together. Full
+	// config key: apm_config.instrumentation.disabled_namespaces
+	DisabledNamespaces []string `mapstructure:"disabled_namespaces"`
+	// LibVersions is a map of tracer libraries to inject with their versions. The key is the language and the value is
+	// the version of the library to inject. If empty, the auto instrumentation will inject all libraries. Full config
+	// key: apm_config.instrumentation.lib_versions
+	LibVersions map[string]string `mapstructure:"lib_versions"`
+	// Version is the version of the autoinstrumentation logic to use. We don't expose this option to the user, and V1
+	// is deprecated and slated for removal. Full config key: apm_config.instrumentation.version
+	Version string `mapstructure:"version"`
+	// InjectorImageTag is the tag of the image to use for the auto instrumentation injector library. Full config key:
+	// apm_config.instrumentation.injector_image_tag
+	InjectorImageTag string `mapstructure:"injector_image_tag"`
+}
+
+// NewInstrumentationConfig creates a new InstrumentationConfig from the datadog config. It returns an error if the
+// configuration is invalid.
+func NewInstrumentationConfig(datadogConfig config.Component) (*InstrumentationConfig, error) {
+	cfg := &InstrumentationConfig{}
+	err := datadogConfig.UnmarshalKey("apm_config.instrumentation", cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse apm_config.instrumentation: %w", err)
+	}
+
+	// Ensure both enabled and disabled namespaces are not set together.
+	if len(cfg.EnabledNamespaces) > 0 && len(cfg.DisabledNamespaces) > 0 {
+		return nil, fmt.Errorf("apm.instrumentation.enabled_namespaces and apm.instrumentation.disabled_namespaces are mutually exclusive and cannot be set together")
+	}
+
+	return cfg, nil
+}
+
 var (
 	minimumCPULimit    resource.Quantity = resource.MustParse("0.05")  // 0.05 core, otherwise copying + library initialization is going to take forever
 	minimumMemoryLimit resource.Quantity = resource.MustParse("100Mi") // 100 MB (recommended minimum by Alpine)
@@ -56,7 +100,6 @@ type initResourceRequirementConfiguration map[corev1.ResourceName]resource.Quant
 
 // retrieveConfig retrieves the configuration for the autoinstrumentation webhook from the datadog config
 func retrieveConfig(datadogConfig config.Component, injectionFilter mutatecommon.InjectionFilter) (webhookConfig, error) {
-
 	webhookConfig := webhookConfig{
 		isEnabled: datadogConfig.GetBool("admission_controller.auto_instrumentation.enabled"),
 		endpoint:  datadogConfig.GetString("admission_controller.auto_instrumentation.endpoint"),
@@ -71,13 +114,18 @@ func retrieveConfig(datadogConfig config.Component, injectionFilter mutatecommon
 		profilingEnabled: getOptionalStringValue(datadogConfig, "admission_controller.auto_instrumentation.profiling.enabled"),
 
 		containerRegistry: mutatecommon.ContainerRegistry(datadogConfig, "admission_controller.auto_instrumentation.container_registry"),
-		injectorImageTag:  datadogConfig.GetString("apm_config.instrumentation.injector_image_tag"),
 		injectionFilter:   injectionFilter,
 	}
-	webhookConfig.pinnedLibraries = getPinnedLibraries(datadogConfig, webhookConfig.containerRegistry)
 
-	var err error
-	if webhookConfig.version, err = instrumentationVersion(datadogConfig.GetString("apm_config.instrumentation.version")); err != nil {
+	instCfg, err := NewInstrumentationConfig(datadogConfig)
+	if err != nil {
+		return webhookConfig, fmt.Errorf("unable to parse apm_config.instrumentation configuration: %w", err)
+	}
+
+	webhookConfig.pinnedLibraries = getPinnedLibraries(instCfg.LibVersions, webhookConfig.containerRegistry)
+	webhookConfig.injectorImageTag = instCfg.InjectorImageTag
+
+	if webhookConfig.version, err = instrumentationVersion(instCfg.Version); err != nil {
 		return webhookConfig, fmt.Errorf("invalid version for key apm_config.instrumentation.version: %w", err)
 	}
 
@@ -118,13 +166,9 @@ func getOptionalStringValue(datadogConfig config.Component, key string) *string 
 
 // getPinnedLibraries returns tracing libraries to inject as configured by apm_config.instrumentation.lib_versions
 // given a registry.
-func getPinnedLibraries(datadogConfig config.Component, registry string) []libInfo {
-	// If APM Instrumentation is enabled and configuration apm_config.instrumentation.lib_versions specified,
-	// inject only the libraries from the configuration
-	singleStepLibraryVersions := datadogConfig.GetStringMapString("apm_config.instrumentation.lib_versions")
-
+func getPinnedLibraries(libVersions map[string]string, registry string) []libInfo {
 	var res []libInfo
-	for lang, version := range singleStepLibraryVersions {
+	for lang, version := range libVersions {
 		l := language(lang)
 		if !l.isSupported() {
 			log.Warnf("APM Instrumentation detected configuration for unsupported language: %s. Tracing library for %s will not be injected", lang, lang)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -119,7 +119,7 @@ func retrieveConfig(datadogConfig config.Component, injectionFilter mutatecommon
 
 	instCfg, err := NewInstrumentationConfig(datadogConfig)
 	if err != nil {
-		return webhookConfig, fmt.Errorf("unable to parse apm_config.instrumentation configuration: %w", err)
+		return webhookConfig, err
 	}
 
 	webhookConfig.pinnedLibraries = getPinnedLibraries(instCfg.LibVersions, webhookConfig.containerRegistry)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -3,14 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package autoinstrumentation_test
+//go:build kubeapiserver
+
+package autoinstrumentation
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
 
@@ -18,14 +19,14 @@ func TestNewInstrumentationConfig(t *testing.T) {
 	tests := []struct {
 		name       string
 		configPath string
-		expected   *autoinstrumentation.InstrumentationConfig
+		expected   *InstrumentationConfig
 		shouldErr  bool
 	}{
 		{
 			name:       "valid config enabled namespaces",
 			configPath: "testdata/enabled_namespaces.yaml",
 			shouldErr:  false,
-			expected: &autoinstrumentation.InstrumentationConfig{
+			expected: &InstrumentationConfig{
 				Enabled:            true,
 				EnabledNamespaces:  []string{"default"},
 				DisabledNamespaces: []string{},
@@ -40,7 +41,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 			name:       "valid config disabled namespaces",
 			configPath: "testdata/disabled_namespaces.yaml",
 			shouldErr:  false,
-			expected: &autoinstrumentation.InstrumentationConfig{
+			expected: &InstrumentationConfig{
 				Enabled:            true,
 				EnabledNamespaces:  []string{},
 				DisabledNamespaces: []string{"default"},
@@ -60,7 +61,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockConfig := configmock.NewFromFile(t, tt.configPath)
-			actual, err := autoinstrumentation.NewInstrumentationConfig(mockConfig)
+			actual, err := NewInstrumentationConfig(mockConfig)
 			if tt.shouldErr {
 				require.Error(t, err)
 				return

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -1,0 +1,72 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package autoinstrumentation_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/autoinstrumentation"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+)
+
+func TestNewInstrumentationConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		configPath string
+		expected   *autoinstrumentation.InstrumentationConfig
+		shouldErr  bool
+	}{
+		{
+			name:       "valid config enabled namespaces",
+			configPath: "testdata/enabled_namespaces.yaml",
+			shouldErr:  false,
+			expected: &autoinstrumentation.InstrumentationConfig{
+				Enabled:            true,
+				EnabledNamespaces:  []string{"default"},
+				DisabledNamespaces: []string{},
+				LibVersions: map[string]string{
+					"python": "default",
+				},
+				Version:          "v2",
+				InjectorImageTag: "foo",
+			},
+		},
+		{
+			name:       "valid config disabled namespaces",
+			configPath: "testdata/disabled_namespaces.yaml",
+			shouldErr:  false,
+			expected: &autoinstrumentation.InstrumentationConfig{
+				Enabled:            true,
+				EnabledNamespaces:  []string{},
+				DisabledNamespaces: []string{"default"},
+				LibVersions: map[string]string{
+					"python": "default",
+				},
+				Version:          "v2",
+				InjectorImageTag: "foo",
+			},
+		},
+		{
+			name:       "both enabled and disabled namespaces",
+			configPath: "testdata/both_enabled_and_disabled.yaml",
+			shouldErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.NewFromFile(t, tt.configPath)
+			actual, err := autoinstrumentation.NewInstrumentationConfig(mockConfig)
+			if tt.shouldErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/both_enabled_and_disabled.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/both_enabled_and_disabled.yaml
@@ -1,0 +1,8 @@
+---
+apm_config:
+  instrumentation:
+    enabled_namespaces:
+      - "foo"
+    disabled_namespaces:
+      - "bar"
+

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/disabled_namespaces.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/disabled_namespaces.yaml
@@ -1,0 +1,11 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    disabled_namespaces:
+      - "default"
+    lib_versions:
+      python: "default"
+    version: "v2"
+    injector_image_tag: "foo"
+

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/enabled_namespaces.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/enabled_namespaces.yaml
@@ -1,0 +1,11 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    enabled_namespaces:
+      - "default"
+    lib_versions:
+      python: "default"
+    version: "v2"
+    injector_image_tag: "foo"
+


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit refactors instrumentation config into it's own struct with `mapstructure` tags. This will enable us to read the configuration as a block and have strong control on validation.

### Motivation
In https://github.com/DataDog/datadog-agent/pull/33388, we implemented a proof of concept for the [Kubernetes SSI | Workload Selection](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing) RFC. In that design, we need a list of targets that need to be loaded from a single key. Additionally, we will need the ability to return an error if `enabled_namespaces` and `targets` are both defined. This change sets us up for success to make those changes more cleanly.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I have added additional unit tests beyond the existing tests.

### Possible Drawbacks / Trade-offs
I dislike that this is being instantiated inside of the webhook config and we should look to refactor that.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
There is more work to do in ensuring this config is wired in everywhere. Most specifically, it is still read in InjectionFilter which I plan to address as a follow up.