### PR TITLE
Docker static quality gates metrics weren't correctly registered

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -637,13 +637,6 @@ workflow:
     when: never
   - !reference [.except_mergequeue]
 
-.except_release_branch_tagged_commit_and_mq:
-  - <<: *if_release_branch
-    when: never
-  - <<: *if_tagged_commit
-    when: never
-  - !reference [.except_mergequeue]
-
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -637,6 +637,11 @@ workflow:
     when: never
   - !reference [.except_mergequeue]
 
+.except_release_branch_and_mq:
+  - <<: *if_release_branch
+    when: never
+  - !reference [.except_mergequeue]
+
 .on_main_or_release_branch_or_deploy_always:
   - <<: *if_deploy
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -637,8 +637,10 @@ workflow:
     when: never
   - !reference [.except_mergequeue]
 
-.except_release_branch_and_mq:
+.except_release_branch_tagged_commit_and_mq:
   - <<: *if_release_branch
+    when: never
+  - <<: *if_tagged_commit
     when: never
   - !reference [.except_mergequeue]
 

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -1,7 +1,8 @@
 static_quality_gates:
   stage: functional_test
   rules:
-    - !reference [.except_release_branch_tagged_commit_and_mq]
+    - !reference [.not_on_release_branch_or_tagged_commit]
+    - !reference [.except_mergequeue]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -1,7 +1,7 @@
 static_quality_gates:
   stage: functional_test
   rules:
-    - !reference [.not_on_release_branch_or_tagged_commit]
+    - !reference [.except_release_branch_and_mq]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -1,7 +1,7 @@
 static_quality_gates:
   stage: functional_test
   rules:
-    - !reference [.except_release_branch_and_mq]
+    - !reference [.except_release_branch_tagged_commit_and_mq]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -1,7 +1,7 @@
 static_quality_gates:
   stage: functional_test
   rules:
-    - !reference [.except_main_or_release_branch]
+    - !reference [.not_on_release_branch_or_tagged_commit]
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/tasks/static_quality_gates/static_quality_gate_docker_agent_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_docker_agent_amd64.py
@@ -37,7 +37,7 @@ def entrypoint(**kwargs):
     gate_name = "static_quality_gate_docker_agent_amd64"
 
     metric_handler.register_gate_tags(
-        "static_quality_gate_docker_agent", gate_name="static_quality_gate_docker_agent", arch="x64", os="docker"
+        gate_name, gate_name=gate_name, arch="x64", os="docker"
     )
 
     metric_handler.register_metric(gate_name, "max_on_wire_size", max_on_wire_size)

--- a/tasks/static_quality_gates/static_quality_gate_docker_agent_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_docker_agent_amd64.py
@@ -36,9 +36,7 @@ def entrypoint(**kwargs):
     max_on_disk_size = arguments.max_on_disk_size
     gate_name = "static_quality_gate_docker_agent_amd64"
 
-    metric_handler.register_gate_tags(
-        gate_name, gate_name=gate_name, arch="x64", os="docker"
-    )
+    metric_handler.register_gate_tags(gate_name, gate_name=gate_name, arch="x64", os="docker")
 
     metric_handler.register_metric(gate_name, "max_on_wire_size", max_on_wire_size)
     metric_handler.register_metric(gate_name, "max_on_disk_size", max_on_disk_size)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix a naming issue preventing docker gates metrics to be sent. Also makes static quality gates run on main (without notification) to get main current metrics.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->