### PR TITLE
[CWS] turn `DefaultProgOpts` into a function

### DIFF
--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -49,23 +49,25 @@ type ProgOpts struct {
 }
 
 // DefaultProgOpts default options
-var DefaultProgOpts = ProgOpts{
-	EBPFOpts: &cbpfc.EBPFOpts{
-		PacketStart: asm.R1,
-		PacketEnd:   asm.R2,
-		Result:      asm.R3,
-		Working: [4]asm.Register{
-			asm.R4,
-			asm.R5,
-			asm.R6,
-			asm.R7,
+func DefaultProgOpts() ProgOpts {
+	return ProgOpts{
+		EBPFOpts: &cbpfc.EBPFOpts{
+			PacketStart: asm.R1,
+			PacketEnd:   asm.R2,
+			Result:      asm.R3,
+			Working: [4]asm.Register{
+				asm.R4,
+				asm.R5,
+				asm.R6,
+				asm.R7,
+			},
+			StackOffset: 16, // adapt using the stack size used outside of the filter itself, ex: map_lookup
 		},
-		StackOffset: 16, // adapt using the stack size used outside of the filter itself, ex: map_lookup
-	},
-	sendEventLabel: "send_event",
-	ctxSave:        asm.R9,
-	MaxTailCalls:   probes.RawPacketFilterMaxTailCall,
-	MaxProgSize:    4000,
+		sendEventLabel: "send_event",
+		ctxSave:        asm.R9,
+		MaxTailCalls:   probes.RawPacketFilterMaxTailCall,
+		MaxProgSize:    4000,
+	}
 }
 
 // BPFFilterToInsts compile a bpf filter expression

--- a/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap_unsupported.go
@@ -26,7 +26,9 @@ type ProgOpts struct {
 }
 
 // DefaultProgOpts default options
-var DefaultProgOpts ProgOpts
+func DefaultProgOpts() ProgOpts {
+	return ProgOpts{}
+}
 
 // BPFFilterToInsts compile a bpf filter expression
 func BPFFilterToInsts(_ int, _ string, _ ProgOpts) (asm.Instructions, error) {

--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -78,7 +78,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 				BPFFilter: "tcp dst port 5555 and tcp[tcpflags] == tcp-syn",
 			},
 		}
-		testRawPacketFilter(t, filters, 2, 1, rawpacket.DefaultProgOpts, true)
+		testRawPacketFilter(t, filters, 2, 1, rawpacket.DefaultProgOpts(), true)
 	})
 
 	t.Run("syn-port-std-ko", func(t *testing.T) {
@@ -88,7 +88,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 				BPFFilter: "tcp dst port 6666 and tcp[tcpflags] == tcp-syn",
 			},
 		}
-		testRawPacketFilter(t, filters, 0, 1, rawpacket.DefaultProgOpts, true)
+		testRawPacketFilter(t, filters, 0, 1, rawpacket.DefaultProgOpts(), true)
 	})
 
 	t.Run("syn-port-std-limit-ko", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 			},
 		}
 
-		opts := rawpacket.DefaultProgOpts
+		opts := rawpacket.DefaultProgOpts()
 		opts.NopInstLen = opts.MaxProgSize
 
 		testRawPacketFilter(t, filters, -1, 0, opts, false)
@@ -112,7 +112,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 				BPFFilter: "tcp dst port number and tcp[tcpflags] == tcp-syn",
 			},
 		}
-		testRawPacketFilter(t, filters, -1, 0, rawpacket.DefaultProgOpts, false)
+		testRawPacketFilter(t, filters, -1, 0, rawpacket.DefaultProgOpts(), false)
 	})
 
 	t.Run("syn-port-multi-ok", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 			},
 		}
 
-		opts := rawpacket.DefaultProgOpts
+		opts := rawpacket.DefaultProgOpts()
 		opts.NopInstLen = opts.MaxProgSize - 50
 
 		testRawPacketFilter(t, filters, 2, 2, opts, true)
@@ -145,7 +145,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 			},
 		}
 
-		opts := rawpacket.DefaultProgOpts
+		opts := rawpacket.DefaultProgOpts()
 		opts.NopInstLen = opts.MaxProgSize - 50
 
 		testRawPacketFilter(t, filters, 0, 2, opts, true)
@@ -163,7 +163,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 			},
 		}
 
-		opts := rawpacket.DefaultProgOpts
+		opts := rawpacket.DefaultProgOpts()
 		opts.NopInstLen = opts.MaxProgSize - 50
 
 		testRawPacketFilter(t, filters, 2, 1, opts, false)
@@ -185,7 +185,7 @@ func TestRawPacketTailCalls(t *testing.T) {
 			},
 		}
 
-		opts := rawpacket.DefaultProgOpts
+		opts := rawpacket.DefaultProgOpts()
 		opts.MaxTailCalls = 0
 		opts.NopInstLen = opts.MaxProgSize - 50
 

--- a/pkg/security/probe/model_ebpf.go
+++ b/pkg/security/probe/model_ebpf.go
@@ -35,7 +35,7 @@ func NewEBPFModel(probe *EBPFProbe) *model.Model {
 				if probe.isRawPacketNotSupported() {
 					return fmt.Errorf("%s is not available on this kernel version", field)
 				}
-				if _, err := rawpacket.BPFFilterToInsts(0, value.Value.(string), rawpacket.DefaultProgOpts); err != nil {
+				if _, err := rawpacket.BPFFilterToInsts(0, value.Value.(string), rawpacket.DefaultProgOpts()); err != nil {
 					return err
 				}
 			}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -498,7 +498,7 @@ func (p *EBPFProbe) setupRawPacketProgs(rs *rules.RuleSet) error {
 	}
 
 	// adapt max instruction limits depending of the kernel version
-	opts := rawpacket.DefaultProgOpts
+	opts := rawpacket.DefaultProgOpts()
 	if p.kernelVersion.Code >= kernel.Kernel5_2 {
 		opts.MaxProgSize = 1_000_000
 	}

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -247,12 +247,12 @@ func TestRawPacketFilter(t *testing.T) {
 
 	for _, filter := range filters {
 		t.Run(filter.BPFFilter, func(t *testing.T) {
-			runTest(t, []rawpacket.Filter{filter}, rawpacket.DefaultProgOpts)
+			runTest(t, []rawpacket.Filter{filter}, rawpacket.DefaultProgOpts())
 		})
 	}
 
 	t.Run("all-without-limit", func(t *testing.T) {
-		runTest(t, filters, rawpacket.DefaultProgOpts)
+		runTest(t, filters, rawpacket.DefaultProgOpts())
 	})
 
 	t.Run("all-with-limit", func(t *testing.T) {
@@ -261,7 +261,7 @@ func TestRawPacketFilter(t *testing.T) {
 			return kv.IsDebianKernel() && kv.Code < kernel.Kernel5_2
 		})
 
-		opts := rawpacket.DefaultProgOpts
+		opts := rawpacket.DefaultProgOpts()
 		opts.MaxProgSize = 4000
 		opts.NopInstLen = 3500
 		runTest(t, filters, opts)


### PR DESCRIPTION
### What does this PR do?

Turn `DefaultProgOpts` into a function so that it's not stored as a global even if network is not used.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->