### PR TITLE
Improve the 'Failed to create source' error message to include some hints as to what failed

### DIFF
--- a/pkg/logs/launchers/integration/launcher.go
+++ b/pkg/logs/launchers/integration/launcher.go
@@ -146,7 +146,7 @@ func (s *Launcher) run() {
 func (s *Launcher) receiveSources(cfg integrations.IntegrationConfig) {
 	sources, err := ad.CreateSources(cfg.Config)
 	if err != nil {
-		ddLog.Errorf("Failed to create source for %q: %v", cfg.Config.Name, err)
+		ddLog.Errorf("Failed to create source for %q (provider: '%s', serviceID: '%s', source: '%s'): %v", cfg.Config.Name, cfg.Config.Provider, cfg.Config.ServiceID, cfg.Config.Source, err)
 		return
 	}
 


### PR DESCRIPTION

### What does this PR do?
Improves the 'Failed to create source' error message to include some hints as to what failed

### Motivation
![Screenshot 2025-02-06 at 11 14 49 AM](https://github.com/user-attachments/assets/f26c0df7-10fa-4eb1-a466-78a975c1b813)
This is very difficult to debug in large cluster! Something is failing too parse, but I do not know what!


### Describe how you validated your changes
It's valid go! I have not run local tests, still getting up to speed on this codebase

### Possible Drawbacks / Trade-offs
Perhaps theres a better / more standard way of annotating the Error log?

