### PR TITLE
[AGNTLOG-61] Log Compression validator 

### DIFF
--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -116,7 +116,7 @@ func (l *LogsConfigKeys) compressionKind() string {
 		log.Debugf("Logs agent is using: %s compression", compressionKind)
 		return compressionKind
 	default:
-		log.Warnf("Invalid compression kind: %s, falling back to default compression", compressionKind)
+		log.Warnf("Invalid compression kind: '%s', falling back to default compression: '%s' ", compressionKind, pkgconfigsetup.DefaultLogCompressionKind)
 		return pkgconfigsetup.DefaultLogCompressionKind
 	}
 }

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -110,7 +110,15 @@ func (l *LogsConfigKeys) devModeUseProto() bool {
 }
 
 func (l *LogsConfigKeys) compressionKind() string {
-	return l.getConfig().GetString(l.getConfigKey("compression_kind"))
+	compressionKind := l.getConfig().GetString(l.getConfigKey("compression_kind"))
+	switch compressionKind {
+	case "zstd", "gzip":
+		log.Debugf("Logs agent is using: %s compression", compressionKind)
+		return compressionKind
+	default:
+		log.Warnf("Invalid compression kind: %s, falling back to default compression", compressionKind)
+		return pkgconfigsetup.DefaultLogCompressionKind
+	}
 }
 
 func (l *LogsConfigKeys) compressionLevel() int {

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -639,6 +639,19 @@ func (suite *EndpointsTestSuite) TestMainApiKeyRotation() {
 	suite.Equal("5678", http.GetAPIKey())
 }
 
+func (suite *EndpointsTestSuite) TestLogCompressionKind() {
+	suite.config.SetWithoutSource("logs_config.compression_kind", "gzip")
+	logsConfig := defaultLogsConfigKeys(suite.config)
+	suite.Equal(logsConfig.compressionKind(), "gzip")
+
+	suite.config.SetWithoutSource("logs_config.compression_kind", "zstd")
+	suite.Equal(logsConfig.compressionKind(), "zstd")
+
+	// Invalid compression should fall back to the default log agent compression kind
+	suite.config.SetWithoutSource("logs_config.compression_kind", "notgzip")
+	suite.Equal(logsConfig.compressionKind(), pkgconfigsetup.DefaultLogCompressionKind)
+}
+
 func (suite *EndpointsTestSuite) TestLogsConfigApiKeyRotation() {
 	suite.config.SetWithoutSource("api_key", "abcd")
 	suite.config.SetWithoutSource("logs_config.api_key", "1234")

--- a/comp/logs/agent/config/endpoints_test.go
+++ b/comp/logs/agent/config/endpoints_test.go
@@ -647,6 +647,9 @@ func (suite *EndpointsTestSuite) TestLogCompressionKind() {
 	suite.config.SetWithoutSource("logs_config.compression_kind", "zstd")
 	suite.Equal(logsConfig.compressionKind(), "zstd")
 
+	suite.config.SetWithoutSource("logs_config.compression_kind", "")
+	suite.Equal(logsConfig.compressionKind(), pkgconfigsetup.DefaultLogCompressionKind)
+
 	// Invalid compression should fall back to the default log agent compression kind
 	suite.config.SetWithoutSource("logs_config.compression_kind", "notgzip")
 	suite.Equal(logsConfig.compressionKind(), pkgconfigsetup.DefaultLogCompressionKind)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -81,6 +81,9 @@ const (
 	// DefaultCompressorKind is the default compressor. Options available are 'zlib' and 'zstd'
 	DefaultCompressorKind = "zstd"
 
+	// DefaultLogCompressionKind is the default log compressor. Options available are 'zstd' and 'gzip'
+	DefaultLogCompressionKind = "gzip"
+
 	// DefaultZstdCompressionLevel is the default compression level for `zstd`.
 	// Compression level 1 provides the lowest compression ratio, but uses much less RSS especially
 	// in situations where we have a high value for `GOMAXPROCS`.
@@ -2427,7 +2430,7 @@ func bindEnvAndSetLogsConfigKeys(config pkgconfigmodel.Setup, prefix string) {
 	config.BindEnv(prefix + "dd_url")
 	config.BindEnv(prefix + "additional_endpoints")
 	config.BindEnvAndSetDefault(prefix+"use_compression", true)
-	config.BindEnvAndSetDefault(prefix+"compression_kind", "gzip")
+	config.BindEnvAndSetDefault(prefix+"compression_kind", DefaultLogCompressionKind)
 	config.BindEnvAndSetDefault(prefix+"zstd_compression_level", DefaultZstdCompressionLevel) // Default level for the zstd algorithm
 	config.BindEnvAndSetDefault(prefix+"compression_level", DefaultGzipCompressionLevel)      // Default level for the gzip algorithm
 	config.BindEnvAndSetDefault(prefix+"batch_wait", DefaultBatchWait)

--- a/releasenotes/notes/log-compression-validator-4ef4ab86cfadf4f9.yaml
+++ b/releasenotes/notes/log-compression-validator-4ef4ab86cfadf4f9.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add logging for log compression configuration.
+    The agent now validates the log compression configuration and fallback to default compression when there is invalid option.

--- a/releasenotes/notes/log-compression-validator-4ef4ab86cfadf4f9.yaml
+++ b/releasenotes/notes/log-compression-validator-4ef4ab86cfadf4f9.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Add logging for log compression configuration.
-    The agent now validates the log compression configuration and fallback to default compression when there is invalid option.
+    - Add logging for log compression configuration.
+    - The agent now validates the log compression setting and falls back to the default compression if an invalid option is provided.

--- a/releasenotes/notes/log-compression-validator-4ef4ab86cfadf4f9.yaml
+++ b/releasenotes/notes/log-compression-validator-4ef4ab86cfadf4f9.yaml
@@ -9,4 +9,4 @@
 enhancements:
   - |
     - Add logging for log compression configuration.
-    - The agent now validates the log compression setting and falls back to the default compression if an invalid option is provided.
+    - The Agent now validates the log compression setting and falls back to the default compression if an invalid option is provided.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a new validator and unit test for existing log compression config for the log agent. 

### Motivation
Previously if the user used an invalid config for the compression, the agent would skip compression instead of falling back to the default compression 

### Describe how you validated your changes
Used the following configs for the compression_kind:
1. gzip
2. zstd
3. mowmow

```
log_level: debug
logs_config:
    use_compression: true
    compression_kind: mowmow
```
There should be debug and warn logs for the type of compression the log agent is using. eg:
```
Logs agent is using: %s compression
```
and
```
Invalid compression kind: %s, falling back to default compression
```


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->