### PR TITLE
Revert "[clusteragent/admission/common/label_selectors] Depend only on mutate_unlabelled"

### DIFF
--- a/pkg/clusteragent/admission/common/label_selectors.go
+++ b/pkg/clusteragent/admission/common/label_selectors.go
@@ -17,7 +17,9 @@ import (
 func DefaultLabelSelectors(useNamespaceSelector bool) (namespaceSelector, objectSelector *metav1.LabelSelector) {
 	var labelSelector metav1.LabelSelector
 
-	if pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled") {
+	if pkgconfigsetup.Datadog().GetBool("admission_controller.mutate_unlabelled") ||
+		pkgconfigsetup.Datadog().GetBool("apm_config.instrumentation.enabled") ||
+		len(pkgconfigsetup.Datadog().GetStringSlice("apm_config.instrumentation.enabled_namespaces")) > 0 {
 		// Accept all, ignore pods if they're explicitly filtered-out
 		labelSelector = metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{


### PR DESCRIPTION
Reverts DataDog/datadog-agent#34049

This doesn't work for the APM webhook. We'll need to define proper label selectors for APM before we make this change.