### PR TITLE
[EBPF] gpu: increase ringbuffer size

### DIFF
--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -46,7 +46,7 @@ const (
 
 var (
 	// defaultRingBufferSize controls the amount of memory in bytes used for buffering perf event data
-	defaultRingBufferSize = os.Getpagesize()
+	defaultRingBufferSize = 2 * os.Getpagesize()
 )
 
 // bpfMapName stores the name of the BPF maps storing statistics and other info
@@ -302,6 +302,9 @@ func (p *Probe) setupSharedBuffer(o *manager.Options) {
 
 	p.m.Manager.RingBuffers = append(p.m.Manager.RingBuffers, rb)
 	p.eventHandler = rbHandler
+
+	rb.TelemetryEnabled = true
+	ebpftelemetry.ReportRingBufferTelemetry(rb)
 }
 
 // CollectConsumedEvents waits until the debug collector stores count events and returns them


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increases the ringbuffer size for the `cudaEvents` map and enables reporting telemetry.

### Motivation

Have visibility into losses and reduce them.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Existing tests should pass.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->