### PR TITLE
Add /dd_tracer/node/node_modules to NODE_PATH for serverless-init

### DIFF
--- a/cmd/serverless-init/mode/initcontainer_mode.go
+++ b/cmd/serverless-init/mode/initcontainer_mode.go
@@ -98,7 +98,8 @@ type Tracer struct {
 
 func instrumentNode() {
 	currNodePath := os.Getenv("NODE_PATH")
-	os.Setenv("NODE_PATH", addToString(currNodePath, ":", "/dd_tracer/node/"))
+	legacyDatadogNodePath := addToString(currNodePath, ":", "/dd_tracer/node/")
+	os.Setenv("NODE_PATH", addToString(legacyDatadogNodePath, ":", "/dd_tracer/node/node_modules"))
 
 	currNodeOptions := os.Getenv("NODE_OPTIONS")
 	os.Setenv("NODE_OPTIONS", addToString(currNodeOptions, " ", "--require dd-trace/init"))

--- a/cmd/serverless-init/mode/initcontainer_mode_test.go
+++ b/cmd/serverless-init/mode/initcontainer_mode_test.go
@@ -90,7 +90,7 @@ func TestNodeTracerIsAutoInstrumented(t *testing.T) {
 	autoInstrumentTracer(fs)
 
 	assert.Equal(t, "--require dd-trace/init", os.Getenv("NODE_OPTIONS"))
-	assert.Equal(t, "/dd_tracer/node/", os.Getenv("NODE_PATH"))
+	assert.Equal(t, "/dd_tracer/node/:/dd_tracer/node/node_modules", os.Getenv("NODE_PATH"))
 }
 
 func TestDotNetTracerIsAutoInstrumented(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Appends `/dd_tracer/node/node_modules` to `NODE_PATH` for serverless-init.

### Motivation

Documentation for Node was updated to use a different installation directory for the Datadog Tracer. https://github.com/DataDog/documentation/pull/24660

https://docs.datadoghq.com/serverless/guide/gcr_serverless_init/?code-lang=nodejs
Instructions before update:
```
COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
```
Instructions after update (current):
```
RUN npm install --prefix /dd_tracer/node dd-trace  --save
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

* Automated test to assert `NODE_PATH` has both `/dd_tracer/node` and `/dd_tracer/node/node_modules` appended.
* Built serverless-init locally and followed Dockerfile [instructions](https://docs.datadoghq.com/serverless/guide/gcr_serverless_init/?code-lang=nodejs) to instrument a Node Express app and confirm Datadog Tracer is found via the `NODE_PATH`
  - Installed Datadog Tracer using legacy instructions: `COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/`
  - Installed Datadog Tracer using current instructions:  `RUN npm install --prefix /dd_tracer/node dd-trace  --save`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->