### PR TITLE
usm: http2: Make TestHTTP2KernelTelemetry generic per HTTP2_TELEMETRY_MAX_PATH_LEN

### DIFF
--- a/pkg/network/protocols/http2/telemetry.go
+++ b/pkg/network/protocols/http2/telemetry.go
@@ -27,7 +27,7 @@ type kernelTelemetry struct {
 	// endOfStreamRST Count of RST flags seen
 	endOfStreamRST *libtelemetry.TLSAwareCounter
 	// pathSizeBucket Count of path sizes divided into buckets.
-	pathSizeBucket [http2PathBuckets + 1]*libtelemetry.TLSAwareCounter
+	pathSizeBucket [PathBucketsCount + 1]*libtelemetry.TLSAwareCounter
 	// literalValueExceedsFrame Count of times we couldn't retrieve the literal value due to reaching the end of the frame.
 	literalValueExceedsFrame *libtelemetry.TLSAwareCounter
 	// exceedingMaxInterestingFrames Count of times we reached the max number of frames per iteration.
@@ -113,10 +113,10 @@ func (t *HTTP2Telemetry) Sub(other HTTP2Telemetry) *HTTP2Telemetry {
 	}
 }
 
-func computePathSizeBucketDifferences(pathSizeBucket, otherPathSizeBucket [http2PathBuckets + 1]uint64) [http2PathBuckets + 1]uint64 {
-	var result [http2PathBuckets + 1]uint64
+func computePathSizeBucketDifferences(pathSizeBucket, otherPathSizeBucket [PathBucketsCount + 1]uint64) [PathBucketsCount + 1]uint64 {
+	var result [PathBucketsCount + 1]uint64
 
-	for i := 0; i < http2PathBuckets+1; i++ {
+	for i := 0; i < PathBucketsCount+1; i++ {
 		result[i] = pathSizeBucket[i] - otherPathSizeBucket[i]
 	}
 

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -16,7 +16,7 @@ import "C"
 
 const (
 	maxHTTP2Path        = C.HTTP2_MAX_PATH_LEN
-	http2PathBuckets    = C.HTTP2_TELEMETRY_PATH_BUCKETS
+	PathBucketsCount    = C.HTTP2_TELEMETRY_PATH_BUCKETS
 	MaxTelemetryPathLen = C.HTTP2_TELEMETRY_MAX_PATH_LEN
 	PathBucketSize      = C.HTTP2_TELEMETRY_PATH_BUCKETS_SIZE
 	// The kernel limit per page in the per-cpu array of the http2 terminated connections map.

--- a/pkg/network/protocols/http2/types.go
+++ b/pkg/network/protocols/http2/types.go
@@ -15,8 +15,10 @@ package http2
 import "C"
 
 const (
-	maxHTTP2Path     = C.HTTP2_MAX_PATH_LEN
-	http2PathBuckets = C.HTTP2_TELEMETRY_PATH_BUCKETS
+	maxHTTP2Path        = C.HTTP2_MAX_PATH_LEN
+	http2PathBuckets    = C.HTTP2_TELEMETRY_PATH_BUCKETS
+	MaxTelemetryPathLen = C.HTTP2_TELEMETRY_MAX_PATH_LEN
+	PathBucketSize      = C.HTTP2_TELEMETRY_PATH_BUCKETS_SIZE
 	// The kernel limit per page in the per-cpu array of the http2 terminated connections map.
 	HTTP2TerminatedBatchSize = C.HTTP2_TERMINATED_BATCH_SIZE
 	// The upper limit for the size of the raw status code.

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -5,7 +5,7 @@ package http2
 
 const (
 	maxHTTP2Path        = 0xa0
-	http2PathBuckets    = 0x7
+	PathBucketsCount    = 0x7
 	MaxTelemetryPathLen = 0x78
 	PathBucketSize      = 0xa
 

--- a/pkg/network/protocols/http2/types_linux.go
+++ b/pkg/network/protocols/http2/types_linux.go
@@ -4,8 +4,10 @@
 package http2
 
 const (
-	maxHTTP2Path     = 0xa0
-	http2PathBuckets = 0x7
+	maxHTTP2Path        = 0xa0
+	http2PathBuckets    = 0x7
+	MaxTelemetryPathLen = 0x78
+	PathBucketSize      = 0xa
 
 	HTTP2TerminatedBatchSize = 0x55
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Makes `TestHTTP2KernelTelemetry` generic per `HTTP2_TELEMETRY_MAX_PATH_LEN`

Introducing a helper function to generate an input string with a desired huffman encoded representation
### Motivation

1. Removing hard-coded and unclear values
2. Allow generating fixed size huffman encoded strings
3. Allow more tests to use strings with known-length huffman encoded represntation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->