### PR TITLE
Add log/message to the snmp scan device command

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -336,7 +336,7 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 		}
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
-	fmt.Printf("Successfully connected to SNMP agent on %s:%d\n", snmp.LocalAddr, snmp.Port)
+	fmt.Printf("Successfully connected to SNMP agent on %s:%d\n", snmp.Target, snmp.Port)
 	fmt.Printf("Starting the scan for device: %s\n", deviceAddr)
 	err = snmpScanner.RunDeviceScan(snmp, namespace, deviceID)
 	if err != nil {

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -336,7 +336,6 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 		}
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
-	fmt.Printf("Successfully connected to SNMP agent on %s:%d\n", snmp.Target, snmp.Port)
 	fmt.Printf("Starting the scan for device: %s\n", deviceAddr)
 	err = snmpScanner.RunDeviceScan(snmp, namespace, deviceID)
 	if err != nil {

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -309,6 +309,7 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	deviceID := namespace + ":" + connParams.IPAddress
 	// Since the snmp connection can take a while, start by sending an in progress status for the start of the scan
 	// before connecting to the agent
+	fmt.Printf("Initializing scan for device: %s\n", deviceID)
 	inProgressStatusPayload := metadata.NetworkDevicesMetadata{
 		DeviceScanStatus: &metadata.ScanStatusMetadata{
 			DeviceID:   deviceID,
@@ -335,6 +336,8 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 		}
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
+	fmt.Printf("Successfully connected to SNMP agent on %s:%d\n", snmp.LocalAddr, snmp.Port)
+	fmt.Printf("Starting the scan for device: %s\n", deviceAddr)
 	err = snmpScanner.RunDeviceScan(snmp, namespace, deviceID)
 	if err != nil {
 		// Send an error status if we can't scan the device
@@ -363,6 +366,7 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	if err = snmpScanner.SendPayload(completedStatusPayload); err != nil {
 		return fmt.Errorf("unable to send completed status: %v", err)
 	}
+	fmt.Printf("Scan completed successfully for device: %s\n", deviceAddr)
 	return nil
 }
 

--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -309,7 +309,7 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	deviceID := namespace + ":" + connParams.IPAddress
 	// Since the snmp connection can take a while, start by sending an in progress status for the start of the scan
 	// before connecting to the agent
-	fmt.Printf("Initializing scan for device: %s\n", deviceID)
+	fmt.Printf("Initializing scan for device: %s\n", deviceAddr)
 	inProgressStatusPayload := metadata.NetworkDevicesMetadata{
 		DeviceScanStatus: &metadata.ScanStatusMetadata{
 			DeviceID:   deviceID,
@@ -336,7 +336,7 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 		}
 		return fmt.Errorf("unable to connect to SNMP agent on %s:%d: %w", snmp.LocalAddr, snmp.Port, err)
 	}
-	fmt.Printf("Starting the scan for device: %s\n", deviceAddr)
+	fmt.Printf("Starting scan for device: %s\n", deviceAddr)
 	err = snmpScanner.RunDeviceScan(snmp, namespace, deviceID)
 	if err != nil {
 		// Send an error status if we can't scan the device
@@ -365,7 +365,7 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	if err = snmpScanner.SendPayload(completedStatusPayload); err != nil {
 		return fmt.Errorf("unable to send completed status: %v", err)
 	}
-	fmt.Printf("Scan completed successfully for device: %s\n", deviceAddr)
+	fmt.Printf("Completed scan successfully for device: %s\n", deviceAddr)
 	return nil
 }
 

--- a/pkg/networkdevice/metadata/payload_utils.go
+++ b/pkg/networkdevice/metadata/payload_utils.go
@@ -61,6 +61,7 @@ func BatchDeviceScan(namespace string, collectTime time.Time, batchSize int, dev
 
 	curPayload := newNetworkDevicesMetadata(namespace, "", collectTime)
 	lastProgressPercent := -1
+
 	for i, oid := range deviceOIDs {
 		payloads, curPayload, resourceCount = appendToPayloads(namespace, "", collectTime, batchSize, resourceCount, payloads, curPayload)
 		curPayload.DeviceOIDs = append(curPayload.DeviceOIDs, *oid)

--- a/pkg/networkdevice/metadata/payload_utils.go
+++ b/pkg/networkdevice/metadata/payload_utils.go
@@ -6,6 +6,7 @@
 package metadata
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
@@ -59,12 +60,19 @@ func BatchDeviceScan(namespace string, collectTime time.Time, batchSize int, dev
 	var resourceCount int
 
 	curPayload := newNetworkDevicesMetadata(namespace, "", collectTime)
-
-	for _, oid := range deviceOIDs {
+	lastProgressPercent := -1
+	for i, oid := range deviceOIDs {
 		payloads, curPayload, resourceCount = appendToPayloads(namespace, "", collectTime, batchSize, resourceCount, payloads, curPayload)
 		curPayload.DeviceOIDs = append(curPayload.DeviceOIDs, *oid)
+
+		progressPercent := int(float32(i+1) / float32(len(deviceOIDs)) * 100)
+		if progressPercent != lastProgressPercent {
+			fmt.Printf("\rScanning progress: %d%%", progressPercent)
+			lastProgressPercent = progressPercent
+		}
 	}
 	payloads = append(payloads, curPayload)
+	fmt.Println()
 	return payloads
 }
 

--- a/pkg/networkdevice/metadata/payload_utils.go
+++ b/pkg/networkdevice/metadata/payload_utils.go
@@ -6,7 +6,6 @@
 package metadata
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/snmp/gosnmplib"
@@ -60,20 +59,12 @@ func BatchDeviceScan(namespace string, collectTime time.Time, batchSize int, dev
 	var resourceCount int
 
 	curPayload := newNetworkDevicesMetadata(namespace, "", collectTime)
-	lastProgressPercent := -1
 
-	for i, oid := range deviceOIDs {
+	for _, oid := range deviceOIDs {
 		payloads, curPayload, resourceCount = appendToPayloads(namespace, "", collectTime, batchSize, resourceCount, payloads, curPayload)
 		curPayload.DeviceOIDs = append(curPayload.DeviceOIDs, *oid)
-
-		progressPercent := int(float32(i+1) / float32(len(deviceOIDs)) * 100)
-		if progressPercent != lastProgressPercent {
-			fmt.Printf("\rScanning progress: %d%%", progressPercent)
-			lastProgressPercent = progressPercent
-		}
 	}
 	payloads = append(payloads, curPayload)
-	fmt.Println()
 	return payloads
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds log messages to the scan device command to inform the user how it's progressing.

### Motivation

https://datadoghq.atlassian.net/browse/NDMII-3340

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

I tested locally by running the scan command.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/cd90d453-650a-4b76-91e4-db70ea741a43" />

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->