### PR TITLE
Fix null pointer in autoscaling admission when leader election fails at startup

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -433,10 +433,10 @@ func start(log log.Component,
 			log.Error("Admission controller is disabled, vertical autoscaling requires the admission controller to be enabled. Vertical scaling will be disabled.")
 		}
 
-		if adapter, err := provider.StartWorkloadAutoscaling(mainCtx, clusterID, apiCl, rcClient, wmeta, demultiplexer); err != nil {
-			pkglog.Errorf("Error while starting workload autoscaling: %v", err)
-		} else {
+		if adapter, err := provider.StartWorkloadAutoscaling(mainCtx, clusterID, le.IsLeader, apiCl, rcClient, wmeta, demultiplexer); err == nil {
 			pa = adapter
+		} else {
+			return fmt.Errorf("Error while starting workload autoscaling: %v", err)
 		}
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/local"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection"
 )
 
 const maxDatadogPodAutoscalerObjects int = 100
@@ -32,6 +31,7 @@ const maxDatadogPodAutoscalerObjects int = 100
 func StartWorkloadAutoscaling(
 	ctx context.Context,
 	clusterID string,
+	isLeaderFunc func() bool,
 	apiCl *apiserver.APIClient,
 	rcClient workload.RcClient,
 	wlm workloadmeta.Component,
@@ -41,21 +41,16 @@ func StartWorkloadAutoscaling(
 		return nil, fmt.Errorf("Impossible to start workload autoscaling without valid APIClient")
 	}
 
-	le, err := leaderelection.GetLeaderEngine()
-	if err != nil {
-		return nil, fmt.Errorf("Unable to start workload autoscaling as LeaderElection failed with: %v", err)
-	}
-
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: apiCl.Cl.CoreV1().Events("")})
 	eventRecorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: "datadog-workload-autoscaler"})
 
 	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
-	podPatcher := workload.NewPodPatcher(store, le.IsLeader, apiCl.DynamicCl, eventRecorder)
+	podPatcher := workload.NewPodPatcher(store, isLeaderFunc, apiCl.DynamicCl, eventRecorder)
 	podWatcher := workload.NewPodWatcher(wlm, podPatcher)
 	localRecommender := local.NewRecommender(podWatcher, store)
 
-	_, err = workload.NewConfigRetriever(store, le.IsLeader, rcClient)
+	_, err := workload.NewConfigRetriever(store, isLeaderFunc, rcClient)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start workload autoscaling config retriever: %w", err)
 	}
@@ -69,7 +64,7 @@ func StartWorkloadAutoscaling(
 
 	limitHeap := autoscaling.NewHashHeap(maxDatadogPodAutoscalerObjects, store)
 
-	controller, err := workload.NewController(clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, le.IsLeader, store, podWatcher, sender, limitHeap)
+	controller, err := workload.NewController(clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start workload autoscaling controller: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Fix a null pointer panic in admission controller when Autoscaling is enabled but failed to start (due to any reason, but mostly observed due to leader election).

### Motivation

Fix `panic`.

### Describe how you validated your changes

Non-regression on Autoscaling.
Panic should not happen anymore, can be confirmed in staging.

### Possible Drawbacks / Trade-offs

This PR also makes Cluster Agent fails on Autoscaling start error, which is desirable anyway as silently running without Autoscaling would be unexpected.

### Additional Notes