### PR TITLE
[workloadmeta/kubemetadata] Avoid dependency on kubernetes apiserver controllers package

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -21,7 +21,6 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	as "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	apicommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -212,7 +211,7 @@ func getPodMetadata(w http.ResponseWriter, r *http.Request) {
 	nodeName := vars["nodeName"]
 	podName := vars["podName"]
 	ns := vars["ns"]
-	metaList, errMetaList := controllers.GetPodMetadataNames(nodeName, ns, podName)
+	metaList, errMetaList := as.GetPodMetadataNames(nodeName, ns, podName)
 	if errMetaList != nil {
 		log.Errorf("Could not retrieve the metadata of: %s from the cache", podName) //nolint:errcheck
 		http.Error(w, errMetaList.Error(), http.StatusInternalServerError)

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -25,7 +25,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
@@ -220,7 +219,7 @@ func (c *collector) parsePods(
 			continue
 		}
 
-		metadata, err := c.getMetadata(controllers.GetPodMetadataNames, metadataByNsPods, pod)
+		metadata, err := c.getMetadata(apiserver.GetPodMetadataNames, metadataByNsPods, pod)
 		if err != nil {
 			log.Debugf("Could not fetch metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
 		}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -588,17 +588,12 @@ func GetMetadataMapBundleOnNode(nodeName string) (*apiv1.MetadataResponse, error
 
 // GetPodMetadataNames is used when the API endpoint of the DCA to get the metadata of a pod is hit.
 func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
-	cacheKey := cache.BuildAgentKey(MetadataMapperCachePrefix, nodeName)
-	metaBundleInterface, found := cache.Cache.Get(cacheKey)
-	if !found {
+	metaBundle, err := getMetadataMapBundle(nodeName)
+	if err != nil {
 		log.Tracef("no metadata was found for the pod %s on node %s", podName, nodeName)
 		return nil, nil
 	}
 
-	metaBundle, ok := metaBundleInterface.(*MetadataMapperBundle)
-	if !ok {
-		return nil, fmt.Errorf("invalid cache format for the cacheKey: %s", cacheKey)
-	}
 	// The list of metadata collected in the metaBundle is extensible and is handled here.
 	// If new cluster level tags need to be collected by the agent, only this needs to be modified.
 	serviceList, foundServices := metaBundle.ServicesForPod(ns, podName)
@@ -606,7 +601,7 @@ func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
 		log.Tracef("no cached services list found for the pod %s on the node %s", podName, nodeName)
 		return nil, nil
 	}
-	log.Tracef("CacheKey: %s, with %d services", cacheKey, len(serviceList))
+	log.Tracef("found %d services for the pod %s on the node %s", len(serviceList), podName, nodeName)
 	var metaList []string
 	for _, s := range serviceList {
 		metaList = append(metaList, fmt.Sprintf("kube_service:%s", s))

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -586,6 +586,34 @@ func GetMetadataMapBundleOnNode(nodeName string) (*apiv1.MetadataResponse, error
 	return stats, nil
 }
 
+// GetPodMetadataNames is used when the API endpoint of the DCA to get the metadata of a pod is hit.
+func GetPodMetadataNames(nodeName, ns, podName string) ([]string, error) {
+	cacheKey := cache.BuildAgentKey(MetadataMapperCachePrefix, nodeName)
+	metaBundleInterface, found := cache.Cache.Get(cacheKey)
+	if !found {
+		log.Tracef("no metadata was found for the pod %s on node %s", podName, nodeName)
+		return nil, nil
+	}
+
+	metaBundle, ok := metaBundleInterface.(*MetadataMapperBundle)
+	if !ok {
+		return nil, fmt.Errorf("invalid cache format for the cacheKey: %s", cacheKey)
+	}
+	// The list of metadata collected in the metaBundle is extensible and is handled here.
+	// If new cluster level tags need to be collected by the agent, only this needs to be modified.
+	serviceList, foundServices := metaBundle.ServicesForPod(ns, podName)
+	if !foundServices {
+		log.Tracef("no cached services list found for the pod %s on the node %s", podName, nodeName)
+		return nil, nil
+	}
+	log.Tracef("CacheKey: %s, with %d services", cacheKey, len(serviceList))
+	var metaList []string
+	for _, s := range serviceList {
+		metaList = append(metaList, fmt.Sprintf("kube_service:%s", s))
+	}
+	return metaList, nil
+}
+
 func getMetadataMapBundle(nodeName string) (*MetadataMapperBundle, error) {
 	nodeNameCacheKey := cache.BuildAgentKey(MetadataMapperCachePrefix, nodeName)
 	metaBundle, found := cache.Cache.Get(nodeNameCacheKey)

--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller_test.go
@@ -807,7 +807,7 @@ func TestMetadataController(t *testing.T) {
 	})
 
 	testutil.AssertTrueBeforeTimeout(t, 100*time.Millisecond, 2*time.Second, func() bool {
-		metadataNames, err := GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
+		metadataNames, err := apiserver.GetPodMetadataNames(node.Name, pod.Namespace, pod.Name)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
### What does this PR do?

Refactors some code in `pkg/util/kubernetes/apiserver` to avoid importing `pkg/util/kubernetes/apiserver/controllers` in the `kubemetadata` workloadmeta collector.

It's the only place in the core agent that imports `pkg/util/kubernetes/apiserver/controllers`. We shouldn't have this dependency because the `controllers` package should only be responsible for running the controllers needed by the Cluster Agent.

The dependency was there just because of a function `GetPodMetadataNames` that shouldn't really be there, as there are other similar functions already defined in `pkg/util/kubernetes/apiserver/apiserver.go`.

This change reduces a bit the binary size of the core agent and should not affect functionality.


### Describe how you validated your changes

I deployed the Agent on Kubernetes and checked with `agent tagger-list` that the `kube_service` tag is added to the containers as expected.

We have some e2e tests that check for the tag.
