### PR TITLE
[CWS] Fix local builds of the `cluster-agent` and `cws-instrumentation`

### DIFF
--- a/tasks/cluster_agent.py
+++ b/tasks/cluster_agent.py
@@ -133,8 +133,8 @@ def image_build(ctx, arch=None, tag=AGENT_TAG, push=False):
     ctx.run(f"chmod +x {latest_cws_instrumentation_file}")
 
     build_context = "Dockerfiles/cluster-agent"
-    exec_path = f"{build_context}/datadog-cluster-agent.{arch}"
-    cws_instrumentation_base = f"{build_context}/datadog-cws-instrumentation"
+    exec_path = f"{build_context}/datadog-cluster-agent"
+    cws_instrumentation_base = f"{build_context}/cws-instrumentation"
     cws_instrumentation_exec_path = f"{cws_instrumentation_base}/cws-instrumentation.{arch}"
 
     dockerfile_path = f"{build_context}/Dockerfile"

--- a/tasks/cws_instrumentation.py
+++ b/tasks/cws_instrumentation.py
@@ -98,18 +98,8 @@ def image_build(ctx, arch=None, tag=AGENT_TAG, push=False):
     ctx.run(f"chmod +x {latest_file}")
 
     build_context = "Dockerfiles/cws-instrumentation"
-    cws_instrumentation_base = f"{build_context}/datadog-cws-instrumentation"
-    exec_path = f"{cws_instrumentation_base}/cws-instrumentation.{arch}"
+    exec_path = f"{build_context}/cws-instrumentation.{arch}"
     dockerfile_path = f"{build_context}/Dockerfile"
-
-    try:
-        os.mkdir(cws_instrumentation_base)
-    except FileExistsError:
-        # Directory already exists
-        pass
-    except OSError as e:
-        # Handle other OS-related errors
-        print(f"Error creating directory: {e}")
 
     shutil.copy2(latest_file, exec_path)
     ctx.run(f"docker build -t {tag} --platform linux/{arch} {build_context} -f {dockerfile_path}")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the local builds of the `cluster-agent` and `cws-instrumentation` following a regression introduced by https://github.com/DataDog/datadog-agent/pull/33698.

### Motivation

Make sure the following `inv` tasks work:
- `inv -e cluster-agent.image-build`
- `inv -e cws-instrumentation.image-build`
