### PR TITLE
Increase the timeout for the fips-server start command

### DIFF
--- a/test/new-e2e/tests/fips-compliance/common.go
+++ b/test/new-e2e/tests/fips-compliance/common.go
@@ -9,13 +9,12 @@ package fipscompliance
 import (
 	"fmt"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
-
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/test/new-e2e/tests/fips-compliance/common.go
+++ b/test/new-e2e/tests/fips-compliance/common.go
@@ -65,12 +65,12 @@ func (s *fipsServer) Start(t *testing.T, tc cipherTestCase) {
 			require.NoError(c, err)
 		}
 		assert.Nil(c, err)
-	}, 120*time.Second, 10*time.Second)
+	}, 120*time.Second, 10*time.Second, "docker-compose timed out starting server")
 
 	// Wait for container to start and ensure it's a fresh instance
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		serverLogs, _ := s.dockerHost.Execute("docker logs dd-fips-server")
-		assert.Contains(c, serverLogs, "Server Starting...", "Server should start")
+		assert.Contains(c, serverLogs, "Server Starting...", "fips-server timed out waiting for cipher initialization to finish")
 		assert.Equal(c, 1, strings.Count(serverLogs, "Server Starting..."), "Server should start only once, logs from previous runs should not be present")
 	}, 60*time.Second, 5*time.Second)
 }

--- a/test/new-e2e/tests/fips-compliance/common.go
+++ b/test/new-e2e/tests/fips-compliance/common.go
@@ -15,9 +15,10 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type cipherTestCase struct {
@@ -64,7 +65,7 @@ func (s *fipsServer) Start(t *testing.T, tc cipherTestCase) {
 			require.NoError(c, err)
 		}
 		assert.Nil(c, err)
-	}, 60*time.Second, 20*time.Second)
+	}, 120*time.Second, 10*time.Second)
 
 	// Wait for container to start and ensure it's a fresh instance
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
@@ -24,8 +25,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-
-	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
@@ -90,6 +89,9 @@ func (s *fipsServerWinSuite) SetupSuite() {
 		// The connectivity-datadog-core-endpoints diagnoses require a non-empty API key
 		windowsAgent.WithZeroAPIKey())
 	require.NoError(s.T(), err)
+
+	// Start the fips-server in the Setup step so we pull the image from ghcr.io before a test runs
+	s.fipsServer.Start()
 }
 
 func (s *fipsServerWinSuite) generateTraffic() {

--- a/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_ciphers_win_test.go
@@ -91,7 +91,7 @@ func (s *fipsServerWinSuite) SetupSuite() {
 	require.NoError(s.T(), err)
 
 	// Start the fips-server in the Setup step so we pull the image from ghcr.io before a test runs
-	s.fipsServer.Start()
+	s.fipsServer.Start(s.T(), cipherTestCase{cert: "rsa"})
 }
 
 func (s *fipsServerWinSuite) generateTraffic() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Saw a [CI failure](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/791694405#L346) around this but the docker command sometimes takes a bit, lets increase the timeout

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->