### PR TITLE
[EBPF] gpu: limit warning logs in NVML

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -10,6 +10,7 @@ package nvml
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"go.uber.org/fx"
 
@@ -26,6 +27,8 @@ const (
 	componentName = "workloadmeta-nvml"
 	nvidiaVendor  = "nvidia"
 )
+
+var logLimiter = log.NewLogLimit(20, 10*time.Minute)
 
 type collector struct {
 	id      string
@@ -107,19 +110,25 @@ func (c *collector) getGPUdeviceInfo(device nvml.Device) (*workloadmeta.GPU, err
 		// If any mid detection fails, we will return an mig disabled in config
 		migDeviceCount, ret := c.nvmlLib.DeviceGetMaxMigDeviceCount(device)
 		if ret != nvml.SUCCESS {
-			log.Warnf("failed to get MIG capable device count: %v", nvml.ErrorString(ret))
+			if logLimiter.ShouldLog() {
+				log.Warnf("failed to get MIG capable device count: %v", nvml.ErrorString(ret))
+			}
 			return &gpuDeviceInfo, nil
 		}
 		migDevs := make([]*workloadmeta.MigDevice, 0, migDeviceCount)
 		for j := 0; j < migDeviceCount; j++ {
 			migDevice, ret := c.nvmlLib.DeviceGetMigDeviceHandleByIndex(device, j)
 			if ret != nvml.SUCCESS {
-				log.Warnf("failed to get handle for MIG device %d: %v", j, nvml.ErrorString(ret))
+				if logLimiter.ShouldLog() {
+					log.Warnf("failed to get handle for MIG device %d: %v", j, nvml.ErrorString(ret))
+				}
 				return &gpuDeviceInfo, nil
 			}
 			migDeviceInfo, err := c.getDeviceInfoMig(migDevice)
 			if err != nil {
-				log.Warnf("failed to get device info for MIG device %d: %v", j, err)
+				if logLimiter.ShouldLog() {
+					log.Warnf("failed to get device info for MIG device %d: %v", j, err)
+				}
 				return &gpuDeviceInfo, nil
 			}
 			migDevs = append(migDevs, migDeviceInfo)
@@ -183,14 +192,18 @@ func (c *collector) Pull(_ context.Context) error {
 
 		arch, ret := dev.GetArchitecture()
 		if ret != nvml.SUCCESS {
-			log.Warnf("failed to get architecture for device index %d: %v", i, nvml.ErrorString(ret))
+			if logLimiter.ShouldLog() {
+				log.Warnf("failed to get architecture for device index %d: %v", i, nvml.ErrorString(ret))
+			}
 		} else {
 			gpu.Architecture = gpuArchToString(arch)
 		}
 
 		major, minor, ret := dev.GetCudaComputeCapability()
 		if ret != nvml.SUCCESS {
-			log.Warnf("failed to get CUDA compute capability for device index %d: %v", i, nvml.ErrorString(ret))
+			if logLimiter.ShouldLog() {
+				log.Warnf("failed to get CUDA compute capability for device index %d: %v", i, nvml.ErrorString(ret))
+			}
 		} else {
 			gpu.ComputeCapability.Major = major
 			gpu.ComputeCapability.Minor = minor
@@ -198,7 +211,9 @@ func (c *collector) Pull(_ context.Context) error {
 
 		devAttr, ret := dev.GetAttributes()
 		if ret != nvml.SUCCESS {
-			log.Warnf("failed to get device attributes for device index %d: %v", i, nvml.ErrorString(ret))
+			if logLimiter.ShouldLog() {
+				log.Warnf("failed to get device attributes for device index %d: %v", i, nvml.ErrorString(ret))
+			}
 		} else {
 			gpu.SMCount = int(devAttr.MultiprocessorCount)
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Limits the warning logs emitted by the NVML workloadmeta collector, as some of those warnings can be repeated on every pull and stop being informative (e.g., not all devices support the `GetAttributes()` call).

### Motivation

Reduce noise in logs.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated locally that the log volume is reduced.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->