### PR TITLE
Remove remapCase map from config nodes

### DIFF
--- a/pkg/config/nodetreemodel/inner_node_test.go
+++ b/pkg/config/nodetreemodel/inner_node_test.go
@@ -36,16 +36,13 @@ func TestMergeToEmpty(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := &innerNode{
-		remapCase: map[string]string{"a": "a", "b": "b", "c": "c"},
 		children: map[string]Node{
 			"a": &leafNodeImpl{val: "apple", source: model.SourceFile},
 			"b": &leafNodeImpl{val: 123, source: model.SourceFile},
 			"c": &innerNode{
-				remapCase: map[string]string{"d": "d", "e": "e"},
 				children: map[string]Node{
 					"d": &leafNodeImpl{val: true, source: model.SourceFile},
 					"e": &innerNode{
-						remapCase: map[string]string{"f": "f"},
 						children: map[string]Node{
 							"f": &leafNodeImpl{val: 456, source: model.SourceFile},
 						},
@@ -95,17 +92,14 @@ func TestMergeTwoTree(t *testing.T) {
 	require.NoError(t, err)
 
 	expected := &innerNode{
-		remapCase: map[string]string{"a": "a", "b": "b", "z": "z", "c": "c"},
 		children: map[string]Node{
 			"a": &leafNodeImpl{val: "orange", source: model.SourceEnvVar},
 			"b": &leafNodeImpl{val: 123, source: model.SourceFile},
 			"z": &leafNodeImpl{val: 987, source: model.SourceEnvVar},
 			"c": &innerNode{
-				remapCase: map[string]string{"d": "d", "e": "e"},
 				children: map[string]Node{
 					"d": &leafNodeImpl{val: false, source: model.SourceEnvVar},
 					"e": &innerNode{
-						remapCase: map[string]string{"f": "f", "g": "g"},
 						children: map[string]Node{
 							"f": &leafNodeImpl{val: 456, source: model.SourceEnvVar},
 							"g": &leafNodeImpl{val: "kiwi", source: model.SourceEnvVar},

--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -97,7 +97,6 @@ type InnerNode interface {
 	SetAt([]string, interface{}, model.Source) (bool, error)
 	InsertChildNode(string, Node)
 	RemoveChild(string)
-	makeRemapCase()
 	DumpSettings(func(model.Source) bool) map[string]interface{}
 }
 

--- a/pkg/config/nodetreemodel/read_config_file_test.go
+++ b/pkg/config/nodetreemodel/read_config_file_test.go
@@ -172,11 +172,9 @@ c:
 	assert.Equal(t, model.SourceDefault, cfg.GetSource("c.e.f"))
 
 	expected := &innerNode{
-		remapCase: map[string]string{"a": "a", "c": "c"},
 		children: map[string]Node{
 			"a": &leafNodeImpl{val: "orange", source: model.SourceFile},
 			"c": &innerNode{
-				remapCase: map[string]string{"d": "d"},
 				children: map[string]Node{
 					"d": &leafNodeImpl{val: 1234, source: model.SourceFile},
 				},
@@ -209,11 +207,9 @@ c:
 	assert.Equal(t, "unknown key from YAML: c.unknown", c.warnings[0])
 
 	expected := &innerNode{
-		remapCase: map[string]string{"a": "a", "c": "c"},
 		children: map[string]Node{
 			"a": &leafNodeImpl{val: "orange", source: model.SourceFile},
 			"c": &innerNode{
-				remapCase: map[string]string{"d": "d"},
 				children: map[string]Node{
 					"d": &leafNodeImpl{val: 1234, source: model.SourceFile},
 				},
@@ -244,12 +240,10 @@ c: 1234
 	assert.Equal(t, "invalid type from configuration for key 'c'", c.warnings[0])
 
 	expected := &innerNode{
-		remapCase: map[string]string{"a": "a", "c": "c"},
 		children: map[string]Node{
 			"a": &leafNodeImpl{val: "orange", source: model.SourceFile},
 			"c": &innerNode{
-				remapCase: map[string]string{},
-				children:  map[string]Node{},
+				children: map[string]Node{},
 			},
 		},
 	}

--- a/pkg/config/nodetreemodel/struct_node.go
+++ b/pkg/config/nodetreemodel/struct_node.go
@@ -77,9 +77,6 @@ func (n *structNodeImpl) InsertChildNode(string, Node) {}
 // RemoveChild is not implemented for struct node
 func (n *structNodeImpl) RemoveChild(string) {}
 
-// makeRemapCase not implemented
-func (n *structNodeImpl) makeRemapCase() {}
-
 // Clone clones a LeafNode
 func (n *structNodeImpl) Clone() Node {
 	return &structNodeImpl{val: n.val}


### PR DESCRIPTION
### What does this PR do?

Removes the `remapCase` map from nodetreemodel.

### Motivation

The remapCase map was originally thought to be needed for two reasons:
1. The original design of nodetreemodel would treat map values as their own nodes, as leaf nodes must hold scalar values
2. [This test](https://github.com/DataDog/datadog-agent/blob/4abf43e023502f553d2d388b5a00d98425418889/pkg/config/structure/unmarshal_test.go#L54) seemed to require preserving case so that marshalling would work the same as before.

Once we changed leaf nodes such that they could hold complex types like map values, and didn't need to hold scalars, (1) was no longer true. Therefore, we can fix (2) by downcasing all keys when an inner node is constructed. This lets us treat all config keys are lower-case and get rid of the remapCase map, saving a lot of memory at runtime. Since viper already treats all keys as lower-case, this is a compatible change.

### Describe how you validated your changes

Behavior covered by unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
