### PR TITLE
Port Linux FIPS ciphers E2E test to Windows

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -217,6 +217,10 @@ new-e2e-fips-compliance-test:
   variables:
     TARGETS: ./tests/fips-compliance
     TEAM: agent-runtimes
+  parallel:
+    matrix:
+      - EXTRA_PARAMS: --run "TestFIPSCiphersLinuxSuite$"
+      - EXTRA_PARAMS: --run "TestLinuxFIPSComplianceSuite$"
 
 new-e2e-windows-fips-compliance-test:
   extends: .new_e2e_template
@@ -233,6 +237,7 @@ new-e2e-windows-fips-compliance-test:
   parallel:
     matrix:
       - EXTRA_PARAMS: --run "TestWindowsVM$"
+      - EXTRA_PARAMS: --run "TestFIPSCiphersWindowsSuite$"
 
 new-e2e-windows-service-test:
   extends: .new_e2e_template

--- a/test/new-e2e/tests/fips-compliance/common.go
+++ b/test/new-e2e/tests/fips-compliance/common.go
@@ -1,0 +1,151 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fipscompliance contains tests for the FIPS Agent runtime behavior
+package fipscompliance
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type cipherTestCase struct {
+	cert   string
+	cipher string
+	tlsMax string
+	want   bool
+}
+
+// fipsServer is a helper for interacting with a datadog/apps-fips-server container
+type fipsServer struct {
+	composeFiles string
+	dockerHost   *components.RemoteHost
+}
+
+func newFIPSServer(dockerHost *components.RemoteHost, composeFiles string) fipsServer {
+	s := fipsServer{
+		dockerHost:   dockerHost,
+		composeFiles: composeFiles,
+	}
+	return s
+}
+
+func (s *fipsServer) Start(t *testing.T, tc cipherTestCase) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		// stop currently running server, if any, so we can reset logs+env
+		s.Stop()
+
+		// start datadog/apps-fips-server with env vars from the test case
+		envVars := map[string]string{
+			"CERT": tc.cert,
+		}
+		if tc.cipher != "" {
+			envVars["CIPHER"] = fmt.Sprintf("-c %s", tc.cipher)
+		}
+		if tc.tlsMax != "" {
+			envVars["TLS_MAX"] = fmt.Sprintf("--tls-max %s", tc.tlsMax)
+		}
+
+		cmd := fmt.Sprintf("docker-compose -f %s up --detach --wait --timeout 300", strings.TrimSpace(s.composeFiles))
+		_, err := s.dockerHost.Execute(cmd, client.WithEnvVariables(envVars))
+		if err != nil {
+			t.Logf("Error starting fips-server: %v", err)
+			require.NoError(c, err)
+		}
+		assert.Nil(c, err)
+	}, 60*time.Second, 20*time.Second)
+
+	// Wait for container to start and ensure it's a fresh instance
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		serverLogs, _ := s.dockerHost.Execute("docker logs dd-fips-server")
+		assert.Contains(c, serverLogs, "Server Starting...", "Server should start")
+		assert.Equal(c, 1, strings.Count(serverLogs, "Server Starting..."), "Server should start only once, logs from previous runs should not be present")
+	}, 60*time.Second, 5*time.Second)
+}
+
+func (s *fipsServer) Logs() string {
+	return s.dockerHost.MustExecute("docker logs dd-fips-server")
+}
+
+func (s *fipsServer) Stop() {
+	fipsContainer := s.dockerHost.MustExecute("docker container ls -a --filter name=dd-fips-server --format '{{.Names}}'")
+	if fipsContainer != "" {
+		s.dockerHost.MustExecute(fmt.Sprintf("docker-compose -f %s down fips-server", strings.TrimSpace(s.composeFiles)))
+	}
+}
+
+var (
+	testcases = []cipherTestCase{
+		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", want: true},
+		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", want: true},
+		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", want: true},
+		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", want: true},
+		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", want: false},
+		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", want: false},
+		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", want: false},
+		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", want: false},
+		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", want: false},
+		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", want: false},
+		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", want: false},
+		// TODO: the below are approved for TLS 1.3 but not supported by our fips-server yet
+		//   see https://github.com/DataDog/test-infra-definitions/blob/221bbc806266eb15b90cb875deb79180e7591fbc/components/datadog/apps/fips/images/fips-server/src/tls.go#L48-L58
+		// {cert: "rsa", cipher: "TLS_AES_128_GCM_SHA256", tlsMax: "1.3", want: true},
+		// {cert: "rsa", cipher: "TLS_AES_256_GCM_SHA384", tlsMax: "1.3", want: true},
+	}
+)
+
+type fipsServerSuite[Env any] struct {
+	e2e.BaseSuite[Env]
+
+	fipsServer fipsServer
+	// generates traffic to the FIPS server when called
+	generateTestTraffic func()
+}
+
+// TestFIPSCiphers tests that generateTestTraffic communicates with fipsServer as defined
+// in each test case. Some cases assert that a FIPS-compliant cipher is used, others assert that a non-FIPS cipher is not used.
+func (s *fipsServerSuite[Env]) TestFIPSCiphers() {
+	for _, tc := range testcases {
+		s.Run(fmt.Sprintf("FIPS enabled testing '%v -c %v' (should connect %v)", tc.cert, tc.cipher, tc.want), func() {
+			// Start the fips-server and waits for it to be ready
+			s.fipsServer.Start(s.T(), tc)
+			s.T().Cleanup(func() {
+				s.fipsServer.Stop()
+			})
+
+			s.generateTestTraffic()
+
+			serverLogs := s.fipsServer.Logs()
+			if tc.want {
+				assert.Contains(s.T(), serverLogs, fmt.Sprintf("Negotiated cipher suite: %s", tc.cipher))
+			} else {
+				assert.Contains(s.T(), serverLogs, "no cipher suite supported by both client and server")
+			}
+		})
+	}
+}
+
+// TestFIPSCiphersTLSVersion tests that generateTestTraffic rejects fipsServer when the TLS version is too low
+func (s *fipsServerSuite[Env]) TestFIPSCiphersTLSVersion() {
+	tc := cipherTestCase{cert: "rsa", tlsMax: "1.1"}
+	s.fipsServer.Start(s.T(), tc)
+	s.T().Cleanup(func() {
+		s.fipsServer.Stop()
+	})
+
+	s.generateTestTraffic()
+
+	serverLogs := s.fipsServer.Logs()
+	assert.Contains(s.T(), serverLogs, "tls: client offered only unsupported version")
+}

--- a/test/new-e2e/tests/fips-compliance/fips_ciphers_nix_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_ciphers_nix_test.go
@@ -8,6 +8,7 @@ package fipscompliance
 import (
 	_ "embed"
 	"fmt"
+	"os"
 	"strings"
 
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/require"
 )
 
 //go:embed fixtures/docker-compose.yaml
@@ -29,6 +31,9 @@ type fipsServerLinuxSuite struct {
 }
 
 func TestFIPSCiphersLinuxSuite(t *testing.T) {
+	require.NotEmpty(t, os.Getenv("E2E_COMMIT_SHA"), "E2E_COMMIT_SHA must be set")
+	require.NotEmpty(t, os.Getenv("E2E_PIPELINE_ID"), "E2E_PIPELINE_ID must be set")
+
 	e2e.Run(
 		t,
 		&fipsServerLinuxSuite{},

--- a/test/new-e2e/tests/fips-compliance/fips_ciphers_nix_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_ciphers_nix_test.go
@@ -9,7 +9,6 @@ import (
 	_ "embed"
 	"fmt"
 	"strings"
-	"time"
 
 	"testing"
 
@@ -18,50 +17,21 @@ import (
 	awsdocker "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/docker"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/dockeragentparams"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-)
-
-type cipherTestCase struct {
-	cert   string
-	cipher string
-	tlsMax string
-	want   bool
-}
-
-var (
-	testcases = []cipherTestCase{
-		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", want: true},
-		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", want: true},
-		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", want: true},
-		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", want: true},
-		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", want: false},
-		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", want: false},
-		{cert: "ecc", cipher: "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", want: false},
-		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", want: false},
-		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", want: false},
-		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", want: false},
-		{cert: "rsa", cipher: "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA", want: false},
-		// TODO: the below are approved for TLS 1.3 but not supported by our fips-server yet
-		//   see https://github.com/DataDog/test-infra-definitions/blob/221bbc806266eb15b90cb875deb79180e7591fbc/components/datadog/apps/fips/images/fips-server/src/tls.go#L48-L58
-		// {cert: "rsa", cipher: "TLS_AES_128_GCM_SHA256", tlsMax: "1.3", want: true},
-		// {cert: "rsa", cipher: "TLS_AES_256_GCM_SHA384", tlsMax: "1.3", want: true},
-	}
 )
 
 //go:embed fixtures/docker-compose.yaml
 var dockerCompose string
 
-type fipsServerSuite struct {
-	e2e.BaseSuite[environments.DockerHost]
+type fipsServerLinuxSuite struct {
+	fipsServerSuite[environments.DockerHost]
 }
 
-func TestFIPSCiphersSuite(t *testing.T) {
+func TestFIPSCiphersLinuxSuite(t *testing.T) {
 	e2e.Run(
 		t,
-		&fipsServerSuite{},
+		&fipsServerLinuxSuite{},
 		e2e.WithProvisioner(
 			awsdocker.Provisioner(
 				awsdocker.WithAgentOptions(
@@ -74,76 +44,17 @@ func TestFIPSCiphersSuite(t *testing.T) {
 	)
 }
 
-func (v *fipsServerSuite) TestFIPSCiphersFIPSEnabled() {
-	composeFiles := strings.Split(v.Env().RemoteHost.MustExecute(`docker inspect --format='{{index (index .Config.Labels "com.docker.compose.project.config_files")}}' datadog-agent`), ",")
+func (s *fipsServerLinuxSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+
+	host := s.Env().RemoteHost
+	// lookup the compose file used by environments.DockerHost
+	composeFiles := strings.Split(host.MustExecute(`docker inspect --format='{{index (index .Config.Labels "com.docker.compose.project.config_files")}}' datadog-agent`), ",")
 	formattedComposeFiles := strings.Join(composeFiles, " -f ")
-
-	for _, tc := range testcases {
-		v.Run(fmt.Sprintf("FIPS enabled testing '%v -c %v' (should connect %v)", tc.cert, tc.cipher, tc.want), func() {
-
-			// Start the fips-server and waits for it to be ready
-			runFipsServer(v, tc, formattedComposeFiles)
-			defer stopFipsServer(v, formattedComposeFiles)
-
-			// Run diagnose to send requests and verify the server logs
-			runAgentDiagnose(v, formattedComposeFiles)
-
-			serverLogs := v.Env().RemoteHost.MustExecute("docker logs dd-fips-server")
-			if tc.want {
-				assert.Contains(v.T(), serverLogs, fmt.Sprintf("Negotiated cipher suite: %s", tc.cipher))
-			} else {
-				assert.Contains(v.T(), serverLogs, "no cipher suite supported by both client and server")
-			}
-		})
-	}
-}
-
-func (v *fipsServerSuite) TestFIPSCiphersTLSVersion() {
-	composeFiles := strings.Split(v.Env().RemoteHost.MustExecute(`docker inspect --format='{{index (index .Config.Labels "com.docker.compose.project.config_files")}}' datadog-agent`), ",")
-	formattedComposeFiles := strings.Join(composeFiles, " -f ")
-
-	runFipsServer(v, cipherTestCase{cert: "rsa", tlsMax: "1.1"}, formattedComposeFiles)
-	defer stopFipsServer(v, formattedComposeFiles)
-
-	runAgentDiagnose(v, formattedComposeFiles)
-
-	serverLogs := v.Env().RemoteHost.MustExecute("docker logs dd-fips-server")
-	assert.Contains(v.T(), serverLogs, "tls: client offered only unsupported version")
-}
-
-func runFipsServer(v *fipsServerSuite, tc cipherTestCase, composeFiles string) {
-	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		stopFipsServer(v, composeFiles)
-		envvar := fmt.Sprintf("CERT=%s", tc.cert)
-		if tc.cipher != "" {
-			envvar = fmt.Sprintf(`%s CIPHER="-c %s"`, envvar, tc.cipher)
-		}
-		if tc.tlsMax != "" {
-			envvar = fmt.Sprintf(`%s TLS_MAX="--tls-max %s"`, envvar, tc.tlsMax)
-		}
-
-		_, err := v.Env().RemoteHost.Execute(fmt.Sprintf("%s docker-compose -f %s up --detach  --wait --timeout 300", envvar, strings.TrimSpace(composeFiles)))
-		if err != nil {
-			v.T().Logf("Error starting fips-server: %v", err)
-			require.NoError(t, err)
-		}
-		assert.Nil(t, err)
-	}, 60*time.Second, 20*time.Second)
-
-	require.EventuallyWithT(v.T(), func(t *assert.CollectT) {
-		serverLogs, _ := v.Env().RemoteHost.Execute("docker logs dd-fips-server")
-		assert.Contains(t, serverLogs, "Server Starting...", "Server should start")
-		assert.Equal(t, 1, strings.Count(serverLogs, "Server Starting..."), "Server should start only once, logs from previous runs should not be present")
-	}, 60*time.Second, 5*time.Second)
-}
-
-func runAgentDiagnose(v *fipsServerSuite, composeFiles string) {
-	_ = v.Env().RemoteHost.MustExecute(fmt.Sprintf(`docker-compose -f %s exec agent sh -c "GOFIPS=1 DD_DD_URL=https://dd-fips-server:443 agent diagnose --include connectivity-datadog-core-endpoints --local"`, strings.TrimSpace(composeFiles)))
-}
-
-func stopFipsServer(v *fipsServerSuite, composeFiles string) {
-	fipsContainer := v.Env().RemoteHost.MustExecute("docker container ls -a --filter name=dd-fips-server --format '{{.Names}}'")
-	if fipsContainer != "" {
-		v.Env().RemoteHost.MustExecute(fmt.Sprintf("docker-compose -f %s down fips-server", strings.TrimSpace(composeFiles)))
+	formattedComposeFiles = strings.TrimSpace(formattedComposeFiles)
+	// supply workers to base fipsServerSuite
+	s.fipsServer = newFIPSServer(host, formattedComposeFiles)
+	s.generateTestTraffic = func() {
+		_ = host.MustExecute(fmt.Sprintf(`docker-compose -f %s exec agent sh -c "GOFIPS=1 DD_DD_URL=https://dd-fips-server:443 agent diagnose --include connectivity-datadog-core-endpoints --local"`, formattedComposeFiles))
 	}
 }

--- a/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
@@ -1,0 +1,221 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package fipscompliance
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
+	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/docker"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+
+	infraos "github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed fixtures/docker-compose-fips-server.yaml
+var dockerFipsServerCompose []byte
+
+type multiVMEnv struct {
+	WindowsVM     *components.RemoteHost
+	LinuxDockerVM *components.RemoteHost
+	LinuxDocker   *components.RemoteHostDocker
+}
+
+type fipsServerWinSuite struct {
+	e2e.BaseSuite[multiVMEnv]
+}
+
+func TestFIPSCiphersWindowsSuite(t *testing.T) {
+	suiteParams := []e2e.SuiteOption{e2e.WithPulumiProvisioner(multiVMEnvProvisioner(), nil)}
+
+	e2e.Run(
+		t,
+		&fipsServerWinSuite{},
+		suiteParams...,
+	)
+}
+
+func (s *fipsServerWinSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+
+	// Enable FIPS mode
+	err := windowsCommon.EnableFIPSMode(s.Env().WindowsVM)
+	require.NoError(s.T(), err)
+
+	// Install FIPS Agent
+	// NOTE: Installing the Agent manually instead of using the Agent component
+	// to make devloops easier, as the Agent component does not support
+	// installing locally built packages.
+	if _, set := windowsAgent.LookupFlavorFromEnv(); !set {
+		os.Setenv(windowsAgent.PackageFlavorEnvVar, "fips")
+	}
+	agentPackage, err := windowsAgent.GetPackageFromEnv()
+	require.NoError(s.T(), err)
+	logFile := filepath.Join(s.SessionOutputDir(), "install.log")
+	_, err = windowsAgent.InstallAgent(s.Env().WindowsVM,
+		windowsAgent.WithPackage(agentPackage),
+		windowsAgent.WithInstallLogFile(logFile))
+	require.NoError(s.T(), err)
+}
+
+func (s *fipsServerWinSuite) fipsServerUp(tc cipherTestCase) {
+	// Write docker-compose.yaml to disk
+	host := s.Env().LinuxDockerVM
+	_, err := host.WriteFile("/tmp/docker-compose.yaml", dockerFipsServerCompose)
+	require.NoError(s.T(), err)
+
+	// stop currently running server, so we can reset logs+env
+	s.fipsServerDown()
+
+	// start datadog/appd-fips-server with env vars from the test case
+	envVars := map[string]string{
+		"CERT": tc.cert,
+	}
+	if tc.cipher != "" {
+		envVars["CIPHER"] = fmt.Sprintf("-c %s", tc.cipher)
+	}
+	if tc.tlsMax != "" {
+		envVars["TLS_MAX"] = fmt.Sprintf("--tls-max %s", tc.tlsMax)
+	}
+
+	cmd := "docker-compose -f /tmp/docker-compose.yaml up --detach --wait --timeout 300"
+	_, err = host.Execute(cmd, client.WithEnvVariables(envVars))
+	require.NoError(s.T(), err)
+
+	// Wait for container to start and ensure it's a fresh instance
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		serverLogs, _ := host.Execute("docker logs dd-fips-server")
+		assert.Contains(t, serverLogs, "Server Starting...", "Server should start")
+		assert.Equal(t, 1, strings.Count(serverLogs, "Server Starting..."), "Server should start only once, logs from previous runs should not be present")
+	}, 60*time.Second, 5*time.Second)
+}
+
+func (s *fipsServerWinSuite) fipsServerDown() {
+	host := s.Env().LinuxDockerVM
+	_, err := host.Execute("docker-compose -f /tmp/docker-compose.yaml down")
+	require.NoError(s.T(), err)
+}
+
+func (s *fipsServerWinSuite) TestFIPSCiphers() {
+	host := s.Env().WindowsVM
+	dockerHost := s.Env().LinuxDockerVM
+
+	for _, tc := range testcases {
+		s.Run(fmt.Sprintf("FIPS enabled testing '%v -c %v' (should connect %v)", tc.cert, tc.cipher, tc.want), func() {
+			// Start the fips-server and waits for it to be ready
+			s.fipsServerUp(tc)
+			s.T().Cleanup(func() {
+				s.fipsServerDown()
+			})
+
+			agentEnv := map[string]string{
+				// datadog/apps-fips-server creates self-signed certed
+				"DD_SKIP_SSL_VALIDATION": "true",
+				// point diagnose command at datadog/apps-fips-server container
+				"DD_DD_URL": fmt.Sprintf(`https://%s:443`, dockerHost.HostOutput.Address),
+			}
+			agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
+			cmd := fmt.Sprintf(`& '%s' diagnose --include connectivity-datadog-core-endpoints --local`, agent)
+			host.Execute(cmd, client.WithEnvVariables(agentEnv))
+
+			serverLogs := dockerHost.MustExecute("docker logs dd-fips-server")
+			if tc.want {
+				assert.Contains(s.T(), serverLogs, fmt.Sprintf("Negotiated cipher suite: %s", tc.cipher))
+			} else {
+				assert.Contains(s.T(), serverLogs, "no cipher suite supported by both client and server")
+			}
+		})
+	}
+}
+
+// multiVMEnvProvisioner provisions a Windows VM and a Linux Docker VM
+//
+// This allows us to run the datadog/apps-fips-server container on the Linux VM,
+// and query it from the Agent running on the Windows VM.
+//
+// Why do we do it this way?
+//   - The fips_ciphers_nix_test.go uses test-infra DockerHost which doesn't support Windows.
+//   - The fips-server is a go binary, so it might be portable to Windows, but TBD.
+//   - The datadog/apps-fips-server container is only built for Linux, but Windows
+//     Server / Docker EE do NOT support Linux containers.
+//   - AWS only supports nested virtualization on metal instances, so that's a hurdle to using WSL2,
+//     plus would also have to do the WSL2 and docker setup manually.
+//   - E2E environments/provisioners are not flexible, so we must create our own to customize the env
+//   - E2E environments/provisioners are not reusable, so we have to copy/paste the DockerHost setup
+func multiVMEnvProvisioner() provisioners.PulumiEnvRunFunc[multiVMEnv] {
+	return func(ctx *pulumi.Context, env *multiVMEnv) error {
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+
+		windowsVM, err := ec2.NewVM(awsEnv, "WindowsVM", ec2.WithOS(infraos.WindowsDefault))
+		if err != nil {
+			return err
+		}
+		windowsVM.Export(ctx, &env.WindowsVM.HostOutput)
+
+		err = linuxDockerVMProvisioner(ctx, awsEnv, env)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func linuxDockerVMProvisioner(ctx *pulumi.Context, awsEnv aws.Environment, env *multiVMEnv) error {
+	linuxDockerVM, err := ec2.NewVM(awsEnv, "LinuxDockerVM", ec2.WithOS(infraos.UbuntuDefault))
+	if err != nil {
+		return err
+	}
+	linuxDockerVM.Export(ctx, &env.LinuxDockerVM.HostOutput)
+
+	// Install+Configure Docker on LinuxDockerVM
+	//
+	// copied from docker environment/provisioner
+	//
+
+	// install the ECR credentials helper
+	// required to get pipeline agent images
+	// TODO: cred helper might not be needed? not sure about auth on fips-server image
+	installEcrCredsHelperCmd, err := ec2.InstallECRCredentialsHelper(awsEnv, linuxDockerVM)
+	if err != nil {
+		return err
+	}
+	manager, err := docker.NewManager(&awsEnv, linuxDockerVM, utils.PulumiDependsOn(installEcrCredsHelperCmd))
+	if err != nil {
+		return err
+	}
+	err = manager.Export(ctx, &env.LinuxDocker.ManagerOutput)
+	if err != nil {
+		return err
+	}
+	//
+	// end copied from docker environment/provisioner
+	//
+
+	return nil
+}

--- a/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
@@ -30,7 +28,6 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +41,7 @@ type multiVMEnv struct {
 }
 
 type fipsServerWinSuite struct {
-	e2e.BaseSuite[multiVMEnv]
+	fipsServerSuite[multiVMEnv]
 }
 
 func TestFIPSCiphersWindowsSuite(t *testing.T) {
@@ -60,8 +57,20 @@ func TestFIPSCiphersWindowsSuite(t *testing.T) {
 func (s *fipsServerWinSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 
-	// Enable FIPS mode
-	err := windowsCommon.EnableFIPSMode(s.Env().WindowsVM)
+	agentHost := s.Env().WindowsVM
+	dockerHost := s.Env().LinuxDockerVM
+
+	// supply workers to base fipsServerSuite
+	composeFilePath := "/tmp/docker-compose.yaml"
+	s.fipsServer = newFIPSServer(dockerHost, composeFilePath)
+	s.generateTestTraffic = s.generateTraffic
+
+	// Write docker-compose.yaml to disk
+	_, err := dockerHost.WriteFile(composeFilePath, dockerFipsServerCompose)
+	require.NoError(s.T(), err)
+
+	// Enable FIPS mode for OS
+	err = windowsCommon.EnableFIPSMode(agentHost)
 	require.NoError(s.T(), err)
 
 	// Install FIPS Agent
@@ -73,97 +82,55 @@ func (s *fipsServerWinSuite) SetupSuite() {
 	}
 	agentPackage, err := windowsAgent.GetPackageFromEnv()
 	require.NoError(s.T(), err)
+	s.T().Logf("Using Agent: %#v", agentPackage)
 	logFile := filepath.Join(s.SessionOutputDir(), "install.log")
-	_, err = windowsAgent.InstallAgent(s.Env().WindowsVM,
+	_, err = windowsAgent.InstallAgent(agentHost,
 		windowsAgent.WithPackage(agentPackage),
 		windowsAgent.WithInstallLogFile(logFile))
 	require.NoError(s.T(), err)
 }
 
-func (s *fipsServerWinSuite) fipsServerUp(tc cipherTestCase) {
-	// Write docker-compose.yaml to disk
-	host := s.Env().LinuxDockerVM
-	_, err := host.WriteFile("/tmp/docker-compose.yaml", dockerFipsServerCompose)
-	require.NoError(s.T(), err)
-
-	// stop currently running server, so we can reset logs+env
-	s.fipsServerDown()
-
-	// start datadog/appd-fips-server with env vars from the test case
-	envVars := map[string]string{
-		"CERT": tc.cert,
-	}
-	if tc.cipher != "" {
-		envVars["CIPHER"] = fmt.Sprintf("-c %s", tc.cipher)
-	}
-	if tc.tlsMax != "" {
-		envVars["TLS_MAX"] = fmt.Sprintf("--tls-max %s", tc.tlsMax)
-	}
-
-	cmd := "docker-compose -f /tmp/docker-compose.yaml up --detach --wait --timeout 300"
-	_, err = host.Execute(cmd, client.WithEnvVariables(envVars))
-	require.NoError(s.T(), err)
-
-	// Wait for container to start and ensure it's a fresh instance
-	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-		serverLogs, _ := host.Execute("docker logs dd-fips-server")
-		assert.Contains(t, serverLogs, "Server Starting...", "Server should start")
-		assert.Equal(t, 1, strings.Count(serverLogs, "Server Starting..."), "Server should start only once, logs from previous runs should not be present")
-	}, 60*time.Second, 5*time.Second)
-}
-
-func (s *fipsServerWinSuite) fipsServerDown() {
-	host := s.Env().LinuxDockerVM
-	_, err := host.Execute("docker-compose -f /tmp/docker-compose.yaml down")
-	require.NoError(s.T(), err)
-}
-
-func (s *fipsServerWinSuite) TestFIPSCiphers() {
-	host := s.Env().WindowsVM
+func (s *fipsServerWinSuite) generateTraffic() {
+	agentHost := s.Env().WindowsVM
 	dockerHost := s.Env().LinuxDockerVM
-
-	for _, tc := range testcases {
-		s.Run(fmt.Sprintf("FIPS enabled testing '%v -c %v' (should connect %v)", tc.cert, tc.cipher, tc.want), func() {
-			// Start the fips-server and waits for it to be ready
-			s.fipsServerUp(tc)
-			s.T().Cleanup(func() {
-				s.fipsServerDown()
-			})
-
-			agentEnv := map[string]string{
-				// datadog/apps-fips-server creates self-signed certed
-				"DD_SKIP_SSL_VALIDATION": "true",
-				// point diagnose command at datadog/apps-fips-server container
-				"DD_DD_URL": fmt.Sprintf(`https://%s:443`, dockerHost.HostOutput.Address),
-			}
-			agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
-			cmd := fmt.Sprintf(`& '%s' diagnose --include connectivity-datadog-core-endpoints --local`, agent)
-			host.Execute(cmd, client.WithEnvVariables(agentEnv))
-
-			serverLogs := dockerHost.MustExecute("docker logs dd-fips-server")
-			if tc.want {
-				assert.Contains(s.T(), serverLogs, fmt.Sprintf("Negotiated cipher suite: %s", tc.cipher))
-			} else {
-				assert.Contains(s.T(), serverLogs, "no cipher suite supported by both client and server")
-			}
-		})
+	agentEnv := map[string]string{
+		// datadog/apps-fips-server creates self-signed cert
+		"DD_SKIP_SSL_VALIDATION": "true",
+		// point diagnose command at datadog/apps-fips-server container
+		"DD_DD_URL": fmt.Sprintf(`https://%s:443`, dockerHost.HostOutput.Address),
 	}
+	agent := `C:\Program Files\Datadog\Datadog Agent\bin\agent.exe`
+	cmd := fmt.Sprintf(`& '%s' diagnose --include connectivity-datadog-core-endpoints --local`, agent)
+	agentHost.Execute(cmd, client.WithEnvVariables(agentEnv))
 }
 
 // multiVMEnvProvisioner provisions a Windows VM and a Linux Docker VM
 //
 // This allows us to run the datadog/apps-fips-server container on the Linux VM,
-// and query it from the Agent running on the Windows VM.
+// and query it from the Agent running on the Windows VM. This is different from
+// the Linux test which runs the Agent and fips-server on the same host with environments.DockerHost.
+// This means the DockerHost provisioner args are not usable in this test, and this test isn't using any
+// special params right now so we didn't copy over the param code.
 //
-// Why do we do it this way?
-//   - The fips_ciphers_nix_test.go uses test-infra DockerHost which doesn't support Windows.
-//   - The fips-server is a go binary, so it might be portable to Windows, but TBD.
-//   - The datadog/apps-fips-server container is only built for Linux, but Windows
-//     Server / Docker EE do NOT support Linux containers.
+// Why use a custom provisioner?
+//   - fips_ciphers_nix_test.go uses test-infra DockerHost which doesn't support Windows.
+//   - E2E environments/provisioners are not flexible/combineable, so we must create one from scratch to customize the env
+//
+// Can fips-server run on Windows?
+//   - The datadog/apps-fips-server container is only built for Linux
+//   - it's a go binary, so it might be portable to Windows / Windows container
+//
+// Can we run the Linux container on Windows?
+//   - Windows Server / Docker EE do not support Linux containers
+//   - AWS only has built-in Windows Server AMIs, not clients, so its more effort to use
+//     a custom AMI and then install Docker Desktop to get Linux container support.
 //   - AWS only supports nested virtualization on metal instances, so that's a hurdle to using WSL2,
 //     plus would also have to do the WSL2 and docker setup manually.
-//   - E2E environments/provisioners are not flexible, so we must create our own to customize the env
-//   - E2E environments/provisioners are not reusable, so we have to copy/paste the DockerHost setup
+//
+// Long term vision / ideal scenario:
+//   - port fips-server to Windows and create a Windows container image
+//   - Add Windows support to test-infra DockerHost
+//   - Use DockerHost env in this test
 func multiVMEnvProvisioner() provisioners.PulumiEnvRunFunc[multiVMEnv] {
 	return func(ctx *pulumi.Context, env *multiVMEnv) error {
 		awsEnv, err := aws.NewEnvironment(ctx)

--- a/test/new-e2e/tests/fips-compliance/fixtures/docker-compose-fips-server.yaml
+++ b/test/new-e2e/tests/fips-compliance/fixtures/docker-compose-fips-server.yaml
@@ -1,0 +1,10 @@
+---
+version: "3.9"
+
+services:
+  fips-server:
+    container_name: "dd-fips-server"
+    image: "ghcr.io/datadog/apps-fips-server:main"
+    ports:
+      - "443:443"
+    entrypoint: ["./run.sh", "${CERT:-rsa}", "${CIPHER}", "${TLS_MAX}"]

--- a/test/new-e2e/tests/windows/common/agent/agent_install_params.go
+++ b/test/new-e2e/tests/windows/common/agent/agent_install_params.go
@@ -124,6 +124,14 @@ func WithValidAPIKey() InstallAgentOption {
 	}
 }
 
+// WithZeroAPIKey sets APIKEY=00000000000000000000000000000000
+//
+// Useful for cases that require api_key to be configured but do
+// not need it to be a real/valid api key.
+func WithZeroAPIKey() InstallAgentOption {
+	return WithAPIKey("00000000000000000000000000000000")
+}
+
 // WithInstallLogFile specifies the file on the local test runner to save the MSI install logs.
 func WithInstallLogFile(logFileName string) InstallAgentOption {
 	return func(i *InstallAgentParams) error {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Port Linux FIPS ciphers E2E test to Windows

The new E2E test has two hosts
- the Agent runs on a Windows host
- the `datadog/apps-fips-server` container runs on a Linux host

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1212
https://datadoghq.atlassian.net/browse/WINA-1263

Add automated test for Windows FIPS Agent ciphersuites

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
N/A, new test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->