### PR TITLE
feat(notification): Display the pipeline duration in the message

### DIFF
--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -157,6 +157,9 @@ def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCo
     commit_url_github = f"{GITHUB_BASE_URL}/{project_name}/commit/{commit.id}"
     commit_short_sha = commit.id[-8:]
     author = commit.author_name
+    finish = datetime.fromisoformat(pipeline.finished_at) if pipeline.finished_at else datetime.now(timezone.utc)
+    delta = finish - datetime.fromisoformat(pipeline.started_at)
+    duration = f"[:hourglass: {int(delta.total_seconds() / 60)} min]"
 
     # Try to find a PR id (e.g #12345) in the commit title and add a link to it in the message if found.
     pr_info = get_pr_from_commit(commit_title, project_name)
@@ -165,7 +168,7 @@ def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCo
         parsed_pr_id, pr_url_github = pr_info
         enhanced_commit_title = enhanced_commit_title.replace(f"#{parsed_pr_id}", f"<{pr_url_github}|#{parsed_pr_id}>")
 
-    return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state}.
+    return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state} {duration}.
 {enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github}|link>) by {author}"""
 
 

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -40,6 +40,8 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.return_value.trace.return_value = b"Log trace"
         repo_mock.pipelines.get.return_value.ref = "test"
         repo_mock.pipelines.get.return_value.source = "push"
+        repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
+        repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:59:48.396Z"
         list_mock = repo_mock.pipelines.get.return_value.jobs.list
         list_mock.side_effect = [get_fake_jobs(), []]
         with patch.dict('os.environ', {}, clear=True):
@@ -59,6 +61,8 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.return_value.trace.return_value = b"Log trace"
         repo_mock.pipelines.get.return_value.ref = "test"
         repo_mock.pipelines.get.return_value.source = "push"
+        repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
+        repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:59:48.396Z"
 
         failed = FailedJobs()
         failed.add_failed_job(
@@ -214,6 +218,8 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.pipelines.get.return_value.ref = "test"
         repo_mock.pipelines.get.return_value.source = "push"
+        repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
+        repo_mock.pipelines.get.return_value.finished_at = None
 
         with patch.dict('os.environ', {}, clear=True):
             notify.send_message(MockContext(), "42", dry_run=True)
@@ -236,9 +242,12 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.pipelines.get.return_value.ref = "test"
         repo_mock.pipelines.get.return_value.source = "push"
+        repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
+        repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T08:21:48.396Z"
 
         notify.send_message(MockContext(), "42", dry_run=True)
         self.assertTrue("rocket" in print_mock.mock_calls[0].args[0])
+        self.assertTrue("[:hourglass: 142 min]" in print_mock.mock_calls[0].args[0])
         trace_mock.assert_called()
         list_mock.assert_called()
         repo_mock.jobs.get.assert_called()
@@ -256,10 +265,13 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.pipelines.get.return_value.ref = "test"
         repo_mock.pipelines.get.return_value.source = "api"
+        repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
+        repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:59:48.396Z"
 
         with patch.dict('os.environ', {}, clear=True):
             notify.send_message(MockContext(), "42", dry_run=True)
         self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
+        self.assertTrue("[:hourglass: 60 min]" in print_mock.mock_calls[0].args[0])
         trace_mock.assert_called()
         list_mock.assert_called()
         repo_mock.jobs.get.assert_called()
@@ -278,9 +290,12 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
         repo_mock.pipelines.get.return_value.ref = "test"
         repo_mock.pipelines.get.return_value.source = "pipeline"
+        repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
+        repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:41:48.396Z"
 
         notify.send_message(MockContext(), "42", dry_run=True)
         self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
+        self.assertTrue("[:hourglass: 42 min]" in print_mock.mock_calls[0].args[0])
         trace_mock.assert_called()
         list_mock.assert_called()
         repo_mock.jobs.get.assert_called()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add the pipeline duration to the notification message we receive in `datadog-agent-pipelines` channel
![image](https://github.com/user-attachments/assets/ea711a8e-e9b4-4e6a-b80c-ff54c2fd91e7)


### Motivation
Even if we have monitors in the average duration of pipelines, having a direct view on it could help detect earlier anomalies.

### Describe how you validated your changes
Updated the UT
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->