### PR TITLE
remove rebuild step from create rc pr workflow

### DIFF
--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -113,6 +113,9 @@ jobs:
               run: |
                 is_qualification=$(inv -e release.is-qualification -r 6.53.x --output)
                 echo "IS_QUALIFICATION=$is_qualification" >> $GITHUB_ENV
+                if [[ "$is_qualification" == "true" && "${{ steps.check_for_changes.outputs.CHANGES }}" == "false" ]]; then
+                  inv -e release.alert-ci-on-call -r 6.53.x --slack-webhook=${{ secrets.SLACK_DATADOG_AGENT_CI_WEBHOOK }}
+                fi
 
             - name: Create RC PR
               if: ${{ steps.check_for_changes.outputs.CHANGES == 'true' || ( env.IS_AGENT6_RELEASE == 'true' && env.IS_QUALIFICATION == 'false') }}
@@ -124,8 +127,3 @@ jobs:
                 else
                   inv -e release.create-rc -r "$MATRIX" --slack-webhook=${{ secrets.AGENT_RELEASE_SYNC_SLACK_WEBHOOK }}
                 fi
-
-            - name: Rebuild agent 6 RC pipeline if no changes and in qualification phase
-              if: ${{ env.IS_AGENT6_RELEASE == 'true' && steps.check_for_changes.outputs.CHANGES == 'false' && env.IS_QUALIFICATION == 'true' }}
-              run: |
-                inv -e release.run-rc-pipeline -r 6.53.x

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -605,10 +605,7 @@ def get_qualification_rc_tag(ctx, release_branch):
 
 
 @task
-def run_rc_pipeline(ctx, release_branch, gitlab_tag=None, k8s_deployments=False):
-    if not gitlab_tag:
-        gitlab_tag = get_qualification_rc_tag(ctx, release_branch)
-
+def run_rc_pipeline(ctx, gitlab_tag, k8s_deployments=False):
     run(
         ctx,
         git_ref=gitlab_tag,
@@ -618,6 +615,15 @@ def run_rc_pipeline(ctx, release_branch, gitlab_tag=None, k8s_deployments=False)
         rc_build=True,
         rc_k8s_deployments=k8s_deployments,
     )
+
+
+@task
+def alert_ci_on_call(ctx, release_branch, slack_webhook):
+    gitlab_tag = get_qualification_rc_tag(ctx, release_branch)
+    payload = {
+        'message': f":loudspeaker: Agent 6 Update:\nThere is an ongoing Agent 6 release and since there are no new changes there will be no RC bump this week.\n\nPlease rerun the previous build pipeline:\ninv release.run-rc-pipeline --gitlab-tag {gitlab_tag}"
+    }
+    send_slack_msg(ctx, payload, slack_webhook)
 
 
 @task(help={'key': "Path to an existing release.json key, separated with double colons, eg. 'last_stable::6'"})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
remove the rebuild step from the create_rc_pr workflow and replace it with a message


### Motivation
We can't trigger a GITLAB build pipeline from GITHUB automatically, and we don't want to: it would assume storing a GITLAB secret on an unsafe place.
As a consequence we still need a manual action to trigger the regular weekly pipeline of Agent6:
- Merge the RC PR and trigger the build in nominal cases
- Trigger the build on `qualification` phase when no changes during a week.
More documentation [here](https://datadoghq.atlassian.net/wiki/x/cgEaCgE)


### Describe how you validated your changes
[successful workflow](https://github.com/DataDog/datadog-agent/actions/runs/13301854280)
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
ran the workflow to check that a message sends to slack:
![image](https://github.com/user-attachments/assets/2ac03f20-63a7-4a63-a5fd-f3fb401d03f2)


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->