### PR TITLE
fix(fleet): Mark TestInstallParity as flaky

### DIFF
--- a/test/new-e2e/tests/installer/script/default_script_test.go
+++ b/test/new-e2e/tests/installer/script/default_script_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
@@ -84,6 +85,8 @@ func (s *installScriptDefaultSuite) TestInstallParity() {
 	if _, ok := os.LookupEnv("E2E_PIPELINE_ID"); !ok {
 		s.T().Skip("Skipping test due to missing E2E_PIPELINE_ID variable")
 	}
+
+	flake.Mark(s.T()) // TODO: Fixme once installer 0.10.0 is released
 
 	defer s.Purge()
 


### PR DESCRIPTION
### What does this PR do?
Marks `TestInstallParity` as flaky

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->