### PR TITLE
[cmd/security-agent/main_windows] Use remote workloadmeta catalog

### DIFF
--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -39,7 +39,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig"
 	"github.com/DataDog/datadog-agent/comp/core/sysprobeconfig/sysprobeconfigimpl"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
+	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd"


### PR DESCRIPTION
### What does this PR do?

This PR changes the workloadmeta collector catalog used by the security-agent on windows. Before it was using the one that includes all the collectors, but in should use the remote catalog instead.

The linux version is already using the remote catalog, plus the windows one already specifies that it wants to use "remote" here:
https://github.com/DataDog/datadog-agent/blob/dee20b3f6e0f9b836ca7fb54a580b54985412c47/cmd/security-agent/main_windows.go#L127 so the change shouldn't affect functionality, but it's going to remove unnecessary collector imports.


### Describe how you validated your changes

I don't think we need specific tests for this one, but I'll leave it to the agent-security team to decide.