### PR TITLE
[EBPF] gpu: add memory usage percentage

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -34,10 +34,12 @@ import (
 )
 
 const (
-	gpuMetricsNs     = "gpu."
-	metricNameMemory = gpuMetricsNs + "memory"
-	metricNameUtil   = gpuMetricsNs + "utilization"
-	metricNameMaxMem = gpuMetricsNs + "memory.max"
+	gpuMetricsNs         = "gpu."
+	metricNameUtil       = gpuMetricsNs + "utilization"
+	metricNameMemory     = gpuMetricsNs + "memory.used"
+	metricNameMaxMem     = gpuMetricsNs + "memory.used.max"
+	metricNameMemoryPerc = gpuMetricsNs + "memory.utilization"
+	metricNameMaxMemPerc = gpuMetricsNs + "memory.utilization.max"
 )
 
 // Check represents the GPU check that will be periodically executed via the Run() function
@@ -187,6 +189,8 @@ func (c *Check) emitSysprobeMetrics(snd sender.Sender) error {
 		snd.Gauge(metricNameUtil, metrics.UtilizationPercentage, "", tags)
 		snd.Gauge(metricNameMemory, float64(metrics.Memory.CurrentBytes), "", tags)
 		snd.Gauge(metricNameMaxMem, float64(metrics.Memory.MaxBytes), "", tags)
+		snd.Gauge(metricNameMemoryPerc, metrics.Memory.CurrentBytesPercentage, "", tags)
+		snd.Gauge(metricNameMaxMemPerc, metrics.Memory.MaxBytesPercentage, "", tags)
 
 		c.activeMetrics[key] = true
 	}

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -37,9 +37,7 @@ const (
 	gpuMetricsNs         = "gpu."
 	metricNameUtil       = gpuMetricsNs + "utilization"
 	metricNameMemory     = gpuMetricsNs + "memory.used"
-	metricNameMaxMem     = gpuMetricsNs + "memory.used.max"
 	metricNameMemoryPerc = gpuMetricsNs + "memory.utilization"
-	metricNameMaxMemPerc = gpuMetricsNs + "memory.utilization.max"
 )
 
 // Check represents the GPU check that will be periodically executed via the Run() function
@@ -188,9 +186,7 @@ func (c *Check) emitSysprobeMetrics(snd sender.Sender) error {
 		tags := c.getTagsForKey(key)
 		snd.Gauge(metricNameUtil, metrics.UtilizationPercentage, "", tags)
 		snd.Gauge(metricNameMemory, float64(metrics.Memory.CurrentBytes), "", tags)
-		snd.Gauge(metricNameMaxMem, float64(metrics.Memory.MaxBytes), "", tags)
 		snd.Gauge(metricNameMemoryPerc, metrics.Memory.CurrentBytesPercentage, "", tags)
-		snd.Gauge(metricNameMaxMemPerc, metrics.Memory.MaxBytesPercentage, "", tags)
 
 		c.activeMetrics[key] = true
 	}
@@ -202,7 +198,6 @@ func (c *Check) emitSysprobeMetrics(snd sender.Sender) error {
 		if !active {
 			tags := c.getTagsForKey(key)
 			snd.Gauge(metricNameMemory, 0, "", tags)
-			snd.Gauge(metricNameMaxMem, 0, "", tags)
 			snd.Gauge(metricNameUtil, 0, "", tags)
 
 			delete(c.activeMetrics, key)

--- a/pkg/collector/corechecks/gpu/model/model.go
+++ b/pkg/collector/corechecks/gpu/model/model.go
@@ -9,10 +9,16 @@ package model
 
 // MemoryMetrics contains the memory stats for a given memory type
 type MemoryMetrics struct {
-	CurrentBytes           uint64  `json:"current_bytes"`
-	MaxBytes               uint64  `json:"max_bytes"`
+	// CurrentBytes is the amount of memory that is allocated when the stats are generated.
+	CurrentBytes uint64 `json:"current_bytes"`
+
+	// MaxBytes is the maximum amount of memory that has been allocated in the interval.
+	// While it's not reported to the backend, we leave it as it's useful for debugging
+	// and unit testing.
+	MaxBytes uint64 `json:"max_bytes"`
+
+	// CurrentBytesPercentage is the percentage (0-1) of the current memory usage compared to the total memory available.
 	CurrentBytesPercentage float64 `json:"current_bytes_percentage"`
-	MaxBytesPercentage     float64 `json:"max_bytes_percentage"`
 }
 
 // UtilizationMetrics contains the GPU stats for a given device and process

--- a/pkg/collector/corechecks/gpu/model/model.go
+++ b/pkg/collector/corechecks/gpu/model/model.go
@@ -9,8 +9,10 @@ package model
 
 // MemoryMetrics contains the memory stats for a given memory type
 type MemoryMetrics struct {
-	CurrentBytes uint64 `json:"current_bytes"`
-	MaxBytes     uint64 `json:"max_bytes"`
+	CurrentBytes           uint64  `json:"current_bytes"`
+	MaxBytes               uint64  `json:"max_bytes"`
+	CurrentBytesPercentage float64 `json:"current_bytes_percentage"`
+	MaxBytesPercentage     float64 `json:"max_bytes_percentage"`
 }
 
 // UtilizationMetrics contains the GPU stats for a given device and process

--- a/pkg/collector/corechecks/gpu/model/model.go
+++ b/pkg/collector/corechecks/gpu/model/model.go
@@ -17,7 +17,9 @@ type MemoryMetrics struct {
 	// and unit testing.
 	MaxBytes uint64 `json:"max_bytes"`
 
-	// CurrentBytesPercentage is the percentage (0-1) of the current memory usage compared to the total memory available.
+	// CurrentBytesPercentage is the percentage of the current memory
+	// usage compared to the total memory available: CurrentBytesPercentage =
+	// CurrentBytes / Total Device Memory, so it's a value between 0 and 1.
 	CurrentBytesPercentage float64 `json:"current_bytes_percentage"`
 }
 

--- a/pkg/gpu/aggregator.go
+++ b/pkg/gpu/aggregator.go
@@ -40,11 +40,15 @@ type aggregator struct {
 
 	// deviceMaxThreads is the maximum number of threads the GPU can run in parallel, for utilization calculations
 	deviceMaxThreads uint64
+
+	// deviceMemory is the total memory available on the GPU, in bytes
+	deviceMemory uint64
 }
 
-func newAggregator(deviceMaxThreads uint64) *aggregator {
+func newAggregator(deviceMaxThreads uint64, deviceMemory uint64) *aggregator {
 	return &aggregator{
 		deviceMaxThreads: deviceMaxThreads,
+		deviceMemory:     deviceMemory,
 	}
 }
 
@@ -121,6 +125,8 @@ func (agg *aggregator) getStats(utilizationNormFactor float64) model.Utilization
 		lastValue, maxValue := memTsBuilder.GetLastAndMax()
 		stats.Memory.CurrentBytes += uint64(lastValue)
 		stats.Memory.MaxBytes += uint64(maxValue)
+		stats.Memory.CurrentBytesPercentage = float64(stats.Memory.CurrentBytes) / float64(agg.deviceMemory)
+		stats.Memory.MaxBytesPercentage = float64(stats.Memory.MaxBytes) / float64(agg.deviceMemory)
 	}
 
 	// Flush the data that we used

--- a/pkg/gpu/aggregator.go
+++ b/pkg/gpu/aggregator.go
@@ -125,9 +125,9 @@ func (agg *aggregator) getStats(utilizationNormFactor float64) model.Utilization
 		lastValue, maxValue := memTsBuilder.GetLastAndMax()
 		stats.Memory.CurrentBytes += uint64(lastValue)
 		stats.Memory.MaxBytes += uint64(maxValue)
-		stats.Memory.CurrentBytesPercentage = float64(stats.Memory.CurrentBytes) / float64(agg.deviceMemory)
-		stats.Memory.MaxBytesPercentage = float64(stats.Memory.MaxBytes) / float64(agg.deviceMemory)
 	}
+
+	stats.Memory.CurrentBytesPercentage = float64(stats.Memory.CurrentBytes) / float64(agg.deviceMemory)
 
 	// Flush the data that we used
 	agg.flush()

--- a/pkg/gpu/stats.go
+++ b/pkg/gpu/stats.go
@@ -120,7 +120,12 @@ func (g *statsGenerator) getOrCreateAggregator(sKey streamKey) (*aggregator, err
 			return nil, fmt.Errorf("Error getting number of GPU cores: %s", nvml.ErrorString(ret))
 		}
 
-		g.aggregators[aggKey] = newAggregator(uint64(maxThreads))
+		memUsage, ret := gpuDevice.GetMemoryInfo()
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("Error getting memory info: %s", nvml.ErrorString(ret))
+		}
+
+		g.aggregators[aggKey] = newAggregator(uint64(maxThreads), memUsage.Total)
 	}
 
 	// Update the last check time and the measured interval, as these change between check runs

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -95,6 +95,7 @@ func TestGetStatsWithOnlyCurrentStreamData(t *testing.T) {
 	require.NotNil(t, metrics)
 	require.Equal(t, allocSize*2, metrics.Memory.CurrentBytes)
 	require.Equal(t, allocSize*2, metrics.Memory.MaxBytes)
+	require.Equal(t, (allocSize*2)/testutil.DefaultTotalMemory, metrics.Memory.CurrentBytesPercentage)
 
 	// defined kernel is using only 1 core for 9 of the 10 seconds
 	expectedUtil := 1.0 / testutil.DefaultGpuCores * 0.9
@@ -148,6 +149,7 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 	require.NotNil(t, metrics)
 	require.Equal(t, uint64(0), metrics.Memory.CurrentBytes)
 	require.Equal(t, allocSize, metrics.Memory.MaxBytes)
+	require.Equal(t, 0.0, metrics.Memory.CurrentBytesPercentage)
 
 	// numThreads / DefaultGpuCores is the utilization for the
 	threadSecondsUsed := float64(numThreads) * float64(endKtime-startKtime) / 1e9
@@ -224,6 +226,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 	require.NotNil(t, metrics)
 	require.Equal(t, allocSize+shmemSize, metrics.Memory.CurrentBytes)
 	require.Equal(t, allocSize*2+shmemSize, metrics.Memory.MaxBytes)
+	require.Equal(t, (allocSize+shmemSize)/testutil.DefaultTotalMemory, metrics.Memory.CurrentBytesPercentage)
 
 	// numThreads / DefaultGpuCores is the utilization for the
 	threadSecondsUsed := float64(numThreads) * float64(endKtime-startKtime) / 1e9

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -95,7 +95,7 @@ func TestGetStatsWithOnlyCurrentStreamData(t *testing.T) {
 	require.NotNil(t, metrics)
 	require.Equal(t, allocSize*2, metrics.Memory.CurrentBytes)
 	require.Equal(t, allocSize*2, metrics.Memory.MaxBytes)
-	require.Equal(t, (allocSize*2)/testutil.DefaultTotalMemory, metrics.Memory.CurrentBytesPercentage)
+	require.Equal(t, float64(allocSize*2)/float64(testutil.DefaultTotalMemory), metrics.Memory.CurrentBytesPercentage)
 
 	// defined kernel is using only 1 core for 9 of the 10 seconds
 	expectedUtil := 1.0 / testutil.DefaultGpuCores * 0.9
@@ -226,7 +226,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 	require.NotNil(t, metrics)
 	require.Equal(t, allocSize+shmemSize, metrics.Memory.CurrentBytes)
 	require.Equal(t, allocSize*2+shmemSize, metrics.Memory.MaxBytes)
-	require.Equal(t, (allocSize+shmemSize)/testutil.DefaultTotalMemory, metrics.Memory.CurrentBytesPercentage)
+	require.Equal(t, float64(allocSize+shmemSize)/float64(testutil.DefaultTotalMemory), metrics.Memory.CurrentBytesPercentage)
 
 	// numThreads / DefaultGpuCores is the utilization for the
 	threadSecondsUsed := float64(numThreads) * float64(endKtime-startKtime) / 1e9

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -70,6 +70,9 @@ var DefaultProcessInfo = []nvml.ProcessInfo{
 	{Pid: 5678, UsedGpuMemory: 200},
 }
 
+// DefaultTotalMemory is the total memory for the default device returned by the mock
+var DefaultTotalMemory = uint64(1000)
+
 // GetDeviceMock returns a mock of the nvml.Device with the given UUID.
 func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 	return &nvmlmock.Device{
@@ -93,6 +96,9 @@ func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 		},
 		GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
 			return DefaultProcessInfo, nvml.SUCCESS
+		},
+		GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
+			return nvml.Memory{Total: DefaultTotalMemory, Free: 500}, nvml.SUCCESS
 		},
 	}
 }
@@ -123,6 +129,9 @@ func GetBasicNvmlMock() *nvmlmock.Interface {
 		},
 		DeviceGetComputeRunningProcessesFunc: func(nvml.Device) ([]nvml.ProcessInfo, nvml.Return) {
 			return DefaultProcessInfo, nvml.SUCCESS
+		},
+		DeviceGetMemoryInfoFunc: func(nvml.Device) (nvml.Memory, nvml.Return) {
+			return nvml.Memory{Total: DefaultTotalMemory, Free: 500}, nvml.SUCCESS
 		},
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a `gpu.memory.utilization` metric to include the percentage of memory used for each process. It also changes the `gpu.memory` metric to `gpu.memory.used` to avoid confusion and match better with similar metrics (e.g., `system.mem.used`). The `.max` variant is removed in this PR too, as it's not used right now in the backend and we will later implement alternative metrics to achieve the same purpose in a better way.

### Motivation

Feature parity with DCGM.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

E2E tests should see the new metric with non zero values

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->