### PR TITLE
SMP lower `quality_gate_idle` limit

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -35,7 +35,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "359.0 MiB"
+      upper_bound: "350.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

Lowers `quality_gate_idle` limit from `359 MiB` to `350 MiB`

### Motivation

Noticed the agent has used less memory for `quality_gate_idle` in last nights nightly and the latest [commit](https://github.com/DataDog/datadog-agent/commit/6917889a0e43b24e6a3750014ccc9eef28a55a1e) off of main at the time of running another large quality gate job