### PR TITLE
Disable fentry by default in event stream

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -381,7 +381,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.flow_monitor.period"), "10s")
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "network.raw_classifier_handle"), 0)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_ring_buffer"), true)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry"), true)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.use_fentry"), false)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "event_stream.buffer_size"), 0)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "envs_with_value"), []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH", "HISTSIZE", "HISTFILESIZE", "GLIBC_TUNABLES"})
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "runtime_compilation.enabled"), false)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Disable fentry by default as it trigger a kernel bug.

```
[92791.043467] task:system-probe    state:D stack:0     pid:82617 tgid:3768  ppid:3292   flags:0x00004006
[92791.043473] Call Trace:
[92791.043475]  <TASK>
[92791.043496]  __schedule+0x27c/0x6a0
[92791.043542]  schedule+0x33/0x110
[92791.043555]  schedule_timeout+0x157/0x170
[92791.043588]  wait_for_completion+0x88/0x150
[92791.043626]  __wait_rcu_gp+0x150/0x160
[92791.043645]  ? 0xffffffffc0256600
[92791.043716]  synchronize_rcu_tasks_generic+0x64/0xe0
[92791.043722]  ? __pfx_call_rcu_tasks+0x10/0x10
[92791.043731]  ? __pfx_wakeme_after_rcu+0x10/0x10
[92791.043759]  synchronize_rcu_tasks+0x15/0x20
[92791.043768]  ftrace_shutdown.part.0+0xd5/0x1f0
[92791.043784]  ? 0xffffffffc0256600
[92791.043797]  ? __pfx_module_param_sysfs_setup+0x10/0x10
[92791.043805]  unregister_ftrace_function+0x47/0x170
[92791.043825]  ? 0xffffffffc0256600
[92791.043837]  ? __pfx_module_param_sysfs_setup+0x10/0x10
[92791.043847]  unregister_ftrace_direct+0x64/0x1f0
[92791.043855]  ? kmalloc_trace+0x139/0x360
[92791.043864]  ? bpf_trampoline_update+0x68/0x650
[92791.043892]  ? 0xffffffffc0256600
[92791.043904]  ? __pfx_module_param_sysfs_setup+0x10/0x10
[92791.043914]  bpf_trampoline_update+0x4e1/0x650
[92791.043950]  bpf_trampoline_unlink_prog+0x9d/0x130
[92791.043968]  bpf_tracing_link_release+0x16/0x50
[92791.043979]  bpf_link_free+0x6d/0x100
[92791.043993]  bpf_link_release+0x26/0x40
[92791.044000]  __fput+0x9e/0x2e0
[92791.044024]  ____fput+0xe/0x20
[92791.044032]  task_work_run+0x5e/0xa0
[92791.044050]  do_exit+0x2bb/0x530
[92791.044064]  ? bpf_trampoline_6442526190+0x59/0xa4
[92791.044087]  do_group_exit+0x35/0x90
[92791.044104]  get_signal+0x972/0x9b0
[92791.044151]  arch_do_signal_or_restart+0x39/0x120
[92791.044199]  syscall_exit_to_user_mode+0x203/0x260
[92791.044217]  do_syscall_64+0x8d/0x170
[92791.044239]  ? __audit_syscall_exit+0xd1/0x140
[92791.044256]  ? syscall_exit_work+0x12b/0x150
[92791.044271]  ? syscall_exit_to_user_mode_prepare+0x39/0x80
[92791.044279]  ? syscall_exit_to_user_mode+0x83/0x260
[92791.044296]  ? do_syscall_64+0x8d/0x170
[92791.044303]  ? syscall_exit_work+0x12b/0x150
[92791.044316]  ? syscall_exit_to_user_mode_prepare+0x39/0x80
[92791.044324]  ? syscall_exit_to_user_mode+0x83/0x260
[92791.044340]  ? do_syscall_64+0x8d/0x170
[92791.044351]  ? do_syscall_64+0x8d/0x170
[92791.044366]  ? syscall_exit_to_user_mode+0x83/0x260
[92791.044382]  ? do_syscall_64+0x8d/0x170
[92791.044389]  ? irqentry_exit+0x43/0x50
[92791.044409]  entry_SYSCALL_64_after_hwframe+0x78/0x80
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->