### PR TITLE
Add queue, retry, and timeout to logs agent exporter

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
@@ -8,6 +8,7 @@ package logsagentexporter
 
 import (
 	"context"
+	"time"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 	exp "go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
@@ -84,6 +86,9 @@ func (f *factory) createLogsExporter(
 		set,
 		c,
 		exporter.ConsumeLogs,
+		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0 * time.Second}),
+		exporterhelper.WithRetry(configretry.NewDefaultBackOffConfig()),
+		exporterhelper.WithQueue(exporterhelper.NewDefaultQueueConfig()),
 		exporterhelper.WithShutdown(func(context.Context) error {
 			cancel()
 			return nil

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/factory.go
@@ -35,6 +35,7 @@ const (
 type Config struct {
 	OtelSource    string
 	LogSourceName string
+	QueueSettings exporterhelper.QueueConfig
 }
 
 type factory struct {
@@ -52,6 +53,7 @@ func NewFactory(logsAgentChannel chan *message.Message) exp.Factory {
 			return &Config{
 				OtelSource:    otelSource,
 				LogSourceName: LogSourceName,
+				QueueSettings: exporterhelper.NewDefaultQueueConfig(),
 			}
 		},
 		exp.WithLogs(f.createLogsExporter, stability),
@@ -88,7 +90,7 @@ func (f *factory) createLogsExporter(
 		exporter.ConsumeLogs,
 		exporterhelper.WithTimeout(exporterhelper.TimeoutConfig{Timeout: 0 * time.Second}),
 		exporterhelper.WithRetry(configretry.NewDefaultBackOffConfig()),
-		exporterhelper.WithQueue(exporterhelper.NewDefaultQueueConfig()),
+		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithShutdown(func(context.Context) error {
 			cancel()
 			return nil

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/stormcat24/protodep v0.1.8
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
+	go.opentelemetry.io/collector/config/configretry v1.25.0
 	go.opentelemetry.io/collector/exporter v0.119.0
 	go.opentelemetry.io/collector/exporter/exportertest v0.119.0
 	go.opentelemetry.io/collector/pdata v1.25.0
@@ -143,7 +144,6 @@ require (
 	github.com/tklauser/numcpus v0.8.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.25.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.119.0 // indirect
 	go.opentelemetry.io/collector/consumer v1.25.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumertest v0.119.0 // indirect


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds exporterhelper settings to mirror collector-contrib datadog exporter usage of logs agent exporter. https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/factory.go#L528-L530

### Motivation
OTAGENT-265

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Verified tests still pass, and `otelcol_exporter_queue_capacity` metric now shows for logs.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->