### PR TITLE
Change schedule to match agent release calendar

### DIFF
--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -213,10 +213,10 @@ def create_release_notes(cutoff_date, teams):
     milestones = {
         '"Cut-off"': cutoff_date,
         '"RC.1 built"': cutoff_date + timedelta(days=1),
-        '"Staging deployment"': cutoff_date + timedelta(days=3),
+        '"Staging deployment"': cutoff_date + timedelta(days=4),
         '"Prod deployment start"': cutoff_date + timedelta(days=11),
-        '"Full prod deployment"': cutoff_date + timedelta(days=20),
-        '"Release"': cutoff_date + timedelta(days=26),
+        '"Full prod deployment"': cutoff_date + timedelta(days=18),
+        '"Release"': cutoff_date + timedelta(days=27),
     }
 
     line('h2', 'Schedule')


### PR DESCRIPTION
### What does this PR do?

This PR changes the function generating the release schedule so it matches the formulas in [Agent Release calendar](https://docs.google.com/spreadsheets/d/14PXAEEm2EZWfR8dWdOOHjeU_lt8zx9waRe_BIzQ36s4/edit?pli=1&gid=0#gid=0).

### Motivation

Unify the process so there are no two different sources of release schedule dates.