### PR TITLE
PR Commenter don't fail if PR missing

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -388,6 +388,7 @@ def pr_commenter(
     delete: bool = False,
     force_delete: bool = False,
     echo: bool = False,
+    fail_on_pr_missing: bool = False,
 ):
     """
     Will comment or update current comment posted on the PR with the new data.
@@ -397,6 +398,7 @@ def pr_commenter(
     - delete: If True and the body is empty, will delete the comment.
     - force_delete: Won't throw error if the comment to delete is not found.
     - echo: Print comment content to stdout.
+    - fail_on_pr_missing: If True, will raise an error if the PR is not found. Only a warning is printed otherwise.
 
     Inspired by the pr-commenter binary from <https://github.com/DataDog/devtools>
     """
@@ -413,6 +415,9 @@ def pr_commenter(
     if pr_id is None:
         branch = os.environ["CI_COMMIT_BRANCH"]
         prs = list(github.get_pr_for_branch(branch))
+        if len(prs) == 0 and not fail_on_pr_missing:
+            print(f'{color_message("Warning", Color.ORANGE)}: No PR found for branch {branch}, skipping PR comment')
+            return
         assert len(prs) == 1, f"Expected 1 PR for branch {branch}, found {len(prs)} PRs"
         pr = prs[0]
     else:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

By default, the pr-commenter task won't fail if the PR is not created yet.

### Motivation

The goal is to make all jobs from the notify stage not failing, except if it's an important failure we have to fix.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Test:

![image](https://github.com/user-attachments/assets/39e8e470-b6de-4aba-8d53-45fec44f836b)
