### PR TITLE
[chore] Ensure artifacts always upload for ocb build, even when job fails

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -67,6 +67,7 @@ datadog_otel_components_ocb_build:
       - ocb-output.log
       - otelcol-custom.log
       - flare-info.log
+    when: always
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:

--- a/test/otel/testdata/ocb_build_script.sh
+++ b/test/otel/testdata/ocb_build_script.sh
@@ -39,6 +39,5 @@ grep -q 'ddflare/dd-autoconfigured' flare-info.log || (echo "ddflare extension s
 grep -q 'health_check/dd-autoconfigured' flare-info.log || (echo "health_check extension should be enabled" && exit 1)
 grep -q 'pprof/dd-autoconfigured' flare-info.log || (echo "pprof extension should be enabled" && exit 1)
 grep -q 'zpages/dd-autoconfigured' flare-info.log || (echo "zpages extension should be enabled" && exit 1)
-exit 1 # remove this line after checking that artifgacts still upload
 
-# echo "OCB build script completed successfully"
+echo "OCB build script completed successfully"

--- a/test/otel/testdata/ocb_build_script.sh
+++ b/test/otel/testdata/ocb_build_script.sh
@@ -39,5 +39,6 @@ grep -q 'ddflare/dd-autoconfigured' flare-info.log || (echo "ddflare extension s
 grep -q 'health_check/dd-autoconfigured' flare-info.log || (echo "health_check extension should be enabled" && exit 1)
 grep -q 'pprof/dd-autoconfigured' flare-info.log || (echo "pprof extension should be enabled" && exit 1)
 grep -q 'zpages/dd-autoconfigured' flare-info.log || (echo "zpages extension should be enabled" && exit 1)
+exit 1 # remove this line after checking that artifgacts still upload
 
-echo "OCB build script completed successfully"
+# echo "OCB build script completed successfully"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
adds a `when:always` to artifacts stage of ocb component build test
### Motivation
be able to view logs when job fails (otherwise there's no point)
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
more artifacts
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->