### PR TITLE
[EBPF] gpu: introduce lazy ELF section reader

### DIFF
--- a/pkg/gpu/cuda/cubin.go
+++ b/pkg/gpu/cuda/cubin.go
@@ -134,7 +134,7 @@ type sectionParserFunc func(*elfSection, []byte) error
 
 type sectionParser struct {
 	prefix []byte
-	funct  sectionParserFunc
+	parser sectionParserFunc
 }
 
 // cubinParser is a helper struct to parse the cubin ELF sections
@@ -152,10 +152,10 @@ func newCubinParser() *cubinParser {
 	}
 
 	cp.sectionParsers = []sectionParser{
-		{prefix: []byte(".nv.info"), funct: cp.parseNvInfoSection},
-		{prefix: []byte(".text"), funct: cp.parseTextSection},
-		{prefix: []byte(".nv.shared"), funct: cp.parseSharedMemSection},
-		{prefix: []byte(".nv.constant"), funct: cp.parseConstantMemSection},
+		{prefix: []byte(".nv.info"), parser: cp.parseNvInfoSection},
+		{prefix: []byte(".text"), parser: cp.parseTextSection},
+		{prefix: []byte(".nv.shared"), parser: cp.parseSharedMemSection},
+		{prefix: []byte(".nv.constant"), parser: cp.parseConstantMemSection},
 	}
 
 	return cp
@@ -197,7 +197,7 @@ func (cp *cubinParser) parseCubinElf(data []byte) error {
 				kernelName = sect.nameBytes[len(parser.prefix)+1:]
 			}
 
-			err := parser.funct(sect, kernelName)
+			err := parser.parser(sect, kernelName)
 			if err != nil {
 				return fmt.Errorf("failed to parse section %s: %w", sect.Name(), err)
 			}

--- a/pkg/gpu/cuda/elf.go
+++ b/pkg/gpu/cuda/elf.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
+// Some of the code of this file is based on the debug/elf package from the Go standard library.
+
 package cuda
 
 import (
@@ -48,6 +50,7 @@ func (l *lazySectionReader) Err() error {
 
 // Iterate reads the ELF sections and yields them one by one. After iterating
 // through all sections, the error field l.err is set if an error occurred.
+// Part of the code has been adapted from the NewFile method in the debug/elf package of the Go standard library.
 func (l *lazySectionReader) Iterate() iter.Seq[*elfSection] {
 	sr := io.NewSectionReader(l.reader, 0, 1<<63-1)
 
@@ -275,6 +278,8 @@ func (l *lazySectionReader) Iterate() iter.Seq[*elfSection] {
 	}
 }
 
+// readSection reads the section header at the given offset and initializes the current section.
+// Part of the code has been taken from the NewFile method in the debug/elf package of the Go standard library.
 func (l *lazySectionReader) readSection(reader io.ReaderAt, cls elf.Class, bo binary.ByteOrder, offset int64) error {
 	// sectionHeaderBuffer is already allocated with the correct size based on the header size
 	// attribute of the ELF file, so we can reuse it for every section.

--- a/pkg/gpu/cuda/elf.go
+++ b/pkg/gpu/cuda/elf.go
@@ -1,0 +1,375 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package cuda
+
+import (
+	"debug/elf"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"iter"
+	"unsafe"
+)
+
+type formatError struct {
+	off int64
+	msg string
+	val any
+}
+
+func (e *formatError) Error() string {
+	msg := e.msg
+	if e.val != nil {
+		msg += fmt.Sprintf(" '%v' ", e.val)
+	}
+	msg += fmt.Sprintf("in record at byte %#x", e.off)
+	return msg
+}
+
+// sliceCap is like SliceCapWithSize but using generics.
+func sliceCap[E any](c uint64) int {
+	var v E
+	size := uint64(unsafe.Sizeof(v))
+	return sliceCapWithSize(size, c)
+}
+
+// chunk is an arbitrary limit on how much memory we are willing
+// to allocate without concern.
+const chunk = 10 << 20 // 1
+
+// sliceCapWithSize returns the capacity to use when allocating a slice.
+// After the slice is allocated with the capacity, it should be
+// built using append. This will avoid allocating too much memory
+// if the capacity is large and incorrect.
+//
+// A negative result means that the value is always too big.
+func sliceCapWithSize(size, c uint64) int {
+	if int64(c) < 0 || c != uint64(int(c)) {
+		return -1
+	}
+	if size > 0 && c > (1<<64-1)/size {
+		return -1
+	}
+	if c*size > chunk {
+		c = chunk / size
+		if c == 0 {
+			c = 1
+		}
+	}
+	return int(c)
+}
+
+type elfSection struct {
+	elf.SectionHeader
+
+	reader     *io.SectionReader
+	nameOffset uint32
+}
+
+type lazyElfSections struct {
+	reader io.ReaderAt
+	err    error
+}
+
+func newLazyElfSections(reader io.ReaderAt) *lazyElfSections {
+	return &lazyElfSections{reader: reader}
+}
+
+func (l *lazyElfSections) iterate() iter.Seq[*elfSection] {
+	sr := io.NewSectionReader(l.reader, 0, 1<<63-1)
+
+	// Read and decode ELF identifier
+	var ident [16]uint8
+	if _, err := l.reader.ReadAt(ident[0:], 0); err != nil {
+		l.err = err
+		return nil
+	}
+	if ident[0] != '\x7f' || ident[1] != 'E' || ident[2] != 'L' || ident[3] != 'F' {
+		l.err = &formatError{0, "bad magic number", ident[0:4]}
+		return nil
+	}
+
+	cls := elf.Class(ident[elf.EI_CLASS])
+	switch cls {
+	case elf.ELFCLASS32:
+	case elf.ELFCLASS64:
+		// ok
+	default:
+		l.err = &formatError{0, "unknown ELF class", cls}
+		return nil
+	}
+
+	data := elf.Data(ident[elf.EI_DATA])
+	var bo binary.ByteOrder
+	switch data {
+	case elf.ELFDATA2LSB:
+		bo = binary.LittleEndian
+	case elf.ELFDATA2MSB:
+		bo = binary.BigEndian
+	default:
+		l.err = &formatError{0, "unknown ELF data encoding", data}
+		return nil
+	}
+
+	version := elf.Version(ident[elf.EI_VERSION])
+	if version != elf.EV_CURRENT {
+		l.err = &formatError{0, "unknown ELF version", version}
+		return nil
+	}
+
+	// Read ELF file header
+	var phoff int64
+	var phentsize, phnum int
+	var shoff int64
+	var shentsize, shnum, shstrndx int
+	switch cls {
+	case elf.ELFCLASS32:
+		var hdr elf.Header32
+		data := make([]byte, unsafe.Sizeof(hdr))
+		if _, err := sr.ReadAt(data, 0); err != nil {
+			l.err = err
+			return nil
+		}
+		if v := elf.Version(bo.Uint32(data[unsafe.Offsetof(hdr.Version):])); v != version {
+			l.err = &formatError{0, "mismatched ELF version", v}
+			return nil
+		}
+		phoff = int64(bo.Uint32(data[unsafe.Offsetof(hdr.Phoff):]))
+		phentsize = int(bo.Uint16(data[unsafe.Offsetof(hdr.Phentsize):]))
+		phnum = int(bo.Uint16(data[unsafe.Offsetof(hdr.Phnum):]))
+		shoff = int64(bo.Uint32(data[unsafe.Offsetof(hdr.Shoff):]))
+		shentsize = int(bo.Uint16(data[unsafe.Offsetof(hdr.Shentsize):]))
+		shnum = int(bo.Uint16(data[unsafe.Offsetof(hdr.Shnum):]))
+		shstrndx = int(bo.Uint16(data[unsafe.Offsetof(hdr.Shstrndx):]))
+	case elf.ELFCLASS64:
+		var hdr elf.Header64
+		data := make([]byte, unsafe.Sizeof(hdr))
+		if _, err := sr.ReadAt(data, 0); err != nil {
+			l.err = err
+			return nil
+		}
+		if v := elf.Version(bo.Uint32(data[unsafe.Offsetof(hdr.Version):])); v != version {
+			l.err = &formatError{0, "mismatched ELF version", v}
+			return nil
+		}
+		phoff = int64(bo.Uint64(data[unsafe.Offsetof(hdr.Phoff):]))
+		phentsize = int(bo.Uint16(data[unsafe.Offsetof(hdr.Phentsize):]))
+		phnum = int(bo.Uint16(data[unsafe.Offsetof(hdr.Phnum):]))
+		shoff = int64(bo.Uint64(data[unsafe.Offsetof(hdr.Shoff):]))
+		shentsize = int(bo.Uint16(data[unsafe.Offsetof(hdr.Shentsize):]))
+		shnum = int(bo.Uint16(data[unsafe.Offsetof(hdr.Shnum):]))
+		shstrndx = int(bo.Uint16(data[unsafe.Offsetof(hdr.Shstrndx):]))
+	}
+
+	if shoff < 0 {
+		l.err = &formatError{0, "invalid shoff", shoff}
+		return nil
+	}
+	if phoff < 0 {
+		l.err = &formatError{0, "invalid phoff", phoff}
+		return nil
+	}
+
+	if shoff == 0 && shnum != 0 {
+		l.err = &formatError{0, "invalid ELF shnum for shoff=0", shnum}
+		return nil
+	}
+
+	if shnum > 0 && shstrndx >= shnum {
+		l.err = &formatError{0, "invalid ELF shstrndx", shstrndx}
+		return nil
+	}
+
+	var wantPhentsize, wantShentsize int
+	switch cls {
+	case elf.ELFCLASS32:
+		wantPhentsize = 8 * 4
+		wantShentsize = 10 * 4
+	case elf.ELFCLASS64:
+		wantPhentsize = 2*4 + 6*8
+		wantShentsize = 4*4 + 6*8
+	}
+	if phnum > 0 && phentsize < wantPhentsize {
+		l.err = &formatError{0, "invalid ELF phentsize", phentsize}
+		return nil
+	}
+
+	// If the number of sections is greater than or equal to SHN_LORESERVE
+	// (0xff00), shnum has the value zero and the actual number of section
+	// header table entries is contained in the sh_size field of the section
+	// header at index 0.
+	if shoff > 0 && shnum == 0 {
+		var typ, link uint32
+		sr.Seek(shoff, io.SeekStart)
+		switch cls {
+		case elf.ELFCLASS32:
+			sh := new(elf.Section32)
+			if err := binary.Read(sr, bo, sh); err != nil {
+				l.err = err
+				return nil
+			}
+			shnum = int(sh.Size)
+			typ = sh.Type
+			link = sh.Link
+		case elf.ELFCLASS64:
+			sh := new(elf.Section64)
+			if err := binary.Read(sr, bo, sh); err != nil {
+				l.err = err
+				return nil
+			}
+			shnum = int(sh.Size)
+			typ = sh.Type
+			link = sh.Link
+		}
+		if elf.SectionType(typ) != elf.SHT_NULL {
+			l.err = &formatError{shoff, "invalid type of the initial section", elf.SectionType(typ)}
+			return nil
+		}
+
+		if shnum < int(elf.SHN_LORESERVE) {
+			l.err = &formatError{shoff, "invalid ELF shnum contained in sh_size", shnum}
+			return nil
+		}
+
+		// If the section name string table section index is greater than or
+		// equal to SHN_LORESERVE (0xff00), this member has the value
+		// SHN_XINDEX (0xffff) and the actual index of the section name
+		// string table section is contained in the sh_link field of the
+		// section header at index 0.
+		if shstrndx == int(elf.SHN_XINDEX) {
+			shstrndx = int(link)
+			if shstrndx < int(elf.SHN_LORESERVE) {
+				l.err = &formatError{shoff, "invalid ELF shstrndx contained in sh_link", shstrndx}
+				return nil
+			}
+		}
+	}
+
+	if shnum > 0 && shentsize < wantShentsize {
+		l.err = &formatError{0, "invalid ELF shentsize", shentsize}
+		return nil
+	}
+
+	// Read section headers
+	c := sliceCap[elf.Section](uint64(shnum))
+	if c < 0 {
+		l.err = &formatError{0, "too many sections", shnum}
+		return nil
+	}
+
+	var nameSection *elfSection
+	var err error
+	if shstrndx > 0 {
+		sectOffset := shoff + int64(shstrndx)*int64(shentsize)
+		nameSection, err = l.readSection(sr, cls, bo, sectOffset, int64(shentsize))
+		if err != nil {
+			l.err = &formatError{sectOffset, "cannot parse names section: %w", err}
+			return nil
+		}
+
+		if nameSection.Type != elf.SHT_STRTAB {
+			l.err = &formatError{sectOffset, "invalid ELF section name string table type", nameSection.Type}
+			return nil
+		}
+	}
+
+	return func(yield func(*elfSection) bool) {
+		for i := 0; i < shnum; i++ {
+			off := shoff + int64(i)*int64(shentsize)
+			var sect *elfSection
+			sect, err = l.readSection(sr, cls, bo, off, int64(shentsize))
+			if err != nil {
+				l.err = err
+				return
+			}
+
+			if nameSection != nil {
+				var ok bool
+				sect.Name, ok = getString(nameSection.reader, int64(sect.nameOffset))
+				if !ok {
+					l.err = &formatError{off, "bad section name index", sect.nameOffset}
+					return
+				}
+			}
+
+			if !yield(sect) {
+				return
+			}
+		}
+	}
+}
+
+func (l *lazyElfSections) readSection(reader io.ReaderAt, cls elf.Class, bo binary.ByteOrder, offset int64, size int64) (*elfSection, error) {
+	shdata := make([]byte, size)
+	if _, err := reader.ReadAt(shdata, offset); err != nil {
+		return nil, err
+	}
+
+	s := new(elfSection)
+	switch cls {
+	case elf.ELFCLASS32:
+		var sh elf.Section32
+		s.nameOffset = bo.Uint32(shdata[unsafe.Offsetof(sh.Name):])
+		s.SectionHeader = elf.SectionHeader{
+			Type:      elf.SectionType(bo.Uint32(shdata[unsafe.Offsetof(sh.Type):])),
+			Flags:     elf.SectionFlag(bo.Uint32(shdata[unsafe.Offsetof(sh.Flags):])),
+			Addr:      uint64(bo.Uint32(shdata[unsafe.Offsetof(sh.Addr):])),
+			Offset:    uint64(bo.Uint32(shdata[unsafe.Offsetof(sh.Off):])),
+			FileSize:  uint64(bo.Uint32(shdata[unsafe.Offsetof(sh.Size):])),
+			Link:      bo.Uint32(shdata[unsafe.Offsetof(sh.Link):]),
+			Info:      bo.Uint32(shdata[unsafe.Offsetof(sh.Info):]),
+			Addralign: uint64(bo.Uint32(shdata[unsafe.Offsetof(sh.Addralign):])),
+			Entsize:   uint64(bo.Uint32(shdata[unsafe.Offsetof(sh.Entsize):])),
+		}
+	case elf.ELFCLASS64:
+		var sh elf.Section64
+		s.nameOffset = bo.Uint32(shdata[unsafe.Offsetof(sh.Name):])
+		s.SectionHeader = elf.SectionHeader{
+			Type:      elf.SectionType(bo.Uint32(shdata[unsafe.Offsetof(sh.Type):])),
+			Flags:     elf.SectionFlag(bo.Uint64(shdata[unsafe.Offsetof(sh.Flags):])),
+			Offset:    bo.Uint64(shdata[unsafe.Offsetof(sh.Off):]),
+			FileSize:  bo.Uint64(shdata[unsafe.Offsetof(sh.Size):]),
+			Addr:      bo.Uint64(shdata[unsafe.Offsetof(sh.Addr):]),
+			Link:      bo.Uint32(shdata[unsafe.Offsetof(sh.Link):]),
+			Info:      bo.Uint32(shdata[unsafe.Offsetof(sh.Info):]),
+			Addralign: bo.Uint64(shdata[unsafe.Offsetof(sh.Addralign):]),
+			Entsize:   bo.Uint64(shdata[unsafe.Offsetof(sh.Entsize):]),
+		}
+	}
+	if int64(s.Offset) < 0 {
+		return nil, &formatError{offset, "invalid section offset", int64(s.Offset)}
+	}
+	if int64(s.FileSize) < 0 {
+		return nil, &formatError{offset, "invalid section size", int64(s.FileSize)}
+	}
+	s.reader = io.NewSectionReader(reader, int64(s.Offset), int64(s.FileSize))
+
+	if s.Flags&elf.SHF_COMPRESSED == 0 {
+		s.Size = s.FileSize
+	} else {
+		// Ignore compressed sections
+		return nil, nil
+	}
+
+	return s, nil
+}
+
+func getString(reader *io.SectionReader, start int64) (string, bool) {
+	var data []byte
+	var b [1]byte
+
+	for ; ; start++ {
+		if _, err := reader.ReadAt(b[:], int64(start)); err != nil {
+			return "", false
+		}
+		if b[0] == 0 {
+			break
+		}
+		data = append(data, b[0])
+	}
+
+	return string(data), true
+}

--- a/pkg/gpu/cuda/elf.go
+++ b/pkg/gpu/cuda/elf.go
@@ -21,7 +21,7 @@ import (
 const stringBufferSize = 256
 
 // errorUnsupported is returned when an unsupported section is found, which indicates we should skip that section
-var errorUnsupported = fmt.Errorf("unsupported section parsing")
+var errorUnsupported = errors.New("unsupported section parsing")
 
 // lazySectionReader is a lazy reader for ELF sections, with reduced number of allocations.
 // It's oriented around an iterator pattern, where only one section is read (and allocated) at a time.

--- a/pkg/gpu/cuda/elf_test.go
+++ b/pkg/gpu/cuda/elf_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package cuda
+
+import (
+	"debug/elf"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+)
+
+func TestLazySectionReader(t *testing.T) {
+	curDir, err := testutil.CurDir()
+	require.NoError(t, err)
+
+	libdir := filepath.Join(curDir, "..", "..", "network", "usm", "testdata", "site-packages", "ddtrace")
+	lib := filepath.Join(libdir, fmt.Sprintf("libssl.so.%s", runtime.GOARCH))
+
+	f, err := os.Open(lib)
+	require.NoError(t, err)
+	t.Cleanup(func() { f.Close() })
+
+	// Read using the regular ELF reader first
+	elfFile, err := elf.NewFile(f)
+	require.NoError(t, err)
+	t.Cleanup(func() { elfFile.Close() })
+
+	sectsByIndex := make(map[int]*elf.Section)
+	for i, sect := range elfFile.Sections {
+		sectsByIndex[i] = sect
+	}
+
+	// Read using the lazy reader now
+	reader := newLazySectionReader(f)
+
+	i := 0 // canot use the enumerator index as this is a range-over iterator, not a regular slice
+	for sect := range reader.Iterate() {
+		require.Greater(t, len(sectsByIndex), i)
+
+		origSect := sectsByIndex[i]
+		require.Equal(t, origSect.Offset, sect.Offset, "Offset mismatch in section number %d", i)
+		require.Equal(t, origSect.Size, sect.Size, "Size mismatch in section number %d", i)
+		require.Equal(t, origSect.Name, sect.Name(), "Name mismatch in section number %d", i)
+		i++
+	}
+}

--- a/pkg/gpu/cuda/elf_test.go
+++ b/pkg/gpu/cuda/elf_test.go
@@ -52,4 +52,6 @@ func TestLazySectionReader(t *testing.T) {
 		require.Equal(t, origSect.Name, sect.Name(), "Name mismatch in section number %d", i)
 		i++
 	}
+
+	require.Equal(t, len(sectsByIndex), i, "Mismatch in number of sections")
 }

--- a/pkg/gpu/cuda/elf_test.go
+++ b/pkg/gpu/cuda/elf_test.go
@@ -6,7 +6,6 @@
 package cuda
 
 import (
-	"debug/elf"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 )
 
 func TestLazySectionReader(t *testing.T) {
@@ -30,11 +30,11 @@ func TestLazySectionReader(t *testing.T) {
 	t.Cleanup(func() { f.Close() })
 
 	// Read using the regular ELF reader first
-	elfFile, err := elf.NewFile(f)
+	elfFile, err := safeelf.NewFile(f)
 	require.NoError(t, err)
 	t.Cleanup(func() { elfFile.Close() })
 
-	sectsByIndex := make(map[int]*elf.Section)
+	sectsByIndex := make(map[int]*safeelf.Section)
 	for i, sect := range elfFile.Sections {
 		sectsByIndex[i] = sect
 	}

--- a/pkg/gpu/cuda/elf_test.go
+++ b/pkg/gpu/cuda/elf_test.go
@@ -34,24 +34,19 @@ func TestLazySectionReader(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { elfFile.Close() })
 
-	sectsByIndex := make(map[int]*safeelf.Section)
-	for i, sect := range elfFile.Sections {
-		sectsByIndex[i] = sect
-	}
-
 	// Read using the lazy reader now
 	reader := newLazySectionReader(f)
 
 	i := 0 // canot use the enumerator index as this is a range-over iterator, not a regular slice
 	for sect := range reader.Iterate() {
-		require.Greater(t, len(sectsByIndex), i)
+		require.Greater(t, len(elfFile.Sections), i)
 
-		origSect := sectsByIndex[i]
+		origSect := elfFile.Sections[i]
 		require.Equal(t, origSect.Offset, sect.Offset, "Offset mismatch in section number %d", i)
 		require.Equal(t, origSect.Size, sect.Size, "Size mismatch in section number %d", i)
 		require.Equal(t, origSect.Name, sect.Name(), "Name mismatch in section number %d", i)
 		i++
 	}
 
-	require.Equal(t, len(sectsByIndex), i, "Mismatch in number of sections")
+	require.Equal(t, len(elfFile.Sections), i, "Mismatch in number of sections")
 }

--- a/pkg/gpu/cuda/fatbin_test.go
+++ b/pkg/gpu/cuda/fatbin_test.go
@@ -47,10 +47,8 @@ func TestParseFatbinFromPath(t *testing.T) {
 		kern2MangledName: 256,
 	}
 
-	expectedConstantMemSizes := map[string]uint64{
-		kern1MangledName: 0,
-		kern2MangledName: 0,
-	}
+	expectedConstMemSizeBeforeSm70 := uint64(332)
+	expectedConstMemSizeAfterSm70 := uint64(364)
 
 	for key, kernel := range res.kernels {
 		seenSmVersionsAndKernels[key.SmVersion] = append(seenSmVersionsAndKernels[key.SmVersion], key.Name)
@@ -62,7 +60,12 @@ func TestParseFatbinFromPath(t *testing.T) {
 		// The memory sizes are different for sm_90, checked with cuobjdump
 		if key.SmVersion != 90 {
 			require.Equal(t, expectedMemSize, kernel.SharedMem, "unexpected shared memory size for kernel %s, sm=%d", key.Name, key.SmVersion)
-			require.Equal(t, expectedConstantMemSizes[key.Name], kernel.ConstantMem, "unexpected constant memory size for kernel %s, sm=%d", key.Name, key.SmVersion)
+
+			expectedConstMemSize := expectedConstMemSizeBeforeSm70
+			if key.SmVersion >= 70 {
+				expectedConstMemSize = expectedConstMemSizeAfterSm70
+			}
+			require.Equal(t, expectedConstMemSize, kernel.ConstantMem, "unexpected constant memory size for kernel %s, sm=%d", key.Name, key.SmVersion)
 		}
 
 		require.Greater(t, kernel.KernelSize, uint64(0), "unexpected kernel size for kernel %s, sm=%d", key.Name, key.SmVersion)

--- a/pkg/gpu/cuda/fatbin_test.go
+++ b/pkg/gpu/cuda/fatbin_test.go
@@ -47,6 +47,11 @@ func TestParseFatbinFromPath(t *testing.T) {
 		kern2MangledName: 256,
 	}
 
+	expectedConstantMemSizes := map[string]uint64{
+		kern1MangledName: 0,
+		kern2MangledName: 0,
+	}
+
 	for key, kernel := range res.kernels {
 		seenSmVersionsAndKernels[key.SmVersion] = append(seenSmVersionsAndKernels[key.SmVersion], key.Name)
 		require.Equal(t, key.Name, kernel.Name)
@@ -57,6 +62,7 @@ func TestParseFatbinFromPath(t *testing.T) {
 		// The memory sizes are different for sm_90, checked with cuobjdump
 		if key.SmVersion != 90 {
 			require.Equal(t, expectedMemSize, kernel.SharedMem, "unexpected shared memory size for kernel %s, sm=%d", key.Name, key.SmVersion)
+			require.Equal(t, expectedConstantMemSizes[key.Name], kernel.ConstantMem, "unexpected constant memory size for kernel %s, sm=%d", key.Name, key.SmVersion)
 		}
 
 		require.Greater(t, kernel.KernelSize, uint64(0), "unexpected kernel size for kernel %s, sm=%d", key.Name, key.SmVersion)

--- a/pkg/gpu/cuda/testdata/README.md
+++ b/pkg/gpu/cuda/testdata/README.md
@@ -1,5 +1,5 @@
 This folder contains sample data to test the fatbin parser. The sample.cu file can be compiled just with running `make`.
 
-The compiler required is `nvcc`, to install in Ubuntu run `sudo apt-get install nvidia-cuda-dev`. Use `cuobjdump` (from the same package) to dump the fatbin file manually and check the results.
+The compiler required is `nvcc`, to install in Ubuntu run `sudo apt-get install nvidia-cuda-dev`. Use `cuobjdump` (from the same package) to dump the fatbin file manually and check the results. The argument `-res-usage` can be used in that command to check the resource usage for each kernel (note that sometimes, the resource usage for the same kernel might vary between architectures).
 
 The sample binary is checked into source for tests, to avoid having the dependency on the compiler in the CI.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR introduces a "lazy" section reader for ELF files in the GPU fatbin parsing code. Instead of parsing all the sections at once, this reader parses sections one at a time and yields them through an iterator. This means that we only have one section allocated at a time and we can reuse internal buffers and structures, which makes it much more efficient in terms of memory.

### Motivation

While dogfooding, we have detected payloads have up to two thousand kernels. With several ELF sections per kernel, the number of sections to parse is very large and that causes us to hit memory limits. This PR should reduce that memory usage.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Existing unit tests cover the parsing of CUDA binaries. Additionally, a test that parses an ELF file (non-cubin, just the SSL library we have as test data for binary inspection) using the `debug/elf` package and compares with this lazy reader has been added to ensure that we get the same results and we don't miss any sections.

Benchmarks have also been performed. The following shows the reduction in memory usage with the `heavy-sample` benchmark:

Before
``` 
goarch: arm64
pkg: github.com/DataDog/datadog-agent/pkg/gpu/cuda
BenchmarkParseFatbinFromPath/heavy-sample-8         	      31	  38484138 ns/op	 6731705 B/op	   19193 allocs/op
PASS
``` 

After:
```
pkg: github.com/DataDog/datadog-agent/pkg/gpu/cuda
BenchmarkParseFatbinFromPath/heavy-sample-8         	    39	  33560752 ns/op	 4960563 B/op	    5786 allocs/op
``` 

Most of the reduction is in the `parseCubinElf` function, which as can be seen in the profile sees a reduction from ~65MB to ~17MB (15% of the original memory usage). The difference in time is negligible, as most of the time of that benchmark is spent on reading the file from disk.

Memory profile before: 

![Screenshot 2025-02-11 at 00 03 02](https://github.com/user-attachments/assets/1f3fce2e-ef7d-4aa8-9115-4ac28f274bd4)

Memory profile after:

![Screenshot 2025-02-11 at 14 21 36](https://github.com/user-attachments/assets/2e147506-2f62-44b2-97bf-1312f77f8495)


### Possible Drawbacks / Trade-offs

### Additional Notes


