### PR TITLE
Enable PDB collection by default

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/poddisruptionbudget.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/poddisruptionbudget.go
@@ -47,7 +47,7 @@ func NewPodDisruptionBudgetCollectorVersion(metadataAsTags utils.MetadataAsTags)
 		lister:   nil,
 		metadata: &collectors.CollectorMetadata{
 			IsDefaultVersion:          true,
-			IsStable:                  false,
+			IsStable:                  true,
 			IsMetadataProducer:        true,
 			IsManifestProducer:        true,
 			SupportsManifestBuffering: true,

--- a/releasenotes-dca/notes/collect-pdb-default-bb9ff45d4e7d7415.yaml
+++ b/releasenotes-dca/notes/collect-pdb-default-bb9ff45d4e7d7415.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Enable collection of Pod Disruption Budgets by default in the orchestrator check.


### PR DESCRIPTION
### What does this PR do?
Enable collection of Pod Disruption Budgets by default in the orchestrator check

### Motivation
Make the PDB view GA.