### PR TITLE
Encode directly into byte sequence when encoding jsonPayload

### DIFF
--- a/pkg/logs/processor/json.go
+++ b/pkg/logs/processor/json.go
@@ -6,8 +6,8 @@
 package processor
 
 import (
-	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
@@ -64,6 +64,132 @@ func (j *jsonEncoder) Encode(msg *message.Message, hostname string) error {
 	return nil
 }
 
+// func encodeInner(payload jsonPayload) ([]byte, error) {
+// 	return json.Marshal(payload)
+// }
+
+// func encodeInner(payload jsonPayload) ([]byte, error) {
+// 	var sb strings.Builder
+// 	sb.Grow(255) // arbitrary constant, unclear if too big or too small
+
+// 	sb.WriteByte('{')
+// 	// "message": <string>
+// 	sb.WriteString(`"message":`)
+// 	escapedString(&sb, payload.Message)
+// 	sb.WriteByte(',')
+
+// 	// "status": <string>
+// 	sb.WriteString(`"status":`)
+// 	escapedString(&sb, payload.Status)
+// 	sb.WriteByte(',')
+
+// 	// "timestamp": <number>
+// 	sb.WriteString(`"timestamp":`)
+// 	sb.WriteString(strconv.FormatInt(payload.Timestamp, 10))
+// 	sb.WriteByte(',')
+
+// 	// "hostname": <string>
+// 	sb.WriteString(`"hostname":`)
+// 	escapedString(&sb, payload.Hostname)
+// 	sb.WriteByte(',')
+
+// 	// "service": <string>
+// 	sb.WriteString(`"service":`)
+// 	escapedString(&sb, payload.Service)
+// 	sb.WriteByte(',')
+
+// 	// "ddsource": <string>
+// 	sb.WriteString(`"ddsource":`)
+// 	escapedString(&sb, payload.Source)
+// 	sb.WriteByte(',')
+
+// 	// "ddtags": <string>
+// 	sb.WriteString(`"ddtags":`)
+// 	escapedString(&sb, payload.Tags)
+
+// 	sb.WriteByte('}')
+
+// 	return []byte(sb.String()), nil
+// }
+
+// func escapedString(sb *strings.Builder, s string) {
+// 	sb.WriteByte('"')
+// 	for i := 0; i < len(s); i++ {
+// 		c := s[i]
+// 		switch c {
+// 		case '\\':
+// 			sb.WriteString(`\\`)
+// 		case '"':
+// 			sb.WriteString(`\"`)
+// 		case '\n':
+// 			sb.WriteString(`\n`)
+// 		case '\r':
+// 			sb.WriteString(`\r`)
+// 		case '\t':
+// 			sb.WriteString(`\t`)
+// 		default:
+//			// TODO chars <0x20
+// 			sb.WriteByte(c)
+// 		}
+// 	}
+// 	sb.WriteByte('"')
+// }
+
 func encodeInner(payload jsonPayload) ([]byte, error) {
-	return json.Marshal(payload)
+	b := make([]byte, 0, 256) // arbitrary constant, unclear if too big or too small
+
+	b = append(b, '{')
+
+	b = append(b, `"message":`...)
+	b = escapedString(b, payload.Message)
+	b = append(b, ',')
+
+	b = append(b, `"status":`...)
+	b = escapedString(b, payload.Status)
+	b = append(b, ',')
+
+	b = append(b, `"timestamp":`...)
+	b = strconv.AppendInt(b, payload.Timestamp, 10)
+	b = append(b, ',')
+
+	b = append(b, `"hostname":`...)
+	b = escapedString(b, payload.Hostname)
+	b = append(b, ',')
+
+	b = append(b, `"service":`...)
+	b = escapedString(b, payload.Service)
+	b = append(b, ',')
+
+	b = append(b, `"ddsource":`...)
+	b = escapedString(b, payload.Source)
+	b = append(b, ',')
+
+	b = append(b, `"ddtags":`...)
+	b = escapedString(b, payload.Tags)
+
+	b = append(b, '}')
+	return b, nil
+}
+
+func escapedString(b []byte, s string) []byte {
+	b = append(b, '"')
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			b = append(b, `\\`...)
+		case '"':
+			b = append(b, `\"`...)
+		case '\n':
+			b = append(b, `\n`...)
+		case '\r':
+			b = append(b, `\r`...)
+		case '\t':
+			b = append(b, `\t`...)
+		default:
+			// TODO chars <0x20
+			b = append(b, s[i])
+		}
+	}
+	b = append(b, '"')
+	return b
 }

--- a/pkg/logs/processor/processor_test.go
+++ b/pkg/logs/processor/processor_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Encode directly into byte sequence when encoding jsonPayload

This commit -- with commented code that will be removed showing the
other things I've tried -- has an implementation of encodeInner that
has no interior string, only a []byte.

Original encodeInner micro-benchmark:

    goos: darwin
    goarch: arm64
    pkg: github.com/DataDog/datadog-agent/pkg/logs/processor
    cpu: Apple M1 Max
    BenchmarkEncodeInner/empty_payload-10            4392625               268.0 ns/op           208 B/op          2 allocs/op
    BenchmarkEncodeInner/all_fields_populated-10     3784881               316.0 ns/op           256 B/op          2 allocs/op
    BenchmarkEncodeInner/emjois_in_fields-10         3575017               333.9 ns/op           288 B/op          2 allocs/op
    BenchmarkEncodeInner/escape_sequences_in_message-10              3319614               361.9 ns/op           288 B/op          2 allocs/op
    PASS
    ok      github.com/DataDog/datadog-agent/pkg/logs/processor     6.618s

Current result:

    goos: darwin
    goarch: arm64
    pkg: github.com/DataDog/datadog-agent/pkg/logs/processor
    cpu: Apple M1 Max
    BenchmarkEncodeInner/empty_payload-10            8610205               126.1 ns/op           256 B/op          1 allocs/op
    BenchmarkEncodeInner/all_fields_populated-10     6992306               173.1 ns/op           256 B/op          1 allocs/op
    BenchmarkEncodeInner/emjois_in_fields-10         5120106               231.9 ns/op           256 B/op          1 allocs/op
    BenchmarkEncodeInner/escape_sequences_in_message-10              5314688               225.9 ns/op           256 B/op          1 allocs/op
    PASS
    ok      github.com/DataDog/datadog-agent/pkg/logs/processor     5.753s

I am curious what the Regression Detector will say.


### Motivation

I want to see if we can optimize this. The quality-gate-logs profiles show this
area as consuming 12% of heap memory. It'd be neat if we could cut that.

### Describe how you validated your changes

I haven't yet. I'm reasonably sure that the escaping for instance is not
complete yet, it's just what I could quickly google. So that for one is 
suspicious.

### Additional Notes

This change is part of a graphite stack. It is probably best to start at the bottom
of the stack and then work up when reading.