### PR TITLE
fix(ssi): extraneous or incorrect fields should error

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -171,7 +171,7 @@ type InstrumentationConfig struct {
 // configuration is invalid.
 func NewInstrumentationConfig(datadogConfig config.Component) (*InstrumentationConfig, error) {
 	cfg := &InstrumentationConfig{}
-	err := structure.UnmarshalKey(datadogConfig, "apm_config.instrumentation", cfg)
+	err := structure.UnmarshalKey(datadogConfig, "apm_config.instrumentation", cfg, structure.ErrorUnused)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse apm_config.instrumentation: %w", err)
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -39,6 +39,12 @@ func TestNewInstrumentationConfig(t *testing.T) {
 			},
 		},
 		{
+			name:       "config with extra fields errors",
+			configPath: "testdata/extra_fields.yaml",
+			shouldErr:  true,
+			expected:   nil,
+		},
+		{
 			name:       "valid config disabled namespaces",
 			configPath: "testdata/disabled_namespaces.yaml",
 			shouldErr:  false,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/extra_fields.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/extra_fields.yaml
@@ -1,0 +1,12 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "Python Apps"
+        podSelector:
+          matchLabels:
+            language: "python"
+        fooBar: "baz"
+        ddTraceVersions:
+          python: "v2"

--- a/pkg/config/structure/go.mod
+++ b/pkg/config/structure/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.0-devel
 	github.com/DataDog/viper v1.14.0
+	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
 )
@@ -22,7 +23,6 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
-	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -10,14 +10,17 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/DataDog/viper"
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/cast"
+
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
-	"github.com/DataDog/viper"
-	"github.com/spf13/cast"
 )
 
 // features allowed for handling edge-cases
@@ -25,6 +28,7 @@ type featureSet struct {
 	allowSquash        bool
 	convertEmptyStrNil bool
 	convertArrayToMap  bool
+	errorUnused        bool
 }
 
 // UnmarshalKeyOption is an option that affects the enabled features in UnmarshalKey
@@ -36,6 +40,11 @@ var EnableSquash UnmarshalKeyOption = func(fs *featureSet) {
 	fs.allowSquash = true
 }
 
+// ErrorUnused allows UnmarshalKey to return an error if there are unused keys in the config.
+var ErrorUnused UnmarshalKeyOption = func(fs *featureSet) {
+	fs.errorUnused = true
+}
+
 // ConvertEmptyStringToNil allows UnmarshalKey to implicitly convert empty strings into nil slices
 var ConvertEmptyStringToNil UnmarshalKeyOption = func(fs *featureSet) {
 	fs.convertEmptyStrNil = true
@@ -45,6 +54,11 @@ var ConvertEmptyStringToNil UnmarshalKeyOption = func(fs *featureSet) {
 var ImplicitlyConvertArrayToMapSet UnmarshalKeyOption = func(fs *featureSet) {
 	fs.convertArrayToMap = true
 }
+
+// errorUnused is a viper.DecoderConfigOption that enables erroring on unused keys
+var errorUnused = viper.DecoderConfigOption(func(cfg *mapstructure.DecoderConfig) {
+	cfg.ErrorUnused = true
+})
 
 // legacyConvertArrayToMap convert array to map when DD_CONF_NODETREEMODEL is disabled
 var legacyConvertArrayToMap = viper.DecodeHook(
@@ -81,10 +95,15 @@ func UnmarshalKey(cfg model.Reader, key string, target interface{}, opts ...Unma
 		o(fs)
 	}
 
+	decodeHooks := []viper.DecoderConfigOption{}
 	if fs.convertArrayToMap {
-		return cfg.UnmarshalKey(key, target, legacyConvertArrayToMap)
+		decodeHooks = append(decodeHooks, legacyConvertArrayToMap)
 	}
-	return cfg.UnmarshalKey(key, target)
+	if fs.errorUnused {
+		decodeHooks = append(decodeHooks, errorUnused)
+	}
+
+	return cfg.UnmarshalKey(key, target, decodeHooks...)
 }
 
 func unmarshalKeyReflection(cfg model.Reader, key string, target interface{}, opts ...UnmarshalKeyOption) error {
@@ -164,6 +183,7 @@ func fieldNameToKey(field reflect.StructField) (string, specifierSet) {
 
 func copyStruct(target reflect.Value, source nodetreemodel.Node, fs *featureSet) error {
 	targetType := target.Type()
+	usedFields := make(map[string]struct{})
 	for i := 0; i < targetType.NumField(); i++ {
 		f := targetType.Field(i)
 		ch, _ := utf8.DecodeRuneInString(f.Name)
@@ -179,6 +199,7 @@ func copyStruct(target reflect.Value, source nodetreemodel.Node, fs *featureSet)
 			if err != nil {
 				return err
 			}
+			usedFields[fieldKey] = struct{}{}
 			continue
 		}
 		child, err := source.GetChild(fieldKey)
@@ -191,6 +212,24 @@ func copyStruct(target reflect.Value, source nodetreemodel.Node, fs *featureSet)
 		err = copyAny(target.FieldByName(f.Name), child, fs)
 		if err != nil {
 			return err
+		}
+		usedFields[fieldKey] = struct{}{}
+	}
+
+	if fs.errorUnused {
+		inner, ok := source.(nodetreemodel.InnerNode)
+		if !ok {
+			return fmt.Errorf("source is not an inner node")
+		}
+		var unusedKeys []string
+		for _, key := range inner.ChildrenKeys() {
+			if _, used := usedFields[key]; !used {
+				unusedKeys = append(unusedKeys, key)
+			}
+		}
+		if len(unusedKeys) > 0 {
+			sort.Strings(unusedKeys)
+			return fmt.Errorf("found unused config keys: %v", unusedKeys)
 		}
 	}
 	return nil

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -12,11 +12,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
 )
 
 // Struct that is used within the config
@@ -1205,6 +1206,11 @@ type squashConfig struct {
 	Endpoint endpoint `mapstructure:",squash"`
 }
 
+type serviceConfig struct {
+	Host     string   `mapstructure:"host"`
+	Endpoint endpoint `mapstructure:"endpoint"`
+}
+
 func TestUnmarshalKeyWithSquash(t *testing.T) {
 	confYaml := `
 service:
@@ -1224,6 +1230,52 @@ service:
 		assert.Equal(t, svc.Endpoint.Name, "intake")
 		assert.Equal(t, svc.Endpoint.APIKey, "abc1")
 	})
+}
+
+func TestUnmarshalKeyWithErrorUnused(t *testing.T) {
+	testcases := []struct {
+		name    string
+		conf    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "ErrUnused flag succeeds without option",
+			conf: `
+service:
+  host: datad0g.com
+`,
+			wantErr: false,
+		},
+		{
+			name: "ErrUnused flag fails with option",
+			conf: `
+service:
+  host: datad0g.com
+  name: intake
+  apikey: abc1
+  foo: bar
+`,
+			wantErr: true,
+			errMsg:  "found unused config keys: [apikey foo name]",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConfig := newConfigFromYaml(t, tc.conf)
+			mockConfig.SetKnown("service")
+
+			svc := &serviceConfig{}
+			err := unmarshalKeyReflection(mockConfig, "service", svc, ErrorUnused)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func TestUnmarshalKeysToMapOfString(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit ensures that extraneous fields (and by extension, incorrect fields) will throw an error instead of silently being ignored.

### Motivation
In [Kubernetes SSI | Workload Selection 🎯](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing), we have a pretty complex config structure for targets. Because the first target that matches applies, having a misconfigured target will be really confusing. Additionally, almost all fields in a target are optional, so it would be very easy to typo and end up with wildly different behavior.

A simple example is one I found myself typing `selector` when the actual key is `podSelector`. A default pod selector matches all pods, so this felt like the feature was totally broken when in fact I simply had an incorrect key.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The additional unit tests.

### Possible Drawbacks / Trade-offs
Another solution is that we can use the `viper.UnmarshallKey` in the short term so that we can enable `ErrorUnused` and add a TODO. This would allow us to make the agent release without needing to modify the `structure` package.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I did not add a release note because this is fixing a bug in an unreleased feature. We have a release note for the feature as a whole.