### PR TITLE
feat(ci): Print variables used in rules for investigation

### DIFF
--- a/.gitlab/.pre/include.yml
+++ b/.gitlab/.pre/include.yml
@@ -5,3 +5,4 @@ include:
   - .gitlab/.pre/cancel-prev-pipelines.yml
   - .gitlab/.pre/create_release_qa_cards.yml
   - .gitlab/.pre/gitlab_configuration.yml
+  - .gitlab/.pre/print-rule-variables.yml

--- a/.gitlab/.pre/print-rule-variables.yml
+++ b/.gitlab/.pre/print-rule-variables.yml
@@ -1,0 +1,7 @@
+---
+print-rule-variables:
+  stage: .pre
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:arm64"]
+  script:
+    - inv pipeline.print-variables

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -918,3 +918,17 @@ def compare_to_itself(ctx):
         ctx.run(f"git checkout {current_branch}", hide=True)
         ctx.run(f"git branch -D {new_branch}", hide=True)
         ctx.run(f"git push origin :{new_branch}", hide=True)
+
+
+@task
+def print_variables(_):
+    print("Printing variables used in gitlab rules")
+    with open(".gitlab-ci.yml") as f:
+        config = f.readlines()
+    variable = re.compile(r"\$([A-Z0-9_]+)")
+    variables = set()
+    for line in config:
+        for var in variable.findall(line):
+            variables.add(var)
+    for var in variables:
+        print(f" - {var}:{os.environ.get(var, 'undefined')}")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Print the variables used in the `.gitlab-ci.yml` file in a log

### Motivation
We cannot retrieve the variables of a pipeline once it's triggered, and it makes it cumbersome to easily investigate the gitlab rules. Displaying them will help in investigation with rule issues.

### Describe how you validated your changes
n/a
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->