### PR TITLE
Fix pushing of tags on `release.tag-version` task

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -234,9 +234,9 @@ def tag_version(
         start_qual: Will start the qualification phase for agent 6 release candidate by adding a qualification tag
 
     Examples:
-        $ inv -e release.tag-version 7.27.x            # Create tags and push them to origin
-        $ inv -e release.tag-version 7.27.x --no-push  # Create tags locally; don't push them
-        $ inv -e release.tag-version 7.29.x --force    # Create tags (overwriting existing tags with the same name), force-push them to origin
+        $ inv -e release.tag-version -r 7.27.x            # Create tags and push them to origin
+        $ inv -e release.tag-version -r 7.27.x --no-push  # Create tags locally; don't push them
+        $ inv -e release.tag-version -r 7.29.x --force    # Create tags (overwriting existing tags with the same name), force-push them to origin
     """
 
     assert release_branch or version
@@ -258,10 +258,10 @@ def tag_version(
                     ctx, get_default_modules()["."], QUALIFICATION_TAG, commit, force_option, False
                 )
 
-    if push:
-        tags_list = ' '.join(tags)
-        ctx.run(f"git push origin {tags_list}{force_option}")
-        print(f"Pushed tag {tags_list}")
+        if push:
+            tags_list = ' '.join(tags)
+            ctx.run(f"git push origin {tags_list}{force_option}")
+            print(f"Pushed tag {tags_list}")
     print(f"Created tags for version {agent_version}")
 
 


### PR DESCRIPTION
### What does this PR do?

It fixes the pushing of tags on the `release.tag-version` invoke task by bringing it under the `agent_context` (so that it runs on the worktree where the tag is created). It also updates the docstring with the now necessary flag.

### Motivation

Found this to fail while tagging 7.62.0.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->