### PR TITLE
trivy: init and disable trivy logs

### DIFF
--- a/pkg/util/trivy/init.go
+++ b/pkg/util/trivy/init.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+
+// Package trivy holds the scan components
+package trivy
+
+import (
+	trivylog "github.com/aquasecurity/trivy/pkg/log"
+)
+
+func init() {
+	trivylog.InitLogger(false, true)
+}

--- a/pkg/util/trivy/init.go
+++ b/pkg/util/trivy/init.go
@@ -13,5 +13,7 @@ import (
 )
 
 func init() {
+	// by default trivy stores all logs until InitLogger is called
+	// we call it as soon as possible, asking to disable trivy logs
 	trivylog.InitLogger(false, true)
 }


### PR DESCRIPTION
### What does this PR do?

By default, trivy uses the following algorithm for logs:
- by default it uses a deferred logger (something that stores in memory all logs)
- when `log.InitLogger` is called, the deferred logs are evaluated against the loaded config and displayed

This means that if `InitLogger` is not called (as is the case today) all logs are stored in memory and never showed. This PR inits the logger (in an init function) explicitly asking to discard logs. This means that we get the same behavior, without the memory impact.



### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->