### PR TITLE
[networks] Fix flaking networks e2e test

### DIFF
--- a/test/new-e2e/tests/npm/common_1host.go
+++ b/test/new-e2e/tests/npm/common_1host.go
@@ -83,7 +83,7 @@ func test1HostFakeIntakeNPM[Env any](v *e2e.BaseSuite[Env], FakeIntake *componen
 		t.Logf("hostname+networkID %v seen connections", hostnameNetID)
 	}, 120*time.Second, time.Second, "no connections received")
 
-	// looking for 5 payloads and check if the last 2 have a span of 30s +/- 500ms
+	// looking for 5 payloads and check if the last 2 have a span of 30s +/- 1s
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		cnx, err := FakeIntake.Client().GetConnections()
 		assert.NoError(t, err)
@@ -99,7 +99,7 @@ func test1HostFakeIntakeNPM[Env any](v *e2e.BaseSuite[Env], FakeIntake *componen
 		t.Logf("hostname+networkID %v diff time %f seconds", targetHostnameNetID, dt)
 
 		// we want the test fail now, not retrying on the next payloads
-		assert.Greater(t, 0.5, math.Abs(dt-30), "delta between collection is higher than 500ms")
+		assert.Greater(t, 1.0, math.Abs(dt-30), "delta between collection is higher than 1s")
 	}, 150*time.Second, time.Second, "not enough connections received")
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Increases the 500ms tolerance of an NPM e2e test. Occasionally this would flake just barely over the limit, like 530ms.

### Motivation
Fixes a flake in e2e testing

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->