### PR TITLE
chore(apm): consolidate External Data Origin Detection

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -318,8 +318,14 @@ func (t *remoteTagger) queryContainerIDFromOriginInfo(originInfo origindetection
 		)
 		defer queryCancel()
 
-		// Call the gRPC method to get the container ID from the origin info
+		// Call the gRPC method to get the container ID from the OriginInfo.
 		containerIDResponse, err := t.client.TaggerGenerateContainerIDFromOriginInfo(queryCtx, &pb.GenerateContainerIDFromOriginInfoRequest{
+			LocalData: &pb.GenerateContainerIDFromOriginInfoRequest_LocalData{
+				ProcessID:   &originInfo.LocalData.ProcessID,
+				ContainerID: &originInfo.LocalData.ContainerID,
+				Inode:       &originInfo.LocalData.Inode,
+				PodUID:      &originInfo.LocalData.PodUID,
+			},
 			ExternalData: &pb.GenerateContainerIDFromOriginInfoRequest_ExternalData{
 				Init:          &originInfo.ExternalData.Init,
 				ContainerName: &originInfo.ExternalData.ContainerName,

--- a/comp/core/tagger/server/server.go
+++ b/comp/core/tagger/server/server.go
@@ -197,10 +197,15 @@ func (s *Server) TaggerFetchEntity(_ context.Context, in *pb.FetchEntityRequest)
 	}, nil
 }
 
-// TaggerGenerateContainerIDFromOriginInfo request the generation of a container ID from external data from the Tagger.
-// This function takes an Origin Info but only uses the ExternalData part of it, this is done for backward compatibility.
+// TaggerGenerateContainerIDFromOriginInfo requests the Tagger to generate a container ID from the given OriginInfo.
 func (s *Server) TaggerGenerateContainerIDFromOriginInfo(_ context.Context, in *pb.GenerateContainerIDFromOriginInfoRequest) (*pb.GenerateContainerIDFromOriginInfoResponse, error) {
 	generatedContainerID, err := s.taggerComponent.GenerateContainerIDFromOriginInfo(origindetection.OriginInfo{
+		LocalData: origindetection.LocalData{
+			ProcessID:   *in.LocalData.ProcessID,
+			ContainerID: *in.LocalData.ContainerID,
+			Inode:       *in.LocalData.Inode,
+			PodUID:      *in.LocalData.PodUID,
+		},
 		ExternalData: origindetection.ExternalData{
 			Init:          *in.ExternalData.Init,
 			ContainerName: *in.ExternalData.ContainerName,

--- a/pkg/trace/api/container_linux_test.go
+++ b/pkg/trace/api/container_linux_test.go
@@ -20,6 +20,7 @@ import (
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/api/internal/header"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/testutil"
 
 	"github.com/DataDog/datadog-go/v5/statsd"
@@ -204,6 +205,8 @@ func TestGetContainerID(t *testing.T) {
 		})
 	}
 
+	// Test invalid LocalData headers
+	provider.containerIDFromOriginInfo = config.NoopContainerIDFromOriginInfoFunc
 	invalidLocalDataLists := []string{
 		"",
 		",",

--- a/pkg/trace/api/pipeline_stats_test.go
+++ b/pkg/trace/api/pipeline_stats_test.go
@@ -51,7 +51,7 @@ func TestPipelineStatsProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 	rec := httptest.NewRecorder()
-	c := &config.AgentConfig{}
+	c := &config.AgentConfig{ContainerIDFromOriginInfo: config.NoopContainerIDFromOriginInfoFunc}
 	newPipelineStatsProxy(c, []*url.URL{u}, []string{"123"}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
 	result := rec.Result()
 	slurp, err := io.ReadAll(result.Body)

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -64,7 +64,7 @@ func TestProfileProxy(t *testing.T) {
 		t.Fatal(err)
 	}
 	rec := httptest.NewRecorder()
-	c := &config.AgentConfig{}
+	c := &config.AgentConfig{ContainerIDFromOriginInfo: config.NoopContainerIDFromOriginInfoFunc}
 	newProfileProxy(c, []*url.URL{u}, []string{"123"}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
 	result := rec.Result()
 	slurp, err := io.ReadAll(result.Body)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -564,9 +564,10 @@ func New() *AgentConfig {
 
 		GlobalTags: computeGlobalTags(),
 
-		Proxy:         http.ProxyFromEnvironment,
-		OTLPReceiver:  &OTLP{},
-		ContainerTags: noopContainerTagsFunc,
+		Proxy:                     http.ProxyFromEnvironment,
+		OTLPReceiver:              &OTLP{},
+		ContainerTags:             noopContainerTagsFunc,
+		ContainerIDFromOriginInfo: NoopContainerIDFromOriginInfoFunc,
 		TelemetryConfig: &TelemetryConfig{
 			Endpoints: []*Endpoint{{Host: TelemetryEndpointPrefix + "datadoghq.com"}},
 		},
@@ -593,6 +594,14 @@ var ErrContainerTagsFuncNotDefined = errors.New("containerTags function not defi
 
 func noopContainerTagsFunc(_ string) ([]string, error) {
 	return nil, ErrContainerTagsFuncNotDefined
+}
+
+// ErrContainerIDFromOriginInfoFuncNotDefined is returned when the ContainerIDFromOriginInfo function is not defined.
+var ErrContainerIDFromOriginInfoFuncNotDefined = errors.New("ContainerIDFromOriginInfo function not defined")
+
+// NoopContainerIDFromOriginInfoFunc is used when the ContainerIDFromOriginInfo function is not defined.
+func NoopContainerIDFromOriginInfoFunc(_ origindetection.OriginInfo) (string, error) {
+	return "", ErrContainerIDFromOriginInfoFuncNotDefined
 }
 
 // APIKey returns the first (main) endpoint's API key.

--- a/pkg/trace/info/info_test.go
+++ b/pkg/trace/info/info_test.go
@@ -438,6 +438,7 @@ func TestInfoConfig(t *testing.T) {
 	conf.ProfilingProxy.AdditionalEndpoints = scrubbedAddEp
 
 	conf.ContainerTags = nil
+	conf.ContainerIDFromOriginInfo = nil
 
 	assert.Equal(*conf, confCopy) // ensure all fields have been exported then parsed correctly
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Consolidate External Data Origin Detection resolution to use the `tagger` and `origindetection` methods instead of the `trace` ones.

### Motivation

This is a step towards migrating the Origin Detection implementations from `trace` to the `tagger` and `origindetection` modules.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by unit and E2E tests. It was also done manually:
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/c69662bf-efb7-46cc-8011-f6c623ccdd4c" />

We can see that we are not getting the container ID with `container_id_only` as this would only work with CGroup v1.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A