### PR TITLE
[EBPF-671] gpu: add sm_active metric

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/device.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device.go
@@ -35,6 +35,7 @@ var allDeviceMetrics = []deviceMetric{
 	{"clock_speed.video", getVideoClockSpeed},
 	{"temperature", getTemperature},
 	{"total_energy_consumption", getTotalEnergyConsumption},
+	{"sm_active", getSMActive},
 }
 
 type deviceCollector struct {
@@ -135,6 +136,11 @@ func getDecoderUtilization(dev nvml.Device) (float64, nvml.Return) {
 func getDramActive(dev nvml.Device) (float64, nvml.Return) {
 	util, ret := dev.GetUtilizationRates()
 	return float64(util.Memory), ret
+}
+
+func getSMActive(dev nvml.Device) (float64, nvml.Return) {
+	util, ret := dev.GetUtilizationRates()
+	return float64(util.Gpu), ret
 }
 
 func getEncoderUtilization(dev nvml.Device) (float64, nvml.Return) {

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -150,7 +150,7 @@ func (v *gpuSuite) TestVectorAddProgramDetected() {
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		// We are not including "gpu.memory", as that represents the "current
 		// memory usage" and that might be zero at the time it's checked
-		metricNames := []string{"gpu.utilization", "gpu.memory.max"}
+		metricNames := []string{"gpu.utilization", "gpu.memory.max", "gpu.sm_active"}
 		for _, metricName := range metricNames {
 			metrics, err := v.Env().FakeIntake.Client().FilterMetrics(metricName, client.WithMetricValueHigherThan(0), client.WithMatchingTags[*aggregator.MetricSeries](mandatoryMetricTagRegexes()))
 			assert.NoError(c, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds the `sm_active` metric based on the amout of time the streaming multiprocessor was active during the interval.

### Motivation

Feature parity with DCGM.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added a check in the e2e test. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->