### PR TITLE
[EBPF] ebpfcheck: use XDP as the program type for the entry count helper

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/map_prog_helper.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/map_prog_helper.go
@@ -120,7 +120,7 @@ func (c *mapProgHelperCache) newHelperProgramForFd(fd int) (helperProgData, erro
 	*/
 
 	spec := &ebpf.ProgramSpec{
-		Type: ebpf.SocketFilter,
+		Type: ebpf.XDP, // Use XDP to ensure  maximum compatibility (e.g., socket filter programs cannot deal with maps that contain spin locks)
 		Instructions: asm.Instructions{
 			// entry
 			btf.WithFuncMetadata(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the program type used in the entry count helper from socket filter to XDP. That way, we can use it to get the number of entries for maps that contain spin locks (`active_flows_spin_locks` which was recently introduced).

### Motivation

Reduce the number of warnings and ensure we get information for all maps.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Existing unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->