### PR TITLE
fix(check_for_changes): Consider only `datadog-agent` for agent6

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -281,7 +281,8 @@ def get_last_release_tag(ctx, repo, pattern):
             code=1,
         )
 
-    release_pattern = re.compile(r'^.*7\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?(\^{})?$')
+    major = 6 if is_agent6(ctx) else 7
+    release_pattern = re.compile(rf'^.*{major}' + r'\.[0-9]+\.[0-9]+(-rc.*|-devel.*)?(\^{})?$')
     tags_without_suffix = [
         line for line in tags.splitlines() if not line.endswith("^{}") and release_pattern.match(line)
     ]

--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -338,7 +338,14 @@ def set_new_release_branch(branch):
 
 
 def generate_repo_data(ctx, warning_mode, next_version, release_branch):
-    repos = ["integrations-core"] if warning_mode else ALL_REPOS
+    if warning_mode:
+        # Warning mode is used to warn integrations so that they prepare their release version in advance.
+        repos = ["integrations-core"]
+    elif next_version.major == 6:
+        # For Agent 6, we are only concerned by datadog-agent. The other repos won't be updated.
+        repos = ["datadog-agent"]
+    else:
+        repos = ALL_REPOS
     previous_tags = find_previous_tags("release-a7", repos, RELEASE_JSON_FIELDS_TO_UPDATE)
     data = {}
     for repo in repos:

--- a/tasks/unit_tests/libs/common/git_tests.py
+++ b/tasks/unit_tests/libs/common/git_tests.py
@@ -116,24 +116,26 @@ class TestGetLastTag(unittest.TestCase):
     def test_ordered(self):
         c = MockContext(
             run={
-                'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
-                    """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
-                       7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2
-                       2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
-                )
+                'git rev-parse --abbrev-ref HEAD': Result("6.53.x"),
+                'git ls-remote -t https://github.com/DataDog/woof "6.56.*"': Result(
+                    """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/6.56.0-rc.1
+                       7c6777bb7add533a789c69293b59e3261711d330	refs/tags/6.56.0-rc.2
+                       2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/6.56.0-rc.3"""
+                ),
             }
         )
-        _, name = get_last_release_tag(c, "woof", "7.56.*")
-        self.assertEqual(name, "7.56.0-rc.3")
+        _, name = get_last_release_tag(c, "woof", "6.56.*")
+        self.assertEqual(name, "6.56.0-rc.3")
 
     def test_non_ordered(self):
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
                     """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
                        7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.11
                        2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
-                )
+                ),
             }
         )
         _, name = get_last_release_tag(c, "woof", "7.56.*")
@@ -142,11 +144,12 @@ class TestGetLastTag(unittest.TestCase):
     def test_suffix_lower(self):
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
                     """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
                        7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.2^{}
                        2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
-                )
+                ),
             }
         )
         _, name = get_last_release_tag(c, "woof", "7.56.*")
@@ -155,11 +158,12 @@ class TestGetLastTag(unittest.TestCase):
     def test_suffix_equal(self):
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
                     """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
                        7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.3^{}
                        2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
-                )
+                ),
             }
         )
         commit, _ = get_last_release_tag(c, "woof", "7.56.*")
@@ -168,11 +172,12 @@ class TestGetLastTag(unittest.TestCase):
     def test_suffix_greater(self):
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -t https://github.com/DataDog/woof "7.56.*"': Result(
                     """e1b8e9163203b7446c74fac0b8d4153eb24227a0	refs/tags/7.56.0-rc.1
                        7c6777bb7add533a789c69293b59e3261711d330	refs/tags/7.56.0-rc.4^{}
                        2b8b710b322feb03148f871a77ab92163a0a12de	refs/tags/7.56.0-rc.3"""
-                )
+                ),
             }
         )
         _, name = get_last_release_tag(c, "woof", "7.56.*")
@@ -181,6 +186,7 @@ class TestGetLastTag(unittest.TestCase):
     def test_only_release_tags(self):
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -t https://github.com/DataDog/woof "7.57.*"': Result(
                     """"43638bd55a74fd6ec51264cc7b3b1003d0b1c7ac    refs/tags/7.57.0-dbm-mongo-1.5
                         e01bcf3d12e6d6742b1fa8296882938c6dba9922    refs/tags/7.57.0-devel
@@ -206,7 +212,7 @@ class TestGetLastTag(unittest.TestCase):
                         91c7c85d7c8fbb94421a90b273aea75630617eef    refs/tags/7.57.1-beta-ndm-rdns-enrichment^{}
                         3ad359da2894fa3de6e265c56dea8fabdb128454    refs/tags/7.57.1-beta-ndm-rdns-enrichment2
                         86683ad80578912014cc947dcf247ba020532403    refs/tags/7.57.1-beta-ndm-rdns-enrichment2^{}"""
-                )
+                ),
             }
         )
         _, name = get_last_release_tag(c, "woof", "7.57.*")
@@ -215,6 +221,7 @@ class TestGetLastTag(unittest.TestCase):
     def test_final_and_rc_tag_on_same_commit(self):
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -t https://github.com/DataDog/baubau "7.61.*"': Result(
                     """8dd145cf716b5c047e81bb287dc58e150b8c2b94	refs/tags/7.61.0
                        45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0^{}
@@ -224,7 +231,7 @@ class TestGetLastTag(unittest.TestCase):
                        3944948c0c26ddcbc4026b98c2709c188d95b702	refs/tags/7.61.0-rc.4^{}
                        c54e5d5694879c51ae5ff8675dacc92976630587	refs/tags/7.61.0-rc.5
                        45f19a6a26c01dae9fdfce944d3fceae7f4e6498	refs/tags/7.61.0-rc.5^{}"""
-                )
+                ),
             }
         )
 

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -735,6 +735,7 @@ class TestCheckForChanges(unittest.TestCase):
         version_mock.return_value = next
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                     "4n0th3rc0mm1t0        refs/heads/main"
                 ),
@@ -794,6 +795,7 @@ class TestCheckForChanges(unittest.TestCase):
             version_mock.return_value = next
             c = MockContext(
                 run={
+                    'git rev-parse --abbrev-ref HEAD': Result("main"),
                     'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                         "4n0th3rc0mm1t9        refs/heads/main"
                     ),
@@ -873,6 +875,7 @@ class TestCheckForChanges(unittest.TestCase):
             version_mock.return_value = next
             c = MockContext(
                 run={
+                    'git rev-parse --abbrev-ref HEAD': Result("main"),
                     'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                         "4n0th3rc0mm1t9        refs/heads/main"
                     ),
@@ -956,6 +959,7 @@ class TestCheckForChanges(unittest.TestCase):
         version_mock.return_value = next
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/main"': Result(
                     "4n0th3rc0mm1t0        refs/heads/main"
                 ),
@@ -1023,6 +1027,7 @@ class TestCheckForChanges(unittest.TestCase):
             version_mock.return_value = next
             c = MockContext(
                 run={
+                    'git rev-parse --abbrev-ref HEAD': Result("main"),
                     'git ls-remote -h https://github.com/DataDog/omnibus-software "refs/heads/7.55.x"': Result(
                         "4n0th3rc0mm1t0        refs/heads/main"
                     ),
@@ -1097,6 +1102,7 @@ class TestCheckForChanges(unittest.TestCase):
         version_mock.return_value = next
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
@@ -1128,6 +1134,7 @@ class TestCheckForChanges(unittest.TestCase):
         version_mock.return_value = next
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t3        refs/heads/main"
                 ),
@@ -1159,6 +1166,7 @@ class TestCheckForChanges(unittest.TestCase):
         version_mock.return_value = next
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t9        refs/heads/main"
                 ),
@@ -1195,6 +1203,7 @@ class TestCheckForChanges(unittest.TestCase):
         version_mock.return_value = next
         c = MockContext(
             run={
+                'git rev-parse --abbrev-ref HEAD': Result("main"),
                 'git ls-remote -h https://github.com/DataDog/integrations-core "refs/heads/7.55.x"': Result(
                     "4n0th3rc0mm1t9        refs/heads/main"
                 ),

--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -701,6 +701,16 @@ class TestGenerateRepoData(unittest.TestCase):
         self.assertEqual("9.1.x", repo_data["datadog-agent-macos-build"]["branch"])
         self.assertEqual("9.1.x", repo_data["datadog-agent"]["branch"])
 
+    @patch('tasks.libs.releasing.json.find_previous_tags', new=MagicMock(return_value={'datadog-agent': '6.53.4-rc.2'}))
+    def test_agent_6(self):
+        next_version = MagicMock()
+        next_version.major = 6
+        next_version.branch.return_value = "6.53.x"
+        repo_data = generate_repo_data(Context(), False, next_version, "6.53.x")
+        self.assertEqual(len(repo_data), 1)
+        self.assertEqual("6.53.x", repo_data["datadog-agent"]["branch"])
+        self.assertEqual("6.53.4-rc.2", repo_data["datadog-agent"]["previous_tag"])
+
 
 class TestCheckForChanges(unittest.TestCase):
     @patch('tasks.release.agent_context')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Check changes on the single `datadog-agent` repository on the agent6 context

### Motivation
Prevent [unexpected failures](https://github.com/DataDog/datadog-agent/actions/runs/13164735671/job/36742028982#step:5:25) in the `create_rc_pr` workflow when running with agent6. There is no need to check other repos than `datadog-agent`, there are not supposed to change and if they do we will hande their update manually

### Describe how you validated your changes
I added a UT for this specific case
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->