### PR TITLE
[networks] Add more test timeouts

### DIFF
--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -84,7 +84,7 @@ func (s *TracerSuite) TestTCPRemoveEntries() {
 	require.NoError(t, server.Run())
 
 	// Connect to server
-	c, err := net.DialTimeout("tcp", server.Address(), 2*time.Second)
+	c, err := server.Dial()
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -104,7 +104,7 @@ func (s *TracerSuite) TestTCPRemoveEntries() {
 	c.Close()
 
 	// Create a new client
-	c2, err := net.DialTimeout("tcp", server.Address(), 1*time.Second)
+	c2, err := server.Dial()
 	require.NoError(t, err)
 
 	// Send a messages
@@ -154,7 +154,7 @@ func (s *TracerSuite) TestTCPRetransmit() {
 	require.NoError(t, server.Run())
 
 	// Connect to server
-	c, err := net.DialTimeout("tcp", server.Address(), time.Second)
+	c, err := server.Dial()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func (s *TracerSuite) TestTCPRetransmitSharedSocket() {
 	require.NoError(t, server.Run())
 
 	// Connect to server
-	c, err := net.DialTimeout("tcp", server.Address(), time.Second)
+	c, err := server.Dial()
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -291,7 +291,7 @@ func (s *TracerSuite) TestTCPRTT() {
 	t.Cleanup(server.Shutdown)
 	require.NoError(t, server.Run())
 
-	c, err := net.DialTimeout("tcp", server.Address(), time.Second)
+	c, err := server.Dial()
 	require.NoError(t, err)
 	defer c.Close()
 
@@ -399,7 +399,7 @@ func (s *TracerSuite) TestConnectionExpirationRegression() {
 	t.Cleanup(server.Shutdown)
 	require.NoError(t, server.Run())
 
-	c, err := net.DialTimeout("tcp", server.Address(), time.Second)
+	c, err := server.Dial()
 	require.NoError(t, err)
 
 	// Write 5 bytes to TCP socket
@@ -2821,7 +2821,7 @@ func skipEbpflessTodo(t *testing.T, cfg *config.Config) {
 }
 
 func getHandshakeBuffer(t *testing.T, srvAddr string) []byte {
-	rawConn, err := net.Dial("tcp", srvAddr)
+	rawConn, err := tracertestutil.DialTCP("tcp", srvAddr)
 	require.NoError(t, err)
 	defer rawConn.Close()
 
@@ -2836,7 +2836,7 @@ func getHandshakeBuffer(t *testing.T, srvAddr string) []byte {
 
 func waitForTracer(t *testing.T, tr *Tracer, srvAddr string) {
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		client, err := net.Dial("tcp", srvAddr)
+		client, err := tracertestutil.DialTCP("tcp", srvAddr)
 		require.NoError(collect, err)
 		defer client.Close()
 
@@ -2882,7 +2882,7 @@ func (s *TracerSuite) TestRawTLSClient() {
 	require.NoError(t, tr.RegisterClient(clientID))
 
 	t.Run("TLS then HTTP", func(t *testing.T) {
-		conn, err := net.Dial("tcp", srv.Address())
+		conn, err := tracertestutil.DialTCP("tcp", srv.Address())
 		require.NoError(t, err)
 		defer conn.Close()
 
@@ -2911,7 +2911,7 @@ func (s *TracerSuite) TestRawTLSClient() {
 	require.NoError(t, tr.RegisterClient(clientID))
 
 	t.Run("HTTP then TLS", func(t *testing.T) {
-		conn, err := net.Dial("tcp", srv.Address())
+		conn, err := tracertestutil.DialTCP("tcp", srv.Address())
 		require.NoError(t, err)
 		defer conn.Close()
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
+	tracertestutil "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/testdns"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -1105,7 +1106,7 @@ func (s *TracerSuite) TestTCPEstablished() {
 	t.Cleanup(server.Shutdown)
 	require.NoError(t, server.Run())
 
-	c, err := net.DialTimeout("tcp", server.Address(), 50*time.Millisecond)
+	c, err := tracertestutil.DialTCP("tcp", server.Address())
 	require.NoError(t, err)
 
 	laddr, raddr := c.LocalAddr(), c.RemoteAddr()
@@ -1304,7 +1305,7 @@ func (s *TracerSuite) TestTCPFailureConnectionRefused() {
 
 	// try to connect to a port where no server is accepting connections
 	srvAddr := "127.0.0.1:9998"
-	conn, err := net.Dial("tcp", srvAddr)
+	conn, err := tracertestutil.DialTCP("tcp", srvAddr)
 	if err == nil {
 		conn.Close() // If the connection unexpectedly succeeds, close it immediately.
 		require.Fail(t, "expected connection to be refused, but it succeeded")
@@ -1350,7 +1351,7 @@ func (s *TracerSuite) TestTCPFailureConnectionResetWithData() {
 	t.Cleanup(srv.Shutdown)
 
 	serverAddr := srv.Address()
-	c, err := net.Dial("tcp", serverAddr)
+	c, err := tracertestutil.DialTCP("tcp", serverAddr)
 	require.NoError(t, err, "could not connect to server: ", err)
 
 	// Write to the server and expect a reset
@@ -1403,7 +1404,7 @@ func (s *TracerSuite) TestTCPFailureConnectionResetNoData() {
 	t.Cleanup(srv.Shutdown)
 
 	serverAddr := srv.Address()
-	c, err := net.Dial("tcp", serverAddr)
+	c, err := tracertestutil.DialTCP("tcp", serverAddr)
 	require.NoError(t, err, "could not connect to server: ", err)
 
 	// Wait briefly to give the server time to close the connection

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
-	tracertestutil "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil/testdns"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -1106,7 +1105,7 @@ func (s *TracerSuite) TestTCPEstablished() {
 	t.Cleanup(server.Shutdown)
 	require.NoError(t, server.Run())
 
-	c, err := tracertestutil.DialTCP("tcp", server.Address())
+	c, err := testutil.DialTCP("tcp", server.Address())
 	require.NoError(t, err)
 
 	laddr, raddr := c.LocalAddr(), c.RemoteAddr()
@@ -1305,7 +1304,7 @@ func (s *TracerSuite) TestTCPFailureConnectionRefused() {
 
 	// try to connect to a port where no server is accepting connections
 	srvAddr := "127.0.0.1:9998"
-	conn, err := tracertestutil.DialTCP("tcp", srvAddr)
+	conn, err := testutil.DialTCP("tcp", srvAddr)
 	if err == nil {
 		conn.Close() // If the connection unexpectedly succeeds, close it immediately.
 		require.Fail(t, "expected connection to be refused, but it succeeded")
@@ -1351,7 +1350,7 @@ func (s *TracerSuite) TestTCPFailureConnectionResetWithData() {
 	t.Cleanup(srv.Shutdown)
 
 	serverAddr := srv.Address()
-	c, err := tracertestutil.DialTCP("tcp", serverAddr)
+	c, err := testutil.DialTCP("tcp", serverAddr)
 	require.NoError(t, err, "could not connect to server: ", err)
 
 	// Write to the server and expect a reset
@@ -1404,7 +1403,7 @@ func (s *TracerSuite) TestTCPFailureConnectionResetNoData() {
 	t.Cleanup(srv.Shutdown)
 
 	serverAddr := srv.Address()
-	c, err := tracertestutil.DialTCP("tcp", serverAddr)
+	c, err := testutil.DialTCP("tcp", serverAddr)
 	require.NoError(t, err, "could not connect to server: ", err)
 
 	// Wait briefly to give the server time to close the connection


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This test adds timeouts to some remaining TCP dials

### Motivation
Fix timeout flakes

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI will test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->