### PR TITLE
[CWS] Do not use fentry if `tasks_rcu_exit_srcu` kernel symbol is found

### DIFF
--- a/pkg/ebpf/kernel_bugs.go
+++ b/pkg/ebpf/kernel_bugs.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package ebpf
+
+// HasTasksRCUExitLockSymbol returns true if the tasks_rcu_exit_srcu symbol is found in the kernel symbols.
+// The tasks_rcu_exit_srcu lock might cause a deadlock when removing fentry trampolines.
+// This was fixed by https://github.com/torvalds/linux/commit/1612160b91272f5b1596f499584d6064bf5be794
+func HasTasksRCUExitLockSymbol() (bool, error) {
+	const tasksRCUExitLockSymbol = "tasks_rcu_exit_srcu"
+	missingSymbols, err := VerifyKernelFuncs(tasksRCUExitLockSymbol)
+	if err != nil {
+		return false, err
+	}
+
+	// VerifyKernelFuncs returns the missing symbols
+	_, isMissing := missingSymbols[tasksRCUExitLockSymbol]
+	return !isMissing, nil
+}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -244,18 +244,14 @@ func (p *EBPFProbe) selectFentryMode() {
 		return
 	}
 
-	// Do not use fentry if the kernel has the tasks_rcu_exit_srcu lock, might cause a deadlock when system-probe exists
-	// This is fixed by https://github.com/torvalds/linux/commit/1612160b91272f5b1596f499584d6064bf5be794
-	const tasksRCUExitDeadLockSymbol = "tasks_rcu_exit_srcu"
-	missingSymbols, err := ddebpf.VerifyKernelFuncs(tasksRCUExitDeadLockSymbol)
+	hasPotentialFentryDeadlock, err := ddebpf.HasTasksRCUExitLockSymbol()
 	if err != nil {
 		p.useFentry = false
-		seclog.Warnf("fentry enabled but failed to verify kernel lock symbol, falling back to kprobe mode")
+		seclog.Warnf("fentry enabled but failed to verify kernel symbols, falling back to kprobe mode")
 		return
 	}
 
-	// VerifyKernelFuncs returns the missing symbols
-	if _, ok := missingSymbols[tasksRCUExitDeadLockSymbol]; !ok {
+	if hasPotentialFentryDeadlock {
 		p.useFentry = false
 		seclog.Warnf("fentry enabled but lock responsible for deadlock was found in kernel symbols, falling back to kprobe mode")
 		return


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Revert back to kprobe mode when `tasks_rcu_exit_srcu` lock is found in kernel symbols.
This lock might cause a deadlock when system-probe exits, and was removed upstream by the following commit (https://github.com/torvalds/linux/commit/1612160b91272f5b1596f499584d6064bf5be794).

Credits to @usamasaqib for the investigation.

### Motivation

### Describe how you validated your changes

Tested with fentry enabled (`DD_EVENT_MONITORING_CONFIG_EVENT_STREAM_USE_FENTRY=true`) on:
- Ubuntu kernel `6.8.0-53-generic`: made sure fentry wasn't used and the kprobe fallback was used instead
- Ubuntu kernel `6.11.0-14-generic`: made sure fentry was used

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->