### PR TITLE
[CWS] optimization to socket bound snapshotting

### DIFF
--- a/pkg/security/probe/procfs/snapshot_bound_sockets.go
+++ b/pkg/security/probe/procfs/snapshot_bound_sockets.go
@@ -9,7 +9,13 @@
 package procfs
 
 import (
+	"bufio"
+	"encoding/hex"
 	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -51,12 +57,13 @@ func GetBoundSockets(p *process.Process) ([]model.SnapshottedBoundSocket, error)
 	}
 
 	// use /proc/[pid]/net/tcp,tcp6,udp,udp6 to extract the ports opened by the current process
-	proc, _ := procfs.NewFS(kernel.HostProc(fmt.Sprintf("%d", p.Pid)))
+	procPath := kernel.HostProc(fmt.Sprintf("%d", p.Pid))
+	proc, _ := procfs.NewFS(procPath)
 	if err != nil {
 		seclog.Warnf("error while opening procfs (pid: %v): %s", p.Pid, err)
 	}
 	// looking for AF_INET sockets
-	TCP, err := proc.NetTCP()
+	TCP, err := parseNetTCP(procPath, false)
 	if err != nil {
 		seclog.Debugf("couldn't snapshot TCP sockets: %v", err)
 	}
@@ -65,7 +72,7 @@ func GetBoundSockets(p *process.Process) ([]model.SnapshottedBoundSocket, error)
 		seclog.Debugf("couldn't snapshot UDP sockets: %v", err)
 	}
 	// looking for AF_INET6 sockets
-	TCP6, err := proc.NetTCP6()
+	TCP6, err := parseNetTCP(procPath, true)
 	if err != nil {
 		seclog.Debugf("couldn't snapshot TCP6 sockets: %v", err)
 	}
@@ -77,8 +84,8 @@ func GetBoundSockets(p *process.Process) ([]model.SnapshottedBoundSocket, error)
 	// searching for socket inode
 	for _, s := range sockets {
 		for _, sock := range TCP {
-			if sock.Inode == s {
-				boundSockets = append(boundSockets, model.SnapshottedBoundSocket{IP: sock.LocalAddr, Port: uint16(sock.LocalPort), Family: unix.AF_INET, Protocol: unix.IPPROTO_TCP})
+			if sock.inode == s {
+				boundSockets = append(boundSockets, model.SnapshottedBoundSocket{IP: sock.ip, Port: sock.port, Family: unix.AF_INET, Protocol: unix.IPPROTO_TCP})
 				break
 			}
 		}
@@ -89,8 +96,8 @@ func GetBoundSockets(p *process.Process) ([]model.SnapshottedBoundSocket, error)
 			}
 		}
 		for _, sock := range TCP6 {
-			if sock.Inode == s {
-				boundSockets = append(boundSockets, model.SnapshottedBoundSocket{IP: sock.LocalAddr, Port: uint16(sock.LocalPort), Family: unix.AF_INET6, Protocol: unix.IPPROTO_TCP})
+			if sock.inode == s {
+				boundSockets = append(boundSockets, model.SnapshottedBoundSocket{IP: sock.ip, Port: sock.port, Family: unix.AF_INET6, Protocol: unix.IPPROTO_TCP})
 				break
 			}
 		}
@@ -104,4 +111,92 @@ func GetBoundSockets(p *process.Process) ([]model.SnapshottedBoundSocket, error)
 	}
 
 	return boundSockets, nil
+}
+
+type netIPEntry struct {
+	ip    net.IP
+	port  uint16
+	inode uint64
+}
+
+func parseNetTCP(procPath string, v6 bool) ([]netTCPEntry, error) {
+	suffix := "net/tcp"
+	if v6 {
+		suffix = "net/tcp6"
+	}
+
+	path := filepath.Join(procPath, suffix)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return parseNetTCPFromReader(f)
+}
+
+func parseNetTCPFromReader(r io.Reader) ([]netTCPEntry, error) {
+	var netTCP []netTCPEntry
+
+	const readLimit = 4294967296 // Byte -> 4 GiB
+	lr := io.LimitReader(r, readLimit)
+	s := bufio.NewScanner(lr)
+	s.Scan() // skip first line with headers
+	for s.Scan() {
+		fields := strings.Fields(s.Text())
+
+		localF := fields[1]
+		ipF, portF, found := strings.Cut(localF, ":")
+		if !found {
+			return nil, fmt.Errorf("unexpected format for local address: %s", localF)
+		}
+
+		ip, err := parseIP(ipF)
+		if err != nil {
+			return nil, err
+		}
+
+		port64, err := strconv.ParseUint(portF, 16, 16)
+		if err != nil {
+			return nil, err
+		}
+		port := uint16(port64)
+
+		inodeF := fields[9]
+		inode, err := strconv.ParseUint(inodeF, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		netTCP = append(netTCP, netIPEntry{
+			ip:    ip,
+			port:  port,
+			inode: inode,
+		})
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
+	return netTCP, nil
+}
+
+func parseIP(hexIP string) (net.IP, error) {
+	byteIP, err := hex.DecodeString(hexIP)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse socket field in %q: %w", hexIP, err)
+	}
+	switch len(byteIP) {
+	case 4:
+		return net.IPv4(byteIP[3], byteIP[2], byteIP[1], byteIP[0]), nil
+	case 16:
+		i := net.IP{
+			byteIP[3], byteIP[2], byteIP[1], byteIP[0],
+			byteIP[7], byteIP[6], byteIP[5], byteIP[4],
+			byteIP[11], byteIP[10], byteIP[9], byteIP[8],
+			byteIP[15], byteIP[14], byteIP[13], byteIP[12],
+		}
+		return i, nil
+	default:
+		return nil, fmt.Errorf("unable to parse IP %s: %v", hexIP, nil)
+	}
 }

--- a/pkg/security/probe/procfs/snapshot_bound_sockets.go
+++ b/pkg/security/probe/procfs/snapshot_bound_sockets.go
@@ -10,7 +10,6 @@ package procfs
 
 import (
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -52,7 +51,7 @@ func GetBoundSockets(p *process.Process) ([]model.SnapshottedBoundSocket, error)
 	}
 
 	// use /proc/[pid]/net/tcp,tcp6,udp,udp6 to extract the ports opened by the current process
-	proc, _ := procfs.NewFS(filepath.Join(kernel.HostProc(fmt.Sprintf("%d", p.Pid))))
+	proc, _ := procfs.NewFS(kernel.HostProc(fmt.Sprintf("%d", p.Pid)))
 	if err != nil {
 		seclog.Warnf("error while opening procfs (pid: %v): %s", p.Pid, err)
 	}

--- a/pkg/security/probe/procfs/snapshot_bound_sockets_test.go
+++ b/pkg/security/probe/procfs/snapshot_bound_sockets_test.go
@@ -1,0 +1,93 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package procfs holds procfs related files
+package procfs
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNetTCPv4(t *testing.T) {
+	content := `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 3500007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000   991        0 6155 1 0000000000000000 100 0 0 10 5
+   1: 3600007F:0035 00000000:0000 0A 00000000:00000000 00:00000000 00000000   991        0 6157 1 0000000000000000 100 0 0 10 5
+   2: 0100007F:A227 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 176859 1 0000000000000000 100 0 0 10 0
+   3: 0100007F:CD1E 0100007F:A227 01 00000000:00000000 00:00000000 00000000  1000        0 175959 1 0000000000000000 20 4 20 10 -1
+   4: 0100007F:A227 0100007F:CD1E 01 00000000:00000000 00:00000000 00000000  1000        0 176863 1 0000000000000000 20 4 30 10 -1`
+
+	res, err := parseNetIPFromReader(strings.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []netIPEntry{
+		{
+			ip:    net.ParseIP("127.0.0.53"),
+			port:  53,
+			inode: 6155,
+		},
+		{
+			ip:    net.ParseIP("127.0.0.54"),
+			port:  53,
+			inode: 6157,
+		},
+		{
+			ip:    net.ParseIP("127.0.0.1"),
+			port:  41511,
+			inode: 176859,
+		},
+		{
+			ip:    net.ParseIP("127.0.0.1"),
+			port:  52510,
+			inode: 175959,
+		},
+		{
+			ip:    net.ParseIP("127.0.0.1"),
+			port:  41511,
+			inode: 176863,
+		},
+	}
+
+	assert.Equal(t, expected, res)
+}
+
+func TestParseNetTCPv6(t *testing.T) {
+	content := `  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 00000000000000000000000000000000:0016 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 7254 1 0000000000000000 100 0 0 10 0
+   1: 00000000000000000000000000000000:3241 00000000000000000000000000000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 8529 1 0000000000000000 100 0 0 10 0
+   2: 0000000000000000FFFF00000246A8C0:0016 0000000000000000FFFF00000146A8C0:D6DB 01 00000000:00000000 02:000047EC 00000000     0        0 9193 4 0000000000000000 20 4 1 10 79`
+
+	res, err := parseNetIPFromReader(strings.NewReader(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []netIPEntry{
+		{
+			ip:    net.ParseIP("::"),
+			port:  22,
+			inode: 7254,
+		},
+		{
+			ip:    net.ParseIP("::"),
+			port:  12865,
+			inode: 8529,
+		},
+		{
+			ip:    net.ParseIP("0000:0000:0000:0000:0000:ffff:c0a8:4602"),
+			port:  22,
+			inode: 9193,
+		},
+	}
+
+	assert.Equal(t, expected, res)
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

[pprof](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astripe&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZT5WEoPg42pgAAAABhBWlQ1V0V6aEFBQnBsdW5ZU0cxRmx3QUEAAAAkMDE5NGY5NjItOGQ2NC00ODgxLWFmNzgtYTdkNjUyNWE5ZTg0AAh2Dw&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&my_code=disabled&profile_type=alloc-size&profileId=AZT5WEzhAABplunYSG1FlwAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1739349661705&to_ts=1739353261705&live=false)

This PR optimizes the way we collect bound sockets, reducing the amount of allocation related to parsing /proc. Some profiles showed that this code path could allocate a lot more than expected [pprof](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astripe&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZT5WEoPg42pgAAAABhBWlQ1V0V6aEFBQnBsdW5ZU0cxRmx3QUEAAAAkMDE5NGY5NjItOGQ2NC00ODgxLWFmNzgtYTdkNjUyNWE5ZTg0AAh2Dw&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&my_code=disabled&profile_type=alloc-size&profileId=AZT5WEzhAABplunYSG1FlwAA&refresh_mode=paused&stream_sort=%40metrics.core_alloc_bytes_per_sec%2Cdesc&viz=stream&from_ts=1739349661705&to_ts=1739353261705&live=false).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->