### PR TITLE
[EBPF] gpu: enable periodic uprobe attacher scan

### DIFF
--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -26,8 +26,8 @@ type Config struct {
 	ebpf.Config
 	// Enabled indicates whether the GPU monitoring probe is enabled.
 	Enabled bool
-	// ScanTerminatedProcessesInterval is the interval at which the probe scans for terminated processes.
-	ScanTerminatedProcessesInterval time.Duration
+	// ScanProcessesInterval is the interval at which the probe scans for new or terminated processes.
+	ScanProcessesInterval time.Duration
 	// InitialProcessSync indicates whether the probe should sync the process list on startup.
 	InitialProcessSync bool
 	// NVMLLibraryPath is the path of the native libnvidia-ml.so library
@@ -40,11 +40,11 @@ type Config struct {
 func New() *Config {
 	spCfg := pkgconfigsetup.SystemProbe()
 	return &Config{
-		Config:                          *ebpf.NewConfig(),
-		ScanTerminatedProcessesInterval: time.Duration(spCfg.GetInt(sysconfig.FullKeyPath(GPUNS, "process_scan_interval_seconds"))) * time.Second,
-		InitialProcessSync:              spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "initial_process_sync")),
-		NVMLLibraryPath:                 spCfg.GetString(sysconfig.FullKeyPath(GPUNS, "nvml_lib_path")),
-		Enabled:                         spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enabled")),
-		ConfigureCgroupPerms:            spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "configure_cgroup_perms")),
+		Config:                *ebpf.NewConfig(),
+		ScanProcessesInterval: time.Duration(spCfg.GetInt(sysconfig.FullKeyPath(GPUNS, "process_scan_interval_seconds"))) * time.Second,
+		InitialProcessSync:    spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "initial_process_sync")),
+		NVMLLibraryPath:       spCfg.GetString(sysconfig.FullKeyPath(GPUNS, "nvml_lib_path")),
+		Enabled:               spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enabled")),
+		ConfigureCgroupPerms:  spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "configure_cgroup_perms")),
 	}
 }

--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -104,7 +104,7 @@ func (c *cudaEventConsumer) Start() {
 	c.wg.Add(1)
 	go func() {
 		c.running.Store(true)
-		processSync := time.NewTicker(c.cfg.ScanTerminatedProcessesInterval)
+		processSync := time.NewTicker(c.cfg.ScanProcessesInterval)
 
 		defer func() {
 			cleanupExit()

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -324,9 +324,11 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 				},
 			},
 		},
-		EbpfConfig:         &cfg.Config,
-		PerformInitialScan: cfg.InitialProcessSync,
-		SharedLibsLibset:   sharedlibraries.LibsetGPU,
+		EbpfConfig:                     &cfg.Config,
+		PerformInitialScan:             cfg.InitialProcessSync,
+		SharedLibsLibset:               sharedlibraries.LibsetGPU,
+		ScanProcessesInterval:          cfg.ScanProcessesInterval,
+		EnablePeriodicScanNewProcesses: true,
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Enables the periodic scan for processes in the GPU uprobe attacher.

### Motivation

Similar as https://github.com/DataDog/datadog-agent/pull/32400, we want to enable periodic scan of processes to avoid missing open shared libraries.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Tested locally that we are scanning for processes.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->