### PR TITLE
feat(trigger_release): Create `on_failure` jobs for trigger_release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -298,6 +298,9 @@ variables:
 .if_deploy: &if_deploy
   if: $DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null
 
+.if_deploy_stable: &if_deploy_stable
+  if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH == "stable"
+
 .if_not_deploy: &if_not_deploy
   if: $DEPLOY_AGENT != "true" && $DDR_WORKFLOW_ID == null
 
@@ -606,6 +609,12 @@ workflow:
     when: manual
     allow_failure: true
   - when: on_success
+
+# Alternative of the above to have an agent-release-management trigger
+# for stable branches in case of failure in any previous job
+.on_deploy_stable_on_failure:
+  - <<: *if_deploy_stable
+  - when: on_failure
 
 .except_deploy:
   - <<: *if_deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -614,7 +614,7 @@ workflow:
 # for stable branches in case of failure in any previous job
 .on_deploy_stable_on_failure:
   - <<: *if_deploy_stable
-  - when: on_failure
+    when: on_failure
 
 .except_deploy:
   - <<: *if_deploy

--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -21,7 +21,6 @@ needs-rules:
     - deploy_containers-cws-instrumentation-rc-mutable
     - deploy_containers-cws-instrumentation-rc-versioned
     - dogstatsd_x64_size_test
-    - generate_windows_gitlab_runner_bump_pr
     - go_mod_tidy_check
     - lint_flavor_dogstatsd_linux-x64
     - lint_flavor_heroku_linux-x64
@@ -43,7 +42,9 @@ needs-rules:
     - tests_windows_secagent_x64
     - tests_windows_sysprobe_x64
     - trigger_auto_staging_release
+    - trigger_auto_staging_release_on_failure
     - trigger_manual_prod_release
+    - trigger_manual_prod_release_on_failure
 
 # Lists jobs that are allowed to not be within JOBOWNERS
 job-owners:

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -126,8 +126,8 @@ deploy_containers*                     @Datadog/agent-delivery
 deploy_containers-cws-instrumentation* @DataDog/agent-security
 
 # Trigger release
-trigger_manual_prod_release            @DataDog/agent-delivery
-trigger_auto_staging_release           @DataDog/agent-delivery
+trigger_manual_prod_release*            @DataDog/agent-delivery
+trigger_auto_staging_release*           @DataDog/agent-delivery
 generate_windows_gitlab_runner_bump_pr* @DataDog/agent-delivery
 
 # Integration test

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -41,6 +41,16 @@ trigger_auto_staging_release:
       when: never
     - !reference [.on_deploy]
 
+trigger_auto_staging_release_on_failure:
+  extends: .agent_release_management_trigger
+  variables:
+    AUTO_RELEASE: "false"
+    TARGET_REPO: staging
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
+      when: never
+    - !reference [.on_deploy_failure]
+
 trigger_manual_prod_release:
   extends: .agent_release_management_trigger
   variables:
@@ -53,6 +63,19 @@ trigger_manual_prod_release:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never
     - !reference [.on_deploy_stable_or_beta_manual_auto_on_stable]
+
+trigger_manual_prod_release_on_failure:
+  extends: .agent_release_management_trigger
+  variables:
+    AUTO_RELEASE: "false"
+    TARGET_REPO: prod
+    # The jobs in the downstream pipeline will all be manual, so following
+    # the created pipeline would likely cause this job to timeout
+    NO_FOLLOW: "--no-follow"
+  rules:
+    - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
+      when: never
+    - !reference [.on_deploy_stable_on_failure]
 
 include:
   - https://gitlab-templates.ddbuild.io/slack-notifier/v3-sdm/template.yml


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Duplicate the jobs triggering the `agent_release_management` pipeline

### Motivation
In the current situation, if any of the jobs declared in the previous stages of `trigger_release` fail, the jobs of this stage will be skipped.
Similarly to `deploy_container`
<img width="320" alt="image" src="https://github.com/user-attachments/assets/0015830a-727b-4408-94a2-4817cb442225" />
We create duplicates of the `trigger_release_*` jobs to have them available in case of failure in the previous jobs.
![image](https://github.com/user-attachments/assets/9f7f39c0-4c7a-4220-a082-bfdcd24a711d)

https://datadoghq.atlassian.net/browse/ACIX-542

### Describe how you validated your changes
n/a
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->