### PR TITLE
2 small cgroup parsing fixes

### DIFF
--- a/pkg/util/cgroups/pid_mapper.go
+++ b/pkg/util/cgroups/pid_mapper.go
@@ -169,7 +169,7 @@ func (pm *procPidMapper) refreshMapping(cacheValidity time.Duration) {
 				return nil
 			}
 
-			pid, err := strconv.ParseInt(de.Name(), 10, 64)
+			pid, err := strconv.ParseInt(de.Name(), 10, 0)
 			if err != nil {
 				return godirwalk.SkipThis
 			}

--- a/pkg/util/cgroups/readerv2.go
+++ b/pkg/util/cgroups/readerv2.go
@@ -57,9 +57,6 @@ func (r *readerV2) parseCgroups() (map[string]Cgroup, error) {
 						return err
 					}
 					res[id] = newCgroupV2(id, r.cgroupRoot, relPath, r.cgroupControllers, r.pidMapper)
-					if err != nil {
-						return err
-					}
 				}
 
 				return err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes 2 small issues with `pkg/util/cgroup`:
- a duplicated error handling when parsing cgroup v2 entries
- the bit size used in `strconv.ParseInt` in the pid mapper was not matching how it was used 

### Motivation

Those errors were uncovered while working on https://github.com/DataDog/datadog-agent/pull/33438

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->