### PR TITLE
[Windows][Fleet Automation] Refactor E2E tests

### DIFF
--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -3,45 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package installer contains code for the E2E tests for the Datadog installer on Windows
 package installer
 
 import (
-	"fmt"
-	"os"
-	"path"
-	"strings"
-
 	agentVersion "github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	suiteasserts "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/suite-assertions"
+	"os"
 )
 
-// PackageVersion is a helper type to store both the version and the package version of a binary.
-// The package version has the "-1" suffix, whereas the binary's "version" command does not contain the "-1" suffix.
-type PackageVersion struct {
-	value        string
-	packageValue string
-}
-
-// Version the version without the package suffix
-func (v PackageVersion) Version() string {
-	return v.value
-}
-
-// PackageVersion the version with the package suffix
-func (v PackageVersion) PackageVersion() string {
-	return v.packageValue
-}
-
-func newVersionFromPackageVersion(packageVersion string) PackageVersion {
-	return PackageVersion{
-		value:        strings.TrimSuffix(packageVersion, "-1"),
-		packageValue: packageVersion,
-	}
-}
-
-// BaseInstallerSuite the base suite for all installer tests on Windows.
+// BaseSuite the base suite for all installer tests on Windows (install script, MSI, exe etc...).
 // To run the test suites locally, pick a pipeline and define the following environment variables:
 // E2E_PIPELINE_ID: the ID of the pipeline
 // CURRENT_AGENT_VERSION: pull it from one of the jobs that builds the Agent
@@ -51,40 +24,57 @@ func newVersionFromPackageVersion(packageVersion string) PackageVersion {
 //
 // For example:
 //
+//	CI_COMMIT_SHA=ac2acaffab7b039f8c2524df8ae82f9f5fd04d5d;
 //	E2E_PIPELINE_ID=40537701;
 //	CURRENT_AGENT_VERSION=7.57.0-devel+git.370.d429ae3;
 //	STABLE_INSTALLER_VERSION_PACKAGE=7.56.0-installer-0.4.6-1-1
 //	STABLE_AGENT_VERSION_PACKAGE=7.55.2-1
-type BaseInstallerSuite struct {
+type BaseSuite struct {
 	e2e.BaseSuite[environments.WindowsHost]
 	installer              *DatadogInstaller
+	installScript          *DatadogInstallScript
 	currentAgentVersion    agentVersion.Version
 	stableInstallerVersion PackageVersion
 	stableAgentVersion     PackageVersion
 }
 
-// Installer the Datadog Installer for testing.
-func (s *BaseInstallerSuite) Installer() *DatadogInstaller {
+// Installer The Datadog Installer for testing.
+func (s *BaseSuite) Installer() *DatadogInstaller {
 	return s.installer
 }
 
+// InstallScript The Datadog Install script for testing.
+func (s *BaseSuite) InstallScript() *DatadogInstallScript { return s.installScript }
+
+// Require instantiates a suiteAssertions for the current suite.
+// This allows writing assertions in a "natural" way, i.e.:
+//
+//	suite.Require().HasAService(...).WithUserSid(...)
+//
+// Ideally this suite assertion would exist at a higher level of abstraction
+// so that it could be shared by multiple suites, but for now it exists only
+// on the Windows Datadog installer `BaseSuite` object.
+func (s *BaseSuite) Require() *suiteasserts.SuiteAssertions {
+	return suiteasserts.New(s.BaseSuite.Require(), s)
+}
+
 // CurrentAgentVersion the version of the Agent in the current pipeline
-func (s *BaseInstallerSuite) CurrentAgentVersion() *agentVersion.Version {
+func (s *BaseSuite) CurrentAgentVersion() *agentVersion.Version {
 	return &s.currentAgentVersion
 }
 
 // StableInstallerVersion the version of the last published stable installer
-func (s *BaseInstallerSuite) StableInstallerVersion() PackageVersion {
+func (s *BaseSuite) StableInstallerVersion() PackageVersion {
 	return s.stableInstallerVersion
 }
 
 // StableAgentVersion the version of the last published stable agent
-func (s *BaseInstallerSuite) StableAgentVersion() PackageVersion {
+func (s *BaseSuite) StableAgentVersion() PackageVersion {
 	return s.stableAgentVersion
 }
 
 // SetupSuite checks that the environment variables are correctly setup for the test
-func (s *BaseInstallerSuite) SetupSuite() {
+func (s *BaseSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
 
 	// TODO:FA-779
@@ -108,37 +98,8 @@ func (s *BaseInstallerSuite) SetupSuite() {
 }
 
 // BeforeTest creates a new Datadog Installer and sets the output logs directory for each tests
-func (s *BaseInstallerSuite) BeforeTest(suiteName, testName string) {
+func (s *BaseSuite) BeforeTest(suiteName, testName string) {
 	s.BaseSuite.BeforeTest(suiteName, testName)
-	s.ensureDirs()
 	s.installer = NewDatadogInstaller(s.Env(), s.SessionOutputDir())
-}
-
-// Require instantiates a suiteAssertions for the current suite.
-// This allows writing assertions in a "natural" way, i.e.:
-//
-//	suite.Require().HasAService(...).WithUserSid(...)
-//
-// Ideally this suite assertion would exist at a higher level of abstraction
-// so that it could be shared by multiple suites, but for now it exists only
-// on the Windows Datadog installer `BaseInstallerSuite` object.
-func (s *BaseInstallerSuite) Require() *suiteasserts.SuiteAssertions {
-	return suiteasserts.New(s.BaseSuite.Require(), s)
-}
-
-// ensureDirs enforces the required dirs are created.
-// They should be created by the powershell script but here we use the MSI; so this
-// is a quick fix with hardcoded paths that should be removed once the powershell
-// script is used.
-func (s *BaseInstallerSuite) ensureDirs() {
-	basePath := "C:/ProgramData/Datadog Installer"
-	paths := []string{
-		path.Join(basePath, "packages"),
-		path.Join(basePath, "configs"),
-		path.Join(basePath, "locks"),
-		path.Join(basePath, "tmp"),
-	}
-	for _, p := range paths {
-		s.Env().RemoteHost.MustExecute(fmt.Sprintf("New-Item -Path \"%s\" -ItemType Directory -Force", p))
-	}
+	s.installScript = NewDatadogInstallScript(s.Env())
 }

--- a/test/new-e2e/tests/installer/windows/consts/consts.go
+++ b/test/new-e2e/tests/installer/windows/consts/consts.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package consts list the common packages paths used in the Datadog Installer tests.
+package consts
+
+import (
+	"fmt"
+	"path"
+)
+
+const (
+	// AgentPackage is the name of the Datadog Agent package
+	// We use a constant to make it easier for calling code, because depending on the context
+	// the Agent package can be referred to as "agent-package" (like in the OCI registry) or "datadog-agent" (in the
+	// local database once the Agent is installed).
+	AgentPackage string = "datadog-agent"
+	// InstallerPackage is the name of the Datadog Installer package
+	InstallerPackage string = "datadog-installer"
+	// Path is the path where the Datadog Installer is installed on disk
+	Path string = "C:\\Program Files\\Datadog\\Datadog Installer"
+	// BinaryName is the name of the Datadog Installer binary on disk
+	BinaryName string = "datadog-installer.exe"
+	// ServiceName the installer service name
+	ServiceName string = "Datadog Installer"
+	// ConfigPath is the location of the Datadog Installer's configuration on disk
+	ConfigPath string = "C:\\ProgramData\\Datadog\\datadog.yaml"
+	// RegistryKeyPath is the root registry key that the Datadog Installer uses to store some state
+	RegistryKeyPath string = `HKLM:\SOFTWARE\Datadog\Datadog Installer`
+	// NamedPipe is the name of the named pipe used by the Datadog Installer
+	NamedPipe string = `\\.\pipe\dd_installer`
+
+	// baseConfigPath is the base path for the Installer configuration
+	baseConfigPath = "C:/ProgramData/Datadog Installer"
+)
+
+var (
+	// BinaryPath is the path of the Datadog Installer binary on disk
+	BinaryPath = path.Join(Path, BinaryName)
+
+	// InstallerConfigPaths are the paths that the Datadog Installer uses to store its working files.
+	// They are normally created by the install script / bootstrap.
+	InstallerConfigPaths = []string{
+		path.Join(baseConfigPath, "packages"),
+		path.Join(baseConfigPath, "configs"),
+		path.Join(baseConfigPath, "locks"),
+		path.Join(baseConfigPath, "tmp"),
+	}
+)
+
+// GetExperimentDirFor is the path to the experiment symbolic link on disk
+func GetExperimentDirFor(packageName string) string {
+	return fmt.Sprintf("C:\\ProgramData\\Datadog Installer\\packages\\%s\\experiment", packageName)
+}
+
+// GetStableDirFor is the path to the stable symbolic link on disk
+func GetStableDirFor(packageName string) string {
+	return fmt.Sprintf("C:\\ProgramData\\Datadog Installer\\packages\\%s\\stable", packageName)
+}

--- a/test/new-e2e/tests/installer/windows/install_script.go
+++ b/test/new-e2e/tests/installer/windows/install_script.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installer
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/optional"
+	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/pipeline"
+	e2eos "github.com/DataDog/test-infra-definitions/components/os"
+	"strings"
+)
+
+// DatadogInstallScript represents an interface to the Datadog Install script on the remote host.
+type DatadogInstallScript struct {
+	env *environments.WindowsHost
+}
+
+// NewDatadogInstallScript instantiates a new instance of the Datadog Install Script running on
+// a remote Windows host.
+func NewDatadogInstallScript(env *environments.WindowsHost) *DatadogInstallScript {
+	return &DatadogInstallScript{
+		env: env,
+	}
+}
+
+// Run runs the Datadog Installer install script on the remote host.
+func (d *DatadogInstallScript) Run(opts ...Option) (string, error) {
+	params := Params{
+		extraEnvVars: make(map[string]string),
+	}
+	err := optional.ApplyOptions(&params, opts)
+	if err != nil {
+		return "", err
+	}
+	if params.installerURL == "" {
+		artifactURL, err := pipeline.GetPipelineArtifact(d.env.Environment.PipelineID(), pipeline.AgentS3BucketTesting, pipeline.DefaultMajorVersion, func(artifact string) bool {
+			return strings.Contains(artifact, "datadog-installer") && strings.HasSuffix(artifact, ".exe")
+		})
+		if err != nil {
+			return "", err
+		}
+		// update URL
+		params.installerURL = artifactURL
+	}
+
+	// Set the environment variables for the install script
+	envVars := installer.InstallScriptEnv(e2eos.AMD64Arch)
+	for k, v := range params.extraEnvVars {
+		envVars[k] = v
+	}
+	envVars["DD_INSTALLER_URL"] = params.installerURL
+
+	cmd := fmt.Sprintf(`Set-ExecutionPolicy Bypass -Scope Process -Force;
+		[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
+		iex ((New-Object System.Net.WebClient).DownloadString('https://installtesting.datad0g.com/pipeline-%s/scripts/Install-Datadog.ps1'))`, d.env.Environment.PipelineID())
+	return d.env.RemoteHost.Execute(cmd, client.WithEnvVariables(envVars))
+}

--- a/test/new-e2e/tests/installer/windows/installer.go
+++ b/test/new-e2e/tests/installer/windows/installer.go
@@ -8,6 +8,7 @@ package installer
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,34 +19,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/optional"
 	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
-	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent/installers/v2"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/pipeline"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
-)
-
-const (
-	// AgentPackage is the name of the Datadog Agent package
-	// We use a constant to make it easier for calling code, because depending on the context
-	// the Agent package can be referred to as "agent-package" (like in the OCI registry) or "datadog-agent" (in the
-	// local database once the Agent is installed).
-	AgentPackage string = "datadog-agent"
-	// Path is the path where the Datadog Installer is installed on disk
-	Path string = "C:\\Program Files\\Datadog\\Datadog Installer"
-	// BinaryName is the name of the Datadog Installer binary on disk
-	BinaryName string = "datadog-installer.exe"
-	// ServiceName the installer service name
-	ServiceName string = "Datadog Installer"
-	// ConfigPath is the location of the Datadog Installer's configuration on disk
-	ConfigPath string = "C:\\ProgramData\\Datadog\\datadog.yaml"
-	// RegistryKeyPath is the root registry key that the Datadog Installer uses to store some state
-	RegistryKeyPath string = `HKLM:\SOFTWARE\Datadog\Datadog Installer`
-	// NamedPipe is the name of the named pipe used by the Datadog Installer
-	NamedPipe string = `\\.\pipe\dd_installer`
-)
-
-var (
-	// BinaryPath is the path of the Datadog Installer binary on disk
-	BinaryPath = path.Join(Path, BinaryName)
 )
 
 // DatadogInstaller represents an interface to the Datadog Installer on the remote host.
@@ -63,7 +38,7 @@ func NewDatadogInstaller(env *environments.WindowsHost, outputDir string) *Datad
 	}
 
 	return &DatadogInstaller{
-		binaryPath: path.Join(Path, BinaryName),
+		binaryPath: path.Join(consts.Path, consts.BinaryName),
 		env:        env,
 		outputDir:  outputDir,
 	}
@@ -138,28 +113,6 @@ func (d *DatadogInstaller) runCommand(command, packageName string, opts ...insta
 	return d.execute(fmt.Sprintf("%s %s", command, packageURL), client.WithEnvVariables(envVars))
 }
 
-// RunInstallScript runs the Datadog Installer install script on the remote host.
-func (d *DatadogInstaller) RunInstallScript(extraEnvVars map[string]string) (string, error) {
-	// Get the URL of the installer.exe artifact from the pipeline
-	artifactURL, err := pipeline.GetPipelineArtifact(d.env.Environment.PipelineID(), pipeline.AgentS3BucketTesting, pipeline.DefaultMajorVersion, func(artifact string) bool {
-		return strings.Contains(artifact, "datadog-installer") && strings.HasSuffix(artifact, ".exe")
-	})
-	if err != nil {
-		return "", err
-	}
-	// Set the environment variables for the install script
-	envVars := installer.InstallScriptEnv(e2eos.AMD64Arch)
-	for k, v := range extraEnvVars {
-		envVars[k] = v
-	}
-	envVars["DD_INSTALLER_URL"] = artifactURL
-
-	cmd := fmt.Sprintf(`Set-ExecutionPolicy Bypass -Scope Process -Force;
-		[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072;
-		iex ((New-Object System.Net.WebClient).DownloadString('https://installtesting.datad0g.com/pipeline-%s/scripts/Install-Datadog.ps1'))`, d.env.Environment.PipelineID())
-	return d.env.RemoteHost.Execute(cmd, client.WithEnvVariables(envVars))
-}
-
 // InstallPackage will attempt to use the Datadog Installer to install the package given in parameter.
 // version: A function that returns the version of the package to install. By default, it will install
 // the package matching the current pipeline. This is a function so that it can be combined with
@@ -196,68 +149,25 @@ func (d *DatadogInstaller) Purge() (string, error) {
 	return d.executeFromCopy("purge")
 }
 
-// Params contains the optional parameters for the Datadog Installer Install command
-type Params struct {
-	installerURL   string
-	msiArgs        []string
-	msiLogFilename string
-}
-
-// Option is an optional function parameter type for the Datadog Installer Install command
-type Option func(*Params) error
-
-// WithInstallerURL uses a specific URL for the Datadog Installer Install command instead of using the pipeline URL.
-func WithInstallerURL(installerURL string) Option {
-	return func(params *Params) error {
-		params.installerURL = installerURL
-		return nil
-	}
-}
-
-// WithMSIArg uses a specific URL for the Datadog Installer Install command instead of using the pipeline URL.
-func WithMSIArg(arg string) Option {
-	return func(params *Params) error {
-		params.msiArgs = append(params.msiArgs, arg)
-		return nil
-	}
-}
-
-// WithMSILogFile sets the filename for the MSI log file, to be stored in the output directory.
-func WithMSILogFile(filename string) Option {
-	return func(params *Params) error {
-		params.msiLogFilename = filename
-		return nil
-	}
-}
-
-// WithInstallerURLFromInstallersJSON uses a specific URL for the Datadog Installer from an installers_v2.json
-// file.
-// jsonURL: The URL of the installers_v2.json file, i.e. pipeline.StableURL
-// version: The artifact version to retrieve, i.e. "7.56.0-installer-0.4.5-1"
-//
-// Example: WithInstallerURLFromInstallersJSON(pipeline.StableURL, "7.56.0-installer-0.4.5-1")
-// will look into "https://s3.amazonaws.com/ddagent-windows-stable/stable/installers_v2.json" for the Datadog Installer
-// version "7.56.0-installer-0.4.5-1"
-func WithInstallerURLFromInstallersJSON(jsonURL, version string) Option {
-	return func(params *Params) error {
-		url, err := installers.GetProductURL(jsonURL, "datadog-installer", version, "x86_64")
-		if err != nil {
-			return err
-		}
-		params.installerURL = url
-		return nil
+func (d *DatadogInstaller) createInstallerFolders() {
+	for _, p := range consts.InstallerConfigPaths {
+		d.env.RemoteHost.MustExecute(fmt.Sprintf("New-Item -Path \"%s\" -ItemType Directory -Force", p))
 	}
 }
 
 // Install will attempt to install the Datadog Installer on the remote host.
 // By default, it will use the installer from the current pipeline.
-func (d *DatadogInstaller) Install(opts ...Option) error {
-	params := Params{
-		msiLogFilename: "install.log",
+func (d *DatadogInstaller) Install(opts ...MsiOption) error {
+	params := MsiParams{
+		msiLogFilename:         "install.log",
+		createInstallerFolders: true,
 	}
 	err := optional.ApplyOptions(&params, opts)
 	if err != nil {
 		return err
+	}
+	if params.createInstallerFolders {
+		d.createInstallerFolders()
 	}
 	// MSI can install from a URL or a local file
 	msiPath := params.installerURL
@@ -291,8 +201,8 @@ func (d *DatadogInstaller) Install(opts ...Option) error {
 }
 
 // Uninstall will attempt to uninstall the Datadog Installer on the remote host.
-func (d *DatadogInstaller) Uninstall(opts ...Option) error {
-	params := Params{
+func (d *DatadogInstaller) Uninstall(opts ...MsiOption) error {
+	params := MsiParams{
 		msiLogFilename: "uninstall.log",
 	}
 	err := optional.ApplyOptions(&params, opts)
@@ -314,14 +224,4 @@ func (d *DatadogInstaller) Uninstall(opts ...Option) error {
 		msiArgs = strings.Join(params.msiArgs, " ")
 	}
 	return windowsCommon.MsiExec(d.env.RemoteHost, "/x", productCode, msiArgs, logPath)
-}
-
-// GetExperimentDirFor is the path to the experiment symbolic link on disk
-func GetExperimentDirFor(packageName string) string {
-	return fmt.Sprintf("C:\\ProgramData\\Datadog Installer\\packages\\%s\\experiment", packageName)
-}
-
-// GetStableDirFor is the path to the stable symbolic link on disk
-func GetStableDirFor(packageName string) string {
-	return fmt.Sprintf("C:\\ProgramData\\Datadog Installer\\packages\\%s\\stable", packageName)
 }

--- a/test/new-e2e/tests/installer/windows/package_version.go
+++ b/test/new-e2e/tests/installer/windows/package_version.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installer
+
+import "strings"
+
+// PackageVersion is a helper type to store both the version and the package version of a binary.
+// The package version has the "-1" suffix, whereas the binary's "version" command does not contain the "-1" suffix.
+type PackageVersion struct {
+	value        string
+	packageValue string
+}
+
+// Version the version without the package suffix
+func (v PackageVersion) Version() string {
+	return v.value
+}
+
+// PackageVersion the version with the package suffix
+func (v PackageVersion) PackageVersion() string {
+	return v.packageValue
+}
+
+func newVersionFromPackageVersion(packageVersion string) PackageVersion {
+	return PackageVersion{
+		value:        strings.TrimSuffix(packageVersion, "-1"),
+		packageValue: packageVersion,
+	}
+}

--- a/test/new-e2e/tests/installer/windows/params.go
+++ b/test/new-e2e/tests/installer/windows/params.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package installer
+
+import "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent/installers/v2"
+
+// Params contains the optional parameters for the Datadog Install Script command
+type Params struct {
+	installerURL string
+	// For now the extraEnvVars are only used by the install script,
+	// but they can (and should) be passed to the executable.
+	extraEnvVars map[string]string
+}
+
+// Option is an optional function parameter type for the Params
+type Option func(*Params) error
+
+// WithExtraEnvVars specifies additional environment variables.
+func WithExtraEnvVars(envVars map[string]string) Option {
+	return func(params *Params) error {
+		params.extraEnvVars = envVars
+		return nil
+	}
+}
+
+// WithInstallerURL uses a specific URL for the Datadog Installer Install command instead of using the pipeline URL.
+func WithInstallerURL(installerURL string) Option {
+	return func(params *Params) error {
+		params.installerURL = installerURL
+		return nil
+	}
+}
+
+// WithInstallerURLFromInstallersJSON uses a specific URL for the Datadog Installer from an installers_v2.json
+// file.
+// jsonURL: The URL of the installers_v2.json file, i.e. pipeline.StableURL
+// version: The artifact version to retrieve, i.e. "7.56.0-installer-0.4.5-1"
+//
+// Example: WithInstallerURLFromInstallersJSON(pipeline.StableURL, "7.56.0-installer-0.4.5-1")
+// will look into "https://s3.amazonaws.com/ddagent-windows-stable/stable/installers_v2.json" for the Datadog Installer
+// version "7.56.0-installer-0.4.5-1"
+func WithInstallerURLFromInstallersJSON(jsonURL, version string) Option {
+	return func(params *Params) error {
+		url, err := installers.GetProductURL(jsonURL, "datadog-installer", version, "x86_64")
+		if err != nil {
+			return err
+		}
+		params.installerURL = url
+		return nil
+	}
+}
+
+// MsiParams contains the optional parameters for the Datadog Installer Install command
+type MsiParams struct {
+	Params
+	msiArgs                []string
+	msiLogFilename         string
+	createInstallerFolders bool
+}
+
+// MsiOption is an optional function parameter type for the Datadog Installer Install command
+type MsiOption func(*MsiParams) error
+
+// WithOption converts an Option to an MsiOption (downcast)
+// allowing to use the base Option methods on with a func that accepts MsiOptions
+func WithOption(opt Option) MsiOption {
+	return func(params *MsiParams) error {
+		return opt(&params.Params)
+	}
+}
+
+// WithMSIArg uses a specific URL for the Datadog Installer Install command instead of using the pipeline URL.
+func WithMSIArg(arg string) MsiOption {
+	return func(params *MsiParams) error {
+		params.msiArgs = append(params.msiArgs, arg)
+		return nil
+	}
+}
+
+// WithMSILogFile sets the filename for the MSI log file, to be stored in the output directory.
+func WithMSILogFile(filename string) MsiOption {
+	return func(params *MsiParams) error {
+		params.msiLogFilename = filename
+		return nil
+	}
+}
+
+// CreateInstallerFolders Specifies whether to create some folders that are necessary for the Datadog Installer.
+// Those folders are normally created when using the install script / bootstrapper, but are not when installing
+// the Datadog Installer MSI directly.
+func CreateInstallerFolders(create bool) MsiOption {
+	return func(params *MsiParams) error {
+		params.createInstallerFolders = create
+		return nil
+	}
+}

--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_host_asserts.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/components"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -186,9 +187,9 @@ func (r *RemoteWindowsHostAssertions) HasNoNamedPipe(pipeName string) *RemoteWin
 func (r *RemoteWindowsHostAssertions) HasARunningDatadogInstallerService() *RemoteWindowsHostAssertions {
 	r.suite.T().Helper()
 
-	r.HasAService("Datadog Installer").
+	r.HasAService(consts.ServiceName).
 		WithStatus("Running").
-		HasNamedPipe(`\\.\pipe\dd_installer`).
+		HasNamedPipe(consts.NamedPipe).
 		WithSecurity(
 			// Only accessible to Administrators and LocalSystem
 			common.NewProtectedSecurityInfo(

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/agent-user_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/agent-user_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 
@@ -19,7 +20,7 @@ import (
 )
 
 type testAgentInstallWithAgentUserSuite struct {
-	installerwindows.BaseInstallerSuite
+	installerwindows.BaseSuite
 	agentUser string
 }
 
@@ -50,13 +51,13 @@ func (s *testAgentInstallWithAgentUserSuite) installAgent() {
 	// Arrange
 
 	// Act
-	_, err := s.Installer().InstallPackage(installerwindows.AgentPackage)
+	_, err := s.Installer().InstallPackage(consts.AgentPackage)
 
 	// Assert
 	s.Require().NoErrorf(err, "failed to install the Datadog Agent package")
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().
-		HasRegistryKey(installerwindows.RegistryKeyPath).
+		HasRegistryKey(consts.RegistryKeyPath).
 		WithValueEqual("installedUser", s.agentUser)
 	identity, err := windowsCommon.GetIdentityForUser(s.Env().RemoteHost, s.agentUser)
 	s.Require().NoError(err)

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/install_test.go
@@ -7,6 +7,7 @@
 package agenttests
 
 import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"path/filepath"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -18,7 +19,7 @@ import (
 )
 
 type testAgentInstallSuite struct {
-	installerwindows.BaseInstallerSuite
+	installerwindows.BaseSuite
 }
 
 // TestAgentInstalls tests the usage of the Datadog installer to install the Datadog Agent package.
@@ -42,7 +43,7 @@ func (s *testAgentInstallSuite) installAgent() {
 	// Arrange
 
 	// Act
-	output, err := s.Installer().InstallPackage(installerwindows.AgentPackage)
+	output, err := s.Installer().InstallPackage(consts.AgentPackage)
 
 	// Assert
 	s.Require().NoErrorf(err, "failed to install the Datadog Agent package: %s", output)
@@ -53,13 +54,13 @@ func (s *testAgentInstallSuite) removeAgentPackage() {
 	// Arrange
 
 	// Act
-	output, err := s.Installer().RemovePackage(installerwindows.AgentPackage)
+	output, err := s.Installer().RemovePackage(consts.AgentPackage)
 
 	// Assert
 	s.Require().NoErrorf(err, "failed to remove the Datadog Agent package: %s", output)
 	s.Require().Host(s.Env().RemoteHost).HasNoDatadogAgentService()
 	s.Require().Host(s.Env().RemoteHost).
-		NoDirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage),
+		NoDirExists(consts.GetStableDirFor(consts.AgentPackage),
 			"the package directory should be removed")
 }
 
@@ -85,6 +86,6 @@ func (s *testAgentInstallSuite) uninstallAgentWithMSI() {
 	// Assert
 	s.Require().NoErrorf(err, "failed to uninstall the Datadog Agent package")
 	s.Require().Host(s.Env().RemoteHost).
-		DirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage),
+		DirExists(consts.GetStableDirFor(consts.AgentPackage),
 			"the package directory should still exist after manually uninstalling the Agent with the MSI")
 }

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -6,6 +6,7 @@
 package agenttests
 
 import (
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -15,7 +16,7 @@ import (
 )
 
 type testAgentUpgradeSuite struct {
-	installerwindows.BaseInstallerSuite
+	installerwindows.BaseSuite
 }
 
 // TestAgentUpgrades tests the usage of the Datadog installer to upgrade the Datadog Agent package.
@@ -41,11 +42,11 @@ func (s *testAgentUpgradeSuite) TestUpgradeAgentPackage() {
 // TestDowngradeAgentPackage tests that it's possible to downgrade the Datadog Agent using the Datadog installer.
 func (s *testAgentUpgradeSuite) TestDowngradeAgentPackage() {
 	// Arrange
-	_, err := s.Installer().InstallPackage(installerwindows.AgentPackage)
+	_, err := s.Installer().InstallPackage(consts.AgentPackage)
 	s.Require().NoErrorf(err, "failed to install the stable Datadog Agent package")
 
 	// Act
-	_, err = s.Installer().InstallExperiment(installerwindows.AgentPackage,
+	_, err = s.Installer().InstallExperiment(consts.AgentPackage,
 		installer.WithRegistry("install.datadoghq.com"),
 		installer.WithVersion(s.StableAgentVersion().PackageVersion()),
 		installer.WithAuthentication(""),
@@ -58,7 +59,7 @@ func (s *testAgentUpgradeSuite) TestDowngradeAgentPackage() {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, s.StableAgentVersion().Version())
 		}).
-		DirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage))
+		DirExists(consts.GetStableDirFor(consts.AgentPackage))
 }
 
 func (s *testAgentUpgradeSuite) TestExperimentFailure() {
@@ -68,7 +69,7 @@ func (s *testAgentUpgradeSuite) TestExperimentFailure() {
 	})
 
 	// Act
-	_, err := s.Installer().InstallExperiment(installerwindows.AgentPackage,
+	_, err := s.Installer().InstallExperiment(consts.AgentPackage,
 		installer.WithRegistry("install.datadoghq.com"),
 		installer.WithVersion("unknown-version"),
 		installer.WithAuthentication(""),
@@ -87,7 +88,7 @@ func (s *testAgentUpgradeSuite) TestExperimentCurrentVersion() {
 	})
 
 	// Act
-	_, err := s.Installer().InstallExperiment(installerwindows.AgentPackage,
+	_, err := s.Installer().InstallExperiment(consts.AgentPackage,
 		installer.WithRegistry("install.datadoghq.com"),
 		installer.WithVersion(s.StableAgentVersion().PackageVersion()),
 		installer.WithAuthentication(""),
@@ -100,7 +101,7 @@ func (s *testAgentUpgradeSuite) TestExperimentCurrentVersion() {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, s.StableAgentVersion().Version())
 		}).
-		DirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage))
+		DirExists(consts.GetStableDirFor(consts.AgentPackage))
 }
 
 func (s *testAgentUpgradeSuite) TestStopWithoutExperiment() {
@@ -120,7 +121,7 @@ func (s *testAgentUpgradeSuite) installStableAgent() {
 	// Arrange
 
 	// Act
-	output, err := s.Installer().InstallPackage(installerwindows.AgentPackage,
+	output, err := s.Installer().InstallPackage(consts.AgentPackage,
 		installer.WithRegistry("install.datadoghq.com"),
 		installer.WithVersion(s.StableAgentVersion().PackageVersion()),
 		installer.WithAuthentication(""),
@@ -133,14 +134,14 @@ func (s *testAgentUpgradeSuite) installStableAgent() {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, s.StableAgentVersion().Version())
 		}).
-		DirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage))
+		DirExists(consts.GetStableDirFor(consts.AgentPackage))
 }
 
 func (s *testAgentUpgradeSuite) startLatestExperiment() {
 	// Arrange
 
 	// Act
-	output, err := s.Installer().InstallExperiment(installerwindows.AgentPackage)
+	output, err := s.Installer().InstallExperiment(consts.AgentPackage)
 
 	// Assert
 	s.Require().NoErrorf(err, "failed to upgrade to the latest Datadog Agent package: %s", output)
@@ -149,14 +150,14 @@ func (s *testAgentUpgradeSuite) startLatestExperiment() {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, s.CurrentAgentVersion().GetNumberAndPre())
 		}).
-		DirExists(installerwindows.GetExperimentDirFor(installerwindows.AgentPackage))
+		DirExists(consts.GetExperimentDirFor(consts.AgentPackage))
 }
 
 func (s *testAgentUpgradeSuite) stopExperiment() {
 	// Arrange
 
 	// Act
-	output, err := s.Installer().RemoveExperiment(installerwindows.AgentPackage)
+	output, err := s.Installer().RemoveExperiment(consts.AgentPackage)
 
 	// Assert
 	s.Require().NoErrorf(err, "failed to remove the experiment for the Datadog Agent package: %s", output)
@@ -167,5 +168,5 @@ func (s *testAgentUpgradeSuite) stopExperiment() {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, s.StableAgentVersion().Version())
 		}).
-		DirExists(installerwindows.GetStableDirFor(installerwindows.AgentPackage))
+		DirExists(consts.GetStableDirFor(consts.AgentPackage))
 }

--- a/test/new-e2e/tests/installer/windows/suites/install-script/agent-user_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/agent-user_test.go
@@ -6,9 +6,11 @@
 package agenttests
 
 import (
+	"fmt"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	windowsCommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 
@@ -18,7 +20,7 @@ import (
 )
 
 type testInstallScriptWithAgentUserSuite struct {
-	installerwindows.BaseInstallerSuite
+	installerwindows.BaseSuite
 	agentUser string
 }
 
@@ -39,16 +41,19 @@ func (s *testInstallScriptWithAgentUserSuite) TestInstallScriptWithAgentUser() {
 	// Arrange
 
 	// Act
-	out, err := s.Installer().RunInstallScript(map[string]string{
+	out, err := s.InstallScript().Run(installerwindows.WithExtraEnvVars(map[string]string{
 		"DD_AGENT_USER_NAME": s.agentUser,
-	})
+	}))
 	s.T().Log(out)
 
 	// Assert
+	if s.NoError(err) {
+		fmt.Printf("%s\n", out)
+	}
 	s.Require().NoErrorf(err, "install script failed")
 	s.Require().Host(s.Env().RemoteHost).
 		HasARunningDatadogAgentService().
-		HasRegistryKey(installerwindows.RegistryKeyPath).
+		HasRegistryKey(consts.RegistryKeyPath).
 		WithValueEqual("installedUser", s.agentUser)
 	identity, err := windowsCommon.GetIdentityForUser(s.Env().RemoteHost, s.agentUser)
 	s.Require().NoError(err)

--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type testInstallScriptSuite struct {
-	installerwindows.BaseInstallerSuite
+	installerwindows.BaseSuite
 }
 
 // TestAgentInstalls tests the usage of the Datadog installer to install the Datadog Agent package.
@@ -43,10 +43,10 @@ func (s *testInstallScriptSuite) InstallLastStable() {
 	// Arrange
 
 	// Act
-	output, err := s.Installer().RunInstallScript(map[string]string{
+	output, err := s.InstallScript().Run(installerwindows.WithExtraEnvVars(map[string]string{
 		"DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT": s.StableAgentVersion().PackageVersion(),
 		"DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE":        "install.datadoghq.com",
-	})
+	}))
 
 	// Assert
 	if s.NoError(err) {

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/base_installer_package_suite.go
@@ -8,6 +8,7 @@ package installertests
 import (
 	"embed"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
@@ -15,12 +16,12 @@ import (
 //go:embed fixtures/sample_config
 var fixturesFS embed.FS
 
-// baseInstallerSuite is the base test suite for tests of the installer MSI
-type baseInstallerSuite struct {
-	installerwindows.BaseInstallerSuite
+// baseInstallerPackageSuite is the base test suite for tests of the installer MSI
+type baseInstallerPackageSuite struct {
+	installerwindows.BaseSuite
 }
 
-func (s *baseInstallerSuite) freshInstall() {
+func (s *baseInstallerPackageSuite) freshInstall() {
 	// Arrange
 
 	// Act
@@ -31,45 +32,45 @@ func (s *baseInstallerSuite) freshInstall() {
 	// Assert
 	s.requireInstalled()
 	s.Require().Host(s.Env().RemoteHost).
-		HasAService(installerwindows.ServiceName).
+		HasAService(consts.ServiceName).
 		// the service cannot start because of the missing API key
 		WithStatus("Stopped").
 		// no named pipe when service is not running
-		HasNoNamedPipe(installerwindows.NamedPipe)
+		HasNoNamedPipe(consts.NamedPipe)
 	// no status when service is not running (no daemon/named pipe)
 	_, err := s.Installer().Status()
 	s.Require().Error(err)
 }
 
-func (s *baseInstallerSuite) startServiceWithConfigFile() {
+func (s *baseInstallerPackageSuite) startServiceWithConfigFile() {
 	// Arrange
-	s.Env().RemoteHost.CopyFileFromFS(fixturesFS, "fixtures/sample_config", installerwindows.ConfigPath)
+	s.Env().RemoteHost.CopyFileFromFS(fixturesFS, "fixtures/sample_config", consts.ConfigPath)
 
 	// Act
-	s.Require().NoError(common.StartService(s.Env().RemoteHost, installerwindows.ServiceName))
+	s.Require().NoError(common.StartService(s.Env().RemoteHost, consts.ServiceName))
 
 	// Assert
 	s.Require().Host(s.Env().RemoteHost).
-		HasAService(installerwindows.ServiceName).
+		HasAService(consts.ServiceName).
 		WithStatus("Running")
 }
 
-func (s *baseInstallerSuite) requireInstalled() {
+func (s *baseInstallerPackageSuite) requireInstalled() {
 	s.Require().Host(s.Env().RemoteHost).
-		HasBinary(installerwindows.BinaryPath).
+		HasBinary(consts.BinaryPath).
 		WithSignature(agent.GetCodeSignatureThumbprints()).
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().NotEmpty(version)
 		}).
-		HasAService(installerwindows.ServiceName).
+		HasAService(consts.ServiceName).
 		WithIdentity(common.GetIdentityForSID(common.LocalSystemSID)).
-		HasRegistryKey(installerwindows.RegistryKeyPath).
+		HasRegistryKey(consts.RegistryKeyPath).
 		WithValueEqual("installedUser", agent.DefaultAgentUserName)
 }
 
-func (s *baseInstallerSuite) requireUninstalled() {
+func (s *baseInstallerPackageSuite) requireUninstalled() {
 	s.Require().Host(s.Env().RemoteHost).
-		NoFileExists(installerwindows.BinaryPath).
-		HasNoService(installerwindows.ServiceName).
-		HasNoRegistryKey(installerwindows.RegistryKeyPath)
+		NoFileExists(consts.BinaryPath).
+		HasNoService(consts.ServiceName).
+		HasNoRegistryKey(consts.RegistryKeyPath)
 }

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/rollback_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type testInstallerRollbackSuite struct {
-	baseInstallerSuite
+	baseInstallerPackageSuite
 }
 
 // TestInstallerRollback tests the MSI rollback of the Datadog Installer on a system.

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/system_integrity_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/system_integrity_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 type testSystemIntegrityInstallerSuite struct {
-	installerwindows.BaseInstallerSuite
+	installerwindows.BaseSuite
 	name  string
 	sutFn func(suite *testSystemIntegrityInstallerSuite)
 }

--- a/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/installer-package/upgrade_test.go
@@ -10,43 +10,44 @@ import (
 
 	agentVersion "github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
-	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	win "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
+	ins "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/pipeline"
 )
 
 type testInstallerUpgradesSuite struct {
-	installerwindows.BaseInstallerSuite
+	ins.BaseSuite
 }
 
 // TestInstallerUpgrades tests the upgrades of the Datadog installer on a system.
 func TestInstallerUpgrades(t *testing.T) {
-	e2e.Run(t, &testInstallerUpgradesSuite{}, e2e.WithProvisioner(winawshost.ProvisionerNoAgentNoFakeIntake()))
+	e2e.Run(t, &testInstallerUpgradesSuite{}, e2e.WithProvisioner(win.ProvisionerNoAgentNoFakeIntake()))
 }
 
 // TestUpgrades tests upgrading the stable version of the Datadog installer to the latest from the pipeline.
 func (s *testInstallerUpgradesSuite) TestUpgrades() {
 	// Arrange
 	s.Require().NoError(s.Installer().Install(
-		installerwindows.WithInstallerURLFromInstallersJSON(pipeline.StableURL, s.StableInstallerVersion().PackageVersion())),
-		installerwindows.WithMSILogFile("install.log"),
+		ins.WithOption(ins.WithInstallerURLFromInstallersJSON(pipeline.StableURL, s.StableInstallerVersion().PackageVersion()))),
+		ins.WithMSILogFile("install.log"),
 	)
 	// sanity check: make sure we did indeed install the stable version
 	s.Require().Host(s.Env().RemoteHost).
-		HasBinary(installerwindows.BinaryPath).
+		HasBinary(consts.BinaryPath).
 		// Don't check the binary signature because it could have been updated since the last stable was built
 		WithVersionEqual(s.StableInstallerVersion().Version())
 
 	// Act
 	// Install "latest" from the pipeline
 	s.Require().NoError(s.Installer().Install(
-		installerwindows.WithMSILogFile("upgrade.log"),
+		ins.WithMSILogFile("upgrade.log"),
 	))
 
 	// Assert
 	s.Require().Host(s.Env().RemoteHost).
-		HasBinary(installerwindows.BinaryPath).
+		HasBinary(consts.BinaryPath).
 		WithSignature(agent.GetCodeSignatureThumbprints()).
 		WithVersionMatchPredicate(func(version string) {
 			// We have to use a predicate and parse the installer's version here because unlike the stable format
@@ -55,7 +56,7 @@ func (s *testInstallerUpgradesSuite) TestUpgrades() {
 			//		CURRENT_AGENT_VERSION: 7.57.0-devel+git.479.c6f7923.pipeline.40641070
 			//		version: 7.57.0-devel+git.481.634b7cd
 			actualVersion, err := agentVersion.New(version, "")
-			s.Require().NoError(err, "Agent version was in the wrong format")
+			s.Require().NoErrorf(err, "Agent version %s is in the wrong format", version)
 			s.Require().Equal(s.CurrentAgentVersion().GetNumberAndPre(), actualVersion.GetNumberAndPre())
 		})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR refactors the E2E tests for Fleet Automation on Windows. Notably it renames two "base suites" that were sharing the same name, which was confusing.
It also introduces a new type for handling the `install-script` related operations instead of re-using the `installer` type.

#### Previous class diagram:
```mermaid
classDiagram
direction LR
	namespace installer {
        class BaseInstallerSuite {
        }
	}
	namespace agenttests {
        class testAgentInstallWithAgentUserSuite {
        }
        class testAgentInstallSuite {
        }
        class testAgentUpgradeSuite {
        }
        class testInstallScriptWithAgentUserSuite {
        }
        class testInstallScriptSuite {
        }
	}
    namespace installertests {
        class baseInstallerSuite {
        }
        class testSystemIntegrityInstallerSuite {
        }
        class testInstallerUpgradesSuite {
        }
        class testInstallerSuite {
        }
        class testInstallerRollbackSuite {
        }
    }
    BaseInstallerSuite <|-- testAgentInstallWithAgentUserSuite
    BaseInstallerSuite <|-- testAgentInstallSuite 
    BaseInstallerSuite <|-- testAgentUpgradeSuite
    BaseInstallerSuite <|-- testInstallScriptWithAgentUserSuite
    BaseInstallerSuite <|-- testInstallScriptSuite

    BaseInstallerSuite <|-- baseInstallerSuite
    BaseInstallerSuite <|-- testSystemIntegrityInstallerSuite
    BaseInstallerSuite <|-- testInstallerUpgradesSuite
    baseInstallerSuite <|-- testInstallerSuite
    baseInstallerSuite <|-- testInstallerRollbackSuite
```
#### New class diagram:
```mermaid
classDiagram
direction LR
	namespace installer {
        class BaseSuite {
        }
	}
	namespace agenttests {
        class testAgentInstallWithAgentUserSuite {
        }
        class testAgentInstallSuite {
        }
        class testAgentUpgradeSuite {
        }
        class testInstallScriptWithAgentUserSuite {
        }
        class testInstallScriptSuite {
        }
	}
    namespace installertests {
        class baseInstallerPackageSuite {
        }
        class testSystemIntegrityInstallerSuite {
        }
        class testInstallerUpgradesSuite {
        }
        class testInstallerSuite {
        }
        class testInstallerRollbackSuite {
        }
    }
    BaseSuite <|-- testAgentInstallWithAgentUserSuite
    BaseSuite <|-- testAgentInstallSuite 
    BaseSuite <|-- testAgentUpgradeSuite
    BaseSuite <|-- testInstallScriptWithAgentUserSuite
    BaseSuite <|-- testInstallScriptSuite

    BaseSuite <|-- baseInstallerPackageSuite
    BaseSuite <|-- testSystemIntegrityInstallerSuite
    BaseSuite <|-- testInstallerUpgradesSuite
    baseInstallerPackageSuite <|-- testInstallerSuite
    baseInstallerPackageSuite <|-- testInstallerRollbackSuite

```
### Motivation
Ease comprehension

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
E2E tests
https://datadoghq.atlassian.net/browse/WINA-1016
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->