### PR TITLE
[EBPF] gpu: add active PIDs to GPUs in workloadmeta

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -233,6 +233,17 @@ func (c *collector) Pull(_ context.Context) error {
 			gpu.SMCount = int(devAttr.MultiprocessorCount)
 		}
 
+		procs, ret := dev.GetComputeRunningProcesses()
+		if ret != nvml.SUCCESS {
+			if logLimiter.ShouldLog() {
+				log.Warnf("failed to get compute running processes for device index %d: %v", i, nvml.ErrorString(ret))
+			}
+		} else {
+			for _, proc := range procs {
+				gpu.ActivePIDs = append(gpu.ActivePIDs, int(proc.Pid))
+			}
+		}
+
 		event := workloadmeta.CollectorEvent{
 			Source: workloadmeta.SourceRuntime,
 			Type:   workloadmeta.EventTypeSet,

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -64,6 +64,7 @@ var DefaultGPUAttributes = nvml.DeviceAttributes{
 	MultiprocessorCount: 10,
 }
 
+// DefaultProcessInfo is the list of processes running on the default device returned by the mock
 var DefaultProcessInfo = []nvml.ProcessInfo{
 	{Pid: 1, UsedGpuMemory: 100},
 	{Pid: 5678, UsedGpuMemory: 200},

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -64,6 +64,11 @@ var DefaultGPUAttributes = nvml.DeviceAttributes{
 	MultiprocessorCount: 10,
 }
 
+var DefaultProcessInfo = []nvml.ProcessInfo{
+	{Pid: 1, UsedGpuMemory: 100},
+	{Pid: 5678, UsedGpuMemory: 200},
+}
+
 // GetDeviceMock returns a mock of the nvml.Device with the given UUID.
 func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 	return &nvmlmock.Device{
@@ -84,6 +89,9 @@ func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 		},
 		GetAttributesFunc: func() (nvml.DeviceAttributes, nvml.Return) {
 			return DefaultGPUAttributes, nvml.SUCCESS
+		},
+		GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
+			return DefaultProcessInfo, nvml.SUCCESS
 		},
 	}
 }
@@ -111,6 +119,9 @@ func GetBasicNvmlMock() *nvmlmock.Interface {
 		},
 		DeviceGetMigModeFunc: func(nvml.Device) (int, int, nvml.Return) {
 			return nvml.DEVICE_MIG_DISABLE, 0, nvml.SUCCESS
+		},
+		DeviceGetComputeRunningProcessesFunc: func(nvml.Device) ([]nvml.ProcessInfo, nvml.Return) {
+			return DefaultProcessInfo, nvml.SUCCESS
 		},
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds current active PIDs to the workloadmeta GPU entities

### Motivation

Include information for tagging processes using GPUs.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests included with mocks. Also manually validated by running in a GPU host and ensuring that active PIDs were present with `agent workload-list`. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->