### PR TITLE
Account for fentry deadlock bug when deciding if fentry is supported

### DIFF
--- a/pkg/ebpf/kernel_bugs_test.go
+++ b/pkg/ebpf/kernel_bugs_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2025-present Datadog, Inc.
 
 //go:build linux_bpf
 

--- a/pkg/ebpf/kernel_bugs_test.go
+++ b/pkg/ebpf/kernel_bugs_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ebpf
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasTasksRCUExitLockSymbol(t *testing.T) {
+	funcCache = newExistCache("./testdata/kallsyms.fentry.bug")
+
+	hasDeadlock, err := HasTasksRCUExitLockSymbol()
+	require.NoError(t, err)
+	require.True(t, hasDeadlock)
+
+	funcCache = newExistCache("./testdata/kallsyms.fentry.nobug")
+	hasDeadlock, err = HasTasksRCUExitLockSymbol()
+	require.NoError(t, err)
+	require.False(t, hasDeadlock)
+}

--- a/pkg/ebpf/testdata/kallsyms.fentry.bug
+++ b/pkg/ebpf/testdata/kallsyms.fentry.bug
@@ -1,0 +1,2 @@
+0000000000000000 A irq_stack_union
+0000000000000000 d tasks_rcu_exit_srcu

--- a/pkg/ebpf/testdata/kallsyms.fentry.nobug
+++ b/pkg/ebpf/testdata/kallsyms.fentry.nobug
@@ -1,0 +1,2 @@
+0000000000000000 A irq_stack_union
+0000000000000000 d console_srcu

--- a/pkg/network/usm/sharedlibraries/ebpf.go
+++ b/pkg/network/usm/sharedlibraries/ebpf.go
@@ -588,6 +588,12 @@ func fexitSupported(funcName string) bool {
 	}
 	defer l.Close()
 
+	hasPotentialFentryDeadlock, err := ddebpf.HasTasksRCUExitLockSymbol()
+	if hasPotentialFentryDeadlock || (err != nil) {
+		// incase of error, let's be safe and assume the bug is present
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds an additional check to verify that the condition for a deadlock on container exit is not present when enabling fentry

### Motivation
See https://datadoghq.atlassian.net/wiki/spaces/EBPF/pages/4708172020/System-probe+hangs+on+container+exit

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Add new UT

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->