### PR TITLE
[EBPF] gpu: fallback container -> device assignment in systems with only one GPU

### DIFF
--- a/pkg/gpu/context_test.go
+++ b/pkg/gpu/context_test.go
@@ -46,8 +46,25 @@ func TestFilterDevicesForContainer(t *testing.T) {
 		},
 	}
 
+	containerIDNoGpu := "abcdef2"
+	containerNoGpu := &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   containerIDNoGpu,
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name: containerIDNoGpu,
+		},
+		AllocatedResources: nil,
+	}
+
 	wmetaMock.Set(container)
 	storeContainer, err := wmetaMock.GetContainer(containerID)
+	require.NoError(t, err, "container should be found in the store")
+	require.NotNil(t, storeContainer, "container should be found in the store")
+
+	wmetaMock.Set(containerNoGpu)
+	storeContainer, err = wmetaMock.GetContainer(containerIDNoGpu)
 	require.NoError(t, err, "container should be found in the store")
 	require.NotNil(t, storeContainer, "container should be found in the store")
 
@@ -68,6 +85,19 @@ func TestFilterDevicesForContainer(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, filtered, 1)
 		testutil.RequireDeviceListsEqual(t, filtered, sysCtx.gpuDevices[deviceIndex:deviceIndex+1])
+	})
+
+	t.Run("ContainerWithNoGPUs", func(t *testing.T) {
+		_, err := sysCtx.filterDevicesForContainer(sysCtx.gpuDevices, containerIDNoGpu)
+		require.Error(t, err, "expected an error when filtering a container with no GPUs")
+	})
+
+	t.Run("ContainerWithNoGPUsButOnlyOneDeviceInSystem", func(t *testing.T) {
+		sysDevices := sysCtx.gpuDevices[:1]
+		filtered, err := sysCtx.filterDevicesForContainer(sysDevices, containerIDNoGpu)
+		require.NoError(t, err)
+		require.Len(t, filtered, 1)
+		testutil.RequireDeviceListsEqual(t, filtered, sysDevices)
 	})
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a fallback for the case where a container has no GPU devices assigned but we only have one GPU in the system. In that case, it will assign that single GPU, as there's no other option.

### Motivation

Fallback to get data in the situation where PodResources API is not accessible and we have only one GPU.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests included.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->