### PR TITLE
service discovery: Do not use @args for Java naming

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/java.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/java.go
@@ -42,7 +42,11 @@ func (jd javaDetector) detect(args []string) (metadata ServiceMetadata, success 
 			strings.HasPrefix(a, "-X") ||
 			strings.HasPrefix(a, "-javaagent:") ||
 			strings.HasPrefix(a, "-verbose:")
-		shouldSkipArg := prevArgIsFlag || hasFlagPrefix || includesAssignment
+		// @ is used to point to a file with more arguments. We do not supported
+		// at the moment, so explicitly ignore it to avoid naming services
+		// based on this file name.
+		atArg := strings.HasPrefix(a, "@")
+		shouldSkipArg := prevArgIsFlag || hasFlagPrefix || includesAssignment || atArg
 		if !shouldSkipArg {
 			arg := removeFilePath(a)
 

--- a/pkg/collector/corechecks/servicediscovery/usm/service_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service_test.go
@@ -219,6 +219,24 @@ func TestExtractServiceMetadata(t *testing.T) {
 			expectedGeneratedNameSource: CommandLine,
 		},
 		{
+			name: "java ignore @",
+			cmdline: []string{
+				"java", "@/tmp/foo21321312.tmp",
+			},
+			lang:                        language.Java,
+			expectedGeneratedName:       "java",
+			expectedGeneratedNameSource: CommandLine,
+		},
+		{
+			name: "java ignore @2",
+			cmdline: []string{
+				"java", "@foo.extra", "myapp",
+			},
+			lang:                        language.Java,
+			expectedGeneratedName:       "myapp",
+			expectedGeneratedNameSource: CommandLine,
+		},
+		{
 			name: "java kafka",
 			cmdline: []string{
 				"java", "-Xmx4000m", "-Xms4000m", "-XX:ReservedCodeCacheSize=256m", "kafka.Kafka",


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `@arg` specifies a file containg more command line arguments.  We do not currently support it, but at least avoid using that file name for the service name, since some services put a temporary filename there.

### Motivation

Noticed since some services generate random filenames "fooxyz.tmp". Those result in a service name of "tmp" currently.

### Describe how you validated your changes

Unit tests added.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->