### PR TITLE
chore(origindetection): remove queryContainerIDFromOriginInfo retry

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -301,10 +301,11 @@ func (t *remoteTagger) queryContainerIDFromOriginInfo(originInfo origindetection
 	}
 
 	// Create the context with the auth token
-	queryCtx, queryCancel := context.WithCancel(
+	queryCtx, queryCancel := context.WithTimeout(
 		metadata.NewOutgoingContext(t.ctx, metadata.MD{
 			"authorization": []string{fmt.Sprintf("Bearer %s", t.token)},
 		}),
+		1*time.Second,
 	)
 	defer queryCancel()
 

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -200,7 +200,7 @@ func (t *remoteTagger) Start(ctx context.Context) error {
 	retries := 0
 	expBackoff := backoff.NewExponentialBackOff()
 	expBackoff.InitialInterval = 50 * time.Millisecond
-	expBackoff.MaxInterval = 200 * time.Millisecond
+	expBackoff.MaxInterval = 500 * time.Millisecond
 	expBackoff.MaxElapsedTime = 5 * time.Second
 	err = backoff.Retry(func() error {
 		select {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the Exponential BackOff in `queryContainerIDFromOriginInfo()`.

### Motivation

The current settings do not allow for additional collections while also increasing the resolution. Keeping the retry mechanism in place unnecessarily prolongs execution without adding value.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by unit and E2E tests. It was also done manually:

<img width="1161" alt="image" src="https://github.com/user-attachments/assets/be3cec85-b4ec-4dee-baf9-b546da209de8" />

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A