### PR TITLE
[usm] Move telemetry goroutine from network-tracer to the usm monitor

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -50,7 +50,7 @@ var networkTracerModuleConfigNamespaces = []string{"network_config", "service_mo
 
 const maxConntrackDumpSize = 3000
 
-func createNetworkTracerModule(cfg *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
+func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
 	ncfg := networkconfig.New()
 
 	// Checking whether the current OS + kernel version is supported by the tracer
@@ -69,7 +69,7 @@ func createNetworkTracerModule(cfg *sysconfigtypes.Config, deps module.FactoryDe
 
 	done := make(chan struct{})
 	if err == nil {
-		startTelemetryReporter(cfg, done)
+		startTelemetryReporter(done)
 	}
 
 	return &networkTracer{tracer: t, done: done}, err
@@ -363,7 +363,7 @@ func writeConnections(w http.ResponseWriter, marshaler marshal.Marshaler, cs *ne
 	log.Tracef("/connections: %d connections", len(cs.Conns))
 }
 
-func startTelemetryReporter(_ *sysconfigtypes.Config, done <-chan struct{}) {
+func startTelemetryReporter(done <-chan struct{}) {
 	telemetry.SetStatsdClient(statsd.Client)
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Moves USM's telemetry goroutine from the network tracer to the USM monitor.

### Motivation

Encapsulate all USM logic under its monitor.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->