### PR TITLE
[HA Agent] Case Insensitive config_id comparison

### DIFF
--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -8,6 +8,7 @@ package haagentimpl
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	haagent "github.com/DataDog/datadog-agent/comp/haagent/def"
@@ -108,7 +109,7 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 			})
 			continue
 		}
-		if haAgentMsg.ConfigID != h.GetConfigID() {
+		if strings.ToLower(haAgentMsg.ConfigID) != strings.ToLower(h.GetConfigID()) {
 			h.log.Warnf("Skipping invalid HA_AGENT update %s: expected configID %s, got %s",
 				configPath, h.GetConfigID(), haAgentMsg.ConfigID)
 			applyStateCallback(configPath, state.ApplyStatus{

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -109,7 +109,7 @@ func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyS
 			})
 			continue
 		}
-		if strings.ToLower(haAgentMsg.ConfigID) != strings.ToLower(h.GetConfigID()) {
+		if !strings.EqualFold(haAgentMsg.ConfigID, h.GetConfigID()) {
 			h.log.Warnf("Skipping invalid HA_AGENT update %s: expected configID %s, got %s",
 				configPath, h.GetConfigID(), haAgentMsg.ConfigID)
 			applyStateCallback(configPath, state.ApplyStatus{

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -128,6 +128,18 @@ func Test_haAgentImpl_onHaAgentUpdate(t *testing.T) {
 			expectedAgentState: haagent.Active,
 		},
 		{
+			name:         "successful update with leader matching current agent with different case sensitivity",
+			initialState: haagent.Unknown,
+			updates: map[string]state.RawConfig{
+				testRCConfigID: {Config: []byte(`{"config_id":"testconfig01","active_agent":"my-agent-hostname"}`)},
+			},
+			expectedApplyID: testRCConfigID,
+			expectedApplyStatus: state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+			},
+			expectedAgentState: haagent.Active,
+		},
+		{
 			name:         "successful update with leader NOT matching current agent",
 			initialState: haagent.Unknown,
 			updates: map[string]state.RawConfig{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[HA Agent] Case Insensitive config_id comparison

### Motivation



### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->