### PR TITLE
[ACIX-546] Fix tag-devel for releasing

### DIFF
--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -136,18 +136,3 @@ def agent_context(ctx, branch: str | None = None, skip_checkout=False, commit: s
     finally:
         # Exit
         exit_env()
-
-
-def maybe_agent_context(
-    condition: bool, ctx, branch: str | None = None, skip_checkout=False, commit: str | None = None
-):
-    """Like agent_context if condition is True, otherwise does nothing."""
-
-    @contextmanager
-    def empty_context():
-        yield
-
-    if condition:
-        return agent_context(ctx, branch, skip_checkout=skip_checkout, commit=commit)
-    else:
-        return empty_context()

--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -136,3 +136,18 @@ def agent_context(ctx, branch: str | None = None, skip_checkout=False, commit: s
     finally:
         # Exit
         exit_env()
+
+
+def maybe_agent_context(
+    condition: bool, ctx, branch: str | None = None, skip_checkout=False, commit: str | None = None
+):
+    """Like agent_context if condition is True, otherwise does nothing."""
+
+    @contextmanager
+    def empty_context():
+        yield
+
+    if condition:
+        return agent_context(ctx, branch, skip_checkout=skip_checkout, commit=commit)
+    else:
+        return empty_context()

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -269,7 +269,7 @@ def tag_version(
 
 @task
 def tag_devel(ctx, release_branch, commit="HEAD", push=True, force=False):
-    with agent_context(ctx, get_default_branch(major=int(release_branch[0]))):
+    with agent_context(ctx, get_default_branch(major=get_version_major(release_branch))):
         tag_version(ctx, release_branch, commit, push, force, devel=True)
         tag_modules(ctx, release_branch, commit, push, force, devel=True, trust=True)
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -269,8 +269,9 @@ def tag_version(
 
 @task
 def tag_devel(ctx, release_branch, commit="HEAD", push=True, force=False):
-    tag_version(ctx, release_branch, commit, push, force, devel=True)
-    tag_modules(ctx, release_branch, commit, push, force, devel=True, trust=True)
+    with agent_context(ctx, get_default_branch(major=int(release_branch[0]))):
+        tag_version(ctx, release_branch, commit, push, force, devel=True)
+        tag_modules(ctx, release_branch, commit, push, force, devel=True, trust=True)
 
 
 @task

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -41,7 +41,7 @@ from tasks.libs.common.git import (
 )
 from tasks.libs.common.gomodules import get_default_modules
 from tasks.libs.common.user_interactions import yes_no_question
-from tasks.libs.common.worktree import agent_context
+from tasks.libs.common.worktree import agent_context, maybe_agent_context
 from tasks.libs.pipeline.notifications import (
     DEFAULT_JIRA_PROJECT,
     DEFAULT_SLACK_CHANNEL,
@@ -174,7 +174,15 @@ def __tag_single_module(ctx, module, tag_name, commit, force_option, devel):
 
 @task
 def tag_modules(
-    ctx, release_branch=None, commit="HEAD", push=True, force=False, devel=False, version=None, trust=False
+    ctx,
+    release_branch=None,
+    commit="HEAD",
+    push=True,
+    force=False,
+    devel=False,
+    version=None,
+    trust=False,
+    skip_context=False,
 ):
     """Create tags for Go nested modules for a given Datadog Agent version.
 
@@ -184,6 +192,7 @@ def tag_modules(
         push: Will push the tags to the origin remote (on by default).
         force: Will allow the task to overwrite existing tags. Needed to move existing tags (off by default).
         devel: Will create -devel tags (used after creation of the release branch).
+        skip_context: Skip the agent context. Useful when the context is already set up.
 
     Examples:
         $ inv -e release.tag-modules 7.27.x                 # Create tags and push them to origin
@@ -196,7 +205,7 @@ def tag_modules(
     agent_version = version or deduce_version(ctx, release_branch, trust=trust)
 
     tags = []
-    with agent_context(ctx, release_branch, skip_checkout=release_branch is None):
+    with maybe_agent_context(not skip_context, ctx, release_branch, skip_checkout=release_branch is None):
         force_option = __get_force_option(force)
         for module in get_default_modules().values():
             # Skip main module; this is tagged at tag_version via __tag_single_module.
@@ -224,6 +233,7 @@ def tag_version(
     version=None,
     trust=False,
     start_qual=False,
+    skip_context=False,
 ):
     """Create tags for a given Datadog Agent version.
 
@@ -234,6 +244,7 @@ def tag_version(
         force: Will allow the task to overwrite existing tags. Needed to move existing tags (off by default).
         devel: Will create -devel tags (used after creation of the release branch)
         start_qual: Will start the qualification phase for agent 6 release candidate by adding a qualification tag
+        skip_context: Skip the agent context. Useful when the context is already set up.
 
     Examples:
         $ inv -e release.tag-version -r 7.27.x            # Create tags and push them to origin
@@ -247,7 +258,7 @@ def tag_version(
 
     # Always tag the main module
     force_option = __get_force_option(force)
-    with agent_context(ctx, release_branch, skip_checkout=release_branch is None):
+    with maybe_agent_context(not skip_context, ctx, release_branch, skip_checkout=release_branch is None):
         tags = __tag_single_module(ctx, get_default_modules()["."], agent_version, commit, force_option, devel)
 
         # create or update the qualification tag using the force option (points tag to next RC)
@@ -567,8 +578,8 @@ def build_rc(ctx, release_branch, patch_version=False, k8s_deployments=False, st
         # tag_version only takes the highest version (Agent 7 currently), and creates
         # the tags for all supported versions
         # TODO: make it possible to do Agent 6-only or Agent 7-only tags?
-        tag_version(ctx, version=str(new_version), force=False, start_qual=start_qual)
-        tag_modules(ctx, version=str(new_version), force=False)
+        tag_version(ctx, version=str(new_version), force=False, start_qual=start_qual, skip_context=True)
+        tag_modules(ctx, version=str(new_version), force=False, skip_context=True)
 
         print(color_message(f"Waiting until the {new_version} tag appears in Gitlab", "bold"))
         gitlab_tag = None


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`tag-devel` should not try to switch to the release branch which isn't created yet.
There won't be a second switch since the first `agent_context` will disallow other inner contexts to switch to another branch.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->