### PR TITLE
[CWS] tests: avoid calling `t.Fatal` from probe goroutine

### DIFF
--- a/pkg/security/tests/activity_dumps_test.go
+++ b/pkg/security/tests/activity_dumps_test.go
@@ -570,7 +570,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
-				t.Fatal("Got a signal that should have been suppressed")
+				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
 		}, time.Second*3, "test_autosuppression_exec")
@@ -589,7 +589,7 @@ func TestActivityDumpsAutoSuppression(t *testing.T) {
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
-				t.Fatal("Got a signal that should have been suppressed")
+				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
 		}, time.Second*3, "test_autosuppression_dns")
@@ -679,7 +679,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
-				t.Fatal("Got a signal that should have been suppressed")
+				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
 		}, time.Second*3, "test_autosuppression_exec")
@@ -698,7 +698,7 @@ func TestActivityDumpsAutoSuppressionDriftOnly(t *testing.T) {
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dockerInstance2.containerID) {
-				t.Fatal("Got a signal that should have been suppressed")
+				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
 		}, time.Second*3, "test_autosuppression_dns")

--- a/pkg/security/tests/cgroup_test.go
+++ b/pkg/security/tests/cgroup_test.go
@@ -344,12 +344,14 @@ func TestCGroupSnapshot(t *testing.T) {
 		cgroupFS := utils.NewCGroupFS()
 		_, _, cgroupSysFSPath, err := cgroupFS.FindCGroupContext(uint32(os.Getpid()), uint32(os.Getpid()))
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 
 		var stats unix.Stat_t
 		if err := unix.Stat(cgroupSysFSPath, &stats); err != nil {
-			t.Fatal(err)
+			t.Error(err)
+			return
 		}
 		assert.Equal(t, stats.Ino, testsuiteEntry.CGroup.CGroupFile.Inode)
 

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -49,6 +49,11 @@ func TestLink(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Run("link", ifSyscallSupported("SYS_LINK", func(t *testing.T, syscallNB uintptr) {
 		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall(syscallNB, uintptr(testOldFilePtr), uintptr(testNewFilePtr), 0)
@@ -158,10 +163,6 @@ func TestLink(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), true)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -44,6 +44,11 @@ func TestMkdir(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	mkdirMode := uint16(0o707)
 	expectedMode := uint16(applyUmask(int(mkdirMode)))
 
@@ -152,10 +157,6 @@ func TestMkdir(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), true)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -36,6 +36,11 @@ func TestMMapEvent(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Run("mmap", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			data, err := unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC, unix.MAP_SHARED|unix.MAP_ANON)
@@ -54,10 +59,6 @@ func TestMMapEvent(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), false)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 
 			test.validateMMapSchema(t, event)
@@ -81,6 +82,11 @@ func TestMMapApproverZero(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	test.WaitSignal(t, func() error {
 		data, err := unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_NONE, unix.MAP_SHARED|unix.MAP_ANON)
 		if err != nil {
@@ -98,10 +104,6 @@ func TestMMapApproverZero(t *testing.T) {
 		value, _ := event.GetFieldValue("event.async")
 		assert.Equal(t, value.(bool), false)
 
-		executable, err := os.Executable()
-		if err != nil {
-			t.Fatal(err)
-		}
 		assertFieldEqual(t, event, "process.file.path", executable)
 
 		test.validateMMapSchema(t, event)

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -36,6 +36,11 @@ func TestMProtectEvent(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Run("mprotect", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var data []byte
@@ -56,10 +61,6 @@ func TestMProtectEvent(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), false)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 
 			test.validateMProtectSchema(t, event)

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -102,6 +102,11 @@ func TestRawPacket(t *testing.T) {
 	testDestIP := "192.168.172.171"
 	testUDPDestPort := uint16(12345)
 
+	_, expectedIPNet, err := net.ParseCIDR(testDestIP + "/32")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	// create dummy interface
 	dummy, err := testutils.CreateDummyInterface(testutils.CSMDummyInterface, testDestIP+"/32")
 	if err != nil {
@@ -142,10 +147,6 @@ func TestRawPacket(t *testing.T) {
 			assert.Equal(t, "packet", event.GetType(), "wrong event type")
 			assertTriggeredRule(t, rule, "test_rule_raw_packet_udp4")
 			assertFieldEqual(t, event, "packet.l3_protocol", int(model.EthPIP))
-			_, expectedIPNet, err := net.ParseCIDR(testDestIP + "/32")
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "packet.destination.ip", *expectedIPNet)
 			assertFieldEqual(t, event, "packet.l4_protocol", int(model.IPProtoUDP))
 			assertFieldEqual(t, event, "packet.destination.port", int(testUDPDestPort))

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -49,6 +49,11 @@ func TestOpen(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	testFile, testFilePtr, err := test.Path("test-open")
 	if err != nil {
 		t.Fatal(err)
@@ -334,10 +339,6 @@ func TestOpen(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), true)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 
@@ -376,10 +377,6 @@ func TestOpen(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), true)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -2279,7 +2279,8 @@ func TestProcessResolution(t *testing.T) {
 		// it still checks the ResolveFromProcfs returns the correct entry
 		procEntry := resolver.ResolveFromProcfs(pid, nil)
 		if procEntry == nil {
-			t.Fatalf("not able to resolve the entry")
+			t.Errorf("not able to resolve the entry of pid %d", pid)
+			return
 		}
 
 		equals(t, mapsEntry, procEntry, false)

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -39,6 +39,11 @@ func TestRename(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	fileMode := 0o447
 	expectedMode := uint16(applyUmask(fileMode))
 	testOldFile, testOldFilePtr, err := test.CreateWithOptions("test-rename", 98, 99, fileMode)
@@ -203,10 +208,6 @@ func TestRename(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), true)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -37,6 +37,11 @@ func TestRmdir(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	mkdirMode := 0o707
 	expectedMode := uint16(applyUmask(mkdirMode))
 
@@ -159,10 +164,6 @@ func TestRmdir(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), true)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -855,7 +855,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
-				t.Fatal("Got a signal that should have been suppressed")
+				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
 		}, time.Second*3, "test_autosuppression_exec")
@@ -874,7 +874,7 @@ func TestSecurityProfileAutoSuppression(t *testing.T) {
 			return err
 		}, func(_ *rules.Rule, event *model.Event) bool {
 			if event.ProcessContext.ContainerID == containerutils.ContainerID(dump.ContainerID) {
-				t.Fatal("Got a signal that should have been suppressed")
+				t.Error("Got a signal that should have been suppressed")
 			}
 			return false
 		}, time.Second*3, "test_autosuppression_dns")
@@ -2197,7 +2197,7 @@ func TestSecurityProfilePersistence(t *testing.T) {
 			_, err := dockerInstance2.Command("getconf", []string{"-a"}, []string{}).CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *model.Event) bool {
-			t.Fatal("Got an event that should have been suppressed")
+			t.Error("Got an event that should have been suppressed")
 			return false
 		}, time.Second*3, "test_autosuppression_exec")
 		if err != nil {

--- a/pkg/security/tests/security_profile_test.go
+++ b/pkg/security/tests/security_profile_test.go
@@ -310,7 +310,7 @@ func TestAnomalyDetection(t *testing.T) {
 			// don't do anything
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection.")
+			t.Error("Should not had receive any anomaly detection.")
 			return false
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -379,7 +379,7 @@ func TestAnomalyDetection(t *testing.T) {
 			// don't do anything
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection.")
+			t.Error("Should not had receive any anomaly detection.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -462,7 +462,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection during warm up.")
+			t.Error("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*5, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -473,7 +473,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection during warm up.")
+			t.Error("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -503,7 +503,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection during warm up.")
+			t.Error("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*5, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -516,7 +516,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection during warm up.")
+			t.Error("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -527,7 +527,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection during warm up.")
+			t.Error("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -538,7 +538,7 @@ func TestAnomalyDetectionWarmup(t *testing.T) {
 			cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal("Should not had receive any anomaly detection during warm up.")
+			t.Error("Should not had receive any anomaly detection during warm up.")
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -617,7 +617,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*3, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -651,7 +651,7 @@ func TestSecurityProfileReinsertionPeriod(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*3, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1106,7 +1106,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1165,7 +1165,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1176,7 +1176,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1196,7 +1196,7 @@ func TestSecurityProfileLifeCycleExecs(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been discarded"))
+			t.Error(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1280,7 +1280,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1337,7 +1337,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1348,7 +1348,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1368,7 +1368,7 @@ func TestSecurityProfileLifeCycleDNS(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been discarded"))
+			t.Error(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1457,7 +1457,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// We shouldn't see anything: the profile is still learning
 			data, _ := event.MarshalJSON()
-			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
+			t.Error(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
 			// we answer false on purpose: we might have 2 or more syscall anomaly events
 			return false
 		}, time.Second*2, model.SyscallsEventType, events.AnomalyDetectionRuleID)
@@ -1475,7 +1475,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// this time we shouldn't see anything new.
 			data, _ := event.MarshalJSON()
-			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
+			t.Error(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
 			return false
 		}, time.Second*2, model.SyscallsEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1534,7 +1534,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// this time we shouldn't see anything new.
 			data, _ := event.MarshalJSON()
-			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
+			t.Error(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
 			return false
 		}, time.Second*2, model.SyscallsEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1556,7 +1556,7 @@ func TestSecurityProfileLifeCycleSyscall(t *testing.T) {
 		}, func(_ *rules.Rule, event *events.CustomEvent) bool {
 			// We shouldn't see anything: the profile is unstable
 			data, _ := event.MarshalJSON()
-			t.Fatal(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
+			t.Error(fmt.Errorf("syscall anomaly detected when it should have been ignored: %s", string(data)))
 			// we answer false on purpose: we might have 2 or more syscall anomaly events
 			return false
 		}, time.Second*2, model.SyscallsEventType, events.AnomalyDetectionRuleID)
@@ -1642,7 +1642,7 @@ func TestSecurityProfileLifeCycleEvictionProcess(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1820,7 +1820,7 @@ func TestSecurityProfileLifeCycleEvictionDNS(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.DNSEventType, events.AnomalyDetectionRuleID)
 	})
@@ -1998,7 +1998,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			_, err = cmd.CombinedOutput()
 			return err
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been reinserted"))
+			t.Error(errors.New("catch a custom event that should had been reinserted"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -2019,7 +2019,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been discarded"))
+			t.Error(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -2042,7 +2042,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been discarded"))
+			t.Error(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})
@@ -2065,7 +2065,7 @@ func TestSecurityProfileLifeCycleEvictionProcessUnstable(t *testing.T) {
 			_, _ = cmd.CombinedOutput()
 			return nil
 		}, func(_ *rules.Rule, _ *events.CustomEvent) bool {
-			t.Fatal(errors.New("catch a custom event that should had been discarded"))
+			t.Error(errors.New("catch a custom event that should had been discarded"))
 			return false
 		}, time.Second*2, model.ExecEventType, events.AnomalyDetectionRuleID)
 	})

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -37,6 +37,11 @@ func TestUnlink(t *testing.T) {
 	}
 	defer test.Close()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	fileMode := 0o447
 	expectedMode := uint16(applyUmask(fileMode))
 	testFile, testFilePtr, err := test.CreateWithOptions("test-unlink", 98, 99, fileMode)
@@ -154,10 +159,6 @@ func TestUnlink(t *testing.T) {
 			value, _ := event.GetFieldValue("event.async")
 			assert.Equal(t, value.(bool), true)
 
-			executable, err := os.Executable()
-			if err != nil {
-				t.Fatal(err)
-			}
 			assertFieldEqual(t, event, "process.file.path", executable)
 		})
 	})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Avoid calling `t.Fatal` in callback functions called by the probe event goroutine.

### Motivation

Calling `t.Fatal` stops the execution of the calling goroutine. When used in a test callback, this causes the probe event goroutine to be stopped, thus causing the test module to enter a state in which the following tests cannot be run. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->