### PR TITLE
service discovery: Add params to endpoint

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/params.go
+++ b/pkg/collector/corechecks/servicediscovery/module/params.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package module
+
+import (
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	heartbeatParam = "heartbeat"
+	heartbeatTime  = 15 * time.Minute
+)
+
+type params struct {
+	heartbeatTime time.Duration
+}
+
+func defaultParams() params {
+	return params{
+		heartbeatTime: heartbeatTime,
+	}
+}
+
+func (params params) updateQuery(query url.Values) {
+	query.Set(heartbeatParam, strconv.Itoa(int(params.heartbeatTime.Seconds())))
+}
+
+func parseDuration(raw string) (time.Duration, error) {
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, err
+	}
+
+	return time.Duration(val) * time.Second, err
+}
+
+func parseParams(query url.Values) (params, error) {
+	params := defaultParams()
+
+	raw := query.Get(heartbeatParam)
+	if raw != "" {
+		heartbeat, err := parseDuration(raw)
+		if err != nil {
+			return params, err
+		}
+		params.heartbeatTime = heartbeat
+	}
+
+	return params, nil
+}

--- a/pkg/collector/corechecks/servicediscovery/module/params_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/params_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package module
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParams(t *testing.T) {
+	def := defaultParams()
+
+	values := url.Values{}
+	params, err := parseParams(values)
+	require.NoError(t, err)
+	require.Equal(t, def, params)
+
+	values.Set(heartbeatParam, "abc")
+	_, err = parseParams(values)
+	require.Error(t, err)
+
+	values.Set(heartbeatParam, "0")
+	params, err = parseParams(values)
+	require.NoError(t, err)
+	require.Equal(t, time.Duration(0), params.heartbeatTime)
+
+	values.Set(heartbeatParam, "5")
+	params, err = parseParams(values)
+	require.NoError(t, err)
+	require.Equal(t, 5*time.Second, params.heartbeatTime)
+
+	params = defaultParams()
+	params.heartbeatTime = 2 * time.Second
+	params.updateQuery(values)
+	params, err = parseParams(values)
+	require.NoError(t, err)
+	require.Equal(t, 2*time.Second, params.heartbeatTime)
+}


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allow the endpoint to accept parameters (currently only the heartbeat time).  This is useful for debugging as well as to speed up tests in cases where mocking the time is not appropriate.

### Motivation

Split from https://github.com/DataDog/datadog-agent/pull/33602
Will be used in tests there.

### Describe how you validated your changes

Unit tests added.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->