### PR TITLE
[netpath] Deduplicate traceroutes by dest port and container

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/common/pathtest.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/common/pathtest.go
@@ -6,7 +6,6 @@
 package common
 
 import (
-	"encoding/binary"
 	"hash/fnv"
 
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
@@ -32,9 +31,7 @@ type Pathtest struct {
 // GetHash returns the hash of the Pathtest
 func (p Pathtest) GetHash() uint64 {
 	h := fnv.New64()
-	h.Write([]byte(p.Hostname))                  //nolint:errcheck
-	binary.Write(h, binary.LittleEndian, p.Port) //nolint:errcheck
-	h.Write([]byte(p.Protocol))                  //nolint:errcheck
-	h.Write([]byte(p.SourceContainerID))         //nolint:errcheck
+	h.Write([]byte(p.Hostname)) //nolint:errcheck
+	h.Write([]byte(p.Protocol)) //nolint:errcheck
 	return h.Sum64()
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/common/pathtest_test.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/common/pathtest_test.go
@@ -44,8 +44,8 @@ func TestPathtest_GetHash(t *testing.T) {
 	}
 
 	assert.NotEqual(t, p1.GetHash(), p2.GetHash())
-	assert.NotEqual(t, p1.GetHash(), p3.GetHash())
+	assert.Equal(t, p1.GetHash(), p3.GetHash())
 	assert.NotEqual(t, p2.GetHash(), p3.GetHash())
 	assert.NotEqual(t, p1.GetHash(), p4.GetHash())
-	assert.NotEqual(t, p1.GetHash(), p5.GetHash())
+	assert.Equal(t, p1.GetHash(), p5.GetHash())
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR prevents duplicate traceroutes for the same IP on different ports or different containers.

It still holds onto the correct port/container information, it's just not generating another traceroute with it.


### Motivation
Want to reduce the number of traceroute pathtests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The test checks for this, should still pass

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->