### PR TITLE
Prevent setting a probabilistic decision maker for OTLP spans sampled by the Error Sampler

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4464,6 +4464,8 @@ api_key:
     # probabilistic_sampler:
       ## @param sampling_percentage - number - optional - default: 100
       ## @env DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE - number - optional - default: 100
+      ## If `apm_config.probabilistic_sampler.enabled` is enabled, this config is ignored, `apm_config.probabilistic_sampler.enabled.sampling_percentage`
+      ## is used instead.
       ## Percentage of traces to ingest (0 100]. Invalid values (<= 0 || > 100) are disconsidered and the default is used.
       ## If incoming spans have a sampling.priority set by the user, it will be followed and the sampling percentage will
       ## be overridden.

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -107,7 +107,7 @@ func (s *PrioritySampler) Sample(now time.Time, trace *pb.TraceChunk, root *pb.S
 	// Regardless of rates, sampling here is based on the metadata set
 	// by the client library. Which, is turn, is based on agent hints,
 	// but the rule of thumb is: respect client choice.
-	sampled := samplingPriority > 0
+	sampled := samplingPriority.IsKeep()
 
 	serviceSignature := ServiceSignature{Name: root.Service, Env: toSamplerEnv(tracerEnv, s.agentEnv)}
 	s.sampler.metrics.record(sampled, newMetricsKey(serviceSignature.Name, serviceSignature.Env, &samplingPriority))

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -68,6 +68,11 @@ const (
 	samplerHasher = uint64(1111111111111111111)
 )
 
+// IsKeep returns whether the priority is "keep".
+func (s SamplingPriority) IsKeep() bool {
+	return s == PriorityAutoKeep || s == PriorityUserKeep
+}
+
 func (s SamplingPriority) tagValue() string {
 	switch s {
 	case PriorityUserDrop:

--- a/releasenotes/notes/fix-ingestion-reason-for-otlp-spans-71a29c0ffb8f7ade.yaml
+++ b/releasenotes/notes/fix-ingestion-reason-for-otlp-spans-71a29c0ffb8f7ade.yaml
@@ -12,5 +12,5 @@ fixes:
     even when an OTLP span was sampled by the Error Sampler.
     To enable the Error Sampler for OTLP spans, you need to set
     ``DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE``
-    to 99 or lower, or enabled ``DD_APM_PROBABILISTIC_SAMPLER_ENABLED``
+    to 99 or lower, or enable ``DD_APM_PROBABILISTIC_SAMPLER_ENABLED``
     and set ``DD_APM_PROBABILISTIC_SAMPLER_PERCENTAGE`` to 99 or lower.

--- a/releasenotes/notes/fix-ingestion-reason-for-otlp-spans-71a29c0ffb8f7ade.yaml
+++ b/releasenotes/notes/fix-ingestion-reason-for-otlp-spans-71a29c0ffb8f7ade.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue where ``ingestion_reason:probabilistic`` is set
+    even when an OTLP span was sampled by the Error Sampler.
+    To enable the Error Sampler for OTLP spans, you need to set
+    ``DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE``
+    to 99 or lower, or enabled ``DD_APM_PROBABILISTIC_SAMPLER_ENABLED``
+    and set ``DD_APM_PROBABILISTIC_SAMPLER_PERCENTAGE`` to 99 or lower.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When Error Sampler works, avoid setting neither `_dd.p.dm:-4` or `_dd.p.dm:-9` to prevent from applying `ingestion_reason:probabilistic` to OTLP errors.


### Motivation

OTLP error spans always have `ingestion_reason:probabilistic`. It should be `ingestion_reason:error` when Error Sampler works.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

For testing, send OTLP error spans from Python with OTel SDK every 10 milliseconds.

We can see transition from `ingestion_reason:probabilistic` to `ingestion_reason:error` after this PR.

![2025-02-02_09-09-11](https://github.com/user-attachments/assets/752cd8c8-8daa-49d5-a9c4-e3ed843c68ee)

Tested with two patterns.

1. Set `DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE=1` to run Error Sampler easily.
2. `DD_APM_PROBABILISTIC_SAMPLER_ENABLED=true` and `DD_APM_PROBABILISTIC_SAMPLER_PERCENTAGE=0`


<details><summary>docker-compose.yaml and Python app</summary>

```yaml
services:
  agent:
    container_name: agent
    # Before
    # image: datadog/agent:7.62.0
    # After
    image: datadog/agent-dev:keisku-apms-14685-error-sampler-py3@sha256:2f7302ccb7c92484f0b57a590793eb85bc02e59b3029560709624cafbc664247
    volumes:
      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
      - /var/run/docker.sock:/var/run/docker.sock:ro
      - /var/lib/cloud/data/instance-id:/var/lib/cloud/data/instance-id:ro
    pid: host
    environment:
      - DD_API_KEY
      - DD_HOSTNAME_FILE=/var/lib/cloud/data/instance-id
      - DD_ENV=docker-keisuke-ubuntu
      - DD_APM_ENABLED=true
      - DD_APM_NON_LOCAL_TRAFFIC=true
      - DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317
      - DD_OTLP_CONFIG_DEBUG_VERBOSITY=detailed
      # Pattern 1
      - DD_OTLP_CONFIG_TRACES_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE=1
      # Pattern 2
      # - DD_APM_PROBABILISTIC_SAMPLER_ENABLED=true
      # - DD_APM_PROBABILISTIC_SAMPLER_PERCENTAGE=0
  error-generator-py:
    container_name: error-generator-py
    build:
      context: ./python
      dockerfile: Dockerfile
    restart: always
    environment:
      - OTEL_EXPORTER_OTLP_ENDPOINT=http://agent:4317
      - OTEL_SERVICE_NAME=python-opentelemetry-error-generator
      - ERROR_GENERATOR_INTERVAL=10
```

```Dockerfile
FROM python:3.13-slim
RUN pip install opentelemetry-api opentelemetry-exporter-otlp opentelemetry-sdk
COPY --chmod=755 <<app.py /src/
import os
import time

from opentelemetry import trace
from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
from opentelemetry.sdk.resources import Resource
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import BatchSpanProcessor
from opentelemetry.trace import Status, StatusCode

trace.set_tracer_provider(TracerProvider())
tracer = trace.get_tracer(__name__)

otlp_exporter = OTLPSpanExporter(insecure=True)

span_processor = BatchSpanProcessor(otlp_exporter)

trace.get_tracer_provider().add_span_processor(span_processor)

def generate_error():
    with tracer.start_as_current_span("generate_error") as span:
        span.set_status(Status(StatusCode.ERROR))
        span.record_exception(Exception("This is an intentional error"))

interval = int(os.getenv("ERROR_GENERATOR_INTERVAL", 1000))

while True:
    generate_error()
    time.sleep(interval / 1000)
app.py
CMD ["python", "/src/app.py"]
```

</details>

<details><summary>span in JSON before PR</summary>

```json
{
  "trace": {
    "root_id": "7981140922446959578",
    "spans": {
      "7981140922446959578": {
        "trace_id": "a78dd7365a74854ba7d4dd9c8fdef5ec",
        "span_id": "7981140922446959578",
        "parent_id": "0",
        "start": 1738296239.08292,
        "end": 1738296239.08297,
        "duration": 0.000050126,
        "error": 1,
        "status": "error",
        "type": "custom",
        "service": "python-opentelemetry-error-generator",
        "name": "main.internal",
        "resource": "generate_error",
        "resource_hash": "745adb92501bc84b",
        "meta": {
          "_dd.agent_hostname": "i-09df1e4674d40f561",
          "_dd.agent_rare_sampler.enabled": "false",
          "_dd.agent_version": "7.62.0",
          "_dd.error_tracking.fingerprints.stable.materials": "[{\"name\":\"SERVICE\",\"location\":{\"source\":\"EVENT\",\"path\":\"service\",\"ranges\":[[0,36]]}},{\"name\":\"ERROR_TYPE\",\"location\":{\"source\":\"EVENT\",\"path\":\"meta.error.type\",\"ranges\":[[0,9]]}},{\"name\":\"ERROR_MESSAGE\",\"location\":{\"source\":\"EVENT\",\"path\":\"meta.error.message\",\"ranges\":[[0,4],[5,7],[8,10],[11,22],[23,28]]}}]",
          "_dd.error_tracking.fingerprints.stable.source": "datadog",
          "_dd.error_tracking.fingerprints.stable.value": "88E7626C53C8576C39EE63B27FE21CAF",
          "_dd.error_tracking.fingerprints.stable.version": "10",
          "_dd.filter.id": "7LSJkDrRRue_7dNexVP2hw",
          "_dd.filter.type": "spans-errors-sampling-processor",
          "_dd.hostname": "i-09df1e4674d40f561",
          "_dd.issue.muted": "false",
          "_dd.issue.state": "OPEN",
          "_dd.language": "python",
          "_dd.p.dm": "-9",
          "_dd.p.ftid": "a78dd7365a74854ba7d4dd9c8fdef5ec",
          "_dd.p.tid": "a78dd7365a74854b",
          "_dd.span_events.has_exception": "true",
          "_dd.tracer_version": "otlp-1.29.0",
          "ddtags": "ingestion_reason:probabilistic",
          "error.fingerprint": "v10.88E7626C53C8576C39EE63B27FE21CAF",
          "error.message": "This is an intentional error",
          "error.stack": "Exception: This is an intentional error\n",
          "error.type": "Exception",
          "events": "[{\"time_unix_nano\":1738296239082965988,\"name\":\"exception\",\"attributes\":{\"exception.type\":\"Exception\",\"exception.message\":\"This is an intentional error\",\"exception.stacktrace\":\"Exception: This is an intentional error\\n\",\"exception.escaped\":\"False\"}}]",
          "issue.first_seen_version": "",
          "issue.id": "8e9acffe-ded3-11ef-81c0-da7ad0900002",
          "language": "python",
          "otel.library.name": "__main__",
          "otel.status_code": "Error",
          "otel.trace_id": "a78dd7365a74854ba7d4dd9c8fdef5ec",
          "span.kind": "internal",
          "telemetry.sdk.language": "python",
          "telemetry.sdk.name": "opentelemetry",
          "telemetry.sdk.version": "1.29.0"
        },
        "metrics": {
          "_dd.agent_errors_sampler.target_tps": 10,
          "_dd.agent_priority_sampler.target_tps": 10,
          "_dd.otlp_sr": 0.01,
          "_dd1.sr.esusr": 0.01,
          "_dd1.sr.esusr_trace": 0,
          "_sampling_priority_rate_v1": 0.101626016260163,
          "_sampling_priority_v1": 1,
          "_top_level": 1,
          "_trace_root": 1,
          "issue.age": 77683222,
          "issue.first_seen": 1738218559999
        },
        "host_id": 29538221517,
        "host_groups": [],
        "hostname": "i-09df1e4674d40f561-7591",
        "env": "docker-keisuke-ubuntu",
        "metadata": {
          "sds_info": []
        },
        "span_events": [
          {
            "name": "exception",
            "time_unix_nano": 1.738296239082966e+18,
            "attributes": {
              "exception.escaped": "False",
              "exception.message": "This is an intentional error",
              "exception.stacktrace": "Exception: This is an intentional error\n",
              "exception.type": "Exception"
            }
          }
        ],
        "ingestion_reason": "probabilistic",
        "children_ids": []
      }
    }
  },
  "orphaned": [],
  "is_truncated": false,
  "is_summary": false
}
```

</details>


<details><summary>span in JSON after PR</summary>

```json
{
  "trace": {
    "root_id": "15910729098197527177",
    "spans": {
      "15910729098197527177": {
        "trace_id": "26e30be60330e6686d5e1c99f0ebf847",
        "span_id": "15910729098197527177",
        "parent_id": "0",
        "start": 1738297238.90397,
        "end": 1738297238.904,
        "duration": 0.000034457,
        "error": 1,
        "status": "error",
        "type": "custom",
        "service": "python-opentelemetry-error-generator",
        "name": "main.internal",
        "resource": "generate_error",
        "resource_hash": "745adb92501bc84b",
        "meta": {
          "_dd.agent_hostname": "i-09df1e4674d40f561",
          "_dd.agent_rare_sampler.enabled": "false",
          "_dd.agent_version": "7.64.0-devel+git.149.8974346",
          "_dd.error_tracking.fingerprints.stable.materials": "[{\"name\":\"SERVICE\",\"location\":{\"source\":\"EVENT\",\"path\":\"service\",\"ranges\":[[0,36]]}},{\"name\":\"ERROR_TYPE\",\"location\":{\"source\":\"EVENT\",\"path\":\"meta.error.type\",\"ranges\":[[0,9]]}},{\"name\":\"ERROR_MESSAGE\",\"location\":{\"source\":\"EVENT\",\"path\":\"meta.error.message\",\"ranges\":[[0,4],[5,7],[8,10],[11,22],[23,28]]}}]",
          "_dd.error_tracking.fingerprints.stable.source": "datadog",
          "_dd.error_tracking.fingerprints.stable.value": "88E7626C53C8576C39EE63B27FE21CAF",
          "_dd.error_tracking.fingerprints.stable.version": "10",
          "_dd.filter.id": "7LSJkDrRRue_7dNexVP2hw",
          "_dd.filter.type": "spans-errors-sampling-processor",
          "_dd.hostname": "i-09df1e4674d40f561",
          "_dd.issue.muted": "false",
          "_dd.issue.state": "OPEN",
          "_dd.language": "python",
          "_dd.p.ftid": "26e30be60330e6686d5e1c99f0ebf847",
          "_dd.p.tid": "26e30be60330e668",
          "_dd.span_events.has_exception": "true",
          "_dd.tracer_version": "otlp-1.29.0",
          "ddtags": "ingestion_reason:error",
          "error.fingerprint": "v10.88E7626C53C8576C39EE63B27FE21CAF",
          "error.message": "This is an intentional error",
          "error.stack": "Exception: This is an intentional error\n",
          "error.type": "exception",
          "events": "[{\"time_unix_nano\":1738297238903998680,\"name\":\"exception\",\"attributes\":{\"exception.type\":\"Exception\",\"exception.message\":\"This is an intentional error\",\"exception.stacktrace\":\"Exception: This is an intentional error\\n\",\"exception.escaped\":\"False\"}}]",
          "issue.first_seen_version": "",
          "issue.id": "8e9acffe-ded3-11ef-81c0-da7ad0900002",
          "language": "python",
          "otel.library.name": "__main__",
          "otel.status_code": "Error",
          "otel.trace_id": "26e30be60330e6686d5e1c99f0ebf847",
          "span.kind": "internal",
          "telemetry.sdk.language": "python",
          "telemetry.sdk.name": "opentelemetry",
          "telemetry.sdk.version": "1.29.0"
        },
        "metrics": {
          "_dd.agent_errors_sampler.target_tps": 10,
          "_dd.agent_priority_sampler.target_tps": 10,
          "_dd.errors_sr": 0.0512820512820513,
          "_dd.otlp_sr": 0.01,
          "_dd1.sr.esusr": 0.01,
          "_dd1.sr.esusr_trace": 0,
          "_sampling_priority_v1": 0,
          "_top_level": 1,
          "_trace_root": 1,
          "issue.age": 78682339,
          "issue.first_seen": 1738218559999
        },
        "host_id": 29538221517,
        "host_groups": [],
        "hostname": "i-09df1e4674d40f561-7591",
        "env": "docker-keisuke-ubuntu",
        "metadata": {
          "sds_info": []
        },
        "span_events": [
          {
            "name": "exception",
            "time_unix_nano": 1.7382972389039987e+18,
            "attributes": {
              "exception.escaped": "False",
              "exception.message": "This is an intentional error",
              "exception.stacktrace": "Exception: This is an intentional error\n",
              "exception.type": "Exception"
            }
          }
        ],
        "ingestion_reason": "error",
        "children_ids": []
      }
    }
  },
  "orphaned": [],
  "is_truncated": false,
  "is_summary": false
}
```

</details>

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Pattern 1

https://github.com/DataDog/datadog-agent/blob/91794f654cad0d5a4ab1b455dfe626f30d8cb890/pkg/trace/agent/agent.go#L690-L700

Pattern 2

https://github.com/DataDog/datadog-agent/blob/91794f654cad0d5a4ab1b455dfe626f30d8cb890/pkg/trace/agent/agent.go#L653-L665
