### PR TITLE
[netpath] Fix flake in e2e test

### DIFF
--- a/test/new-e2e/tests/netpath/network-path-integration/fake-traceroute/datadog_ttl.yaml
+++ b/test/new-e2e/tests/netpath/network-path-integration/fake-traceroute/datadog_ttl.yaml
@@ -1,0 +1,3 @@
+network_path:
+  collector:
+    max_ttl: 10 # reduce the max TTL to make the test run faster


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This fixes a flake in the e2e test - when the agent runs a traceroute before the setup script completes, it would try all 30 hops and this would take a long time, too long for the shortened 2 minute timeout. In response this PR:

* Reduces the max hops to 10
* Increases the timeout to match the other netpath tests

### Motivation
Flakes in main

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
e2e test in CI should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->