### PR TITLE
[Network Path] Ignore gopacket unsupported layers to avoid false negatives, fix UDP payload calculation

### DIFF
--- a/pkg/networkpath/traceroute/icmp/tcp_parser.go
+++ b/pkg/networkpath/traceroute/icmp/tcp_parser.go
@@ -43,8 +43,8 @@ func NewICMPTCPParser() Parser {
 	icmpParser := &TCPParser{}
 	icmpParser.packetParser = gopacket.NewDecodingLayerParser(layers.LayerTypeICMPv4, &icmpParser.icmpLayer, &icmpParser.innerPayload)
 	icmpParser.innerPacketParser = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &icmpParser.innerIPLayer, &icmpParser.innerTCPLayer)
-	// TODO: can we ignore unsupported layers?
-	//icmpParser.packetParser.IgnoreUnsupported = true
+	icmpParser.packetParser.IgnoreUnsupported = true
+	icmpParser.innerPacketParser.IgnoreUnsupported = true
 	return icmpParser
 }
 

--- a/pkg/networkpath/traceroute/icmp/udp_parser.go
+++ b/pkg/networkpath/traceroute/icmp/udp_parser.go
@@ -41,7 +41,6 @@ func NewICMPUDPParser() Parser {
 	icmpParser := &UDPParser{}
 	icmpParser.packetParser = gopacket.NewDecodingLayerParser(layers.LayerTypeICMPv4, &icmpParser.icmpLayer)
 	icmpParser.innerPacketParser = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &icmpParser.innerIPLayer, &icmpParser.innerUDPLayer)
-	// TODO: can we ignore unsupported layers?
 	icmpParser.packetParser.IgnoreUnsupported = true
 	icmpParser.innerPacketParser.IgnoreUnsupported = true
 	return icmpParser

--- a/pkg/networkpath/traceroute/icmp/udp_parser.go
+++ b/pkg/networkpath/traceroute/icmp/udp_parser.go
@@ -25,7 +25,6 @@ type (
 		innerIPLayer  layers.IPv4
 		innerUDPLayer layers.UDP
 		innerTCPLayer layers.TCP
-		innerPayload  gopacket.Payload
 		// packetParser is parser for the ICMP segment of the packet
 		packetParser *gopacket.DecodingLayerParser
 		// innerPacketParser is necessary for ICMP packets
@@ -44,6 +43,7 @@ func NewICMPUDPParser() Parser {
 	icmpParser.innerPacketParser = gopacket.NewDecodingLayerParser(layers.LayerTypeIPv4, &icmpParser.innerIPLayer, &icmpParser.innerUDPLayer)
 	// TODO: can we ignore unsupported layers?
 	icmpParser.packetParser.IgnoreUnsupported = true
+	icmpParser.innerPacketParser.IgnoreUnsupported = true
 	return icmpParser
 }
 
@@ -74,7 +74,6 @@ func (p *UDPParser) Parse(header *ipv4.Header, payload []byte) (*Response, error
 	p.innerIPLayer = layers.IPv4{}
 	p.innerTCPLayer = layers.TCP{}
 	p.innerUDPLayer = layers.UDP{}
-	p.innerPayload = gopacket.Payload{}
 
 	p.icmpResponse = &Response{} // ensure we get a fresh ICMPResponse each run
 	p.icmpResponse.SrcIP = header.Src

--- a/pkg/networkpath/traceroute/tcp/parser.go
+++ b/pkg/networkpath/traceroute/tcp/parser.go
@@ -38,6 +38,7 @@ type (
 func newParser() *parser {
 	tcpParser := &parser{}
 	tcpParser.decodingLayerParser = gopacket.NewDecodingLayerParser(layers.LayerTypeTCP, &tcpParser.layer)
+	tcpParser.decodingLayerParser.IgnoreUnsupported = true
 	return tcpParser
 }
 

--- a/pkg/networkpath/traceroute/udp/udpv4.go
+++ b/pkg/networkpath/traceroute/udp/udpv4.go
@@ -80,7 +80,10 @@ func (u *UDPv4) createRawUDPBuffer(sourceIP net.IP, sourcePort uint16, destIP ne
 		SrcPort: layers.UDPPort(sourcePort),
 		DstPort: layers.UDPPort(destPort),
 	}
-	udpPaylod := []byte("NSMNC\x00\x00\x00")
+	udpPayload := []byte("NSMNC\x00\x00\x00")
+	id := uint16(ttl) + destPort
+	udpPayload[6] = byte((id >> 8) & 0xff)
+	udpPayload[7] = byte(id & 0xff)
 
 	// TODO: compute checksum before serialization so we
 	// can set ID field of the IP header to detect NATs just
@@ -102,7 +105,7 @@ func (u *UDPv4) createRawUDPBuffer(sourceIP net.IP, sourcePort uint16, destIP ne
 	err = gopacket.SerializeLayers(u.buffer, opts,
 		ipLayer,
 		udpLayer,
-		gopacket.Payload(udpPaylod),
+		gopacket.Payload(udpPayload),
 	)
 	if err != nil {
 		return nil, nil, 0, 0, fmt.Errorf("failed to serialize packet: %w", err)

--- a/pkg/networkpath/traceroute/udp/udpv4_test.go
+++ b/pkg/networkpath/traceroute/udp/udpv4_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package udp
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/ipv4"
+)
+
+func TestCreateRawUDPBuffer(t *testing.T) {
+	srcIP := net.ParseIP("1.2.3.4")
+	dstIP := net.ParseIP("5.6.7.8")
+	srcPort := uint16(12345)
+	dstPort := uint16(33434)
+	ttl := 4
+
+	udp := NewUDPv4(dstIP, dstPort, 1, 1, 1, 0, 0)
+	udp.srcIP = srcIP
+	udp.srcPort = srcPort
+
+	expectedIPHeader := &ipv4.Header{
+		Version:  4,
+		TTL:      ttl, // this will be replaced for each test
+		ID:       41821,
+		Protocol: 17,
+		Dst:      dstIP,
+		Src:      srcIP,
+		Len:      20,
+		TotalLen: 36,
+		Checksum: 50008,
+		Flags:    2, // Don't fragment flag set
+	}
+
+	// most of this is just copied from the output of the function
+	// we don't need to test gopacket's ability to serialize a packet
+	// we need to ensure that the logic that calculates the payload is correct
+	// which means we have to check the last 8 bytes of the packet, really just
+	// the last two
+	expectedPktBytes := []byte{
+		0x45, 0x0, 0x0, 0x24, 0xa3, 0x5d, 0x40, 0x0, 0x4, 0x11, 0xc3, 0x58, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x30, 0x39, 0x82, 0x9a, 0x0, 0x10, 0xdb, 0xa6, 0x4e, 0x53, 0x4d, 0x4e, 0x43, 0x0, 0x82, 0x9e,
+	}
+
+	// based on bytes 26-27 of expectedPktBytes
+	expectedChecksum := uint16(0xdba6)
+
+	ipHeader, pktBytes, actualChecksum, headerLength, err := udp.createRawUDPBuffer(udp.srcIP, udp.srcPort, udp.Target, udp.TargetPort, ttl)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedIPHeader, ipHeader)
+	assert.Equal(t, 20, headerLength)
+	assert.Equal(t, expectedPktBytes, pktBytes)
+	assert.Equal(t, expectedChecksum, actualChecksum)
+}

--- a/pkg/networkpath/traceroute/udp/udpv4_test.go
+++ b/pkg/networkpath/traceroute/udp/udpv4_test.go
@@ -7,6 +7,7 @@ package udp
 
 import (
 	"net"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,10 @@ import (
 )
 
 func TestCreateRawUDPBuffer(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("TestCreateRawTCPSyn is broken on macOS")
+	}
+
 	srcIP := net.ParseIP("1.2.3.4")
 	dstIP := net.ParseIP("5.6.7.8")
 	srcPort := uint16(12345)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Ignores unsupported layers for all of our packet parsers. While the responses we care about usually won't have additional layers beyond what we're have decoders for, we have seen several cases where a UDP ICMP response to our traceroute has additional layers after the UDP header.

Specifically the problem for Windows UDP traceroutes was that while the outer packet parser ignored unsupported layers, the inner packet parser did not.

The other bug resolved with this PR has to do with the payload calculation for UDP traceroute. Currently, the payload is the same at each TTL leading to an identical UDP checksum. This makes it more difficult to ensure we're matching the right packet with the right TTL and could lead hops being shown at the wrong TTL, especially in a (forthcoming) parallelized traceroute.

### Motivation
We've seen this impact UDP traceroutes on Windows.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Validated my changes by running TCP and UDP traceroutes on Windows and ensuring that we're still seeing the expected hops. For Linux, I ran TCP traceroute with the agent.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->