### PR TITLE
fix(issue.assign): Remove unexpected reference to `containers`

### DIFF
--- a/tasks/libs/issue/assign.py
+++ b/tasks/libs/issue/assign.py
@@ -140,7 +140,6 @@ def team_to_label(team):
         'telemetry-and-analytics': "agent-apm",
         'fleet': "fleet-automation",
         'debugger': "dynamic-intrumentation",
-        'container-integrations': "containers",
         'agent-e2e-testing': "agent-e2e-test",
         'agent-integrations': "integrations",
         'asm-go': "agent-security",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove unexpected reference to `containers`

### Motivation
Prevent bad assignation from issues like [here](https://github.com/DataDog/datadog-agent/actions/runs/13148199911/job/36690694600): the job detected `container-integrations` but this mapping sent `containers` which doesn't exist on the maps, thus sent the message to #agent-devx-help

### Describe how you validated your changes
Local testing
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->