### PR TITLE
Remove lazy linker flag

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -324,11 +324,6 @@ def get_build_flags(
     if os.getenv('DD_CXX'):
         env['CXX'] = os.getenv('DD_CXX')
 
-    if sys.platform == 'linux' and os.getenv('GOOS') != "windows":
-        # Enable lazy binding, which seems to be overridden when loading containerd
-        # Required to fix go-nvml compilation (see https://github.com/NVIDIA/go-nvml/issues/18)
-        extldflags += "-Wl,-z,lazy "
-
     if extldflags:
         ldflags += f"'-extldflags={extldflags}' "
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
It seems those flags are not needed anymore, possibly since we now don't depend on `plugin` (through `containerd`) https://github.com/DataDog/datadog-agent/pull/32538.


### Motivation
Not use the linker flags if we can avoid it.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI is enough, if the issue still exists then the agent would fail to run.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The flags were added in https://github.com/DataDog/datadog-agent/pull/29647.