### PR TITLE
Fix windows status e2e assertion with wording change

### DIFF
--- a/test/new-e2e/tests/windows/fips-test/fips_test.go
+++ b/test/new-e2e/tests/windows/fips-test/fips_test.go
@@ -80,7 +80,7 @@ func (s *fipsAgentSuite) TestWithSystemFIPSDisabled() {
 		s.Run("gofips disabled", func() {
 			status, err := s.execAgentCommand("status")
 			require.NoError(s.T(), err)
-			assert.Contains(s.T(), status, "FIPS compliant: false")
+			assert.Contains(s.T(), status, "FIPS Mode: disabled")
 		})
 	})
 }
@@ -105,13 +105,13 @@ func (s *fipsAgentSuite) TestWithSystemFIPSEnabled() {
 		s.Run("gofips enabled", func() {
 			status, err := s.execAgentCommand("status")
 			require.NoError(s.T(), err)
-			assert.Contains(s.T(), status, "FIPS compliant: true")
+			assert.Contains(s.T(), status, "FIPS Mode: enabled")
 		})
 
 		s.Run("gofips disabled", func() {
 			status, err := s.execAgentCommand("status")
 			require.NoError(s.T(), err)
-			assert.Contains(s.T(), status, "FIPS compliant: true")
+			assert.Contains(s.T(), status, "FIPS Mode: enabled")
 		})
 	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/33507 missed updating these assertions as well because it did not run in the CI for that PR

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->