### PR TITLE
[workloadmeta/catalog-core] Remove kubeapiserver

### DIFF
--- a/comp/core/workloadmeta/collectors/catalog-core/catalog.go
+++ b/comp/core/workloadmeta/collectors/catalog-core/catalog.go
@@ -4,8 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package catalog is a wrapper that loads the available workloadmeta
-// collectors. It exists as a shorthand for importing all packages manually in
-// all of the agents.
+// collectors. This is the catalog used by the core agent.
 package catalog
 
 import (

--- a/comp/core/workloadmeta/collectors/catalog-core/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-core/options.go
@@ -4,8 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package catalog is a wrapper that loads the available workloadmeta
-// collectors. It exists as a shorthand for importing all packages manually in
-// all of the agents.
+// collectors. This is the catalog used by the core agent.
 package catalog
 
 import (
@@ -18,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/docker"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecs"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecsfargate"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubeapiserver"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubelet"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/nvml"
@@ -36,7 +34,6 @@ func getCollectorOptions() []fx.Option {
 		docker.GetFxOptions(),
 		ecs.GetFxOptions(),
 		ecsfargate.GetFxOptions(),
-		kubeapiserver.GetFxOptions(),
 		kubelet.GetFxOptions(),
 		kubemetadata.GetFxOptions(),
 		podman.GetFxOptions(),


### PR DESCRIPTION
### What does this PR do?

Small cleanup in the workloadmeta catalog used by the core agent.

This PR removes the kubeapiserver collector from the workloadmeta catalog used by the Core Agent.

The collector is only relevant for the Cluster Agent, and while it was previously imported, it was never actually running because its attributes specify that it is only for the Cluster Agent.

This change is purely for clarity. The collector did not introduce any additional dependencies beyond those already required elsewhere in the code, so there is no impact on binary size.

### Describe how you validated your changes

Covered by tests.