### PR TITLE
[EBPF] gpu: use flaky.MarkOnLog on e2e test

### DIFF
--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -53,8 +53,9 @@ func mandatoryMetricTagRegexes() []*regexp.Regexp {
 // TestGPUSuite runs tests for the VM interface to ensure its implementation is correct.
 // Not to be run in parallel, as some tests wait until the checks are available.
 func TestGPUSuite(t *testing.T) {
-	// incident-33572
-	flake.Mark(t)
+	// incident-33572. Pulumi seems to sometimes fail to create the stack with an error
+	// we are not able to debug from the logs. We mark the test as flaky in that case only.
+	flake.MarkOnLog(t, "error: an unhandled error occurred: waiting for RPCs:")
 	provParams := getDefaultProvisionerParams()
 
 	// Append our vectorAdd image for testing

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -142,20 +142,6 @@ func gpuInstanceProvisioner(params *provisionerParams) provisioners.Provisioner 
 		if err != nil {
 			return fmt.Errorf("validateDockerCuda failed: %w", err)
 		}
-		// incident-33572: log the output of the CUDA validation command
-		pulumi.All(dockerCudaValidateCmd.StdoutOutput(), dockerCudaValidateCmd.StderrOutput()).ApplyT(func(args []interface{}) error {
-			stdout := args[0].(string)
-			stderr := args[1].(string)
-			err := ctx.Log.Info(fmt.Sprintf("Docker CUDA validation stdout: %s", stdout), nil)
-			if err != nil {
-				return err
-			}
-			err = ctx.Log.Info(fmt.Sprintf("Docker CUDA validation stderr: %s", stderr), nil)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
 
 		// Combine agent options from the parameters with the fakeintake and docker dependencies
 		params.agentOptions = append(params.agentOptions,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR switches the flake marker in the GPU e2e test for the recently introduced `flaky.MarkOnLog`, so that we only mark the job as flaky in the specific case we've encountered of the Pulumi error resolving options.

It also removes a redundant log output related to the same incident.

### Motivation

Ensure the E2E test runs on PRs, to avoid introducing errors without noticing.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated in CI

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->