### PR TITLE
Add `privkey` and `authkey` in the scrubber

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -155,7 +155,7 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 		[]string{"community_string", "authKey", "authkey", "privKey", "privkey", "community", "authentication_key", "privacy_key", "Authorization", "authorization"},
 		[]byte(`$1 "********"`),
 	)
-	snmpReplacer.LastUpdated = parseVersion("7.53.0") // https://github.com/DataDog/datadog-agent/pull/23515
+	snmpReplacer.LastUpdated = parseVersion("7.64.0") // https://github.com/DataDog/datadog-agent/pull/33742
 	snmpMultilineReplacer := matchYAMLKeyWithListValue(
 		"(community_strings)",
 		"community_strings",

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -151,8 +151,8 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	)
 	tokenReplacer.LastUpdated = defaultVersion
 	snmpReplacer := matchYAMLKey(
-		`(community_string|authKey|privKey|community|authentication_key|privacy_key|Authorization|authorization)`,
-		[]string{"community_string", "authKey", "privKey", "community", "authentication_key", "privacy_key", "Authorization", "authorization"},
+		`(community_string|auth[Kk]ey|priv[Kk]ey|community|authentication_key|privacy_key|Authorization|authorization)`,
+		[]string{"community_string", "authKey", "authkey", "privKey", "privkey", "community", "authentication_key", "privacy_key", "Authorization", "authorization"},
 		[]byte(`$1 "********"`),
 	)
 	snmpReplacer.LastUpdated = parseVersion("7.53.0") // https://github.com/DataDog/datadog-agent/pull/23515

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -357,8 +357,14 @@ func TestSNMPConfig(t *testing.T) {
 		`authKey: password`,
 		`authKey: "********"`)
 	assertClean(t,
+		`authkey: password`,
+		`authkey: "********"`)
+	assertClean(t,
 		`privKey: password`,
 		`privKey: "********"`)
+	assertClean(t,
+		`privkey: password`,
+		`privkey: "********"`)
 	assertClean(t,
 		`community_string: p@ssw0r)`,
 		`community_string: "********"`)

--- a/pkg/util/scrubber/yaml_scrubber_test.go
+++ b/pkg/util/scrubber/yaml_scrubber_test.go
@@ -35,6 +35,23 @@ func TestScrubDataObj(t *testing.T) {
 			},
 		},
 		{
+			name: "SNMPConfig",
+			input: map[string]interface{}{
+				"community_string": "password123",
+				"authKey":          "password",
+				"authkey":          "password",
+				"privKey":          "password",
+				"privkey":          "password",
+			},
+			expected: map[string]interface{}{
+				"community_string": "********",
+				"authKey":          "********",
+				"authkey":          "********",
+				"privKey":          "********",
+				"privkey":          "********",
+			},
+		},
+		{
 			name: "Scrub sensitive info from nested map",
 			input: map[string]interface{}{
 				"user": map[string]interface{}{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR aims to scrub `privkey` and `authkey` in addition of `privKey` and `authKey`.

### Motivation

An accident occurred where a configuration had the concerned keys present in their configuration

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->