### PR TITLE
Change bininspect.InspectWithDWARF to take dwarf data

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -8,6 +8,7 @@
 package diconfig
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -41,9 +42,14 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 		targetFunctions[probe.FuncName] = true
 	}
 
-	dwarfData, err := loadDWARF(procInfo.BinaryPath)
+	elfFile, err := safeelf.Open(procInfo.BinaryPath)
 	if err != nil {
-		return fmt.Errorf("could not retrieve debug information from binary: %w", err)
+		return fmt.Errorf("could not open elf file %w", err)
+	}
+
+	dwarfData, ok := bininspect.HasDwarfInfo(elfFile)
+	if !ok || dwarfData == nil {
+		return errors.New("could not get debug information from binary")
 	}
 
 	typeMap, err := getTypeMap(dwarfData, targetFunctions)
@@ -52,12 +58,6 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 	}
 
 	procInfo.TypeMap = typeMap
-
-	elfFile, err := safeelf.Open(procInfo.BinaryPath)
-	if err != nil {
-		return fmt.Errorf("could not open elf file %w", err)
-	}
-
 	procInfo.DwarfData = dwarfData
 
 	fieldIDs := make([]bininspect.FieldIdentifier, 0)
@@ -68,7 +68,7 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 		}
 	}
 
-	r, err := bininspect.InspectWithDWARF(elfFile, functions, fieldIDs)
+	r, err := bininspect.InspectWithDWARF(elfFile, dwarfData, functions, fieldIDs)
 	if err != nil {
 		return fmt.Errorf("could not determine locations of variables from debug information %w", err)
 	}

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -46,6 +46,7 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 	if err != nil {
 		return fmt.Errorf("could not open elf file %w", err)
 	}
+	defer elfFile.Close()
 
 	dwarfData, ok := bininspect.HasDwarfInfo(elfFile)
 	if !ok || dwarfData == nil {

--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -30,7 +30,7 @@ type dwarfInspector struct {
 // It also returns some additional relevant metadata about the given file.
 // It is using the DWARF debug data to obtain information, and therefore should be run on elf files that contain debug
 // data, like our test binaries.
-func InspectWithDWARF(elfFile *safeelf.File, functions []string, structFields []FieldIdentifier) (*Result, error) {
+func InspectWithDWARF(elfFile *safeelf.File, dwarfData *dwarf.Data, functions []string, structFields []FieldIdentifier) (*Result, error) {
 	if elfFile == nil {
 		return nil, ErrNilElf
 	}
@@ -39,12 +39,6 @@ func InspectWithDWARF(elfFile *safeelf.File, functions []string, structFields []
 	arch, err := GetArchitecture(elfFile)
 	if err != nil {
 		return nil, err
-	}
-
-	dwarfData, ok := HasDwarfInfo(elfFile)
-
-	if !ok || dwarfData == nil {
-		return nil, errors.New("expected dwarf data")
 	}
 
 	inspector := dwarfInspector{

--- a/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
+++ b/pkg/network/protocols/http/gotls/lookup/internal/generate_luts.go
@@ -10,6 +10,7 @@ package main
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -260,8 +261,12 @@ func inspectBinary(binary lutgen.Binary) (interface{}, error) {
 		return bininspect.Result{}, err
 	}
 
-	// Inspect the binary using `binspect`
-	result, err := bininspect.InspectWithDWARF(elfFile, functionsToFind, FieldsToFind)
+	dwarfData, ok := bininspect.HasDwarfInfo(elfFile)
+	if !ok {
+		return bininspect.Result{}, errors.New("expected dwarf data")
+	}
+
+	result, err := bininspect.InspectWithDWARF(elfFile, dwarfData, functionsToFind, FieldsToFind)
 	if err != nil {
 		return bininspect.Result{}, err
 	}


### PR DESCRIPTION
### What does this PR do?

This moves the loading of DWARF data into memory from inside the bininspect InspectWithDWARF API to outside of it. This allows dynamic instrumentation to re-use the allocated DWARF data which would then get passed in. This should drastically reduce the size of allocations in Go DI while having no effect in the one other place where the function is used.

### Motivation

Remove large allocations in the system-probe. The DWARF info was loaded twice, doubling the the size of allocation.

### Describe how you validated your changes

We will check continuous profiler on nightly build.

### Possible Drawbacks / Trade-offs

We can simplify the DWARF parsing code in Go DI moving everything into bininspect instead of marrying data from two separate sources. 