### PR TITLE
chore: deprecate auto-instrumentation v1

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
@@ -9,6 +9,8 @@ package autoinstrumentation
 
 import (
 	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type version int
@@ -22,6 +24,7 @@ const (
 func instrumentationVersion(v string) (version, error) {
 	switch v {
 	case "v1":
+		log.Warn("apm.instrumentation.version v1 is deprecated and slated for removal")
 		return instrumentationV1, nil
 	case "v2":
 		return instrumentationV2, nil


### PR DESCRIPTION
### What does this PR do?

Deprecates v1 of auto-instrumentation webhook. This will be removed in a future version of the agent.

### Motivation

We have been running `v2` by default in the clusteragent since `7.57` and are planning on ripping out `v1` in the next release after `7.64`.

### Describe how you validated your changes

N/A This is just a log line.