### PR TITLE
APM: Normalize env as a tag value not a full tag (APMS-14643)

### DIFF
--- a/cmd/trace-agent/config/remote/config.go
+++ b/cmd/trace-agent/config/remote/config.go
@@ -120,5 +120,5 @@ func normalize(configsRequest *pbgo.ClientGetConfigsRequest) {
 	// err is explicitly ignored as it is not an actual error and the expected normalized service
 	// is returned regardless.
 	configsRequest.Client.ClientTracer.Service, _ = traceutil.NormalizeService(configsRequest.Client.ClientTracer.Service, configsRequest.Client.ClientTracer.Language)
-	configsRequest.Client.ClientTracer.Env = traceutil.NormalizeTag(configsRequest.Client.ClientTracer.Env)
+	configsRequest.Client.ClientTracer.Env = traceutil.NormalizeTagValue(configsRequest.Client.ClientTracer.Env)
 }

--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -214,7 +214,7 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	}
 
 	prevEnv := c.DefaultEnv
-	c.DefaultEnv = traceutil.NormalizeTag(c.DefaultEnv)
+	c.DefaultEnv = traceutil.NormalizeTagValue(c.DefaultEnv)
 	if c.DefaultEnv != prevEnv {
 		log.Debugf("Normalized DefaultEnv from %q to %q", prevEnv, c.DefaultEnv)
 	}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -322,7 +322,7 @@ func (a *Agent) Process(p *api.Payload) {
 	sampledChunks := new(writer.SampledChunks)
 	statsInput := stats.NewStatsInput(len(p.TracerPayload.Chunks), p.TracerPayload.ContainerID, p.ClientComputedStats, a.conf)
 
-	p.TracerPayload.Env = traceutil.NormalizeTag(p.TracerPayload.Env)
+	p.TracerPayload.Env = traceutil.NormalizeTagValue(p.TracerPayload.Env)
 
 	a.discardSpans(p)
 
@@ -521,7 +521,7 @@ func (a *Agent) processStats(in *pb.ClientStatsPayload, lang, tracerVersion, con
 	if in.Env == "" {
 		in.Env = a.conf.DefaultEnv
 	}
-	in.Env = traceutil.NormalizeTag(in.Env)
+	in.Env = traceutil.NormalizeTagValue(in.Env)
 	if in.TracerVersion == "" {
 		in.TracerVersion = tracerVersion
 	}

--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -169,7 +169,7 @@ func (a *Agent) normalize(ts *info.TagStats, s *pb.Span) error {
 		s.Type = traceutil.TruncateUTF8(s.Type, MaxTypeLen)
 	}
 	if env, ok := s.Meta["env"]; ok {
-		s.Meta["env"] = traceutil.NormalizeTag(env)
+		s.Meta["env"] = traceutil.NormalizeTagValue(env)
 	}
 	if sc, ok := s.Meta["http.status_code"]; ok {
 		if !isValidStatusCode(sc) {

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -461,9 +461,9 @@ func TestNormalizeEnv(t *testing.T) {
 	a := &Agent{conf: config.New()}
 	ts := newTagStats()
 	s := newTestSpan()
-	s.Meta["env"] = "DEVELOPMENT"
+	s.Meta["env"] = "123DEVELOPMENT"
 	assert.NoError(t, a.normalize(ts, s))
-	assert.Equal(t, "development", s.Meta["env"])
+	assert.Equal(t, "123development", s.Meta["env"])
 	assert.Equal(t, newTagStats(), ts)
 }
 

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -444,7 +444,7 @@ func (o *OTLPReceiver) receiveResourceSpansV1(ctx context.Context, rspans ptrace
 	p.TracerPayload = &pb.TracerPayload{
 		Hostname:        hostname,
 		Chunks:          o.createChunks(tracesByID, priorityByID),
-		Env:             traceutil.NormalizeTag(env),
+		Env:             traceutil.NormalizeTagValue(env),
 		ContainerID:     containerID,
 		LanguageName:    tagstats.Lang,
 		LanguageVersion: tagstats.LangVersion,

--- a/pkg/trace/traceutil/normalize.go
+++ b/pkg/trace/traceutil/normalize.go
@@ -128,10 +128,10 @@ func NormalizeTagValue(v string) string {
 	return normalize(v, false)
 }
 
-func normalize(v string, allowDigitStartChar bool) string {
+func normalize(v string, removeDigitStartChar bool) string {
 	// Fast path: Check if the tag is valid and only contains ASCII characters,
 	// if yes return it as-is right away. For most use-cases this reduces CPU usage.
-	if isNormalizedASCIITag(v, allowDigitStartChar) {
+	if isNormalizedASCIITag(v, removeDigitStartChar) {
 		return v
 	}
 	// the algorithm works by creating a set of cuts marking start and end offsets in v
@@ -185,7 +185,7 @@ func normalize(v string, allowDigitStartChar bool) string {
 			chars++
 		// If it's not a unicode letter, and it's the first char, and digits are allowed for the start char,
 		// we should goto end because the remaining cases are not valid for a start char.
-		case allowDigitStartChar && chars == 0:
+		case removeDigitStartChar && chars == 0:
 			trim = i + jump
 			goto end
 		case unicode.IsDigit(r) || r == '.' || r == '/' || r == '-':

--- a/releasenotes/notes/traceagent-envnorm-24129c7e92fbeda9.yaml
+++ b/releasenotes/notes/traceagent-envnorm-24129c7e92fbeda9.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Fix an issue where the environment tag was normalized incorrectly. This resulted in some valid envs e.g. (123foo) having the leading digits removed, this fix allows these envs to pass through unedited.
+    APM: Fix an issue where the environment tag was normalized incorrectly. This resulted in some valid envs, like `123foo`, having the leading digits removed. This fix allows these envs to pass through unedited.

--- a/releasenotes/notes/traceagent-envnorm-24129c7e92fbeda9.yaml
+++ b/releasenotes/notes/traceagent-envnorm-24129c7e92fbeda9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix an issue where the environment tag was normalized incorrectly. This resulted in some valid envs e.g. (123foo) having the leading digits removed, this fix allows these envs to pass through unedited.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Normalize env as a tag value not a full tag.

### Motivation
For some envs the normalization logic here wasn't quite correct as the env as a tag _VALUE_ can start with a number e.g. `1prod` is a valid env but we were incorrectly attempting to normalize it as a full tag value. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Modified the existing unit test here to verify the correct normalizer is being used. No manual validation necessary, but I did run a quick test where I set the env to `1andrew`, sent some test spans, and then observed the correct env in the backend.
### Possible Drawbacks / Trade-offs
It's _possible_ a customer is relying on this broken normalization logic to fix an env for them, but this would result in broken behavior today (as evidenced by the customer request where this problem was found). Therefore this change seems worthwhile to make.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->