### PR TITLE
[NDMII-3310] Allow integrations to self-declare as HA Supported

### DIFF
--- a/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
+++ b/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go
@@ -142,3 +142,8 @@ func (c *CheckWrapper) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	}
 	return c.inner.GetDiagnoses()
 }
+
+// IsHASupported implements Check#IsHASupported
+func (c *CheckWrapper) IsHASupported() bool {
+	return c.inner.IsHASupported()
+}

--- a/comp/haagent/def/component.go
+++ b/comp/haagent/def/component.go
@@ -23,9 +23,6 @@ type Component interface {
 	// the state is set to active, otherwise standby.
 	SetLeader(leaderAgentHostname string)
 
-	// ShouldRunIntegration returns true if the integration should be run
-	ShouldRunIntegration(integrationName string) bool
-
-	// IsHaIntegration return true if it's an HA integration.
-	IsHaIntegration(integrationName string) bool
+	// IsActive returns true if the agent should run checks
+	IsActive() bool
 }

--- a/comp/haagent/impl/config.go
+++ b/comp/haagent/impl/config.go
@@ -10,20 +10,6 @@ import (
 	helpers "github.com/DataDog/datadog-agent/comp/haagent/helpers"
 )
 
-// validHaIntegrations represent the list of integrations that will be considered as
-// an "HA Integration", meaning it will only run on the active Agent.
-// At the moment, the list of HA Integrations is hardcoded here, but we might provide
-// more dynamic way to configure which integration should be considered HA Integration.
-var validHaIntegrations = map[string]bool{
-	// NDM integrations
-	"snmp":        true,
-	"cisco_aci":   true,
-	"cisco_sdwan": true,
-
-	// Other integrations
-	"network_path": true,
-}
-
 type haAgentConfigs struct {
 	enabled  bool
 	configID string

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -70,18 +70,8 @@ func (h *haAgentImpl) resetAgentState() {
 	h.state.Store(string(haagent.Unknown))
 }
 
-// ShouldRunIntegration return true if the agent integrations should to run.
-// When ha-agent is disabled, the agent behave as standalone agent (non HA) and will always run all integrations.
-func (h *haAgentImpl) ShouldRunIntegration(integrationName string) bool {
-	if h.Enabled() && validHaIntegrations[integrationName] {
-		return h.GetState() == haagent.Active
-	}
-	return true
-}
-
-// IsHaIntegration return true if it's an HA integration.
-func (h *haAgentImpl) IsHaIntegration(integrationName string) bool {
-	return validHaIntegrations[integrationName]
+func (h *haAgentImpl) IsActive() bool {
+	return h.GetState() == haagent.Active
 }
 
 func (h *haAgentImpl) onHaAgentUpdate(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {

--- a/comp/haagent/mock/mock.go
+++ b/comp/haagent/mock/mock.go
@@ -48,11 +48,7 @@ func (m *mockHaAgent) SetState(state haagent.State) {
 	m.state = state
 }
 
-func (m *mockHaAgent) ShouldRunIntegration(_ string) bool {
-	return true
-}
-
-func (m *mockHaAgent) IsHaIntegration(_ string) bool {
+func (m *mockHaAgent) IsActive() bool {
 	return true
 }
 

--- a/pkg/collector/check/check.go
+++ b/pkg/collector/check/check.go
@@ -54,6 +54,8 @@ type Check interface {
 	InstanceConfig() string
 	// GetDiagnoses returns the diagnoses cached in last run or diagnose explicitly
 	GetDiagnoses() ([]diagnosis.Diagnosis, error)
+	// IsHASupported returns if the check is compatible with High Availability
+	IsHASupported() bool
 }
 
 // Info is an interface to pull information from types capable to run checks. This is a subsection from the Check

--- a/pkg/collector/check/stats/stats_test.go
+++ b/pkg/collector/check/stats/stats_test.go
@@ -20,12 +20,13 @@ import (
 
 // Mock Check implementation used for testing
 type mockCheck struct {
-	cfgSource  string
-	loaderName string
-	id         checkid.ID
-	stringVal  string
-	version    string
-	interval   time.Duration
+	cfgSource   string
+	loaderName  string
+	id          checkid.ID
+	stringVal   string
+	version     string
+	interval    time.Duration
+	haSupported bool
 }
 
 // Mock Check interface implementation
@@ -35,26 +36,29 @@ func (mc *mockCheck) ID() checkid.ID          { return mc.id }
 func (mc *mockCheck) String() string          { return mc.stringVal }
 func (mc *mockCheck) Version() string         { return mc.version }
 func (mc *mockCheck) Interval() time.Duration { return mc.interval }
+func (mc *mockCheck) IsHASupported() bool     { return mc.haSupported }
 
 func newMockCheck() StatsCheck {
 	return &mockCheck{
-		cfgSource:  "checkConfigSrc",
-		id:         "checkID",
-		stringVal:  "checkString",
-		loaderName: "mockLoader",
-		version:    "checkVersion",
-		interval:   15 * time.Second,
+		cfgSource:   "checkConfigSrc",
+		id:          "checkID",
+		stringVal:   "checkString",
+		loaderName:  "mockLoader",
+		version:     "checkVersion",
+		interval:    15 * time.Second,
+		haSupported: false,
 	}
 }
 
 func newMockCheckWithInterval(interval time.Duration) StatsCheck {
 	return &mockCheck{
-		cfgSource:  "checkConfigSrc",
-		id:         "checkID",
-		stringVal:  "checkString",
-		loaderName: "mockloader",
-		version:    "checkVersion",
-		interval:   interval,
+		cfgSource:   "checkConfigSrc",
+		id:          "checkID",
+		stringVal:   "checkString",
+		loaderName:  "mockloader",
+		version:     "checkVersion",
+		interval:    interval,
+		haSupported: false,
 	}
 }
 
@@ -80,6 +84,7 @@ func TestNewStats(t *testing.T) {
 	assert.Equal(t, stats.CheckVersion, "checkVersion")
 	assert.Equal(t, stats.CheckConfigSource, "checkConfigSrc")
 	assert.Equal(t, stats.Interval, 15*time.Second)
+	assert.Equal(t, stats.HASupported, false)
 }
 
 func TestNewStatsStateTelemetryInitialized(t *testing.T) {

--- a/pkg/collector/check/stub/stub.go
+++ b/pkg/collector/check/stub/stub.go
@@ -70,3 +70,6 @@ func (c *StubCheck) InstanceConfig() string { return "" }
 
 // GetDiagnoses returns the diagnoses of the check
 func (c *StubCheck) GetDiagnoses() ([]diagnosis.Diagnosis, error) { return nil, nil }
+
+// IsHASupported returns false
+func (c *StubCheck) IsHASupported() bool { return false }

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -285,3 +285,8 @@ func (c *CheckBase) GetSenderStats() (stats.SenderStats, error) {
 func (c *CheckBase) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	return nil, nil
 }
+
+// IsHASupported returns if the check is compatible with High Availability
+func (c *CheckBase) IsHASupported() bool {
+	return false
+}

--- a/pkg/collector/corechecks/embed/apm/apm.go
+++ b/pkg/collector/corechecks/embed/apm/apm.go
@@ -254,6 +254,11 @@ func (c *APMCheck) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	return nil, nil
 }
 
+// IsHASupported returns if the check is compatible with High Availability
+func (c *APMCheck) IsHASupported() bool {
+	return false
+}
+
 // Factory creates a new check factory
 func Factory() option.Option[func() check.Check] {
 	return option.New(newCheck)

--- a/pkg/collector/corechecks/embed/process/process_agent.go
+++ b/pkg/collector/corechecks/embed/process/process_agent.go
@@ -248,6 +248,11 @@ func (c *ProcessAgentCheck) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	return nil, nil
 }
 
+// IsHASupported returns if the check is compatible with High Availability
+func (c *ProcessAgentCheck) IsHASupported() bool {
+	return false
+}
+
 // Factory creates a new check factory
 func Factory() option.Option[func() check.Check] {
 	return option.New(newCheck)

--- a/pkg/collector/corechecks/longrunning_test.go
+++ b/pkg/collector/corechecks/longrunning_test.go
@@ -90,6 +90,11 @@ func (m *mockLongRunningCheck) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	return nil, nil
 }
 
+func (m *mockLongRunningCheck) IsHASupported() bool {
+	args := m.Called()
+	return args.Bool(0)
+}
+
 func (m *mockLongRunningCheck) GetSender() (sender.Sender, error) {
 	args := m.Called()
 	s := args.Get(0)

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/sdwan.go
@@ -290,6 +290,11 @@ func (c *CiscoSdwanCheck) Interval() time.Duration {
 	return c.interval
 }
 
+// IsHASupported returns true if the check supports HA
+func (c *CiscoSdwanCheck) IsHASupported() bool {
+	return true
+}
+
 func boolPointer(b bool) *bool {
 	return &b
 }

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -138,6 +138,11 @@ func (c *Check) Configure(senderManager sender.SenderManager, integrationConfigD
 	return nil
 }
 
+// IsHASupported returns true if the check supports HA
+func (c *Check) IsHASupported() bool {
+	return true
+}
+
 // Factory creates a new check factory
 func Factory(telemetry telemetryComp.Component) option.Option[func() check.Check] {
 	return option.New(func() check.Check {

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -8,9 +8,10 @@ package snmp
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"sync"
 	"time"
+
+	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"go.uber.org/atomic"
@@ -195,6 +196,11 @@ func (c *Check) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	}
 
 	return c.singleDeviceCk.GetDiagnoses(), nil
+}
+
+// IsHASupported returns true if the check supports HA
+func (c *Check) IsHASupported() bool {
+	return true
 }
 
 // Factory creates a new check factory

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -63,10 +63,11 @@ type PythonCheck struct {
 	telemetry      bool // whether or not the telemetry is enabled for this check
 	initConfig     string
 	instanceConfig string
+	haSupported    bool
 }
 
 // NewPythonCheck conveniently creates a PythonCheck instance
-func NewPythonCheck(senderManager sender.SenderManager, name string, class *C.rtloader_pyobject_t) (*PythonCheck, error) {
+func NewPythonCheck(senderManager sender.SenderManager, name string, class *C.rtloader_pyobject_t, haSupported bool) (*PythonCheck, error) {
 	glock, err := newStickyLock()
 	if err != nil {
 		return nil, err
@@ -82,6 +83,7 @@ func NewPythonCheck(senderManager sender.SenderManager, name string, class *C.rt
 		interval:      defaults.DefaultCheckInterval,
 		lastWarnings:  []error{},
 		telemetry:     utils.IsCheckTelemetryEnabled(name, pkgconfigsetup.Datadog()),
+		haSupported:   haSupported,
 	}
 	runtime.SetFinalizer(pyCheck, pythonCheckFinalizer)
 
@@ -403,6 +405,11 @@ func (c *PythonCheck) GetDiagnoses() ([]diagnosis.Diagnosis, error) {
 	}
 
 	return diagnoses, nil
+}
+
+// IsHASupported returns the HA_SUPPORTED class attribute defined at Python Check level
+func (c *PythonCheck) IsHASupported() bool {
+	return c.haSupported
 }
 
 // pythonCheckFinalizer is a finalizer that decreases the reference count on the PyObject refs owned

--- a/pkg/collector/python/loader_test.go
+++ b/pkg/collector/python/loader_test.go
@@ -18,3 +18,7 @@ func TestLoadWheelCheck(t *testing.T) {
 func TestLoadCustomCheck(t *testing.T) {
 	testLoadCustomCheck(t)
 }
+
+func TestLoadHACheck(t *testing.T) {
+	testLoadHACheck(t)
+}

--- a/pkg/collector/python/test_check.go
+++ b/pkg/collector/python/test_check.go
@@ -690,7 +690,7 @@ func testGetDiagnoses(t *testing.T) {
 
 // NewPythonFakeCheck create a fake PythonCheck
 func NewPythonFakeCheck(senderManager sender.SenderManager) (*PythonCheck, error) {
-	c, err := NewPythonCheck(senderManager, "fake_check", nil)
+	c, err := NewPythonCheck(senderManager, "fake_check", nil, false)
 
 	// Remove check finalizer that may trigger race condition while testing
 	if err == nil {

--- a/pkg/collector/python/test_loader.go
+++ b/pkg/collector/python/test_loader.go
@@ -15,6 +15,7 @@ import (
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/stretchr/testify/assert"
 )
@@ -64,6 +65,19 @@ int get_attr_string(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const c
 	return get_attr_string_return;
 }
 
+int get_attr_bool_return = 0;
+rtloader_pyobject_t *get_attr_bool_py_class = NULL;
+const char *get_attr_bool_attr_name = NULL;
+int get_attr_bool_attr_value = 0;
+
+int get_attr_bool(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *attr_name, bool *value) {
+	get_attr_bool_py_class = py_class;
+	get_attr_bool_attr_name = attr_name;
+	*value = get_attr_bool_attr_value;
+
+	return get_attr_bool_return;
+}
+
 extern int get_check_return;
 extern int get_check_calls;
 extern rtloader_pyobject_t *get_check_py_class;
@@ -107,6 +121,11 @@ void reset_loader_mock() {
 	get_attr_string_py_class = NULL;
 	get_attr_string_attr_name = NULL;
 	get_attr_string_attr_value = NULL;
+
+	get_attr_bool_return = 0;
+	get_attr_bool_py_class = NULL;
+	get_attr_bool_attr_name = NULL;
+	get_attr_bool_attr_value = 0;
 
 	get_check_return = 0;
 	get_check_calls = 0;
@@ -205,4 +224,91 @@ func testLoadWheelCheck(t *testing.T) {
 	assert.Equal(t, C.get_class_dd_wheel_py_class, check.(*PythonCheck).class)
 	// test we call get_attr_string on the module
 	assert.Equal(t, C.get_attr_string_py_class, C.get_class_dd_wheel_py_module)
+}
+
+func testLoadHACheck(t *testing.T) {
+	conf := integration.Config{
+		Name:       "fake_check",
+		Instances:  []integration.Data{integration.Data("{\"value\": 1}")},
+		InitConfig: integration.Data("{}"),
+	}
+
+	rtloader = newMockRtLoaderPtr()
+	defer func() { rtloader = nil }()
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	logReceiver := option.None[integrations.Component]()
+	tagger := nooptagger.NewComponent()
+	loader, err := NewPythonCheckLoader(senderManager, logReceiver, tagger)
+	assert.Nil(t, err)
+
+	testCases := []struct {
+		name                string
+		haAgentEnabled      bool
+		getAttrBoolReturn   int
+		getAttrBoolValue    int
+		expectedHaSupported bool
+		expectedGetAttrRun  bool
+	}{
+		{
+			name:                "HA Agent not enabled",
+			haAgentEnabled:      false,
+			getAttrBoolReturn:   0,
+			getAttrBoolValue:    0,
+			expectedHaSupported: false,
+			expectedGetAttrRun:  false,
+		}, {
+			name:                "get_attr_bool returns an error",
+			haAgentEnabled:      true,
+			getAttrBoolReturn:   0,
+			getAttrBoolValue:    0,
+			expectedHaSupported: false,
+			expectedGetAttrRun:  true,
+		}, {
+			name:                "get_attr_bool returns false",
+			haAgentEnabled:      true,
+			getAttrBoolReturn:   1,
+			getAttrBoolValue:    0,
+			expectedHaSupported: false,
+			expectedGetAttrRun:  true,
+		}, {
+			name:                "get_attr_bool returns true",
+			haAgentEnabled:      true,
+			getAttrBoolReturn:   1,
+			getAttrBoolValue:    1,
+			expectedHaSupported: true,
+			expectedGetAttrRun:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			C.reset_loader_mock()
+
+			pkgconfigsetup.Datadog().SetWithoutSource("ha_agent.enabled", tc.haAgentEnabled)
+
+			// testing loading custom checks
+			C.get_class_return = 1
+			C.get_class_py_module = newMockPyObjectPtr()
+			C.get_class_py_class = newMockPyObjectPtr()
+			C.get_attr_string_return = 0
+			C.get_check_return = 0
+			C.get_check_deprecated_check = newMockPyObjectPtr()
+			C.get_check_deprecated_return = 1
+
+			C.get_attr_bool_return = C.int(tc.getAttrBoolReturn)
+			C.get_attr_bool_attr_value = C.int(tc.getAttrBoolValue)
+
+			check, err := loader.Load(senderManager, conf, conf.Instances[0])
+			// Remove check finalizer that may trigger race condition while testing
+			runtime.SetFinalizer(check, nil)
+
+			assert.Nil(t, err)
+			assert.Equal(t, "fake_check", check.(*PythonCheck).ModuleName)
+			assert.Equal(t, "unversioned", check.(*PythonCheck).version)
+			assert.Equal(t, C.get_class_py_class, check.(*PythonCheck).class)
+			// test we call get_attr_bool on the class if get_attr_bool is run
+			assert.Equal(t, tc.expectedGetAttrRun, C.get_attr_bool_py_class == C.get_class_py_class)
+			assert.Equal(t, tc.expectedHaSupported, check.(*PythonCheck).haSupported)
+		})
+	}
 }

--- a/pkg/collector/worker/worker.go
+++ b/pkg/collector/worker/worker.go
@@ -141,7 +141,7 @@ func (w *Worker) Run() {
 		checkLogger := CheckLogger{Check: check}
 		longRunning := check.Interval() == 0
 
-		if !w.haAgent.ShouldRunIntegration(check.String()) {
+		if w.haAgent.Enabled() && check.IsHASupported() && !w.haAgent.IsActive() {
 			checkLogger.Debug("Check is an HA integration and current agent is not leader, skipping execution...")
 			continue
 		}

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -114,6 +114,26 @@ func newCheck(t *testing.T, id string, doErr bool, runFunc func(checkid.ID)) *te
 	}
 }
 
+type testHACheck struct {
+	testCheck
+}
+
+func (c *testHACheck) IsHASupported() bool {
+	return true
+}
+
+func newHACheck(t *testing.T, id string, doErr bool, runFunc func(checkid.ID)) *testHACheck {
+	return &testHACheck{
+		testCheck: testCheck{
+			doErr:    doErr,
+			t:        t,
+			id:       id,
+			runFunc:  runFunc,
+			runCount: atomic.NewUint64(0),
+		},
+	}
+}
+
 func assertErrorCount(t *testing.T, c check.Check, count int) {
 	stats, found := expvars.CheckStats(c.ID())
 	require.True(t, found)
@@ -686,7 +706,7 @@ func TestWorker_HaIntegration(t *testing.T) {
 			pendingChecksChan := make(chan check.Check, 10)
 			mockShouldAddStatsFunc := func(checkid.ID) bool { return true }
 
-			snmpCheck := newCheck(t, "snmp:123", false, nil)
+			snmpCheck := newHACheck(t, "snmp:123", false, nil)
 			unknownCheck := newCheck(t, "unknown-check:123", false, nil)
 
 			pendingChecksChan <- snmpCheck

--- a/releasenotes/notes/enable-ha-supported-integrations-32c59c3bb1b8caf5.yaml
+++ b/releasenotes/notes/enable-ha-supported-integrations-32c59c3bb1b8caf5.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Update HA Agent feature to work with HA Enabled integrations.
+    Allow integrations to self-declare as HA Supported.

--- a/releasenotes/notes/enable-ha-supported-integrations-32c59c3bb1b8caf5.yaml
+++ b/releasenotes/notes/enable-ha-supported-integrations-32c59c3bb1b8caf5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enables High Availability on SNMP, Cisco SD-WAN, and Network Path integrations.

--- a/releasenotes/notes/enable-ha-supported-integrations-32c59c3bb1b8caf5.yaml
+++ b/releasenotes/notes/enable-ha-supported-integrations-32c59c3bb1b8caf5.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Enables High Availability on SNMP, Cisco SD-WAN, and Network Path integrations.
+    Update HA Agent feature to work with HA Enabled integrations.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR enables integrations to self-declare as HA compatible.
For go checks, integrations have to implement a method `IsHASupported()` returning true and for python checks, integrations have to add a class attribute `HA_SUPPORTED = True` to their class
HA will be enable for all supported integrations if there is the config `ha_agent: enabled: true` in the `datadog.yaml` 


### QA

Setup:

1/ Setup 2 Agent with HA feature enabled

```
ha_agent:
  enabled: true
config_id: my-config
```

2/ Configure HA Supported corecheck and python integration instances.

Example:

- corechecks: snmp, network_path, sd_wan
- python: cisco_aci

Verification:

- Check that HA Supported integrations only run on Active agent
- Check that HA Supported integrations only run on Active agent after a failover
- Check that non-HA integrations run on both agents

✅ Manual QA already done
