### PR TITLE
service discovery: Fix test cleanup

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/network_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/network_test.go
@@ -315,6 +315,9 @@ func TestNetworkStats(t *testing.T) {
 
 	mTimeProvider.EXPECT().Now().Return(now).AnyTimes()
 	mock.EXPECT().removePid(uint32(pid)).Return(nil).Times(1)
+	mock.EXPECT().removePid(gomock.Not(uint32(pid))).AnyTimes()
 	r := getServicesWithParams(t, url, &params)
 	t.Log(r.StoppedServices)
+
+	mock.EXPECT().close().Times(1)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Create the module directly in the test instead of using the system-probe module mechanism since that doesn't provide an easy way to shutdown the module properly between tests.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-56
https://datadoghq.atlassian.net/browse/DSCVR-57

### Describe how you validated your changes

Test case being modified.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->