### PR TITLE
[CWS-4006] Add `product_tags` field to rules

### DIFF
--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -164,14 +164,15 @@ func ReportRuleSetLoaded(acc *events.AgentContainerContext, sender events.EventS
 // RuleState defines a loaded rule
 // easyjson:json
 type RuleState struct {
-	ID         string            `json:"id"`
-	Version    string            `json:"version,omitempty"`
-	Expression string            `json:"expression"`
-	Status     string            `json:"status"`
-	Message    string            `json:"message,omitempty"`
-	Tags       map[string]string `json:"tags,omitempty"`
-	Actions    []RuleAction      `json:"actions,omitempty"`
-	ModifiedBy []*PolicyState    `json:"modified_by,omitempty"`
+	ID          string            `json:"id"`
+	Version     string            `json:"version,omitempty"`
+	Expression  string            `json:"expression"`
+	Status      string            `json:"status"`
+	Message     string            `json:"message,omitempty"`
+	Tags        map[string]string `json:"tags,omitempty"`
+	ProductTags []string          `json:"product_tags,omitempty"`
+	Actions     []RuleAction      `json:"actions,omitempty"`
+	ModifiedBy  []*PolicyState    `json:"modified_by,omitempty"`
 }
 
 // PolicyState is used to report policy was loaded
@@ -261,12 +262,13 @@ func PolicyStateFromRule(rule *rules.PolicyRule) *PolicyState {
 // RuleStateFromRule returns a rule state based on the given rule
 func RuleStateFromRule(rule *rules.PolicyRule, status string, message string) *RuleState {
 	ruleState := &RuleState{
-		ID:         rule.Def.ID,
-		Version:    rule.Policy.Def.Version,
-		Expression: rule.Def.Expression,
-		Status:     status,
-		Message:    message,
-		Tags:       rule.Def.Tags,
+		ID:          rule.Def.ID,
+		Version:     rule.Policy.Def.Version,
+		Expression:  rule.Def.Expression,
+		Status:      status,
+		Message:     message,
+		Tags:        rule.Def.Tags,
+		ProductTags: rule.Def.ProductTags,
 	}
 
 	for _, action := range rule.Actions {

--- a/pkg/security/rules/monitor/policy_monitor_easyjson.go
+++ b/pkg/security/rules/monitor/policy_monitor_easyjson.go
@@ -254,6 +254,29 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 				}
 				in.Delim('}')
 			}
+		case "product_tags":
+			if in.IsNull() {
+				in.Skip()
+				out.ProductTags = nil
+			} else {
+				in.Delim('[')
+				if out.ProductTags == nil {
+					if !in.IsDelim(']') {
+						out.ProductTags = make([]string, 0, 4)
+					} else {
+						out.ProductTags = []string{}
+					}
+				} else {
+					out.ProductTags = (out.ProductTags)[:0]
+				}
+				for !in.IsDelim(']') {
+					var v5 string
+					v5 = string(in.String())
+					out.ProductTags = append(out.ProductTags, v5)
+					in.WantComma()
+				}
+				in.Delim(']')
+			}
 		case "actions":
 			if in.IsNull() {
 				in.Skip()
@@ -270,9 +293,9 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.Actions = (out.Actions)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v5 RuleAction
-					(v5).UnmarshalEasyJSON(in)
-					out.Actions = append(out.Actions, v5)
+					var v6 RuleAction
+					(v6).UnmarshalEasyJSON(in)
+					out.Actions = append(out.Actions, v6)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -293,17 +316,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 					out.ModifiedBy = (out.ModifiedBy)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v6 *PolicyState
+					var v7 *PolicyState
 					if in.IsNull() {
 						in.Skip()
-						v6 = nil
+						v7 = nil
 					} else {
-						if v6 == nil {
-							v6 = new(PolicyState)
+						if v7 == nil {
+							v7 = new(PolicyState)
 						}
-						(*v6).UnmarshalEasyJSON(in)
+						(*v7).UnmarshalEasyJSON(in)
 					}
-					out.ModifiedBy = append(out.ModifiedBy, v6)
+					out.ModifiedBy = append(out.ModifiedBy, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -352,18 +375,32 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('{')
-			v7First := true
-			for v7Name, v7Value := range in.Tags {
-				if v7First {
-					v7First = false
+			v8First := true
+			for v8Name, v8Value := range in.Tags {
+				if v8First {
+					v8First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v7Name))
+				out.String(string(v8Name))
 				out.RawByte(':')
-				out.String(string(v7Value))
+				out.String(string(v8Value))
 			}
 			out.RawByte('}')
+		}
+	}
+	if len(in.ProductTags) != 0 {
+		const prefix string = ",\"product_tags\":"
+		out.RawString(prefix)
+		{
+			out.RawByte('[')
+			for v9, v10 := range in.ProductTags {
+				if v9 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v10))
+			}
+			out.RawByte(']')
 		}
 	}
 	if len(in.Actions) != 0 {
@@ -371,11 +408,11 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v8, v9 := range in.Actions {
-				if v8 > 0 {
+			for v11, v12 := range in.Actions {
+				if v11 > 0 {
 					out.RawByte(',')
 				}
-				(v9).MarshalEasyJSON(out)
+				(v12).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}
@@ -385,14 +422,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor1(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v10, v11 := range in.ModifiedBy {
-				if v10 > 0 {
+			for v13, v14 := range in.ModifiedBy {
+				if v13 > 0 {
 					out.RawByte(',')
 				}
-				if v11 == nil {
+				if v14 == nil {
 					out.RawString("null")
 				} else {
-					(*v11).MarshalEasyJSON(out)
+					(*v14).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -770,17 +807,17 @@ func easyjson6151911dDecodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 					out.Rules = (out.Rules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v12 *RuleState
+					var v15 *RuleState
 					if in.IsNull() {
 						in.Skip()
-						v12 = nil
+						v15 = nil
 					} else {
-						if v12 == nil {
-							v12 = new(RuleState)
+						if v15 == nil {
+							v15 = new(RuleState)
 						}
-						(*v12).UnmarshalEasyJSON(in)
+						(*v15).UnmarshalEasyJSON(in)
 					}
-					out.Rules = append(out.Rules, v12)
+					out.Rules = append(out.Rules, v15)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -821,14 +858,14 @@ func easyjson6151911dEncodeGithubComDataDogDatadogAgentPkgSecurityRulesMonitor5(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v13, v14 := range in.Rules {
-				if v13 > 0 {
+			for v16, v17 := range in.Rules {
+				if v16 > 0 {
 					out.RawByte(',')
 				}
-				if v14 == nil {
+				if v17 == nil {
 					out.RawString("null")
 				} else {
-					(*v14).MarshalEasyJSON(out)
+					(*v17).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -40,6 +40,8 @@ const (
 	OverrideEveryField OverrideField = "every"
 	// OverrideTagsField used to override the tags
 	OverrideTagsField OverrideField = "tags"
+	// OverrideProductTagsField used to override the product_tags field
+	OverrideProductTagsField OverrideField = "product_tags"
 )
 
 // OverrideOptions defines combine options
@@ -68,6 +70,7 @@ type RuleDefinition struct {
 	Expression             string                 `yaml:"expression" json:"expression,omitempty"`
 	Description            string                 `yaml:"description,omitempty" json:"description,omitempty"`
 	Tags                   map[string]string      `yaml:"tags,omitempty" json:"tags,omitempty"`
+	ProductTags            []string               `yaml:"product_tags,omitempty" json:"product_tags,omitempty"`
 	AgentVersionConstraint string                 `yaml:"agent_version,omitempty" json:"agent_version,omitempty"`
 	Filters                []string               `yaml:"filters,omitempty" json:"filters,omitempty"`
 	Disabled               bool                   `yaml:"disabled,omitempty" json:"disabled,omitempty"`

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -81,6 +81,9 @@ func applyOverride(rd1, rd2 *PolicyRule) {
 		if slices.Contains(rd2.Def.OverrideOptions.Fields, OverrideTagsField) {
 			rd1.Def.Tags = rd2.Def.Tags
 		}
+		if slices.Contains(rd2.Def.OverrideOptions.Fields, OverrideProductTagsField) {
+			rd1.Def.ProductTags = rd2.Def.ProductTags
+		}
 	}
 }
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -317,6 +317,7 @@ func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, pRule *PolicyRule
 	for k, v := range pRule.Def.Tags {
 		tags = append(tags, k+":"+v)
 	}
+	tags = append(tags, pRule.Def.ProductTags...)
 
 	expandedRules := expandFim(pRule.Def.ID, pRule.Def.GroupID, pRule.Def.Expression)
 

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -306,6 +306,12 @@
           },
           "type": "object"
         },
+        "product_tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "agent_version": {
           "type": "string"
         },

--- a/pkg/security/secl/schemas/ruleset_loaded.schema.json
+++ b/pkg/security/secl/schemas/ruleset_loaded.schema.json
@@ -89,6 +89,12 @@
                         "type": "string"
                     }
                 },
+                "product_tags": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "actions": {
                     "type": "array",
                     "items": {

--- a/pkg/security/tests/event_test.go
+++ b/pkg/security/tests/event_test.go
@@ -291,7 +291,7 @@ func TestEventProductTags(t *testing.T) {
 
 	rule := &rules.RuleDefinition{
 		ID:          "event_product_tags",
-		Expression:  `open.file.path == "{{.Root}}/test-event-ruletags" && open.flags&O_CREAT == O_CREAT`,
+		Expression:  `open.file.path == "{{.Root}}/test-event-product-tags" && open.flags&O_CREAT == O_CREAT`,
 		ProductTags: []string{"tag:test_tag"},
 	}
 
@@ -301,7 +301,7 @@ func TestEventProductTags(t *testing.T) {
 	}
 	defer test.Close()
 
-	testFile, _, err := test.Path("test-event-ruletags")
+	testFile, _, err := test.Path("test-event-product-tags")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +314,7 @@ func TestEventProductTags(t *testing.T) {
 				return err
 			}
 			return f.Close()
-		}, func(rule *rules.Rule, event *model.Event) bool {
+		}, func(rule *rules.Rule, _ *model.Event) bool {
 			assert.Contains(t, rule.Tags, "tag:test_tag")
 			return true
 		}, getEventTimeout, "event_product_tags")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a new `product_tags` field to rules. Similarly to the `tags`, this new field can be used to add tags to events that match the corresponding rule. However this one allows providing tags with duplicate keys/tag names.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->