### PR TITLE
[pkg/util/trivy/docker] Add missing go build tag

### DIFF
--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build trivy
+//go:build trivy && docker
 
 package trivy
 


### PR DESCRIPTION
### What does this PR do?

Adds a missing go build tag.
The code in `pkg/util/trivy/docker.go` is specific for docker, and we have a docker build tag, so we should use it here.

### Describe how you validated your changes

Should be covered by tests.
