### PR TITLE
[CWS] Fix panic when appending variable field

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -182,6 +182,9 @@ func (s *ScopedStringArrayVariable) Set(ctx *Context, value interface{}) error {
 
 // Append a value to the array
 func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) error {
+	if reflect.TypeOf(value).Kind() == reflect.String {
+		value = []string{value.(string)}
+	}
 	return s.Set(ctx, append(s.strFnc(ctx), value.([]string)...))
 }
 
@@ -223,6 +226,9 @@ func (v *ScopedIntArrayVariable) Set(ctx *Context, value interface{}) error {
 
 // Append a value to the array
 func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
+	if reflect.TypeOf(value).Kind() == reflect.Int {
+		value = []int{value.(int)}
+	}
 	return v.Set(ctx, append(v.intFnc(ctx), value.([]int)...))
 }
 

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -182,8 +182,8 @@ func (s *ScopedStringArrayVariable) Set(ctx *Context, value interface{}) error {
 
 // Append a value to the array
 func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) error {
-	if reflect.TypeOf(value).Kind() == reflect.String {
-		value = []string{value.(string)}
+	if val, ok := value.(string); ok {
+		value = []string{val}
 	}
 	return s.Set(ctx, append(s.strFnc(ctx), value.([]string)...))
 }
@@ -226,8 +226,8 @@ func (v *ScopedIntArrayVariable) Set(ctx *Context, value interface{}) error {
 
 // Append a value to the array
 func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
-	if reflect.TypeOf(value).Kind() == reflect.Int {
-		value = []int{value.(int)}
+	if val, ok := value.(int); ok {
+		value = []int{val}
 	}
 	return v.Set(ctx, append(v.intFnc(ctx), value.([]int)...))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fix the panic error that happens when we try appending a string secl variable during rule evaluation.
<img width="1500" alt="Capture d’écran 2025-02-17 à 15 44 32" src="https://github.com/user-attachments/assets/1ed3695e-e8b5-48f9-b712-7ebf1187c500" />

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->