### PR TITLE
Minor fix for Agent Log & Metric team names

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -10,7 +10,7 @@ github_team = "agent-metrics-logs"
 github_labels = ["team/agent-metrics-logs"]
 exclude_members = ["olivielpeau"]
 
-[teams."Agent Logs"]
+[teams."Agent Log Pipelines"]
 jira_project = "AGNTLOG"
 jira_issue_type = "Task"
 jira_statuses = ["To Do", "In Progress", "Done"]
@@ -18,7 +18,7 @@ github_team = "agent-log-pipelines"
 github_labels = ["team/agent-log-pipelines"]
 exclude_members = [""]
 
-[teams."Agent Metrics"]
+[teams."Agent Metric Pipelines"]
 jira_project = "AGTMETRICS"
 jira_issue_type = "Task"
 jira_statuses = ["To Do", "In Progress", "Done"]


### PR DESCRIPTION
### What does this PR do?

Changing:

- `Agent Logs` -> `Agent Log Pipelines`
- `Agent Metrics` -> `Agent Metric Pipelines`

### Motivation

Making sure names match up correctly.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->