### PR TITLE
Ensure developer docs reflect the current version of Go

### DIFF
--- a/docs/public/.hooks/inject_variables.py
+++ b/docs/public/.hooks/inject_variables.py
@@ -7,17 +7,20 @@ from markdown.preprocessors import Preprocessor
 @cache
 def variable_replacements():
     return {
-        "<<<GO_VERSION>>>": get_go_version(),
+        f"<<<{variable}>>>": replacement
+        for variable, replacement in (
+            ("GO_VERSION", get_go_version()),
+        )
     }
 
 
 def get_go_version():
-    return Path('.go-version').read_text(encoding="utf-8")
+    return Path(".go-version").read_text(encoding="utf-8").strip()
 
 
 class VariableInjectionPreprocessor(Preprocessor):
     def run(self, lines):  # noqa: PLR6301
-        markdown = '\n'.join(lines)
+        markdown = "\n".join(lines)
         for variable, replacement in variable_replacements().items():
             markdown = markdown.replace(variable, replacement)
 

--- a/docs/public/.hooks/inject_variables.py
+++ b/docs/public/.hooks/inject_variables.py
@@ -1,0 +1,24 @@
+from functools import cache
+from pathlib import Path
+
+from markdown.preprocessors import Preprocessor
+
+
+@cache
+def variable_replacements():
+    return {
+        "<<<GO_VERSION>>>": get_go_version(),
+    }
+
+
+def get_go_version():
+    return Path('.go-version').read_text(encoding="utf-8")
+
+
+class VariableInjectionPreprocessor(Preprocessor):
+    def run(self, lines):  # noqa: PLR6301
+        markdown = '\n'.join(lines)
+        for variable, replacement in variable_replacements().items():
+            markdown = markdown.replace(variable, replacement)
+
+        return markdown.splitlines()

--- a/docs/public/.hooks/inject_variables.py
+++ b/docs/public/.hooks/inject_variables.py
@@ -1,10 +1,8 @@
-from functools import cache
 from pathlib import Path
 
 from markdown.preprocessors import Preprocessor
 
 
-@cache
 def variable_replacements():
     return {
         f"<<<{variable}>>>": replacement

--- a/docs/public/.hooks/plugin_register.py
+++ b/docs/public/.hooks/plugin_register.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from markdown.extensions import Extension
+
+HERE = os.path.dirname(__file__)
+
+
+def on_config(
+    config,
+    **kwargs,  # noqa: ARG001
+):
+    config.markdown_extensions.append(GlobalExtension())
+
+
+class GlobalExtension(Extension):
+    def extendMarkdown(self, md):  # noqa: N802, PLR6301
+        sys.path.insert(0, HERE)
+
+        from inject_variables import VariableInjectionPreprocessor
+
+        md.preprocessors.register(VariableInjectionPreprocessor(), VariableInjectionPreprocessor.__name__, 100)
+
+        sys.path.pop(0)

--- a/docs/public/setup.md
+++ b/docs/public/setup.md
@@ -150,7 +150,7 @@ See also some notes in [./checks](https://github.com/DataDog/datadog-agent/tree/
 
 ### Golang
 
-You must [install Golang](https://golang.org/doc/install) version `1.23.5` or later. Make sure that `$GOPATH/bin` is in your `$PATH`, otherwise [tooling](#tooling) cannot use any additional tool it might need.
+You must [install Golang](https://golang.org/doc/install) version `<<<GO_VERSION>>>` or later. Make sure that `$GOPATH/bin` is in your `$PATH`, otherwise [tooling](#tooling) cannot use any additional tool it might need.
 
 !!! note
     Versions of Golang that aren't an exact match to the version specified in our build images (see e.g. [here](https://github.com/DataDog/datadog-agent-buildimages/blob/c025473ee467ee6d884d532e4c12c7d982ce8fe1/circleci/Dockerfile#L43)) may not be able to build the agent and/or the [rtloader](https://github.com/DataDog/datadog-agent/tree/main/rtloader) binary properly.

--- a/docs/public/setup.md
+++ b/docs/public/setup.md
@@ -88,7 +88,7 @@ After downloading the archive corresponding to your platform and architecture, e
 deva is available on PyPI and can be installed with [pip](https://github.com/pypa/pip).
 
 ```
-pip install deva
+pip install datadog-agent-dev
 ```
 
 !!! warning

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - Internals: architecture/dogstatsd/internals.md
 
 hooks:
+- docs/public/.hooks/plugin_register.py
 - docs/public/.hooks/title_from_content.py
 
 plugins:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,9 @@ nav:
   - DogStatsD:
     - Internals: architecture/dogstatsd/internals.md
 
+watch:
+- .go-version
+
 hooks:
 - docs/public/.hooks/plugin_register.py
 - docs/public/.hooks/title_from_content.py

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -32,7 +32,6 @@ GO_VERSION_REFERENCES: list[tuple[str, str, str, bool]] = [
     ("./cmd/process-agent/README.md", "`go >= ", "`", False),
     ("./pkg/logs/launchers/windowsevent/README.md", "install go ", "+,", False),
     ("./.wwhrd.yml", "raw.githubusercontent.com/golang/go/go", "/LICENSE", True),
-    ("./docs/public/setup.md", "version `", "` or later", True),
     ("./go.work", "go ", "", False),
     ("./go.work", "toolchain go", "", True),
 ]


### PR DESCRIPTION
### What does this PR do?

This adds a hook which injects the version anywhere the variable is referenced, and makes it easy to extend for other variables