### PR TITLE
system-probe: flare: Pull runtime configuration via the config handler of system-probe

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -138,7 +138,6 @@ func provideRemoteConfig(fb flaretypes.FlareBuilder) error {
 func provideConfigDump(fb flaretypes.FlareBuilder) error {
 	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", getProcessAgentFullConfig)                                                //nolint:errcheck
 	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.Datadog().AllSettings()) }) //nolint:errcheck
-	fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", getSystemProbeConfig)                                                      //nolint:errcheck
 	return nil
 }
 
@@ -148,6 +147,10 @@ func provideSystemProbe(fb flaretypes.FlareBuilder) error {
 	if pkgconfigsetup.SystemProbe().GetBool("system_probe_config.enabled") {
 		_ = fb.AddFileFromFunc(filepath.Join("expvar", "system-probe"), getSystemProbeStats)
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "system_probe_telemetry.log"), getSystemProbeTelemetry)
+		_ = fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", getSystemProbeConfig)
+	} else {
+		// If system probe is disabled, we still want to include the system probe config file
+		_ = fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.SystemProbe().AllSettings()) })
 	}
 	return nil
 }

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -136,9 +136,9 @@ func provideRemoteConfig(fb flaretypes.FlareBuilder) error {
 }
 
 func provideConfigDump(fb flaretypes.FlareBuilder) error {
-	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", getProcessAgentFullConfig)                                                                 //nolint:errcheck
-	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.Datadog().AllSettings()) })                  //nolint:errcheck
-	fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.SystemProbe().AllSettings()) }) //nolint:errcheck
+	fb.AddFileFromFunc("process_agent_runtime_config_dump.yaml", getProcessAgentFullConfig)                                                //nolint:errcheck
+	fb.AddFileFromFunc("runtime_config_dump.yaml", func() ([]byte, error) { return yaml.Marshal(pkgconfigsetup.Datadog().AllSettings()) }) //nolint:errcheck
+	fb.AddFileFromFunc("system_probe_runtime_config_dump.yaml", getSystemProbeConfig)                                                      //nolint:errcheck
 	return nil
 }
 
@@ -258,6 +258,12 @@ func getSystemProbeStats() ([]byte, error) {
 func getSystemProbeTelemetry() ([]byte, error) {
 	sysProbeClient := sysprobeclient.Get(getSystemProbeSocketPath())
 	url := sysprobeclient.URL("/telemetry")
+	return getHTTPData(sysProbeClient, url)
+}
+
+func getSystemProbeConfig() ([]byte, error) {
+	sysProbeClient := sysprobeclient.Get(getSystemProbeSocketPath())
+	url := sysprobeclient.URL("/config")
 	return getHTTPData(sysProbeClient, url)
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When a flare is being requested, we will pull system-probe configuration via the `/config` handler of the system-probe config.

### Motivation

The current code, represented the configuration loaded from the configuration yaml, and didn't take into account the environment variables in the system-probe container.
As a result, pulling a flare over k8s environment, resulted in inaccurate system-probe runtime configuration dump.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Existing E2E tests

Manual QA - 
#### System-probe enabled

1. Deploy the image on k8s with system-probe enabled
    ```yaml
    datadog:
     apiKeyExistingSecret: datadog-secret
     serviceMonitoring:
      enabled: true
    
    agents:
      containers:
        systemProbe:
          env:
            - name: DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP2_MONITORING
              value: "true"
            - name: DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED
              value: "false"
            - name: DD_SERVICE_MONITORING_CONFIG_TLS_NODEJS_ENABLED
              value: "true"
    ```
2. Request for a flare via the UI or via the agent container `agent flare`
3. Verify the value of `service_monitoring_config.enable_http2_monitoring` is true, `service_monitoring_config.tls.istio.enabled` is false, and `service_monitoring_config.tls.nodejs.enabled` is true

#### System-probe disabled

1. Deploy the image on k8s with system-probe enabled
    ```yaml
    datadog:
     apiKeyExistingSecret: datadog-secret
    
    agents:
      containers:
        systemProbe:
          env:
            - name: DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP2_MONITORING
              value: "true"
            - name: DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED
              value: "false"
            - name: DD_SERVICE_MONITORING_CONFIG_TLS_NODEJS_ENABLED
              value: "true"
    ```
2. Request for a flare via the UI or via the agent container `agent flare`
3. Verify the value of `service_monitoring_config.enable_http2_monitoring` is false, `service_monitoring_config.tls.istio.enabled` is true, and `service_monitoring_config.tls.nodejs.enabled` is missing

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->