### PR TITLE
[workloadmeta/collectors/ecs] Leave runtime empty

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
@@ -102,7 +102,6 @@ func (c *collector) parseTaskContainers(
 			Type:   workloadmeta.EventTypeSet,
 			Entity: &workloadmeta.Container{
 				EntityID: entityID,
-				Runtime:  workloadmeta.ContainerRuntimeDocker,
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: container.DockerName,
 				},
@@ -110,6 +109,35 @@ func (c *collector) parseTaskContainers(
 					Status: workloadmeta.ContainerStatusUnknown,
 					Health: workloadmeta.ContainerHealthUnknown,
 				},
+				// Edge Case: Setting the runtime to "docker" causes issues,
+				// although it's correct.
+				//
+				// In ECS, the logs agent assigns the "source" and "service"
+				// tags based on the name of the container image. The ECS v1
+				// collector does not gather container image information; only
+				// the Docker collector does. As a result, the information
+				// becomes complete only after the Docker collector has
+				// processed the container.
+				//
+				// If the runtime is set here and the ECS collector runs before
+				// the Docker collector, and the logs check configuration is
+				// generated before the Docker collector stores the information,
+				// the image details will be missing. As a result, the logs
+				// configuration will have an incorrect "source" and "service"
+				// tags.
+				//
+				// Setting an empty runtime here is a workaround to ensure that
+				// the "source" and "service" tags are correct. The reason is
+				// that autodiscovery is not expecting an empty runtime because
+				// it uses it to generate the AD identifiers and things like the
+				// service ID. Also, the logs agent rejects config with an empty
+				// service ID. As a result, with an empty runtime, the logs
+				// config will not be created until the Docker collector has run
+				// and the image info is available.
+				//
+				// TODO: Remove this workaround when there's a better way of
+				// handling this in AD + logs agent.
+				Runtime: "",
 			},
 		})
 	}

--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser_test.go
@@ -23,6 +23,7 @@ import (
 // which is the default parser when other metadata endpoints are not available.
 func TestPullWithV1Parser(t *testing.T) {
 	entityID := "task1"
+	containerID := "someID"
 	tags := map[string]string{"foo": "bar"}
 
 	tests := []struct {
@@ -55,7 +56,7 @@ func TestPullWithV1Parser(t *testing.T) {
 						{
 							Arn: entityID,
 							Containers: []v1.Container{
-								{DockerID: "foo"},
+								{DockerID: containerID},
 							},
 						},
 					}, nil
@@ -83,6 +84,13 @@ func TestPullWithV1Parser(t *testing.T) {
 
 			taskTags := c.resourceTags[entityID].tags
 			assert.Equal(t, taskTags, test.expectedTags)
+
+			// This is only needed because of the workaround about the empty
+			// runtime documented in the parseTaskContainers function. Remove
+			// this when the workaround is no longer needed.
+			storedContainer, err := c.store.GetContainer(containerID)
+			require.NoError(t, err)
+			assert.Empty(t, storedContainer.Runtime)
 		})
 	}
 

--- a/releasenotes/notes/fix-ecs-runtime-3e75bbcb8d328b1d.yaml
+++ b/releasenotes/notes/fix-ecs-runtime-3e75bbcb8d328b1d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where the "source" and "service" tags were incorrectly set to
+    "kubernetes" in logs when the Agent runs on ECS EC2.


### PR DESCRIPTION
### What does this PR do?

Fixes issue where the "source" and "service" tags are incorrectly set to "kubernetes" in logs when the Agent runs on ECS EC2.

The PR https://github.com/DataDog/datadog-agent/pull/32668 set the runtime for containers collected by the ECS collector when using the v1 parser. The change made sense but broke the logs in a really unexpected way.

We need to leave the runtime empty as it was before the change. I'll try to explain the reason.

In ECS, the logs agent assigns the "source" and "service" tags based on the name of the container image. The ECS v1 collector does not gather container image information; only the Docker collector does. As a result, the information becomes complete only after the Docker collector has processed the container.

If the runtime is set by the the ECS collector, and it runs before the Docker collector, and the logs check configuration is generated before the Docker collector stores the information, the image details will be missing. As a result, the logs configuration will have an incorrect "source" and "service" tags. More specifically, it defaults to "kubernetes" for both, which doesn't make sense on ECS EC2.

Setting an empty runtime is a workaround (I don't know if it was like that before the PR mentioned above intentionally or not) to ensure that the "source" and "service" tags are correct. The reason is that autodiscovery is not expecting an empty runtime because it uses it to generate the AD identifiers and things like the service ID. Also, the logs agent rejects config with an empty service ID. As a result, with an empty runtime, the logs config will not be created until the Docker collector has run and the image info is available.

Some links in the code about this:
- This is where the "kubernetes default comes from:
https://github.com/DataDog/datadog-agent/blob/60a8883df322de46879d7f5ab799058fcc4b57b7/pkg/logs/launchers/container/tailerfactory/defaults.go#L91
- This is the function that sets the entity name for a container used in AD and other places. It's empty when there's no runtime:
https://github.com/DataDog/datadog-agent/blob/60a8883df322de46879d7f5ab799058fcc4b57b7/pkg/util/containers/entity.go#L22
- This is where the function in the previous point is used to build the service ID, which is also going to be empty when there's no runtime:
https://github.com/DataDog/datadog-agent/blob/60a8883df322de46879d7f5ab799058fcc4b57b7/comp/core/autodiscovery/listeners/service.go#L67
- This is where logs agent refuses a config that doesn't have a service ID:
https://github.com/DataDog/datadog-agent/blob/60a8883df322de46879d7f5ab799058fcc4b57b7/pkg/logs/schedulers/ad/scheduler.go#L242

Note that this only applies to the case where the v1 endpoint is used which was the default when the issue was introduced, but it's no longer the case.

Also, the original bug addressed by https://github.com/DataDog/datadog-agent/pull/32668 no longer needs the runtime to be set thanks to this PR: https://github.com/DataDog/datadog-agent/pull/32769


### Describe how you validated your changes

I deployed on ECS EC2. Deployed several tasks and verified that the "source" and "service" tags were correct.
