### PR TITLE
usm: http, http2: Use object pool for latencies

### DIFF
--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -220,10 +220,15 @@ func (p *protocol) setupMapCleaner(mgr *manager.Manager) {
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.telemetry.Log()
+	stats := p.statkeeper.GetAndResetAllStats()
 	return &protocols.ProtocolStats{
-		Type:  protocols.HTTP,
-		Stats: p.statkeeper.GetAndResetAllStats(),
-	}, nil
+			Type:  protocols.HTTP,
+			Stats: stats,
+		}, func() {
+			for _, elem := range stats {
+				elem.Close()
+			}
+		}
 }
 
 // IsBuildModeSupported returns always true, as http module is supported by all modes.

--- a/pkg/network/protocols/http/stats.go
+++ b/pkg/network/protocols/http/stats.go
@@ -228,6 +228,7 @@ func (r *RequestStats) AddRequest(statusCode uint16, latency float64, staticTags
 
 	if stats.Latencies == nil {
 		if err := stats.initSketch(); err != nil {
+			log.Warnf("could not add request latency to ddsketch: %v", err)
 			return
 		}
 

--- a/pkg/network/protocols/http/stats_test.go
+++ b/pkg/network/protocols/http/stats_test.go
@@ -76,3 +76,31 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	assert.True(t, val >= expectedValue-acceptableError)
 	assert.True(t, val <= expectedValue+acceptableError)
 }
+
+func benchmarkRequestStatsPool(b *testing.B, reqNum int) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stats := NewRequestStats()
+		for j := 0; j < reqNum; j++ {
+			stats.AddRequest(405, 10.0, 1, nil)
+		}
+		stats.Close()
+	}
+}
+
+func BenchmarkRequestStatsPool_10Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 10)
+}
+
+func BenchmarkRequestStatsPool_100Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 100)
+}
+
+func BenchmarkRequestStatsPool_1000Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 1000)
+}
+
+func BenchmarkRequestStatsPool_10000Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 10000)
+}

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -426,10 +426,15 @@ func (p *Protocol) setupHTTP2InFlightMapCleaner(mgr *manager.Manager) {
 func (p *Protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.telemetry.Log()
+	stats := p.statkeeper.GetAndResetAllStats()
 	return &protocols.ProtocolStats{
-		Type:  protocols.HTTP2,
-		Stats: p.statkeeper.GetAndResetAllStats(),
-	}, nil
+			Type:  protocols.HTTP2,
+			Stats: stats,
+		}, func() {
+			for _, elem := range stats {
+				elem.Close()
+			}
+		}
 }
 
 // IsBuildModeSupported returns always true, as http2 module is supported by all modes.

--- a/pkg/network/protocols/sketchespool.go
+++ b/pkg/network/protocols/sketchespool.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package protocols
+
+import (
+	ddsync "github.com/DataDog/datadog-agent/pkg/util/sync"
+	"github.com/DataDog/sketches-go/ddsketch"
+)
+
+// RelativeAccuracy defines the acceptable error in quantile values calculated by DDSketch.
+// For example, if the actual value at p50 is 100, with a relative accuracy of 0.01 the value calculated
+// will be between 99 and 101
+const RelativeAccuracy = 0.01
+
+var (
+	// SketchesPool is a pool of DDSketches
+	SketchesPool = ddsync.NewTypedPool[ddsketch.DDSketch](func() *ddsketch.DDSketch {
+		latencies, err := ddsketch.NewDefaultDDSketch(RelativeAccuracy)
+		if err != nil {
+			return nil
+		}
+		return latencies
+	})
+)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We leverage object pool instead of reallocating ddsketch object

### Motivation

Performance improvement.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Benchmark results:
```
main:
BenchmarkRequestStatsPool_10Reqs
BenchmarkRequestStatsPool_10Reqs-16       	 1000000	      1316 ns/op	     592 B/op	       9 allocs/op
BenchmarkRequestStatsPool_100Reqs
BenchmarkRequestStatsPool_100Reqs-16      	  153340	      8860 ns/op	    1808 B/op	      13 allocs/op
BenchmarkRequestStatsPool_1000Reqs
BenchmarkRequestStatsPool_1000Reqs-16     	   24699	     52517 ns/op	    1808 B/op	      13 allocs/op
BenchmarkRequestStatsPool_10000Reqs
BenchmarkRequestStatsPool_10000Reqs-16    	    3877	    317198 ns/op	    1808 B/op	      13 allocs/op

branch:
BenchmarkRequestStatsPool_10Reqs
BenchmarkRequestStatsPool_10Reqs-16       	 1924906	       700.7 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_100Reqs
BenchmarkRequestStatsPool_100Reqs-16      	  325545	      3820 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_1000Reqs
BenchmarkRequestStatsPool_1000Reqs-16     	   37941	     30833 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_10000Reqs
BenchmarkRequestStatsPool_10000Reqs-16    	    3649	    294629 ns/op	      65 B/op	       1 allocs/op
```

Deployed on [oddish-c](https://ddstaging.datadoghq.com/profiling/comparison?compare_end_A=1739731181563&compare_end_B=1739774281589&compare_query_A=kube_cluster_name%3Aoddish-c%20service%3Asystem-probe%20image_tag%3Adev-arbitman-usmon-1409-ot-beta-jmx-a4b1d955&compare_query_B=kube_cluster_name%3Aoddish-c%20service%3Asystem-probe%20image_tag%3Adev-arbitman-usmon-1324-new-ot-beta-jmx-4dc21acd&compare_start_A=1739695601994.1025&compare_start_B=1739729130785.4185&compareValuesMode=absolute&my_code=disabled&op_filter=focus_on%28initSketch%29) - 
1. CPU consumption of initSketches from the http code - disappeared from the profile
2. Allocations are down by 60%