### PR TITLE
enable ecs by default

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3305,12 +3305,12 @@ api_key:
 #
 # ecs_metadata_timeout: 500
 
-## @param ecs_task_collection_enabled - boolean - optional - default: false
-## @env DD_ECS_TASK_COLLECTION_ENABLED - boolean - optional - default: false
+## @param ecs_task_collection_enabled - boolean - optional - default: true
+## @env DD_ECS_TASK_COLLECTION_ENABLED - boolean - optional - default: true
 ## The Agent can collect detailed task information from the metadata API exposed by the ECS Agent,
 ## which is used for the orchestrator ECS check.
 #
-# ecs_task_collection_enabled: false
+# ecs_task_collection_enabled: true
 
 {{ end -}}
 {{- if .CRI }}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -578,7 +578,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("ecs_metadata_retry_initial_interval", 100*time.Millisecond)
 	config.BindEnvAndSetDefault("ecs_metadata_retry_max_elapsed_time", 3000*time.Millisecond)
 	config.BindEnvAndSetDefault("ecs_metadata_retry_timeout_factor", 3)
-	config.BindEnvAndSetDefault("ecs_task_collection_enabled", false)
+	config.BindEnvAndSetDefault("ecs_task_collection_enabled", true)
 	config.BindEnvAndSetDefault("ecs_task_cache_ttl", 3*time.Minute)
 	config.BindEnvAndSetDefault("ecs_task_collection_rate", 35)
 	config.BindEnvAndSetDefault("ecs_task_collection_burst", 60)

--- a/releasenotes/notes/releasenotes-bac55ded540c6e83.yaml
+++ b/releasenotes/notes/releasenotes-bac55ded540c6e83.yaml
@@ -1,3 +1,3 @@
 upgrade:
   - |
-    Enabled ECS task collection by default (ecs_task_collection_enabled = true).
+    Enabled ECS task collection by default (see `ecs_task_collection_enabled` in the datadog.yaml configuruation).

--- a/releasenotes/notes/releasenotes-bac55ded540c6e83.yaml
+++ b/releasenotes/notes/releasenotes-bac55ded540c6e83.yaml
@@ -1,3 +1,3 @@
 upgrade:
   - |
-    Enabled ECS task collection by default (see `ecs_task_collection_enabled` in the datadog.yaml configuruation).
+    ECS task collection is now enabled by default (see `ecs_task_collection_enabled` in the datadog.yaml configuration).

--- a/releasenotes/notes/releasenotes-bac55ded540c6e83.yaml
+++ b/releasenotes/notes/releasenotes-bac55ded540c6e83.yaml
@@ -1,0 +1,3 @@
+upgrade:
+  - |
+    Enabled ECS task collection by default (ecs_task_collection_enabled = true).


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Tested on my staging ECS cluster.
Specifying `DD_ECS_TASK_COLLECTION_ENABLED` to `true` and not specifying it enables ECS task collection.
Specifying `DD_ECS_TASK_COLLECTION_ENABLED` to false disables ECS task collection.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->