### PR TITLE
logs: skip temporary buffer between serialization and compression

### DIFF
--- a/pkg/logs/sender/serializer_test.go
+++ b/pkg/logs/sender/serializer_test.go
@@ -6,6 +6,7 @@
 package sender
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,15 +20,15 @@ func TestLineSerializer(t *testing.T) {
 
 	serializer := LineSerializer
 
-	payload = serializer.Serialize(messages)
+	payload = serializeToBytes(t, serializer, messages)
 	assert.Len(t, payload, 0)
 
 	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0)}
-	payload = serializer.Serialize(messages)
+	payload = serializeToBytes(t, serializer, messages)
 	assert.Equal(t, []byte("a"), payload)
 
 	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0), message.NewMessage([]byte("b"), nil, "", 0)}
-	payload = serializer.Serialize(messages)
+	payload = serializeToBytes(t, serializer, messages)
 	assert.Equal(t, []byte("a\nb"), payload)
 }
 
@@ -37,14 +38,23 @@ func TestArraySerializer(t *testing.T) {
 
 	serializer := ArraySerializer
 
-	payload = serializer.Serialize(messages)
+	payload = serializeToBytes(t, serializer, messages)
 	assert.Equal(t, []byte("[]"), payload)
 
 	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0)}
-	payload = serializer.Serialize(messages)
+	payload = serializeToBytes(t, serializer, messages)
 	assert.Equal(t, []byte("[a]"), payload)
 
 	messages = []*message.Message{message.NewMessage([]byte("a"), nil, "", 0), message.NewMessage([]byte("b"), nil, "", 0)}
-	payload = serializer.Serialize(messages)
+	payload = serializeToBytes(t, serializer, messages)
 	assert.Equal(t, []byte("[a,b]"), payload)
+}
+
+func serializeToBytes(t *testing.T, s Serializer, messages []*message.Message) []byte {
+	t.Helper()
+
+	var payload bytes.Buffer
+	err := s.Serialize(messages, &payload)
+	assert.NoError(t, err)
+	return payload.Bytes()
 }

--- a/pkg/util/compression/compression.go
+++ b/pkg/util/compression/compression.go
@@ -51,3 +51,21 @@ type StreamCompressor interface {
 
 // ZstdCompressionLevel is a wrapper type over int for the compression level for zstd compression, if that is selected.
 type ZstdCompressionLevel int
+
+// NoopStreamCompressor is a no-op implementation of StreamCompressor
+type NoopStreamCompressor struct {
+	io.Writer
+}
+
+// Close closes the underlying writer
+func (n *NoopStreamCompressor) Close() error {
+	if c, ok := n.Writer.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// Flush is a no-op
+func (n *NoopStreamCompressor) Flush() error {
+	return nil
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently when sending a log message to the backend, we first serialize the message to `[]byte` then compress it. With this PR, the serialization is done directly to a `io.Writer`, alllowing to do the serialization and the compression at the same time, skipping the intermediary buffer completely.

The previous code has a log needing the "uncompressed size" so this PR includes a writer wrapper that allows to compute it on the fly. If desired we could drop this log, and the wrapper altogether. 

### Motivation

### Describe how you validated your changes

This code is tested. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->