### PR TITLE
Store APIKey in FakeIntake per payload, add /debug/lastAPIKey

### DIFF
--- a/test/fakeintake/api/api.go
+++ b/test/fakeintake/api/api.go
@@ -20,6 +20,7 @@ type Payload struct {
 //nolint:revive // TODO(APL) Fix revive linter
 type ParsedPayload struct {
 	Timestamp time.Time   `json:"timestamp"`
+	APIKey    string      `json:"api_key"`
 	Data      interface{} `json:"data"`
 	Encoding  string      `json:"encoding"`
 }

--- a/test/fakeintake/api/api.go
+++ b/test/fakeintake/api/api.go
@@ -11,6 +11,7 @@ import "time"
 //nolint:revive // TODO(APL) Fix revive linter
 type Payload struct {
 	Timestamp   time.Time `json:"timestamp"`
+	APIKey      string    `json:"api_key"`
 	Data        []byte    `json:"data"`
 	Encoding    string    `json:"encoding"`
 	ContentType string    `json:"content_type"`

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -411,6 +411,7 @@ func (c *Client) GetLastAPIKey() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -405,6 +405,19 @@ func (c *Client) ConfigureOverride(override api.ResponseOverride) error {
 	return nil
 }
 
+// GetLastAPIKey returns the last apiKey sent with a payload to the intake
+func (c *Client) GetLastAPIKey() (string, error) {
+	resp, err := http.Get(fmt.Sprintf("%s/debug/lastAPIKey", c.fakeIntakeURL))
+	if err != nil {
+		return "", err
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(body)), nil
+}
+
 func (c *Client) getMetric(name string) ([]*aggregator.MetricSeries, error) {
 	err := c.getMetrics()
 	if err != nil {

--- a/test/fakeintake/server/server.go
+++ b/test/fakeintake/server/server.go
@@ -358,7 +358,7 @@ func (fi *Server) handleDatadogRequest(w http.ResponseWriter, req *http.Request)
 
 	apiKey := fi.extractDatadogAPIKey(req)
 	if apiKey != "" {
-		fi.store.SetRecentAPIKey(apiKey)
+		fi.store.SetLastAPIKey(apiKey)
 	}
 
 	log.Printf("Handling Datadog %s request to %s, header %v", req.Method, req.URL.Path, redactHeader(req.Header))
@@ -477,7 +477,7 @@ func (fi *Server) extractDatadogAPIKey(req *http.Request) string {
 }
 
 func (fi *Server) handleGetLastAPIKey(w http.ResponseWriter, _req *http.Request) {
-	apiKey, err := fi.store.GetRecentAPIKey()
+	apiKey, err := fi.store.GetLastAPIKey()
 	if err != nil {
 		response := buildErrorResponse(err)
 		writeHTTPResponse(w, response)

--- a/test/fakeintake/server/serverstore/db.go
+++ b/test/fakeintake/server/serverstore/db.go
@@ -7,6 +7,7 @@ package serverstore
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -121,10 +122,14 @@ func (s *sqlStore) Close() {
 	os.Remove(s.path)
 }
 
+func (s *sqlStore) MostRecentPayloadAPIKey(route string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}
+
 // AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
-func (s *sqlStore) AppendPayload(route string, data []byte, encoding string, contentType string, collectTime time.Time) error {
+func (s *sqlStore) AppendPayload(route string, apiKey string, data []byte, encoding string, contentType string, collectTime time.Time) error {
 	now := time.Now()
-	_, err := s.db.Exec("INSERT INTO payloads (timestamp, data, encoding, content_type, route) VALUES (?, ?, ?, ?, ?)", collectTime.Unix(), data, encoding, contentType, route)
+	_, err := s.db.Exec("INSERT INTO payloads (timestamp, apiKey, data, encoding, content_type, route) VALUES (?, ?, ?, ?, ?, ?)", collectTime.Unix(), data, encoding, contentType, route)
 	if err != nil {
 		return err
 	}

--- a/test/fakeintake/server/serverstore/db.go
+++ b/test/fakeintake/server/serverstore/db.go
@@ -100,7 +100,7 @@ func newSQLStore() *sqlStore {
 	CREATE TABLE IF NOT EXISTS payloads (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		timestamp INTEGER NOT NULL,
-		apiKey VARCHAR(32) NOT NULL,
+		api_key VARCHAR(32) NOT NULL,
 		data BLOB NOT NULL,
 		encoding VARCHAR(10) NOT NULL,
 		content_type VARCHAR(20),
@@ -123,14 +123,18 @@ func (s *sqlStore) Close() {
 	os.Remove(s.path)
 }
 
-func (s *sqlStore) MostRecentPayloadAPIKey(route string) (string, error) {
-	return "", fmt.Errorf("not implemented")
+func (s *sqlStore) SetRecentAPIKey(_ string) {
+	// pass
+}
+
+func (s *sqlStore) GetRecentAPIKey() (string, error) {
+	return "", fmt.Errorf("sqlstore does not track recent APIKey")
 }
 
 // AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
 func (s *sqlStore) AppendPayload(route string, apiKey string, data []byte, encoding string, contentType string, collectTime time.Time) error {
 	now := time.Now()
-	_, err := s.db.Exec("INSERT INTO payloads (timestamp, apiKey, data, encoding, content_type, route) VALUES (?, ?, ?, ?, ?, ?)", collectTime.Unix(), apiKey, data, encoding, contentType, route)
+	_, err := s.db.Exec("INSERT INTO payloads (timestamp, api_key, data, encoding, content_type, route) VALUES (?, ?, ?, ?, ?, ?)", collectTime.Unix(), apiKey, data, encoding, contentType, route)
 	if err != nil {
 		return err
 	}
@@ -160,7 +164,7 @@ func (s *sqlStore) CleanUpPayloadsOlderThan(time time.Time) {
 // GetRawPayloads returns all raw payloads for a given route
 func (s *sqlStore) GetRawPayloads(route string) []api.Payload {
 	now := time.Now()
-	rows, err := s.db.Query("SELECT timestamp, apiKey, data, encoding, content_type FROM payloads WHERE route = ?", route)
+	rows, err := s.db.Query("SELECT timestamp, api_key, data, encoding, content_type FROM payloads WHERE route = ?", route)
 	if err != nil {
 		log.Println("Error fetching raw payloads: ", err)
 		return nil

--- a/test/fakeintake/server/serverstore/db.go
+++ b/test/fakeintake/server/serverstore/db.go
@@ -123,12 +123,12 @@ func (s *sqlStore) Close() {
 	os.Remove(s.path)
 }
 
-func (s *sqlStore) SetRecentAPIKey(_ string) {
+func (s *sqlStore) SetLastAPIKey(_ string) {
 	// pass
 }
 
-func (s *sqlStore) GetRecentAPIKey() (string, error) {
-	return "", fmt.Errorf("sqlstore does not track recent APIKey")
+func (s *sqlStore) GetLastAPIKey() (string, error) {
+	return "", fmt.Errorf("sqlstore does not track last APIKey")
 }
 
 // AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store

--- a/test/fakeintake/server/serverstore/in_memory.go
+++ b/test/fakeintake/server/serverstore/in_memory.go
@@ -57,6 +57,8 @@ func (s *inMemoryStore) GetRecentAPIKey() (string, error) {
 
 // AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
 func (s *inMemoryStore) AppendPayload(route string, apiKey string, data []byte, encoding string, contentType string, collectTime time.Time) error {
+	// Set the recent APIKey first, to avoid deadlocking
+	s.SetRecentAPIKey(apiKey)
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	rawPayload := api.Payload{
@@ -68,7 +70,6 @@ func (s *inMemoryStore) AppendPayload(route string, apiKey string, data []byte, 
 	}
 	s.rawPayloads[route] = append(s.rawPayloads[route], rawPayload)
 	s.NbPayloads.WithLabelValues(route).Set(float64(len(s.rawPayloads[route])))
-	s.SetRecentAPIKey(apiKey)
 	return nil
 }
 

--- a/test/fakeintake/server/serverstore/in_memory.go
+++ b/test/fakeintake/server/serverstore/in_memory.go
@@ -6,6 +6,7 @@
 package serverstore
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -37,12 +38,22 @@ func newInMemoryStore() *inMemoryStore {
 	}
 }
 
+func (s *inMemoryStore) MostRecentPayloadAPIKey(route string) (string, error) {
+	payloads, found := s.rawPayloads[route]
+	if !found {
+		return "", fmt.Errorf("route not found!")
+	}
+	lastPayload := payloads[len(payloads)-1]
+	return lastPayload.APIKey, nil
+}
+
 // AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
-func (s *inMemoryStore) AppendPayload(route string, data []byte, encoding string, contentType string, collectTime time.Time) error {
+func (s *inMemoryStore) AppendPayload(route string, apiKey string, data []byte, encoding string, contentType string, collectTime time.Time) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	rawPayload := api.Payload{
 		Timestamp:   collectTime,
+		APIKey:      apiKey,
 		Data:        data,
 		Encoding:    encoding,
 		ContentType: contentType,

--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -22,10 +22,10 @@ import (
 type Store interface {
 	// AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
 	AppendPayload(route string, apiKey string, data []byte, encoding string, contentType string, collectTime time.Time) error
-	// SetRecentAPIKey sets the most recent API Key
-	SetRecentAPIKey(apiKey string)
-	// GetRecentAPIKey gets the most recent API Keys
-	GetRecentAPIKey() (string, error)
+	// SetLastAPIKey sets the last seen API Key
+	SetLastAPIKey(apiKey string)
+	// GetLastAPIKey gets the last seen API Keys
+	GetLastAPIKey() (string, error)
 	// CleanUpPayloadsOlderThan removes payloads older than the given time
 	CleanUpPayloadsOlderThan(time.Time)
 	// GetRawPayloads returns all raw payloads for a given route

--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -22,8 +22,10 @@ import (
 type Store interface {
 	// AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
 	AppendPayload(route string, apiKey string, data []byte, encoding string, contentType string, collectTime time.Time) error
-	// MostRecentPayloadAPIKey gets the apikey from the most recent payload at the given route
-	MostRecentPayloadAPIKey(route string) (string, error)
+	// SetRecentAPIKey sets the most recent API Key
+	SetRecentAPIKey(apiKey string)
+	// GetRecentAPIKey gets the most recent API Keys
+	GetRecentAPIKey() (string, error)
 	// CleanUpPayloadsOlderThan removes payloads older than the given time
 	CleanUpPayloadsOlderThan(time.Time)
 	// GetRawPayloads returns all raw payloads for a given route
@@ -64,6 +66,7 @@ func GetJSONPayloads(store Store, route string) ([]api.ParsedPayload, error) {
 		}
 		parsedPayloads = append(parsedPayloads, api.ParsedPayload{
 			Timestamp: payload.Timestamp,
+			APIKey:    payload.APIKey,
 			Data:      parsedPayload,
 			Encoding:  payload.Encoding,
 		})

--- a/test/fakeintake/server/serverstore/store.go
+++ b/test/fakeintake/server/serverstore/store.go
@@ -21,7 +21,9 @@ import (
 // Store is the interface for a store that can store payloads and try parsing them
 type Store interface {
 	// AppendPayload adds a payload to the store and tries parsing and adding a dumped json to the parsed store
-	AppendPayload(route string, data []byte, encoding string, contentType string, collectTime time.Time) error
+	AppendPayload(route string, apiKey string, data []byte, encoding string, contentType string, collectTime time.Time) error
+	// MostRecentPayloadAPIKey gets the apikey from the most recent payload at the given route
+	MostRecentPayloadAPIKey(route string) (string, error)
 	// CleanUpPayloadsOlderThan removes payloads older than the given time
 	CleanUpPayloadsOlderThan(time.Time)
 	// GetRawPayloads returns all raw payloads for a given route

--- a/test/fakeintake/server/serverstore/store_test.go
+++ b/test/fakeintake/server/serverstore/store_test.go
@@ -37,12 +37,13 @@ func (suite *StoreTestSuite) TestAppendPayload() {
 	data := []byte(`{"key":"value"}`)
 	parserMap["testRoute"] = jsonParser
 	defer delete(parserMap, "testRoute")
-	err := store.AppendPayload("testRoute", data, "json", "", time.Now())
+	err := store.AppendPayload("testRoute", "1234", data, "json", "", time.Now())
 	assert.NoError(suite.T(), err)
 
 	rawPayloads := store.GetRawPayloads("testRoute")
 	assert.Len(suite.T(), rawPayloads, 1)
 	assert.Equal(suite.T(), data, rawPayloads[0].Data)
+	assert.Equal(suite.T(), "1234", rawPayloads[0].APIKey)
 
 	jsonPayloads, err := GetJSONPayloads(store, "testRoute")
 	require.NoError(suite.T(), err)
@@ -59,10 +60,10 @@ func (suite *StoreTestSuite) TestCleanUpPayloadsOlderThan() {
 	parserMap["testRoute"] = jsonParser
 	defer delete(parserMap, "testRoute")
 	// Add an old payload expected to be cleaned up first
-	err := store.AppendPayload("testRoute", []byte("{}"), "json", "", now.Add(-48*time.Hour))
+	err := store.AppendPayload("testRoute", "1234", []byte("{}"), "json", "", now.Add(-48*time.Hour))
 	require.NoError(suite.T(), err)
 
-	err = store.AppendPayload("testRoute", []byte("{}"), "json", "", now)
+	err = store.AppendPayload("testRoute", "1234", []byte("{}"), "json", "", now)
 	require.NoError(suite.T(), err)
 
 	rawPayloads := store.GetRawPayloads("testRoute")
@@ -82,10 +83,10 @@ func (suite *StoreTestSuite) TestGetRouteStats() {
 	store := suite.StoreConstructor()
 	defer store.Close()
 
-	err := store.AppendPayload("routeA", []byte("{}"), "json", "", time.Now())
+	err := store.AppendPayload("routeA", "1234", []byte("{}"), "json", "", time.Now())
 	require.NoError(suite.T(), err)
 
-	err = store.AppendPayload("routeB", []byte("{}"), "json", "", time.Now())
+	err = store.AppendPayload("routeB", "1234", []byte("{}"), "json", "", time.Now())
 	require.NoError(suite.T(), err)
 
 	stats := store.GetRouteStats()
@@ -100,7 +101,7 @@ func (suite *StoreTestSuite) TestFlush() {
 
 	parserMap["testRoute"] = jsonParser
 	defer delete(parserMap, "testRoute")
-	err := store.AppendPayload("testRoute", []byte("{}"), "json", "", time.Now())
+	err := store.AppendPayload("testRoute", "1234", []byte("{}"), "json", "", time.Now())
 	require.NoError(suite.T(), err)
 
 	store.Flush()


### PR DESCRIPTION
### What does this PR do?

Stores APIKeys in the FakeIntake. Clients can use `client.GetLastAPIKey` to retrieve the most recently seen apiKey. Retrieving payloads using `/fakeintake/payloads?endpoint=[endpoint]` will also include the apiKey for each payload.

### Motivation

Test that apiKeys can be refreshed and that the fakeIntake will observe the change.

### Describe how you validated your changes

An upcoming PR will include an e2e test that uses this functionality.

To manually test, run the fakeintake in one terminal:

```
cd test/fakeintake/cmd/server
go run .
```

Then run the agent, with the `DD_API_KEY` env var defined to have a valid api key:

```
DD_API_KEY=$DD_API_KEY DD_URL=http://localhost:80  bin/agent/agent run -c bin/agent/dist/datadog.yaml
```

Then curl the fakeintake's debug endpoint to see the api key in use:

```
curl -L "http://localhost:80/fakeintake/payloads?endpoint=/intake/"
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->