### PR TITLE
Remove unused public methods from metadata comps

### DIFF
--- a/comp/core/agenttelemetry/def/component.go
+++ b/comp/core/agenttelemetry/def/component.go
@@ -10,10 +10,7 @@ package agenttelemetry
 
 // Component is the component type
 type Component interface {
-	// GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
-	GetAsJSON() ([]byte, error)
-
-	// Sends event payload.
+	// SendEvent sends event payload.
 	//    payloadType - should be registered in datadog-agent\comp\core\agenttelemetry\impl\config.go
 	//    payload     - de-serializable into JSON
 	SendEvent(eventType string, eventPayload []byte) error

--- a/comp/core/agenttelemetry/impl/agenttelemetry.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry.go
@@ -500,7 +500,7 @@ func (a *atel) writePayload(w http.ResponseWriter, _ *http.Request) {
 	}
 
 	a.logComp.Info("Showing agent telemetry payload")
-	payload, err := a.GetAsJSON()
+	payload, err := a.getAsJSON()
 	if err != nil {
 		httputils.SetJSONError(w, a.logComp.Error(err.Error()), 500)
 		return
@@ -509,7 +509,7 @@ func (a *atel) writePayload(w http.ResponseWriter, _ *http.Request) {
 	w.Write(payload)
 }
 
-func (a *atel) GetAsJSON() ([]byte, error) {
+func (a *atel) getAsJSON() ([]byte, error) {
 	session, err := a.loadPayloads(a.atelCfg.Profiles)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load agent telemetry payload: %w", err)

--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -322,7 +322,7 @@ func (p *Payload) UnmarshalJSON(b []byte) (err error) {
 }
 
 func getPayload(a *atel) (*Payload, error) {
-	payloadJSON, err := a.GetAsJSON()
+	payloadJSON, err := a.getAsJSON()
 	if err != nil {
 		return nil, err
 	}
@@ -835,7 +835,7 @@ func TestOneProfileWithOneMetricMultipleContextsGenerateTwoPayloads(t *testing.T
 	a := getTestAtel(t, tel, o, s, nil, r)
 	require.True(t, a.enabled)
 
-	payloadJSON, err := a.GetAsJSON()
+	payloadJSON, err := a.getAsJSON()
 	require.NoError(t, err)
 	var payload map[string]interface{}
 	err = json.Unmarshal(payloadJSON, &payload)

--- a/comp/metadata/inventoryagent/component.go
+++ b/comp/metadata/inventoryagent/component.go
@@ -13,8 +13,6 @@ type Component interface {
 	// Set updates a metadata value in the payload. The given value will be stored in the cache without being copied. It is
 	// up to the caller to make sure the given value will not be modified later.
 	Set(name string, value interface{})
-	// GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
-	GetAsJSON() ([]byte, error)
 	// Get returns a copy of the agent metadata. Useful to be incorporated in the status page.
 	Get() map[string]interface{}
 }

--- a/comp/metadata/inventoryagent/inventoryagentimpl/mock.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/mock.go
@@ -45,11 +45,6 @@ func newMock() MockProvides {
 // Set is an empty function on this mock
 func (m *inventoryagentMock) Set(string, interface{}) {}
 
-// GetAsJSON is a mocked function
-func (m *inventoryagentMock) GetAsJSON() ([]byte, error) {
-	return []byte("{}"), nil
-}
-
 // Get is a mocked function
 func (m *inventoryagentMock) Get() map[string]interface{} {
 	return nil

--- a/comp/metadata/inventorychecks/component.go
+++ b/comp/metadata/inventorychecks/component.go
@@ -17,8 +17,6 @@ type Component interface {
 	Set(instanceID string, key string, value interface{})
 	// GetInstanceMetadata returns metadata for a specific check instance
 	GetInstanceMetadata(instanceID string) map[string]interface{}
-	// GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
-	GetAsJSON() ([]byte, error)
 	// Refresh trigger a new payload to be send while still respecting the minimal interval between two updates.
 	Refresh()
 }

--- a/comp/metadata/inventorychecks/inventorychecksimpl/mock.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/mock.go
@@ -46,9 +46,6 @@ func (m *InventorychecksMock) Set(instanceID string, key string, value interface
 // Refresh is a empty method for the inventorychecks mock
 func (m *InventorychecksMock) Refresh() {}
 
-// GetAsJSON returns an hardcoded empty JSON dict
-func (m *InventorychecksMock) GetAsJSON() ([]byte, error) { return []byte("{}"), nil }
-
 // GetInstanceMetadata returns all the metadata set for an instanceID using the Set method
 func (m *InventorychecksMock) GetInstanceMetadata(instanceID string) map[string]interface{} {
 	if metadata, found := m.metadata[instanceID]; found {

--- a/comp/metadata/inventoryhost/component.go
+++ b/comp/metadata/inventoryhost/component.go
@@ -10,8 +10,6 @@ package inventoryhost
 
 // Component is the component type.
 type Component interface {
-	// GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
-	GetAsJSON() ([]byte, error)
 	// Refresh trigger a new payload to be send while still respecting the minimal interval between two updates.
 	Refresh()
 }

--- a/comp/metadata/inventoryotel/component.go
+++ b/comp/metadata/inventoryotel/component.go
@@ -10,8 +10,4 @@ package inventoryotel
 
 // Component is the component type.
 type Component interface {
-	// GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
-	GetAsJSON() ([]byte, error)
-	// Get returns a copy of the agent metadata. Useful to be incorporated in the status page.
-	Get() map[string]interface{}
 }

--- a/comp/metadata/inventoryotel/inventoryotelimpl/mock.go
+++ b/comp/metadata/inventoryotel/inventoryotelimpl/mock.go
@@ -31,10 +31,6 @@ func newMock() iointerface.Component {
 	return &inventoryotelMock{}
 }
 
-func (m *inventoryotelMock) GetAsJSON() ([]byte, error) {
-	return []byte("{}"), nil
-}
-
 func (m *inventoryotelMock) Get() map[string]interface{} {
 	return nil
 }

--- a/comp/metadata/packagesigning/component.go
+++ b/comp/metadata/packagesigning/component.go
@@ -10,6 +10,4 @@ package packagesigning
 
 // Component is the component type.
 type Component interface {
-	// GetAsJSON returns the payload as a JSON string. Useful to be displayed in the CLI or added to a flare.
-	GetAsJSON() ([]byte, error)
 }

--- a/comp/metadata/packagesigning/packagesigningimpl/mock.go
+++ b/comp/metadata/packagesigning/packagesigningimpl/mock.go
@@ -30,12 +30,6 @@ type MockProvides struct {
 // MockPkgSigning is the mocked struct that implements the packagesigning component interface
 type MockPkgSigning struct{}
 
-// GetAsJSON is a mocked method on the component
-func (ps *MockPkgSigning) GetAsJSON() ([]byte, error) {
-	str := "some bytes"
-	return []byte(str), nil
-}
-
 // newMock returns the mocked packagesigning struct
 func newMock() MockProvides {
 	ps := &MockPkgSigning{}


### PR DESCRIPTION
### What does this PR do?

Now that we have a status and cli components we no longer need those public methods

### Motivation

Simplify API and maintenance.

### Describe how you validated your changes

Running the CI is enough since those methods are no longer used.