### PR TITLE
fix(github): Remove deprecated fields of the `datadog-static-analysis` action

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -20,7 +20,5 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_STATIC_ANALYZER_API_KEY }}
         dd_app_key: ${{ secrets.DD_STATIC_ANALYZER_APP_KEY }}
-        dd_service: datadog-agent
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR removes deprecated fields in the datadog-static-analyzer-github-action. There should be no functional impact or changes observed, as these fields are effectively no-ops today.

Duplicate of #33839 from someone with write permissions on the repo cc @amaanq


### Motivation
https://datadoghq.atlassian.net/browse/K9VULN-3470

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->