### PR TITLE
trivy: skip download of java database

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -984,7 +984,7 @@ replace github.com/vishvananda/netlink => github.com/DataDog/netlink v1.0.1-0.20
 // Pull in replacements needed by upstream Trivy
 replace (
 	// Maps to Trivy fork https://github.com/DataDog/trivy/commits/lebauce/container-artifact
-	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20241223234648-d2ac813bf11b
+	github.com/aquasecurity/trivy => github.com/DataDog/trivy v0.0.0-20250218170738-01563331e03d
 	github.com/saracen/walker => github.com/DataDog/walker v0.0.0-20230418153152-7f29bb2dc950
 )
 

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,8 @@ github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.26.0 h1:AdiclwuXhWbW
 github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.26.0/go.mod h1:2wJmnlzc4t/VEn5xm0ilrz/XEf8LSoJ2Tf3PtRAKyDo=
 github.com/DataDog/sketches-go v1.4.6 h1:acd5fb+QdUzGrosfNLwrIhqyrbMORpvBy7mE+vHlT3I=
 github.com/DataDog/sketches-go v1.4.6/go.mod h1:7Y8GN8Jf66DLyDhc94zuWA3uHEt/7ttt8jHOBWWrSOg=
-github.com/DataDog/trivy v0.0.0-20241223234648-d2ac813bf11b h1:wCKboWBVsnpnFnBKGhQ3jeQOVDPQkMRTLWcs2bxRjss=
-github.com/DataDog/trivy v0.0.0-20241223234648-d2ac813bf11b/go.mod h1:qJj5iHmlvtSbgmRWJDANpAFmmxcXuKGQfucp9VtJfR8=
+github.com/DataDog/trivy v0.0.0-20250218170738-01563331e03d h1:zaaGs05EmJf1JupTJ9INwkCam/SN49Fdwy5gxEwOYgU=
+github.com/DataDog/trivy v0.0.0-20250218170738-01563331e03d/go.mod h1:qJj5iHmlvtSbgmRWJDANpAFmmxcXuKGQfucp9VtJfR8=
 github.com/DataDog/viper v1.14.0 h1:dIjTe/uJiah+QFqFZ+MXeqgmUvWhg37l37ZxFWxr3is=
 github.com/DataDog/viper v1.14.0/go.mod h1:wDdUVJ2SHaMaPrCZrlRCObwkubsX8j5sme3LaR/SGTc=
 github.com/DataDog/watermarkpodautoscaler/apis v0.0.0-20250108152814-82e58d0231d1 h1:9hiwoIk8FOsXDkdcdgNJ48iYaPfn+/7bXEwAnnfKjTc=

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -140,9 +140,6 @@ func DefaultDisabledCollectors(enabledAnalyzers []string) []analyzer.Type {
 		analyzer.TypeRpmArchive,
 	)
 
-	// FIXME: the java analyzer requires some javadb, let's skip it for now
-	disabledAnalyzers = append(disabledAnalyzers, analyzer.TypeJar, analyzer.TypeGradleLock, analyzer.TypePom, analyzer.TypeSbtLock)
-
 	return disabledAnalyzers
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR bumps trivy to include https://github.com/aquasecurity/trivy/commit/01563331e03dcaead2d69ab4fcadf37e30a52ead that allows re-enabling jar analyzer without the need to download a java digest database from the internet at runtime.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->