### PR TITLE
feat(ssi): add release note for workload selection

### DIFF
--- a/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
+++ b/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
@@ -8,12 +8,10 @@
 ---
 features:
   - |
-    Target based workload selection is now available for Single Step Instrumentation. This feature allows you to target
-    specific workloads for instrumentation using pod and namespace label selectors. By using user defined labels, a
-    single operator is able to select workloads for instrumentation without modifying their applications. For
-    example, the following configuration injects the python tracer with a default version for pods with a
-    `launguage=python`:
-
+    Target-based workload selection is now available for Single Step Instrumentation. This feature enables you to
+    instrument specific workloads using pod and namespace label selectors. By applying user-defined labels, you can
+    select workloads for instrumentation without modifying applications. For example, the following configuration
+    injects the Python tracer with a default version for pods labeled with `language=python`:
     ```yaml
     instrumentation:
       enabled: true
@@ -27,9 +25,8 @@ features:
     ```
 
     Targets can also be chained together, with the first matching rule taking precedence. For example, the following
-    configuration installs the Python tracer for pods matching the label `language=python` and installs the Java:
-    tracer for all pods in a namespace with the label `language=java`. If a pod matches both rules, the first match
-    takes precedence:
+    configuration installs the Python tracer for pods labeled `language=python` and the Java tracer for pods in a
+    namespace labeled `language=java`. If a pod matches both rules, the first match takes precedence:
     ```
     instrumentation:
       enabled: true

--- a/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
+++ b/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
@@ -1,0 +1,49 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Target based workload selection is now available for Single Step Instrumentation. This feature allows you to target
+    specific workloads for instrumentation using pod and namespace label selectors. By using user defined labels, a
+    single operator will be able to select workloads for instrumentation without modifying their applications. For
+    example, the following configuration will inject the python tracer with a default version for pods with a
+    `launguage=python`:
+
+    ```yaml
+    instrumentation:
+      enabled: true
+      targets:
+        - name: "Python Services"
+          podSelector:
+            matchLabels:
+              language: "python"
+          ddTraceVersions:
+            python: "default"
+    ```
+
+    Targets can also be chained together, with the first matching rule taking precedence. For example, the following
+    configuration will install the python tracer for pods matching the label `language=python` and will install the java:
+    tracer for all pods in a namespace with the label `language=java`. If a pod matches both rules, the first match
+    takes precedence:
+    ```
+    instrumentation:
+      enabled: true
+      targets:
+        - name: "Python Services"
+          podSelector:
+            matchLabels:
+              language: "python"
+          ddTraceVersions:
+            python: "default"
+        - name: "Java Namespaces"
+          namespaceSelector:
+            matchLabels:
+              language: "java"
+          ddTraceVersions:
+            python: "default"
+    ```

--- a/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
+++ b/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
@@ -10,8 +10,8 @@ features:
   - |
     Target based workload selection is now available for Single Step Instrumentation. This feature allows you to target
     specific workloads for instrumentation using pod and namespace label selectors. By using user defined labels, a
-    single operator will be able to select workloads for instrumentation without modifying their applications. For
-    example, the following configuration will inject the python tracer with a default version for pods with a
+    single operator is able to select workloads for instrumentation without modifying their applications. For
+    example, the following configuration injects the python tracer with a default version for pods with a
     `launguage=python`:
 
     ```yaml
@@ -27,7 +27,7 @@ features:
     ```
 
     Targets can also be chained together, with the first matching rule taking precedence. For example, the following
-    configuration will install the python tracer for pods matching the label `language=python` and will install the java:
+    configuration installs the Python tracer for pods matching the label `language=python` and installs the Java:
     tracer for all pods in a namespace with the label `language=java`. If a pod matches both rules, the first match
     takes precedence:
     ```


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit adds a release note for the workload selection changes.

### Motivation
See [Kubernetes SSI | Workload Selection 🎯](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing).

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This change only includes the release note, though feature was implemented over many changes:
* https://github.com/DataDog/datadog-agent/pull/33388
* https://github.com/DataDog/datadog-agent/pull/33508
* https://github.com/DataDog/datadog-agent/pull/33561
* https://github.com/DataDog/datadog-agent/pull/33599
* https://github.com/DataDog/datadog-agent/pull/33796
* https://github.com/DataDog/datadog-agent/pull/33803
* https://github.com/DataDog/datadog-agent/pull/33907
* https://github.com/DataDog/datadog-agent/pull/33958
* https://github.com/DataDog/datadog-agent/pull/33959
