### PR TITLE
New package static quality gates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,8 +169,8 @@ variables:
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
   # SUFFIX variable to _test_only
-  DATADOG_AGENT_BUILDIMAGES_SUFFIX: "_test_only"
-  DATADOG_AGENT_BUILDIMAGES: v55508864-5558bd15
+  DATADOG_AGENT_BUILDIMAGES_SUFFIX: ""
+  DATADOG_AGENT_BUILDIMAGES: v55677206-ea52e48c
   DATADOG_AGENT_WINBUILDIMAGES_SUFFIX: ""
   DATADOG_AGENT_WINBUILDIMAGES: v54965839-ff6db30b
   DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX: ""

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,8 +169,8 @@ variables:
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
   # SUFFIX variable to _test_only
-  DATADOG_AGENT_BUILDIMAGES_SUFFIX: ""
-  DATADOG_AGENT_BUILDIMAGES: v54965839-ff6db30b
+  DATADOG_AGENT_BUILDIMAGES_SUFFIX: "_test_only"
+  DATADOG_AGENT_BUILDIMAGES: v55508864-5558bd15
   DATADOG_AGENT_WINBUILDIMAGES_SUFFIX: ""
   DATADOG_AGENT_WINBUILDIMAGES: v54965839-ff6db30b
   DATADOG_AGENT_ARMBUILDIMAGES_SUFFIX: ""

--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -9,6 +9,16 @@ static_quality_gates:
   needs:
     - job: agent_deb-x64-a7
       artifacts: true
+    - job: agent_deb-arm64-a7
+      artifacts: true
+    - job: agent_rpm-x64-a7
+      artifacts: true
+    - job: agent_rpm-arm64-a7
+      artifacts: true
+    - job: agent_suse-x64-a7
+      artifacts: true
+    - job: agent_suse-arm64-a7
+      artifacts: true
     - job: docker_build_agent7
       artifacts: true
     - job: docker_build_agent7_arm64
@@ -20,6 +30,28 @@ static_quality_gates:
     - job: docker_build_cluster_agent_amd64
       artifacts: true
     - job: docker_build_cluster_agent_arm64
+      artifacts: true
+    - job: docker_build_dogstatsd_amd64
+      artifacts: true
+    - job: docker_build_dogstatsd_arm64
+      artifacts: true
+    - job: dogstatsd_deb-x64
+      artifacts: true
+    - job: dogstatsd_deb-arm64
+      artifacts: true
+    - job: dogstatsd_rpm-x64
+      artifacts: true
+    - job: dogstatsd_suse-x64
+      artifacts: true
+    - job: iot_agent_deb-x64
+      artifacts: true
+    - job: iot_agent_deb-arm64
+      artifacts: true
+    - job: iot_agent_rpm-x64
+      artifacts: true
+    - job: iot_agent_rpm-arm64
+      artifacts: true
+    - job: iot_agent_suse-x64
       artifacts: true
   # Static Quality Gates aren't enforced until Q1
   allow_failure: true

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -39,7 +39,7 @@ def display_pr_comment(
     :return:
     """
     title = f"Static quality checks {SUCCESS_CHAR if final_state else FAIL_CHAR}"
-    body_info = body_pattern.format("Info")
+    body_info = "<details>\n<summary>Successful checks</summary>\n" + body_pattern.format("Info")
     body_error = body_pattern.format("Error")
     body_error_footer = body_error_footer_pattern
 
@@ -64,6 +64,7 @@ def display_pr_comment(
             with_error = True
 
     body_error_footer += "\n</details>\n"
+    body_info += "\n</details>\n"
     body = f"Please find below the results from static quality gates\n{body_error+body_error_footer if with_error else ''}\n\n{body_info if with_info else ''}"
 
     pr_commenter(ctx, title=title, body=body)

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -39,7 +39,7 @@ def display_pr_comment(
     :return:
     """
     title = f"Static quality checks {SUCCESS_CHAR if final_state else FAIL_CHAR}"
-    body_info = "<details>\n<summary>Successful checks</summary>\n" + body_pattern.format("Info")
+    body_info = "<details>\n<summary>Successful checks</summary>\n\n" + body_pattern.format("Info")
     body_error = body_pattern.format("Error")
     body_error_footer = body_error_footer_pattern
 

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -110,16 +110,16 @@ class GateMetricHandler:
             self.metadata[gate][key] = kwargs[key]
 
     def _add_gauge(self, timestamp, common_tags, gate, metric_name, metric_key):
-        if self.metrics[gate].get(metric_key, None) is None:
-            return None
-        return create_gauge(
-            metric_name,
-            timestamp,
-            self.metrics[gate][metric_key],
-            tags=common_tags,
-            metric_origin=get_metric_origin(ORIGIN_PRODUCT, ORIGIN_CATEGORY, ORIGIN_SERVICE),
-            unit="byte",
-        )
+        if self.metrics[gate].get(metric_key):
+            return create_gauge(
+                metric_name,
+                timestamp,
+                self.metrics[gate][metric_key],
+                tags=common_tags,
+                metric_origin=get_metric_origin(ORIGIN_PRODUCT, ORIGIN_CATEGORY, ORIGIN_SERVICE),
+                unit="byte",
+            )
+        return None
 
     def _generate_series(self):
         if not self.git_ref or not self.bucket_branch:

--- a/tasks/static_quality_gates/lib/package_agent_lib.py
+++ b/tasks/static_quality_gates/lib/package_agent_lib.py
@@ -44,7 +44,7 @@ def check_package_size(package_on_wire_size, package_on_disk_size, max_on_wire_s
         raise AssertionError(error_message)
 
 
-def generic_docker_agent_quality_gate(gate_name, arch, os, flavor, **kwargs):
+def generic_package_agent_quality_gate(gate_name, arch, os, flavor, **kwargs):
     arguments = argument_extractor(
         kwargs, max_on_wire_size=read_byte_input, max_on_disk_size=read_byte_input, ctx=None, metricHandler=None
     )
@@ -57,8 +57,14 @@ def generic_docker_agent_quality_gate(gate_name, arch, os, flavor, **kwargs):
 
     metric_handler.register_metric(gate_name, "max_on_wire_size", max_on_wire_size)
     metric_handler.register_metric(gate_name, "max_on_disk_size", max_on_disk_size)
+    package_arm = arch
+    if os == "centos" or os == "suse":
+        if arch == "arm64":
+            package_arm = "aarch64"
+        elif arch == "amd64":
+            package_arm = "x86_64"
 
-    package_path = find_package_path(flavor, os, arch)
+    package_path = find_package_path(flavor, os, package_arm)
 
     package_on_wire_size, package_on_disk_size = calculate_package_size(
         ctx, os, package_path, gate_name, metric_handler

--- a/tasks/static_quality_gates/lib/package_agent_lib.py
+++ b/tasks/static_quality_gates/lib/package_agent_lib.py
@@ -1,0 +1,66 @@
+import tempfile
+
+from tasks.libs.common.color import color_message
+from tasks.libs.package.size import directory_size, extract_package, file_size
+from tasks.static_quality_gates.lib.gates_lib import argument_extractor, find_package_path, read_byte_input
+
+
+def calculate_package_size(ctx, package_os, package_path, gate_name, metric_handler):
+    with tempfile.TemporaryDirectory() as extract_dir:
+        extract_package(ctx=ctx, package_os=package_os, package_path=package_path, extract_dir=extract_dir)
+        package_on_wire_size = file_size(path=package_path)
+        package_on_disk_size = directory_size(ctx, path=extract_dir)
+
+        metric_handler.register_metric(gate_name, "current_on_wire_size", package_on_wire_size)
+        metric_handler.register_metric(gate_name, "current_on_disk_size", package_on_disk_size)
+    return package_on_wire_size, package_on_disk_size
+
+
+def check_package_size(package_on_wire_size, package_on_disk_size, max_on_wire_size, max_on_disk_size):
+    error_message = ""
+    if package_on_wire_size > max_on_wire_size:
+        err_msg = f"Package size on wire (compressed package size) {package_on_wire_size} is higher than the maximum allowed {max_on_wire_size} by the gate !\n"
+        print(color_message(err_msg, "red"))
+        error_message += err_msg
+    else:
+        print(
+            color_message(
+                f"package_on_wire_size <= max_on_wire_size, ({package_on_wire_size}) <= ({max_on_wire_size})",
+                "green",
+            )
+        )
+    if package_on_disk_size > max_on_disk_size:
+        err_msg = f"Package size on disk (uncompressed package size) {package_on_disk_size} is higher than the maximum allowed {max_on_disk_size} by the gate !\n"
+        print(color_message(err_msg, "red"))
+        error_message += err_msg
+    else:
+        print(
+            color_message(
+                f"package_on_disk_size <= max_on_disk_size, ({package_on_disk_size}) <= ({max_on_disk_size})",
+                "green",
+            )
+        )
+    if error_message != "":
+        raise AssertionError(error_message)
+
+
+def generic_docker_agent_quality_gate(gate_name, arch, os, flavor, **kwargs):
+    arguments = argument_extractor(
+        kwargs, max_on_wire_size=read_byte_input, max_on_disk_size=read_byte_input, ctx=None, metricHandler=None
+    )
+    ctx = arguments.ctx
+    metric_handler = arguments.metricHandler
+    max_on_wire_size = arguments.max_on_wire_size
+    max_on_disk_size = arguments.max_on_disk_size
+
+    metric_handler.register_gate_tags(gate_name, gate_name=gate_name, arch=arch, os=os)
+
+    metric_handler.register_metric(gate_name, "max_on_wire_size", max_on_wire_size)
+    metric_handler.register_metric(gate_name, "max_on_disk_size", max_on_disk_size)
+
+    package_path = find_package_path(flavor, os, arch)
+
+    package_on_wire_size, package_on_disk_size = calculate_package_size(
+        ctx, os, package_path, gate_name, metric_handler
+    )
+    check_package_size(package_on_wire_size, package_on_disk_size, max_on_wire_size, max_on_disk_size)

--- a/tasks/static_quality_gates/static_quality_gate_agent_deb_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_deb_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_deb_arm64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_agent_deb_arm64", "arm64", "debian", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_deb_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_agent_deb_arm64", "arm64", "debian", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_rpm_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_agent_rpm_amd64", "amd64", "centos", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_rpm_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_agent_rpm_amd64", "amd64", "centos", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_rpm_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_rpm_arm64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_agent_rpm_arm64", "arm64", "centos", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_rpm_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_rpm_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_agent_rpm_arm64", "arm64", "centos", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_suse_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_agent_suse_amd64", "amd64", "suse", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_suse_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_agent_suse_amd64", "amd64", "suse", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_suse_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_suse_arm64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_agent_suse_arm64", "arm64", "suse", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_agent_suse_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_suse_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_agent_suse_arm64", "arm64", "suse", "datadog-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_dogstatsd_deb_amd64", "amd64", "debian", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_dogstatsd_deb_amd64", "amd64", "debian", "dogstatsd", **kwargs
+        "static_quality_gate_dogstatsd_deb_amd64", "amd64", "debian", "datadog-dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_dogstatsd_deb_amd64", "amd64", "debian", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_arm64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_dogstatsd_deb_arm64", "arm64", "debian", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_dogstatsd_deb_arm64", "arm64", "debian", "dogstatsd", **kwargs
+        "static_quality_gate_dogstatsd_deb_arm64", "arm64", "debian", "datadog-dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_deb_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_dogstatsd_deb_arm64", "arm64", "debian", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_rpm_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_dogstatsd_rpm_amd64", "amd64", "centos", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_rpm_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_dogstatsd_rpm_amd64", "amd64", "centos", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_rpm_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_dogstatsd_rpm_amd64", "amd64", "centos", "dogstatsd", **kwargs
+        "static_quality_gate_dogstatsd_rpm_amd64", "amd64", "centos", "datadog-dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_suse_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_dogstatsd_suse_amd64", "amd64", "suse", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_suse_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_dogstatsd_suse_amd64", "amd64", "suse", "dogstatsd", **kwargs
+        "static_quality_gate_dogstatsd_suse_amd64", "amd64", "suse", "datadog-dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_dogstatsd_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_dogstatsd_suse_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_dogstatsd_suse_amd64", "amd64", "suse", "dogstatsd", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_iot_agent_deb_amd64", "amd64", "debian", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_iot_agent_deb_amd64", "amd64", "debian", "iot-agent", **kwargs
+        "static_quality_gate_iot_agent_deb_amd64", "amd64", "debian", "datadog-iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_iot_agent_deb_amd64", "amd64", "debian", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_iot_agent_deb_arm64", "arm64", "debian", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_iot_agent_deb_arm64", "arm64", "debian", "iot-agent", **kwargs
+        "static_quality_gate_iot_agent_deb_arm64", "arm64", "debian", "datadog-iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_deb_arm64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_iot_agent_deb_arm64", "arm64", "debian", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_iot_agent_rpm_amd64", "amd64", "centos", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_iot_agent_rpm_amd64", "amd64", "centos", "iot-agent", **kwargs
+        "static_quality_gate_iot_agent_rpm_amd64", "amd64", "centos", "datadog-iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_iot_agent_rpm_amd64", "amd64", "centos", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_iot_agent_rpm_arm64", "arm64", "centos", "iot-agent", **kwargs
+        "static_quality_gate_iot_agent_rpm_arm64", "arm64", "centos", "datadog-iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_arm64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_iot_agent_rpm_arm64", "arm64", "centos", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_arm64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_rpm_arm64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_iot_agent_rpm_arm64", "arm64", "centos", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_suse_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_package_age
 
 def entrypoint(**kwargs):
     generic_package_agent_quality_gate(
-        "static_quality_gate_iot_agent_suse_amd64", "amd64", "suse", "iot-agent", **kwargs
+        "static_quality_gate_iot_agent_suse_amd64", "amd64", "suse", "datadog-iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_suse_amd64.py
@@ -1,7 +1,7 @@
-from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agent_quality_gate
+from tasks.static_quality_gates.lib.package_agent_lib import generic_package_agent_quality_gate
 
 
 def entrypoint(**kwargs):
-    generic_docker_agent_quality_gate(
+    generic_package_agent_quality_gate(
         "static_quality_gate_iot_agent_suse_amd64", "amd64", "suse", "iot-agent", **kwargs
     )

--- a/tasks/static_quality_gates/static_quality_gate_iot_agent_suse_amd64.py
+++ b/tasks/static_quality_gates/static_quality_gate_iot_agent_suse_amd64.py
@@ -3,5 +3,5 @@ from tasks.static_quality_gates.lib.package_agent_lib import generic_docker_agen
 
 def entrypoint(**kwargs):
     generic_docker_agent_quality_gate(
-        "static_quality_gate_agent_deb_amd64", "amd64", "debian", "datadog-agent", **kwargs
+        "static_quality_gate_iot_agent_suse_amd64", "amd64", "suse", "iot-agent", **kwargs
     )

--- a/tasks/unit_tests/quality_gates_tests.py
+++ b/tasks/unit_tests/quality_gates_tests.py
@@ -38,7 +38,7 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         pr_commenter_mock.assert_called_with(
             ANY,
             title='Static quality checks ✅',
-            body='Please find below the results from static quality gates\n\n\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateA|10MiB|10MiB|10MiB|10MiB|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n',
+            body='Please find below the results from static quality gates\n\n\n<details>\n<summary>Successful checks</summary>\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateA|10MiB|10MiB|10MiB|10MiB|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n\n</details>\n',
         )
 
     @patch.dict(
@@ -100,7 +100,7 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         pr_commenter_mock.assert_called_with(
             ANY,
             title='Static quality checks ❌',
-            body='Please find below the results from static quality gates\n### Error\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|❌|gateA|10MiB|10MiB|10MiB|10MiB|\n<details>\n<summary>Gate failure full details</summary>\n\n|Quality gate|Error type|Error message|\n|----|---|--------|\n|gateA|AssertionError|some_msg_A|\n\n</details>\n\n\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n',
+            body='Please find below the results from static quality gates\n### Error\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|❌|gateA|10MiB|10MiB|10MiB|10MiB|\n<details>\n<summary>Gate failure full details</summary>\n\n|Quality gate|Error type|Error message|\n|----|---|--------|\n|gateA|AssertionError|some_msg_A|\n\n</details>\n\n\n<details>\n<summary>Successful checks</summary>\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n\n</details>\n',
         )
 
     @patch.dict(

--- a/tasks/unit_tests/quality_gates_tests.py
+++ b/tasks/unit_tests/quality_gates_tests.py
@@ -38,7 +38,7 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         pr_commenter_mock.assert_called_with(
             ANY,
             title='Static quality checks ✅',
-            body='Please find below the results from static quality gates\n\n\n<details>\n<summary>Successful checks</summary>\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateA|10MiB|10MiB|10MiB|10MiB|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n\n</details>\n',
+            body='Please find below the results from static quality gates\n\n\n<details>\n<summary>Successful checks</summary>\n\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateA|10MiB|10MiB|10MiB|10MiB|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n\n</details>\n',
         )
 
     @patch.dict(
@@ -100,7 +100,7 @@ class TestQualityGatesPrMessage(unittest.TestCase):
         pr_commenter_mock.assert_called_with(
             ANY,
             title='Static quality checks ❌',
-            body='Please find below the results from static quality gates\n### Error\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|❌|gateA|10MiB|10MiB|10MiB|10MiB|\n<details>\n<summary>Gate failure full details</summary>\n\n|Quality gate|Error type|Error message|\n|----|---|--------|\n|gateA|AssertionError|some_msg_A|\n\n</details>\n\n\n<details>\n<summary>Successful checks</summary>\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n\n</details>\n',
+            body='Please find below the results from static quality gates\n### Error\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|❌|gateA|10MiB|10MiB|10MiB|10MiB|\n<details>\n<summary>Gate failure full details</summary>\n\n|Quality gate|Error type|Error message|\n|----|---|--------|\n|gateA|AssertionError|some_msg_A|\n\n</details>\n\n\n<details>\n<summary>Successful checks</summary>\n\n### Info\n\n|Result|Quality gate|On disk size|On disk size limit|On wire size|On wire size limit|\n|----|----|----|----|----|----|\n|✅|gateB|10MiB|10MiB|10MiB|10MiB|\n\n</details>\n',
         )
 
     @patch.dict(

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,7 +1,9 @@
+# Package gates
 static_quality_gate_agent_deb_amd64:
   max_on_wire_size: "214.3 MiB"
   max_on_disk_size: "858.45 MiB"
 
+# Docker images gate
 static_quality_gate_docker_agent_amd64:
   max_on_wire_size: "321.56 MiB"
   max_on_disk_size: "942.69 MiB"

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -3,6 +3,62 @@ static_quality_gate_agent_deb_amd64:
   max_on_wire_size: "214.3 MiB"
   max_on_disk_size: "858.45 MiB"
 
+static_quality_gate_agent_deb_arm64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_agent_rpm_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_agent_rpm_arm64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_agent_suse_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_agent_suse_arm64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_dogstatsd_deb_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_dogstatsd_deb_arm64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_dogstatsd_rpm_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_dogstatsd_suse_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_iot_agent_deb_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_iot_agent_deb_arm64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_iot_agent_rpm_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_iot_agent_rpm_arm64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
+static_quality_gate_iot_agent_suse_amd64:
+  max_on_wire_size: "214.3 MiB"
+  max_on_disk_size: "858.45 MiB"
+
 # Docker images gate
 static_quality_gate_docker_agent_amd64:
   max_on_wire_size: "321.56 MiB"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR add `deb`, `rpm` and `suse` package static quality gates for `datadog-agent`, `dogstatsd` and `iot-agent` for `arm64` and `amd64`

### Motivation

[P2 Static Quality Gates](https://docs.google.com/document/d/1_hJaDb487YSz2QhFAk_yDq0cN2ZfRxHas8rldrTagc0/edit?tab=t.0#heading=h.sx6yg2d6xess)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Depends on the following [datadog-agent-buildimages PR](https://github.com/DataDog/datadog-agent-buildimages/pull/752)