### PR TITLE
[pkg/util/crio] Add missing go build tag

### DIFF
--- a/pkg/util/crio/crio_util.go
+++ b/pkg/util/crio/crio_util.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build crio
+
 // Package crio provides a crio client.
 package crio
 


### PR DESCRIPTION
### What does this PR do?

Adds a missing go build tag.
The code in `pkg/util/crio/crio_util.go` is specific for crio, and we have a `crio` build tag, so we should use it here.


### Describe how you validated your changes

Automated tests should be enough.