### PR TITLE
Adjust quality gates thresholds

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,26 +1,26 @@
 # Package gates
 static_quality_gate_agent_deb_amd64:
-  max_on_wire_size: "193.53 MiB"
+  max_on_wire_size: "212.33 MiB"
   max_on_disk_size: "847.49 MiB"
 
 static_quality_gate_agent_deb_arm64:
-  max_on_wire_size: "172.13 MiB"
+  max_on_wire_size: "192.5 MiB"
   max_on_disk_size: "836.66 MiB"
 
 static_quality_gate_agent_rpm_amd64:
-  max_on_wire_size: "196.0 MiB"
+  max_on_wire_size: "215.76 MiB"
   max_on_disk_size: "847.82 MiB"
 
 static_quality_gate_agent_rpm_arm64:
-  max_on_wire_size: "177.77 MiB"
+  max_on_wire_size: "194.24 MiB"
   max_on_disk_size: "836.66 MiB"
 
 static_quality_gate_agent_suse_amd64:
-  max_on_wire_size: "196.0 MiB"
+  max_on_wire_size: "215.76 MiB"
   max_on_disk_size: "847.82 MiB"
 
 static_quality_gate_agent_suse_arm64:
-  max_on_wire_size: "177.77 MiB"
+  max_on_wire_size: "194.24 MiB"
   max_on_disk_size: "836.66 MiB"
 
 static_quality_gate_dogstatsd_deb_amd64:

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,26 +1,26 @@
 # Package gates
 static_quality_gate_agent_deb_amd64:
-  max_on_wire_size: "212.83 MiB"
+  max_on_wire_size: "193.53 MiB"
   max_on_disk_size: "847.49 MiB"
 
 static_quality_gate_agent_deb_arm64:
-  max_on_wire_size: "192.17 MiB"
+  max_on_wire_size: "172.13 MiB"
   max_on_disk_size: "836.66 MiB"
 
 static_quality_gate_agent_rpm_amd64:
-  max_on_wire_size: "214.3 MiB"
-  max_on_disk_size: "858.45 MiB"
+  max_on_wire_size: "196.0 MiB"
+  max_on_disk_size: "847.82 MiB"
 
 static_quality_gate_agent_rpm_arm64:
-  max_on_wire_size: "194.46 MiB"
+  max_on_wire_size: "177.77 MiB"
   max_on_disk_size: "836.66 MiB"
 
 static_quality_gate_agent_suse_amd64:
-  max_on_wire_size: "214.3 MiB"
-  max_on_disk_size: "858.45 MiB"
+  max_on_wire_size: "196.0 MiB"
+  max_on_disk_size: "847.82 MiB"
 
 static_quality_gate_agent_suse_arm64:
-  max_on_wire_size: "194.46 MiB"
+  max_on_wire_size: "177.77 MiB"
   max_on_disk_size: "836.66 MiB"
 
 static_quality_gate_dogstatsd_deb_amd64:
@@ -85,10 +85,10 @@ static_quality_gate_docker_dogstatsd_arm64:
   max_on_disk_size: "56.27 MiB"
 
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_wire_size: "117.28 MiB"
-  max_on_disk_size: "277.7 MiB"
+  max_on_wire_size: "116.28 MiB"
+  max_on_disk_size: "274.78 MiB"
 
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_wire_size: "112.12 MiB"
-  max_on_disk_size: "293.73 MiB"
+  max_on_wire_size: "111.12 MiB"
+  max_on_disk_size: "290.82 MiB"
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates thresholds to hold a `+10MiB` in relative size between gate upper bound and current main gate sizes

### Motivation

[Dashboard](https://app.datadoghq.com/dashboard/5np-man-vak/static-quality-gates?fromUser=false&refresh_mode=sliding&from_ts=1739780026761&to_ts=1739866426761&live=true)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->