### PR TITLE
Add uid as a tag to k[ret]probe stats

### DIFF
--- a/pkg/ebpf/telemetry/debugfs_stat_collector_linux.go
+++ b/pkg/ebpf/telemetry/debugfs_stat_collector_linux.go
@@ -81,8 +81,8 @@ func NewDebugFsStatCollector() prometheus.Collector {
 		return &NoopDebugFsStatCollector{}
 	}
 	return &DebugFsStatCollector{
-		hits:           prometheus.NewDesc(kprobeTelemetryName+"__hits", "Counter tracking number of probe hits", []string{"probe_name", "probe_type"}, nil),
-		misses:         prometheus.NewDesc(kprobeTelemetryName+"__misses", "Counter tracking number of probe misses", []string{"probe_name", "probe_type"}, nil),
+		hits:           prometheus.NewDesc(kprobeTelemetryName+"__hits", "Counter tracking number of probe hits", []string{"probe_name", "probe_type", "uid"}, nil),
+		misses:         prometheus.NewDesc(kprobeTelemetryName+"__misses", "Counter tracking number of probe misses", []string{"probe_name", "probe_type", "uid"}, nil),
 		lastProbeStats: make(map[eventKey]int),
 		tracefsRoot:    root,
 	}
@@ -95,6 +95,8 @@ func (c *DebugFsStatCollector) updateProbeStats(pid int, probeType profileType, 
 		log.Debugf("error retrieving %s probe stats: %s", probeType.String(), err)
 		return
 	}
+
+	var uid string
 	for event, st := range m {
 		parts := eventRegexp.FindStringSubmatch(event)
 		if len(parts) > 2 {
@@ -105,22 +107,24 @@ func (c *DebugFsStatCollector) updateProbeStats(pid int, probeType profileType, 
 					continue
 				}
 			}
+
 			// strip UID and PID from name
-			event = parts[1]
+			event = strings.ToLower(parts[1])
+			uid = strings.ToLower(parts[2])
 		}
 		event = strings.ToLower(event)
 
 		hitsKey := eventKey{probeType, hits, event}
 		hitsDelta := float64(int(st.Hits) - c.lastProbeStats[hitsKey])
 		if hitsDelta > 0 {
-			ch <- prometheus.MustNewConstMetric(c.hits, prometheus.CounterValue, hitsDelta, event, probeType.String())
+			ch <- prometheus.MustNewConstMetric(c.hits, prometheus.CounterValue, hitsDelta, event, probeType.String(), uid)
 		}
 		c.lastProbeStats[hitsKey] = int(st.Hits)
 
 		missesKey := eventKey{probeType, misses, event}
 		missesDelta := float64(int(st.Misses) - c.lastProbeStats[missesKey])
 		if missesDelta > 0 {
-			ch <- prometheus.MustNewConstMetric(c.misses, prometheus.CounterValue, missesDelta, event, probeType.String())
+			ch <- prometheus.MustNewConstMetric(c.misses, prometheus.CounterValue, missesDelta, event, probeType.String(), uid)
 		}
 		c.lastProbeStats[missesKey] = int(st.Misses)
 	}

--- a/pkg/ebpf/telemetry/debugfs_stat_collector_linux.go
+++ b/pkg/ebpf/telemetry/debugfs_stat_collector_linux.go
@@ -96,8 +96,9 @@ func (c *DebugFsStatCollector) updateProbeStats(pid int, probeType profileType, 
 		return
 	}
 
-	var uid string
 	for event, st := range m {
+		uid := ""
+
 		parts := eventRegexp.FindStringSubmatch(event)
 		if len(parts) > 2 {
 			// only get stats for our pid

--- a/pkg/ebpf/telemetry/debugfs_test.go
+++ b/pkg/ebpf/telemetry/debugfs_test.go
@@ -47,11 +47,11 @@ func TestGetProbeStats(t *testing.T) {
 }
 
 func TestEventRegex(t *testing.T) {
-	samples := map[string]KprobeStats{
-		"r_tcp_sendmsg_net_7178":      {Hits: 1111389857, Misses: 0},
-		"r_tcp_sendmsg_http_4256":     {Hits: 549926224, Misses: 0},
-		"p_tcp_sendmsg_security_4256": {Hits: 549925022, Misses: 0},
-		"p_tcp_set_state__4256":       {Hits: 2372974219, Misses: 155370519},
+	samples := []string{
+		"r_tcp_sendmsg_net_7178",
+		"r_tcp_sendmsg_http_4256",
+		"p_tcp_sendmsg_security_4256",
+		"p_tcp_set_state__4256",
 	}
 
 	uids := map[string]bool{
@@ -61,7 +61,7 @@ func TestEventRegex(t *testing.T) {
 		"":         true,
 	}
 
-	for event, _ := range samples {
+	for _, event := range samples {
 		parts := eventRegexp.FindStringSubmatch(event)
 		require.Greater(t, len(parts), 3)
 

--- a/pkg/ebpf/telemetry/debugfs_test.go
+++ b/pkg/ebpf/telemetry/debugfs_test.go
@@ -8,6 +8,7 @@
 package telemetry
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,4 +44,29 @@ func TestGetProbeStats(t *testing.T) {
 
 	stats = getProbeStats(1, testProfile)
 	require.Empty(t, stats)
+}
+
+func TestEventRegex(t *testing.T) {
+	samples := map[string]KprobeStats{
+		"r_tcp_sendmsg_net_7178":      {Hits: 1111389857, Misses: 0},
+		"r_tcp_sendmsg_http_4256":     {Hits: 549926224, Misses: 0},
+		"p_tcp_sendmsg_security_4256": {Hits: 549925022, Misses: 0},
+		"p_tcp_set_state__4256":       {Hits: 2372974219, Misses: 155370519},
+	}
+
+	uids := map[string]bool{
+		"net":      true,
+		"http":     true,
+		"security": true,
+		"":         true,
+	}
+
+	for event, _ := range samples {
+		parts := eventRegexp.FindStringSubmatch(event)
+		require.Greater(t, len(parts), 3)
+
+		uid := strings.ToLower(parts[2])
+		_, ok := uids[uid]
+		require.True(t, ok)
+	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds UID as a new tag to k[ret]probe hits/misses stats.

### Motivation
De-duplicate metrics different UIDs attach kprobes to the same kernel function.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Functional test added in PR.


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->