### PR TITLE
Fix mistakes in 7.62.0 changelog

### DIFF
--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -29,6 +29,10 @@ Enhancement Notes
   reducing memory, CPU, and network usage in the Cluster Agent while preserving
   full metric functionality.
 
+- The Datadog Cluster Agent admission controller agent sidecar injection now sets up
+  Agent sidecars to run with securityContext of `readOnlyRootFilesystem:false` by default.
+  Advanced users can customize the securityContext via clusterAgent.admissionController.agentSidecarInjection.profiles.
+
 
 .. _Release Notes_7.62.0_Bug Fixes:
 
@@ -41,6 +45,12 @@ Bug Fixes
 
 - Add mapping for apiservices and customresourcedefinitions to KSM check to
   prevent errors on startup with discovering resources.
+
+- Include `gpu_vendor` pod tags on the Datadog Cluster Agent when
+  enabling datadog.clusterTagger.collectKubernetesTags.
+
+- When the Datadog Cluster Agent injects the Datadog Agent as a sidecar
+  on a Job, the agent will now exit when the main Job completes.
 
 
 .. _Release Notes_7.61.0:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,8 @@ Prelude
 -------
 
 Released on: 2025-01-29
-Pinned to datadog-agent v7.62.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7620>`_.
+
+- Please refer to the `7.62.0 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7620>`_ for the list of changes on the Core Checks
 
 .. _Release Notes_7.62.0_New Features:
 
@@ -51,10 +52,6 @@ Enhancement Notes
 - Adds tagger tags to pod manifests.
 
 - Added the output of ``sestatus`` into the Agent flare. This information will appear in ``system-probe/selinux_sestatus.log``.
-
-- The Datadog Cluster Agent admission controller agent sidecar injection now sets up
-  Agent sidecars to run with securityContext of `readOnlyRootFilesystem:false` by default.
-  Advanced users can customize the securityContext via clusterAgent.admissionController.agentSidecarInjection.profiles.
 
 - Extended Agent telemetry histogram details, specifically:
     - Added previously omitted and implicit `+Inf` bucket value to histogram payload.
@@ -122,17 +119,11 @@ Bug Fixes
 
 - Use ``/var/run/syslog`` as the default syslog socket path on macOS.
 
-- Include `gpu_vendor` pod tags on the Datadog Cluster Agent when
-  enabling datadog.clusterTagger.collectKubernetesTags.
-
 - Fixes consistency issue with container image filters.
   Depending on the Agent configuration, filters were sometimes behaving differently
   for metrics and logs. For example, an image filter that worked for excluding logs
   didn't work when used to exclude metrics, and vice versa. 
   The exclusion logic is now consistent between metrics and logs.
-
-- When the Datadog Cluster Agent injects the Datadog Agent as a sidecar
-  on a Job, the agent will now exit when the main Job completes.
 
 - Fixed race condition in stream UDS clients of Dogstatsd that
   allowed for the loss of received data.


### PR DESCRIPTION
### What does this PR do?

Fix the prelude for the Agent changelog and move entries from Agent changelog to DCA changelog.

### Motivation

A combination of mishaps led us to fumble the changelog prelude, and we also found out that there were a few changelog entries that belonged to the DCA.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->