### PR TITLE
AMLII-2255 Set SO_PASSCRED before binding the socket

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -221,6 +221,12 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 		}
 	}
 
+	if rcvbuf := config.GetInt("dogstatsd_so_rcvbuf"); rcvbuf != 0 {
+		if err := conn.SetReadBuffer(rcvbuf); err != nil {
+			log.Warnf("could not set socket rcvbuf: %s", err)
+		}
+	}
+
 	for {
 		var n int
 		var oobn int

--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -221,7 +221,7 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 		}
 	}
 
-	if rcvbuf := config.GetInt("dogstatsd_so_rcvbuf"); rcvbuf != 0 {
+	if rcvbuf := l.config.GetInt("dogstatsd_so_rcvbuf"); rcvbuf != 0 {
 		if err := conn.SetReadBuffer(rcvbuf); err != nil {
 			log.Warnf("could not set socket rcvbuf: %s", err)
 		}

--- a/comp/dogstatsd/listeners/uds_linux.go
+++ b/comp/dogstatsd/listeners/uds_linux.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -40,14 +41,9 @@ func getUDSAncillarySize() int {
 
 // enableUDSPassCred enables credential passing from the kernel for origin detection.
 // That flag can be ignored if origin dection is disabled.
-func enableUDSPassCred(conn netUnixConn) error {
-	rawconn, err := conn.SyscallConn()
-	if err != nil {
-		return err
-	}
-
+func enableUDSPassCred(rawconn syscall.RawConn) error {
 	var e error
-	err = rawconn.Control(func(fd uintptr) {
+	err := rawconn.Control(func(fd uintptr) {
 		e = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PASSCRED, 1)
 	})
 	if err != nil {

--- a/comp/dogstatsd/listeners/uds_nolinux.go
+++ b/comp/dogstatsd/listeners/uds_nolinux.go
@@ -9,6 +9,7 @@ package listeners
 
 import (
 	"errors"
+	"syscall"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
@@ -25,7 +26,7 @@ func getUDSAncillarySize() int {
 }
 
 // enableUDSPassCred returns a "not implemented" error on non-linux hosts
-func enableUDSPassCred(rawconn sysctl.RawConn) error {
+func enableUDSPassCred(rawconn syscall.RawConn) error {
 	return ErrLinuxOnly
 }
 

--- a/comp/dogstatsd/listeners/uds_nolinux.go
+++ b/comp/dogstatsd/listeners/uds_nolinux.go
@@ -26,7 +26,7 @@ func getUDSAncillarySize() int {
 }
 
 // enableUDSPassCred returns a "not implemented" error on non-linux hosts
-func enableUDSPassCred(rawconn syscall.RawConn) error {
+func enableUDSPassCred(_ syscall.RawConn) error {
 	return ErrLinuxOnly
 }
 

--- a/comp/dogstatsd/listeners/uds_nolinux.go
+++ b/comp/dogstatsd/listeners/uds_nolinux.go
@@ -25,9 +25,7 @@ func getUDSAncillarySize() int {
 }
 
 // enableUDSPassCred returns a "not implemented" error on non-linux hosts
-//
-//nolint:revive // TODO(AML) Fix revive linter
-func enableUDSPassCred(_ netUnixConn) error {
+func enableUDSPassCred(rawconn sysctl.RawConn) error {
 	return ErrLinuxOnly
 }
 

--- a/releasenotes/notes/amlii-2255-670a004a90c8f786.yaml
+++ b/releasenotes/notes/amlii-2255-670a004a90c8f786.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fixed a bug in the dogstatsd unix socket server that caused metrics to miss container tags and the agent to report ``matched PID for the process is 0`` warnings.

--- a/releasenotes/notes/amlii-2255-670a004a90c8f786.yaml
+++ b/releasenotes/notes/amlii-2255-670a004a90c8f786.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fixed a bug in the dogstatsd unix socket server that caused metrics to miss container tags and the agent to report ``matched PID for the process is 0`` warnings.
+    Fixed a bug in the DogStatsD Unix socket server that caused metrics to miss container tags and the Agent to report ``matched PID for the process is 0`` warnings.


### PR DESCRIPTION
### What does this PR do?

Fix a socket configuration race in unix socket-based origin detection.

### Motivation

Fewer errors.

### Describe how you validated your changes

Run a client that sends metrics to the agent via a unix socket.

Restart the agent. No `matched PID for the process is 0` should be logged.

### Possible Drawbacks / Trade-offs

### Additional Notes

Linux kernel only attaches process credentials if the socket is unconnected or when either side has requested it. Setting SO_PASSCRED on a socket already bound then races with the data being sent by the dogstatsd client.

Using net.ListenConfig#Control callback allows us to modify the socket state before the socket is attached to an address, preventing the clients sending data without SO_PASSCRED being enabled on a socket and eliminating the race.
