### PR TITLE
[workloadmeta/collectors/ecs] Leave runtime empty when using v4 metadata

### DIFF
--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -214,9 +214,14 @@ func ParseV4TaskContainers(
 		}
 
 		source := workloadmeta.SourceNodeOrchestrator
-		containerEvent.Runtime = workloadmeta.ContainerRuntimeDocker
+		// Edge Case: Setting the runtime to "docker" causes issues, although
+		// it's correct. This is the same case explained in
+		// comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
+		containerEvent.Runtime = ""
 		if task.LaunchType == "FARGATE" {
 			source = workloadmeta.SourceRuntime
+			// Unlike in the case above, it is OK to set the runtime here, as
+			// the logs agent does not collect logs in ECS Fargate.
 			containerEvent.Runtime = workloadmeta.ContainerRuntimeECSFargate
 		}
 


### PR DESCRIPTION
### What does this PR do?

Fixes the same issue describe in this PR https://github.com/DataDog/datadog-agent/pull/33857 but this time for cases where the v4 metadata endpoint is used. This endpoint is used when the ECS explorer is enabled, which is going to be the default in 7.64.0.

See the PR above for a detailed explanation of the issue.

No changelog needed for this one because it was already added for the PR above.

### Describe how you validated your changes

Run the Agent on ECS EC2 with `DD_ECS_TASK_COLLECTION_ENABLED=true`. Check that the logs include the correct "source" and "service". Before this fix, sometimes they were incorrectly set to "Kubernetes".