### PR TITLE
[NPM-4178] Add parallel traceroute implementation

### DIFF
--- a/pkg/networkpath/traceroute/common/traceroute_parallel.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel.go
@@ -1,0 +1,146 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// ErrReceiveProbeNoPkt is returned when ReceiveProbe() didn't find anything new.
+// This is normal if the RTT is long
+var ErrReceiveProbeNoPkt = errors.New("ReceiveProbe() doesn't have new packets")
+
+// ProbeResponse is the response of a single probe in a traceroute
+type ProbeResponse struct {
+	// TTL is the Time To Live of the probe that was originally sent
+	TTL uint8
+	// IP is the IP address of the responding host
+	IP netip.Addr
+	// RTT is the round-trip time of the probe
+	RTT time.Duration
+	// IsDest is true if the responding host is the destination
+	IsDest bool
+}
+
+// TracerouteDriver is an implementation of traceroute send+receive of packets
+type TracerouteDriver interface {
+	// Send a traceroute packet with a specific TTL
+	SendProbe(ttl uint8) error
+	// Poll to get a traceroute response with a timeout
+	ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
+}
+
+// TracerouteParallelParams are the parameters for TracerouteParallel
+type TracerouteParallelParams struct {
+	// MinTTL is the TTL to start the traceroute at
+	MinTTL uint8
+	// MaxTTL is the TTL to end the traceroute at
+	MaxTTL uint8
+	// TracerouteTimeout is the maximum time to wait for a response
+	TracerouteTimeout time.Duration
+	// PollFrequency is how often to poll for a response
+	PollFrequency time.Duration
+	// SendDelay is the delay between sending probes (typically small)
+	SendDelay time.Duration
+}
+
+// TracerouteParallel runs a traceroute in parallel
+func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TracerouteParallelParams) ([]*ProbeResponse, error) {
+	if p.MinTTL > p.MaxTTL {
+		return nil, fmt.Errorf("min TTL must be less than or equal to max TTL")
+	}
+
+	results := make([]*ProbeResponse, int(p.MaxTTL-p.MinTTL+1))
+
+	delaySum := p.SendDelay * time.Duration(len(results))
+	timeoutCtx, cancel := context.WithTimeout(ctx, p.TracerouteTimeout+delaySum)
+	defer cancel()
+
+	g, groupCtx := errgroup.WithContext(timeoutCtx)
+	writerCtx, writerCancel := context.WithCancel(groupCtx)
+	defer writerCancel()
+
+	// start a goroutine to SendProbe() in a loop
+	g.Go(func() error {
+		for i := int(p.MinTTL); i <= int(p.MaxTTL); i++ {
+			// leave if we got cancelled
+			select {
+			case <-writerCtx.Done():
+				return nil
+			default:
+			}
+
+			err := t.SendProbe(uint8(i))
+			if err != nil {
+				return err
+			}
+
+			time.Sleep(p.SendDelay)
+		}
+		return nil
+	})
+
+	// poll for ReceiveProbe() in a loop and write it to results[]
+	g.Go(func() error {
+		for {
+			// leave if we got cancelled, SendProbe() failed, etc
+			select {
+			// doesn't use writerCtx because even if we writerCancel(), we want to keep reading
+			case <-groupCtx.Done():
+				return nil
+			default:
+			}
+
+			probe, err := t.ReceiveProbe(p.PollFrequency)
+			if err == ErrReceiveProbeNoPkt {
+				continue
+			}
+			if err != nil {
+				return err
+			}
+			if probe == nil {
+				return fmt.Errorf("ReceiveProbe() returned nil without an error (this indicates a bug in the TracerouteDriver)")
+			}
+			if probe.TTL < p.MinTTL || probe.TTL > p.MaxTTL {
+				return fmt.Errorf("received an invalid TTL (expected TTL in [%d, %d]): %d", probe.TTL, p.MinTTL, p.MaxTTL)
+			}
+
+			results[probe.TTL-p.MinTTL] = probe
+			// no need to send more probes if we found the destination
+			if probe.IsDest {
+				writerCancel()
+			}
+		}
+	})
+
+	// check for an error from the goroutines
+	err := g.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	// finally, if we got externally cancelled, report that
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	destIdx := slices.IndexFunc(results, func(pr *ProbeResponse) bool {
+		return pr != nil && pr.IsDest
+	})
+	// trim off anything after the destination
+	if destIdx != -1 {
+		results = slices.Clip(results[:destIdx+1])
+	}
+
+	return results, nil
+}

--- a/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
@@ -1,0 +1,420 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test
+
+package common
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MockDriver struct {
+	t      *testing.T
+	params TracerouteParallelParams
+
+	sentTTLs map[uint8]struct{}
+
+	sendHandler    func(ttl uint8) error
+	receiveHandler func() (*ProbeResponse, error)
+}
+
+func initMockDriver(t *testing.T, params TracerouteParallelParams) *MockDriver {
+	return &MockDriver{
+		t:              t,
+		params:         params,
+		sentTTLs:       make(map[uint8]struct{}),
+		sendHandler:    nil,
+		receiveHandler: nil,
+	}
+}
+
+func (m *MockDriver) SendProbe(ttl uint8) error {
+	require.NotContains(m.t, m.sentTTLs, ttl, "same TTL sent twice")
+	m.sentTTLs[ttl] = struct{}{}
+
+	m.t.Logf("wrote %d\n", ttl)
+	if m.sendHandler == nil {
+		return nil
+	}
+	return m.sendHandler(ttl)
+}
+
+func (m *MockDriver) ReceiveProbe(timeout time.Duration) (*ProbeResponse, error) {
+	require.Equal(m.t, m.params.PollFrequency, timeout)
+
+	if m.receiveHandler == nil {
+		return nil, ErrReceiveProbeNoPkt
+	}
+	res, err := m.receiveHandler()
+	if !errors.Is(err, ErrReceiveProbeNoPkt) {
+		m.t.Logf("read %+v, %v\n", res, err)
+	}
+	return res, err
+}
+
+func noData(pollFrequency time.Duration) (*ProbeResponse, error) {
+	time.Sleep(pollFrequency)
+	return nil, ErrReceiveProbeNoPkt
+}
+
+var testParams = TracerouteParallelParams{
+	MinTTL:            1,
+	MaxTTL:            10,
+	TracerouteTimeout: 50 * time.Millisecond,
+	PollFrequency:     1 * time.Millisecond,
+	SendDelay:         1 * time.Millisecond,
+}
+
+const mockDestTTL = 5
+
+func mockResult(ttl uint8) *ProbeResponse {
+	if ttl > mockDestTTL {
+		return nil
+	}
+	return &ProbeResponse{
+		TTL: ttl,
+		IP:  netip.AddrFrom4([4]byte{10, 0, 0, ttl}),
+		// mock RTT as the TTL in milliseconds
+		RTT:    time.Duration(ttl) * time.Millisecond,
+		IsDest: ttl == mockDestTTL,
+	}
+}
+
+func TestParallelTraceroute(t *testing.T) {
+	// basic test that checks if the traceroute runs correctly
+	m := initMockDriver(t, testParams)
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+
+	expectedTTL := uint8(1)
+	m.sendHandler = func(ttl uint8) error {
+		require.Equal(t, expectedTTL, ttl)
+		expectedTTL++
+
+		result := mockResult(ttl)
+
+		if result != nil {
+			expectedResults = append(expectedResults, result)
+			receiveProbes <- result
+			if result.IsDest {
+				close(receiveProbes)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		probe, ok := <-receiveProbes
+		if !ok {
+			return noData(testParams.PollFrequency)
+		}
+		return probe, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL)
+}
+
+func testParallelTracerouteShuffled(t *testing.T, seed int64) {
+	// similar to TestParallelTraceroute, except it shuffles the received probes
+	// and expects them to come back in the correct order
+	r := rand.New(rand.NewSource(seed))
+
+	m := initMockDriver(t, testParams)
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+
+	m.sendHandler = func(ttl uint8) error {
+		result := mockResult(ttl)
+		if result != nil {
+			expectedResults = append(expectedResults, result)
+
+			if result.IsDest {
+				for _, p := range r.Perm(len(expectedResults)) {
+					receiveProbes <- expectedResults[p]
+				}
+				close(receiveProbes)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		probe, ok := <-receiveProbes
+		if !ok {
+			return noData(testParams.PollFrequency)
+		}
+		return probe, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL)
+}
+func TestParallelTracerouteShuffled(t *testing.T) {
+	for seed := range 3 {
+		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
+			testParallelTracerouteShuffled(t, int64(seed))
+		})
+	}
+}
+
+var errMock = errors.New("mock error")
+
+func TestParallelTracerouteSendErr(t *testing.T) {
+	// this test checks that TracerouteParallel returns an error if SendProbe() fails
+	m := initMockDriver(t, testParams)
+
+	hasCalled := false
+	m.sendHandler = func(_ uint8) error {
+		require.False(t, hasCalled, "SendProbe() called more than once")
+		hasCalled = true
+
+		return errMock
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.Nil(t, results)
+	require.ErrorIs(t, err, errMock)
+}
+
+func TestParallelTracerouteReceiveErr(t *testing.T) {
+	// this test checks that TracerouteParallel returns an error if ReceiveProbe() fails
+	m := initMockDriver(t, testParams)
+
+	hasCalled := false
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		require.False(t, hasCalled, "ReceiveProbe() called more than once")
+		hasCalled = true
+
+		return nil, errMock
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.Nil(t, results)
+	require.ErrorIs(t, err, errMock)
+}
+
+func TestParallelTracerouteTimeout(t *testing.T) {
+	// this test checks that TracerouteParallel times out when it is waiting for
+	// a response during the traceroute
+	m := initMockDriver(t, testParams)
+
+	totalCalls := 0
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		totalCalls++
+		return noData(testParams.PollFrequency)
+	}
+
+	start := time.Now()
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.NoError(t, err)
+
+	// divide by 2 to give margin for error
+	require.Greater(t, time.Since(start), testParams.TracerouteTimeout/2)
+	// make sure it kept polling repeatedly
+	require.Greater(t, totalCalls, 5)
+	for _, res := range results {
+		require.Nil(t, res)
+	}
+}
+
+func TestParallelTracerouteMinTTL(t *testing.T) {
+	// same as TestParallelTraceroute but it checks that we don't send TTL=1 when MinTTL=2
+
+	// make a copy of testParams
+	testParams := testParams
+	testParams.MinTTL = 2
+	m := initMockDriver(t, testParams)
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+
+	// expectedTTL starts at 2 in this test
+	expectedTTL := uint8(2)
+	m.sendHandler = func(ttl uint8) error {
+		require.Equal(t, expectedTTL, ttl)
+		expectedTTL++
+
+		result := mockResult(ttl)
+
+		if result != nil {
+			expectedResults = append(expectedResults, result)
+			receiveProbes <- result
+			if result.IsDest {
+				close(receiveProbes)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		probe, ok := <-receiveProbes
+		if !ok {
+			return noData(testParams.PollFrequency)
+		}
+		return probe, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL-1)
+}
+
+func TestParallelTracerouteReportsExternalCancellation(t *testing.T) {
+	// this test checks that TracerouteParallel forwards a cancellation from the context
+	m := initMockDriver(t, testParams)
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	// cancel it right away
+	cancel(errMock)
+
+	results, err := TracerouteParallel(ctx, m, testParams)
+	require.Nil(t, results)
+	require.ErrorIs(t, err, context.Canceled)
+	require.ErrorIs(t, context.Cause(ctx), errMock)
+}
+
+func TestParallelTracerouteMissingHop(t *testing.T) {
+	// this test simulates a missing hop at TTL=3
+	m := initMockDriver(t, testParams)
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+
+	m.sendHandler = func(ttl uint8) error {
+		result := mockResult(ttl)
+		skipHop := ttl == 3
+
+		if result != nil {
+			if skipHop {
+				result = nil
+			}
+			expectedResults = append(expectedResults, result)
+
+			if result != nil {
+				receiveProbes <- result
+				if result.IsDest {
+					close(receiveProbes)
+				}
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		probe, ok := <-receiveProbes
+		if !ok {
+			return noData(testParams.PollFrequency)
+		}
+		return probe, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL)
+}
+
+func TestParallelTracerouteMissingDest(t *testing.T) {
+	// this test simulates not getting the destination back - it should keep sending probes until MaxTTL
+	m := initMockDriver(t, testParams)
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+
+	m.sendHandler = func(ttl uint8) error {
+		result := mockResult(ttl)
+		skipHop := ttl == mockDestTTL
+
+		if result != nil {
+			if skipHop {
+				result = nil
+			}
+			expectedResults = append(expectedResults, result)
+
+			if !skipHop {
+				receiveProbes <- result
+			}
+		}
+
+		if ttl == testParams.MaxTTL {
+			close(receiveProbes)
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		probe, ok := <-receiveProbes
+		if !ok {
+			return noData(testParams.PollFrequency)
+		}
+		return probe, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.NoError(t, err)
+	require.Len(t, results, int(testParams.MaxTTL))
+	for i, r := range results {
+		// up to but excluding the destination TTL, we should have results
+		if i < len(expectedResults) {
+			require.Equal(t, expectedResults[i], r, "mismatch at index %d", i)
+		} else {
+			// after that, it should all be zero up to MaxTTL
+			require.Zero(t, r, "expected zero at index %d", i)
+		}
+	}
+}
+
+func TestParallelTracerouteProbeSanityCheck(t *testing.T) {
+	// this probe checks that TracerouteParallel yells at you when it reads
+	// a an invalid TTL
+	m := initMockDriver(t, testParams)
+
+	hasReceived := false
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		require.False(t, hasReceived, "ReceiveProbe() called more than once")
+		hasReceived = true
+		result := mockResult(1)
+		require.NotNil(t, result)
+		result.TTL = 123
+		return result, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.Nil(t, results)
+	require.ErrorContains(t, err, "received an invalid TTL")
+}
+
+func TestParallelTracerouteProbeReturnValueCheck(t *testing.T) {
+	// this probe checks that TracerouteParallel yells at you when you return nothing at all
+	m := initMockDriver(t, testParams)
+
+	hasReceived := false
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		require.False(t, hasReceived, "ReceiveProbe() called more than once")
+		hasReceived = true
+		return nil, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.Nil(t, results)
+	require.ErrorContains(t, err, "ReceiveProbe() returned nil without an error")
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a parallel traceroute implementation which is agnostic to the transport layer and IP protocol version.

### Motivation
Want to use this in netpath

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
```
go test -race -timeout 10s -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common -count=1
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->