### PR TITLE
[Backport 7.62.x] Generate buildenv bump PR on rc only 

### DIFF
--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -77,9 +77,28 @@ generate_windows_gitlab_runner_bump_pr:
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
-    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$/
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+  script:
+    # We are using the agent platform auto PR github app to access the buildenv repository (already used for macOS builds)
+    - !reference [.setup_github_app_agent_platform_auto_pr]
+    - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt
+    - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
+    - inv -e github.update-windows-runner-version
 
-  script: 
+# Manual job to generate the gitlab bump pr on buildenv if trigger_auto_staging_release fails
+generate_windows_gitlab_runner_bump_pr_manual:
+  stage: trigger_release
+  extends: .slack-notifier-base
+  needs: ["trigger_auto_staging_release"]
+  tags: ["arch:amd64"]
+  rules:
+    - if: $DDR_WORKFLOW_ID != null
+      when: never
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
+      when: never
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+      when: manual
+  script:
     # We are using the agent platform auto PR github app to access the buildenv repository (already used for macOS builds)
     - !reference [.setup_github_app_agent_platform_auto_pr]
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -78,6 +78,7 @@ generate_windows_gitlab_runner_bump_pr:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
+
   script:
     # We are using the agent platform auto PR github app to access the buildenv repository (already used for macOS builds)
     - !reference [.setup_github_app_agent_platform_auto_pr]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Backport #33540 to the 7.62.x branch
Generate `buildenv` bump PR on rc only

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->