### PR TITLE
[corechecks/cluster/ksm] Expose resource annotations after custom resources configured

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -353,16 +353,6 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 		builder.WithKubeClient(apiServerClient.InformerCl)
 	}
 
-	// Enable exposing resource annotations explicitly for kube_<resource>_annotations metadata metrics.
-	// Equivalent to configuring --metric-annotations-allowlist.
-	allowedAnnotations := map[string][]string{}
-	for _, collector := range collectors {
-		// Any annotation can be used for label joins.
-		allowedAnnotations[collector] = []string{"*"}
-	}
-
-	builder.WithAllowAnnotations(allowedAnnotations)
-
 	// Prepare watched namespaces
 	namespaces := k.instance.Namespaces
 
@@ -402,6 +392,16 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 	builder.WithGenerateCustomResourceStoresFunc(builder.GenerateCustomResourceStoresFunc)
 	builder.WithCustomResourceStoreFactories(cr.factories...)
 	builder.WithCustomResourceClients(cr.clients)
+
+	// Enable exposing resource annotations explicitly for kube_<resource>_annotations metadata metrics.
+	// Equivalent to configuring --metric-annotations-allowlist.
+	allowedAnnotations := map[string][]string{}
+	for _, collector := range collectors {
+		// Any annotation can be used for label joins.
+		allowedAnnotations[collector] = []string{"*"}
+	}
+
+	builder.WithAllowAnnotations(allowedAnnotations)
 
 	// Enable exposing resource labels explicitly for kube_<resource>_labels metadata metrics.
 	// Equivalent to configuring --metric-labels-allowlist.

--- a/releasenotes-dca/notes/fix-annotations-as-tags-custom-collectors-7e657f9e7921838a.yaml
+++ b/releasenotes-dca/notes/fix-annotations-as-tags-custom-collectors-7e657f9e7921838a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix issue where annotations as tags were not showing up properly
+    when certain resource collectors were enabled.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix an issue where annotations as tags were not being applied properly when specific resource collectors were enabled.

### Motivation

Fixes CONS-7005.

When enabling certain resource collectors, annotations as tags may stop working (labels as tags remain unaffected). This happens because of the ordering in the code; previously we would:
1. Configure annotations as tags
2. Define the custom factories
3. Configure labels as tags

At the first step, the kube state metrics builder checks against a static list of collectors [here](https://github.com/kubernetes/kube-state-metrics/blob/76c5888e3402c946abd6f31876f3aada4c0c84fc/internal/store/builder.go#L313-L349). As the collectors are not yet defined (happens in step 2), annotations as tags would be incomplete whereas labels as tags would work as expected.

This PR re-orders the code such that we have:
1. Define the custom factories
2. Configure annotations as tags
3. Configure labels as tags

Which allows both annotations and labels to be attached properly to associated metrics.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Configure the ksm check to enable certain collectors
```
datadog:
  ...
  kubeStateMetricsCore:
    enabled: true
    collectCrdMetrics: true
    collectApiServicesMetrics: true
    labelsAsTags:
      deployment:
        example-label: kube_example_label
    annotationsAsTags:
      deployment:
        example-annotation: kube_example_annotation

clusterAgent:
  image:
    name: cluster-agent
    tag: 7.62.0
```
2. Start a deployment:
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: example-deployment
  labels:
    app: example
    example-label: label-1
  annotations:
    example-annotation: annotation-1
spec:
  replicas: 1
  selector:
    matchLabels:
      app: example
  template:
    metadata:
      labels:
        app: example
    spec:
      containers:
      - image: busybox
        command:
          - sleep
          - "3600"
        imagePullPolicy: IfNotPresent
        name: busybox
```
3. Verify that labels as tags appear, but annotations as tags do not
4. Pull in these changes; verify that now both the expected annotations and labels as tags appear
<img width="1367" alt="image" src="https://github.com/user-attachments/assets/b2c47b51-8aca-42c0-ace8-077a3f0b5d85" />

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
E2E testing for this feature will be added in this PR: https://github.com/DataDog/datadog-agent/pull/33286