### PR TITLE
[netpath] Fix flaking of e2e test

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -955,15 +955,19 @@ func (c *Client) GetNDMFlows() ([]*aggregator.NDMFlow, error) {
 	return ndmflows, nil
 }
 
-// GetNetpathEvents returns the latest netpath events by destination
-func (c *Client) GetNetpathEvents() ([]*aggregator.Netpath, error) {
+// GetLatestNetpathEvents returns the latest netpath events by destination
+func (c *Client) GetLatestNetpathEvents() ([]*aggregator.Netpath, error) {
 	err := c.getNetpathEvents()
 	if err != nil {
 		return nil, err
 	}
 	var netpaths []*aggregator.Netpath
 	for _, name := range c.netpathAggregator.GetNames() {
-		netpaths = append(netpaths, c.netpathAggregator.GetPayloadsByName(name)...)
+		payloads := c.netpathAggregator.GetPayloadsByName(name)
+		if len(payloads) > 0 {
+			// take the latest payload for this destination
+			netpaths = append(netpaths, payloads[len(payloads)-1])
+		}
 	}
 	return netpaths, nil
 }

--- a/test/new-e2e/tests/netpath/network-path-integration/common_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/common_test.go
@@ -58,12 +58,12 @@ func assertMetrics(fakeIntake *components.FakeIntake, c *assert.CollectT, metric
 }
 
 func (s *baseNetworkPathIntegrationTestSuite) findNetpath(isMatch func(*aggregator.Netpath) bool) (*aggregator.Netpath, error) {
-	nps, err := s.Env().FakeIntake.Client().GetNetpathEvents()
+	nps, err := s.Env().FakeIntake.Client().GetLatestNetpathEvents()
 	if err != nil {
 		return nil, err
 	}
 	if nps == nil {
-		return nil, fmt.Errorf("GetNetpathEvents() returned nil netpaths")
+		return nil, fmt.Errorf("GetLatestNetpathEvents() returned nil netpaths")
 	}
 
 	var match *aggregator.Netpath

--- a/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
@@ -97,9 +97,9 @@ func (s *fakeTracerouteTestSuite) TestFakeTraceroute() {
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		nps, err := s.Env().FakeIntake.Client().GetNetpathEvents()
-		assert.NoError(c, err, "GetNetpathEvents() errors")
-		if !assert.NotNil(c, nps, "GetNetpathEvents() returned nil netpaths") {
+		nps, err := s.Env().FakeIntake.Client().GetLatestNetpathEvents()
+		assert.NoError(c, err, "GetLatestNetpathEvents() errors")
+		if !assert.NotNil(c, nps, "GetLatestNetpathEvents() returned nil netpaths") {
 			return
 		}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
I misunderstood `GetPayloadsByName` - it returns all payloads including older ones. So it needs to take the latest netpath only, otherwise it can get stuck looking at old data.

### Motivation
Fix one cause of flaking in netpath e2e tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
```
aws-vault exec sso-agent-sandbox-account-admin -- inv new-e2e-tests.run --targets=github.com/DataDog/datadog-agent/test/new-e2e/tests/netpath --run=TestFakeTracerouteSuite
```

### Possible Drawbacks / Trade-offs
There might be another source of flaking related to the metric aggregator. Will see what the stats look like after merging this. We should see [this dashboard](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40ci.job.name%3A%22new-e2e-netpath%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1738621839758&end=1739226639758&paused=false) drop its error count.
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->