### PR TITLE
[AGENTRUN-73] Migrate ddflareextension server to use IPC certificate

### DIFF
--- a/comp/otelcol/ddflareextension/impl/server.go
+++ b/comp/otelcol/ddflareextension/impl/server.go
@@ -8,17 +8,9 @@ package ddflareextensionimpl
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"fmt"
-	"math/big"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
 
@@ -41,75 +33,6 @@ func validateToken(next http.Handler) http.Handler {
 }
 
 func newServer(endpoint string, handler http.Handler, auth bool) (*server, error) {
-
-	// Generate a self-signed certificate
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, err
-	}
-
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		return nil, err
-	}
-
-	template := x509.Certificate{
-		SerialNumber: serialNumber,
-		Subject: pkix.Name{
-			Organization: []string{"Datadog Inc."},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
-		IsCA:                  true,
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature | x509.KeyUsageCRLSign,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
-		BasicConstraintsValid: true,
-	}
-
-	for _, h := range []string{"127.0.0.1", "localhost", "::1"} {
-		if ip := net.ParseIP(h); ip != nil {
-			template.IPAddresses = append(template.IPAddresses, ip)
-		} else {
-			template.DNSNames = append(template.DNSNames, h)
-		}
-	}
-
-	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
-	if err != nil {
-		return nil, err
-	}
-	// parse the resulting certificate so we can use it again
-	_, err = x509.ParseCertificate(certDER)
-	if err != nil {
-		return nil, err
-	}
-	// PEM encode the certificate (this is a standard TLS encoding)
-	b := pem.Block{Type: "CERTIFICATE", Bytes: certDER}
-	certPEM := pem.EncodeToMemory(&b)
-
-	keyPEM := pem.EncodeToMemory(&pem.Block{
-		Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key),
-	})
-
-	pair, err := tls.X509KeyPair(certPEM, keyPEM)
-	if err != nil {
-		return nil, fmt.Errorf("unable to generate TLS key pair: %v", err)
-	}
-
-	tlsCertPool := x509.NewCertPool()
-	ok := tlsCertPool.AppendCertsFromPEM(certPEM)
-	if !ok {
-		return nil, fmt.Errorf("unable to add new certificate to pool")
-	}
-
-	// Create TLS configuration
-	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{pair},
-		NextProtos:   []string{"h2"},
-		MinVersion:   tls.VersionTLS12,
-	}
-
 	r := mux.NewRouter()
 	r.Handle("/", handler)
 
@@ -122,7 +45,7 @@ func newServer(endpoint string, handler http.Handler, auth bool) (*server, error
 
 	s := &http.Server{
 		Addr:      endpoint,
-		TLSConfig: tlsConfig,
+		TLSConfig: util.GetTLSServerConfig(),
 		Handler:   r,
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR is making use of the IPC certificate (introduced in #31838) to start the `ddflareextension` server.


### Motivation
This is useful to secure the communication between the coreAgent and `otel-agent`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Changes are validated by OTEL Agent e2e test in [this file](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/tests/otel/utils/config_utils.go).
