### PR TITLE
[CONTINT-4587] Port legacy integration docker e2e tests

### DIFF
--- a/test/new-e2e/tests/containers/docker_test.go
+++ b/test/new-e2e/tests/containers/docker_test.go
@@ -75,6 +75,78 @@ func (suite *DockerSuite) TestDockerMetrics() {
 			},
 		})
 	}
+
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "docker.images.available",
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{},
+			Value: &testMetricExpectValueArgs{
+				Min: 4,
+				Max: 4,
+			},
+		},
+	})
+
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "docker.images.intermediate",
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{},
+			Value: &testMetricExpectValueArgs{
+				Min: 0,
+				Max: 0,
+			},
+		},
+	})
+
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "docker.containers.running",
+			Tags: []string{`^short_image:redis$`},
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{
+				`^docker_image:public.ecr.aws/docker/library/redis:latest$`,
+				`^image_id:sha256:`,
+				`^image_name:public.ecr.aws/docker/library/redis$`,
+				`^image_tag:latest$`,
+				`^short_image:redis$`,
+			},
+			Value: &testMetricExpectValueArgs{
+				Min: 1,
+				Max: 1,
+			},
+		},
+	})
+
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "docker.containers.running.total",
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{},
+			Value: &testMetricExpectValueArgs{
+				Min: 5,
+				Max: 5,
+			},
+		},
+	})
+
+	suite.testMetric(&testMetricArgs{
+		Filter: testMetricFilterArgs{
+			Name: "docker.containers.stopped.total",
+		},
+		Expect: testMetricExpectArgs{
+			Tags: &[]string{},
+			Value: &testMetricExpectValueArgs{
+				Min: 0,
+				Max: 0,
+			},
+		},
+	})
 }
 
 func (suite *DockerSuite) TestDSDWithUDS() {


### PR DESCRIPTION
### What does this PR do?

Port the legacy integration docker e2e tests from [`test/integration/corechecks/docker/globalmetrics_test.go`](https://github.com/DataDog/datadog-agent/blob/main/test/integration/corechecks/docker/globalmetrics_test.go) to the new e2e framework.

### Motivation

Get rid of tests run only on CircleCI.

### Describe how you validated your changes

Let the e2e tests run.

### Possible Drawbacks / Trade-offs

### Additional Notes

Follow-up of #32895 which was porting the tests of [`test/integration/corechecks/docker/basemetrics_test.go`](https://github.com/DataDog/datadog-agent/blob/main/test/integration/corechecks/docker/basemetrics_test.go).