### PR TITLE
[CONTP-547] add trace logs to pld handler to check the state of the detected languages

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/process"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
@@ -111,7 +112,9 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 
 	ownersLanguagesFromRequest := getOwnersLanguages(requestData, time.Now().Add(handler.cfg.languageTTL))
 
+	log.Tracef("Owner Languages state pre merge-and-flush:\n %s", handler.ownersLanguages.String())
 	err = handler.ownersLanguages.mergeAndFlush(ownersLanguagesFromRequest, handler.wlm)
+	log.Tracef("Owner Languages state post merge-and-flush:\n %s", handler.ownersLanguages.String())
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to store some (or all) languages in workloadmeta store: %s", err), http.StatusInternalServerError)
 		ProcessedRequests.Inc(statusError)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

Adds logs with TRACE loglevel in the PLD handler to log the state of detected languages before and after mergeAndFlush operation on each request received from the PLD client.

### Motivation

Have better visibility and be able to debug issues.

Related to [this](https://github.com/DataDog/datadog-agent/pull/33253).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Buit custom image of the cluster agent and deployed it with loglevel: TRACE along with some python apps and apm instrumentation enabled. 

The DCA logs show the following:

```
2025-02-14 11:33:05 UTC | CLUSTER | TRACE | (api/v1/languagedetection/handler.go:115 in leaderHandler) | Owner Languages state pre merge-and-flush:
 ===== default/Deployment/dummy-python-app ====
clean
python-container: python,
===== dev-1/Deployment/dummy-python-app ====
clean
python-container: python,
===== dev-3/Deployment/dummy-python-app ====
clean
python-container: python,
===== dev-2/Deployment/dummy-python-app ====
clean
python-container: python,
2025-02-14 11:33:05 UTC | CLUSTER | TRACE | (api/v1/languagedetection/handler.go:117 in leaderHandler) | Owner Languages state post merge-and-flush:
 ===== default/Deployment/dummy-python-app ====
clean
python-container: python,
===== dev-1/Deployment/dummy-python-app ====
clean
python-container: python,
===== dev-3/Deployment/dummy-python-app ====
clean
python-container: python,
===== dev-2/Deployment/dummy-python-app ====
clean
python-container: python,
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->