### PR TITLE
[EBPF] gpu: do not parse all nvInfo attributes

### DIFF
--- a/pkg/gpu/cuda/fatbin_test.go
+++ b/pkg/gpu/cuda/fatbin_test.go
@@ -60,6 +60,10 @@ func TestParseFatbinFromPath(t *testing.T) {
 		}
 
 		require.Greater(t, kernel.KernelSize, uint64(0), "unexpected kernel size for kernel %s, sm=%d", key.Name, key.SmVersion)
+
+		for attr := range kernel.attributes {
+			require.Contains(t, enabledNvInfoAttrs, attr)
+		}
 	}
 
 	// From the Makefile, all the -gencode arch=compute_XX,code=sm_XX flags
@@ -125,6 +129,10 @@ func TestParseBigFatbinFromPath(t *testing.T) {
 		}
 
 		require.Greater(t, kernel.KernelSize, uint64(0), "unexpected kernel size for kernel %s, sm=%d", key.Name, key.SmVersion)
+
+		for attr := range kernel.attributes {
+			require.Contains(t, enabledNvInfoAttrs, attr)
+		}
 	}
 
 	// From the Makefile, all the -gencode arch=compute_XX,code=sm_XX flags


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes the parsing of the `.nv.info` section of _cubin_ payloads so that we only parse the attributes we are interested in. Right now we are not using them in the code so this parsing is effectively disabled, but we're leaving the code as in the future we will want some of these attributes to better calculate SM occupancy (e.g., knowing the number of registers used by a kernel is important).

### Motivation

When attaching to PyTorch kernels, these had a lot of attributes and some of them were fairly big (over 1KB in some cases). Storing all this data for no purpose was increasing the memory usage of the agent by a lot, causing OOMs.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests validate that the parsing works correclty.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->