### PR TITLE
Force the milestone name to the '0' patch when opening a PR

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -736,11 +736,16 @@ Make sure that milestone is open before trying again.""",
 
 
 def create_release_pr(title, base_branch, target_branch, version, changelog_pr=False, milestone=None):
-    milestone_name = milestone or str(version)
+    if milestone:
+        milestone_name = milestone
+    else:
+        # The milestone name is always using the .0 patch version (at least for now)
+        # Unless we pass explicitly the name, we use the version and force the patch version
+        milestone_name = str(version)
+        milestone_name = re.sub('.[0-9]+$', '.0', milestone_name)
 
     labels = [
         "team/agent-delivery",
-        "team/agent-release-management",
     ]
     if changelog_pr:
         labels.append(f"backport/{get_default_branch()}")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1417,6 +1417,7 @@ def bump_integrations_core(ctx, slack_webhook=None):
     current = current_version(ctx, 7)
     current.rc = False
     current.devel = False
+    current.patch = 0
     pr_url = create_datadog_agent_pr(
         commit_message, main_branch, bump_integrations_core_branch, str(current), body=github_workflow_url
     )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Force the milestone name to the '0' patch when opening a PR

### Motivation

We currently always use the `7.XX.0` milestone, even if the PR is for a patch release `7.XX.Y`, where Y != 0. It's a bit confusing but we use it as `7.64.x`. This is a problem in our tasks breaks opening PRs when the version is for a patch release because of this, trying to create a PR with a milestone that does not exist. This PR quickly fixes that. 

However, we should probably think about that milestone and how we use it. Should we rename them to `7.YY.x`, our should we use the "real" patch version in the milestone? I do not have a definite answer yet but we'll think about it

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->