### PR TITLE
process agent: connections check: Expose connection check interval via environment variable

### DIFF
--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -172,7 +172,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 		"DD_PROCESS_ADDITIONAL_ENDPOINTS",
 	)
 	procBindEnvAndSetDefault(config, "process_config.events_additional_endpoints", make(map[string][]string))
-	config.SetKnown("process_config.intervals.connections")
+	procBindEnv(config, "process_config.intervals.connections")
 	procBindEnvAndSetDefault(config, "process_config.expvar_port", DefaultProcessExpVarPort)
 	procBindEnvAndSetDefault(config, "process_config.log_file", DefaultProcessAgentLogFile)
 	procBindEnvAndSetDefault(config, "process_config.internal_profiling.enabled", false)

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -142,6 +142,10 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.language_detection.grpc_port",
 			defaultValue: DefaultProcessEntityStreamPort,
 		},
+		{
+			key:          "process_config.intervals.connections",
+			defaultValue: nil,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -457,6 +461,12 @@ func TestEnvVarOverride(t *testing.T) {
 			env:      "DD_PROCESS_CONFIG_LANGUAGE_DETECTION_GRPC_PORT",
 			value:    "5431",
 			expected: 5431,
+		},
+		{
+			key:      "process_config.intervals.connections",
+			env:      "DD_PROCESS_CONFIG_INTERVALS_CONNECTIONS",
+			value:    "10",
+			expected: "10",
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allowing modifying the connections check interval via environment variable

### Motivation

Allowing changing the default interval via environment variable, for testing purposes, but only customer escalations.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Automatic tests were added.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->