### PR TITLE
podresources: Fix path to check socket

### DIFF
--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -233,7 +233,8 @@ func detectPodman(features FeatureMap, cfg model.Reader) {
 }
 
 func detectPodResources(features FeatureMap, cfg model.Reader) {
-	// We only check the path from config. Default socket path is defined in the config
+	// We only check the path from config. Default socket path is defined in the config,
+	// without the unix:/// prefix, as socket.IsAvailable receives a filesystem path.
 	socketPath := cfg.GetString("kubernetes_kubelet_podresources_socket")
 
 	exists, reachable := socket.IsAvailable(socketPath, socketTimeout)

--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -234,7 +234,7 @@ func detectPodman(features FeatureMap, cfg model.Reader) {
 
 func detectPodResources(features FeatureMap, cfg model.Reader) {
 	// We only check the path from config. Default socket path is defined in the config
-	socketPath := getDefaultSocketPrefix() + cfg.GetString("kubernetes_kubelet_podresources_socket")
+	socketPath := cfg.GetString("kubernetes_kubelet_podresources_socket")
 
 	exists, reachable := socket.IsAvailable(socketPath, socketTimeout)
 	if exists && reachable {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix the socket path used to check the presence of the PodResources socket.

### Motivation

Fix a bug where the socket prefix was being added despite us trying to use it as a filesystem path.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated running the agent in a k8s environment and ensuring it can access the `kubelet.sock` file and connect to it.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->