### PR TITLE
Converter: Support Defined but empty components

### DIFF
--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -63,7 +63,10 @@ func addComponentToConfig(conf *confmap.Conf, comp component) {
 	if present {
 		componentsMap, ok := components.(map[string]any)
 		if !ok {
-			return
+			// components map is nil. It is defined but section is empty.
+			// need to create map manually
+			stringMapConf[comp.Type] = make(map[string]any)
+			componentsMap = stringMapConf[comp.Type].(map[string]any)
 		}
 		componentsMap[comp.EnhancedName] = comp.Config
 	} else {

--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -63,10 +63,14 @@ func addComponentToConfig(conf *confmap.Conf, comp component) {
 	if present {
 		componentsMap, ok := components.(map[string]any)
 		if !ok {
-			// components map is nil. It is defined but section is empty.
-			// need to create map manually
-			stringMapConf[comp.Type] = make(map[string]any)
-			componentsMap = stringMapConf[comp.Type].(map[string]any)
+			if components == nil {
+				// components map is nil. It is defined but section is empty.
+				// need to create map manually
+				stringMapConf[comp.Type] = make(map[string]any)
+				componentsMap = stringMapConf[comp.Type].(map[string]any)
+			} else {
+				return
+			}
 		}
 		componentsMap[comp.EnhancedName] = comp.Config
 	} else {

--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -66,8 +66,9 @@ func addComponentToConfig(conf *confmap.Conf, comp component) {
 			if components == nil {
 				// components map is nil. It is defined but section is empty.
 				// need to create map manually
-				stringMapConf[comp.Type] = make(map[string]any)
-				componentsMap = stringMapConf[comp.Type].(map[string]any)
+
+				componentsMap = make(map[string]any)
+				stringMapConf[comp.Type] = componentsMap
 			} else {
 				return
 			}

--- a/comp/otelcol/converter/impl/converter_test.go
+++ b/comp/otelcol/converter/impl/converter_test.go
@@ -72,6 +72,11 @@ func TestConvert(t *testing.T) {
 			expectedResult: "connectors/set-default/config-result.yaml",
 		},
 		{
+			name:           "extensions/empty-extensions",
+			provided:       "extensions/empty-extensions/config.yaml",
+			expectedResult: "extensions/empty-extensions/config-result.yaml",
+		},
+		{
 			name:           "extensions/no-extensions",
 			provided:       "extensions/no-extensions/config.yaml",
 			expectedResult: "extensions/no-extensions/config-result.yaml",
@@ -85,6 +90,11 @@ func TestConvert(t *testing.T) {
 			name:           "extensions/no-changes",
 			provided:       "extensions/no-changes/config.yaml",
 			expectedResult: "extensions/no-changes/config.yaml",
+		},
+		{
+			name:           "processors/empty-processors",
+			provided:       "processors/empty-processors/config.yaml",
+			expectedResult: "processors/empty-processors/config-result.yaml",
 		},
 		{
 			name:           "processors/no-processors",
@@ -105,6 +115,11 @@ func TestConvert(t *testing.T) {
 			name:           "processors/no-changes",
 			provided:       "processors/no-changes/config.yaml",
 			expectedResult: "processors/no-changes/config.yaml",
+		},
+		{
+			name:           "receivers/empty-receivers",
+			provided:       "receivers/empty-receivers/config.yaml",
+			expectedResult: "receivers/empty-receivers/config-result.yaml",
 		},
 		{
 			name:           "receivers/job-name-change",

--- a/comp/otelcol/converter/impl/prometheus.go
+++ b/comp/otelcol/converter/impl/prometheus.go
@@ -60,8 +60,8 @@ func addPrometheusReceiver(conf *confmap.Conf, comp component) {
 	if receivers, ok := stringMapConf["receivers"]; ok {
 		receiversMap, ok := receivers.(map[string]any)
 		if ok {
-			// Only check if ok. If !ok, this means receivers section is empty, and it will be created in call to 
-			// addComponentToConfig further down. 
+			// Only check if ok. If !ok, this means receivers section is empty, and it will be created in call to
+			// addComponentToConfig further down.
 			for receiver, receiverConfig := range receiversMap {
 				if componentName(receiver) == comp.Name {
 					receiverConfigMap, ok := receiverConfig.(map[string]any)

--- a/comp/otelcol/converter/impl/testdata/extensions/empty-extensions/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/empty-extensions/config-result.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+
+exporters:
+  nop:
+
+extensions:
+  pprof/dd-autoconfigured:
+  health_check/dd-autoconfigured:
+  zpages/dd-autoconfigured:
+    endpoint: "localhost:55679"
+  ddflare/dd-autoconfigured:
+
+service:
+  extensions:
+    [
+      pprof/dd-autoconfigured,
+      zpages/dd-autoconfigured,
+      health_check/dd-autoconfigured,
+      ddflare/dd-autoconfigured,
+    ]
+  pipelines:
+    traces:
+      receivers: [nop]
+      exporters: [nop]
+    metrics:
+      receivers: [nop]
+      exporters: [nop]
+    logs:
+      receivers: [nop]
+      exporters: [nop]
+

--- a/comp/otelcol/converter/impl/testdata/extensions/empty-extensions/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/extensions/empty-extensions/config.yaml
@@ -1,0 +1,19 @@
+receivers:
+    otlp:
+
+exporters:
+    nop:
+
+extensions:
+
+service:
+    pipelines:
+        traces:
+            receivers: [nop]
+            exporters: [nop]
+        metrics:
+            receivers: [nop]
+            exporters: [nop]
+        logs:
+            receivers: [nop]
+            exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/processors/empty-processors/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/processors/empty-processors/config-result.yaml
@@ -1,0 +1,40 @@
+receivers:
+    otlp:
+    prometheus/user-defined:
+      config:
+        scrape_configs:
+          - job_name: 'datadog-agent'
+            scrape_interval: 60s
+            static_configs:
+              - targets: ['0.0.0.0:8888']
+
+exporters:
+    datadog:
+      api:
+        key: abcde12345
+
+extensions:
+  pprof/user-defined:
+  health_check/user-defined:
+  zpages/user-defined:
+    endpoint: "localhost:55679"
+  ddflare/user-defined:
+    
+processors:
+  infraattributes/dd-autoconfigured:
+
+service:
+    extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+    pipelines:
+        traces:
+            receivers: [nop]
+            processors: [infraattributes/dd-autoconfigured]
+            exporters: [datadog]
+        metrics:
+            receivers: [nop, prometheus/user-defined]
+            processors: [infraattributes/dd-autoconfigured]
+            exporters: [datadog]
+        logs:
+            receivers: [nop]
+            processors: [infraattributes/dd-autoconfigured]
+            exporters: [datadog]

--- a/comp/otelcol/converter/impl/testdata/processors/empty-processors/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/processors/empty-processors/config.yaml
@@ -1,0 +1,36 @@
+receivers:
+    otlp:
+    prometheus/user-defined:
+      config:
+        scrape_configs:
+          - job_name: 'datadog-agent'
+            scrape_interval: 60s
+            static_configs:
+              - targets: ['0.0.0.0:8888']
+
+exporters:
+    datadog:
+      api:
+        key: abcde12345
+
+extensions:
+  pprof/user-defined:
+  health_check/user-defined:
+  zpages/user-defined:
+    endpoint: "localhost:55679"
+  ddflare/user-defined:
+
+processors: 
+
+service:
+    extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+    pipelines:
+        traces:
+            receivers: [nop]
+            exporters: [datadog]
+        metrics:
+            receivers: [nop, prometheus/user-defined]
+            exporters: [datadog]
+        logs:
+            receivers: [nop]
+            exporters: [datadog]

--- a/comp/otelcol/converter/impl/testdata/receivers/empty-receivers/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/receivers/empty-receivers/config-result.yaml
@@ -1,0 +1,39 @@
+receivers:
+    prometheus/dd-autoconfigured:
+      config:
+        scrape_configs:
+          - job_name: 'datadog-agent'
+            scrape_interval: 60s
+            static_configs:
+              - targets: ['0.0.0.0:8888']
+
+exporters:
+    datadog:
+      api:
+        key: abcde12345
+
+extensions:
+  pprof/user-defined:
+  health_check/user-defined:
+  zpages/user-defined:
+    endpoint: "localhost:55679"
+  ddflare/user-defined:
+    
+processors:
+  infraattributes/user-defined:
+
+service:
+    extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+    pipelines:
+        traces:
+            processors: [infraattributes/user-defined]
+            exporters: [datadog]
+        metrics:
+            processors: [infraattributes/user-defined]
+            exporters: [datadog]
+        logs:
+            processors: [infraattributes/user-defined]
+            exporters: [datadog]
+        metrics/dd-autoconfigured/datadog:
+            receivers: [prometheus/dd-autoconfigured]
+            exporters: [datadog]

--- a/comp/otelcol/converter/impl/testdata/receivers/empty-receivers/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/receivers/empty-receivers/config.yaml
@@ -1,0 +1,29 @@
+receivers:
+
+exporters:
+    datadog:
+      api:
+        key: abcde12345
+
+extensions:
+  pprof/user-defined:
+  health_check/user-defined:
+  zpages/user-defined:
+    endpoint: "localhost:55679"
+  ddflare/user-defined:
+    
+processors:
+  infraattributes/user-defined:
+
+service:
+    extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+    pipelines:
+        traces:
+            processors: [infraattributes/user-defined]
+            exporters: [datadog]
+        metrics:
+            processors: [infraattributes/user-defined]
+            exporters: [datadog]
+        logs:
+            processors: [infraattributes/user-defined]
+            exporters: [datadog]


### PR DESCRIPTION
### What does this PR do?
Previously, when a component config section was defined but empty, this lead to the component not being added.
e.g. if you had extensions defined as so:
```
extensions:
```

Then we wouldn't add the extensions to this, but we would add them to the pipelines, which would lead to otel-agent failing to start. 

This PR fixes this bug (the type assertion to map was failing when the section is left empty).

This PR addresses this for processors, receivers and extensions. exporters and connectors are not affected because we don't add these component types in converter. 

### Motivation
OTAGENT-269

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->