### PR TITLE
[clusteragent/admission/common/label_selectors] Depend only on mutate_unlabelled

### DIFF
--- a/pkg/clusteragent/admission/common/label_selectors.go
+++ b/pkg/clusteragent/admission/common/label_selectors.go
@@ -17,9 +17,7 @@ import (
 func DefaultLabelSelectors(useNamespaceSelector bool) (namespaceSelector, objectSelector *metav1.LabelSelector) {
 	var labelSelector metav1.LabelSelector
 
-	if pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled") ||
-		pkgconfigsetup.Datadog().GetBool("apm_config.instrumentation.enabled") ||
-		len(pkgconfigsetup.Datadog().GetStringSlice("apm_config.instrumentation.enabled_namespaces")) > 0 {
+	if pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled") {
 		// Accept all, ignore pods if they're explicitly filtered-out
 		labelSelector = metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{


### PR DESCRIPTION
### What does this PR do?

This PR updates the default label selectors used by the config, tagsfromlabels, and apm admission webhooks in the cluster agent.

Previously, these selectors were tied to APM-specific settings because both config and tagsfromlabels needed to run when APM was enabled. However, a prior PR decoupled these webhooks, so we no longer need to check those APM settings.

@betterengineering, we could explore defining more specific label selectors for APM using the new target options in a future PR.


### Describe how you validated your changes

Should be covered by tests. This can be tested together with the rest of changes that affect the admission controller in this release.
