### PR TITLE
trivy: use trivy directly instead of our own driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/alecthomas/participle v0.7.1 // indirect
 	github.com/alecthomas/units v0.0.0-20240626203959-61d1e3462e30
-	github.com/aquasecurity/trivy-db v0.0.0-20240910133327-7e0f4d2ed4c1 // indirect
+	github.com/aquasecurity/trivy-db v0.0.0-20240910133327-7e0f4d2ed4c1
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/aws/aws-lambda-go v1.37.0
 	github.com/aws/aws-sdk-go v1.55.6 // indirect

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -140,6 +140,10 @@ func DefaultDisabledCollectors(enabledAnalyzers []string) []analyzer.Type {
 		analyzer.TypeLicenseFile,
 		analyzer.TypeRpmArchive,
 	)
+
+	// FIXME: the java analyzer requires some javadb, let's skip it for now
+	disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeJar)
+
 	return disabledAnalyzers
 }
 

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -280,7 +280,7 @@ func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applie
 
 	trivyReport, err := s.ScanArtifact(ctx, types.ScanOptions{
 		ScanRemovedPackages: false,
-		PkgTypes:            []types.PkgType{types.PkgTypeOS, types.PkgTypeLibrary},
+		PkgTypes:            types.PkgTypes,
 		PkgRelationships:    ftypes.Relationships,
 		Scanners:            types.Scanners{types.SBOMScanner},
 	})

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -10,20 +10,17 @@ package trivy
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"runtime"
 	"slices"
-	"sort"
 	"sync"
-
-	"golang.org/x/xerrors"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/sbom"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
+	"github.com/aquasecurity/trivy-db/pkg/db"
 	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	"github.com/aquasecurity/trivy/pkg/fanal/applier"
 	"github.com/aquasecurity/trivy/pkg/fanal/artifact"
@@ -33,7 +30,11 @@ import (
 	"github.com/aquasecurity/trivy/pkg/fanal/walker"
 	"github.com/aquasecurity/trivy/pkg/sbom/cyclonedx"
 	"github.com/aquasecurity/trivy/pkg/scanner"
+	"github.com/aquasecurity/trivy/pkg/scanner/langpkg"
+	"github.com/aquasecurity/trivy/pkg/scanner/local"
+	"github.com/aquasecurity/trivy/pkg/scanner/ospkg"
 	"github.com/aquasecurity/trivy/pkg/types"
+	"github.com/aquasecurity/trivy/pkg/vulnerability"
 
 	// This is required to load sqlite based RPM databases
 	_ "modernc.org/sqlite"
@@ -63,6 +64,10 @@ type Collector struct {
 	persistentCache  CacheWithCleaner
 	marshaler        cyclonedx.Marshaler
 	wmeta            option.Option[workloadmeta.Component]
+
+	osScanner   ospkg.Scanner
+	langScanner langpkg.Scanner
+	vulnClient  vulnerability.Client
 }
 
 var globalCollector *Collector
@@ -153,6 +158,10 @@ func NewCollector(cfg config.Component, wmeta option.Option[workloadmeta.Compone
 		},
 		marshaler: cyclonedx.NewMarshaler(""),
 		wmeta:     wmeta,
+
+		osScanner:   ospkg.NewScanner(),
+		langScanner: langpkg.NewScanner(),
+		vulnClient:  vulnerability.NewClient(db.Config{}),
 	}, nil
 }
 
@@ -251,66 +260,6 @@ func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions
 	return c.scanFilesystem(ctx, path, nil, scanOptions)
 }
 
-type driver struct {
-	applier applier.Applier
-}
-
-func (d *driver) Scan(_ context.Context, target, artifactKey string, blobKeys []string, _ types.ScanOptions) (
-	types.Results, ftypes.OS, error) {
-
-	detail, err := d.applier.ApplyLayers(artifactKey, blobKeys)
-	switch {
-	case errors.Is(err, analyzer.ErrUnknownOS):
-		log.Debug("OS is not detected.")
-
-		// Packages may contain OS-independent binary information even though OS is not detected.
-		if len(detail.Packages) != 0 {
-			detail.OS = ftypes.OS{Family: "none"}
-		}
-
-		// If OS is not detected and repositories are detected, we'll try to use repositories as OS.
-		if detail.Repository != nil {
-			log.Debug("Package repository %s, version %s", string(detail.Repository.Family), detail.Repository.Release)
-			log.Debug("Assuming OS family %s, version %s", string(detail.Repository.Family), detail.Repository.Release)
-			detail.OS = ftypes.OS{
-				Family: detail.Repository.Family,
-				Name:   detail.Repository.Release,
-			}
-		}
-	case errors.Is(err, analyzer.ErrNoPkgsDetected):
-		log.Warn("No OS package is detected. Make sure you haven't deleted any files that contain information about the installed packages.")
-		log.Warn(`e.g. files under "/lib/apk/db/", "/var/lib/dpkg/" and "/var/lib/rpm"`)
-	case err != nil:
-		return nil, ftypes.OS{}, xerrors.Errorf("failed to apply layers: %w", err)
-	}
-
-	results := make([]types.Result, 0, 1+len(detail.Applications))
-
-	// main OS result
-	osresult := types.Result{
-		Target: fmt.Sprintf("%s (%s %s)", target, detail.OS.Family, detail.OS.Name),
-		Class:  types.ClassOSPkg,
-		Type:   detail.OS.Family,
-	}
-
-	sort.Sort(detail.Packages)
-	osresult.Packages = detail.Packages
-	results = append(results, osresult)
-
-	for _, app := range detail.Applications {
-		sort.Sort(app.Packages)
-		appresult := types.Result{
-			Target:   app.FilePath,
-			Class:    types.ClassLangPkg,
-			Type:     app.Type,
-			Packages: app.Packages,
-		}
-		results = append(results, appresult)
-	}
-
-	return results, detail.OS, nil
-}
-
 func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applier applier.Applier, imgMeta *workloadmeta.ContainerImageMetadata, cache CacheWithCleaner, useCache bool) (*types.Report, error) {
 	if useCache && imgMeta != nil && cache != nil {
 		// The artifact reference is only needed to clean up the blobs after the scan.
@@ -322,7 +271,8 @@ func (c *Collector) scan(ctx context.Context, artifact artifact.Artifact, applie
 		cache.setKeysForEntity(imgMeta.EntityID.ID, append(artifactReference.BlobIDs, artifactReference.ID))
 	}
 
-	s := scanner.NewScanner(&driver{applier: applier}, artifact)
+	localScanner := local.NewScanner(applier, c.osScanner, c.langScanner, c.vulnClient)
+	s := scanner.NewScanner(localScanner, artifact)
 
 	trivyReport, err := s.ScanArtifact(ctx, types.ScanOptions{
 		ScanRemovedPackages: false,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes our own driver implementation and makes use of trivy provided local scanner. This is more correct in that it's doing the same thing as the agentless scanner, and it means we are sure to report the packages exactly how the backend is expecting them.

This PR also disables the java/jar analyzer while we figure out the java DB issue (to come in a follow up PR).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->