### PR TITLE
trivy: prevent rekor artifact download by unregistering `UnpackagedPostHandler`

### DIFF
--- a/pkg/util/trivy/init.go
+++ b/pkg/util/trivy/init.go
@@ -9,6 +9,10 @@
 package trivy
 
 import (
+	"sync"
+
+	trivyhandler "github.com/aquasecurity/trivy/pkg/fanal/handler"
+	ftypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	trivylog "github.com/aquasecurity/trivy/pkg/log"
 )
 
@@ -17,3 +21,9 @@ func init() {
 	// we call it as soon as possible, asking to disable trivy logs
 	trivylog.InitLogger(false, true)
 }
+
+var ensureTrivyInit = sync.OnceFunc(func() {
+	// making sure the Unpackaged post handler relying on external DBs is
+	// deregistered
+	trivyhandler.DeregisterPostHandler(ftypes.UnpackagedPostHandler)
+})

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -153,6 +153,8 @@ func DefaultDisabledHandlers() []ftypes.HandlerType {
 
 // NewCollector returns a new collector
 func NewCollector(cfg config.Component, wmeta option.Option[workloadmeta.Component]) (*Collector, error) {
+	ensureTrivyInit()
+
 	return &Collector{
 		config: collectorConfig{
 			clearCacheOnClose: cfg.GetBool("sbom.clear_cache_on_exit"),


### PR DESCRIPTION
### What does this PR do?

Similar to how we are trying to prevent the jar analyzer from downloading a database from the internet, the `UnpackagedPostHandler` is trying to download some SBOM data from rekor https://github.com/DataDog/trivy/blob/266d9b1f4bd2e89f1d58a16698f755a1734c644e/pkg/fanal/handler/unpackaged/unpackaged.go#L31. This PR unregisters this analyzer to prevent this behavior.

This operation is not done in an `init` function to ensure the "unregister" happens after the "register" and not before because of some init ordering issue.

This is again part of the initiative to share some code and behaviors with agentless-scanner.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->