### PR TITLE
Change reported digest for containerd image layers to the rootfs diffid

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image_test.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image_test.go
@@ -113,6 +113,14 @@ func TestGetLayersWithHistory(t *testing.T) {
 				Comment:    "empty5",
 			},
 		},
+		RootFS: ocispec.RootFS{
+			DiffIDs: []digest.Digest{
+				digest.FromString("abc"),
+				digest.FromString("def"),
+				digest.FromString("ghi"),
+				digest.FromString("jkl"),
+			},
+		},
 	}
 
 	manifest := ocispec.Manifest{
@@ -144,7 +152,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 	assert.Equal(t, []workloadmeta.ContainerImageLayer{
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("foo").String(),
+			Digest:    digest.FromString("abc").String(),
 			SizeBytes: 1,
 			History: &ocispec.History{
 				Comment:    "not-empty1",
@@ -165,7 +173,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 		},
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("bar").String(),
+			Digest:    digest.FromString("def").String(),
 			SizeBytes: 2,
 			History: &ocispec.History{
 				Comment:    "not-empty2",
@@ -180,7 +188,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 		},
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("baz").String(),
+			Digest:    digest.FromString("ghi").String(),
 			SizeBytes: 3,
 			History: &ocispec.History{
 				Comment:    "not-empty3",
@@ -201,7 +209,7 @@ func TestGetLayersWithHistory(t *testing.T) {
 		},
 		{
 			MediaType: ocispec.MediaTypeImageLayer,
-			Digest:    digest.FromString("bow").String(),
+			Digest:    digest.FromString("jkl").String(),
 			SizeBytes: 4,
 		},
 	}, layers)


### PR DESCRIPTION
### What does this PR do?

Change the value of the digest field associated with containerd image layers to that of the RootFS DiffIDs.

### Motivation

https://dd.slack.com/archives/C4TQDFK1P/p1738256994492399
https://dd.slack.com/archives/C4TQDFK1P/p1738693120924119

This is already what is being used for docker and for cri-o, so this PR brings containerd in line with the other 2 container runtimes. It should also fix an issue where layer vulnerabilities are not properly being associated with the expected layers

### Describe how you validated your changes

Full QA can be found [here](https://datadoghq.atlassian.net/wiki/spaces/~63dac561bf837c6893d7c08b/pages/4690281688/Containerd+image+layer+digest+-+diff_id)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->