### PR TITLE
[EBPF-674] gpu: do not switch devices on non-global streams

### DIFF
--- a/pkg/gpu/consumer.go
+++ b/pkg/gpu/consumer.go
@@ -282,18 +282,16 @@ func (c *cudaEventConsumer) getStreamKey(header *gpuebpf.CudaEventHeader) (strea
 		containerID: containerID,
 	}
 
-	// Try to get the GPU device if we can, but do not fail if we can't as we want to report
-	// the data even if we can't get the GPU UUID
 	gpuDevice, err := c.sysCtx.getCurrentActiveGpuDevice(int(pid), int(tid), containerID)
 	if err != nil {
 		c.telemetry.missingDevices.Inc()
 		return streamKey{}, fmt.Errorf("Error getting GPU device for process %d: %w", pid, err)
-	} else {
-		var ret nvml.Return
-		key.gpuUUID, ret = gpuDevice.GetUUID()
-		if ret != nvml.SUCCESS {
-			return streamKey{}, fmt.Errorf("Error getting GPU UUID for process %d: %v", pid, nvml.ErrorString(ret))
-		}
+	}
+
+	var ret nvml.Return
+	key.gpuUUID, ret = gpuDevice.GetUUID()
+	if ret != nvml.SUCCESS {
+		return streamKey{}, fmt.Errorf("Error getting GPU UUID for process %d: %v", pid, nvml.ErrorString(ret))
 	}
 
 	if header.Stream_id != 0 {

--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -59,7 +59,8 @@ func TestGetStreamKeyUpdatesCorrectlyWhenChangingDevice(t *testing.T) {
 	// Configure the visible devices for our process
 	ctx.visibleDevicesCache[int(pid)] = []nvml.Device{testutil.GetDeviceMock(0), testutil.GetDeviceMock(1)}
 
-	streamKey := consumer.getStreamKey(&headerStreamSpecific)
+	streamKey, err := consumer.getStreamKey(&headerStreamSpecific)
+	require.NoError(t, err)
 	require.NotNil(t, streamKey)
 	require.Equal(t, pid, streamKey.pid)
 	require.Equal(t, streamID, streamKey.stream)
@@ -68,7 +69,9 @@ func TestGetStreamKeyUpdatesCorrectlyWhenChangingDevice(t *testing.T) {
 	require.Equal(t, testutil.GPUUUIDs[0], streamKey.gpuUUID)
 
 	// Check the same thing happens with the global stream
-	globalStreamKey := consumer.getStreamKey(&headerGlobalStream)
+	globalStreamKey, err := consumer.getStreamKey(&headerGlobalStream)
+
+	require.NoError(t, err)
 	require.NotNil(t, globalStreamKey)
 	require.Equal(t, pid, globalStreamKey.pid)
 	require.Equal(t, globalStream, globalStreamKey.stream)
@@ -87,14 +90,16 @@ func TestGetStreamKeyUpdatesCorrectlyWhenChangingDevice(t *testing.T) {
 
 	// The stream key for the specific stream should not change, as streams are per-device
 	// and cannot change devices during its lifetime
-	streamKey = consumer.getStreamKey(&headerStreamSpecific)
+	streamKey, err = consumer.getStreamKey(&headerStreamSpecific)
+	require.NoError(t, err)
 	require.NotNil(t, streamKey)
 	require.Equal(t, pid, streamKey.pid)
 	require.Equal(t, streamID, streamKey.stream)
 	require.Equal(t, testutil.GPUUUIDs[0], streamKey.gpuUUID)
 
 	// The global stream should change, as the global stream can change devices
-	globalStreamKey = consumer.getStreamKey(&headerGlobalStream)
+	globalStreamKey, err = consumer.getStreamKey(&headerGlobalStream)
+	require.NoError(t, err)
 	require.NotNil(t, globalStreamKey)
 	require.Equal(t, pid, globalStreamKey.pid)
 	require.Equal(t, globalStream, globalStreamKey.stream)

--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -11,10 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
+	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -31,4 +33,70 @@ func TestConsumerCanStartAndStop(t *testing.T) {
 
 	consumer.Stop()
 	require.Eventually(t, func() bool { return !consumer.running.Load() }, 100*time.Millisecond, 10*time.Millisecond)
+}
+
+func TestGetStreamKeyUpdatesCorrectlyWhenChangingDevice(t *testing.T) {
+	ctx, err := getSystemContext(testutil.GetBasicNvmlMock(), kernel.ProcFSRoot(), testutil.GetWorkloadMetaMock(t), testutil.GetTelemetryMock(t))
+	require.NoError(t, err)
+
+	consumer := newCudaEventConsumer(ctx, nil, nil, testutil.GetTelemetryMock(t))
+
+	pid := uint32(1)
+	pidTgid := uint64(pid)<<32 + uint64(pid)
+
+	streamID := uint64(120)
+	headerStreamSpecific := gpuebpf.CudaEventHeader{
+		Pid_tgid:  pidTgid,
+		Stream_id: streamID,
+	}
+
+	globalStream := uint64(0)
+	headerGlobalStream := gpuebpf.CudaEventHeader{
+		Pid_tgid:  pidTgid,
+		Stream_id: globalStream,
+	}
+
+	// Configure the visible devices for our process
+	ctx.visibleDevicesCache[int(pid)] = []nvml.Device{testutil.GetDeviceMock(0), testutil.GetDeviceMock(1)}
+
+	streamKey := consumer.getStreamKey(&headerStreamSpecific)
+	require.NotNil(t, streamKey)
+	require.Equal(t, pid, streamKey.pid)
+	require.Equal(t, streamID, streamKey.stream)
+
+	// The stream should have the default selected device, which is 0
+	require.Equal(t, testutil.GPUUUIDs[0], streamKey.gpuUUID)
+
+	// Check the same thing happens with the global stream
+	globalStreamKey := consumer.getStreamKey(&headerGlobalStream)
+	require.NotNil(t, globalStreamKey)
+	require.Equal(t, pid, globalStreamKey.pid)
+	require.Equal(t, globalStream, globalStreamKey.stream)
+
+	// Again, this should be on the default device
+	require.Equal(t, testutil.GPUUUIDs[0], globalStreamKey.gpuUUID)
+
+	// Now we trigger a setDevice event on this process
+	setDev := gpuebpf.CudaSetDeviceEvent{
+		Header: gpuebpf.CudaEventHeader{
+			Pid_tgid: pidTgid,
+		},
+		Device: 1,
+	}
+	consumer.handleSetDevice(&setDev)
+
+	// The stream key for the specific stream should not change, as streams are per-device
+	// and cannot change devices during its lifetime
+	streamKey = consumer.getStreamKey(&headerStreamSpecific)
+	require.NotNil(t, streamKey)
+	require.Equal(t, pid, streamKey.pid)
+	require.Equal(t, streamID, streamKey.stream)
+	require.Equal(t, testutil.GPUUUIDs[0], streamKey.gpuUUID)
+
+	// The global stream should change, as the global stream can change devices
+	globalStreamKey = consumer.getStreamKey(&headerGlobalStream)
+	require.NotNil(t, globalStreamKey)
+	require.Equal(t, pid, globalStreamKey.pid)
+	require.Equal(t, globalStream, globalStreamKey.stream)
+	require.Equal(t, testutil.GPUUUIDs[1], globalStreamKey.gpuUUID)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Change the logic for assigning stream keys to events. CUDA streams are associated to a single device (the one active at the time of the stream creation) and therefore we shouldn't change their device once they're created. The global stream, on the other hand, can change its current device. 

### Motivation

Accuracy of the solution with respect to actual CUDA behavior.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added a unit tests, existing unit tests should pass.

### Possible Drawbacks / Trade-offs

This solution is implemented as a temporary patch. After 7.64 we will refactor the code and take into account these issues to build a better architecture.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->