### PR TITLE
[OTAGENT-21] respect the FF metricremappingdisabled in serializer exporter

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics"
+	pkgdatadog "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -87,7 +88,10 @@ func translatorFromConfig(
 		metrics.WithFallbackSourceProvider(hostGetter),
 		metrics.WithHistogramMode(histogramMode),
 		metrics.WithDeltaTTL(cfg.DeltaTTL),
-		metrics.WithOTelPrefix(),
+	}
+
+	if !pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled() {
+		options = append(options, metrics.WithOTelPrefix())
 	}
 
 	if statsIn != nil {

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -238,7 +238,7 @@ require (
 
 require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.25.0 // indirect
+	go.opentelemetry.io/collector/featuregate v1.25.0
 )
 
 require (


### PR DESCRIPTION
### What does this PR do?
Respect FF `exporter.datadogexporter.metricremappingdisabled` in serializer exporter. When enabled, the serializer exporter does not prepend otel prefix to OTel host metrics or otelcol prefix to trace agent internal metrics. For now it is disabled by default.

### Motivation
In preparation of metric semantic convergence work.

### Describe how you validated your changes
new unit tests