### PR TITLE
trivy: adjust skip and onlydirs for languages

### DIFF
--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -72,6 +72,16 @@ type Collector struct {
 
 var globalCollector *Collector
 
+var trivyDefaultSkipDirs = []string{
+	// already included in Trivy's defaultSkipDirs
+	// "**/.git",
+	// "proc",
+	// "sys",
+	// "dev",
+
+	"**/.cargo/git/**",
+}
+
 func getDefaultArtifactOption(opts sbom.ScanOptions) artifact.Option {
 	parallel := 1
 	if opts.Fast {
@@ -88,7 +98,9 @@ func getDefaultArtifactOption(opts sbom.ScanOptions) artifact.Option {
 		WalkerOption:      walker.Option{},
 	}
 
-	if len(opts.Analyzers) == 1 && opts.Analyzers[0] == OSAnalyzers {
+	option.WalkerOption.SkipDirs = trivyDefaultSkipDirs
+
+	if looselyCompareAnalyzers(opts.Analyzers, []string{OSAnalyzers}) {
 		option.WalkerOption.OnlyDirs = []string{
 			"/etc/*",
 			"/lib/apk/db/*",
@@ -97,6 +109,31 @@ func getDefaultArtifactOption(opts sbom.ScanOptions) artifact.Option {
 			"/var/lib/dpkg/**",
 			"/var/lib/rpm/*",
 		}
+	} else if looselyCompareAnalyzers(opts.Analyzers, []string{OSAnalyzers, LanguagesAnalyzers}) {
+		option.WalkerOption.SkipDirs = append(
+			option.WalkerOption.SkipDirs,
+			"bin/**",
+			"boot/**",
+			"dev/**",
+			"media/**",
+			"mnt/**",
+			"proc/**",
+			"run/**",
+			"sbin/**",
+			"sys/**",
+			"tmp/**",
+			"usr/bin/**",
+			"usr/sbin/**",
+			"var/cache/**",
+			"var/lib/containerd/**",
+			"var/lib/containers/**",
+			"var/lib/docker/**",
+			"var/lib/libvirt/**",
+			"var/lib/snapd/**",
+			"var/log/**",
+			"var/run/**",
+			"var/tmp/**",
+		)
 	}
 
 	return option
@@ -312,4 +349,30 @@ func (c *Collector) scanImage(ctx context.Context, fanalImage ftypes.Image, imgM
 		id:        trivyReport.Metadata.ImageID,
 		marshaler: c.marshaler,
 	}, nil
+}
+
+func looselyCompareAnalyzers(given []string, against []string) bool {
+	target := make(map[string]struct{}, len(against))
+	for _, val := range against {
+		target[val] = struct{}{}
+	}
+
+	validated := make(map[string]struct{})
+
+	for _, val := range given {
+		// if already validated, skip
+		// this allows to support duplicated entries
+		if _, ok := validated[val]; ok {
+			continue
+		}
+
+		// if this value is not in
+		if _, ok := target[val]; !ok {
+			return false
+		}
+		delete(target, val)
+		validated[val] = struct{}{}
+	}
+
+	return len(target) == 0
 }

--- a/pkg/util/trivy/trivy_test.go
+++ b/pkg/util/trivy/trivy_test.go
@@ -60,3 +60,53 @@ func TestExtractLayersFromOverlayFSMounts(t *testing.T) {
 		})
 	}
 }
+
+func TestLooselyCompareAnalyzers(t *testing.T) {
+	entries := []struct {
+		name     string
+		given    []string
+		against  []string
+		expected bool
+	}{
+		{
+			name:     "empty lists",
+			expected: true,
+		},
+		{
+			name:     "os simple",
+			given:    []string{"os"},
+			against:  []string{"os"},
+			expected: true,
+		},
+		{
+			name:     "os duplicated",
+			given:    []string{"os", "os"},
+			against:  []string{"os"},
+			expected: true,
+		},
+		{
+			name:     "os wrong",
+			given:    []string{"languages"},
+			against:  []string{"os"},
+			expected: false,
+		},
+		{
+			name:     "languages and os",
+			given:    []string{"os", "languages"},
+			against:  []string{"os", "languages"},
+			expected: true,
+		},
+		{
+			name:     "languages and os 2",
+			given:    []string{"languages", "os"},
+			against:  []string{"os", "languages"},
+			expected: true,
+		},
+	}
+
+	for _, entry := range entries {
+		t.Run(entry.name, func(t *testing.T) {
+			assert.Equal(t, entry.expected, looselyCompareAnalyzers(entry.given, entry.against))
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Currently when enabling only OS analyzers (the default) we give you a specific "skip/only dirs" config. When enabling languages analyzers you end up falling back to the default (meaning scanning everything).

This PR expand the OS default skip/only dirs with a new config specific to "os + languages", copied from the configuration applied by agentless in this same mode.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->