### PR TITLE
[CONTP-547] assert DetectedLangs in cluster agent cli e2e tests

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -428,6 +428,16 @@ func (suite *k8sSuite) testClusterAgentCLI() {
 			suite.T().Log(stdout)
 		}
 	})
+
+	// TODO: remove this assertion when flaky test investigation is done (CONTP-547)
+	suite.Require().EventuallyWithTf(func(_ *assert.CollectT) {
+		stdout, _, err := suite.podExec("datadog", pod.Items[0].Name, "cluster-agent", []string{"datadog-cluster-agent", "workload-list"})
+		suite.Require().NoError(err)
+		suite.Contains(stdout, "=>[python]")
+		if suite.T().Failed() {
+			suite.T().Log(stdout)
+		}
+	}, 5*time.Minute, 10*time.Second, "Language python should be in DetectedLangs in deployment entity in workloadmeta.")
 }
 
 func (suite *k8sSuite) TestNginx() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add extra assertion to e2e tests.

### Motivation

Related to this.

The previously added assertion verified that the test is not failing due to an issue in the process agent or PLD client. 
The assertion added in this PR is to verify if the test failure is due to failure in communication between the node agent and the cluster agent, or between the cluster agent and the kube api server.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->