### PR TITLE
[CWS] SECL variables fixes and added unit tests

### DIFF
--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -339,10 +339,6 @@ func (e *RuleEngine) LoadPolicies(providers []rules.PolicyProvider, sendLoadedRe
 		return err
 	}
 
-	if currentRuleSet := e.currentRuleSet.Load(); currentRuleSet != nil {
-		currentRuleSet.(*rules.RuleSet).Release()
-	}
-
 	e.currentRuleSet.Store(rs)
 	ruleIDs = append(ruleIDs, rs.ListRuleIDs()...)
 

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -27,10 +27,10 @@ func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]
 	}
 
 	variables := map[string]SECLVariable{
-		"pid": NewIntVariable(func(_ *Context) int {
+		"pid": NewScopedIntVariable(func(_ *Context) int {
 			return os.Getpid()
 		}, nil),
-		"str": NewStringVariable(func(_ *Context) string {
+		"str": NewScopedStringVariable(func(_ *Context) string {
 			return "aaa"
 		}, nil),
 	}
@@ -480,7 +480,7 @@ func TestPartial(t *testing.T) {
 	}
 
 	variables := make(map[string]SECLVariable)
-	variables["var"] = NewBoolVariable(
+	variables["var"] = NewScopedBoolVariable(
 		func(_ *Context) bool {
 			return false
 		},

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -68,6 +68,11 @@ func (i *IntVariable) GetEvaluator() interface{} {
 	}
 }
 
+// Get returns the variable value
+func (i *IntVariable) Get(ctx *Context) interface{} {
+	return i.intFnc(ctx)
+}
+
 // NewIntVariable returns a new integer variable
 func NewIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Context, value interface{}) error) *IntVariable {
 	return &IntVariable{
@@ -92,6 +97,11 @@ func (s *StringVariable) GetEvaluator() interface{} {
 			return s.strFnc(ctx)
 		},
 	}
+}
+
+// Get returns the variable value
+func (s *StringVariable) Get(ctx *Context) interface{} {
+	return s.strFnc(ctx)
 }
 
 // NewStringVariable returns a new string variable
@@ -119,6 +129,11 @@ func (b *BoolVariable) GetEvaluator() interface{} {
 	}
 }
 
+// Get returns the variable value
+func (b *BoolVariable) Get(ctx *Context) interface{} {
+	return b.boolFnc(ctx)
+}
+
 // NewBoolVariable returns a new boolean variable
 func NewBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, value interface{}) error) *BoolVariable {
 	return &BoolVariable{
@@ -140,6 +155,11 @@ func (s *StringArrayVariable) GetEvaluator() interface{} {
 	return &StringArrayEvaluator{
 		EvalFnc: s.strFnc,
 	}
+}
+
+// Get returns the variable value
+func (s *StringArrayVariable) Get(ctx *Context) interface{} {
+	return s.strFnc(ctx)
 }
 
 // Set the array values
@@ -172,18 +192,23 @@ type IntArrayVariable struct {
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (s *IntArrayVariable) GetEvaluator() interface{} {
+func (v *IntArrayVariable) GetEvaluator() interface{} {
 	return &IntArrayEvaluator{
-		EvalFnc: s.intFnc,
+		EvalFnc: v.intFnc,
 	}
 }
 
+// Get returns the variable value
+func (v *IntArrayVariable) Get(ctx *Context) interface{} {
+	return v.intFnc(ctx)
+}
+
 // Set the array values
-func (s *IntArrayVariable) Set(ctx *Context, value interface{}) error {
+func (v *IntArrayVariable) Set(ctx *Context, value interface{}) error {
 	if i, ok := value.(int); ok {
 		value = []int{i}
 	}
-	return s.SettableVariable.Set(ctx, value)
+	return v.SettableVariable.Set(ctx, value)
 }
 
 // Append a value to the array
@@ -204,6 +229,11 @@ func NewIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx *Conte
 // MutableIntVariable describes a mutable integer variable
 type MutableIntVariable struct {
 	Value int
+}
+
+// Get returns the variable value
+func (m *MutableIntVariable) Get() interface{} {
+	return m.Value
 }
 
 // Set the variable with the specified value
@@ -251,6 +281,11 @@ func NewMutableIntVariable() *MutableIntVariable {
 	return &MutableIntVariable{}
 }
 
+// Get returns the variable value
+func (m *MutableBoolVariable) Get() interface{} {
+	return m.Value
+}
+
 // Set the variable with the specified value
 func (m *MutableBoolVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(bool)
@@ -282,6 +317,11 @@ func (m *MutableStringVariable) GetEvaluator() interface{} {
 	}
 }
 
+// Get returns the variable value
+func (m *MutableStringVariable) Get() interface{} {
+	return m.Value
+}
+
 // Append a value to the string
 func (m *MutableStringVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
@@ -307,6 +347,11 @@ func NewMutableStringVariable() *MutableStringVariable {
 // MutableStringArrayVariable describes a mutable string array variable
 type MutableStringArrayVariable struct {
 	LRU *ttlcache.Cache[string, bool]
+}
+
+// Get returns the variable value
+func (m *MutableStringArrayVariable) Get() interface{} {
+	return m.LRU
 }
 
 // Set the variable with the specified value
@@ -362,6 +407,11 @@ func NewMutableStringArrayVariable(size int, ttl time.Duration) *MutableStringAr
 // MutableIntArrayVariable describes a mutable integer array variable
 type MutableIntArrayVariable struct {
 	LRU *ttlcache.Cache[int, bool]
+}
+
+// Get returns the variable value
+func (m *MutableIntArrayVariable) Get() interface{} {
+	return m.LRU
 }
 
 // Set the variable with the specified value
@@ -432,6 +482,7 @@ type VariableOpts struct {
 	TTL  time.Duration
 }
 
+// NewGlobalVariables returns a new set of global variables
 func NewGlobalVariables() *GlobalVariables {
 	return &GlobalVariables{}
 }

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -44,13 +44,13 @@ type MutableVariable interface {
 	Append(ctx *Context, value interface{}) error
 }
 
-// SettableVariable describes a SECL variable
-type SettableVariable struct {
+// settableVariable describes a SECL variable
+type settableVariable struct {
 	setFnc func(ctx *Context, value interface{}) error
 }
 
 // Set the variable with the specified value
-func (v *SettableVariable) Set(ctx *Context, value interface{}) error {
+func (v *settableVariable) Set(ctx *Context, value interface{}) error {
 	if v.setFnc == nil {
 		return errors.New("variable is not mutable")
 	}
@@ -59,13 +59,13 @@ func (v *SettableVariable) Set(ctx *Context, value interface{}) error {
 }
 
 // Append a value to the variable
-func (v *SettableVariable) Append(_ *Context, _ interface{}) error {
+func (v *settableVariable) Append(_ *Context, _ interface{}) error {
 	return errAppendNotSupported
 }
 
 // ScopedIntVariable describes a scoped integer variable
 type ScopedIntVariable struct {
-	SettableVariable
+	settableVariable
 	intFnc func(ctx *Context) int
 }
 
@@ -86,7 +86,7 @@ func (i *ScopedIntVariable) GetValue(ctx *Context) interface{} {
 // NewScopedIntVariable returns a new integer variable
 func NewScopedIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
 	return &ScopedIntVariable{
-		SettableVariable: SettableVariable{
+		settableVariable: settableVariable{
 			setFnc: setFnc,
 		},
 		intFnc: intFnc,
@@ -95,7 +95,7 @@ func NewScopedIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Contex
 
 // ScopedStringVariable describes a string variable
 type ScopedStringVariable struct {
-	SettableVariable
+	settableVariable
 	strFnc func(ctx *Context) string
 }
 
@@ -118,7 +118,7 @@ func (s *ScopedStringVariable) GetValue(ctx *Context) interface{} {
 func NewScopedStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
 	return &ScopedStringVariable{
 		strFnc: strFnc,
-		SettableVariable: SettableVariable{
+		settableVariable: settableVariable{
 			setFnc: setFnc,
 		},
 	}
@@ -126,7 +126,7 @@ func NewScopedStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *
 
 // ScopedBoolVariable describes a boolean variable
 type ScopedBoolVariable struct {
-	SettableVariable
+	settableVariable
 	boolFnc func(ctx *Context) bool
 }
 
@@ -148,7 +148,7 @@ func (b *ScopedBoolVariable) GetValue(ctx *Context) interface{} {
 func NewScopedBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
 	return &ScopedBoolVariable{
 		boolFnc: boolFnc,
-		SettableVariable: SettableVariable{
+		settableVariable: settableVariable{
 			setFnc: setFnc,
 		},
 	}
@@ -156,7 +156,7 @@ func NewScopedBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Con
 
 // ScopedStringArrayVariable describes a scoped string array variable
 type ScopedStringArrayVariable struct {
-	SettableVariable
+	settableVariable
 	strFnc func(ctx *Context) []string
 }
 
@@ -177,7 +177,7 @@ func (s *ScopedStringArrayVariable) Set(ctx *Context, value interface{}) error {
 	if s, ok := value.(string); ok {
 		value = []string{s}
 	}
-	return s.SettableVariable.Set(ctx, value)
+	return s.settableVariable.Set(ctx, value)
 }
 
 // Append a value to the array
@@ -189,7 +189,7 @@ func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) erro
 func NewScopedStringArrayVariable(strFnc func(ctx *Context) []string, setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
 	return &ScopedStringArrayVariable{
 		strFnc: strFnc,
-		SettableVariable: SettableVariable{
+		settableVariable: settableVariable{
 			setFnc: setFnc,
 		},
 	}
@@ -197,7 +197,7 @@ func NewScopedStringArrayVariable(strFnc func(ctx *Context) []string, setFnc fun
 
 // ScopedIntArrayVariable describes a scoped integer array variable
 type ScopedIntArrayVariable struct {
-	SettableVariable
+	settableVariable
 	intFnc func(ctx *Context) []int
 }
 
@@ -218,7 +218,7 @@ func (v *ScopedIntArrayVariable) Set(ctx *Context, value interface{}) error {
 	if i, ok := value.(int); ok {
 		value = []int{i}
 	}
-	return v.SettableVariable.Set(ctx, value)
+	return v.settableVariable.Set(ctx, value)
 }
 
 // Append a value to the array
@@ -230,7 +230,7 @@ func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
 func NewScopedIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
 	return &ScopedIntArrayVariable{
 		intFnc: intFnc,
-		SettableVariable: SettableVariable{
+		settableVariable: settableVariable{
 			setFnc: setFnc,
 		},
 	}

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -78,7 +78,7 @@ func (i *IntVariable) GetEvaluator() interface{} {
 	}
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (i *IntVariable) GetValue(ctx *Context) interface{} {
 	return i.intFnc(ctx)
 }
@@ -109,7 +109,7 @@ func (s *StringVariable) GetEvaluator() interface{} {
 	}
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (s *StringVariable) GetValue(ctx *Context) interface{} {
 	return s.strFnc(ctx)
 }
@@ -139,7 +139,7 @@ func (b *BoolVariable) GetEvaluator() interface{} {
 	}
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (b *BoolVariable) GetValue(ctx *Context) interface{} {
 	return b.boolFnc(ctx)
 }
@@ -167,7 +167,7 @@ func (s *StringArrayVariable) GetEvaluator() interface{} {
 	}
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (s *StringArrayVariable) GetValue(ctx *Context) interface{} {
 	return s.strFnc(ctx)
 }
@@ -208,7 +208,7 @@ func (v *IntArrayVariable) GetEvaluator() interface{} {
 	}
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (v *IntArrayVariable) GetValue(ctx *Context) interface{} {
 	return v.intFnc(ctx)
 }
@@ -241,7 +241,7 @@ type MutableIntVariable struct {
 	Value int
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (m *MutableIntVariable) GetValue() interface{} {
 	return m.Value
 }
@@ -291,7 +291,7 @@ func NewMutableIntVariable() *MutableIntVariable {
 	return &MutableIntVariable{}
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (m *MutableBoolVariable) GetValue() interface{} {
 	return m.Value
 }
@@ -327,7 +327,7 @@ func (m *MutableStringVariable) GetEvaluator() interface{} {
 	}
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (m *MutableStringVariable) GetValue() interface{} {
 	return m.Value
 }
@@ -359,7 +359,7 @@ type MutableStringArrayVariable struct {
 	LRU *ttlcache.Cache[string, bool]
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (m *MutableStringArrayVariable) GetValue() interface{} {
 	return m.LRU.Keys()
 }
@@ -419,7 +419,7 @@ type MutableIntArrayVariable struct {
 	LRU *ttlcache.Cache[int, bool]
 }
 
-// Get returns the variable value
+// GetValue returns the variable value
 func (m *MutableIntArrayVariable) GetValue() interface{} {
 	return m.LRU.Keys()
 }

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -63,14 +63,14 @@ func (v *SettableVariable) Append(_ *Context, _ interface{}) error {
 	return errAppendNotSupported
 }
 
-// IntVariable describes an integer variable
-type IntVariable struct {
+// ScopedIntVariable describes a scoped integer variable
+type ScopedIntVariable struct {
 	SettableVariable
 	intFnc func(ctx *Context) int
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (i *IntVariable) GetEvaluator() interface{} {
+func (i *ScopedIntVariable) GetEvaluator() interface{} {
 	return &IntEvaluator{
 		EvalFnc: func(ctx *Context) int {
 			return i.intFnc(ctx)
@@ -79,13 +79,13 @@ func (i *IntVariable) GetEvaluator() interface{} {
 }
 
 // GetValue returns the variable value
-func (i *IntVariable) GetValue(ctx *Context) interface{} {
+func (i *ScopedIntVariable) GetValue(ctx *Context) interface{} {
 	return i.intFnc(ctx)
 }
 
-// NewIntVariable returns a new integer variable
-func NewIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Context, value interface{}) error) *IntVariable {
-	return &IntVariable{
+// NewScopedIntVariable returns a new integer variable
+func NewScopedIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
+	return &ScopedIntVariable{
 		SettableVariable: SettableVariable{
 			setFnc: setFnc,
 		},
@@ -93,14 +93,14 @@ func NewIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Context, val
 	}
 }
 
-// StringVariable describes a string variable
-type StringVariable struct {
+// ScopedStringVariable describes a string variable
+type ScopedStringVariable struct {
 	SettableVariable
 	strFnc func(ctx *Context) string
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (s *StringVariable) GetEvaluator() interface{} {
+func (s *ScopedStringVariable) GetEvaluator() interface{} {
 	return &StringEvaluator{
 		ValueType: VariableValueType,
 		EvalFnc: func(ctx *Context) string {
@@ -110,13 +110,13 @@ func (s *StringVariable) GetEvaluator() interface{} {
 }
 
 // GetValue returns the variable value
-func (s *StringVariable) GetValue(ctx *Context) interface{} {
+func (s *ScopedStringVariable) GetValue(ctx *Context) interface{} {
 	return s.strFnc(ctx)
 }
 
-// NewStringVariable returns a new string variable
-func NewStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *Context, value interface{}) error) *StringVariable {
-	return &StringVariable{
+// NewScopedStringVariable returns a new scoped string variable
+func NewScopedStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
+	return &ScopedStringVariable{
 		strFnc: strFnc,
 		SettableVariable: SettableVariable{
 			setFnc: setFnc,
@@ -124,14 +124,14 @@ func NewStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *Contex
 	}
 }
 
-// BoolVariable describes a boolean variable
-type BoolVariable struct {
+// ScopedBoolVariable describes a boolean variable
+type ScopedBoolVariable struct {
 	SettableVariable
 	boolFnc func(ctx *Context) bool
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (b *BoolVariable) GetEvaluator() interface{} {
+func (b *ScopedBoolVariable) GetEvaluator() interface{} {
 	return &BoolEvaluator{
 		EvalFnc: func(ctx *Context) bool {
 			return b.boolFnc(ctx)
@@ -140,13 +140,13 @@ func (b *BoolVariable) GetEvaluator() interface{} {
 }
 
 // GetValue returns the variable value
-func (b *BoolVariable) GetValue(ctx *Context) interface{} {
+func (b *ScopedBoolVariable) GetValue(ctx *Context) interface{} {
 	return b.boolFnc(ctx)
 }
 
-// NewBoolVariable returns a new boolean variable
-func NewBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, value interface{}) error) *BoolVariable {
-	return &BoolVariable{
+// NewScopedBoolVariable returns a new boolean variable
+func NewScopedBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
+	return &ScopedBoolVariable{
 		boolFnc: boolFnc,
 		SettableVariable: SettableVariable{
 			setFnc: setFnc,
@@ -154,26 +154,26 @@ func NewBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, 
 	}
 }
 
-// StringArrayVariable describes a string array variable
-type StringArrayVariable struct {
+// ScopedStringArrayVariable describes a scoped string array variable
+type ScopedStringArrayVariable struct {
 	SettableVariable
 	strFnc func(ctx *Context) []string
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (s *StringArrayVariable) GetEvaluator() interface{} {
+func (s *ScopedStringArrayVariable) GetEvaluator() interface{} {
 	return &StringArrayEvaluator{
 		EvalFnc: s.strFnc,
 	}
 }
 
 // GetValue returns the variable value
-func (s *StringArrayVariable) GetValue(ctx *Context) interface{} {
+func (s *ScopedStringArrayVariable) GetValue(ctx *Context) interface{} {
 	return s.strFnc(ctx)
 }
 
 // Set the array values
-func (s *StringArrayVariable) Set(ctx *Context, value interface{}) error {
+func (s *ScopedStringArrayVariable) Set(ctx *Context, value interface{}) error {
 	if s, ok := value.(string); ok {
 		value = []string{s}
 	}
@@ -181,13 +181,13 @@ func (s *StringArrayVariable) Set(ctx *Context, value interface{}) error {
 }
 
 // Append a value to the array
-func (s *StringArrayVariable) Append(ctx *Context, value interface{}) error {
+func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) error {
 	return s.Set(ctx, append(s.strFnc(ctx), value.([]string)...))
 }
 
 // NewStringArrayVariable returns a new string array variable
-func NewStringArrayVariable(strFnc func(ctx *Context) []string, setFnc func(ctx *Context, value interface{}) error) *StringArrayVariable {
-	return &StringArrayVariable{
+func NewScopedStringArrayVariable(strFnc func(ctx *Context) []string, setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
+	return &ScopedStringArrayVariable{
 		strFnc: strFnc,
 		SettableVariable: SettableVariable{
 			setFnc: setFnc,
@@ -195,26 +195,26 @@ func NewStringArrayVariable(strFnc func(ctx *Context) []string, setFnc func(ctx 
 	}
 }
 
-// IntArrayVariable describes an integer array variable
-type IntArrayVariable struct {
+// ScopedIntArrayVariable describes a scoped integer array variable
+type ScopedIntArrayVariable struct {
 	SettableVariable
 	intFnc func(ctx *Context) []int
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (v *IntArrayVariable) GetEvaluator() interface{} {
+func (v *ScopedIntArrayVariable) GetEvaluator() interface{} {
 	return &IntArrayEvaluator{
 		EvalFnc: v.intFnc,
 	}
 }
 
 // GetValue returns the variable value
-func (v *IntArrayVariable) GetValue(ctx *Context) interface{} {
+func (v *ScopedIntArrayVariable) GetValue(ctx *Context) interface{} {
 	return v.intFnc(ctx)
 }
 
 // Set the array values
-func (v *IntArrayVariable) Set(ctx *Context, value interface{}) error {
+func (v *ScopedIntArrayVariable) Set(ctx *Context, value interface{}) error {
 	if i, ok := value.(int); ok {
 		value = []int{i}
 	}
@@ -222,13 +222,13 @@ func (v *IntArrayVariable) Set(ctx *Context, value interface{}) error {
 }
 
 // Append a value to the array
-func (v *IntArrayVariable) Append(ctx *Context, value interface{}) error {
+func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
 	return v.Set(ctx, append(v.intFnc(ctx), value.([]int)...))
 }
 
-// NewIntArrayVariable returns a new integer array variable
-func NewIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx *Context, value interface{}) error) *IntArrayVariable {
-	return &IntArrayVariable{
+// NewScopedIntArrayVariable returns a new integer array variable
+func NewScopedIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
+	return &ScopedIntArrayVariable{
 		intFnc: intFnc,
 		SettableVariable: SettableVariable{
 			setFnc: setFnc,
@@ -236,24 +236,24 @@ func NewIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx *Conte
 	}
 }
 
-// MutableIntVariable describes a mutable integer variable
-type MutableIntVariable struct {
+// IntVariable describes a global integer variable
+type IntVariable struct {
 	Value int
 }
 
 // GetValue returns the variable value
-func (m *MutableIntVariable) GetValue() interface{} {
+func (m *IntVariable) GetValue() interface{} {
 	return m.Value
 }
 
 // Set the variable with the specified value
-func (m *MutableIntVariable) Set(_ *Context, value interface{}) error {
+func (m *IntVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(int)
 	return nil
 }
 
 // Append a value to the integer
-func (m *MutableIntVariable) Append(_ *Context, value interface{}) error {
+func (m *IntVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
 		m.Value += value
@@ -264,7 +264,7 @@ func (m *MutableIntVariable) Append(_ *Context, value interface{}) error {
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (m *MutableIntVariable) GetEvaluator() interface{} {
+func (m *IntVariable) GetEvaluator() interface{} {
 	return &IntEvaluator{
 		EvalFnc: func(*Context) int {
 			return m.Value
@@ -272,13 +272,13 @@ func (m *MutableIntVariable) GetEvaluator() interface{} {
 	}
 }
 
-// MutableBoolVariable describes a mutable boolean variable
-type MutableBoolVariable struct {
+// BoolVariable describes a mutable boolean variable
+type BoolVariable struct {
 	Value bool
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (m *MutableBoolVariable) GetEvaluator() interface{} {
+func (m *BoolVariable) GetEvaluator() interface{} {
 	return &BoolEvaluator{
 		EvalFnc: func(*Context) bool {
 			return m.Value
@@ -286,39 +286,39 @@ func (m *MutableBoolVariable) GetEvaluator() interface{} {
 	}
 }
 
-// NewMutableIntVariable returns a new mutable integer variable
-func NewMutableIntVariable() *MutableIntVariable {
-	return &MutableIntVariable{}
+// NewIntVariable returns a new mutable integer variable
+func NewIntVariable() *IntVariable {
+	return &IntVariable{}
 }
 
 // GetValue returns the variable value
-func (m *MutableBoolVariable) GetValue() interface{} {
+func (m *BoolVariable) GetValue() interface{} {
 	return m.Value
 }
 
 // Set the variable with the specified value
-func (m *MutableBoolVariable) Set(_ *Context, value interface{}) error {
+func (m *BoolVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(bool)
 	return nil
 }
 
 // Append a value to the boolean
-func (m *MutableBoolVariable) Append(_ *Context, _ interface{}) error {
+func (m *BoolVariable) Append(_ *Context, _ interface{}) error {
 	return errAppendNotSupported
 }
 
 // NewMutableBoolVariable returns a new mutable boolean variable
-func NewMutableBoolVariable() *MutableBoolVariable {
-	return &MutableBoolVariable{}
+func NewBoolVariable() *BoolVariable {
+	return &BoolVariable{}
 }
 
-// MutableStringVariable describes a mutable string variable
-type MutableStringVariable struct {
+// StringVariable describes a mutable string variable
+type StringVariable struct {
 	Value string
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (m *MutableStringVariable) GetEvaluator() interface{} {
+func (m *StringVariable) GetEvaluator() interface{} {
 	return &StringEvaluator{
 		ValueType: VariableValueType,
 		EvalFnc: func(_ *Context) string {
@@ -328,12 +328,12 @@ func (m *MutableStringVariable) GetEvaluator() interface{} {
 }
 
 // GetValue returns the variable value
-func (m *MutableStringVariable) GetValue() interface{} {
+func (m *StringVariable) GetValue() interface{} {
 	return m.Value
 }
 
 // Append a value to the string
-func (m *MutableStringVariable) Append(_ *Context, value interface{}) error {
+func (m *StringVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
 		m.Value += value
@@ -344,28 +344,28 @@ func (m *MutableStringVariable) Append(_ *Context, value interface{}) error {
 }
 
 // Set the variable with the specified value
-func (m *MutableStringVariable) Set(_ *Context, value interface{}) error {
+func (m *StringVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(string)
 	return nil
 }
 
-// NewMutableStringVariable returns a new mutable string variable
-func NewMutableStringVariable() *MutableStringVariable {
-	return &MutableStringVariable{}
+// NewStringVariable returns a new mutable string variable
+func NewStringVariable() *StringVariable {
+	return &StringVariable{}
 }
 
-// MutableStringArrayVariable describes a mutable string array variable
-type MutableStringArrayVariable struct {
+// StringArrayVariable describes a mutable string array variable
+type StringArrayVariable struct {
 	LRU *ttlcache.Cache[string, bool]
 }
 
 // GetValue returns the variable value
-func (m *MutableStringArrayVariable) GetValue() interface{} {
+func (m *StringArrayVariable) GetValue() interface{} {
 	return m.LRU.Keys()
 }
 
 // Set the variable with the specified value
-func (m *MutableStringArrayVariable) Set(_ *Context, values interface{}) error {
+func (m *StringArrayVariable) Set(_ *Context, values interface{}) error {
 	if s, ok := values.(string); ok {
 		values = []string{s}
 	}
@@ -377,7 +377,7 @@ func (m *MutableStringArrayVariable) Set(_ *Context, values interface{}) error {
 }
 
 // Append a value to the array
-func (m *MutableStringArrayVariable) Append(_ *Context, value interface{}) error {
+func (m *StringArrayVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
 		m.LRU.Set(value, true, ttlcache.DefaultTTL)
@@ -392,7 +392,7 @@ func (m *MutableStringArrayVariable) Append(_ *Context, value interface{}) error
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (m *MutableStringArrayVariable) GetEvaluator() interface{} {
+func (m *StringArrayVariable) GetEvaluator() interface{} {
 	return &StringArrayEvaluator{
 		EvalFnc: func(*Context) []string {
 			return m.LRU.Keys()
@@ -400,8 +400,8 @@ func (m *MutableStringArrayVariable) GetEvaluator() interface{} {
 	}
 }
 
-// NewMutableStringArrayVariable returns a new mutable string array variable
-func NewMutableStringArrayVariable(size int, ttl time.Duration) *MutableStringArrayVariable {
+// NewStringArrayVariable returns a new mutable string array variable
+func NewStringArrayVariable(size int, ttl time.Duration) *StringArrayVariable {
 	if size == 0 {
 		size = defaultMaxVariables
 	}
@@ -409,23 +409,23 @@ func NewMutableStringArrayVariable(size int, ttl time.Duration) *MutableStringAr
 	lru := ttlcache.New(ttlcache.WithCapacity[string, bool](uint64(size)), ttlcache.WithTTL[string, bool](ttl))
 	go lru.Start()
 
-	return &MutableStringArrayVariable{
+	return &StringArrayVariable{
 		LRU: lru,
 	}
 }
 
-// MutableIntArrayVariable describes a mutable integer array variable
-type MutableIntArrayVariable struct {
+// IntArrayVariable describes a mutable integer array variable
+type IntArrayVariable struct {
 	LRU *ttlcache.Cache[int, bool]
 }
 
 // GetValue returns the variable value
-func (m *MutableIntArrayVariable) GetValue() interface{} {
+func (m *IntArrayVariable) GetValue() interface{} {
 	return m.LRU.Keys()
 }
 
 // Set the variable with the specified value
-func (m *MutableIntArrayVariable) Set(_ *Context, values interface{}) error {
+func (m *IntArrayVariable) Set(_ *Context, values interface{}) error {
 	if i, ok := values.(int); ok {
 		values = []int{i}
 	}
@@ -438,7 +438,7 @@ func (m *MutableIntArrayVariable) Set(_ *Context, values interface{}) error {
 }
 
 // Append a value to the array
-func (m *MutableIntArrayVariable) Append(_ *Context, value interface{}) error {
+func (m *IntArrayVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
 		m.LRU.Set(value, true, ttlcache.DefaultTTL)
@@ -453,7 +453,7 @@ func (m *MutableIntArrayVariable) Append(_ *Context, value interface{}) error {
 }
 
 // GetEvaluator returns the variable SECL evaluator
-func (m *MutableIntArrayVariable) GetEvaluator() interface{} {
+func (m *IntArrayVariable) GetEvaluator() interface{} {
 	return &IntArrayEvaluator{
 		EvalFnc: func(*Context) []int {
 			return m.LRU.Keys()
@@ -461,8 +461,8 @@ func (m *MutableIntArrayVariable) GetEvaluator() interface{} {
 	}
 }
 
-// NewMutableIntArrayVariable returns a new mutable integer array variable
-func NewMutableIntArrayVariable(size int, ttl time.Duration) *MutableIntArrayVariable {
+// NewIntArrayVariable returns a new mutable integer array variable
+func NewIntArrayVariable(size int, ttl time.Duration) *IntArrayVariable {
 	if size == 0 {
 		size = defaultMaxVariables
 	}
@@ -470,7 +470,7 @@ func NewMutableIntArrayVariable(size int, ttl time.Duration) *MutableIntArrayVar
 	lru := ttlcache.New(ttlcache.WithCapacity[int, bool](uint64(size)), ttlcache.WithTTL[int, bool](ttl))
 	go lru.Start()
 
-	return &MutableIntArrayVariable{
+	return &IntArrayVariable{
 		LRU: lru,
 	}
 }
@@ -501,15 +501,15 @@ func NewGlobalVariables() *GlobalVariables {
 func (v *GlobalVariables) NewSECLVariable(_ string, value interface{}, opts VariableOpts) (SECLVariable, error) {
 	switch value := value.(type) {
 	case bool:
-		return NewMutableBoolVariable(), nil
+		return NewBoolVariable(), nil
 	case int:
-		return NewMutableIntVariable(), nil
+		return NewIntVariable(), nil
 	case string:
-		return NewMutableStringVariable(), nil
+		return NewStringVariable(), nil
 	case []string:
-		return NewMutableStringArrayVariable(opts.Size, opts.TTL), nil
+		return NewStringArrayVariable(opts.Size, opts.TTL), nil
 	case []int:
-		return NewMutableIntArrayVariable(opts.Size, opts.TTL), nil
+		return NewIntArrayVariable(opts.Size, opts.TTL), nil
 	default:
 		return nil, fmt.Errorf("unsupported value type: %s", reflect.TypeOf(value))
 	}
@@ -629,35 +629,35 @@ func (v *ScopedVariables) NewSECLVariable(name string, value interface{}, opts V
 
 	switch value.(type) {
 	case int:
-		return NewIntVariable(func(ctx *Context) int {
+		return NewScopedIntVariable(func(ctx *Context) int {
 			if vars := getVariables(ctx); vars != nil {
 				return vars.GetInt(name)
 			}
 			return 0
 		}, setVariable), nil
 	case bool:
-		return NewBoolVariable(func(ctx *Context) bool {
+		return NewScopedBoolVariable(func(ctx *Context) bool {
 			if vars := getVariables(ctx); vars != nil {
 				return vars.GetBool(name)
 			}
 			return false
 		}, setVariable), nil
 	case string:
-		return NewStringVariable(func(ctx *Context) string {
+		return NewScopedStringVariable(func(ctx *Context) string {
 			if vars := getVariables(ctx); vars != nil {
 				return vars.GetString(name)
 			}
 			return ""
 		}, setVariable), nil
 	case []string:
-		return NewStringArrayVariable(func(ctx *Context) []string {
+		return NewScopedStringArrayVariable(func(ctx *Context) []string {
 			if vars := getVariables(ctx); vars != nil {
 				return vars.GetStringArray(name)
 			}
 			return nil
 		}, setVariable), nil
 	case []int:
-		return NewIntArrayVariable(func(ctx *Context) []int {
+		return NewScopedIntArrayVariable(func(ctx *Context) []int {
 			if vars := getVariables(ctx); vars != nil {
 				return vars.GetIntArray(name)
 			}

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -107,8 +107,8 @@ type Process struct {
 	Envp []string `field:"envp,handler:ResolveProcessEnvp,weight:100"` // SECLDoc[envp] Definition:`Environment variables of the process`                                                                                                                         // SECLDoc[envp] Definition:`Environment variables of the process`
 
 	// cache version
-	Variables               eval.NamedVariables `field:"-"`
-	ScrubbedCmdLineResolved bool                `field:"-"`
+	Variables               eval.Variables `field:"-"`
+	ScrubbedCmdLineResolved bool           `field:"-"`
 }
 
 // ExecEvent represents a exec event

--- a/pkg/security/secl/model/model_windows.go
+++ b/pkg/security/secl/model/model_windows.go
@@ -107,8 +107,7 @@ type Process struct {
 	Envp []string `field:"envp,handler:ResolveProcessEnvp,weight:100"` // SECLDoc[envp] Definition:`Environment variables of the process`                                                                                                                         // SECLDoc[envp] Definition:`Environment variables of the process`
 
 	// cache version
-	Variables               eval.Variables `field:"-"`
-	ScrubbedCmdLineResolved bool           `field:"-"`
+	ScrubbedCmdLineResolved bool `field:"-"`
 }
 
 // ExecEvent represents a exec event

--- a/pkg/security/secl/model/variables.go
+++ b/pkg/security/secl/model/variables.go
@@ -13,7 +13,7 @@ import (
 var (
 	// SECLVariables set of variables
 	SECLVariables = map[string]eval.SECLVariable{
-		"process.pid": eval.NewIntVariable(func(ctx *eval.Context) int {
+		"process.pid": eval.NewScopedIntVariable(func(ctx *eval.Context) int {
 			pc := ctx.Event.(*Event).ProcessContext
 			if pc == nil {
 				return 0

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -83,12 +83,12 @@ func NewRuleOpts(eventTypeEnabled map[eval.EventType]bool) *Opts {
 		WithEventTypeEnabled(eventTypeEnabled).
 		WithStateScopes(map[Scope]VariableProviderFactory{
 			"process": func() VariableProvider {
-				return eval.NewScopedVariables(func(ctx *eval.Context) eval.ScopedVariable {
+				return eval.NewScopedVariables(func(ctx *eval.Context) eval.VariableScope {
 					return ctx.Event.(*model.Event).ProcessCacheEntry
 				})
 			},
 			"container": func() VariableProvider {
-				return eval.NewScopedVariables(func(ctx *eval.Context) eval.ScopedVariable {
+				return eval.NewScopedVariables(func(ctx *eval.Context) eval.VariableScope {
 					return ctx.Event.(*model.Event).ContainerContext
 				})
 			},

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -408,8 +408,8 @@ func TestActionSetVariableSize(t *testing.T) {
 					Set: &SetDefinition{
 						Name:   "var2",
 						Append: true,
-						Value:  "foo",
-						Size:   1,
+						Value:  1,
+						Size:   2,
 					},
 				},
 			},
@@ -460,18 +460,16 @@ func TestActionSetVariableSize(t *testing.T) {
 	assert.Contains(t, value, "foo")
 	assert.Len(t, value, 1)
 
-	/*
-		existingVariable = opts.VariableStore.Get("var2")
-		assert.NotNil(t, existingVariable)
+	existingVariable = opts.VariableStore.Get("var2")
+	assert.NotNil(t, existingVariable)
 
-		intArrayVar, ok := existingVariable.(*eval.IntArrayVariable)
-		assert.NotNil(t, intArrayVar)
-		assert.True(t, ok)
+	intArrayVar, ok := existingVariable.(*eval.MutableIntArrayVariable)
+	assert.NotNil(t, intArrayVar)
+	assert.True(t, ok)
 
-		value = intArrayVar.Get(nil)
-		assert.Contains(t, value, 1)
-		assert.Len(t, value, 1)
-	*/
+	value2 := intArrayVar.Get().(*ttlcache.Cache[int, bool]).Keys()
+	assert.Contains(t, value2, 1)
+	assert.Len(t, value2, 1)
 }
 
 func TestActionSetVariableConflict(t *testing.T) {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -340,7 +340,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 					Set: &SetDefinition{
 						Name:   "var1",
 						Append: true,
-						Value:  []string{"foo"},
+						Value:  "foo",
 						TTL: &HumanReadableDuration{
 							Duration: 1 * time.Second,
 						},
@@ -350,7 +350,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 					Set: &SetDefinition{
 						Name:   "var2",
 						Append: true,
-						Value:  []int{123},
+						Value:  123,
 						TTL: &HumanReadableDuration{
 							Duration: 1 * time.Second,
 						},
@@ -414,7 +414,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 
 	existingVariable := opts.VariableStore.Get("var1")
 	assert.NotNil(t, existingVariable)
-	stringArrayVar, ok := existingVariable.(eval.GlobalVariable)
+	stringArrayVar, ok := existingVariable.(eval.Variable)
 	assert.NotNil(t, stringArrayVar)
 	assert.True(t, ok)
 	strValue := stringArrayVar.GetValue()
@@ -424,7 +424,7 @@ func TestActionSetVariableTTL(t *testing.T) {
 
 	existingVariable = opts.VariableStore.Get("var2")
 	assert.NotNil(t, existingVariable)
-	intArrayVar, ok := existingVariable.(eval.GlobalVariable)
+	intArrayVar, ok := existingVariable.(eval.Variable)
 	assert.NotNil(t, intArrayVar)
 	assert.True(t, ok)
 	value := intArrayVar.GetValue()
@@ -457,17 +457,19 @@ func TestActionSetVariableTTL(t *testing.T) {
 
 	value = stringArrayVar.GetValue()
 	assert.NotContains(t, value, "foo")
+	assert.Len(t, value, 0)
 
 	value = intArrayVar.GetValue()
 	assert.NotContains(t, value, 123)
+	assert.Len(t, value, 0)
 
-	// TODO(lebauce): fix ttl for scoped vars
+	value = stringArrayScopedVar.GetValue(ctx)
+	assert.NotContains(t, value, "foo")
+	assert.Len(t, value, 0)
 
-	// value = stringArrayScopedVar.GetValue(ctx)
-	// assert.NotContains(t, strValue, "foo")
-
-	// value = intArrayScopedVar.GetValue(ctx)
-	// assert.NotContains(t, value, 123)
+	value = intArrayScopedVar.GetValue(ctx)
+	assert.NotContains(t, value, 123)
+	assert.Len(t, value, 0)
 }
 
 func TestActionSetVariableSize(t *testing.T) {
@@ -547,7 +549,7 @@ func TestActionSetVariableSize(t *testing.T) {
 
 	existingVariable := opts.VariableStore.Get("var1")
 	assert.NotNil(t, existingVariable)
-	stringArrayVar, ok := existingVariable.(eval.GlobalVariable)
+	stringArrayVar, ok := existingVariable.(eval.Variable)
 	assert.NotNil(t, stringArrayVar)
 	assert.True(t, ok)
 	value := stringArrayVar.GetValue()
@@ -557,7 +559,7 @@ func TestActionSetVariableSize(t *testing.T) {
 
 	existingVariable = opts.VariableStore.Get("var2")
 	assert.NotNil(t, existingVariable)
-	intArrayVar, ok := existingVariable.(eval.GlobalVariable)
+	intArrayVar, ok := existingVariable.(eval.Variable)
 	assert.NotNil(t, intArrayVar)
 	assert.True(t, ok)
 	assert.IsType(t, value, []string{})
@@ -576,7 +578,7 @@ func TestActionSetVariableSize(t *testing.T) {
 	assert.NotNil(t, value)
 	assert.Contains(t, value, "bar")
 	assert.IsType(t, value, []string{})
-	assert.Len(t, value, 2)
+	assert.Len(t, value, 1)
 
 	existingScopedVariable = opts.VariableStore.Get("process.scopedvar2")
 	assert.NotNil(t, existingScopedVariable)
@@ -587,8 +589,7 @@ func TestActionSetVariableSize(t *testing.T) {
 	assert.NotNil(t, value)
 	assert.Contains(t, value, 123)
 	assert.IsType(t, value, []int{})
-	// TODO(lebauce): fix size for scoped vars
-	// assert.Len(t, value, 1)
+	assert.Len(t, value, 1)
 }
 
 func TestActionSetVariableConflict(t *testing.T) {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -382,15 +382,13 @@ func TestActionSetVariableTTL(t *testing.T) {
 	existingVariable := opts.VariableStore.Get("var1")
 	assert.NotNil(t, existingVariable)
 
-	stringArrayVar, ok := existingVariable.(*eval.StringArrayVariable)
+	stringArrayVar, ok := existingVariable.(*eval.MutableStringArrayVariable)
 	assert.NotNil(t, stringArrayVar)
 	assert.True(t, ok)
 
-	assert.Contains(t, stringArrayVar.Get(nil), "foo")
+	assert.True(t, stringArrayVar.LRU.Has("foo"))
 	time.Sleep(time.Second + 100*time.Millisecond)
-	assert.NotContains(t, stringArrayVar.Get(nil), "foo")
-
-	rs.Release()
+	assert.False(t, stringArrayVar.LRU.Has("foo"))
 }
 
 func TestActionSetVariableConflict(t *testing.T) {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -53,7 +53,7 @@ type RuleSet struct {
 	fakeEventCtor    func() eval.Event
 	listenersLock    sync.RWMutex
 	listeners        []RuleSetListener
-	globalVariables  *eval.GlobalVariables
+	globalVariables  *eval.Variables
 	scopedVariables  map[Scope]VariableProvider
 	// fields holds the list of event field queries (like "process.uid") used by the entire set of rules
 	fields []string
@@ -858,6 +858,6 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalO
 		pool:             eval.NewContextPool(),
 		fieldEvaluators:  make(map[string]eval.Evaluator),
 		scopedVariables:  make(map[Scope]VariableProvider),
-		globalVariables:  eval.NewGlobalVariables(),
+		globalVariables:  eval.NewVariables(),
 	}
 }

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -42,7 +42,6 @@ type RuleSetListener interface {
 // RuleSet holds a list of rules, grouped in bucket. An event can be evaluated
 // against it. If the rule matches, the listeners for this rule set are notified
 type RuleSet struct {
-	model.Releasable
 	opts             *Opts
 	evalOpts         *eval.Opts
 	eventRuleBuckets map[eval.EventType]*RuleBucket
@@ -54,7 +53,7 @@ type RuleSet struct {
 	fakeEventCtor    func() eval.Event
 	listenersLock    sync.RWMutex
 	listeners        []RuleSetListener
-	globalVariables  VariableProvider
+	globalVariables  *eval.GlobalVariables
 	scopedVariables  map[Scope]VariableProvider
 	// fields holds the list of event field queries (like "process.uid") used by the entire set of rules
 	fields []string
@@ -836,11 +835,6 @@ func (rs *RuleSet) newFakeEvent() eval.Event {
 	return model.NewFakeEvent()
 }
 
-// Release the rule set
-func (rs *RuleSet) Release() {
-	rs.CallReleaseCallback()
-}
-
 // NewRuleSet returns a new ruleset for the specified data model
 func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalOpts *eval.Opts) *RuleSet {
 	logger := log.OrNullLogger(opts.Logger)
@@ -853,7 +847,7 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalO
 		evalOpts.WithVariableStore(&eval.VariableStore{})
 	}
 
-	ruleset := &RuleSet{
+	return &RuleSet{
 		model:            model,
 		eventCtor:        eventCtor,
 		opts:             opts,
@@ -864,11 +858,6 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts, evalO
 		pool:             eval.NewContextPool(),
 		fieldEvaluators:  make(map[string]eval.Evaluator),
 		scopedVariables:  make(map[Scope]VariableProvider),
+		globalVariables:  eval.NewGlobalVariables(),
 	}
-
-	ruleset.globalVariables = eval.NewScopedVariables(func(_ *eval.Context) eval.ScopedVariable {
-		return ruleset
-	})
-
-	return ruleset
 }

--- a/pkg/security/seclwin/model/model_win.go
+++ b/pkg/security/seclwin/model/model_win.go
@@ -107,8 +107,7 @@ type Process struct {
 	Envp []string `field:"envp,handler:ResolveProcessEnvp,weight:100"` // SECLDoc[envp] Definition:`Environment variables of the process`                                                                                                                         // SECLDoc[envp] Definition:`Environment variables of the process`
 
 	// cache version
-	Variables               eval.NamedVariables `field:"-"`
-	ScrubbedCmdLineResolved bool                `field:"-"`
+	ScrubbedCmdLineResolved bool `field:"-"`
 }
 
 // ExecEvent represents a exec event


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix `TTL` and `size` for scoped variables.

### Motivation

Global and scoped variables were using 2 different implementations, with different behaviours.
In particular, TTL and size were only working correctly for global variables.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->