### PR TITLE
Fix nil and empty slices in Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -282,7 +282,7 @@ func generateLocationVisitsMap(parameter *ditypes.Parameter) (trieKeys, needsExp
 
 	var visit func(param *ditypes.Parameter, path string)
 	visit = func(param *ditypes.Parameter, path string) {
-		if param == nil {
+		if param == nil || param.DoNotCapture {
 			return
 		}
 		trieKeys = append(trieKeys, expressionParamTuple{path + param.Type, param})

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -178,6 +178,8 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					// element of this slice
 					sliceElementType := slicePointer.ParameterPieces[0]
 
+					labelName := randomLabel()
+
 					if slicePointer.Location != nil && sliceLength.Location != nil {
 						// Fields of the slice are directly assigned
 						targetExpressions = append(targetExpressions,
@@ -188,7 +190,6 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 						for i := 0; i < ditypes.SliceMaxLength; i++ {
 							GenerateLocationExpression(limitsInfo, sliceElementType)
 							expressionsToUseForEachSliceElement := collectAllLocationExpressions(sliceElementType, true)
-							labelName := randomLabel()
 							targetExpressions = append(targetExpressions,
 								ditypes.PrintStatement("%s", "Reading slice element "+fmt.Sprintf("%d", i)),
 								ditypes.JumpToLabelIfEqualToLimit(uint(i), sliceIdentifier, labelName),
@@ -196,7 +197,6 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 								ditypes.ApplyOffsetLocationExpression(uint(sliceElementType.TotalSize)*uint(i)),
 							)
 							targetExpressions = append(targetExpressions, expressionsToUseForEachSliceElement...)
-							targetExpressions = append(targetExpressions, ditypes.InsertLabel(labelName))
 						}
 					} else {
 						// Expect address of the slice struct on stack, use offsets accordingly
@@ -220,9 +220,9 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 								ditypes.ApplyOffsetLocationExpression(uint(i*(int(sliceElementType.TotalSize)))),
 							)
 							targetExpressions = append(targetExpressions, expressionsToUseForEachSliceElement...)
-							targetExpressions = append(targetExpressions, ditypes.InsertLabel(labelName))
 						}
 					}
+					targetExpressions = append(targetExpressions, ditypes.InsertLabel(labelName))
 					continue
 					/* end parsing slices */
 				} else if elementParam.Kind == uint(reflect.Array) {
@@ -266,20 +266,6 @@ func collectAllLocationExpressions(parameter *ditypes.Parameter, remove bool) []
 		parameter.LocationExpressions = []ditypes.LocationExpression{}
 	}
 	return expressions
-}
-
-//nolint:all
-func printLocationExpressions(expressions []ditypes.LocationExpression) {
-	for i := range expressions {
-		fmt.Printf("%s %d %d %d %s %s\n",
-			expressions[i].Opcode.String(),
-			expressions[i].Arg1,
-			expressions[i].Arg2,
-			expressions[i].Arg3,
-			expressions[i].Label,
-			expressions[i].CollectionIdentifier,
-		)
-	}
 }
 
 type expressionParamTuple struct {

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -395,3 +395,17 @@ type BPFProgram struct {
 	// Used for bpf code generation
 	Probe *Probe
 }
+
+//nolint:all
+func PrintLocationExpressions(expressions []LocationExpression) {
+	for i := range expressions {
+		fmt.Printf("%s %d %d %d %s %s\n",
+			expressions[i].Opcode.String(),
+			expressions[i].Arg1,
+			expressions[i].Arg2,
+			expressions[i].Arg3,
+			expressions[i].Label,
+			expressions[i].CollectionIdentifier,
+		)
+	}
+}

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -37,6 +37,7 @@ type Parameter struct {
 	Location            *Location            // Location represents where the parameter will be in memory when passed to the target function
 	LocationExpressions []LocationExpression // LocationExpressions are the needed instructions for extracting the parameter value from memory
 	FieldOffset         uint64               // FieldOffset is the offset of Parameter field within a struct, if it is a struct field
+	DoNotCapture        bool                 // DoNotCapture signals to code generation that this parameter or field shouldn't have it's value captured
 	NotCaptureReason    NotCaptureReason     // NotCaptureReason conveys to the user why the parameter was not captured
 	ParameterPieces     []*Parameter         // ParameterPieces are the sub-fields, such as struct fields or array elements
 }

--- a/pkg/dynamicinstrumentation/eventparser/event_parser.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser.go
@@ -188,7 +188,8 @@ func parseTypeDefinition(b []byte) *ditypes.Param {
 		}
 		i += 3
 		if newParam.Size == 0 {
-			if reflect.Kind(newParam.Kind) == reflect.Struct {
+			if reflect.Kind(newParam.Kind) == reflect.Struct ||
+				reflect.Kind(newParam.Kind) == reflect.Slice {
 				goto stackCheck
 			}
 			break

--- a/pkg/dynamicinstrumentation/eventparser/event_parser.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser.go
@@ -79,6 +79,7 @@ func parseParamValue(definition *ditypes.Param, buffer []byte) (*ditypes.Param, 
 		return nil, 0
 	}
 	if definition.Size == 0 {
+		definition.Fields = nil
 		return definition, 0
 	}
 	var bufferIndex int
@@ -181,7 +182,7 @@ func parseTypeDefinition(b []byte) *ditypes.Param {
 	stack := newParamStack()
 	i := 0
 	for {
-		if len(b) < i+3 {
+		if len(b) < i+sizeOfKindAndSize {
 			log.Tracef("could not parse type definition, ran out of buffer while parsing")
 			return nil
 		}
@@ -189,7 +190,7 @@ func parseTypeDefinition(b []byte) *ditypes.Param {
 		kind := b[i]
 		newParam := &ditypes.Param{
 			Kind: kind,
-			Size: byteOrder.Uint16(b[i+1 : i+3]),
+			Size: byteOrder.Uint16(b[i+1 : i+sizeOfKindAndSize]),
 			Type: parseKindToString(kind),
 		}
 		if newParam.Kind == 0 {
@@ -221,7 +222,6 @@ func parseTypeDefinition(b []byte) *ditypes.Param {
 			// case we want the field for the underlying type just for
 			// displaying context to user, but we're not expecting to
 			// populate it with parsed values.
-
 			if len(top.Fields) > 0 {
 				top.Type = fmt.Sprintf("[]%s", top.Fields[0].Type)
 			}

--- a/pkg/dynamicinstrumentation/eventparser/event_parser.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser.go
@@ -53,7 +53,7 @@ func readParams(values []byte) []*ditypes.Param {
 		log.Tracef("DI event bytes (0:100): %v", values[0:100])
 	}
 	outputParams := []*ditypes.Param{}
-	for i := 0; i+3 < len(values); {
+	for i := 0; i+sizeOfKindAndSize < len(values); {
 		paramTypeDefinition := parseTypeDefinition(values[i:])
 		if paramTypeDefinition == nil {
 			break
@@ -195,7 +195,7 @@ func parseTypeDefinition(b []byte) *ditypes.Param {
 		if newParam.Kind == 0 {
 			break
 		}
-		i += 3
+		i += sizeOfKindAndSize
 		if newParam.Size == 0 {
 			if reflect.Kind(newParam.Kind) == reflect.Struct {
 				goto stackCheck
@@ -257,7 +257,7 @@ func countBufferUsedByTypeDefinition(root *ditypes.Param) int {
 	for len(queue) != 0 {
 		front := queue[0]
 		queue = queue[1:]
-		counter += 3
+		counter += sizeOfKindAndSize
 
 		if reflect.Kind(front.Kind) == reflect.Slice && len(front.Fields) > 0 {
 			// The fields of slice elements are amended after the fact to account
@@ -316,3 +316,5 @@ func parseIndividualValue(paramType byte, paramValueBytes []byte) string {
 		return ""
 	}
 }
+
+const sizeOfKindAndSize = 3

--- a/pkg/dynamicinstrumentation/eventparser/event_parser_test.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser_test.go
@@ -166,7 +166,7 @@ func TestReadParams(t *testing.T) {
 				0, 0, 0, 0,
 			},
 			expectedResult: []*ditypes.Param{{
-				Type: "slice", Size: 0x2, Kind: 0x17,
+				Type: "[]struct", Size: 0x2, Kind: 0x17,
 				Fields: []*ditypes.Param{
 					{Type: "struct", Size: 0x3, Kind: 0x19, Fields: []*ditypes.Param{
 						{ValueStr: "1", Type: "uint8", Size: 0x1, Kind: 0x8},
@@ -217,7 +217,7 @@ func TestParseTypeDefinition(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			},
 			expectedResult: &ditypes.Param{
-				Type: "slice", Size: 0x2, Kind: 0x17,
+				Type: "[]struct", Size: 0x2, Kind: 0x17,
 				Fields: []*ditypes.Param{
 					{
 						Type: "struct", Size: 0x3, Kind: 0x19,
@@ -256,7 +256,7 @@ func TestParseTypeDefinition(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			},
 			expectedResult: &ditypes.Param{
-				Type: "slice", Size: 0x2, Kind: 0x17,
+				Type: "[]struct", Size: 0x2, Kind: 0x17,
 				Fields: []*ditypes.Param{
 					{
 						Type: "struct", Size: 0x4, Kind: 0x19,
@@ -337,7 +337,7 @@ func TestParseParams(t *testing.T) {
 			Buffer: []byte{23, 3, 0, 7, 8, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ExpectedOutput: []*ditypes.Param{
 				{
-					Type: "slice",
+					Type: "[]uint",
 					Size: 3,
 					Kind: byte(reflect.Slice),
 					Fields: []*ditypes.Param{
@@ -368,7 +368,7 @@ func TestParseParams(t *testing.T) {
 			Buffer: []byte{22, 8, 0, 7, 8, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ExpectedOutput: []*ditypes.Param{
 				{
-					Type: "ptr",
+					Type: "*uint",
 					Size: 8,
 					Kind: byte(reflect.Pointer),
 					Fields: []*ditypes.Param{
@@ -387,7 +387,7 @@ func TestParseParams(t *testing.T) {
 			Buffer: []byte{22, 8, 0, 25, 3, 0, 1, 1, 0, 2, 8, 0, 4, 2, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ExpectedOutput: []*ditypes.Param{
 				{
-					Type: "ptr",
+					Type: "*struct",
 					Size: 8,
 					Kind: byte(reflect.Pointer),
 					Fields: []*ditypes.Param{
@@ -425,7 +425,7 @@ func TestParseParams(t *testing.T) {
 			Buffer: []byte{22, 8, 0, 25, 3, 0, 1, 1, 0, 2, 8, 0, 4, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ExpectedOutput: []*ditypes.Param{
 				{
-					Type: "ptr",
+					Type: "*struct",
 					Size: 8,
 					Kind: byte(reflect.Pointer),
 					Fields: []*ditypes.Param{

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -113,6 +113,66 @@ var arrayCaptures = fixtures{
 	}}},
 }
 
+var sliceCaptures = fixtures{
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_uint_slice": {"u": {Type: "[]uint", Fields: fieldMap{
+		"[0]uint": capturedValue("uint", "1"),
+		"[1]uint": capturedValue("uint", "2"),
+		"[2]uint": capturedValue("uint", "3"),
+	}}},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_slice": {
+		"a": capturedValue("int", "3"),
+		"xs": {
+			Type: "[]struct",
+			Fields: fieldMap{
+				"[0]struct": &ditypes.CapturedValue{
+					Type: "struct",
+					Fields: fieldMap{
+						"arg_0": capturedValue("uint8", "42"),
+						"arg_1": capturedValue("bool", "true"),
+					},
+				},
+				"[1]struct": &ditypes.CapturedValue{
+					Type: "struct",
+					Fields: fieldMap{
+						"arg_0": capturedValue("uint8", "24"),
+						"arg_1": capturedValue("bool", "true"),
+					},
+				},
+			},
+		},
+	},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_empty_slice_of_structs": {
+		"a": capturedValue("int", "2"),
+		"xs": {
+			Type: "[]struct",
+			Fields: fieldMap{
+				"[0]struct": &ditypes.CapturedValue{
+					Type: "struct",
+					Fields: fieldMap{
+						"arg_0": &ditypes.CapturedValue{Type: "uint8"},
+						"arg_1": &ditypes.CapturedValue{Type: "bool"},
+					},
+				},
+			},
+		},
+	},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_slice_of_structs": {
+		"a": capturedValue("int", "5"),
+		"xs": {
+			Type: "[]struct",
+			Fields: fieldMap{
+				"[0]struct": &ditypes.CapturedValue{
+					Type: "struct",
+					Fields: fieldMap{
+						"arg_0": &ditypes.CapturedValue{Type: "uint8"},
+						"arg_1": &ditypes.CapturedValue{Type: "bool"},
+					},
+				},
+			},
+		},
+	},
+}
+
 var structCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_struct": {"t": {Type: "struct", Fields: fieldMap{
 		"arg_0": capturedValue("string", "a"),
@@ -207,6 +267,7 @@ var expectedCaptures = mergeMaps(
 	stringCaptures,
 	arrayCaptures,
 	structCaptures,
+	sliceCaptures,
 	// mapCaptures,
 	// genericCaptures,
 	// multiParamCaptures,

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -145,15 +145,23 @@ var sliceCaptures = fixtures{
 		"a": capturedValue("int", "2"),
 		"xs": {
 			Type:   "[]struct",
-			Fields: fieldMap{},
+			Fields: nil,
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_slice_of_structs": {
 		"a": capturedValue("int", "5"),
 		"xs": {
 			Type:   "[]struct",
-			Fields: fieldMap{},
+			Fields: nil,
 		},
+	},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_slice_with_other_params": {
+		"a": capturedValue("int8", "1"),
+		"s": {
+			Type:   "[]bool",
+			Fields: nil,
+		},
+		"x": capturedValue("uint", "5"),
 	},
 }
 

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -144,31 +144,15 @@ var sliceCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_empty_slice_of_structs": {
 		"a": capturedValue("int", "2"),
 		"xs": {
-			Type: "[]struct",
-			Fields: fieldMap{
-				"[0]struct": &ditypes.CapturedValue{
-					Type: "struct",
-					Fields: fieldMap{
-						"arg_0": &ditypes.CapturedValue{Type: "uint8"},
-						"arg_1": &ditypes.CapturedValue{Type: "bool"},
-					},
-				},
-			},
+			Type:   "[]struct",
+			Fields: fieldMap{},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_slice_of_structs": {
 		"a": capturedValue("int", "5"),
 		"xs": {
-			Type: "[]struct",
-			Fields: fieldMap{
-				"[0]struct": &ditypes.CapturedValue{
-					Type: "struct",
-					Fields: fieldMap{
-						"arg_0": &ditypes.CapturedValue{Type: "uint8"},
-						"arg_1": &ditypes.CapturedValue{Type: "bool"},
-					},
-				},
-			},
+			Type:   "[]struct",
+			Fields: fieldMap{},
 		},
 	},
 }

--- a/pkg/dynamicinstrumentation/testutil/sample/pointers.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/pointers.go
@@ -87,6 +87,10 @@ func test_string_pointer(z *string) {}
 func test_string_slice_pointer(a *[]string) {}
 
 //nolint:all
+//go:noinline
+func test_nil_pointer(z *bool) {}
+
+//nolint:all
 func ExecutePointerFuncs() {
 	var u64F uint64 = 5
 	swp := structWithPointer{a: &u64F}
@@ -139,4 +143,6 @@ func ExecutePointerFuncs() {
 
 	stringSlice := []string{"aaa", "bbb", "ccc", "ddd"}
 	test_string_slice_pointer(&stringSlice)
+
+	test_nil_pointer(nil)
 }

--- a/pkg/dynamicinstrumentation/testutil/sample/pointers.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/pointers.go
@@ -64,6 +64,10 @@ func test_struct_pointer(x *nStruct) {}
 
 //nolint:all
 //go:noinline
+func test_nil_struct_pointer(x *nStruct) {}
+
+//nolint:all
+//go:noinline
 func test_complex_type(z *reallyComplexType) {}
 
 //nolint:all
@@ -104,7 +108,7 @@ func ExecutePointerFuncs() {
 
 	n := nStruct{true, 1, 2}
 	test_struct_pointer(&n)
-
+	test_nil_struct_pointer(nil)
 	ssaw := swsp{
 		a: 1,
 		b: &n,

--- a/pkg/dynamicinstrumentation/testutil/sample/slices.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/slices.go
@@ -38,7 +38,11 @@ func test_slice_of_slices(u [][]uint) {}
 
 //nolint:all
 //go:noinline
-func test_struct_slice(xs []structWithNoStrings) {}
+func test_struct_slice(xs []structWithNoStrings, a int) {}
+
+//nolint:all
+//go:noinline
+func test_empty_slice_of_structs(xs []structWithNoStrings, a int) {}
 
 //nolint:all
 //go:noinline
@@ -56,7 +60,9 @@ func ExecuteSliceFuncs() {
 
 	test_string_slice([]string{"abc", "xyz", "123"})
 	test_uint_slice([]uint{1, 2, 3})
-	test_struct_slice([]structWithNoStrings{{42, true}, {24, true}})
+	test_struct_slice([]structWithNoStrings{{42, true}, {24, true}}, 3)
+	test_empty_slice_of_structs([]structWithNoStrings{}, 1)
+	test_empty_slice_of_structs(nil, 2)
 
 	test_slice_of_slices([][]uint{
 		{4},

--- a/pkg/dynamicinstrumentation/testutil/sample/slices.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/slices.go
@@ -46,6 +46,10 @@ func test_empty_slice_of_structs(xs []structWithNoStrings, a int) {}
 
 //nolint:all
 //go:noinline
+func test_nil_slice_of_structs(xs []structWithNoStrings, a int) {}
+
+//nolint:all
+//go:noinline
 func test_string_slice(s []string) {}
 
 //nolint:all
@@ -61,8 +65,8 @@ func ExecuteSliceFuncs() {
 	test_string_slice([]string{"abc", "xyz", "123"})
 	test_uint_slice([]uint{1, 2, 3})
 	test_struct_slice([]structWithNoStrings{{42, true}, {24, true}}, 3)
-	test_empty_slice_of_structs([]structWithNoStrings{}, 1)
-	test_empty_slice_of_structs(nil, 2)
+	test_empty_slice_of_structs([]structWithNoStrings{}, 2)
+	test_nil_slice_of_structs([]structWithNoStrings{}, 5)
 
 	test_slice_of_slices([][]uint{
 		{4},

--- a/pkg/dynamicinstrumentation/testutil/sample/slices.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/slices.go
@@ -45,6 +45,10 @@ func test_struct_slice(xs []structWithNoStrings) {}
 func test_string_slice(s []string) {}
 
 //nolint:all
+//go:noinline
+func test_nil_slice(s []bool) {}
+
+//nolint:all
 func ExecuteSliceFuncs() {
 	originalSlice := []int{1, 2, 3}
 	expandSlice(originalSlice)
@@ -60,4 +64,6 @@ func ExecuteSliceFuncs() {
 		{7, 8, 9},
 	})
 	test_empty_slice([]uint{})
+
+	test_nil_slice(nil)
 }

--- a/pkg/dynamicinstrumentation/testutil/sample/slices.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/slices.go
@@ -54,7 +54,7 @@ func test_string_slice(s []string) {}
 
 //nolint:all
 //go:noinline
-func test_nil_slice(s []bool) {}
+func test_nil_slice(a int8, s []bool, x uint) {}
 
 //nolint:all
 func ExecuteSliceFuncs() {
@@ -75,5 +75,5 @@ func ExecuteSliceFuncs() {
 	})
 	test_empty_slice([]uint{})
 
-	test_nil_slice(nil)
+	test_nil_slice(1, nil, 5)
 }

--- a/pkg/dynamicinstrumentation/testutil/sample/slices.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/slices.go
@@ -54,7 +54,11 @@ func test_string_slice(s []string) {}
 
 //nolint:all
 //go:noinline
-func test_nil_slice(a int8, s []bool, x uint) {}
+func test_nil_slice_with_other_params(a int8, s []bool, x uint) {}
+
+//nolint:all
+//go:noinline
+func test_nil_slice(xs []uint16) {}
 
 //nolint:all
 func ExecuteSliceFuncs() {
@@ -75,5 +79,6 @@ func ExecuteSliceFuncs() {
 	})
 	test_empty_slice([]uint{})
 
-	test_nil_slice(1, nil, 5)
+	test_nil_slice_with_other_params(1, nil, 5)
+	test_nil_slice(nil)
 }

--- a/pkg/dynamicinstrumentation/testutil/sample/structs.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/structs.go
@@ -107,11 +107,11 @@ func ExecuteStructFuncs() {
 	test_ten_strings(tenStrings{})
 	test_struct_and_byte('a', s)
 	test_struct_with_array(structWithAnArray{[5]uint8{1, 2, 3, 4, 5}})
-	test_struct_with_a_slice(structWithASlice{1, []uint8{2, 3, 4}})
-	test_struct_with_an_empty_slice(structWithASlice{9, []uint8{}})
-	test_struct_with_a_nil_slice(structWithASlice{9, nil})
+	test_struct_with_a_slice(structWithASlice{1, []uint8{2, 3, 4}, 5})
+	test_struct_with_an_empty_slice(structWithASlice{9, []uint8{}, 5})
+	test_struct_with_a_nil_slice(structWithASlice{9, nil, 5})
 
-	test_pointer_to_struct_with_a_slice(&structWithASlice{5, []uint8{2, 3, 4}})
+	test_pointer_to_struct_with_a_slice(&structWithASlice{5, []uint8{2, 3, 4}, 5})
 	test_pointer_to_struct_with_a_string(&structWithAString{5, "abcdef"})
 
 	tenStr := tenStrings{
@@ -225,6 +225,7 @@ type structWithAnArray struct {
 type structWithASlice struct {
 	x     int
 	slice []uint8
+	z     uint64
 }
 
 type structWithAString struct {

--- a/pkg/dynamicinstrumentation/testutil/sample/structs.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/structs.go
@@ -27,6 +27,14 @@ func test_struct_with_a_slice(s structWithASlice) {}
 
 //nolint:all
 //go:noinline
+func test_struct_with_an_empty_slice(s structWithASlice) {}
+
+//nolint:all
+//go:noinline
+func test_struct_with_a_nil_slice(s structWithASlice) {}
+
+//nolint:all
+//go:noinline
 func test_pointer_to_struct_with_a_slice(s *structWithASlice) {}
 
 //nolint:all
@@ -100,6 +108,9 @@ func ExecuteStructFuncs() {
 	test_struct_and_byte('a', s)
 	test_struct_with_array(structWithAnArray{[5]uint8{1, 2, 3, 4, 5}})
 	test_struct_with_a_slice(structWithASlice{1, []uint8{2, 3, 4}})
+	test_struct_with_an_empty_slice(structWithASlice{9, []uint8{}})
+	test_struct_with_a_nil_slice(structWithASlice{9, nil})
+
 	test_pointer_to_struct_with_a_slice(&structWithASlice{5, []uint8{2, 3, 4}})
 	test_pointer_to_struct_with_a_string(&structWithAString{5, "abcdef"})
 

--- a/pkg/dynamicinstrumentation/testutil/sample/structs.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/structs.go
@@ -110,7 +110,6 @@ func ExecuteStructFuncs() {
 	test_struct_with_a_slice(structWithASlice{1, []uint8{2, 3, 4}, 5})
 	test_struct_with_an_empty_slice(structWithASlice{9, []uint8{}, 5})
 	test_struct_with_a_nil_slice(structWithASlice{9, nil, 5})
-
 	test_pointer_to_struct_with_a_slice(&structWithASlice{5, []uint8{2, 3, 4}, 5})
 	test_pointer_to_struct_with_a_string(&structWithAString{5, "abcdef"})
 

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -162,6 +162,7 @@ func convertSlice(capture *ditypes.Param) *ditypes.CapturedValue {
 		})
 	}
 	sliceValue := &ditypes.CapturedValue{
+		Type:   capture.Type,
 		Fields: convertArgs(defs, capture.Fields),
 	}
 	return sliceValue


### PR DESCRIPTION
### What does this PR do?

This sets up (_or fixes_) support for empty + nil slices so that in the case of empty slices the resulting snapshot displays the empty slice and it doesn't affect the capture of other fields and/or parameters.

It also:
- Adds a bunch more sample functions to the test program.
- Fixes slice program generation to have checks for length

### Motivation

This is a precursor change to set up for support of partial snapshots.

### Describe how you validated your changes

e2e testing.

### Possible Drawbacks / Trade-offs

### Additional Notes
