### PR TITLE
Get `cws-instrumentation` image based on pipeline ID and commit sha

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -378,7 +378,6 @@ new-e2e-cws:
   variables:
     TARGETS: ./tests/cws
     TEAM: csm-threats-agent
-    CWS_INSTRUMENTATION_FULLIMAGEPATH: 669783387624.dkr.ecr.us-east-1.amazonaws.com/cws-instrumentation:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}
   parallel:
     matrix:
       - EXTRA_PARAMS: --run TestAgentSuite

--- a/test/new-e2e/tests/cws/fargate_test.go
+++ b/test/new-e2e/tests/cws/fargate_test.go
@@ -190,7 +190,7 @@ func TestECSFargate(t *testing.T) {
 					"cws-instrumentation-init": {
 						Cpu:       pulumi.IntPtr(0),
 						Name:      pulumi.String("cws-instrumentation-init"),
-						Image:     pulumi.String(getCWSInstrumentationFullImagePath()),
+						Image:     pulumi.String(getCWSInstrumentationFullImagePath(awsEnv.CommonEnvironment)),
 						Essential: pulumi.BoolPtr(false),
 						Command: pulumi.ToStringArray([]string{
 							"/cws-instrumentation",
@@ -289,10 +289,15 @@ const (
 	agentDefaultImagePath              = "public.ecr.aws/datadog/agent:7-rc"
 )
 
-func getCWSInstrumentationFullImagePath() string {
+func getCWSInstrumentationFullImagePath(e *configCommon.CommonEnvironment) string {
 	if fullImagePath := os.Getenv("CWS_INSTRUMENTATION_FULLIMAGEPATH"); fullImagePath != "" {
 		return fullImagePath
 	}
+
+	if e.PipelineID() != "" && e.CommitSHA() != "" {
+		return fmt.Sprintf("669783387624.dkr.ecr.us-east-1.amazonaws.com/cws-instrumentation:%s-%s", e.PipelineID(), e.CommitSHA())
+	}
+
 	return cwsInstrumentationDefaultImagePath
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Similarly to what's done for the agent, get the `cws-instrumentation` container image tag based on the pipeline ID and commit SHA. 

### Motivation

This allows the `TestECSFargate` tests to use the correct `cws-instrumentation` container image when these are run using the `E2E_PIPELINE_ID` and `E2E_COMMIT_SHA` environment variables.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->