### PR TITLE
[pkg/orchestrator/redact] Use orchestrator build tag

### DIFF
--- a/pkg/orchestrator/redact/metadata.go
+++ b/pkg/orchestrator/redact/metadata.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package redact
+
+const consulOriginalPodAnnotation = "consul.hashicorp.com/original-pod"
+
+// hardcode the annotation to avoid importing k8s.io/api
+const kubectlLastAppliedConfigAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
+
+var sensitiveAnnotationsAndLabels = []string{kubectlLastAppliedConfigAnnotation, consulOriginalPodAnnotation}
+
+// UpdateSensitiveAnnotationsAndLabels adds new sensitive annotations or labels key to the list to redact.
+func UpdateSensitiveAnnotationsAndLabels(annotationsAndLabels []string) {
+	sensitiveAnnotationsAndLabels = append(sensitiveAnnotationsAndLabels, annotationsAndLabels...)
+}
+
+// GetSensitiveAnnotationsAndLabels returns the list of sensitive annotations and labels.
+func GetSensitiveAnnotationsAndLabels() []string {
+	return sensitiveAnnotationsAndLabels
+}

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -3,19 +3,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build orchestrator
+
 package redact
 
 import (
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-const consulOriginalPodAnnotation = "consul.hashicorp.com/original-pod"
-
-var sensitiveAnnotationsAndLabels = []string{v1.LastAppliedConfigAnnotation, consulOriginalPodAnnotation}
 
 // RemoveSensitiveAnnotationsAndLabels redacts sensitive annotations and labels like the whole
 // "kubectl.kubernetes.io/last-applied-configuration" annotation value. As it
@@ -29,16 +27,6 @@ func RemoveSensitiveAnnotationsAndLabels(annotations map[string]string, labels m
 			labels[v] = redactedAnnotationValue
 		}
 	}
-}
-
-// UpdateSensitiveAnnotationsAndLabels adds new sensitive annotations or labels key to the list to redact.
-func UpdateSensitiveAnnotationsAndLabels(annotationsAndLabels []string) {
-	sensitiveAnnotationsAndLabels = append(sensitiveAnnotationsAndLabels, annotationsAndLabels...)
-}
-
-// GetSensitiveAnnotationsAndLabels returns the list of sensitive annotations and labels.
-func GetSensitiveAnnotationsAndLabels() []string {
-	return sensitiveAnnotationsAndLabels
 }
 
 // ScrubPodTemplateSpec scrubs a pod template.


### PR DESCRIPTION
### What does this PR do?

Splits the code in `pkg/orchestrator/redact` so that the part that depends on `k8s.io/api/core/v1` is on its own file and gated by the `orchestrator` go build tag. This can be done because this code is only called by code in `pkg/collector/corechecks/cluster/orchestrator/processors/k8s` which is also gated by the `orchestrator` build tag.

This reduces the binary size in agents that import `pkg/orchestrator/redact` but are built without the `orchestrator` flag. See https://github.com/DataDog/datadog-agent/pull/33670#issuecomment-2631337932 and https://github.com/DataDog/datadog-agent/pull/33670#issuecomment-2631389233

### Describe how you validated your changes

Should be covered by tests.
