### PR TITLE
Assorted small fixes for dogstatsd UDS listener.

### DIFF
--- a/comp/dogstatsd/listeners/uds_common.go
+++ b/comp/dogstatsd/listeners/uds_common.go
@@ -14,7 +14,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -270,13 +269,18 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 			// Read the expected packet length (in stream mode)
 			b := []byte{0, 0, 0, 0}
 			_, err = io.ReadFull(conn, b)
-			expectedPacketLength := binary.LittleEndian.Uint32(b)
-
-			switch {
-			case err == io.EOF, errors.Is(err, io.ErrUnexpectedEOF):
-				log.Debugf("dogstatsd-uds: %s connection closed", l.transport)
+			if err != nil {
+				switch {
+				case errors.Is(err, io.EOF):
+					log.Debugf("dogstatsd-uds: %s connection closed", l.transport)
+				case errors.Is(err, io.ErrUnexpectedEOF):
+					log.Errorf("dogstatsd-uds: %s connection closed while reading payload length", l.transport)
+				default:
+					log.Errorf("dogstatsd-uds: %s: error reading payload length: %v", l.transport, err)
+				}
 				return nil
 			}
+			expectedPacketLength = binary.LittleEndian.Uint32(b)
 			if expectedPacketLength > uint32(len(packet.Buffer)) {
 				log.Info("dogstatsd-uds: packet length too large, dropping connection")
 				return nil
@@ -287,12 +291,15 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 		}
 
 		for err == nil {
+			var nRead int
 			if oob != nil {
-				n, oobn, _, _, err = conn.ReadMsgUnix(packet.Buffer[n:maxPacketLength], oobS[oobn:])
+				nRead, oobn, _, _, err = conn.ReadMsgUnix(packet.Buffer[n:maxPacketLength], oobS)
 			} else {
-				n, _, err = conn.ReadFromUnix(packet.Buffer[n:maxPacketLength])
+				nRead, _, err = conn.ReadFromUnix(packet.Buffer[n:maxPacketLength])
 			}
-			if n == 0 && oobn == 0 && l.transport == "unix" {
+			n += nRead
+
+			if nRead == 0 && oobn == 0 && l.transport == "unix" {
 				log.Debugf("dogstatsd-uds: %s connection closed", l.transport)
 				return nil
 			}
@@ -349,7 +356,7 @@ func (l *UDSListener) handleConnection(conn netUnixConn, closeFunc CloseFunction
 
 		if err != nil {
 			// connection has been closed
-			if strings.HasSuffix(err.Error(), " use of closed network connection") {
+			if errors.Is(err, net.ErrClosed) {
 				return nil
 			}
 

--- a/comp/dogstatsd/listeners/uds_datagram.go
+++ b/comp/dogstatsd/listeners/uds_datagram.go
@@ -87,9 +87,13 @@ func (l *UDSDatagramListener) Listen() {
 
 func (l *UDSDatagramListener) listen() {
 	log.Infof("dogstatsd-uds: starting to listen on %s", l.conn.LocalAddr())
-	_ = l.handleConnection(l.conn, func(conn netUnixConn) error {
+	err := l.handleConnection(l.conn, func(conn netUnixConn) error {
 		return conn.Close()
 	})
+	if err != nil {
+		log.Errorf("dogstatsd-uds: error handling connection: %v", err)
+	}
+
 }
 
 // Stop closes the UDS connection and stops listening

--- a/comp/dogstatsd/listeners/uds_integration_test.go
+++ b/comp/dogstatsd/listeners/uds_integration_test.go
@@ -1,0 +1,82 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package listeners
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/packets"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUDSPartialRead(t *testing.T) {
+	socketPath := testSocketPath(t)
+	sync := make(chan error)
+
+	addr := &net.UnixAddr{Net: "unix", Name: socketPath}
+	listen, err := net.ListenUnix(addr.Net, addr)
+	require.NoError(t, err)
+
+	payload := []byte("test_metric:1|c|#tags,tags,tags")
+
+	go func() {
+		sender, err := net.DialUnix(addr.Net, nil, addr)
+		sync <- err
+		if err != nil {
+			return
+		}
+
+		err = binary.Write(sender, binary.LittleEndian, int32(len(payload)))
+		sync <- err
+		if err != nil {
+			return
+		}
+
+		for _, b := range payload {
+			n, err := sender.Write([]byte{b})
+			if n < 1 {
+				sync <- fmt.Errorf("aborted write: %w", err)
+			}
+			sync <- err
+		}
+
+		sync <- sender.Close()
+
+		close(sync)
+	}()
+
+	conn, err := listen.Accept()
+	require.NoError(t, err)
+
+	mockConfig := map[string]any{
+		"dogstatsd_stream_socket": socketPath,
+	}
+
+	packetsChannel := make(chan packets.Packets, 4)
+	deps := fulfillDepsWithConfig(t, mockConfig)
+	telemetryStore := NewTelemetryStore(nil, deps.Telemetry)
+	packetsTelemetryStore := packets.NewTelemetryStore(nil, deps.Telemetry)
+
+	factory, err := udsStreamListenerFactory(packetsChannel, newPacketPoolManagerUDS(deps.Config, packetsTelemetryStore), deps.Config, deps.PidMap, telemetryStore, packetsTelemetryStore, deps.Telemetry)
+	require.NoError(t, err)
+
+	go factory.(*UDSStreamListener).handleConnection(conn.(*net.UnixConn), func(c netUnixConn) error { return c.Close() })
+
+	for err := range sync {
+		require.NoError(t, err)
+	}
+
+	pkts := <-packetsChannel
+	assert.Equal(t, 1, len(pkts))
+	assert.Equal(t, payload, pkts[0].Contents)
+}

--- a/comp/dogstatsd/listeners/uds_stream.go
+++ b/comp/dogstatsd/listeners/uds_stream.go
@@ -102,7 +102,7 @@ func (l *UDSStreamListener) listen() {
 		}
 		go func() {
 			l.connTracker.Track(conn)
-			_ = l.handleConnection(conn, func(c netUnixConn) error {
+			err = l.handleConnection(conn, func(c netUnixConn) error {
 				l.connTracker.Close(c)
 				return nil
 			})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix assorted small issues in dogstatsd uds listener.

### Motivation

Improve error reporting and fix potential issues with partial reads from stream socket.

### Describe how you validated your changes

New test added to cover the correctness issue with partial read.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->