### PR TITLE
apm: Always set content-type even when we reject a payload (APMSP-1791)

### DIFF
--- a/releasenotes/notes/traceagent-contenttype-78d4cdc86e809b9f.yaml
+++ b/releasenotes/notes/traceagent-contenttype-78d4cdc86e809b9f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Return the correct content-type header when rejecting trace payloads.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set the correct content-type header for rejected payloads and add a debug log for overwhelmed trace-agents.

### Motivation
We should tell tracers the correct content type in our responses. Due to setting the status code before calling replyOK we were inadvertently losing the content type and therefore client's expected plain/text type. This caused some tests to fail internally when the trace-agent became overwhelmed in a test and the PHP tracer failed to parse the sampling rates as the content-type was wrong.

The log is added as it would have made this investigation quite a bit faster, letting us know right away where to start looking.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I added a specific unit test for this exact behavior (writing this test taught me about the httptest `Result` method which is critical to making this test pass and truly validating the behavior.

### Possible Drawbacks / Trade-offs
Extra debug log noise? but I believe this trade-off is well worth it.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->