### PR TITLE
fix(invoke UT): Force variable for tests in github actions

### DIFF
--- a/tasks/unit_tests/release_tests.py
+++ b/tasks/unit_tests/release_tests.py
@@ -787,7 +787,7 @@ class TestCheckForChanges(unittest.TestCase):
             }
         ),
     )
-    @patch.dict(os.environ, {'GITLAB_CI': 'true'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'true', 'GITHUB_ACTIONS': 'true'})
     @patch('os.chdir', new=MagicMock())
     def test_changes_new_commit_first_repo(self, version_mock, print_mock, _):
         with mock_git_clone():
@@ -871,7 +871,7 @@ class TestCheckForChanges(unittest.TestCase):
         ),
     )
     @patch('os.chdir', new=MagicMock())
-    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false', 'GITHUB_ACTIONS': 'false'})
     def test_changes_new_commit_all_repo(self, version_mock, print_mock, _):
         with mock_git_clone():
             next = MagicMock()
@@ -1023,7 +1023,7 @@ class TestCheckForChanges(unittest.TestCase):
             }
         ),
     )
-    @patch.dict(os.environ, {'GITLAB_CI': 'true'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'true', 'GITHUB_ACTIONS': 'true'})
     @patch('os.chdir', new=MagicMock())
     def test_changes_new_commit_second_repo_branch_out(self, version_mock, print_mock, _):
         with mock_git_clone():
@@ -1272,7 +1272,7 @@ class TestUpdateModules(unittest.TestCase):
 class TestTagModules(unittest.TestCase):
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(2)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false', 'GITHUB_ACTIONS': 'false'})
     def test_2_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1285,7 +1285,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(3)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false', 'GITHUB_ACTIONS': 'false'})
     def test_3_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1298,7 +1298,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(4)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false', 'GITHUB_ACTIONS': 'false'})
     def test_4_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:
@@ -1315,7 +1315,7 @@ class TestTagModules(unittest.TestCase):
 
     @patch('tasks.release.__tag_single_module', new=MagicMock(side_effect=[[str(i)] for i in range(100)]))
     @patch('tasks.release.agent_context', new=MagicMock())
-    @patch.dict(os.environ, {'GITLAB_CI': 'false'})
+    @patch.dict(os.environ, {'GITLAB_CI': 'false', 'GITHUB_ACTIONS': 'false'})
     def test_100_tags(self):
         c = MockContext(run=Result("yolo"))
         with patch('tasks.release.get_default_modules') as mock_modules:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Force variable for tests in github actions

### Motivation
Tests are also run in github actions, this prevent [failure](https://github.com/DataDog/datadog-agent-macos-build/actions/runs/13319300477/job/37200597479?pr=244)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->