### PR TITLE
feat(ssi): enable target based workload selection

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -197,7 +197,7 @@ func generateAutoInstrumentationWebhook(wmeta workloadmeta.Component, datadogCon
 	mutator := mutatecommon.NewMutators(
 		tagsfromlabels.NewMutator(tagsfromlabels.NewMutatorConfig(datadogConfig), filter),
 		configWebhook.NewMutator(configWebhook.NewMutatorConfig(datadogConfig), filter),
-		autoinstrumentation.NewMutator(config, filter, wmeta),
+		autoinstrumentation.NewNamespaceMutator(config, filter, wmeta),
 	)
 	return autoinstrumentation.NewWebhook(config, wmeta, mutator)
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
@@ -52,12 +51,11 @@ type Webhook struct {
 	mutator mutatecommon.Mutator
 
 	// use to store all the config option from the config component to avoid costly lookups in the admission webhook hot path.
-	config webhookConfig
+	config *WebhookConfig
 }
 
 // NewWebhook returns a new Webhook dependent on the injection filter.
-func NewWebhook(wmeta workloadmeta.Component, datadogConfig config.Component, mutator mutatecommon.Mutator) (*Webhook, error) {
-	config := retrieveConfig(datadogConfig)
+func NewWebhook(config *Config, wmeta workloadmeta.Component, mutator mutatecommon.Mutator) (*Webhook, error) {
 	webhook := &Webhook{
 		name:            webhookName,
 		resources:       map[string][]string{"": {"pods"}},
@@ -65,7 +63,7 @@ func NewWebhook(wmeta workloadmeta.Component, datadogConfig config.Component, mu
 		matchConditions: []admissionregistrationv1.MatchCondition{},
 		mutator:         mutator,
 		wmeta:           wmeta,
-		config:          config,
+		config:          config.Webhook,
 	}
 
 	return webhook, nil
@@ -83,12 +81,12 @@ func (w *Webhook) WebhookType() common.WebhookType {
 
 // IsEnabled returns whether the webhook is enabled
 func (w *Webhook) IsEnabled() bool {
-	return w.config.isEnabled
+	return w.config.IsEnabled
 }
 
 // Endpoint returns the endpoint of the webhook
 func (w *Webhook) Endpoint() string {
-	return w.config.endpoint
+	return w.config.Endpoint
 }
 
 // Resources returns the kubernetes resources for which the webhook should

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -250,8 +250,8 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				tt.expectedInstallType = "k8s_single_step"
 			}
 
-			injector := NewNamespaceMutator(config, filter, wmeta)
-			err = injector.injectAutoInstruConfig(tt.pod, tt.libInfo)
+			mutator := NewNamespaceMutator(config, filter, wmeta)
+			err = mutator.core.injectTracers(tt.pod, tt.libInfo)
 			if tt.wantErr {
 				require.Error(t, err, "expected injectAutoInstruConfig to error")
 			} else {
@@ -598,9 +598,9 @@ func TestInjectAutoInstruConfig(t *testing.T) {
 			require.NoError(t, err)
 			filter, err := NewFilter(config)
 			require.NoError(t, err)
-			injector := NewNamespaceMutator(config, filter, wmeta)
+			mutator := NewNamespaceMutator(config, filter, wmeta)
 
-			err = injector.injectAutoInstruConfig(tt.pod, extractedPodLibInfo{
+			err = mutator.core.injectTracers(tt.pod, extractedPodLibInfo{
 				libs:   tt.libsToInject,
 				source: libInfoSourceLibInjection,
 			})
@@ -1693,7 +1693,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			if tt.wantSkipInjection {
 				return
 			}
-			c.Mutators = mutator.newContainerMutators(requirements)
+			c.Mutators = mutator.core.newContainerMutators(requirements)
 			initalInitContainerCount := len(tt.pod.Spec.InitContainers)
 			err = c.mutatePod(tt.pod)
 			if (err != nil) != tt.wantErr {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -250,7 +250,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				tt.expectedInstallType = "k8s_single_step"
 			}
 
-			injector := NewMutator(config, filter, wmeta)
+			injector := NewNamespaceMutator(config, filter, wmeta)
 			err = injector.injectAutoInstruConfig(tt.pod, tt.libInfo)
 			if tt.wantErr {
 				require.Error(t, err, "expected injectAutoInstruConfig to error")
@@ -598,7 +598,7 @@ func TestInjectAutoInstruConfig(t *testing.T) {
 			require.NoError(t, err)
 			filter, err := NewFilter(config)
 			require.NoError(t, err)
-			injector := NewMutator(config, filter, wmeta)
+			injector := NewNamespaceMutator(config, filter, wmeta)
 
 			err = injector.injectAutoInstruConfig(tt.pod, extractedPodLibInfo{
 				libs:   tt.libsToInject,
@@ -1082,7 +1082,7 @@ func TestExtractLibInfo(t *testing.T) {
 			require.NoError(t, err)
 			filter, err := NewFilter(config)
 			require.NoError(t, err)
-			mutator := NewMutator(config, filter, wmeta)
+			mutator := NewNamespaceMutator(config, filter, wmeta)
 
 			if tt.expectedPodEligible != nil {
 				require.Equal(t, *tt.expectedPodEligible, mutator.isPodEligible(tt.pod))
@@ -1684,7 +1684,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			filter, err := NewFilter(config)
 			require.NoError(t, err)
 
-			mutator := NewMutator(config, filter, wmeta)
+			mutator := NewNamespaceMutator(config, filter, wmeta)
 
 			c := tt.lang.libInfo("", tt.image).initContainers(config.version)[0]
 			requirements, injectionDecision := initContainerResourceRequirements(tt.pod, config.defaultResourceRequirements)
@@ -3604,7 +3604,7 @@ func TestShouldInject(t *testing.T) {
 			require.NoError(t, err)
 			filter, err := NewFilter(config)
 			require.NoError(t, err)
-			mutator := NewMutator(config, filter, wmeta)
+			mutator := NewNamespaceMutator(config, filter, wmeta)
 			require.Equal(t, tt.want, mutator.isPodEligible(tt.pod), "expected webhook.isPodEligible() to be %t", tt.want)
 		})
 	}
@@ -3621,7 +3621,7 @@ func maybeWebhook(wmeta workloadmeta.Component, ddConfig config.Component) (*Web
 		return nil, err
 	}
 
-	injector := NewMutator(config, filter, wmeta)
+	injector := NewNamespaceMutator(config, filter, wmeta)
 	webhook, err := NewWebhook(config, wmeta, injector)
 	if err != nil {
 		return nil, err

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/filter.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/filter.go
@@ -8,14 +8,13 @@
 package autoinstrumentation
 
 import (
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 )
 
 // NewFilter creates a new MutationFilter from the provided FilterConfig.
-func NewFilter(datadogConfig config.Component) (mutatecommon.MutationFilter, error) {
-	enabled := datadogConfig.GetBool("apm_config.instrumentation.enabled")
-	enabledNamespaces := datadogConfig.GetStringSlice("apm_config.instrumentation.enabled_namespaces")
-	disabledNamespaces := datadogConfig.GetStringSlice("apm_config.instrumentation.disabled_namespaces")
-	return mutatecommon.NewDefaultFilter(enabled, enabledNamespaces, disabledNamespaces)
+func NewFilter(config *Config) (mutatecommon.MutationFilter, error) {
+	return mutatecommon.NewDefaultFilter(
+		config.Instrumentation.Enabled,
+		config.Instrumentation.EnabledNamespaces,
+		config.Instrumentation.DisabledNamespaces)
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutator.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
+)
+
+// NewMutatorWithFilter handles the dependency injection for the mutator. If a targets list is defined, it will return
+// a target mutator, otherwise it will return a namespace mutator.
+func NewMutatorWithFilter(c *Config, wmeta workloadmeta.Component) (mutatecommon.MutatorWithFilter, error) {
+	if len(c.Instrumentation.Targets) > 0 {
+		return NewTargetMutator(c, wmeta)
+	}
+
+	return NewNamespaceMutator(c, wmeta)
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_filter.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_filter.go
@@ -38,16 +38,16 @@ type targetInternal struct {
 
 // NewTargetFilter creates a new TargetFilter from a list of targets and disabled namespaces. We convert the targets
 // to a more efficient internal format for quick lookups.
-func NewTargetFilter(targets []Target, wmeta workloadmeta.Component, disabledNamespaces []string, containerRegistry string) (*TargetFilter, error) {
+func NewTargetFilter(config *Config, wmeta workloadmeta.Component) (*TargetFilter, error) {
 	// Create a map of disabled namespaces for quick lookups.
-	disabledNamespacesMap := make(map[string]bool, len(disabledNamespaces))
-	for _, ns := range disabledNamespaces {
+	disabledNamespacesMap := make(map[string]bool, len(config.Instrumentation.DisabledNamespaces))
+	for _, ns := range config.Instrumentation.DisabledNamespaces {
 		disabledNamespacesMap[ns] = true
 	}
 
 	// Convert the targets to internal format.
-	internalTargets := make([]targetInternal, len(targets))
-	for i, t := range targets {
+	internalTargets := make([]targetInternal, len(config.Instrumentation.Targets))
+	for i, t := range config.Instrumentation.Targets {
 		// Convert the pod selector to a label selector.
 		podSelector, err := t.PodSelector.AsLabelSelector()
 		if err != nil {
@@ -78,9 +78,9 @@ func NewTargetFilter(targets []Target, wmeta workloadmeta.Component, disabledNam
 		// Get the library versions to inject. If no versions are specified, we inject all libraries.
 		var libVersions []libInfo
 		if len(t.TracerVersions) == 0 {
-			libVersions = getAllLatestDefaultLibraries(containerRegistry)
+			libVersions = getAllLatestDefaultLibraries(config.containerRegistry)
 		} else {
-			libVersions = getPinnedLibraries(t.TracerVersions, containerRegistry)
+			libVersions = getPinnedLibraries(t.TracerVersions, config.containerRegistry)
 		}
 
 		// Store the target in the internal format.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_filter_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_filter_test.go
@@ -221,7 +221,8 @@ func TestTargetFilter(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// Load the config.
 			mockConfig := configmock.NewFromFile(t, test.configPath)
-			cfg, err := NewInstrumentationConfig(mockConfig)
+			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.container_registry", "registry")
+			config, err := NewConfig(mockConfig)
 			require.NoError(t, err)
 
 			// Create a mock meta.
@@ -238,7 +239,7 @@ func TestTargetFilter(t *testing.T) {
 			}
 
 			// Create the filter.
-			f, err := NewTargetFilter(cfg.Targets, wmeta, cfg.DisabledNamespaces, "registry")
+			f, err := NewTargetFilter(config, wmeta)
 			require.NoError(t, err)
 
 			// Filter the pod.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestTargetFilter(t *testing.T) {
+func TestTargetMutator(t *testing.T) {
 	tests := map[string]struct {
 		configPath string
 		in         *corev1.Pod
@@ -238,8 +238,8 @@ func TestTargetFilter(t *testing.T) {
 				wmeta.Set(&ns)
 			}
 
-			// Create the filter.
-			f, err := NewTargetFilter(config, wmeta)
+			// Create the mutator.
+			f, err := NewTargetMutator(config, wmeta)
 			require.NoError(t, err)
 
 			// Filter the pod.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -22,19 +22,136 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
-func TestTargetMutator(t *testing.T) {
+func TestMutatePod(t *testing.T) {
+	tests := map[string]struct {
+		configPath                  string
+		in                          *corev1.Pod
+		namespaces                  []workloadmeta.KubernetesMetadata
+		expectedEnv                 map[string]string
+		expectedInitContainerImages []string
+		expectNoChange              bool
+	}{
+		"a matching rule has single step enabled": {
+			configPath: "testdata/filter_simple_namespace.yaml",
+			in:         mutatecommon.FakePodWithNamespace("foo-service", "application"),
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("application", nil),
+			},
+			expectedInitContainerImages: []string{
+				"registry/apm-inject:0",
+				"registry/dd-lib-python-init:v2",
+			},
+			expectedEnv: map[string]string{
+				"DD_INJECT_SENDER_TYPE":           "k8s",
+				"DD_INSTRUMENTATION_INSTALL_ID":   "",
+				"DD_INSTRUMENTATION_INSTALL_TYPE": "k8s_single_step",
+				"DD_LOGS_INJECTION":               "true",
+				"DD_RUNTIME_METRICS_ENABLED":      "true",
+				"DD_TRACE_ENABLED":                "true",
+				"DD_TRACE_HEALTH_METRICS_ENABLED": "true",
+				"LD_PRELOAD":                      "/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
+			},
+		},
+		"no matching rule does not mutate pod": {
+			configPath: "testdata/filter_simple_namespace.yaml",
+			in:         mutatecommon.FakePodWithNamespace("foo-service", "foo"),
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("foo", nil),
+			},
+			expectNoChange: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Load the config.
+			mockConfig := configmock.NewFromFile(t, test.configPath)
+			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.container_registry", "registry")
+			config, err := NewConfig(mockConfig)
+			require.NoError(t, err)
+
+			// Create a mock meta.
+			wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Supply(coreconfig.Params{}),
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				coreconfig.MockModule(),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+
+			// Add the namespaces.
+			for _, ns := range test.namespaces {
+				wmeta.Set(&ns)
+			}
+
+			// Create the mutator.
+			f, err := NewTargetMutator(config, wmeta)
+			require.NoError(t, err)
+
+			input := test.in.DeepCopy()
+
+			// Mutate the pod.
+			mutated, err := f.MutatePod(test.in, test.in.Namespace, nil)
+
+			// If there is no change, validate that the pod is unchanged.
+			if test.expectNoChange {
+				require.False(t, mutated)
+				require.NoError(t, err)
+				require.Equal(t, input, test.in)
+				return
+			}
+
+			require.True(t, mutated)
+			require.NoError(t, err)
+			require.Equal(t, 1, len(test.in.Spec.Containers))
+
+			// Validate the desired env.
+			actualEnv := make(map[string]string, len(test.in.Spec.Containers[0].Env))
+			for _, env := range test.in.Spec.Containers[0].Env {
+				actualEnv[env.Name] = env.Value
+			}
+			for k, v := range test.expectedEnv {
+				require.Equal(t, v, actualEnv[k])
+			}
+
+			// Validate the init containers.
+			actualInitContainerImages := make([]string, len(test.in.Spec.InitContainers))
+			for i, ctr := range test.in.Spec.InitContainers {
+				actualInitContainerImages[i] = ctr.Image
+			}
+			require.ElementsMatch(t, test.expectedInitContainerImages, actualInitContainerImages)
+		})
+	}
+}
+
+func TestShouldMutatePod(t *testing.T) {
 	tests := map[string]struct {
 		configPath string
 		in         *corev1.Pod
+		expected   bool
 		namespaces []workloadmeta.KubernetesMetadata
-		expected   []libInfo
 	}{
-		"a rule without selectors applies as a default": {
-			configPath: "testdata/filter.yaml",
+		"a matching rule gets mutated": {
+			configPath: "testdata/filter_no_default.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "application",
+					Labels: map[string]string{
+						"language": "java",
+					},
+				},
+			},
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("application", nil),
+			},
+			expected: true,
+		},
+		"no matching rule is not mutated": {
+			configPath: "testdata/filter_no_default.yaml",
 			in: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -45,6 +162,214 @@ func TestTargetMutator(t *testing.T) {
 			},
 			namespaces: []workloadmeta.KubernetesMetadata{
 				newTestNamespace("default", nil),
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Load the config.
+			mockConfig := configmock.NewFromFile(t, test.configPath)
+			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.container_registry", "registry")
+			config, err := NewConfig(mockConfig)
+			require.NoError(t, err)
+
+			// Create a mock meta.
+			wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Supply(coreconfig.Params{}),
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				coreconfig.MockModule(),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+
+			// Add the namespaces.
+			for _, ns := range test.namespaces {
+				wmeta.Set(&ns)
+			}
+
+			// Create the mutator.
+			f, err := NewTargetMutator(config, wmeta)
+			require.NoError(t, err)
+
+			// Determine if the pod should be mutated.
+			actual := f.ShouldMutatePod(test.in)
+
+			// Validate the output.
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestIsNamespaceEligible(t *testing.T) {
+	tests := map[string]struct {
+		configPath string
+		in         string
+		expected   bool
+		namespaces []workloadmeta.KubernetesMetadata
+	}{
+		"a matchNames namespace is eligible": {
+			configPath: "testdata/filter_no_default.yaml",
+			in:         "billing-service",
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("billing-service", nil),
+			},
+			expected: true,
+		},
+		"a rule without a namespace selector is eligible": {
+			configPath: "testdata/filter_no_default.yaml",
+			in:         "foo",
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("foo", nil),
+			},
+			expected: true,
+		},
+		"a matchLabels namespace is eligible": {
+			configPath: "testdata/filter_no_default.yaml",
+			in:         "foo",
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("foo", map[string]string{
+					"tracing": "yes",
+					"env":     "prod",
+				}),
+			},
+			expected: true,
+		},
+		"a disabled namespace is not eligible": {
+			configPath: "testdata/filter_no_default.yaml",
+			in:         "infra",
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("infra", nil),
+			},
+			expected: false,
+		},
+		"a common disabled namespace is not eligible": {
+			configPath: "testdata/filter_no_default.yaml",
+			in:         "kube-system",
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("kube-system", nil),
+			},
+			expected: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Load the config.
+			mockConfig := configmock.NewFromFile(t, test.configPath)
+			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.container_registry", "registry")
+			config, err := NewConfig(mockConfig)
+			require.NoError(t, err)
+
+			// Create a mock meta.
+			wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Supply(coreconfig.Params{}),
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				coreconfig.MockModule(),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+
+			// Add the namespaces.
+			for _, ns := range test.namespaces {
+				wmeta.Set(&ns)
+			}
+
+			// Create the mutator.
+			f, err := NewTargetMutator(config, wmeta)
+			require.NoError(t, err)
+
+			// Determine if the namespace is eligible.
+			actual := f.IsNamespaceEligible(test.in)
+
+			// Validate the output.
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestGetAnnotationLibraries(t *testing.T) {
+	tests := map[string]struct {
+		configPath string
+		in         *corev1.Pod
+		expected   []libInfo
+	}{
+		"a pod with no annotations gets no values": {
+			configPath: "testdata/filter_limited.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+				},
+			},
+			expected: nil,
+		},
+		"a pod with an annotation gets a value": {
+			configPath: "testdata/filter_limited.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Annotations: map[string]string{
+						"admission.datadoghq.com/python-lib.version": "v2",
+					},
+				},
+			},
+			expected: []libInfo{
+				{
+					ctrName: "",
+					lang:    python,
+					image:   "registry/dd-lib-python-init:v2",
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Load the config.
+			mockConfig := configmock.NewFromFile(t, test.configPath)
+			mockConfig.SetWithoutSource("admission_controller.auto_instrumentation.container_registry", "registry")
+			config, err := NewConfig(mockConfig)
+			require.NoError(t, err)
+
+			// Create a mock meta.
+			wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Supply(coreconfig.Params{}),
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				coreconfig.MockModule(),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+
+			// Create the mutator.
+			f, err := NewTargetMutator(config, wmeta)
+			require.NoError(t, err)
+
+			// Filter the pod.
+			actual := f.getAnnotationLibraries(test.in)
+
+			// Validate the output.
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestGetTargetLibraries(t *testing.T) {
+	tests := map[string]struct {
+		configPath string
+		in         *corev1.Pod
+		namespaces []workloadmeta.KubernetesMetadata
+		expected   []libInfo
+	}{
+		"a rule without selectors applies as a default": {
+			configPath: "testdata/filter.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "foo",
+					Labels: map[string]string{
+						"app": "frontend",
+					},
+				},
+			},
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("foo", nil),
 			},
 			expected: []libInfo{
 				{
@@ -58,14 +383,14 @@ func TestTargetMutator(t *testing.T) {
 			configPath: "testdata/filter_no_default.yaml",
 			in: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
+					Namespace: "foo",
 					Labels: map[string]string{
 						"app": "frontend",
 					},
 				},
 			},
 			namespaces: []workloadmeta.KubernetesMetadata{
-				newTestNamespace("default", nil),
+				newTestNamespace("foo", nil),
 			},
 			expected: nil,
 		},
@@ -215,6 +540,21 @@ func TestTargetMutator(t *testing.T) {
 				},
 			},
 		},
+		"a default disabled namespace gets no tracers": {
+			configPath: "testdata/filter.yaml",
+			in: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kube-system",
+					Labels: map[string]string{
+						"language": "java",
+					},
+				},
+			},
+			namespaces: []workloadmeta.KubernetesMetadata{
+				newTestNamespace("kube-system", nil),
+			},
+			expected: nil,
+		},
 	}
 
 	for name, test := range tests {
@@ -243,7 +583,7 @@ func TestTargetMutator(t *testing.T) {
 			require.NoError(t, err)
 
 			// Filter the pod.
-			actual := f.filter(test.in)
+			actual := f.getTargetLibraries(test.in)
 
 			// Validate the output.
 			require.Equal(t, test.expected, actual)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_limited.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_limited.yaml
@@ -1,0 +1,14 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "Billing Service"
+        podSelector:
+          matchLabels:
+            app: "billing-service"
+        namespaceSelector:
+          matchNames:
+          - "billing-service"
+        ddTraceVersions:
+          python: "v2"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_namespace.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_namespace.yaml
@@ -1,0 +1,11 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "Application Namespace"
+        namespaceSelector:
+          matchNames:
+          - "application"
+        ddTraceVersions:
+          python: "v2"

--- a/pkg/clusteragent/admission/mutate/common/mutator.go
+++ b/pkg/clusteragent/admission/mutate/common/mutator.go
@@ -19,6 +19,13 @@ type Mutator interface {
 	MutatePod(pod *corev1.Pod, ns string, dc dynamic.Interface) (bool, error)
 }
 
+// MutatorWithFilter is a combination interface of Mutator and MutationFilter such that a single struct can be used to
+// both mutate a pod and determine if a pod should be mutated.
+type MutatorWithFilter interface {
+	Mutator
+	MutationFilter
+}
+
 // MutatorFunc is a function that mutates a pod
 type MutatorFunc func(pod *corev1.Pod, ns string, cl dynamic.Interface) (bool, error)
 

--- a/pkg/clusteragent/admission/mutate/common/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/common/test_utils.go
@@ -227,6 +227,14 @@ func FakePodWithNamespaceAndLabel(namespace, k, v string) *corev1.Pod {
 	return pod
 }
 
+// FakePodWithNamespace returns a pod with a namespace.
+func FakePodWithNamespace(name, namespace string) *corev1.Pod {
+	pod := FakePod(name)
+	pod.Namespace = namespace
+
+	return pod
+}
+
 func fakePodWithVolume(podName, volumeName, mountPath string) *corev1.Pod {
 	pod := FakePod(podName)
 	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: volumeName})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR enables target based workload selection that we've been working on over the last few weeks. It does so by refactoring the auto instrumentation config and mutators to be able to accept an interface into the webhook. We vary that implementation based on if the target list is defined, and both mutators use a common core.

### Motivation
See [Kubernetes SSI | Workload Selection 🎯](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
There are extensive unit tests to ensure targets are applied according to the spec. But I wanted to make sure the high level behaviors were what we expect, and I've tested them below. For all of the tests below, I used the `injector-dev` tool in the `auto_inject` repo to build and deploy my container agent using helm.

#### Target Test, Pod Selector
```yaml
  datadog_cluster_yaml:
    apm_config:
      instrumentation:
        enabled: true
        targets:
          - name: "Microservices"
            podSelector:
              matchLabels:
                language: "python"
            ddTraceVersions:
              python: "default"
```

I ensured that with the label `language=python`, my pod was injected with the default python tracer.

#### Target Test, Namespace Selector
```yaml
  datadog_cluster_yaml:
    apm_config:
      instrumentation:
        enabled: true
        targets:
          - name: "Microservices"
            namespaceSlector:
              matchLabels:
                instrument: "yes"
            ddTraceVersions:
              python: "default"
```

I tested both no injection without the namespace label and once I added the label `instrument=yes` to the namespace and restarted my test pod, it was injected.

#### Enabled Namespace and Target List
```yaml
  datadog_cluster_yaml:
    apm_config:
      instrumentation:
        enabled: true
        enabled_namespaces:
          - "test-1"
          - "system"
        targets:
          - name: "Microservices"
            podSelector:
              matchLabels:
                language: "python"
            ddTraceVersions:
              python: "default"
```

This produced the following error, which is expected
```sh
2025-02-11 03:42:39 UTC | CLUSTER | ERROR | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:146 in generateWebhooks) | failed to register APM Instrumentation webhook: failed to create auto instrumentation config: apm.instrumentation.enabled_namespaces and apm.instrumentation.targets are mutually exclusive and cannot be set together
```

SSI did not mutate a pod, which was as suspected.


#### Enabled Namespaces
```yaml
    apm_config:
      instrumentation:
        enabled: true
        enabled_namespaces:
          - "test-1"
```

I ensured that with this config, my test app received all default tracers

### Possible Drawbacks / Trade-offs
The addition of a target mutator has the potential to be confusing and widens our support burden. However, we're adding a rather powerful way to configure workload targeting for SSI in Kubernetes and feel that it's worth it.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is the culmination of several refactors + changes to allow this change to go in more cleanly.