### PR TITLE
add github workflow link to pr body

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -680,7 +680,7 @@ def get_user_query(login):
     return query + string_var
 
 
-def create_datadog_agent_pr(title, base_branch, target_branch, milestone_name, other_labels=None):
+def create_datadog_agent_pr(title, base_branch, target_branch, milestone_name, other_labels=None, body=""):
     print(color_message("Creating PR", "bold"))
 
     github = GithubAPI(repository=GITHUB_REPO_NAME)
@@ -699,7 +699,7 @@ Make sure that milestone is open before trying again.""",
 
     pr = github.create_pr(
         pr_title=title,
-        pr_body="",
+        pr_body=body,
         base_branch=base_branch,
         target_branch=target_branch,
     )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
add github workflow link to automated bump integrations core PR

### Motivation
to easily link back to the workflow that generated the PR

### Describe how you validated your changes
manually triggered workflow and checked [generated PR's body](https://github.com/DataDog/datadog-agent/pull/33762)

![image](https://github.com/user-attachments/assets/32440dcb-ac9f-4bc6-8f44-26ae2d618e60)

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->