### PR TITLE
discovery: module: sort container tags before parsing them

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -725,6 +725,9 @@ func getServiceNameFromContainerTags(tags []string) (string, string) {
 		{"kube_service", nil},
 	}
 
+	// Sort the tags to make the function deterministic
+	slices.Sort(tags)
+
 	for _, tag := range tags {
 		// Get index of separator between name and value
 		sepIndex := strings.IndexRune(tag, ':')
@@ -734,6 +737,11 @@ func getServiceNameFromContainerTags(tags []string) (string, string) {
 		}
 
 		for i := range tagsPriority {
+			if tagsPriority[i].tagValue != nil {
+				// We have seen this tag before, we don't need another value.
+				continue
+			}
+
 			if tag[:sepIndex] != tagsPriority[i].tagName {
 				// Not a tag we care about; we skip it
 				continue

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -1198,6 +1198,16 @@ func TestTagsPriority(t *testing.T) {
 			"service",
 			"my_service",
 		},
+		{
+			"multiple tags",
+			[]string{
+				"service:foo",
+				"service:bar",
+				"other:tag",
+			},
+			"service",
+			"bar",
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes the service naming from container tags deterministic, by sorting the tags list first before going through it. Indeed, in some cases, we can have multiples of the same tag, with different values. In this case, we want to report the first in alphanumerical order, as is done in USM's backend, for example.

### Motivation

Make container service naming deterministic.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Change covered by a unit test.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->