### PR TITLE
[AGENTRUN-122] updating Agent Configuration e2e tests to work with both normal Agent and FIPS Agent

### DIFF
--- a/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
@@ -100,12 +100,6 @@ func fetchAndCheckStatus(v *baseStatusSuite, expectedSections []expectedSection)
 func (v *baseStatusSuite) TestDefaultInstallStatus() {
 	expectedSections := []expectedSection{
 		{
-			name:             `Agent \(.*\)`, // TODO: verify that the right version is output
-			shouldBePresent:  true,
-			shouldContain:    []string{"FIPS Mode: not available"},
-			shouldNotContain: []string{"FIPS proxy"},
-		},
-		{
 			name:            "Aggregator",
 			shouldBePresent: true,
 		},
@@ -200,6 +194,19 @@ func (v *baseStatusSuite) TestDefaultInstallStatus() {
 			shouldBePresent: false,
 		},
 	}
+
+	FIPSSection := expectedSection{
+		name:             `Agent \(.*\)`, // TODO: verify that the right version is output
+		shouldBePresent:  true,
+		shouldNotContain: []string{"FIPS proxy"},
+	}
+
+	if v.Env().Agent.FIPSEnabled {
+		FIPSSection.shouldContain = []string{"FIPS Mode: enabled"}
+	} else {
+		FIPSSection.shouldContain = []string{"FIPS Mode: not available"}
+	}
+	expectedSections = append(expectedSections, FIPSSection)
 
 	fetchAndCheckStatus(v, expectedSections)
 }

--- a/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
@@ -100,6 +100,12 @@ func fetchAndCheckStatus(v *baseStatusSuite, expectedSections []expectedSection)
 func (v *baseStatusSuite) TestDefaultInstallStatus() {
 	expectedSections := []expectedSection{
 		{
+			name:             `Agent \(.*\)`, // TODO: verify that the right version is output
+			shouldBePresent:  true,
+			shouldContain:    shouldContainsFips(v),
+			shouldNotContain: []string{"FIPS proxy"},
+		},
+		{
 			name:            "Aggregator",
 			shouldBePresent: true,
 		},
@@ -195,18 +201,12 @@ func (v *baseStatusSuite) TestDefaultInstallStatus() {
 		},
 	}
 
-	FIPSSection := expectedSection{
-		name:             `Agent \(.*\)`, // TODO: verify that the right version is output
-		shouldBePresent:  true,
-		shouldNotContain: []string{"FIPS proxy"},
-	}
-
-	if v.Env().Agent.FIPSEnabled {
-		FIPSSection.shouldContain = []string{"FIPS Mode: enabled"}
-	} else {
-		FIPSSection.shouldContain = []string{"FIPS Mode: not available"}
-	}
-	expectedSections = append(expectedSections, FIPSSection)
-
 	fetchAndCheckStatus(v, expectedSections)
+}
+
+func shouldContainsFips(v *baseStatusSuite) []string {
+	if v.Env().Agent.FIPSEnabled {
+		return []string{"FIPS Mode: enabled"}
+	}
+	return []string{"FIPS Mode: not available"}
 }

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -41,6 +41,11 @@ func (v *linuxStatusSuite) TestStatusHostname() {
 }
 
 func (v *linuxStatusSuite) TestFIPSProxyStatus() {
+	// Skip this test if the e2e pipeline is running with the FIPS Agent flavor because the FIPS proxy is not supported with the FIPS Agent.
+	if v.Env().Agent.FIPSEnabled {
+		v.T().Skip()
+	}
+
 	v.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig("fips.enabled: true"))))
 
 	expectedSections := []expectedSection{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR updates the `status` command e2e test to ensure consistent functionality with both the FIPS Agent and the standard Agent.

### Motivation
To automatically execute the e2e test pipeline for the FIPS Agent, we need to update tests that currently assume they are running with the standard Agent instead of the FIPS Agent.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
It was made possible by a new flag provided by the e2e framework which indicates if the Agent is FIPS flavor or not.
(DataDog/test-infra-definitions#1414)