### PR TITLE
[CONTP-647] Cluster-agent Add metadata to flare/endpoint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -340,6 +340,7 @@
 /comp/forwarder/eventplatform @DataDog/agent-log-pipelines
 /comp/forwarder/eventplatformreceiver @DataDog/agent-log-pipelines
 /comp/forwarder/orchestrator @DataDog/agent-log-pipelines
+/comp/metadata/clusteragent @DataDog/container-platform
 /comp/metadata/haagent @DataDog/ndm-core
 /comp/metadata/hostgpu @DataDog/ebpf-platform
 /comp/metadata/packagesigning @DataDog/agent-delivery

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -57,7 +57,6 @@ import (
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	dcametadatafx "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/fx"
-	"github.com/DataDog/datadog-agent/comp/metadata/resources/resourcesimpl"
 	metadatarunnerimpl "github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
 	metricscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx"
@@ -144,7 +143,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return demuxInstance.Serializer()
 				}),
 				metadatarunnerimpl.Module(),
-				resourcesimpl.Module(),
 				dcametadatafx.Module())
 		},
 	}

--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -55,6 +55,10 @@ import (
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
+	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
+	dcametadatafx "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/fx"
+	"github.com/DataDog/datadog-agent/comp/metadata/resources/resourcesimpl"
+	metadatarunnerimpl "github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
 	metricscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent"
@@ -136,7 +140,12 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				metricscompressionfx.Module(),
 				createandfetchimpl.Module(),
 				diagnosefx.Module(),
-			)
+				fx.Provide(func(demuxInstance demultiplexer.Component) serializer.MetricSerializer {
+					return demuxInstance.Serializer()
+				}),
+				metadatarunnerimpl.Module(),
+				resourcesimpl.Module(),
+				dcametadatafx.Module())
 		},
 	}
 
@@ -158,6 +167,7 @@ func run(
 	logReceiver option.Option[integrations.Component],
 	authToken authtoken.Component,
 	diagonseComp diagnose.Component,
+	dcametadataComp dcametadata.Component,
 ) error {
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
 	defer mainCtxCancel() // Calling cancel twice is safe
@@ -200,7 +210,7 @@ func run(
 	// start the autoconfig, this will immediately run any configured check
 	ac.LoadAndRun(mainCtx)
 
-	if err = api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagonseComp); err != nil {
+	if err = api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagonseComp, dcametadataComp); err != nil {
 		return log.Errorf("Error while starting agent API, exiting: %v", err)
 	}
 

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -47,6 +47,7 @@ func SetupHandlers(r *mux.Router, wmeta workloadmeta.Component, ac autodiscovery
 		getConfigCheck(w, r, ac)
 	}).Methods("GET")
 	r.HandleFunc("/config", settings.GetFullConfig("")).Methods("GET")
+	r.HandleFunc("/config/by-source", settings.GetFullConfigBySource()).Methods("GET")
 	r.HandleFunc("/config/list-runtime", settings.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settings.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settings.SetValue).Methods("POST")

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	clusterAgentFlare "github.com/DataDog/datadog-agent/pkg/flare/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -33,7 +34,7 @@ import (
 )
 
 // SetupHandlers adds the specific handlers for cluster agent endpoints
-func SetupHandlers(r *mux.Router, wmeta workloadmeta.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, taggerComp tagger.Component, diagnoseComponent diagnose.Component) {
+func SetupHandlers(r *mux.Router, wmeta workloadmeta.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, taggerComp tagger.Component, diagnoseComponent diagnose.Component, dcametadataComp dcametadata.Component) {
 	r.HandleFunc("/version", getVersion).Methods("GET")
 	r.HandleFunc("/hostname", getHostname).Methods("GET")
 	r.HandleFunc("/flare", func(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +54,7 @@ func SetupHandlers(r *mux.Router, wmeta workloadmeta.Component, ac autodiscovery
 	r.HandleFunc("/workload-list", func(w http.ResponseWriter, r *http.Request) {
 		getWorkloadList(w, r, wmeta)
 	}).Methods("GET")
+	r.HandleFunc("/metadata/cluster-agent", dcametadataComp.WritePayloadAsJSON).Methods("GET")
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request, statusComponent status.Component) {

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -41,6 +41,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerserver "github.com/DataDog/datadog-agent/comp/core/tagger/server"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
@@ -56,13 +57,13 @@ var (
 )
 
 // StartServer creates the router and starts the HTTP server
-func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component, authToken authtoken.Component, diagnoseComponent diagnose.Component) error {
+func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component, authToken authtoken.Component, diagnoseComponent diagnose.Component, dcametadataComp dcametadata.Component) error {
 	// create the root HTTP router
 	router = mux.NewRouter()
 	apiRouter = router.PathPrefix("/api/v1").Subrouter()
 
 	// IPC REST API server
-	agent.SetupHandlers(router, w, ac, statusComponent, settings, taggerComp, diagnoseComponent)
+	agent.SetupHandlers(router, w, ac, statusComponent, settings, taggerComp, diagnoseComponent, dcametadataComp)
 
 	// API V1 Metadata APIs
 	v1.InstallMetadataEndpoints(apiRouter, w)

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -60,7 +60,6 @@ import (
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
-	"github.com/DataDog/datadog-agent/comp/metadata/resources/resourcesimpl"
 	metadatarunner "github.com/DataDog/datadog-agent/comp/metadata/runner"
 	metadatarunnerimpl "github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	rccomp "github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
@@ -225,7 +224,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 					return demuxInstance.Serializer()
 				}),
 				metadatarunnerimpl.Module(),
-				resourcesimpl.Module(),
 				dcametadatafx.Module(),
 			)
 		},

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -60,6 +60,9 @@ import (
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
+	"github.com/DataDog/datadog-agent/comp/metadata/resources/resourcesimpl"
+	metadatarunner "github.com/DataDog/datadog-agent/comp/metadata/runner"
+	metadatarunnerimpl "github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
 	rccomp "github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice/rcserviceimpl"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rctelemetryreporter/rctelemetryreporterimpl"
@@ -106,6 +109,8 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
 
+	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
+	dcametadatafx "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/fx"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/languagedetection"
 
 	// Core checks
@@ -215,6 +220,13 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				metricscompressionfx.Module(),
 				diagnosefx.Module(),
 				createandfetchimpl.Module(),
+
+				fx.Provide(func(demuxInstance demultiplexer.Component) serializer.MetricSerializer {
+					return demuxInstance.Serializer()
+				}),
+				metadatarunnerimpl.Module(),
+				resourcesimpl.Module(),
+				dcametadatafx.Module(),
 			)
 		},
 	}
@@ -241,6 +253,8 @@ func start(log log.Component,
 	datadogConfig config.Component,
 	authToken authtoken.Component,
 	diagnoseComp diagnose.Component,
+	dcametadataComp dcametadata.Component,
+	_ metadatarunner.Component,
 ) error {
 	stopCh := make(chan struct{})
 	validatingStopCh := make(chan struct{})
@@ -305,7 +319,7 @@ func start(log log.Component,
 	})
 
 	// Starting server early to ease investigations
-	if err := api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagnoseComp); err != nil {
+	if err := api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagnoseComp, dcametadataComp); err != nil {
 		return fmt.Errorf("Error while starting agent API, exiting: %v", err)
 	}
 

--- a/comp/README.md
+++ b/comp/README.md
@@ -325,6 +325,12 @@ Package streamlogs is metadata provider for streamlogs
 Package metadata implements the "metadata" bundle, providing services and support for all the metadata payload sent
 by the Agent.
 
+### [comp/metadata/clusteragent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/metadata/clusteragent)
+
+*Datadog Team*: container-platform
+
+Package clusteragent is the metadata provider for datadog-cluster-agent process
+
 ### [comp/metadata/haagent](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/metadata/haagent)
 
 *Datadog Team*: ndm-core

--- a/comp/metadata/clusteragent/README.md
+++ b/comp/metadata/clusteragent/README.md
@@ -1,0 +1,78 @@
+# Cluster-agent Metadata Payload
+This package populates some of the cluster-agent related fields in the cluster-agent (DDSQL) table.
+
+This is disabled by default now but can be accessible to flare (cluster-agent-metadata.json) and endpoint of /metadata/cluster-agent.
+If enable_cluster_agent_metadata_collection is enabled, the payload is also sent to backend every 10 minutes (see inventories_max_interval in the config).
+
+# Cluster-agent Configuration
+The agent configurations are scrubbed from any sensitive information (same logic as for the flare). The Format section goes into more detail about what configuration is sent.
+
+Sending Cluster-Agent configuration can be disabled using enable_cluster_agent_metadata_collection.
+
+# Format
+The payload is a JSON dictionary with the following fields:
+
+- `clustername` - string: the name of the cluster.
+- `cluster_id` - string: the unique identifier of the cluster.
+- `timestamp` - int: the timestamp when the payload was created.
+- `datadog_cluster_agent_metadata` - dict of string to JSON type:
+- `agent_version` - string: the version of the Agent sending this payload.
+- `full_configuration` - string: the current Cluster-Agent configuration scrubbed, including all the defaults, as a YAML string.
+- `provided_configuration` - string: the current Cluster-Agent configuration (scrubbed), without the defaults, as a YAML string. This includes the settings configured by the user (through the configuration file, the environment, CLI, etc.).
+- `file_configuration` - string: the Cluster-Agent configuration specified by the configuration file (scrubbed), as a YAML string. Only the settings written in the configuration file are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
+- `environment_variable_configuration` - string: the Cluster-Agent configuration specified by the environment variables (scrubbed), as a YAML string. Only the settings written in the environment variables are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
+- `agent_runtime_configuration` - string: the Cluster-Agent configuration set by the agent itself (scrubbed), as a YAML string. Only the settings set by the agent itself are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
+remote_configuration - string: the Cluster-Agent configuration specified by the Remote Configuration (scrubbed), as a YAML string. Only the settings currently used by Remote Configuration are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
+- `fleet_policies_configuration` - string: the Cluster-Agent configuration specified by the Fleet Automation Policies (scrubbed), as a YAML string. Only the settings currently used by Fleet Automation Policies are included, and their value might not match what's applied by the agent since they can be overridden by other sources.
+- `cli_configuration` - string: the Cluster-Agent configuration specified by the CLI (scrubbed), as a YAML string. Only the settings set in the CLI are included.
+source_local_configuration - string: the Cluster-Agent configuration synchronized from the local Agent process, as a YAML string.
+- `agent_startup_time_ms` - int: the startup time of the agent in milliseconds.
+- `cluster_id_error` - string: any error related to the cluster ID.
+- feature_*` - various types: various feature flags and their statuses.
+
+("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
+
+## Example Payload
+```
+{
+    "clustername": "test-gke",
+    "cluster_id": "d1bd4888-2990-4312-a610-c9eae75acba4",
+    "timestamp": 1742810761534538592,
+    "datadog_cluster_agent_metadata": {
+        "agent_runtime_configuration": "internal_profiling:\n  enabled: true\n",
+        "agent_startup_time_ms": 1742809996230,
+        "agent_version": "7.65.0-devel+git.651.84a74a5",
+        "cli_configuration": "{}\n",
+        "cluster_id_error": "",
+        "environment_variable_configuration": "admission_controller.container_registry: gcr.io/datadoghq\nadmission_controller.enabled: \"true\"\nadmission_controller.failure_policy: Ignore\nadmission_controller.inject_config.local_service_name: datadog-agent-linux\nadmission_controller.inject_config.mode: socket\nadmission_controller.mutate_unlabelled: \"false\"\nadmission_controller.mutation.enabled: \"true\"\nadmission_controller.port: \"8000\"\nadmission_controller.service_name: datadog-agent-linux-cluster-agent-admission-controller\nadmission_controller.validation.enabled: \"true\"\nadmission_controller.webhook_name: datadog-webhook\napi_key: '***************************658e7'\napm_config.install_id: 817926d8-f346-487c-a5bb-c27aa73dfc0b\napm_config.install_time: \"1742809959\"\napm_config.install_type: k8s_manual\nautoscaling.failover.enabled: \"true\"\ncluster_agent.auth_token: '********'\ncluster_agent.collect_kubernetes_tags: \"true\"\ncluster_agent.kubernetes_service_name: datadog-agent-linux-cluster-agent\ncluster_agent.language_detection.patcher.enabled: \"false\"\ncluster_agent.service_account_name: datadog-agent-linux-cluster-agent\ncluster_agent.token_name: datadog-agent-linuxtoken\ncluster_checks.enabled: \"true\"\ncluster_name: minyi-test-gke\ncollect_kubernetes_events: \"true\"\nextra_config_providers: kube_endpoints kube_services\nextra_listeners: kube_endpoints kube_services\nhealth_port: \"5556\"\ninternal_profiling.enabled: \"true\"\nkube_resources_namespace: datadog-agent-helm\nkubernetes_events_source_detection.enabled: \"false\"\nkubernetes_namespace_labels_as_tags: '{\"kubernetes.io/metadata.name\":\"name\"}'\nkubernetes_use_endpoint_slices: \"false\"\nlanguage_detection.enabled: \"false\"\nlanguage_detection.reporting.enabled: \"false\"\nleader_election: \"true\"\nleader_election_default_resource: configmap\nleader_lease_duration: \"15\"\nleader_lease_name: datadog-agent-linux-leader-election\nlog_level: INFO\norchestrator_explorer.container_scrubbing.enabled: \"true\"\norchestrator_explorer.enabled: \"true\"\nproxy:\n  http: \"\"\n  https: \"\"\n  no_proxy:\n  - 169.254.169.254\n  - 100.100.100.200\npython_version: \"3\"\nremote_configuration.enabled: \"false\"\nsecret_backend_command_allow_group_exec_perm: \"true\"\nsecurity_agent.internal_profiling.api_key: '***************************658e7'\nsslkeylogfile: /tmp/sslkeylog.txt\n",
+        "feature_admission_controller_auto_instrumentation_enabled": true,
+        "feature_admission_controller_cws_instrumentation_enabled": false,
+        "feature_admission_controller_enabled": true,
+        "feature_admission_controller_inject_config_enabled": true,
+        "feature_admission_controller_inject_tags_enabled": true,
+        "feature_admission_controller_mutation_enabled": true,
+        "feature_admission_controller_validation_enabled": true,
+        "feature_apm_config_instrumentation_enabled": false,
+        "feature_autoscaling_workload_enabled": false,
+        "feature_cluster_checks_advanced_dispatching_enabled": false,
+        "feature_cluster_checks_enabled": true,
+        "feature_cluster_checks_exclude_checks": [],
+        "feature_compliance_config_enabled": false,
+        "feature_external_metrics_provider_enabled": false,
+        "feature_external_metrics_provider_use_datadogmetric_crd": false,
+        "file_configuration": "{}\n",
+        "flavor": "cluster_agent",
+        "fleet_policies_configuration": "{}\n",
+        "full_configuration": "ac_exclude: xxxx",
+        "install_method_installer_version": "datadog-3.110.2",
+        "install_method_tool": "helm",
+        "install_method_tool_version": "Helm",
+        "is_leader": true,
+        "leader_election": true,
+        "provided_configuration": "admission_controller ***",
+        "remote_configuration": "{}\n",
+        "source_local_configuration": "{}\n"
+    },
+    "uuid": "05284024-b312-f0ac-4769-9e9b99baf163"
+}
+```

--- a/comp/metadata/clusteragent/def/component.go
+++ b/comp/metadata/clusteragent/def/component.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package clusteragent is the metadata provider for datadog-cluster-agent process
+package clusteragent
+
+import "net/http"
+
+// team: container-platform
+
+// Component is the component type.
+type Component interface {
+	// WritePayloadAsJSON writes the payload as JSON to the response writer. It is used by cluster-agent metadata endpoint.
+	WritePayloadAsJSON(w http.ResponseWriter, _ *http.Request)
+}

--- a/comp/metadata/clusteragent/fx/fx.go
+++ b/comp/metadata/clusteragent/fx/fx.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the cluster-agent metadata component
+package fx
+
+import (
+	clusteragent "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
+	clusteragentimpl "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for this component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			clusteragentimpl.NewComponent,
+		),
+		fxutil.ProvideOptional[clusteragent.Component](),
+	)
+}

--- a/comp/metadata/clusteragent/fx/fx.go
+++ b/comp/metadata/clusteragent/fx/fx.go
@@ -10,6 +10,7 @@ import (
 	clusteragent "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	clusteragentimpl "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/impl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"go.uber.org/fx"
 )
 
 // Module defines the fx options for this component
@@ -19,5 +20,6 @@ func Module() fxutil.Module {
 			clusteragentimpl.NewComponent,
 		),
 		fxutil.ProvideOptional[clusteragent.Component](),
+		fx.Invoke(func(_ clusteragent.Component) {}),
 	)
 }

--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -105,7 +105,11 @@ func NewComponent(deps Requires) Provides {
 		dca.clusteridErr = clidErr.Error()
 	}
 	dca.initMetadata()
-	dca.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, dca.getPayload, "datadog-cluster-agent.json")
+	if deps.Config.GetBool("enable_cluster_agent_metadata_collection") {
+		dca.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, dca.getPayload, "datadog-cluster-agent.json")
+	} else {
+		dca.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, nil, dca.getPayload, "datadog-cluster-agent.json")
+	}
 	return Provides{
 		Comp:             dca,
 		MetadataProvider: dca.MetadataProvider(),
@@ -153,11 +157,13 @@ func (dca *datadogclusteragent) getFeatureConfigs() {
 	dca.metadata["feature_admission_controller_mutation_enabled"] = dca.conf.GetBool("admission_controller.mutation.enabled")
 	dca.metadata["feature_admission_controller_auto_instrumentation_enabled"] = dca.conf.GetBool("admission_controller.auto_instrumentation.enabled")
 	dca.metadata["feature_admission_controller_cws_instrumentation_enabled"] = dca.conf.GetBool("admission_controller.cws_instrumentation.enabled")
-	dca.metadata["feature_cluster_checks_enabled"] = dca.conf.GetBool("cluster_checks.enabled")
 	dca.metadata["feature_autoscaling_workload_enabled"] = dca.conf.GetBool("autoscaling.workload.enabled")
 	dca.metadata["feature_external_metrics_provider_enabled"] = dca.conf.GetBool("external_metrics_provider.enabled")
 	dca.metadata["feature_external_metrics_provider_use_datadogmetric_crd"] = dca.conf.GetBool("external_metrics_provider.use_datadogmetric_crd")
 	dca.metadata["feature_compliance_config_enabled"] = dca.conf.GetBool("compliance_config.enabled")
+	dca.metadata["feature_cluster_checks_enabled"] = dca.conf.GetBool("cluster_checks.enabled")
+	dca.metadata["feature_cluster_checks_exclude_checks"] = dca.conf.GetStringSlice("cluster_checks.exclude_checks")
+	dca.metadata["feature_cluster_checks_advanced_dispatching_enabled"] = dca.conf.GetBool("cluster_checks.advanced_dispatching_enabled")
 }
 
 func (dca *datadogclusteragent) getMetadata() map[string]interface{} {

--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -1,0 +1,198 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+// Package clusteragentimpl implements the clusteragent metadata providers interface
+package clusteragentimpl
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	clusteragent "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
+	"github.com/DataDog/datadog-agent/comp/metadata/internal/util"
+	"github.com/DataDog/datadog-agent/comp/metadata/runner/runnerimpl"
+	configFetcher "github.com/DataDog/datadog-agent/pkg/config/fetcher"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
+	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	"github.com/DataDog/datadog-agent/pkg/util/uuid"
+	"github.com/DataDog/datadog-agent/pkg/version"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var (
+	fetchDatadogClusterAgentConfig = configFetcher.DatadogClusterAgentConfig
+)
+
+// Payload handles the JSON unmarshalling of the metadata payload
+type Payload struct {
+	Hostname    string                 `json:"hostname"`
+	Clustername string                 `json:"clustername"`
+	ClusterID   string                 `json:"cluster_id"`
+	Timestamp   int64                  `json:"timestamp"`
+	Metadata    map[string]interface{} `json:"datadog_cluster_agent_metadata"`
+	UUID        string                 `json:"uuid"`
+}
+
+// MarshalJSON serialization a Payload to JSON
+func (p *Payload) MarshalJSON() ([]byte, error) {
+	type PayloadAlias Payload
+	return json.Marshal((*PayloadAlias)(p))
+}
+
+// SplitPayload implements marshaler.AbstractMarshaler#SplitPayload.
+// In this case, the payload can't be split any further.
+func (p *Payload) SplitPayload(_ int) ([]marshaler.AbstractMarshaler, error) {
+	return nil, fmt.Errorf("could not split datadog-cluster-agent process payload any more, payload is too big for intake")
+}
+
+// Requires defines the dependencies for the clusteragent metadata component
+type Requires struct {
+	Log        log.Component
+	Config     config.Component
+	Serializer serializer.MetricSerializer
+}
+
+type datadogclusteragent struct {
+	util.InventoryPayload
+	log          log.Component
+	conf         config.Component
+	hostname     string
+	clustername  string
+	clusterid    string
+	clusteridErr string
+}
+
+// Provides defines the output of the clusteragent metadata component
+type Provides struct {
+	Comp             clusteragent.Component
+	MetadataProvider runnerimpl.Provider
+}
+
+// NewComponent creates a new securityagent metadata Component
+func NewComponent(deps Requires) Provides {
+	hname, _ := hostname.Get(context.Background())
+	clname := clustername.GetClusterName(context.Background(), hname)
+	clid, clidErr := getClusterID()
+	dca := &datadogclusteragent{
+		log:          deps.Log,
+		conf:         deps.Config,
+		hostname:     hname,
+		clustername:  clname,
+		clusterid:    clid,
+		clusteridErr: "",
+	}
+	if clidErr != nil {
+		dca.clusteridErr = clidErr.Error()
+	}
+	dca.InventoryPayload = util.CreateInventoryPayload(deps.Config, deps.Log, deps.Serializer, dca.getPayload, "datadog-cluster-agent.json")
+	return Provides{
+		Comp:             dca,
+		MetadataProvider: dca.MetadataProvider(),
+	}
+}
+
+func (dca *datadogclusteragent) getPayload() marshaler.JSONMarshaler {
+
+	return &Payload{
+		Hostname:    dca.hostname,
+		Clustername: dca.clustername,
+		ClusterID:   dca.clusterid,
+		Timestamp:   time.Now().UnixNano(),
+		Metadata:    dca.getMetadata(),
+		UUID:        uuid.GetUUID(),
+	}
+}
+
+func (dca *datadogclusteragent) initMetadata(metadata map[string]interface{}) {
+	tool := "undefined"
+	toolVersion := ""
+	installerVersion := ""
+
+	install, err := installinfo.Get(dca.conf)
+	if err == nil {
+		tool = install.Tool
+		toolVersion = install.ToolVersion
+		installerVersion = install.InstallerVersion
+	}
+	metadata["cluster_id_error"] = dca.clusteridErr
+	metadata["install_method_tool"] = tool
+	metadata["install_method_tool_version"] = toolVersion
+	metadata["install_method_installer_version"] = installerVersion
+	metadata["agent_version"] = version.AgentVersion
+	metadata["agent_startup_time_ms"] = pkgconfigsetup.StartTime.UnixMilli()
+	metadata["flavor"] = flavor.GetFlavor()
+}
+
+func (dca *datadogclusteragent) getAadmissionControllerConfig(metadata map[string]interface{}) {
+	metadata["feature_admission_controller_enabled"] = dca.conf.GetBool("admission_controller.enabled")
+	metadata["feature_admission_controller_inject_config_enabled"] = dca.conf.GetBool("admission_controller.inject_config.enabled")
+	metadata["feature_admission_controller_inject_tags_enabled"] = dca.conf.GetBool("admission_controller.inject_tags.enabled")
+	metadata["feature_apm_config_instrumentation_enabled"] = dca.conf.GetBool("apm_config.instrumentation.enabled")
+	metadata["feature_admission_controller_validation_enabled"] = dca.conf.GetBool("admission_controller.validation.enabled")
+	metadata["feature_admission_controller_mutation_enabled"] = dca.conf.GetBool("admission_controller.mutation.enabled")
+	metadata["feature_admission_controller_auto_instrumentation_enabled"] = dca.conf.GetBool("admission_controller.auto_instrumentation.enabled")
+	metadata["feature_admission_controller_cws_instrumentation_enabled"] = dca.conf.GetBool("admission_controller.cws_instrumentation.enabled")
+	metadata["feature_cluster_checks_enabled"] = dca.conf.GetBool("cluster_checks.enabled")
+	metadata["feature_autoscaling_workload_enabled"] = dca.conf.GetBool("autoscaling.workload.enabled")
+	metadata["feature_external_metrics_provider_enabled"] = dca.conf.GetBool("external_metrics_provider.enabled")
+	metadata["feature_external_metrics_provider_use_datadogmetric_crd"] = dca.conf.GetBool("external_metrics_provider.use_datadogmetric_crd")
+	metadata["feature_compliance_config_enabled"] = dca.conf.GetBool("compliance_config.enabled")
+}
+
+func (dca *datadogclusteragent) getMetadata() map[string]interface{} {
+	metadata := map[string]interface{}{}
+	dca.initMetadata(metadata)
+	metadata["leader_election"] = dca.conf.GetBool("leader_election")
+	metadata["is_leader"] = false
+	if dca.conf.GetBool("leader_election") {
+		if leaderEngine, err := leaderelection.GetLeaderEngine(); err == nil {
+			metadata["is_leader"] = leaderEngine.IsLeader()
+		}
+	}
+	if str, err := fetchDatadogClusterAgentConfig(dca.conf); err == nil {
+		metadata["full_configuration"] = str
+	} else {
+		dca.log.Debugf("error fetching datadog-cluster-agent config: %s", err)
+	}
+	dca.getAadmissionControllerConfig(metadata)
+	return metadata
+}
+
+func getClusterID() (string, error) {
+	cl, err := as.GetAPIClient()
+	if err != nil {
+		return "", err
+	}
+	coreCl := cl.Cl.CoreV1().(*corev1.CoreV1Client)
+	// get clusterID
+	return common.GetOrCreateClusterID(coreCl)
+}
+
+// WritePayloadAsJSON writes the payload as JSON to the response writer. It is used by cluster-agent metadata endpoint.
+func (dca *datadogclusteragent) WritePayloadAsJSON(w http.ResponseWriter, _ *http.Request) {
+	// GetAsJSON calls getPayload which already scrub the data
+	scrubbed, err := dca.GetAsJSON()
+	if err != nil {
+		httputils.SetJSONError(w, err, 500)
+		return
+	}
+	w.Write(scrubbed)
+}

--- a/comp/metadata/clusteragent/impl/cluster_agent.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent.go
@@ -45,7 +45,6 @@ var (
 
 // Payload handles the JSON unmarshalling of the metadata payload
 type Payload struct {
-	Hostname    string                 `json:"hostname"`
 	Clustername string                 `json:"clustername"`
 	ClusterID   string                 `json:"cluster_id"`
 	Timestamp   int64                  `json:"timestamp"`
@@ -76,7 +75,6 @@ type datadogclusteragent struct {
 	util.InventoryPayload
 	log          log.Component
 	conf         config.Component
-	hostname     string
 	clustername  string
 	clusterid    string
 	clusteridErr string
@@ -91,13 +89,15 @@ type Provides struct {
 
 // NewComponent creates a new securityagent metadata Component
 func NewComponent(deps Requires) Provides {
-	hname, _ := hostname.Get(context.Background())
+	hname, err := hostname.Get(context.Background())
+	if err != nil {
+		hname = ""
+	}
 	clname := clustername.GetClusterName(context.Background(), hname)
 	clid, clidErr := getClusterID()
 	dca := &datadogclusteragent{
 		log:          deps.Log,
 		conf:         deps.Config,
-		hostname:     hname,
 		clustername:  clname,
 		clusterid:    clid,
 		clusteridErr: "",
@@ -121,7 +121,6 @@ func NewComponent(deps Requires) Provides {
 func (dca *datadogclusteragent) getPayload() marshaler.JSONMarshaler {
 
 	return &Payload{
-		Hostname:    dca.hostname,
 		Clustername: dca.clustername,
 		ClusterID:   dca.clusterid,
 		Timestamp:   time.Now().UnixNano(),

--- a/comp/metadata/clusteragent/impl/cluster_agent_noop.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent_noop.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !kubeapiserver
+
+// Package clusteragentimpl contains a no-op implementation of the cluster-agent metatdata provider.
+package clusteragentimpl
+
+import (
+	"net/http"
+
+	clusteragent "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
+)
+
+type noopImpl struct{}
+
+// Provides defines the output of the clusteragent metadata component
+type Provides struct {
+	Comp clusteragent.Component
+}
+
+// NewComponent returns a new instance of the collector component.
+func NewComponent() Provides {
+	dca := &noopImpl{}
+	return Provides{
+		Comp: dca,
+	}
+}
+
+// WritePayloadAsJSON writes the payload as JSON to the response writer. NOOP implementation.
+func (n *noopImpl) WritePayloadAsJSON(_ http.ResponseWriter, _ *http.Request) {}

--- a/comp/metadata/clusteragent/impl/cluster_agent_test.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent_test.go
@@ -73,9 +73,7 @@ func assertClusterAgentPayload(t *testing.T, metadata map[string]interface{}) {
 
 func TestGetMetadata(t *testing.T) {
 	dca := getClusterAgentComp(t)
-	dca.log.Infof("hello")
 	metadata := dca.getMetadata()
-
 	assertClusterAgentPayload(t, metadata)
 }
 

--- a/comp/metadata/clusteragent/impl/cluster_agent_test.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent_test.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package clusteragentimpl
+
+import (
+	"encoding/json"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	serializermock "github.com/DataDog/datadog-agent/pkg/serializer/mocks"
+)
+
+func setupClusterAgentConfig(t *testing.T) config.Component {
+	conf := config.NewMock(t)
+	conf.Set("admission_controller.enabled", true, model.SourceUnknown)
+	conf.Set("admission_controller.inject_config.enabled", true, model.SourceUnknown)
+	conf.Set("admission_controller.inject_tags.enabled", true, model.SourceUnknown)
+	conf.Set("apm_config.instrumentation.enabled", true, model.SourceUnknown)
+	conf.Set("admission_controller.validation.enabled", true, model.SourceUnknown)
+	conf.Set("admission_controller.mutation.enabled", true, model.SourceUnknown)
+	conf.Set("admission_controller.auto_instrumentation.enabled", true, model.SourceUnknown)
+	conf.Set("admission_controller.cws_instrumentation.enabled", true, model.SourceUnknown)
+	conf.Set("cluster_checks.enabled", true, model.SourceUnknown)
+	conf.Set("autoscaling.workload.enabled", true, model.SourceUnknown)
+	conf.Set("external_metrics_provider.enabled", true, model.SourceUnknown)
+	conf.Set("external_metrics_provider.use_datadogmetric_crd", true, model.SourceUnknown)
+	conf.Set("compliance_config.enabled", true, model.SourceUnknown)
+	return conf
+}
+
+func getClusterAgentComp(t *testing.T) *datadogclusteragent {
+	l := logmock.New(t)
+
+	cfg := setupClusterAgentConfig(t)
+
+	r := Requires{
+		Log:        l,
+		Config:     cfg,
+		Serializer: serializermock.NewMetricSerializer(t),
+	}
+
+	comp := NewComponent(r).Comp
+	return comp.(*datadogclusteragent)
+}
+
+func assertClusterAgentPayload(t *testing.T, metadata map[string]interface{}) {
+	assert.Equal(t, true, metadata["feature_admission_controller_enabled"])
+	assert.Equal(t, true, metadata["feature_admission_controller_inject_config_enabled"])
+	assert.Equal(t, true, metadata["feature_admission_controller_inject_tags_enabled"])
+	assert.Equal(t, true, metadata["feature_apm_config_instrumentation_enabled"])
+	assert.Equal(t, true, metadata["feature_admission_controller_validation_enabled"])
+	assert.Equal(t, true, metadata["feature_admission_controller_mutation_enabled"])
+	assert.Equal(t, true, metadata["feature_admission_controller_auto_instrumentation_enabled"])
+	assert.Equal(t, true, metadata["feature_admission_controller_cws_instrumentation_enabled"])
+	assert.Equal(t, true, metadata["feature_cluster_checks_enabled"])
+	assert.Equal(t, true, metadata["feature_autoscaling_workload_enabled"])
+	assert.Equal(t, true, metadata["feature_external_metrics_provider_enabled"])
+	assert.Equal(t, true, metadata["feature_external_metrics_provider_use_datadogmetric_crd"])
+	assert.Equal(t, true, metadata["feature_compliance_config_enabled"])
+}
+
+func TestGetMetadata(t *testing.T) {
+	dca := getClusterAgentComp(t)
+	dca.log.Infof("hello")
+	metadata := dca.getMetadata()
+
+	assertClusterAgentPayload(t, metadata)
+}
+
+func TestWritePayload(t *testing.T) {
+	dca := getClusterAgentComp(t)
+	req := httptest.NewRequest("GET", "http://fake_url.com", nil)
+	w := httptest.NewRecorder()
+	dca.WritePayloadAsJSON(w, req)
+	resp := w.Result()
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	require.NoError(t, err)
+
+	p := Payload{}
+	err = json.Unmarshal(body, &p)
+	require.NoError(t, err)
+	assertClusterAgentPayload(t, p.Metadata)
+}

--- a/comp/metadata/clusteragent/impl/cluster_agent_test.go
+++ b/comp/metadata/clusteragent/impl/cluster_agent_test.go
@@ -71,12 +71,6 @@ func assertClusterAgentPayload(t *testing.T, metadata map[string]interface{}) {
 	assert.Equal(t, true, metadata["feature_compliance_config_enabled"])
 }
 
-func TestGetMetadata(t *testing.T) {
-	dca := getClusterAgentComp(t)
-	metadata := dca.getMetadata()
-	assertClusterAgentPayload(t, metadata)
-}
-
 func TestWritePayload(t *testing.T) {
 	dca := getClusterAgentComp(t)
 	req := httptest.NewRequest("GET", "http://fake_url.com", nil)

--- a/comp/metadata/internal/util/inventory_payload.go
+++ b/comp/metadata/internal/util/inventory_payload.go
@@ -150,6 +150,10 @@ func (i *InventoryPayload) MetadataProvider() runnerimpl.Provider {
 func (i *InventoryPayload) collect(_ context.Context) time.Duration {
 	i.m.Lock()
 	defer i.m.Unlock()
+	if i.serializer == nil {
+		i.log.Tracef("serializer is nil, skipping submission")
+		return i.MinInterval
+	}
 
 	// Collect is called every MinInterval second. To maintain the same order of request as we did in 7.50.0
 	// We need to warranty that metadata information gets sent to the backend at least 1 minute past the startup time.

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -119,7 +119,7 @@ func DatadogClusterAgentConfig(config config.Reader) (string, error) {
 		return "", fmt.Errorf("invalid cluster_agent.cmd_port -- %d", port)
 	}
 
-	c := util.GetClient(false)
+	c := util.GetClient()
 	c.Timeout = config.GetDuration("server_timeout") * time.Second
 
 	ipcAddressWithPort := fmt.Sprintf("https://localhost:%d/config", port)

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -106,34 +106,3 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 
 	return client.FullConfig()
 }
-
-// DatadogClusterAgentConfig fetch the configuration from the cluster-agent process by querying its HTTPS API
-func DatadogClusterAgentConfig(config config.Reader) (string, string, error) {
-	err := util.SetAuthToken(config)
-	if err != nil {
-		return "", "", err
-	}
-
-	port := config.GetInt("cluster_agent.cmd_port")
-	if port <= 0 {
-		return "", "", fmt.Errorf("invalid cluster_agent.cmd_port -- %d", port)
-	}
-
-	c := util.GetClient()
-	c.Timeout = config.GetDuration("server_timeout") * time.Second
-
-	ipcAddressWithPort := fmt.Sprintf("https://localhost:%d/config", port)
-
-	client := settingshttp.NewClient(c, ipcAddressWithPort, "cluster-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
-	fullConfig := ""
-	fullConfigBySource := ""
-	fullConfig, err = client.FullConfig()
-	if err != nil {
-		return fullConfig, fullConfigBySource, err
-	}
-	fullConfigBySource, err = client.FullConfigBySource()
-	if err != nil {
-		return fullConfig, fullConfigBySource, err
-	}
-	return fullConfig, fullConfigBySource, nil
-}

--- a/pkg/config/fetcher/from_processes.go
+++ b/pkg/config/fetcher/from_processes.go
@@ -106,3 +106,24 @@ func ProcessAgentConfig(config config.Reader, getEntireConfig bool) (string, err
 
 	return client.FullConfig()
 }
+
+// DatadogClusterAgentConfig fetch the configuration from the cluster-agent process by querying its HTTPS API
+func DatadogClusterAgentConfig(config config.Reader) (string, error) {
+	err := util.SetAuthToken(config)
+	if err != nil {
+		return "", err
+	}
+
+	port := config.GetInt("cluster_agent.cmd_port")
+	if port <= 0 {
+		return "", fmt.Errorf("invalid cluster_agent.cmd_port -- %d", port)
+	}
+
+	c := util.GetClient(false)
+	c.Timeout = config.GetDuration("server_timeout") * time.Second
+
+	ipcAddressWithPort := fmt.Sprintf("https://localhost:%d/config", port)
+
+	client := settingshttp.NewClient(c, ipcAddressWithPort, "cluster-agent", settingshttp.NewHTTPClientOptions(util.CloseConnection))
+	return client.FullConfig()
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1136,6 +1136,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("integration_profiling", false)
 	config.BindEnvAndSetDefault("integration_check_status_enabled", false)
 	config.BindEnvAndSetDefault("enable_metadata_collection", true)
+	config.BindEnvAndSetDefault("enable_cluster_agent_metadata_collection", false)
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("enable_signing_metadata_collection", true)
 	config.BindEnvAndSetDefault("metadata_provider_stop_timeout", 30*time.Second)

--- a/pkg/flare/clusteragent/archive_dca.go
+++ b/pkg/flare/clusteragent/archive_dca.go
@@ -246,7 +246,7 @@ func getDCAWorkloadList() ([]byte, error) {
 }
 
 func getClusterAgentMetadataPayload() ([]byte, error) {
-	c := util.GetClient(false)
+	c := util.GetClient()
 
 	// Set session token
 	err := util.SetAuthToken(pkgconfigsetup.Datadog())

--- a/pkg/flare/clusteragent/archive_dca.go
+++ b/pkg/flare/clusteragent/archive_dca.go
@@ -79,14 +79,15 @@ func createDCAArchive(fb flaretypes.FlareBuilder, confSearchPaths map[string]str
 	getMetadataMap(fb)               //nolint:errcheck
 	getClusterAgentClusterChecks(fb) //nolint:errcheck
 
-	fb.AddFileFromFunc("agent-daemonset.yaml", getAgentDaemonSet)                  //nolint:errcheck
-	fb.AddFileFromFunc("cluster-agent-deployment.yaml", getClusterAgentDeployment) //nolint:errcheck
-	fb.AddFileFromFunc("helm-values.yaml", getHelmValues)                          //nolint:errcheck
-	fb.AddFileFromFunc("datadog-agent-cr.yaml", getDatadogAgentManifest)           //nolint:errcheck
-	fb.AddFileFromFunc("envvars.log", flarecommon.GetEnvVars)                      //nolint:errcheck
-	fb.AddFileFromFunc("telemetry.log", QueryDCAMetrics)                           //nolint:errcheck
-	fb.AddFileFromFunc("tagger-list.json", getDCATaggerList)                       //nolint:errcheck
-	fb.AddFileFromFunc("workload-list.log", getDCAWorkloadList)                    //nolint:errcheck
+	fb.AddFileFromFunc("agent-daemonset.yaml", getAgentDaemonSet)                     //nolint:errcheck
+	fb.AddFileFromFunc("cluster-agent-deployment.yaml", getClusterAgentDeployment)    //nolint:errcheck
+	fb.AddFileFromFunc("helm-values.yaml", getHelmValues)                             //nolint:errcheck
+	fb.AddFileFromFunc("datadog-agent-cr.yaml", getDatadogAgentManifest)              //nolint:errcheck
+	fb.AddFileFromFunc("envvars.log", flarecommon.GetEnvVars)                         //nolint:errcheck
+	fb.AddFileFromFunc("telemetry.log", QueryDCAMetrics)                              //nolint:errcheck
+	fb.AddFileFromFunc("tagger-list.json", getDCATaggerList)                          //nolint:errcheck
+	fb.AddFileFromFunc("workload-list.log", getDCAWorkloadList)                       //nolint:errcheck
+	fb.AddFileFromFunc("cluster-agent-metadata.json", getClusterAgentMetadataPayload) //nolint:errcheck
 	getPerformanceProfileDCA(fb, pdata)
 
 	if pkgconfigsetup.Datadog().GetBool("external_metrics_provider.enabled") {
@@ -242,6 +243,32 @@ func getDCAWorkloadList() ([]byte, error) {
 	}
 
 	return flare.GetWorkloadList(fmt.Sprintf("https://%v:%v/workload-list?verbose=true", ipcAddress, pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")), true)
+}
+
+func getClusterAgentMetadataPayload() ([]byte, error) {
+	c := util.GetClient(false)
+
+	// Set session token
+	err := util.SetAuthToken(pkgconfigsetup.Datadog())
+	if err != nil {
+		return nil, err
+	}
+
+	targetURL := url.URL{
+		Scheme: "https",
+		Host:   fmt.Sprintf("localhost:%v", pkgconfigsetup.Datadog().GetInt("cluster_agent.cmd_port")),
+		Path:   "metadata/cluster-agent",
+	}
+
+	r, err := util.DoGet(c, targetURL.String(), util.CloseConnection)
+	if err != nil {
+		if r != nil && string(r) != "" {
+			return nil, fmt.Errorf("the agent ran into an error while checking dca metadata: %s", string(r))
+		}
+		return nil, fmt.Errorf("failed to query the agent (running?): %s", err)
+	}
+
+	return r, nil
 }
 
 func getPerformanceProfileDCA(fb flaretypes.FlareBuilder, pdata ProfileData) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a metadata payload for the cluster-agent configuration and 
1. create a cluster-agent-metadata.json in dca flare pkg
2. support clustrer-agent endpoint query [ttps://localhost:5005/metadata/cluster-agent](https://localhost:5005/metadata/cluster-agent)
3. if enable_cluster_agent_metadata_collection is true: send to backend (need handler and schema added to backend which will be addressed in other PRs)


### Motivation
This PR is part of integration of Datadog Cluster Agent’s metadata into REDAPL, which will improve accessibility for both users and metabase application. 

Currently, REDAPL(DDSQL) stores Datadog Agent metadata, including configuration details, enabled features, and version information, enabling user and application queries through DDSQL. The existing metadata payloads support various components such as check_metadata, agent_metadata, and host_metadata. The new Cluster-Agent metadata will leverage a portion of the inventory payload found in the [metadata component](https://github.com/DataDog/datadog-agent/tree/main/comp#compmetadata-component-bundle).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Flare
Run agent flare in dca
```
root@datadog-agent-linux-cluster-agent-77f67b9db7-ls2bb:/# agent flare
Please enter your email: 
sd
Asking the Cluster Agent to build the flare archive.
/tmp/datadog-agent-2025-02-11T23-34-28Z-info.zip is going to be uploaded to Datadog
Are you sure you want to upload a flare? [y/N]
N
Aborting. (You can still use /tmp/datadog-agent-2025-02-11T23-34-28Z-info.zip)
```
download flare zip and cluster-agent-metadata.json can be found. 
```
{
    "clustername": "test-gke",
    "cluster_id": "d1bd4888-2990-4312-a610-c9eae75acba4",
    "timestamp": 1742810761534538592,
    "datadog_cluster_agent_metadata": {
        "agent_runtime_configuration": "internal_profiling:\n  enabled: true\n",
        "agent_startup_time_ms": 1742809996230,
        "agent_version": "7.65.0-devel+git.651.84a74a5",
        "cli_configuration": "{}\n",
        "cluster_id_error": "",
        "environment_variable_configuration": "admission_controller.container_registry: gcr.io/datadoghq\nadmission_controller.enabled: \"true\"\nadmission_controller.failure_policy: Ignore\nadmission_controller.inject_config.local_service_name: datadog-agent-linux\nadmission_controller.inject_config.mode: socket\nadmission_controller.mutate_unlabelled: \"false\"\nadmission_controller.mutation.enabled: \"true\"\nadmission_controller.port: \"8000\"\nadmission_controller.service_name: datadog-agent-linux-cluster-agent-admission-controller\nadmission_controller.validation.enabled: \"true\"\nadmission_controller.webhook_name: datadog-webhook\napi_key: '***************************658e7'\napm_config.install_id: 817926d8-f346-487c-a5bb-c27aa73dfc0b\napm_config.install_time: \"1742809959\"\napm_config.install_type: k8s_manual\nautoscaling.failover.enabled: \"true\"\ncluster_agent.auth_token: '********'\ncluster_agent.collect_kubernetes_tags: \"true\"\ncluster_agent.kubernetes_service_name: datadog-agent-linux-cluster-agent\ncluster_agent.language_detection.patcher.enabled: \"false\"\ncluster_agent.service_account_name: datadog-agent-linux-cluster-agent\ncluster_agent.token_name: datadog-agent-linuxtoken\ncluster_checks.enabled: \"true\"\ncluster_name: minyi-test-gke\ncollect_kubernetes_events: \"true\"\nextra_config_providers: kube_endpoints kube_services\nextra_listeners: kube_endpoints kube_services\nhealth_port: \"5556\"\ninternal_profiling.enabled: \"true\"\nkube_resources_namespace: datadog-agent-helm\nkubernetes_events_source_detection.enabled: \"false\"\nkubernetes_namespace_labels_as_tags: '{\"kubernetes.io/metadata.name\":\"name\"}'\nkubernetes_use_endpoint_slices: \"false\"\nlanguage_detection.enabled: \"false\"\nlanguage_detection.reporting.enabled: \"false\"\nleader_election: \"true\"\nleader_election_default_resource: configmap\nleader_lease_duration: \"15\"\nleader_lease_name: datadog-agent-linux-leader-election\nlog_level: INFO\norchestrator_explorer.container_scrubbing.enabled: \"true\"\norchestrator_explorer.enabled: \"true\"\nproxy:\n  http: \"\"\n  https: \"\"\n  no_proxy:\n  - 169.254.169.254\n  - 100.100.100.200\npython_version: \"3\"\nremote_configuration.enabled: \"false\"\nsecret_backend_command_allow_group_exec_perm: \"true\"\nsecurity_agent.internal_profiling.api_key: '***************************658e7'\nsslkeylogfile: /tmp/sslkeylog.txt\n",
        "feature_admission_controller_auto_instrumentation_enabled": true,
        "feature_admission_controller_cws_instrumentation_enabled": false,
        "feature_admission_controller_enabled": true,
        "feature_admission_controller_inject_config_enabled": true,
        "feature_admission_controller_inject_tags_enabled": true,
        "feature_admission_controller_mutation_enabled": true,
        "feature_admission_controller_validation_enabled": true,
        "feature_apm_config_instrumentation_enabled": false,
        "feature_autoscaling_workload_enabled": false,
        "feature_cluster_checks_advanced_dispatching_enabled": false,
        "feature_cluster_checks_enabled": true,
        "feature_cluster_checks_exclude_checks": [],
        "feature_compliance_config_enabled": false,
        "feature_external_metrics_provider_enabled": false,
        "feature_external_metrics_provider_use_datadogmetric_crd": false,
        "file_configuration": "{}\n",
        "flavor": "cluster_agent",
        "fleet_policies_configuration": "{}\n",
        "full_configuration": "ac_exclude: xxxx",
        "install_method_installer_version": "datadog-3.110.2",
        "install_method_tool": "helm",
        "install_method_tool_version": "Helm",
        "is_leader": true,
        "leader_election": true,
        "provided_configuration": "admission_controller ***",
        "remote_configuration": "{}\n",
        "source_local_configuration": "{}\n"
    },
    "uuid": "05284024-b312-f0ac-4769-9e9b99baf163"
}
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->