### PR TITLE
[FA][HA Agent] Add config_id only to agent running metrics

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -621,6 +621,8 @@ func (agg *BufferedAggregator) appendDefaultSeries(start time.Time, series metri
 			[]string{"ha_agent_state:" + string(agg.haAgent.GetState())},
 		)
 		// Send along a metric to show if HA Agent is running with ha_agent_state tag.
+		// datadog.agent.ha_agent.running is currently used in dashboard to monitor HA Agent state (active/standby)
+		// This metric is not intended to be used as replacement for datadog.agent.running
 		series.Append(&metrics.Serie{
 			Name:           fmt.Sprintf("datadog.%s.ha_agent.running", agg.agentName),
 			Points:         []metrics.Point{{Value: float64(1), Ts: float64(start.Unix())}},

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"expvar"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -608,16 +609,16 @@ func (agg *BufferedAggregator) appendDefaultSeries(start time.Time, series metri
 	series.Append(&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", agg.agentName),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice(agg.tags(true)),
+		Tags:           tagset.CompositeTagsFromSlice(slices.Concat(agg.tags(true), agg.configIDTags())),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 	})
 
 	if agg.haAgent.Enabled() {
-		haAgentTags := append(agg.tags(false),
-			"config_id:"+agg.configID,
-			"ha_agent_state:"+string(agg.haAgent.GetState()),
+		haAgentTags := slices.Concat(agg.tags(false),
+			agg.configIDTags(),
+			[]string{"ha_agent_state:" + string(agg.haAgent.GetState())},
 		)
 		// Send along a metric to show if HA Agent is running with ha_agent_state tag.
 		series.Append(&metrics.Serie{
@@ -883,9 +884,6 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 		if version.AgentPackageVersion != "" {
 			tags = append(tags, "package_version:"+version.AgentPackageVersion)
 		}
-		if agg.configID != "" {
-			tags = append(tags, "config_id:"+agg.configID)
-		}
 	}
 	if agg.haAgent.Enabled() {
 		tags = append(tags, "ha_agent_enabled:true")
@@ -896,6 +894,16 @@ func (agg *BufferedAggregator) tags(withVersion bool) []string {
 		tags = []string{}
 	}
 	return tags
+}
+
+// configIDTags returns the config_id tag for agent telemetry metrics.
+// the result is returned as list of string to ease processing.
+func (agg *BufferedAggregator) configIDTags() []string {
+	var tag []string
+	if agg.configID != "" {
+		tag = append(tag, "config_id:"+agg.configID)
+	}
+	return tag
 }
 
 func (agg *BufferedAggregator) updateChecksTelemetry() {

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -679,6 +679,36 @@ func TestTags(t *testing.T) {
 	}
 }
 
+func TestGonfigIDTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		configID string
+		want     []string
+	}{
+		{
+			name: "without config_id",
+			want: []string{},
+		},
+		{
+			name:     "with config_id",
+			configID: "my-config",
+			want:     []string{"config_id:my-config"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			mockConfig.SetWithoutSource("config_id", tt.configID)
+
+			taggerComponent := taggerMock.SetupFakeTagger(t)
+			mockHaAgent := haagentmock.NewMockHaAgent().(haagentmock.Component)
+
+			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, "my-hostname", time.Second)
+			assert.ElementsMatch(t, tt.want, agg.configIDTags())
+		})
+	}
+}
+
 func TestTimeSamplerFlush(t *testing.T) {
 	mockConfig := configmock.New(t)
 	mockConfig.SetWithoutSource("dogstatsd_pipeline_count", 1)

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -679,7 +679,7 @@ func TestTags(t *testing.T) {
 	}
 }
 
-func TestGonfigIDTags(t *testing.T) {
+func TestConfigIDTags(t *testing.T) {
 	tests := []struct {
 		name     string
 		configID string

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -309,7 +309,7 @@ func TestDefaultSeries(t *testing.T) {
 	expectedSeries := metrics.Series{&metrics.Serie{
 		Name:           fmt.Sprintf("datadog.%s.running", flavor.GetFlavor()),
 		Points:         []metrics.Point{{Value: 1, Ts: float64(start.Unix())}},
-		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion, "config_id:config123", "ha_agent_enabled:true"}),
+		Tags:           tagset.CompositeTagsFromSlice([]string{"version:" + version.AgentVersion, "ha_agent_enabled:true", "config_id:config123"}),
 		Host:           agg.hostname,
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
@@ -658,16 +658,6 @@ func TestTags(t *testing.T) {
 			withVersion:             false,
 			haAgentEnabled:          true,
 			want:                    []string{"ha_agent_enabled:true"},
-		},
-		{
-			name:                    "tags enabled, with version, with config id",
-			hostname:                "hostname",
-			tlmContainerTagsEnabled: true,
-			agentTags:               func(types.TagCardinality) ([]string, error) { return []string{"container_name:agent"}, nil },
-			globalTags:              func(types.TagCardinality) ([]string, error) { return []string{"kube_cluster_name:foo"}, nil },
-			withVersion:             true,
-			configID:                "config123",
-			want:                    []string{"container_name:agent", "version:" + version.AgentVersion, "kube_cluster_name:foo", "config_id:config123"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[HA Agent] Add config_id only to agent running metrics

### Motivation

`config_id` is only needed on `datadog.agent.running` and `datadog.agent.ha_agent.running` metrics.
Hence, we are making sure in this PR that config_id tag is not added elsewhere.

More concretely, it will avoid `datadog.agent.started` metric to be tagged with `config_id` (not needed).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->