### PR TITLE
fix(create_rc_pr): Replace tag by a slack message in `check_for_changes`

### DIFF
--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -185,3 +185,10 @@ def warn_new_commits(release_managers, team, branch, next_rc):
     message += f"cc {' '.join(release_managers)}"
     client = WebClient(os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
     client.chat_postMessage(channel=f"#{team}", text=message)
+
+
+def warn_new_tags(message):
+    from slack_sdk import WebClient
+
+    client = WebClient(os.environ["SLACK_DATADOG_AGENT_BOT_TOKEN"])
+    client.chat_postMessage(channel="#agent-release-sync", text=message)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Replace the `push tag` actions from this task by a slack message sent to the release team.

### Motivation
We currently don't have permissions to update other repositories from the `datadog-agent` side (see [failure example](https://github.com/DataDog/datadog-agent/actions/runs/13330773423/job/37234162959)). We could change this but:
- the simplest way would be to [push in https](https://stackoverflow.com/a/22852314) with the appropriate token, which creates a risk of token leak
- It is really rare to have updates on the release branch of side repositories (`macos-build`, `omnibus`) during an agent release.
- It is simple to ask the addition of the tag if we backport something on these repos.
As a consequence we decided to send a message instead of trying to do write actions.

### Describe how you validated your changes
Updated the UT
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->