### PR TITLE
[AGENTRUN-51] adding test to assert dynamic loading of FIPS OpenSSL libraries

### DIFF
--- a/test/new-e2e/tests/fips-compliance/fips_nix_test.go
+++ b/test/new-e2e/tests/fips-compliance/fips_nix_test.go
@@ -8,21 +8,30 @@ package fipscompliance
 import (
 	_ "embed"
 	"fmt"
+	"strings"
+	"time"
 
 	"testing"
 
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
 )
 
 //go:embed fixtures/openssl-default.cnf
 var defaultOpenSSLConfig []byte
+
+//go:embed fixtures/security-agent.yaml
+var securityAgentConfig string
+
+//go:embed fixtures/system-probe.yaml
+var systemProbeConfig string
 
 type LinuxFIPSComplianceSuite struct {
 	e2e.BaseSuite[environments.Host]
@@ -69,4 +78,38 @@ func (v *LinuxFIPSComplianceSuite) TestFIPSEnabledNoOpenSSLConfig() {
 	assert.NotContains(v.T(), status, "Status date")
 
 	v.Env().RemoteHost.MustExecute("sudo mv /opt/datadog-agent/embedded/ssl/openssl.cnf.tmp /opt/datadog-agent/embedded/ssl/openssl.cnf")
+}
+
+// this test check that the FIPS Agent processes are loaded with the FIPS OpenSSL libraries
+func (v *LinuxFIPSComplianceSuite) TestFIPSEnabledLoadedOPENSSLLibs() {
+	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(
+		awshost.WithEC2InstanceOptions(ec2.WithOS(os.UbuntuDefault)),
+		awshost.WithAgentOptions(
+			agentparams.WithFlavor("datadog-fips-agent"),
+			agentparams.WithSecurityAgentConfig(securityAgentConfig),
+			agentparams.WithSystemProbeConfig(systemProbeConfig),
+		),
+	))
+
+	paths := []string{
+		"/opt/datadog-agent/bin/agent/agent",
+		"/opt/datadog-agent/embedded/bin/trace-agent",
+		"/opt/datadog-agent/embedded/bin/process-agent",
+		"/opt/datadog-agent/embedded/bin/security-agent",
+		"/opt/datadog-agent/embedded/bin/system-probe",
+	}
+	var pid string
+	var err error
+
+	for _, agentPath := range paths {
+		v.T().Logf("Checking loaded libraries for %v", agentPath)
+		v.EventuallyWithT(func(collect *assert.CollectT) {
+			pid, err = v.Env().RemoteHost.Host.Execute(fmt.Sprintf("pidof %v", agentPath))
+			require.NoError(collect, err)
+			pid = strings.TrimSpace(pid)
+			require.NotEmpty(collect, pid)
+		}, time.Second*10, time.Second)
+		loadedLibs := v.Env().RemoteHost.Host.MustExecute(fmt.Sprintf("sudo cat /proc/%s/maps", pid))
+		assert.Contains(v.T(), loadedLibs, "/opt/datadog-agent/embedded/lib/ossl-modules/fips.so")
+	}
 }

--- a/test/new-e2e/tests/fips-compliance/fixtures/security-agent.yaml
+++ b/test/new-e2e/tests/fips-compliance/fixtures/security-agent.yaml
@@ -1,0 +1,2 @@
+runtime_security_config:
+  enabled: true

--- a/test/new-e2e/tests/fips-compliance/fixtures/system-probe.yaml
+++ b/test/new-e2e/tests/fips-compliance/fixtures/system-probe.yaml
@@ -1,0 +1,2 @@
+runtime_security_config:
+  enabled: true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a test to assert dynamic loading of FIPS OpenSSL libraries.