### PR TITLE
chore(apm): consolidate inode Origin Detection

### DIFF
--- a/pkg/trace/api/container_linux_test.go
+++ b/pkg/trace/api/container_linux_test.go
@@ -96,7 +96,6 @@ func TestGetContainerID(t *testing.T) {
 	timeFudgeFactor := 24 * time.Hour
 	c := NewCache(timeFudgeFactor)
 	c.Store(time.Now().Add(timeFudgeFactor), strconv.Itoa(containerPID), containerID, nil)
-	c.Store(time.Now().Add(timeFudgeFactor), containerInode, containerID, nil)
 
 	provider := &cgroupIDProvider{
 		procRoot:   "",
@@ -171,28 +170,14 @@ func TestGetContainerID(t *testing.T) {
 		assert.Equal(t, containerID, provider.GetContainerID(req.Context(), req.Header))
 	})
 
-	t.Run("LocalData header with inode", func(t *testing.T) {
-		req, err := http.NewRequest("GET", "http://example.com", nil)
-		if !assert.NoError(t, err) {
-			t.Fail()
-		}
-		req.Header.Add(header.LocalData, inodePrefix+containerInode)
-		assert.Equal(t, containerID, provider.GetContainerID(req.Context(), req.Header))
-	})
-
 	validLocalDataLists := []string{
 		containerIDPrefix + containerID + "," + containerInode + containerInode,
 		inodePrefix + containerInode + "," + containerIDPrefix + containerID,
 		containerIDPrefix + containerID + "," + inodePrefix,
-		inodePrefix + containerInode + "," + containerIDPrefix,
 		inodePrefix + "," + containerIDPrefix + containerID,
-		containerIDPrefix + "," + inodePrefix + containerInode,
 		containerIDPrefix + containerID + ",",
-		inodePrefix + containerInode + ",",
 		"," + containerIDPrefix + containerID,
-		"," + inodePrefix + containerInode,
 		"," + containerIDPrefix + containerID + ",",
-		"," + inodePrefix + containerInode + ",",
 	}
 	for index, validLocalDataList := range validLocalDataLists {
 		t.Run(fmt.Sprintf("LocalData header as a list (%d/%d)", index, len(validLocalDataLists)), func(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Consolidate Inode resolution for APM by using the Tagger implementation.

### Motivation
This is needed to consolidate all Origin Detection resolutions to use the Tagger implementation.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by unit and E2E tests. It was also done manually

<img width="1026" alt="image" src="https://github.com/user-attachments/assets/2d7432d4-f2c6-41ca-b30c-8abc90b76b5c" />

We can see that we are not getting the container ID with `container_id_only` as this would only work with CGroup v1.

### Possible Drawbacks / Trade-offs
None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Unit tests that are specific to the Inode resolution are not needed anymore as the Tagger implementation has it's own unit tests.

This causes a change in the order of the resolutions, from:

* OriginInfo.LocalData.ContainerID
* OriginInfo.LocalData.Inode
* Datadog-Container-ID
* Process Context
* `Tagger.GenerateContainerIDFromOriginInfo`
* * OriginInfo.LocalData.ContainerID
* * OriginInfo.LocalData.ProcessID
* * OriginInfo.LocalData.Inode
* * OriginInfo.ExternalData

to

* OriginInfo.LocalData.ContainerID
* Datadog-Container-ID
* Process Context
* `Tagger.GenerateContainerIDFromOriginInfo`
* * OriginInfo.LocalData.ContainerID
* * OriginInfo.LocalData.ProcessID
* * OriginInfo.LocalData.Inode
* * OriginInfo.ExternalData

The order of the resolution itself do not impact Origin Detection.