### PR TITLE
[NDM] Use agent logger in GoFlow

### DIFF
--- a/comp/netflow/goflowlib/flowstate.go
+++ b/comp/netflow/goflowlib/flowstate.go
@@ -58,7 +58,7 @@ func StartFlowRoutine(
 	var flowState FlowRunnableState
 
 	formatDriver := NewAggregatorFormatDriver(flowInChan, namespace, listenerFlowCount)
-	logrusLogger := GetLogrusLevel(logger)
+	goflowLogger := &GoflowLoggerAdapter{logger}
 	ctx := context.Background()
 
 	switch flowType {
@@ -71,18 +71,18 @@ func StartFlowRoutine(
 
 		state := netflowstate.NewStateNetFlow(fieldMappings)
 		state.Format = formatDriver
-		state.Logger = logrusLogger
+		state.Logger = goflowLogger
 		state.TemplateSystem = templateSystem
 		flowState = state
 	case common.TypeSFlow5:
 		state := utils.NewStateSFlow()
 		state.Format = formatDriver
-		state.Logger = logrusLogger
+		state.Logger = goflowLogger
 		flowState = state
 	case common.TypeNetFlow5:
 		state := utils.NewStateNFLegacy()
 		state.Format = formatDriver
-		state.Logger = logrusLogger
+		state.Logger = goflowLogger
 		flowState = state
 	default:
 		return nil, fmt.Errorf("unknown flow type: %s", flowType)

--- a/comp/netflow/goflowlib/logger.go
+++ b/comp/netflow/goflowlib/logger.go
@@ -15,26 +15,32 @@ type GoflowLoggerAdapter struct {
 	log.Component
 }
 
+// Printf logs the given formatted arguments at the info level
 func (g *GoflowLoggerAdapter) Printf(format string, params ...interface{}) {
 	g.Infof(format, params...)
 }
 
+// Errorf logs the given formatted arguments at the error level
 func (g *GoflowLoggerAdapter) Errorf(format string, params ...interface{}) {
 	g.Component.Errorf(format, params...)
 }
 
+// Error logs the given arguments, separated by spaces, at the error level
 func (g *GoflowLoggerAdapter) Error(params ...interface{}) {
 	g.Component.Error(params...)
 }
 
+// Warnf logs the given formatted arguments at the warn level
 func (g *GoflowLoggerAdapter) Warnf(format string, params ...interface{}) {
 	g.Component.Warnf(format, params...)
 }
 
+// Warn logs the given arguments, separated by spaces, at the warn level
 func (g *GoflowLoggerAdapter) Warn(params ...interface{}) {
 	g.Component.Warn(params...)
 }
 
+// Fatalf logs the given formatted arguments at the critical level
 func (g *GoflowLoggerAdapter) Fatalf(format string, params ...interface{}) {
 	g.Criticalf(format, params...)
 }

--- a/comp/netflow/goflowlib/logger.go
+++ b/comp/netflow/goflowlib/logger.go
@@ -6,38 +6,33 @@
 package goflowlib
 
 import (
-	"github.com/sirupsen/logrus"
-
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/comp/core/log/def"
 )
 
-var ddLogToLogrusLevel = map[ddlog.LogLevel]logrus.Level{
-	ddlog.TraceLvl:    logrus.TraceLevel,
-	ddlog.DebugLvl:    logrus.DebugLevel,
-	ddlog.InfoLvl:     logrus.InfoLevel,
-	ddlog.WarnLvl:     logrus.WarnLevel,
-	ddlog.ErrorLvl:    logrus.ErrorLevel,
-	ddlog.CriticalLvl: logrus.FatalLevel,
+type GoflowLoggerAdapter struct {
+	log.Component
 }
 
-// GetLogrusLevel returns logrus log level from log.GetLogLevel()
-func GetLogrusLevel(logger log.Component) *logrus.Logger {
-	// TODO: ideally this would be exposed by the log component but there were
-	// some issues getting #19033 merged. Right now this will always be the
-	// datadog log level, even if you pass in a different logger. This problem
-	// will also go away when we upgrade to the latest goflow2, as we will no
-	// longer need to interact with logrus.
-	logLevel, err := ddlog.GetLogLevel()
-	if err != nil {
-		logger.Warnf("error getting log level")
-	}
-	logrusLevel, ok := ddLogToLogrusLevel[logLevel]
-	if !ok {
-		logger.Warnf("no matching logrus level for seelog level: %s", logLevel.String())
-		logrusLevel = logrus.InfoLevel
-	}
-	logrusLogger := logrus.StandardLogger()
-	logrusLogger.SetLevel(logrusLevel)
-	return logrusLogger
+func (g *GoflowLoggerAdapter) Printf(format string, params ...interface{}) {
+	g.Infof(format, params...)
+}
+
+func (g *GoflowLoggerAdapter) Errorf(format string, params ...interface{}) {
+	g.Component.Errorf(format, params...)
+}
+
+func (g *GoflowLoggerAdapter) Error(params ...interface{}) {
+	g.Component.Error(params...)
+}
+
+func (g *GoflowLoggerAdapter) Warnf(format string, params ...interface{}) {
+	g.Component.Warnf(format, params...)
+}
+
+func (g *GoflowLoggerAdapter) Warn(params ...interface{}) {
+	g.Component.Warn(params...)
+}
+
+func (g *GoflowLoggerAdapter) Fatalf(format string, params ...interface{}) {
+	g.Criticalf(format, params...)
 }

--- a/comp/netflow/goflowlib/logger.go
+++ b/comp/netflow/goflowlib/logger.go
@@ -9,6 +9,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/log/def"
 )
 
+// GoflowLoggerAdapter is used to implement goflow's logging interface from our logger
+// https://github.com/netsampler/goflow2/blob/v1/utils/utils.go#L41-L51
 type GoflowLoggerAdapter struct {
 	log.Component
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR updates the logger we pass to GoFlow to use a logger based on our custom logger instead of logrus.

### Motivation
All logs from the previous logger (logrus) where not collected in `.log` files (only logging to stdout) which made it hard to troubleshoot Netflow support issues.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
![image](https://github.com/user-attachments/assets/122b13dd-7d9d-45d9-97fd-5f1045b35e6f)
GoFlow logs are now present in `agent.log`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->