### PR TITLE
[EBPF] gpu: parse kernels only for architectures present in the host

### DIFF
--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -187,7 +187,12 @@ func (ctx *systemContext) getCudaSymbols(path string) (*symbolsEntry, error) {
 		return data, nil
 	}
 
-	data, err := cuda.GetSymbols(path)
+	wantedSmVersions := make(map[uint32]struct{})
+	for _, smVersion := range ctx.deviceSmVersions {
+		wantedSmVersions[uint32(smVersion)] = struct{}{}
+	}
+
+	data, err := cuda.GetSymbols(path, wantedSmVersions)
 	if err != nil {
 		ctx.fatbinTelemetry.readErrors.Inc()
 		return nil, fmt.Errorf("error getting file data: %w", err)

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -37,6 +37,9 @@ type systemContext struct {
 	// deviceSmVersions maps each device index to its SM (Compute architecture) version
 	deviceSmVersions map[int]int
 
+	// smVersionSet is a set of all the seen SM versions, to filter kernels to parse
+	smVersionSet map[uint32]struct{}
+
 	// cudaSymbols maps each executable file path to its Fatbin file data
 	cudaSymbols map[string]*symbolsEntry
 
@@ -102,6 +105,7 @@ func (e *symbolsEntry) updateLastUsedTime() {
 func getSystemContext(nvmlLib nvml.Interface, procRoot string, wmeta workloadmeta.Component, tm telemetry.Component) (*systemContext, error) {
 	ctx := &systemContext{
 		deviceSmVersions:          make(map[int]int),
+		smVersionSet:              make(map[uint32]struct{}),
 		cudaSymbols:               make(map[string]*symbolsEntry),
 		pidMaps:                   make(map[int][]*procfs.ProcMap),
 		nvmlLib:                   nvmlLib,
@@ -175,6 +179,7 @@ func (ctx *systemContext) fillDeviceInfo() error {
 			return err
 		}
 		ctx.deviceSmVersions[i] = smVersion
+		ctx.smVersionSet[uint32(smVersion)] = struct{}{}
 
 		ctx.gpuDevices = append(ctx.gpuDevices, dev)
 	}
@@ -187,14 +192,9 @@ func (ctx *systemContext) getCudaSymbols(path string) (*symbolsEntry, error) {
 		return data, nil
 	}
 
-	wantedSmVersions := make(map[uint32]struct{})
-	for _, smVersion := range ctx.deviceSmVersions {
-		wantedSmVersions[uint32(smVersion)] = struct{}{}
-	}
-
 	log.Debugf("Getting CUDA symbols for %s, wanted SM versions: %v", path, wantedSmVersions)
 
-	data, err := cuda.GetSymbols(path, wantedSmVersions)
+	data, err := cuda.GetSymbols(path, ctx.smVersionSet)
 	if err != nil {
 		ctx.fatbinTelemetry.readErrors.Inc()
 		return nil, fmt.Errorf("error getting file data: %w", err)

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -192,7 +192,7 @@ func (ctx *systemContext) getCudaSymbols(path string) (*symbolsEntry, error) {
 		return data, nil
 	}
 
-	log.Debugf("Getting CUDA symbols for %s, wanted SM versions: %v", path, wantedSmVersions)
+	log.Debugf("Getting CUDA symbols for %s, wanted SM versions: %v", path, ctx.smVersionSet)
 
 	data, err := cuda.GetSymbols(path, ctx.smVersionSet)
 	if err != nil {

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -192,6 +192,8 @@ func (ctx *systemContext) getCudaSymbols(path string) (*symbolsEntry, error) {
 		wantedSmVersions[uint32(smVersion)] = struct{}{}
 	}
 
+	log.Debugf("Getting CUDA symbols for %s, wanted SM versions: %v", path, wantedSmVersions)
+
 	data, err := cuda.GetSymbols(path, wantedSmVersions)
 	if err != nil {
 		ctx.fatbinTelemetry.readErrors.Inc()

--- a/pkg/gpu/cuda/fatbin_test.go
+++ b/pkg/gpu/cuda/fatbin_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 )
 
+// smVersions has all the SM version of the kernels.
+// Retrieved from the Makefile, all the -gencode arch=compute_XX,code=sm_XX flags
+var smVersions = []uint32{50, 52, 60, 61, 70, 75, 80, 86, 89, 90}
+
 // The test data is a CUDA fatbin file compiled with the Makefile present in the same directory,
 // using `make <name>` (for now, only supported samples are `sample` and `heavy-sample`).
 func getCudaSample(t testing.TB, name string) string {
@@ -32,11 +36,18 @@ func getCudaSample(t testing.TB, name string) string {
 	return sample
 }
 
+func smVersionSet() map[uint32]struct{} {
+	smSet := make(map[uint32]struct{})
+	for _, sm := range smVersions {
+		smSet[sm] = struct{}{}
+	}
+	return smSet
+}
+
 func TestParseFatbinFromPath(t *testing.T) {
 	path := getCudaSample(t, "sample")
-	res, err := ParseFatbinFromELFFilePath(path)
+	res, err := ParseFatbinFromELFFilePath(path, smVersionSet())
 	require.NoError(t, err)
-
 	kern1MangledName := "_Z7kernel1Pfi" // = kernel1(float*)
 	kern2MangledName := "_Z7kernel2Pfi" // = kernel2(float*)
 
@@ -66,13 +77,24 @@ func TestParseFatbinFromPath(t *testing.T) {
 		}
 	}
 
-	// From the Makefile, all the -gencode arch=compute_XX,code=sm_XX flags
-	expectedSmVersions := []uint32{50, 52, 60, 61, 70, 75, 80, 86, 89, 90}
-	require.ElementsMatch(t, expectedSmVersions, maps.Keys(seenSmVersionsAndKernels))
+	require.ElementsMatch(t, smVersions, maps.Keys(seenSmVersionsAndKernels))
 
 	// Check that all the kernels are present in each version
 	for version, kernelNames := range seenSmVersionsAndKernels {
 		require.ElementsMatch(t, []string{kern1MangledName, kern2MangledName}, kernelNames, "missing kernels for version %d", version)
+	}
+}
+
+func TestParseFatbinFromPathExcludesSomeSmVersions(t *testing.T) {
+	path := getCudaSample(t, "sample")
+	wantedVersions := map[uint32]struct{}{50: {}, 52: {}, 86: {}}
+	res, err := ParseFatbinFromELFFilePath(path, wantedVersions)
+	require.NoError(t, err)
+
+	// We already check in other tests that we get all the kernels for all the versions
+	// so here we check that we properly exclude the versions we don't want
+	for key := range res.kernels {
+		require.Contains(t, wantedVersions, key.SmVersion)
 	}
 }
 
@@ -82,7 +104,7 @@ func BenchmarkParseFatbinFromPath(b *testing.B) {
 		b.Run(sample, func(b *testing.B) {
 			path := getCudaSample(b, sample)
 			for i := 0; i < b.N; i++ {
-				_, err := ParseFatbinFromELFFilePath(path)
+				_, err := ParseFatbinFromELFFilePath(path, smVersionSet())
 				if err != nil {
 					b.Fatalf("unexpected error: %v", err)
 				}
@@ -96,7 +118,7 @@ func BenchmarkParseFatbinFromPath(b *testing.B) {
 // scales with the number of variables per kernel and kernels.
 func TestParseBigFatbinFromPath(t *testing.T) {
 	path := getCudaSample(t, "heavy-sample")
-	res, err := ParseFatbinFromELFFilePath(path)
+	res, err := ParseFatbinFromELFFilePath(path, smVersionSet())
 	require.NoError(t, err)
 
 	// These parameters need to match the same values used in the Makefile to generate the sample
@@ -135,9 +157,7 @@ func TestParseBigFatbinFromPath(t *testing.T) {
 		}
 	}
 
-	// From the Makefile, all the -gencode arch=compute_XX,code=sm_XX flags
-	expectedSmVersions := []uint32{50, 52, 60, 61, 70, 75, 80, 86, 89, 90}
-	require.ElementsMatch(t, expectedSmVersions, maps.Keys(seenSmVersionsAndKernels))
+	require.ElementsMatch(t, smVersions, maps.Keys(seenSmVersionsAndKernels))
 
 	// Check that all the kernels are present in each version
 	for version, kernelNames := range seenSmVersionsAndKernels {

--- a/pkg/gpu/cuda/symbols.go
+++ b/pkg/gpu/cuda/symbols.go
@@ -21,14 +21,14 @@ type Symbols struct {
 }
 
 // GetSymbols reads an ELF file from the given path and return the parsed CUDA data
-func GetSymbols(path string) (*Symbols, error) {
+func GetSymbols(path string, wantedSmVersions map[uint32]struct{}) (*Symbols, error) {
 	elfFile, err := safeelf.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening ELF file %s: %w", path, err)
 	}
 	defer elfFile.Close()
 
-	fatbin, err := ParseFatbinFromELFFile(elfFile)
+	fatbin, err := ParseFatbinFromELFFile(elfFile, wantedSmVersions)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing fatbin on %s: %w", path, err)
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the Fatbin parsing code to ensure that we only read kernels for the architectures we care about, which are those of the devices present in the host. 

### Motivation

Reduce memory usage of the fatbin parsing code. Also validated in `venomoth` that there's a memory usage reduction.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests ensure that the behavior is correct.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->