### PR TITLE
sbom: split `ScanOptionsFromConfig` into containers/hosts variants

### DIFF
--- a/pkg/sbom/collectors/containerd/containerd.go
+++ b/pkg/sbom/collectors/containerd/containerd.go
@@ -84,7 +84,7 @@ func (c *Collector) Init(cfg config.Component, wmeta option.Option[workloadmeta.
 	}
 	c.wmeta = wmeta
 	c.trivyCollector = trivyCollector
-	c.opts = sbom.ScanOptionsFromConfig(cfg, true)
+	c.opts = sbom.ScanOptionsFromConfigForContainers(cfg)
 	return nil
 }
 

--- a/pkg/sbom/collectors/crio/crio.go
+++ b/pkg/sbom/collectors/crio/crio.go
@@ -73,7 +73,7 @@ func (c *Collector) Init(cfg config.Component, wmeta option.Option[workloadmeta.
 	}
 	c.wmeta = wmeta
 	c.trivyCollector = trivyCollector
-	c.opts = sbom.ScanOptionsFromConfig(cfg, true)
+	c.opts = sbom.ScanOptionsFromConfigForContainers(cfg)
 	return nil
 }
 

--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -79,7 +79,7 @@ func (c *Collector) Init(cfg config.Component, wmeta option.Option[workloadmeta.
 	}
 	c.wmeta = wmeta
 	c.trivyCollector = trivyCollector
-	c.opts = sbom.ScanOptionsFromConfig(cfg, true)
+	c.opts = sbom.ScanOptionsFromConfigForContainers(cfg)
 	return nil
 }
 

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -42,7 +42,7 @@ func (c *Collector) Init(cfg config.Component, wmeta option.Option[workloadmeta.
 		return err
 	}
 	c.trivyCollector = trivyCollector
-	c.opts = sbom.ScanOptionsFromConfig(cfg, false)
+	c.opts = sbom.ScanOptionsFromConfigForHosts(cfg)
 	return nil
 }
 

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -27,23 +27,24 @@ type Report interface {
 	ID() string
 }
 
-// ScanOptionsFromConfig loads the scanning options from the configuration
-func ScanOptionsFromConfig(cfg config.Component, containers bool) (scanOpts ScanOptions) {
-	if containers {
-		scanOpts.CheckDiskUsage = cfg.GetBool("sbom.container_image.check_disk_usage")
-		scanOpts.MinAvailableDisk = uint64(cfg.GetSizeInBytes("sbom.container_image.min_available_disk"))
-		scanOpts.Timeout = time.Duration(cfg.GetInt("sbom.container_image.scan_timeout")) * time.Second
-		scanOpts.WaitAfter = time.Duration(cfg.GetInt("sbom.container_image.scan_interval")) * time.Second
-		scanOpts.Analyzers = cfg.GetStringSlice("sbom.container_image.analyzers")
-		scanOpts.UseMount = cfg.GetBool("sbom.container_image.use_mount")
-		scanOpts.OverlayFsScan = cfg.GetBool("sbom.container_image.overlayfs_direct_scan")
+// ScanOptionsFromConfigForContainers loads the scanning options from the configuration
+func ScanOptionsFromConfigForContainers(cfg config.Component) ScanOptions {
+	return ScanOptions{
+		CheckDiskUsage:   cfg.GetBool("sbom.container_image.check_disk_usage"),
+		MinAvailableDisk: uint64(cfg.GetSizeInBytes("sbom.container_image.min_available_disk")),
+		Timeout:          time.Duration(cfg.GetInt("sbom.container_image.scan_timeout")) * time.Second,
+		WaitAfter:        time.Duration(cfg.GetInt("sbom.container_image.scan_interval")) * time.Second,
+		Analyzers:        cfg.GetStringSlice("sbom.container_image.analyzers"),
+		UseMount:         cfg.GetBool("sbom.container_image.use_mount"),
+		OverlayFsScan:    cfg.GetBool("sbom.container_image.overlayfs_direct_scan"),
 	}
+}
 
-	if len(scanOpts.Analyzers) == 0 {
-		scanOpts.Analyzers = cfg.GetStringSlice("sbom.host.analyzers")
+// ScanOptionsFromConfigForHosts loads the scanning options from the configuration
+func ScanOptionsFromConfigForHosts(cfg config.Component) ScanOptions {
+	return ScanOptions{
+		Analyzers: cfg.GetStringSlice("sbom.host.analyzers"),
 	}
-
-	return
 }
 
 // ScanRequest defines the scan request interface


### PR DESCRIPTION
### What does this PR do?

Small code cleanup to remove the strange `containers bool` argument from `ScanOptionsFromConfig`.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->