### PR TITLE
feat(ssi): add support for trace configs

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -218,6 +218,10 @@ type Target struct {
 	// name and the value is the version to inject. Full config key:
 	// apm_config.instrumentation.targets[].ddTraceVersions
 	TracerVersions map[string]string `mapstructure:"ddTraceVersions"`
+	// TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
+	// as environment variables in addition to the injected tracer. Full config key:
+	// apm_config.instrumentation.targets[].ddTraceConfigs
+	TracerConfigs []TracerConfig `mapstructure:"ddTraceConfigs" json:"ddTraceConfigs"`
 }
 
 // PodSelector is a reconstruction of the metav1.LabelSelector struct to be able to unmarshal the configuration. It
@@ -293,6 +297,23 @@ func (n NamespaceSelector) AsLabelSelector() (labels.Selector, error) {
 	}
 
 	return metav1.LabelSelectorAsSelector(labelSelector)
+}
+
+// TracerConfig is a struct that stores configuration options for a tracer. These will be injected as environment
+// variables to the workload that matches targeting.
+type TracerConfig struct {
+	// Name is the name of the environment variable.
+	Name string `mapstructure:"name" json:"name"`
+	// Value is the value to use.
+	Value string `mapstructure:"value" json:"value"`
+}
+
+// AsEnvVar converts the TracerConfig to a corev1.EnvVar.
+func (c *TracerConfig) AsEnvVar() corev1.EnvVar {
+	return corev1.EnvVar{
+		Name:  c.Name,
+		Value: c.Value,
+	}
 }
 
 var (

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -86,6 +86,16 @@ func TestNewInstrumentationConfig(t *testing.T) {
 						TracerVersions: map[string]string{
 							"java": "default",
 						},
+						TracerConfigs: []TracerConfig{
+							{
+								Name:  "DD_PROFILING_ENABLED",
+								Value: "true",
+							},
+							{
+								Name:  "DD_DATA_JOBS_ENABLED",
+								Value: "true",
+							},
+						},
 					},
 				},
 			},
@@ -132,6 +142,16 @@ func TestNewInstrumentationConfig(t *testing.T) {
 						},
 						TracerVersions: map[string]string{
 							"java": "default",
+						},
+						TracerConfigs: []TracerConfig{
+							{
+								Name:  "DD_PROFILING_ENABLED",
+								Value: "true",
+							},
+							{
+								Name:  "DD_DATA_JOBS_ENABLED",
+								Value: "true",
+							},
 						},
 					},
 				},

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_invalid_configs.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_invalid_configs.yaml
@@ -3,14 +3,14 @@ apm_config:
   instrumentation:
     enabled: true
     targets:
-      - name: "Application Namespace"
-        namespaceSelector:
-          matchNames:
-          - "application"
+      - name: "Python Apps"
+        podSelector:
+          matchLabels:
+            language: "python"
         ddTraceVersions:
           python: "v2"
         ddTraceConfigs:
           - name: "DD_PROFILING_ENABLED"
             value: "true"
-          - name: "DD_DATA_JOBS_ENABLED"
+          - name: "FOO_BAR"
             value: "true"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_configs.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_configs.yaml
@@ -3,10 +3,10 @@ apm_config:
   instrumentation:
     enabled: true
     targets:
-      - name: "Application Namespace"
-        namespaceSelector:
-          matchNames:
-          - "application"
+      - name: "Python Apps"
+        podSelector:
+          matchLabels:
+            language: "python"
         ddTraceVersions:
           python: "v2"
         ddTraceConfigs:

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/targets.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/targets.yaml
@@ -19,3 +19,8 @@ apm_config:
           - "billing"
         ddTraceVersions:
           java: "default"
+        ddTraceConfigs:
+          - name: "DD_PROFILING_ENABLED"
+            value: "true"
+          - name: "DD_DATA_JOBS_ENABLED"
+            value: "true"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/targets_namespace_labels.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/targets_namespace_labels.yaml
@@ -24,3 +24,8 @@ apm_config:
                 - "prod"
         ddTraceVersions:
           java: "default"
+        ddTraceConfigs:
+          - name: "DD_PROFILING_ENABLED"
+            value: "true"
+          - name: "DD_DATA_JOBS_ENABLED"
+            value: "true"

--- a/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
+++ b/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
@@ -46,7 +46,7 @@ features:
     ```
 
     Targets support tracer configuration options in the form of environment variables. All options must have the
-    `DD_` prefix. The following example will install the Python tracer with profiling and data jobs enabled:
+    `DD_` prefix. The following example installs the Python tracer with profiling and data jobs enabled:
     ```
     instrumentation:
       enabled: true

--- a/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
+++ b/releasenotes/notes/target-based-workload-selection-a745168b07add397.yaml
@@ -44,3 +44,22 @@ features:
           ddTraceVersions:
             python: "default"
     ```
+
+    Targets support tracer configuration options in the form of environment variables. All options must have the
+    `DD_` prefix. The following example will install the Python tracer with profiling and data jobs enabled:
+    ```
+    instrumentation:
+      enabled: true
+      targets:
+        - name: "Python Apps"
+          podSelector:
+            matchLabels:
+              language: "python"
+          ddTraceVersions:
+            python: "v2"
+          ddTraceConfigs:
+            - name: "DD_PROFILING_ENABLED"
+              value: "true"
+            - name: "DD_DATA_JOBS_ENABLED"
+              value: "true"
+    ```


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit adds support for adding trace configs in addition to the trace versions in the target based workload selection.

### Motivation
This is an extension of [Kubernetes SSI | Workload Selection 🎯](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing) to be able to support configuring tracers. We keep getting feedback from customers that Single Step is great at delivering a tracing library, but it doesn't allow for configuring the tracing library for any other product we support. This change will enable that for SSI in Kubernetes.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The unit tests added are the main test for this feature. But I also conducted a manual test using the `injector-dev` tooling in the `auto_inject` repo. I used the following config in my helm chart:
```yaml
  datadog_cluster_yaml:
    log_level: DEBUG
    apm_config:
      instrumentation:
        enabled: true
        targets:
          - name: "Python Apps"
            podSelector:
              matchLabels:
                language: "python"
            ddTraceVersions:
              python: "v2"
            ddTraceConfigs:
              - name: "DD_PROFILING_ENABLED"
                value: "true"
              - name: "DD_DATA_JOBS_ENABLED"
                value: "true"
```

I ran the following to deploy a custom cluster agent locally:
```
injector-dev start
injector-dev init-k8s-helm
injector-dev custom-cluster-agent
```

I then restarted the test app to trigger injection:
```
kubectl -n test-1 rollout restart deployment
```

I then confirmed the additional env variables exist:
```
kubectl -n test-1 get pods -o jsonpath="{range .items[*]}{.metadata.name} {'\n'}{range .spec.containers[*]} {.name} {'\n'}{range .env[*]}  {.name}={.value} {'\n'}{end}{'\n'}{end}{'\n'}{end}"

python-app-5869fc58db-lxgmq
 app
  DD_DATA_JOBS_ENABLED=true
  DD_PROFILING_ENABLED=true
  DD_RUNTIME_METRICS_ENABLED=true
  DD_TRACE_HEALTH_METRICS_ENABLED=true
  DD_LOGS_INJECTION=true
  DD_TRACE_ENABLED=true
  DD_INSTRUMENTATION_INSTALL_ID=5a9c4b83-7ee3-4109-800c-5bc7a143007f
  DD_INSTRUMENTATION_INSTALL_TIME=1739325947
  DD_INSTRUMENTATION_INSTALL_TYPE=k8s_single_step
  DD_SERVICE=test-python-app-ssi
  DD_ENV=local
  DD_INTERNAL_POD_UID=
  DD_EXTERNAL_ENV=it-false,cn-app,pu-$(DD_INTERNAL_POD_UID)
  DD_ENTITY_ID=
  DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket
  DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket
  DD_TRACE_DEBUG=true
  LD_PRELOAD=/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so
  DD_INJECT_SENDER_TYPE=k8s
  DD_INJECT_START_TIME=1739325987
  ```

### Possible Drawbacks / Trade-offs
A list of env vars is not as ergonomic as dedicated configuration options. It would be especially confusing if the option also required additional setup. However, dedicated configuration options require an agent release, operator release, and a release of the helm chart. This provides a higher level of flexibility without requiring us to add options for new products.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->