### PR TITLE
Fix flaky test.

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -1972,5 +1972,5 @@ func TestRCConflict(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, client.subscribed)
 	_, err = config.BuildProfile("1.2.3.4.5.6")
-	require.ErrorContains(t, err, "profile \"profile2\" has the same sysObjectID (1.2.3.4.*) as \"profile1\"")
+	require.ErrorContains(t, err, "has the same sysObjectID (1.2.3.4.*)")
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a flaky test (the order in which the profiles are checked is arbitrary, so the error message is sometimes that profile2 conflicts with profile1, and sometimes that profile1 conflicts with profile2).