### PR TITLE
fix(slack): Use a single token

### DIFF
--- a/.github/workflows/assess_permissions.yml
+++ b/.github/workflows/assess_permissions.yml
@@ -37,5 +37,5 @@ jobs:
             - name: Assess Repository Permissions
               env:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+                SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
               run: inv -e github.check-permissions --repo ${{ matrix.value }}

--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -26,6 +26,6 @@ jobs:
     - name: Assign issue
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SLACK_API_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+        SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
       run: |
         inv -e issue.assign-owner -i ${{ github.event.issue.number }}

--- a/.github/workflows/chase_release_managers.yml
+++ b/.github/workflows/chase_release_managers.yml
@@ -32,7 +32,7 @@ jobs:
       env:
         ATLASSIAN_USERNAME : ${{ secrets.ATLASSIAN_USERNAME }}
         ATLASSIAN_PASSWORD : ${{ secrets.ATLASSIAN_PASSWORD }}
-        SLACK_API_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+        SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
         VERSION: ${{ github.event.inputs.version }}
       run: |
         inv -e release.chase-release-managers --version "$VERSION"

--- a/.github/workflows/create_rc_pr.yml
+++ b/.github/workflows/create_rc_pr.yml
@@ -98,7 +98,7 @@ jobs:
               env:
                 ATLASSIAN_USERNAME: ${{ secrets.ATLASSIAN_USERNAME }}
                 ATLASSIAN_PASSWORD: ${{ secrets.ATLASSIAN_PASSWORD }}
-                SLACK_API_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+                SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
                 MATRIX: ${{ matrix.value }}
                 WARNING: ${{ needs.find_release_branches.outputs.warning }}
               run: |

--- a/.github/workflows/external-contributor.yml
+++ b/.github/workflows/external-contributor.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_API_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          SLACK_DATADOG_AGENT_BOT_TOKEN: ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.number }}
           # labels is a comma-separated list of tags

--- a/.github/workflows/label-analysis.yml
+++ b/.github/workflows/label-analysis.yml
@@ -157,5 +157,5 @@ jobs:
         run: pip install -r requirements.txt -r tasks/requirements.txt --break-system-packages
       - name: Ask for code reviews
         env:
-          SLACK_API_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
+          SLACK_DATADOG_AGENT_BOT_TOKEN : ${{ secrets.SLACK_DATADOG_AGENT_BOT_TOKEN }}
         run: inv -e issue.ask-reviews -p ${{ github.event.pull_request.number }}

--- a/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/internal_kubernetes_deploy.yml
@@ -81,5 +81,5 @@ notify-slack:
   script:
     - export SDM_JWT=$(vault read -field=token identity/oidc/token/sdm)
     - python3 -m pip install -r tasks/requirements.txt -r tasks/libs/requirements-notifications.txt
-    - SLACK_API_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_API_TOKEN
+    - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - inv pipeline.changelog ${CI_COMMIT_SHORT_SHA} || exit $?

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -3,7 +3,7 @@
 # Contains jobs which send notifications depending on pipeline status.
 
 .notify_setup:
-  - SLACK_API_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_API_TOKEN
+  - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
   - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN
   - DD_API_KEY=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_API_KEY_ORG2 token) || exit $?; export DD_API_KEY
   - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt
@@ -24,7 +24,7 @@ notify-on-tagged-success:
     MESSAGE_TEXT=":host-green: Tagged build <$CI_PIPELINE_URL|$CI_PIPELINE_ID> succeeded.
     *$CI_COMMIT_REF_NAME* is available in the staging repositories."
     python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt
-    SLACK_API_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_API_TOKEN
+    SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     invoke notify.post-message -c "#agent-release-sync" -m "$MESSAGE_TEXT"
 
 notify:

--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -102,7 +102,7 @@ generate_windows_gitlab_runner_bump_pr:
     - !reference [.setup_github_app_agent_platform_auto_pr]
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
-    - SLACK_API_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_API_TOKEN
+    - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - inv -e github.update-windows-runner-version
 
 # Manual job to generate the gitlab bump pr on buildenv if trigger_auto_staging_release fails
@@ -123,5 +123,5 @@ generate_windows_gitlab_runner_bump_pr_manual:
     - !reference [.setup_github_app_agent_platform_auto_pr]
     - python3 -m pip install -r requirements.txt -r tasks/libs/requirements-notifications.txt
     - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
-    - SLACK_API_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_API_TOKEN
+    - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - inv -e github.update-windows-runner-version

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -144,7 +144,7 @@ def _update_windows_runner_version(new_version=None, buildenv_ref="master"):
 
     from slack_sdk import WebClient
 
-    client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+    client = WebClient(token=os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     client.chat_postMessage(channel="ci-infra-support", text=message)
     return workflow_conclusion
 
@@ -347,7 +347,7 @@ def handle_community_pr(_, repo='', pr_id=-1, labels=''):
     message = f':pr: *New Community PR*\n{title} <{pr.html_url}|{repo}#{pr_id}>'
 
     # Post message
-    client = WebClient(os.environ['SLACK_API_TOKEN'])
+    client = WebClient(os.environ['SLACK_DATADOG_AGENT_BOT_TOKEN'])
     for channel in channels:
         client.chat_postMessage(channel=channel, text=message)
 
@@ -713,7 +713,7 @@ def check_permissions(_, repo: str, channel: str = "agent-devx-help"):
     if idle_teams or idle_contributors:
         from slack_sdk import WebClient
 
-        client = WebClient(token=os.environ['SLACK_API_TOKEN'])
+        client = WebClient(token=os.environ['SLACK_DATADOG_AGENT_BOT_TOKEN'])
         header = f":github: {repo} permissions check\n"
         blocks = [
             {

--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -27,7 +27,7 @@ def assign_owner(_, issue_id, dry_run=False):
         # Post message
         from slack_sdk import WebClient
 
-        client = WebClient(os.environ['SLACK_API_TOKEN'])
+        client = WebClient(os.environ['SLACK_DATADOG_AGENT_BOT_TOKEN'])
         channel = next((chan for team, chan in GITHUB_SLACK_MAP.items() if owner.lower() in team), HELP_SLACK_CHANNEL)
         message = f':githubstatus_partial_outage: *New Community Issue*\n{issue.title} <{issue.html_url}|{gh.repo.name}#{issue_id}>\n'
         if channel == '#agent-ask-anything':
@@ -55,7 +55,7 @@ def ask_reviews(_, pr_id):
 
         from slack_sdk import WebClient
 
-        client = WebClient(os.environ['SLACK_API_TOKEN'])
+        client = WebClient(os.environ['SLACK_DATADOG_AGENT_BOT_TOKEN'])
         emojis = client.emoji_list()
         waves = [emoji for emoji in emojis.data['emoji'] if 'wave' in emoji and 'microwave' not in emoji]
         for reviewer in reviewers:

--- a/tasks/libs/notify/alerts.py
+++ b/tasks/libs/notify/alerts.py
@@ -233,7 +233,7 @@ def send_notification(ctx: Context, alert_jobs, jobowners=".gitlab/JOBOWNERS"):
         if message:
             from slack_sdk import WebClient
 
-            client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+            client = WebClient(token=os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
             client.chat_postMessage(channel=channel, text=message)
 
             # Create metrics for consecutive and cumulative alerts

--- a/tasks/libs/notify/failure_summary.py
+++ b/tasks/libs/notify/failure_summary.py
@@ -303,7 +303,7 @@ def send_summary_slack_notification(
         print(f'Would send to {channel}:')
         print(blocks)
     else:
-        client = WebClient(os.environ["SLACK_API_TOKEN"])
+        client = WebClient(os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
         client.chat_postMessage(channel=channel, blocks=blocks, text=alt_message)
 
 

--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -69,7 +69,7 @@ def send_message(pipeline_id, dry_run):
     from slack_sdk import WebClient
     from slack_sdk.errors import SlackApiError
 
-    client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+    client = WebClient(token=os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     client.chat_postMessage(channel=slack_channel, text=str(message))
     if should_send_message_to_author(pipeline.ref, get_default_branch()):
         author_email = commit.author_email

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -183,5 +183,5 @@ def warn_new_commits(release_managers, team, branch, next_rc):
     message += f"Could you please release and tag your repo to prepare the {next_rc} `datadog-agent` release candidate planned <{rc_schedule_link}|{rc_date.strftime('%Y-%m-%d %H:%M')}> UTC?\n"
     message += "Thanks in advance!\n"
     message += f"cc {' '.join(release_managers)}"
-    client = WebClient(os.environ["SLACK_API_TOKEN"])
+    client = WebClient(os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     client.chat_postMessage(channel=f"#{team}", text=message)

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -286,5 +286,5 @@ def post_message(_: Context, channel: str, message: str):
     """
     from slack_sdk import WebClient
 
-    client = WebClient(token=os.environ['SLACK_API_TOKEN'])
+    client = WebClient(token=os.environ['SLACK_DATADOG_AGENT_BOT_TOKEN'])
     client.chat_postMessage(channel=channel, text=message)

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -477,7 +477,7 @@ def changelog(ctx, new_commit_sha):
     from slack_sdk import WebClient
     from slack_sdk.errors import SlackApiError
 
-    client = WebClient(token=os.environ["SLACK_API_TOKEN"])
+    client = WebClient(token=os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     # Environment variable to deal with both local and CI environments
     if "CI_PROJECT_DIR" in os.environ:
         parent_dir = os.environ["CI_PROJECT_DIR"]

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1142,7 +1142,7 @@ def chase_release_managers(_, version):
 
     from slack_sdk import WebClient
 
-    client = WebClient(os.environ["SLACK_API_TOKEN"])
+    client = WebClient(os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     for channel in sorted(channels):
         print(f"Sending message to {channel}")
         client.chat_postMessage(channel=channel, text=message)
@@ -1161,7 +1161,7 @@ def chase_for_qa_cards(_, version):
         grouped_cards[card["fields"]["project"]["key"]].append(card)
     GITHUB_SLACK_MAP = load_and_validate("github_slack_map.yaml", "DEFAULT_SLACK_CHANNEL", DEFAULT_SLACK_CHANNEL)
     GITHUB_JIRA_MAP = load_and_validate("github_jira_map.yaml", "DEFAULT_JIRA_PROJECT", DEFAULT_JIRA_PROJECT)
-    client = WebClient(os.environ["SLACK_API_TOKEN"])
+    client = WebClient(os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     print(f"Found {len(cards)} QA cards to chase")
     for project, cards in grouped_cards.items():
         team = next(team for team, jira_project in GITHUB_JIRA_MAP.items() if project == jira_project)

--- a/tasks/unit_tests/github_tasks_tests.py
+++ b/tasks/unit_tests/github_tasks_tests.py
@@ -468,7 +468,7 @@ class TestCheckQALabels(unittest.TestCase):
 
 
 class TestCheckPermissions(unittest.TestCase):
-    @patch.dict('os.environ', {'SLACK_API_TOKEN': 'coucou'})
+    @patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'coucou'})
     @patch('slack_sdk.WebClient', autospec=True)
     @patch("tasks.libs.ciproviders.github_api.GithubAPI", autospec=True)
     def test_empty_team(self, gh_mock, web_mock):
@@ -504,7 +504,7 @@ class TestCheckPermissions(unittest.TestCase):
             text=":github: antagonist-ai permissions check\nTeams:\n - <http://secret-agent|secret-agent>\n",
         )
 
-    @patch.dict('os.environ', {'SLACK_API_TOKEN': 'coucou'})
+    @patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'coucou'})
     @patch('slack_sdk.WebClient', autospec=True)
     @patch("tasks.libs.ciproviders.github_api.GithubAPI", autospec=True)
     def test_idle_team(self, gh_mock, web_mock):
@@ -556,7 +556,7 @@ class TestCheckPermissions(unittest.TestCase):
             text=":github: antagonist-ai permissions check\nTeams:\n - <http://secret-agent|secret-agent>\nContributors: defaultdict(<class 'set'>, {'secret-agent': {'tornado'}})\n",
         )
 
-    @patch.dict('os.environ', {'SLACK_API_TOKEN': 'coucou'})
+    @patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'coucou'})
     @patch('slack_sdk.WebClient', autospec=True)
     @patch("tasks.libs.ciproviders.github_api.GithubAPI", autospec=True)
     def test_idle_contributor(self, gh_mock, web_mock):

--- a/tasks/unit_tests/libs/notify/alerts_tests.py
+++ b/tasks/unit_tests/libs/notify/alerts_tests.py
@@ -229,7 +229,7 @@ class TestAlertsSendNotification(unittest.TestCase):
 
     @patch("tasks.libs.notify.alerts.send_metrics")
     @patch('slack_sdk.WebClient', autospec=True)
-    @patch.dict('os.environ', {'SLACK_API_TOKEN': 'coucou'})
+    @patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'coucou'})
     @patch.object(alerts.ConsecutiveJobAlert, 'message', lambda self, _: '\n'.join(self.failures) + '\n')
     @patch.object(alerts.CumulativeJobAlert, 'message', lambda self: '\n'.join(self.failures))
     @patch('tasks.owners.GITHUB_SLACK_MAP', get_github_slack_map())

--- a/tasks/unit_tests/libs/notify/alerts_tests.py
+++ b/tasks/unit_tests/libs/notify/alerts_tests.py
@@ -293,7 +293,7 @@ class TestAlertsSendNotification(unittest.TestCase):
 
     @patch("tasks.libs.notify.alerts.send_metrics")
     @patch('slack_sdk.WebClient', autospec=True)
-    @patch.dict('os.environ', {'SLACK_API_TOKEN': 'coucou'})
+    @patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'coucou'})
     @patch.object(alerts.ConsecutiveJobAlert, 'message', lambda self, _: '\n'.join(self.failures) + '\n')
     @patch.object(alerts.CumulativeJobAlert, 'message', lambda self: '\n'.join(self.failures))
     @patch('tasks.owners.GITHUB_SLACK_MAP', get_github_slack_map())

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -45,7 +45,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:59:48.396Z"
         list_mock = repo_mock.pipelines.get.return_value.jobs.list
         list_mock.side_effect = [get_fake_jobs(), []]
-        with patch.dict('os.environ', {'SLACK_API_TOKEN': 'coin'}, clear=True):
+        with patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'coin'}, clear=True):
             notify.send_message(MockContext(), "42", dry_run=True)
         list_mock.assert_called()
         repo_mock.pipelines.get.assert_called_with("42")
@@ -128,7 +128,7 @@ class TestSendMessage(unittest.TestCase):
             )
         )
         get_failed_jobs_mock.return_value = failed
-        with patch.dict('os.environ', {'SLACK_API_TOKEN': 'meuh'}, clear=True):
+        with patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'meuh'}, clear=True):
             notify.send_message(MockContext(), "42", dry_run=True)
         self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
         get_failed_jobs_mock.assert_called()
@@ -224,7 +224,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
         repo_mock.pipelines.get.return_value.finished_at = None
 
-        with patch.dict('os.environ', {'SLACK_API_TOKEN': 'ouaf'}, clear=True):
+        with patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'ouaf'}, clear=True):
             notify.send_message(MockContext(), "42", dry_run=True)
         self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
         trace_mock.assert_called()
@@ -233,7 +233,7 @@ class TestSendMessage(unittest.TestCase):
 
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
     @patch('slack_sdk.WebClient', new=MagicMock())
-    @patch.dict('os.environ', {'DEPLOY_AGENT': 'true', 'SLACK_API_TOKEN': 'hihan'})
+    @patch.dict('os.environ', {'DEPLOY_AGENT': 'true', 'SLACK_DATADOG_AGENT_BOT_TOKEN': 'hihan'})
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('builtins.print')
     def test_deploy_with_get_failed_call(self, print_mock, api_mock):
@@ -273,7 +273,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
         repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:59:48.396Z"
 
-        with patch.dict('os.environ', {'SLACK_API_TOKEN': 'miaou'}, clear=True):
+        with patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'miaou'}, clear=True):
             notify.send_message(MockContext(), "42", dry_run=True)
         self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
         self.assertTrue("[:hourglass: 60 min]" in print_mock.mock_calls[0].args[0])
@@ -284,7 +284,8 @@ class TestSendMessage(unittest.TestCase):
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
     @patch('slack_sdk.WebClient', new=MagicMock())
     @patch.dict(
-        'os.environ', {'DDR': 'true', 'DDR_WORKFLOW_ID': '1337', 'DEPLOY_AGENT': 'false', 'SLACK_API_TOKEN': 'ni'}
+        'os.environ',
+        {'DDR': 'true', 'DDR_WORKFLOW_ID': '1337', 'DEPLOY_AGENT': 'false', 'SLACK_DATADOG_AGENT_BOT_TOKEN': 'ni'},
     )
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('builtins.print')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use a single token for slack calls

### Motivation
Remove one of the secrets we use

### Describe how you validated your changes
I'll wait the [CI execution](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/56077021) for the call to notification job
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
I chose to keep the older name because it implied less changes, even if the name is less precise.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->