### PR TITLE
Remove test files from the python site-packages folder

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -225,16 +225,21 @@ build do
   command "#{python} -m pip check"
 
   # Removing tests that don't need to be shipped in the embedded folder
-  if windows_target?
-    delete "#{python_3_embedded}/Lib/site-packages/Cryptodome/SelfTest/"
-    delete "#{python_3_embedded}/Lib/site-packages/openstack/tests/"
-    delete "#{python_3_embedded}/Lib/site-packages/psutil/tests/"
-    delete "#{python_3_embedded}/Lib/site-packages/test/" # cm-client
-  else
-    delete "#{install_dir}/embedded/lib/python#{python_version}/site-packages/Cryptodome/SelfTest/"
-    delete "#{install_dir}/embedded/lib/python#{python_version}/site-packages/openstack/tests/"
-    delete "#{install_dir}/embedded/lib/python#{python_version}/site-packages/psutil/tests/"
-    delete "#{install_dir}/embedded/lib/python#{python_version}/site-packages/test/" # cm-client
+  test_folders = [
+    'Cryptodome/SelfTest',
+    'openstack/tests',
+    'psutil/tests',
+    'test', # cm-client
+    'securesystemslib/_vendor/ed25519/test_data',
+    'setuptools/tests',
+    'supervisor/tests',
+  ]
+  test_folders.each do |test_folder|
+    if windows_target?
+      delete "#{python_3_embedded}/Lib/site-packages/#{test_folder}/"
+    else
+      delete "#{install_dir}/embedded/lib/python#{python_version}/site-packages/#{test_folder}/"
+    end
   end
 
   # Ship `requirements-agent-release.txt` file containing the versions of every check shipped with the agent


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Refactor the way we drop tests in the site-package folder
- Remove some extra test folders

### Motivation

- Simplify the recipe for the integrations
- Reduce the size of the final package

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->