### PR TITLE
[K9VULN-3470] ci: remove deprecated fields in `datadog-static-analyzer-github-action`

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -20,7 +20,5 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_STATIC_ANALYZER_API_KEY }}
         dd_app_key: ${{ secrets.DD_STATIC_ANALYZER_APP_KEY }}
-        dd_service: datadog-agent
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2


### PR DESCRIPTION
### What does this PR do?


This PR removes [deprecated fields](https://github.com/DataDog/datadog-static-analyzer-github-action#deprecated-inputs) in the [datadog-static-analyzer-github-action](https://github.com/DataDog/datadog-static-analyzer-github-action). There should be no functional impact or changes observed, as these fields are effectively no-ops today.

### Motivation

The fields have been deprecated for some time now.

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes