### PR TITLE
Update docker jmx agent static quality gates threshold

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -70,11 +70,11 @@ static_quality_gate_docker_agent_arm64:
 
 static_quality_gate_docker_agent_jmx_amd64:
   max_on_wire_size: "393.75 MiB"
-  max_on_disk_size: "1134.21 MiB"
+  max_on_disk_size: "1130.17 MiB"
 
 static_quality_gate_docker_agent_jmx_arm64:
   max_on_wire_size: "373.71 MiB"
-  max_on_disk_size: "1134.64 MiB"
+  max_on_disk_size: "1131.13 MiB"
 
 static_quality_gate_docker_dogstatsd_amd64:
   max_on_wire_size: "28.29 MiB"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update static quality gate threshold for `static_quality_gate_docker_agent_jmx_amd64` and `static_quality_gate_docker_agent_jmx_arm64` to save 4 and 3 MB of reduction.

### Motivation

[Dashboard](https://app.datadoghq.com/dashboard/5np-man-vak/static-quality-gates?fromUser=false&refresh_mode=sliding&from_ts=1739258250400&to_ts=1739431050400&live=true)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->