### PR TITLE
make all CWS tests `allow_failure: true`

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -147,6 +147,7 @@ new-e2e-aml:
     TEAM: agent-metric-logs
 
 new-e2e-cws:
+  allow_failure: true
   extends: .new_e2e_template
   rules: !reference [.on_cws_or_e2e_changes_or_manual]
   needs:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -7,6 +7,7 @@
 
 # Expect warning: github.com/DataDog/datadog-agent/pkg/config.LoadCustom:1501 Unknown environment variable: DD_SYSTEM_PROBE_BPF_DIR
 .kitchen_test_security_agent_linux:
+  allow_failure: true
   extends:
     - .kitchen_test_security_agent
   script:
@@ -93,7 +94,6 @@ kitchen_test_security_agent_arm64:
         KITCHEN_CWS_PLATFORM: [host, docker, ad, ebpfless]
 
 kitchen_test_security_agent_amazonlinux_x64:
-  allow_failure: true
   extends:
     - .kitchen_test_security_agent_linux
     - .kitchen_ec2_location_us_east_1


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make all CWS kitchen and new-e2e tests allowed to fail.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->