### PR TITLE
aggregator: reduce allocation related to `log.Trace`

### DIFF
--- a/pkg/aggregator/sender.go
+++ b/pkg/aggregator/sender.go
@@ -185,7 +185,9 @@ func (s *checkSender) sendMetricSample(
 ) {
 	tags = append(tags, s.checkTags...)
 
-	log.Trace(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+	if log.ShouldLog(log.TraceLvl) {
+		log.Trace(mType.String(), " sample: ", metric, ": ", value, " for hostname: ", hostname, " tags: ", tags)
+	}
 
 	if timestamp == 0 {
 		timestamp = timeNowNano()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[Some profiles on production](https://app.datadoghq.com/profiling/explorer?query=service%3Adatadog-agent%20language%3Ago&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZTm_yEro1_4rwAAABhBWlRtX3lRWUFBQmI5MG1SNkc0UnB3QUEAAAAkMDE5NGU3MDAtZWI1OS00MGM2LWE3N2YtMjAzNDY5ZTIyY2ViAAcdnA&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&my_code=disabled&profile_type=alloc-size&profileId=AZTm_yQYAABb90mR6G4RpwAA&refresh_mode=paused&stream_sort=%40metrics.core_cpu_cores%2Cdesc&viz=stream&from_ts=1739041210025&to_ts=1739044810025&live=false) shows that this `log.Trace` can represent ~10% of all the allocations of the core agent. This PR skips the `log.Trace` if the log level is not trace.

The main issue with `log.Trace` is that the compiler is not able to inline enough to make the log level check be evaluated before the variadic argument pack creation. Resulting in allocations even if the log level is not trace.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->