### PR TITLE
Update the create-release-branches task to create the release branch in the agent on a specific commit

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -686,8 +686,7 @@ def create_and_update_release_branch(
     # Perform branch out in all required repositories
     print(color_message(f"Working repository: {repo}", "bold"))
     if repo == 'datadog-agent':
-        with agent_context(ctx, base_branch or get_default_branch(major=get_version_major(release_branch))):
-            _main()
+        _main()
     else:
         with ctx.cd(f"{base_directory}/{repo}"):
             # Step 1 - Create a local branch out from the default branch
@@ -734,7 +733,7 @@ def create_release_branches(
     # Strings with proper branch/tag names
     release_branch = current.branch()
 
-    with agent_context(ctx, get_default_branch(major=get_version_major(release_branch)), commit=commit):
+    with agent_context(ctx, commit=commit):
         # Step 0: checks
         ctx.run("git fetch")
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -667,7 +667,6 @@ def create_and_update_release_branch(
     """
 
     def _main():
-        ctx.run("git pull")
         print(color_message(f"Branching out to {release_branch}", "bold"))
         ctx.run(f"git checkout -b {release_branch}")
 
@@ -697,13 +696,16 @@ def create_and_update_release_branch(
                 or ctx.run(f"git remote show {upstream} | grep \"HEAD branch\" | sed 's/.*: //'").stdout.strip()
             )
             ctx.run(f"git checkout {main_branch}")
+            ctx.run("git pull")
 
             _main()
 
 
 # TODO: unfreeze is the former name of this task, kept for backward compatibility. Remove in a few weeks.
 @task(help={'upstream': "Remote repository name (default 'origin')"}, aliases=["unfreeze"])
-def create_release_branches(ctx, base_directory="~/dd", major_version: int = 7, upstream="origin", check_state=True):
+def create_release_branches(
+    ctx, commit, base_directory="~/dd", major_version: int = 7, upstream="origin", check_state=True
+):
     """Create and push release branches in Agent repositories and update them.
 
     That includes:
@@ -712,11 +714,12 @@ def create_release_branches(ctx, base_directory="~/dd", major_version: int = 7, 
         - updates entries in .gitlab-ci.yml and .gitlab/notify/notify.yml which depend on local branch name
 
     Args:
+        commit: the commit on which the branch should be created (usually the one before the milestone bump)
         base_directory: Path to the directory where dd repos are cloned, defaults to ~/dd, but can be overwritten.
         use_worktree: If True, will go to datadog-agent-worktree instead of datadog-agent.
 
     Notes:
-        This requires a Github token (either in the GITHUB_TOKEN environment variable, or in the MacOS keychain),
+        This requires a GitHub token (either in the GITHUB_TOKEN environment variable, or in the MacOS keychain),
         with 'repo' permissions.
         This also requires that there are no local uncommitted changes, that the current branch is 'main' or the
         release branch, and that no branch named 'release/<new rc version>' already exists locally or upstream.
@@ -731,7 +734,7 @@ def create_release_branches(ctx, base_directory="~/dd", major_version: int = 7, 
     # Strings with proper branch/tag names
     release_branch = current.branch()
 
-    with agent_context(ctx, get_default_branch()):
+    with agent_context(ctx, get_default_branch(major=get_version_major(release_branch)), commit=commit):
         # Step 0: checks
         ctx.run("git fetch")
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update the create-release-branches task to create the release branch in the agent on a specific commit 

### Motivation

We do not create the branch on top of the main branch anymore

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->