### PR TITLE
[workloadmeta/collectors/catalog-dogstatsd] Delete unused collectors

### DIFF
--- a/cmd/dogstatsd/subcommands/start/command.go
+++ b/cmd/dogstatsd/subcommands/start/command.go
@@ -33,7 +33,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	localTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-less"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-dogstatsd"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd"

--- a/comp/core/workloadmeta/collectors/catalog-dogstatsd/catalog.go
+++ b/comp/core/workloadmeta/collectors/catalog-dogstatsd/catalog.go
@@ -4,8 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package catalog is a wrapper that loads workloadmeta collectors, while having less
-// than the full set. Currently only used by the dogstatsd binary, this catalog does
-// not include the process-collector due to its increased dependency set.
+// than the full set. This is the catalog used by standalone dogstatsd.
 package catalog
 
 import (

--- a/comp/core/workloadmeta/collectors/catalog-dogstatsd/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-dogstatsd/options.go
@@ -4,8 +4,7 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package catalog is a wrapper that loads workloadmeta collectors, while having less
-// than the full set. Currently only used by the dogstatsd binary, this catalog does
-// not include the process-collector due to its increased dependency set.
+// than the full set. This is the catalog used by standalone dogstatsd.
 package catalog
 
 import (

--- a/comp/core/workloadmeta/collectors/catalog-dogstatsd/options.go
+++ b/comp/core/workloadmeta/collectors/catalog-dogstatsd/options.go
@@ -17,12 +17,9 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/docker"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecs"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/ecsfargate"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubeapiserver"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubelet"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/kubemetadata"
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/podman"
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/processcollector"
-	remoteworkloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/internal/remote/workloadmeta"
 )
 
 func getCollectorOptions() []fx.Option {
@@ -34,12 +31,8 @@ func getCollectorOptions() []fx.Option {
 		docker.GetFxOptions(),
 		ecs.GetFxOptions(),
 		ecsfargate.GetFxOptions(),
-		kubeapiserver.GetFxOptions(),
 		kubelet.GetFxOptions(),
 		kubemetadata.GetFxOptions(),
 		podman.GetFxOptions(),
-		remoteworkloadmeta.GetFxOptions(),
-		fx.Supply(remoteworkloadmeta.Params{}),
-		processcollector.GetFxOptions(),
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR deletes from the dogstatsd workloadmeta collectors catalog the ones that don't apply to standalone dogstatsd.

 This PR also renames the catalog since dogstatsd is the only one using it. The name has been changed from catalog-less to catalog-dogstatsd for clarity.


### Describe how you validated your changes

Covered by tests.