### PR TITLE
service discovery: test: Use collect with getServices

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/network_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/network_test.go
@@ -181,7 +181,7 @@ func TestNetwork(t *testing.T) {
 	// test does some basic assertions just to ensure that everything is
 	// hooked up together.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServicesWithParams(t, url, &params)
+		resp := getServicesWithParams(collect, url, &params)
 		service := findService(pid, resp.HeartbeatServices)
 		require.NotNil(collect, service)
 		assert.NotZero(collect, service.RxBytes)
@@ -192,7 +192,7 @@ func TestNetwork(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServicesWithParams(t, url, &params)
+		resp := getServicesWithParams(collect, url, &params)
 		service := findService(pid, resp.HeartbeatServices)
 		require.NotNil(collect, service)
 		assert.Greater(collect, service.RxBytes, old.RxBytes)


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use the CollectT instead of the TestingT with getServices() just like the other assertions in the EventuallyWithT to prevent errors like "panic: Fail in goroutine after TestNetwork has completed".

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-58

### Describe how you validated your changes

Change is in a test.
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->