### PR TITLE
experiment: build and sort a string dictionary per metric payload

### DIFF
--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/richardartoul/molecule"
@@ -507,12 +508,11 @@ func (pb *PayloadsBuilder) finishPayload() error {
 
 	// Sort keys of stringTable and update values to position in the sorted list
 	keys := make([]string, 0, len(pb.stringTable))
-	// do this a bunch of times to try to induce a large effect on memory use, to make sure our instrumentation will detect it.
-	// TODO: remove this when we're sure that we're testing the real memory use of the string table.
-	for i := 0; i < 100; i++ {
-		for key := range pb.stringTable {
-			keys = append(keys, key)
-		}
+	for key := range pb.stringTable {
+		// try to expand memory use artificially to make sure testing will catch it
+		// TODO: remove this when we're sure that we're testing the real memory use of the string table.
+		key := strings.Repeat(key, 100)
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -509,7 +509,7 @@ func (pb *PayloadsBuilder) finishPayload() error {
 	keys := make([]string, 0, len(pb.stringTable))
 	// do this a bunch of times to try to induce a large effect on memory use, to make sure our instrumentation will detect it.
 	// TODO: remove this when we're sure that we're testing the real memory use of the string table.
-	for i := 0; i < 10_000; i++ {
+	for i := 0; i < 100; i++ {
 		for key := range pb.stringTable {
 			keys = append(keys, key)
 		}

--- a/pkg/serializer/internal/metrics/iterable_series.go
+++ b/pkg/serializer/internal/metrics/iterable_series.go
@@ -507,8 +507,12 @@ func (pb *PayloadsBuilder) finishPayload() error {
 
 	// Sort keys of stringTable and update values to position in the sorted list
 	keys := make([]string, 0, len(pb.stringTable))
-	for key := range pb.stringTable {
-		keys = append(keys, key)
+	// do this a bunch of times to try to induce a large effect on memory use, to make sure our instrumentation will detect it.
+	// TODO: remove this when we're sure that we're testing the real memory use of the string table.
+	for i := 0; i < 10_000; i++ {
+		for key := range pb.stringTable {
+			keys = append(keys, key)
+		}
 	}
 	sort.Strings(keys)
 

--- a/test/regression/cases/uds_dogstatsd_to_api_memory/datadog-agent/datadog.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_memory/datadog-agent/datadog.yaml
@@ -1,0 +1,14 @@
+auth_token_file_path: /tmp/agent-auth-token
+
+dd_url: http://127.0.0.1:9091
+process_config.process_dd_url: http://localhost:9092
+
+telemetry.enabled: true
+telemetry.checks: '*'
+
+# Disable cloud detection. This stops the Agent from poking around the
+# execution environment & network. This is particularly important if the target
+# has network access.
+cloud_provider_metadata: []
+
+dogstatsd_socket: '/tmp/dsd.socket'

--- a/test/regression/cases/uds_dogstatsd_to_api_memory/experiment.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_memory/experiment.yaml
@@ -1,0 +1,26 @@
+optimization_goal: memory
+erratic: false
+
+target:
+  name: datadog-agent
+  cpu_allotment: 4
+  memory_allotment: 2GiB
+
+  environment:
+    DD_API_KEY: 00000001
+    DD_HOSTNAME: smp-regression
+
+  profiling_environment:
+    DD_INTERNAL_PROFILING_BLOCK_PROFILE_RATE: 10000
+    DD_INTERNAL_PROFILING_CPU_DURATION: 1m
+    DD_INTERNAL_PROFILING_DELTA_PROFILES: true
+    DD_INTERNAL_PROFILING_ENABLED: true
+    DD_INTERNAL_PROFILING_ENABLE_GOROUTINE_STACKTRACES: true
+    DD_INTERNAL_PROFILING_MUTEX_PROFILE_FRACTION: 10
+    DD_INTERNAL_PROFILING_PERIOD: 1m
+    DD_INTERNAL_PROFILING_UNIX_SOCKET: /smp-host/apm.socket
+    DD_PROFILING_EXECUTION_TRACE_ENABLED: true
+    DD_PROFILING_EXECUTION_TRACE_PERIOD: 1m
+    DD_PROFILING_WAIT_PROFILE: true
+
+    DD_INTERNAL_PROFILING_EXTRA_TAGS: experiment:uds_dogstatsd_to_api_memory

--- a/test/regression/cases/uds_dogstatsd_to_api_memory/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_memory/lading/lading.yaml
@@ -1,0 +1,51 @@
+generator:
+  - unix_datagram:
+      seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
+             59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
+      path: "/tmp/dsd.socket"
+      variant:
+        dogstatsd:
+          contexts:
+            inclusive:
+              min: 1000
+              max: 10000
+          name_length:
+            inclusive:
+              min: 1
+              max: 200
+          tag_length:
+            inclusive:
+              min: 3
+              max: 150
+          tags_per_msg:
+            inclusive:
+              min: 2
+              max: 50
+          multivalue_count:
+            inclusive:
+              min: 2
+              max: 32
+          multivalue_pack_probability: 0.08
+          kind_weights:
+            metric: 90
+            event: 5
+            service_check: 5
+          metric_weights:
+            count: 100
+            gauge: 10
+            timer: 0
+            distribution: 0
+            set: 0
+            histogram: 0
+      bytes_per_second: "100 MiB"
+      maximum_prebuild_cache_size_bytes: "500 Mb"
+
+blackhole:
+  - http:
+      binding_addr: "127.0.0.1:9091"
+  - http:
+      binding_addr: "127.0.0.1:9092"
+
+target_metrics:
+  - prometheus:
+      uri: "http://127.0.0.1:5000/telemetry"


### PR DESCRIPTION
NOT TO BE MERGED

### What does this PR do?

### Motivation

This is an experiment to see how much of a memory impact we see to build a string table for each serialized payload. This is intended to give us a rough idea of the memory cost of implementing a new payload format that would deduplicate strings to save bandwidth.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

AGTMETRICS-12