### PR TITLE
[OTAGENT-293] upgrade modules used by otel to Go 1.23

### DIFF
--- a/comp/api/api/def/go.mod
+++ b/comp/api/api/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/api/api/def
 
-go 1.22.0
+go 1.23.0
 
 require go.uber.org/fx v1.23.0
 

--- a/comp/core/config/go.mod
+++ b/comp/core/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/config
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.56.0-rc.3

--- a/comp/core/flare/builder/go.mod
+++ b/comp/core/flare/builder/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/flare/builder
 
-go 1.22.0
+go 1.23.0
 
 // This section was automatically added by 'invoke modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/flare/types/go.mod
+++ b/comp/core/flare/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/flare/types
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.56.0-rc.3

--- a/comp/core/hostname/hostnameinterface/go.mod
+++ b/comp/core/hostname/hostnameinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3

--- a/comp/core/log/def/go.mod
+++ b/comp/core/log/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/def
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/comp/core/log/fx/go.mod
+++ b/comp/core/log/fx/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/fx
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/impl v0.61.0

--- a/comp/core/log/impl/go.mod
+++ b/comp/core/log/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/impl
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/core/log/mock/go.mod
+++ b/comp/core/log/mock/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/log/mock
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel

--- a/comp/core/secrets/go.mod
+++ b/comp/core/secrets/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/secrets
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.56.0-rc.3

--- a/comp/core/status/go.mod
+++ b/comp/core/status/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/status
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/dustin/go-humanize v1.0.1

--- a/comp/core/tagger/def/go.mod
+++ b/comp/core/tagger/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/def
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.59.0

--- a/comp/core/tagger/fx-remote/go.mod
+++ b/comp/core/tagger/fx-remote/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/fx-remote
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.3
 

--- a/comp/core/tagger/generic_store/go.mod
+++ b/comp/core/tagger/generic_store/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/generic_store
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.59.0

--- a/comp/core/tagger/impl-remote/go.mod
+++ b/comp/core/tagger/impl-remote/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/impl-remote
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.3
 

--- a/comp/core/tagger/origindetection/go.mod
+++ b/comp/core/tagger/origindetection/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/origindetection
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/comp/core/tagger/subscriber/go.mod
+++ b/comp/core/tagger/subscriber/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/subscriber
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/telemetry v0.0.0-20250129172314-517df3f51a84

--- a/comp/core/tagger/tags/go.mod
+++ b/comp/core/tagger/tags/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/tags
 
-go 1.22.0
+go 1.23.0
 
 // This section was automatically added by 'invoke modules.add-all-replace' command, do not edit manually
 

--- a/comp/core/tagger/telemetry/go.mod
+++ b/comp/core/tagger/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/telemetry
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.59.0

--- a/comp/core/tagger/types/go.mod
+++ b/comp/core/tagger/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/types
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.59.0

--- a/comp/core/tagger/utils/go.mod
+++ b/comp/core/tagger/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/tagger/utils
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/comp/core/telemetry/go.mod
+++ b/comp/core/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/core/telemetry
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.56.0-rc.3

--- a/comp/def/go.mod
+++ b/comp/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/def
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/comp/forwarder/defaultforwarder/go.mod
+++ b/comp/forwarder/defaultforwarder/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.57.1

--- a/comp/forwarder/orchestrator/orchestratorinterface/go.mod
+++ b/comp/forwarder/orchestrator/orchestratorinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface
 
-go 1.22.0
+go 1.23.0
 
 require github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.56.0-rc.3
 

--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/logs/agent/config
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3

--- a/comp/otelcol/ddprofilingextension/def/go.mod
+++ b/comp/otelcol/ddprofilingextension/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/def
 
-go 1.22.0
+go 1.23.0
 
 require go.opentelemetry.io/collector/extension v0.119.0
 

--- a/comp/otelcol/ddprofilingextension/impl/go.mod
+++ b/comp/otelcol/ddprofilingextension/impl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/ddprofilingextension/impl
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline
 
-go 1.22.0
+go 1.23.0
 
 require github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.56.0-rc.3
 

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/datadogexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.0-rc.3

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.0-rc.3

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/metrics v0.56.0-rc.3

--- a/comp/otelcol/otlp/components/metricsclient/go.mod
+++ b/comp/otelcol/otlp/components/metricsclient/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace v0.56.0-rc.3

--- a/comp/otelcol/otlp/components/statsprocessor/go.mod
+++ b/comp/otelcol/otlp/components/statsprocessor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.0-rc.3

--- a/comp/otelcol/otlp/testutil/go.mod
+++ b/comp/otelcol/otlp/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.59.0

--- a/comp/serializer/logscompression/go.mod
+++ b/comp/serializer/logscompression/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/serializer/logscompression
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3

--- a/comp/serializer/metricscompression/go.mod
+++ b/comp/serializer/metricscompression/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/serializer/metricscompression
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/comp/trace/agent/def/go.mod
+++ b/comp/trace/agent/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/agent/def
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/proto v0.64.0-devel

--- a/comp/trace/compression/def/go.mod
+++ b/comp/trace/compression/def/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/def
 
-go 1.22.0
+go 1.23.0
 
 // This section was automatically added by 'invoke modules.add-all-replace' command, do not edit manually
 

--- a/comp/trace/compression/impl-gzip/go.mod
+++ b/comp/trace/compression/impl-gzip/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip
 
-go 1.22.0
+go 1.23.0
 
 require github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3
 

--- a/comp/trace/compression/impl-zstd/go.mod
+++ b/comp/trace/compression/impl-zstd/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/comp/trace/compression/impl-zstd
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.0-rc.3

--- a/pkg/aggregator/ckey/go.mod
+++ b/pkg/aggregator/ckey/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/aggregator/ckey
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/tagset v0.56.0-rc.3

--- a/pkg/api/go.mod
+++ b/pkg/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/api
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.56.0-rc.3

--- a/pkg/collector/check/defaults/go.mod
+++ b/pkg/collector/check/defaults/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/collector/check/defaults
 
-go 1.22.0
+go 1.23.0
 
 // This section was automatically added by 'invoke modules.add-all-replace' command, do not edit manually
 

--- a/pkg/config/env/go.mod
+++ b/pkg/config/env/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/env
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.56.0-rc.3

--- a/pkg/config/mock/go.mod
+++ b/pkg/config/mock/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/mock
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel

--- a/pkg/config/model/go.mod
+++ b/pkg/config/model/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/model
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3

--- a/pkg/config/nodetreemodel/go.mod
+++ b/pkg/config/nodetreemodel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/nodetreemodel
 
-go 1.22.0
+go 1.23.0
 
 // Internal deps fix version
 replace github.com/spf13/cast => github.com/DataDog/cast v1.8.0

--- a/pkg/config/setup/go.mod
+++ b/pkg/config/setup/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/setup
 
-go 1.22.0
+go 1.23.0
 
 // Internal deps fix version
 replace github.com/spf13/cast => github.com/DataDog/cast v1.8.0

--- a/pkg/config/structure/go.mod
+++ b/pkg/config/structure/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/structure
 
-go 1.22.0
+go 1.23.0
 
 // Internal deps fix version
 replace github.com/spf13/cast => github.com/DataDog/cast v1.8.0

--- a/pkg/config/teeconfig/go.mod
+++ b/pkg/config/teeconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/teeconfig
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel

--- a/pkg/config/utils/go.mod
+++ b/pkg/config/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/config/utils
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.59.0

--- a/pkg/logs/auditor/go.mod
+++ b/pkg/logs/auditor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/auditor
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.0-rc.3

--- a/pkg/logs/client/go.mod
+++ b/pkg/logs/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/client
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.0-rc.3

--- a/pkg/logs/diagnostic/go.mod
+++ b/pkg/logs/diagnostic/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/diagnostic
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.56.0-rc.3

--- a/pkg/logs/message/go.mod
+++ b/pkg/logs/message/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/message
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.0-rc.3

--- a/pkg/logs/metrics/go.mod
+++ b/pkg/logs/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/metrics
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.56.0-rc.3

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/pipeline
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.56.0-rc.3

--- a/pkg/logs/processor/go.mod
+++ b/pkg/logs/processor/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/processor
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.143

--- a/pkg/logs/sds/go.mod
+++ b/pkg/logs/sds/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/sds
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel

--- a/pkg/logs/sender/go.mod
+++ b/pkg/logs/sender/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/sender
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.0-rc.3

--- a/pkg/logs/sources/go.mod
+++ b/pkg/logs/sources/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/sources
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.0-rc.3

--- a/pkg/logs/status/statusinterface/go.mod
+++ b/pkg/logs/status/statusinterface/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface
 
-go 1.22.0
+go 1.23.0
 
 // This section was automatically added by 'invoke modules.add-all-replace' command, do not edit manually
 

--- a/pkg/logs/status/utils/go.mod
+++ b/pkg/logs/status/utils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/status/utils
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/logs/util/testutils/go.mod
+++ b/pkg/logs/util/testutils/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/logs/util/testutils
 
-go 1.22.0
+go 1.23.0
 
 require github.com/DataDog/datadog-agent/pkg/logs/sources v0.56.0-rc.3
 

--- a/pkg/metrics/go.mod
+++ b/pkg/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/metrics
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.56.0-rc.3

--- a/pkg/obfuscate/go.mod
+++ b/pkg/obfuscate/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/obfuscate
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-go/v5 v5.6.0

--- a/pkg/orchestrator/model/go.mod
+++ b/pkg/orchestrator/model/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/orchestrator/model
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3

--- a/pkg/process/util/api/go.mod
+++ b/pkg/process/util/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/process/util/api
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.143

--- a/pkg/proto/go.mod
+++ b/pkg/proto/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/proto
 
-go 1.22.0
+go 1.23.0
 
 retract v0.46.0-devel
 

--- a/pkg/remoteconfig/state/go.mod
+++ b/pkg/remoteconfig/state/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/remoteconfig/state
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/go-tuf v1.1.0-0.5.2

--- a/pkg/serializer/go.mod
+++ b/pkg/serializer/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/serializer
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.143

--- a/pkg/status/health/go.mod
+++ b/pkg/status/health/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/status/health
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/tagger/types/go.mod
+++ b/pkg/tagger/types/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/tagger/types
 
-go 1.22.0
+go 1.23.0
 
 require github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.1
 

--- a/pkg/tagset/go.mod
+++ b/pkg/tagset/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/tagset
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/sort v0.56.0-rc.3

--- a/pkg/telemetry/go.mod
+++ b/pkg/telemetry/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/telemetry
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.60.1

--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace
 
-go 1.22.0
+go 1.23.0
 
 // NOTE: Prefer using simple `require` directives instead of using `replace` if possible.
 // See https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md

--- a/pkg/trace/stats/oteltest/go.mod
+++ b/pkg/trace/stats/oteltest/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/trace/stats/oteltest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.0-rc.3

--- a/pkg/util/backoff/go.mod
+++ b/pkg/util/backoff/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/backoff
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/buf/go.mod
+++ b/pkg/util/buf/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/buf
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/cache/go.mod
+++ b/pkg/util/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/cache
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/cgroups
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3

--- a/pkg/util/common/go.mod
+++ b/pkg/util/common/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/common
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/compression/go.mod
+++ b/pkg/util/compression/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/compression
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel

--- a/pkg/util/containers/image/go.mod
+++ b/pkg/util/containers/image/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/containers/image
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/defaultpaths/go.mod
+++ b/pkg/util/defaultpaths/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/defaultpaths
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.56.0-rc.3

--- a/pkg/util/executable/go.mod
+++ b/pkg/util/executable/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/executable
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0

--- a/pkg/util/filesystem/go.mod
+++ b/pkg/util/filesystem/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/filesystem
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.59.1

--- a/pkg/util/fxutil/go.mod
+++ b/pkg/util/fxutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/fxutil
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/def v0.56.0-rc.3

--- a/pkg/util/grpc/go.mod
+++ b/pkg/util/grpc/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/grpc
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/api v0.61.0

--- a/pkg/util/hostname/validate/go.mod
+++ b/pkg/util/hostname/validate/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/hostname/validate
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3

--- a/pkg/util/http/go.mod
+++ b/pkg/util/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/http
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.59.0

--- a/pkg/util/json/go.mod
+++ b/pkg/util/json/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/json
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/json-iterator/go v1.1.12

--- a/pkg/util/log/go.mod
+++ b/pkg/util/log/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/log
 
-go 1.22.0
+go 1.23.0
 
 replace github.com/cihub/seelog => github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf // v2.6
 

--- a/pkg/util/log/setup/go.mod
+++ b/pkg/util/log/setup/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/log/setup
 
-go 1.22.0
+go 1.23.0
 
 replace github.com/cihub/seelog => github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf // v2.6
 

--- a/pkg/util/option/go.mod
+++ b/pkg/util/option/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/option
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/pointer/go.mod
+++ b/pkg/util/pointer/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/pointer
 
-go 1.22.0
+go 1.23.0
 
 // This section was automatically added by 'invoke modules.add-all-replace' command, do not edit manually
 

--- a/pkg/util/scrubber/go.mod
+++ b/pkg/util/scrubber/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/scrubber
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/version v0.59.1

--- a/pkg/util/sort/go.mod
+++ b/pkg/util/sort/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/sort
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/startstop/go.mod
+++ b/pkg/util/startstop/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/startstop
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/statstracker/go.mod
+++ b/pkg/util/statstracker/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/statstracker
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/util/system/go.mod
+++ b/pkg/util/system/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/system
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.56.0-rc.3

--- a/pkg/util/system/socket/go.mod
+++ b/pkg/util/system/socket/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/system/socket
 
-go 1.22.0
+go 1.23.0
 
 require github.com/Microsoft/go-winio v0.6.2
 

--- a/pkg/util/testutil/go.mod
+++ b/pkg/util/testutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/testutil
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/util/utilizationtracker/go.mod
+++ b/pkg/util/utilizationtracker/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/utilizationtracker
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/benbjohnson/clock v1.3.5

--- a/pkg/util/uuid/go.mod
+++ b/pkg/util/uuid/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/uuid
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/cache v0.56.0-rc.3

--- a/pkg/util/winutil/go.mod
+++ b/pkg/util/winutil/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/util/winutil
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.56.0-rc.3

--- a/pkg/version/go.mod
+++ b/pkg/version/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/version
 
-go 1.22.0
+go 1.23.0
 
 require github.com/stretchr/testify v1.10.0
 

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -889,7 +889,8 @@ def check_otel_build(ctx):
 @task
 def check_otel_module_versions(ctx):
     pattern = f"^go {PATTERN_MAJOR_MINOR_BUGFIX}\r?$"
-    r = requests.get(OTEL_UPSTREAM_GO_MOD_PATH)
+    # TODO(songy23): restore to OTEL_UPSTREAM_GO_MOD_PATH once otel v0.120.0 is brought to Agent.
+    r = requests.get("https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/main/go.mod")
     matches = re.findall(pattern, r.text, flags=re.MULTILINE)
     if len(matches) != 1:
         raise Exit(f"Error parsing upstream go.mod version: {OTEL_UPSTREAM_GO_MOD_PATH}")

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/test/otel
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel


### PR DESCRIPTION
### What does this PR do?
upgrade modules used by otel to Go 1.23

### Motivation
OTel collector has dropped support for Go 1.22 and migrated to Go 1.23 https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37875 . Agent modules that OTel depends on are no longer blocked to use Go 1.23.