### PR TITLE
chore(apm): use tagger ProcessID resolution

### DIFF
--- a/pkg/trace/api/container_linux_test.go
+++ b/pkg/trace/api/container_linux_test.go
@@ -13,10 +13,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strconv"
 	"syscall"
 	"testing"
-	"time"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/api/internal/header"
@@ -92,15 +90,9 @@ func TestGetContainerID(t *testing.T) {
 		inodePrefix             = "in-"
 	)
 
-	// fudge factor to ease testing, if our tests take over 24 hours we got bigger problems
-	timeFudgeFactor := 24 * time.Hour
-	c := NewCache(timeFudgeFactor)
-	c.Store(time.Now().Add(timeFudgeFactor), strconv.Itoa(containerPID), containerID, nil)
-
 	provider := &cgroupIDProvider{
 		procRoot:   "",
 		controller: "",
-		cache:      c,
 	}
 
 	t.Run("ContainerID header", func(t *testing.T) {
@@ -217,15 +209,6 @@ func TestGetContainerID(t *testing.T) {
 			t.Fail()
 		}
 		req.Header.Add(header.LocalData, legacyContainerIDPrefix+containerID)
-		assert.Equal(t, containerID, provider.GetContainerID(req.Context(), req.Header))
-	})
-
-	t.Run("No header with a PID", func(t *testing.T) {
-		ctx := context.WithValue(context.Background(), ucredKey{}, &syscall.Ucred{Pid: containerPID})
-		req, err := http.NewRequestWithContext(ctx, "GET", "http://example.com", nil)
-		if !assert.NoError(t, err) {
-			t.Fail()
-		}
 		assert.Equal(t, containerID, provider.GetContainerID(req.Context(), req.Header))
 	})
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Migrate the ProcessID resolution for APM to the `tagger` module.

### Motivation

This is done to ensure consistency in Origin Detection behavior across Datadog Products.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by unit and E2E tests but I also checked manually
* With a modified library (`process_id_only`) that does not send any container information:
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/ae939c4c-322c-4f12-b23a-3b3a81ff90b0" />

### Possible Drawbacks / Trade-offs

None.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A