### PR TITLE
Make each scrubber rule case insensitive

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -47,7 +47,7 @@ func init() {
 func AddDefaultReplacers(scrubber *Scrubber) {
 	hintedAPIKeyReplacer := Replacer{
 		// If hinted, mask the value regardless if it doesn't match 32-char hexadecimal string
-		Regex: regexp.MustCompile(`(api_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
+		Regex: regexp.MustCompile(`(?i)(api_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
 		Hints: []string{"api_key", "apikey"},
 		Repl:  []byte(`$1***************************$2`),
 
@@ -55,7 +55,7 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	}
 	hintedAPPKeyReplacer := Replacer{
 		// If hinted, mask the value regardless if it doesn't match 40-char hexadecimal string
-		Regex: regexp.MustCompile(`(ap(?:p|plication)_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
+		Regex: regexp.MustCompile(`(?i)(ap(?:p|plication)_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
 		Hints: []string{"app_key", "appkey", "application_key"},
 		Repl:  []byte(`$1***********************************$2`),
 
@@ -65,8 +65,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	// replacers are check one by one in order. We first try to scrub 64 bytes token, keeping the last 5 digit. If
 	// the token has a different size we scrub it entirely.
 	hintedBearerReplacer := Replacer{
-		Regex: regexp.MustCompile(`\bBearer [a-fA-F0-9]{59}([a-fA-F0-9]{5})\b`),
-		Hints: []string{"Bearer"},
+		Regex: regexp.MustCompile(`(?i)\bBearer [a-fA-F0-9]{59}([a-fA-F0-9]{5})\b`),
+		Hints: []string{"bearer"},
 		Repl:  []byte(`Bearer ***********************************************************$1`),
 
 		// https://github.com/DataDog/datadog-agent/pull/12338
@@ -74,8 +74,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	}
 	// For this one we match any characters
 	hintedBearerInvalidReplacer := Replacer{
-		Regex: regexp.MustCompile(`\bBearer\s+[^*]+\b`),
-		Hints: []string{"Bearer"},
+		Regex: regexp.MustCompile(`(?i)\bBearer\s+[^*]+\b`),
+		Hints: []string{"bearer"},
 		Repl:  []byte("Bearer " + defaultReplacement),
 
 		// https://github.com/DataDog/datadog-agent/pull/23448
@@ -83,33 +83,33 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	}
 
 	apiKeyReplacerYAML := Replacer{
-		Regex: regexp.MustCompile(`(\-|\:|,|\[|\{)(\s+)?\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
+		Regex: regexp.MustCompile(`(?i)(\-|\:|,|\[|\{)(\s+)?\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
 		Repl:  []byte(`$1$2"***************************$3"`),
 
 		// https://github.com/DataDog/datadog-agent/pull/12605
 		LastUpdated: parseVersion("7.39.0"),
 	}
 	apiKeyReplacer := Replacer{
-		Regex: regexp.MustCompile(`\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
+		Regex: regexp.MustCompile(`(?i)\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
 		Repl:  []byte(`***************************$1`),
 
 		LastUpdated: defaultVersion,
 	}
 	appKeyReplacerYAML := Replacer{
-		Regex: regexp.MustCompile(`(\-|\:|,|\[|\{)(\s+)?\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
+		Regex: regexp.MustCompile(`(?i)(\-|\:|,|\[|\{)(\s+)?\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
 		Repl:  []byte(`$1$2"***********************************$3"`),
 
 		// https://github.com/DataDog/datadog-agent/pull/12605
 		LastUpdated: parseVersion("7.39.0"),
 	}
 	appKeyReplacer := Replacer{
-		Regex: regexp.MustCompile(`\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
+		Regex: regexp.MustCompile(`(?i)\b[a-fA-F0-9]{35}([a-fA-F0-9]{5})\b`),
 		Repl:  []byte(`***********************************$1`),
 
 		LastUpdated: defaultVersion,
 	}
 	rcAppKeyReplacer := Replacer{
-		Regex: regexp.MustCompile(`\bDDRCM_[A-Z0-9]+([A-Z0-9]{5})\b`),
+		Regex: regexp.MustCompile(`(?i)\bDDRCM_[A-Z0-9]+([A-Z0-9]{5})\b`),
 		Repl:  []byte(`***********************************$1`),
 
 		// https://github.com/DataDog/datadog-agent/pull/14681
@@ -152,7 +152,7 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	tokenReplacer.LastUpdated = defaultVersion
 	snmpReplacer := matchYAMLKey(
 		`(community_string|authKey|privKey|community|authentication_key|privacy_key|Authorization|authorization)`,
-		[]string{"community_string", "authKey", "privKey", "community", "authentication_key", "privacy_key", "Authorization", "authorization"},
+		[]string{"community_string", "authkey", "privkey", "community", "authentication_key", "privacy_key", "authorization"},
 		[]byte(`$1 "********"`),
 	)
 	snmpReplacer.LastUpdated = parseVersion("7.53.0") // https://github.com/DataDog/datadog-agent/pull/23515
@@ -168,8 +168,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 		   Backreferences are not available in go, so we cannot verify
 		   here that the BEGIN label is the same as the END label.
 		*/
-		Regex: regexp.MustCompile(`-----BEGIN (?:.*)-----[A-Za-z0-9=\+\/\s]*-----END (?:.*)-----`),
-		Hints: []string{"BEGIN"},
+		Regex: regexp.MustCompile(`(?i)-----BEGIN (?:.*)-----[A-Za-z0-9=\+\/\s]*-----END (?:.*)-----`),
+		Hints: []string{"begin"},
 		Repl:  []byte(`********`),
 
 		LastUpdated: defaultVersion,
@@ -244,8 +244,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 
 func matchYAMLKeyPart(part string, hints []string, repl []byte) Replacer {
 	return Replacer{
-		Regex:        regexp.MustCompile(fmt.Sprintf(`(\s*(\w|_)*%s(\w|_)*\s*:).+`, part)),
-		YAMLKeyRegex: regexp.MustCompile(part),
+		Regex:        regexp.MustCompile(fmt.Sprintf(`(?i)(\s*(\w|_)*%s(\w|_)*\s*:).+`, part)),
+		YAMLKeyRegex: regexp.MustCompile("(?i)" + part),
 		Hints:        hints,
 		Repl:         repl,
 	}
@@ -253,8 +253,8 @@ func matchYAMLKeyPart(part string, hints []string, repl []byte) Replacer {
 
 func matchYAMLKey(key string, hints []string, repl []byte) Replacer {
 	return Replacer{
-		Regex:        regexp.MustCompile(fmt.Sprintf(`(\s*%s\s*:).+`, key)),
-		YAMLKeyRegex: regexp.MustCompile(fmt.Sprintf(`^%s$`, key)),
+		Regex:        regexp.MustCompile(fmt.Sprintf(`(?i)(\s*%s\s*:).+`, key)),
+		YAMLKeyRegex: regexp.MustCompile(fmt.Sprintf(`(?i)^%s$`, key)),
 		Hints:        hints,
 		Repl:         repl,
 	}
@@ -262,8 +262,8 @@ func matchYAMLKey(key string, hints []string, repl []byte) Replacer {
 
 func matchYAMLKeyEnding(ending string, hints []string, repl []byte) Replacer {
 	return Replacer{
-		Regex:        regexp.MustCompile(fmt.Sprintf(`(^\s*(\w|_)*%s\s*:).+`, ending)),
-		YAMLKeyRegex: regexp.MustCompile(fmt.Sprintf(`^.*%s$`, ending)),
+		Regex:        regexp.MustCompile(fmt.Sprintf(`(?i)(^\s*(\w|_)*%s\s*:).+`, ending)),
+		YAMLKeyRegex: regexp.MustCompile(fmt.Sprintf(`(?i)^.*%s$`, ending)),
 		Hints:        hints,
 		Repl:         repl,
 	}
@@ -272,7 +272,7 @@ func matchYAMLKeyEnding(ending string, hints []string, repl []byte) Replacer {
 // This only works on a YAML object not on serialized YAML data
 func matchYAMLOnly(key string, cb func(interface{}) interface{}) Replacer {
 	return Replacer{
-		YAMLKeyRegex: regexp.MustCompile(key),
+		YAMLKeyRegex: regexp.MustCompile("(?i)" + key),
 		ProcessValue: cb,
 	}
 }
@@ -307,7 +307,7 @@ func matchYAMLKeyWithListValue(key string, hints string, repl []byte) Replacer {
 		  'pass2']
 	*/
 	return Replacer{
-		Regex: regexp.MustCompile(fmt.Sprintf(`(\s*%s\s*:)\s*(?:\n(?:\s+-\s+.*)*|\[(?:\n?.*?)*?\])`, key)),
+		Regex: regexp.MustCompile(fmt.Sprintf(`(?i)(\s*%s\s*:)\s*(?:\n(?:\s+-\s+.*)*|\[(?:\n?.*?)*?\])`, key)),
 		/*                                     -----------      ---------------  -------------
 		                                       match key(s)     |                |
 		                                                        match multiple   match anything

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -357,8 +357,14 @@ func TestSNMPConfig(t *testing.T) {
 		`authKey: password`,
 		`authKey: "********"`)
 	assertClean(t,
+		`authkey: password`,
+		`authkey: "********"`)
+	assertClean(t,
 		`privKey: password`,
 		`privKey: "********"`)
+	assertClean(t,
+		`privkey: password`,
+		`privkey: "********"`)
 	assertClean(t,
 		`community_string: p@ssw0r)`,
 		`community_string: "********"`)
@@ -380,6 +386,9 @@ func TestSNMPConfig(t *testing.T) {
 	assertClean(t,
 		`   community_string:   'password'   `,
 		`   community_string: "********"`)
+	assertClean(t,
+		`   COMMUNITY_STRING:   'password'   `,
+		`   COMMUNITY_STRING: "********"`)
 	assertClean(t,
 		`
 network_devices:
@@ -668,4 +677,45 @@ log_level: info
 	cleanedString := string(cleaned)
 
 	assert.Equal(t, cleanedConfigFile, cleanedString)
+}
+
+func TestYamlCase(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			"password",
+			`a:
+  - PaSsWoRd: mypass`,
+			`a:
+  - PaSsWoRd: '********'`,
+		},
+		{
+			"token",
+			`- TOKEN: tok`,
+			`- TOKEN: '********'`,
+		},
+		{
+			"authorization",
+			`- AUTHORIZATION: auth`,
+			`- AUTHORIZATION: '********'`,
+		},
+		{
+			"community",
+			`- COMMUNITY: comm`,
+			`- COMMUNITY: '********'`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleaned, err := ScrubYaml([]byte(tc.input))
+			require.NoError(t, err)
+			cleanedString := string(cleaned)
+
+			assert.YAMLEq(t, tc.expected, cleanedString)
+		})
+	}
 }

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -204,9 +204,11 @@ func (c *Scrubber) scrub(data []byte, replacers []Replacer) []byte {
 			continue
 		}
 
+		lowerdata := bytes.ToLower(data)
+
 		containsHint := false
 		for _, hint := range repl.Hints {
-			if bytes.Contains(data, []byte(hint)) {
+			if bytes.Contains(lowerdata, bytes.ToLower([]byte(hint))) {
 				containsHint = true
 				break
 			}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
#incident-34611
-->
### What does this PR do?
Make the scrubber case insensitive.

### Motivation
We had a secret leak due to unexpected casing.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Added unit tests to ensure we catch unexpected casing keys.

### Possible Drawbacks / Trade-offs
Now hints are also used case insensitively, not sure if that could have a performance impact.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->