### PR TITLE
usm: protocols: Change GetStats signature to return cleaner callback

### DIFF
--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -214,7 +214,8 @@ func (p *protocol) setupMapCleaner(mgr *manager.Manager) {
 	p.mapCleaner = mapCleaner
 }
 
-// GetStats returns a map of HTTP stats stored in the following format:
+// GetStats returns a map of HTTP stats and a callback to clean resources.
+// The format of HTTP stats:
 // [source, dest tuple, request path] -> RequestStats object
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -216,13 +216,13 @@ func (p *protocol) setupMapCleaner(mgr *manager.Manager) {
 
 // GetStats returns a map of HTTP stats stored in the following format:
 // [source, dest tuple, request path] -> RequestStats object
-func (p *protocol) GetStats() *protocols.ProtocolStats {
+func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.telemetry.Log()
 	return &protocols.ProtocolStats{
 		Type:  protocols.HTTP,
 		Stats: p.statkeeper.GetAndResetAllStats(),
-	}
+	}, nil
 }
 
 // IsBuildModeSupported returns always true, as http module is supported by all modes.

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -420,7 +420,8 @@ func (p *Protocol) setupHTTP2InFlightMapCleaner(mgr *manager.Manager) {
 	p.http2InFlightMapCleaner = mapCleaner
 }
 
-// GetStats returns a map of HTTP2 stats stored in the following format:
+// GetStats returns a map of HTTP2 stats and a callback to clean resources.
+// The format of HTTP2 stats:
 // [source, dest tuple, request path] -> RequestStats object
 func (p *Protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -422,13 +422,13 @@ func (p *Protocol) setupHTTP2InFlightMapCleaner(mgr *manager.Manager) {
 
 // GetStats returns a map of HTTP2 stats stored in the following format:
 // [source, dest tuple, request path] -> RequestStats object
-func (p *Protocol) GetStats() *protocols.ProtocolStats {
+func (p *Protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.telemetry.Log()
 	return &protocols.ProtocolStats{
 		Type:  protocols.HTTP2,
 		Stats: p.statkeeper.GetAndResetAllStats(),
-	}
+	}, nil
 }
 
 // IsBuildModeSupported returns always true, as http2 module is supported by all modes.

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -352,13 +352,13 @@ func (p *protocol) setupInFlightMapCleaner(mgr *manager.Manager) error {
 
 // GetStats returns a map of Kafka stats stored in the following format:
 // [source, dest tuple, request path] -> RequestStats object
-func (p *protocol) GetStats() *protocols.ProtocolStats {
+func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.telemetry.Log()
 	return &protocols.ProtocolStats{
 		Type:  protocols.Kafka,
 		Stats: p.statkeeper.GetAndResetAllStats(),
-	}
+	}, nil
 }
 
 // IsBuildModeSupported returns always true, as kafka module is supported by all modes.

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -350,7 +350,8 @@ func (p *protocol) setupInFlightMapCleaner(mgr *manager.Manager) error {
 	return nil
 }
 
-// GetStats returns a map of Kafka stats stored in the following format:
+// GetStats returns a map of Kafka stats and a callback to clean resources.
+// The format of the stats:
 // [source, dest tuple, request path] -> RequestStats object
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -228,7 +228,7 @@ func (p *protocol) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map) {
 	}
 }
 
-// GetStats returns a map of Postgres stats.
+// GetStats returns a map of Postgres stats and a callback to clean resources.
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.kernelTelemetry.Log()

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -229,14 +229,14 @@ func (p *protocol) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map) {
 }
 
 // GetStats returns a map of Postgres stats.
-func (p *protocol) GetStats() *protocols.ProtocolStats {
+func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.kernelTelemetry.Log()
 
 	return &protocols.ProtocolStats{
 		Type:  protocols.Postgres,
 		Stats: p.statskeeper.GetAndResetAllStats(),
-	}
+	}, nil
 }
 
 // IsBuildModeSupported returns always true, as postgres module is supported by all modes.

--- a/pkg/network/protocols/protocols.go
+++ b/pkg/network/protocols/protocols.go
@@ -60,8 +60,9 @@ type Protocol interface {
 	Name() string
 
 	// GetStats returns the latest monitoring stats from a protocol
-	// implementation.
-	GetStats() *ProtocolStats
+	// implementation. The second return value is a callback for cleanup
+	// purposes. Each protocol can use it to release resources, if necessary.
+	GetStats() (*ProtocolStats, func())
 
 	// IsBuildModeSupported return true is the given build mode is supported by this protocol.
 	IsBuildModeSupported(buildmode.Type) bool

--- a/pkg/network/protocols/redis/protocol.go
+++ b/pkg/network/protocols/redis/protocol.go
@@ -145,7 +145,7 @@ func (p *protocol) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map) {
 	}
 }
 
-// GetStats returns a map of Redis stats.
+// GetStats returns a map of Redis stats and a callback to clean resources.
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 

--- a/pkg/network/protocols/redis/protocol.go
+++ b/pkg/network/protocols/redis/protocol.go
@@ -146,13 +146,13 @@ func (p *protocol) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map) {
 }
 
 // GetStats returns a map of Redis stats.
-func (p *protocol) GetStats() *protocols.ProtocolStats {
+func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 
 	return &protocols.ProtocolStats{
 		Type:  protocols.Redis,
 		Stats: p.statskeeper.GetAndResetAllStats(),
-	}
+	}, nil
 }
 
 // IsBuildModeSupported returns always true, as Redis module is supported by all modes.

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -432,7 +432,9 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 		return nil, fmt.Errorf("error retrieving connections: %s", err)
 	}
 
-	delta := t.state.GetDelta(clientID, latestTime, active, t.reverseDNS.GetDNSStats(), t.usmMonitor.GetProtocolStats())
+	usmStats, cleaners := t.usmMonitor.GetProtocolStats()
+	defer cleaners()
+	delta := t.state.GetDelta(clientID, latestTime, active, t.reverseDNS.GetDNSStats(), usmStats)
 
 	ips := make(map[util.Address]struct{}, len(delta.Conns)/2)
 	var udpConns, tcpConns int

--- a/pkg/network/usm/debugger/cmd/usm_debugger.go
+++ b/pkg/network/usm/debugger/cmd/usm_debugger.go
@@ -46,7 +46,8 @@ func main() {
 	go func() {
 		t := time.NewTicker(10 * time.Second)
 		for range t.C {
-			_ = monitor.GetProtocolStats()
+			_, cleaners = monitor.GetProtocolStats()
+			cleaners()
 		}
 	}()
 

--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -285,8 +285,8 @@ func (p *goTLSProgram) PostStart(*manager.Manager) error {
 func (p *goTLSProgram) DumpMaps(io.Writer, string, *ebpf.Map) {}
 
 // GetStats is a no-op.
-func (p *goTLSProgram) GetStats() *protocols.ProtocolStats {
-	return nil
+func (p *goTLSProgram) GetStats() (*protocols.ProtocolStats, func()) {
+	return nil, nil
 }
 
 // Stop terminates goTLS main goroutine.

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -569,7 +569,7 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 
 }
 
-// GetStats returns the latest monitoring stats from a protocol implementation.
+// GetStats is a no-op.
 func (o *sslProgram) GetStats() (*protocols.ProtocolStats, func()) {
 	return nil, nil
 }

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -570,8 +570,8 @@ func (o *sslProgram) DumpMaps(w io.Writer, mapName string, currentMap *ebpf.Map)
 }
 
 // GetStats returns the latest monitoring stats from a protocol implementation.
-func (o *sslProgram) GetStats() *protocols.ProtocolStats {
-	return nil
+func (o *sslProgram) GetStats() (*protocols.ProtocolStats, func()) {
+	return nil, nil
 }
 
 const (

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -1559,7 +1559,8 @@ func (i *PrintableInt) Add(other int) {
 func getAndValidateKafkaStats(t *testing.T, monitor *Monitor, expectedStatsCount int, topicName string, validation kafkaParsingValidation, errorCode int32) map[kafka.Key]*kafka.RequestStats {
 	kafkaStats := make(map[kafka.Key]*kafka.RequestStats)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		protocolStats := monitor.GetProtocolStats()
+		protocolStats, cleaners := monitor.GetProtocolStats()
+		defer cleaners()
 		kafkaProtocolStats, exists := protocolStats[protocols.Kafka]
 		// We might not have kafka stats, and it might be the expected case (to capture 0).
 		if exists {
@@ -1588,7 +1589,8 @@ func getAndValidateKafkaStats(t *testing.T, monitor *Monitor, expectedStatsCount
 func getAndValidateKafkaStatsWithErrorCodes(t *testing.T, monitor *Monitor, expectedStatsCount int, topicName string, validation kafkaParsingValidationWithErrorCodes) map[kafka.Key]*kafka.RequestStats {
 	kafkaStats := make(map[kafka.Key]*kafka.RequestStats)
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		protocolStats := monitor.GetProtocolStats()
+		protocolStats, cleaners := monitor.GetProtocolStats()
+		defer cleaners()
 		kafkaProtocolStats, exists := protocolStats[protocols.Kafka]
 		// We might not have kafka stats, and it might be the expected case (to capture 0).
 		if exists {

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -188,7 +188,7 @@ func (m *Monitor) GetUSMStats() map[string]interface{} {
 	return response
 }
 
-// GetProtocolStats returns the current stats for all protocols
+// GetProtocolStats returns the current stats for all protocols and a cleanup function to free resources.
 func (m *Monitor) GetProtocolStats() (map[protocols.ProtocolType]interface{}, func()) {
 	if m == nil {
 		return nil, func() {}

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -189,9 +189,9 @@ func (m *Monitor) GetUSMStats() map[string]interface{} {
 }
 
 // GetProtocolStats returns the current stats for all protocols
-func (m *Monitor) GetProtocolStats() map[protocols.ProtocolType]interface{} {
+func (m *Monitor) GetProtocolStats() (map[protocols.ProtocolType]interface{}, func()) {
 	if m == nil {
-		return nil
+		return nil, func() {}
 	}
 
 	defer func() {

--- a/pkg/network/usm/monitor_testutil.go
+++ b/pkg/network/usm/monitor_testutil.go
@@ -72,8 +72,8 @@ func (p *protocolMock) Stop(mgr *manager.Manager) {
 	}
 }
 
-func (p *protocolMock) DumpMaps(io.Writer, string, *ebpf.Map) {}
-func (p *protocolMock) GetStats() *protocols.ProtocolStats    { return nil }
+func (p *protocolMock) DumpMaps(io.Writer, string, *ebpf.Map)        {}
+func (p *protocolMock) GetStats() (*protocols.ProtocolStats, func()) { return nil, nil }
 
 // IsBuildModeSupported returns always true, as the mock is supported by all modes.
 func (*protocolMock) IsBuildModeSupported(buildmode.Type) bool { return true }

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -596,7 +596,9 @@ func TestOldConnectionRegression(t *testing.T) {
 		}
 
 		// Ensure we have captured a request
-		stats, ok := usmMonitor.GetProtocolStats()[protocols.HTTP]
+		statsObj, cleaners := usmMonitor.GetProtocolStats()
+		defer cleaners()
+		stats, ok := statsObj[protocols.HTTP]
 		require.True(t, ok)
 		httpStats, ok := stats.(map[http.Key]*http.RequestStats)
 		require.True(t, ok)
@@ -649,7 +651,9 @@ func TestLimitListenerRegression(t *testing.T) {
 		}
 
 		// Ensure we have captured a request
-		stats, ok := usmMonitor.GetProtocolStats()[protocols.HTTP]
+		statsObj, cleaners := usmMonitor.GetProtocolStats()
+		defer cleaners()
+		stats, ok := statsObj[protocols.HTTP]
 		require.True(t, ok)
 		httpStats, ok := stats.(map[http.Key]*http.RequestStats)
 		require.True(t, ok)
@@ -912,7 +916,9 @@ func setupUSMTLSMonitor(t *testing.T, cfg *config.Config, reinit bool) *Monitor 
 
 // getHTTPLikeProtocolStats returns the stats for the protocols that store their stats in a map of http.Key and *http.RequestStats as values.
 func getHTTPLikeProtocolStats(monitor *Monitor, protocolType protocols.ProtocolType) map[http.Key]*http.RequestStats {
-	httpStats, ok := monitor.GetProtocolStats()[protocolType]
+	statsObj, cleaners := monitor.GetProtocolStats()
+	defer cleaners()
+	httpStats, ok := statsObj[protocolType]
 	if !ok {
 		return nil
 	}

--- a/pkg/network/usm/postgres_monitor_test.go
+++ b/pkg/network/usm/postgres_monitor_test.go
@@ -773,7 +773,9 @@ func getPostgresDefaultTestConfiguration(enableTLS bool) *config.Config {
 func validatePostgres(t *testing.T, monitor *Monitor, expectedStats map[string]map[postgres.Operation]int, tls bool) {
 	found := make(map[string]map[postgres.Operation]int)
 	require.Eventually(t, func() bool {
-		postgresProtocolStats, exists := monitor.GetProtocolStats()[protocols.Postgres]
+		statsObj, cleaners := monitor.GetProtocolStats()
+		defer cleaners()
+		postgresProtocolStats, exists := statsObj[protocols.Postgres]
 		if !exists {
 			return false
 		}

--- a/pkg/network/usm/usm_grpc_monitor_test.go
+++ b/pkg/network/usm/usm_grpc_monitor_test.go
@@ -532,7 +532,8 @@ func (s *usmGRPCSuite) testGRPCScenarios(t *testing.T, usmMonitor *Monitor, runC
 
 	res := make(map[http.Key]int)
 	assert.Eventually(t, func() bool {
-		stats := usmMonitor.GetProtocolStats()
+		stats, cleaners := usmMonitor.GetProtocolStats()
+		defer cleaners()
 		http2Stats, ok := stats[protocols.HTTP2]
 		if !ok {
 			return false


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allows protocol level resource cleanup.

### Motivation

The new signature adds a second return argument, which is a callback for a function that allows resource cleanup from the protocols.
The main use-case is to use object pool and return elements to it when the inner protocol structure is no longer in use

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

* Dogfooding on oddish-c
* Regular CI

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->