### PR TITLE
logs: do not copy non matching content when apply `MaskSequences`

### DIFF
--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -277,7 +277,9 @@ func (p *Processor) applyRedactingRules(msg *message.Message) bool {
 				return false
 			}
 		case config.MaskSequences:
-			content = rule.Regex.ReplaceAll(content, rule.Placeholder)
+			if rule.Regex.Match(content) {
+				content = rule.Regex.ReplaceAll(content, rule.Placeholder)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`regexp.ReplaceAll` always returns a copy of the given buffer, even when there is no match. Since we can reasonably expect the no match case to happen more often than not, this PR optimizes this behavior by first checking if there is a match and if there is by calling replace all. The advantage is that we skip the copy in the case of a no-match, and `regexp.Match` can also be faster since it does not track groups.


Benchmark:
```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/logs/processor
cpu: Apple M1 Max
                                 │ before.txt  │              after.txt              │
                                 │   sec/op    │   sec/op     vs base                │
MaskSequences/always_matching-10   333.3n ± 3%   576.5n ± 2%  +72.97% (p=0.000 n=10)
MaskSequences/never_matching-10    54.42n ± 1%   10.24n ± 1%  -81.17% (p=0.000 n=10)

                                 │ before.txt │                after.txt                │
                                 │    B/op    │    B/op     vs base                     │
MaskSequences/always_matching-10   40.00 ± 0%   40.00 ± 0%         ~ (p=1.000 n=10) ¹
MaskSequences/never_matching-10    40.00 ± 0%    0.00 ± 0%  -100.00% (p=0.000 n=10)

                                 │ before.txt │                after.txt                │
                                 │ allocs/op  │ allocs/op   vs base                     │
MaskSequences/always_matching-10   2.000 ± 0%   2.000 ± 0%         ~ (p=1.000 n=10) ¹
MaskSequences/never_matching-10    2.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

### Motivation

Internally we deploy the agent with the following rule:
```
    log_processing_rules:
      - type: mask_sequences
        name: mask_api_keys
        replace_placeholder: "api_key=****************************"
        pattern: (?:api_key=[a-f0-9]{28})
      - type: mask_sequences
        name: mask_app_keys
        replace_placeholder: "application_key=************************************"
        pattern: (?:application_key=[a-f0-9]{36})
```
resulting in [some interesting profiles](https://app.datadoghq.com/profiling/explorer?query=service%3Adatadog-agent%20language%3Ago&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZTm89XuR6Vh-wAAABhBWlRtODlaWUFBRER2cXVocEQyMTF3QUEAAAAkMDE5NGU2ZjUtOTUxZS00NzlmLWI5MWMtMzY0YjBkMGVhZDU0AAiqIQ&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&my_code=disabled&profile_type=alloc-size&profileId=AZTm89ZYAADDvquhpD211wAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1739041210025&to_ts=1739044810025&live=false) 

### Describe how you validated your changes

Unit tests are enough for this.

### Possible Drawbacks / Trade-offs

In the case of a match, we will need to run the regexp twice.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->