### PR TITLE
Upgrade lading to `0.25.5` and update trace-agent expvar config in `lading.yaml`

### DIFF
--- a/test/regression/cases/quality_gate_idle/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_idle/lading/lading.yaml
@@ -16,7 +16,7 @@ target_metrics:
       tags:
         sub_agent: "process"
   - expvar: #trace agent telemetry
-      uri: "http://127.0.0.1:5012/debug/vars"
+      uri: "https://127.0.0.1:5012/debug/vars"
       vars:
         - "/Event"
         - "/ServiceCheck"

--- a/test/regression/cases/quality_gate_idle_all_features/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/lading/lading.yaml
@@ -18,7 +18,7 @@ target_metrics:
       tags:
         sub_agent: "process"
   - expvar: #trace agent telemetry
-      uri: "http://127.0.0.1:5012/debug/vars"
+      uri: "https://127.0.0.1:5012/debug/vars"
       vars:
         - "/Event"
         - "/ServiceCheck"

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.4
+  version: 0.25.5
 
 target:
 


### PR DESCRIPTION
### What does this PR do?

Updates lading version from `0.25.4` to `0.25.5`. Also updates the expvar uri for trace-agents debug server to https.

### Motivation

In response to this [PR](https://github.com/DataDog/datadog-agent/pull/33402) which modifies the trace-agents debug endpoint to use https rather than http, we needed to enable https requests in ladings expvar scraping code (hence the lading upgrade) and similarly update the uri config in the experiment `lading.yaml`s to use https.

### Describe how you validated your changes

Some notes in the lading pr [here](https://github.com/DataDog/lading/pull/1213)

[SMPTNG-587](https://datadoghq.atlassian.net/browse/SMPTNG-587)


[SMPTNG-587]: https://datadoghq.atlassian.net/browse/SMPTNG-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ