### PR TITLE
usm: kafka: Use object pool for latencies

### DIFF
--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -356,10 +356,15 @@ func (p *protocol) setupInFlightMapCleaner(mgr *manager.Manager) error {
 func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.telemetry.Log()
+	stats := p.statkeeper.GetAndResetAllStats()
 	return &protocols.ProtocolStats{
-		Type:  protocols.Kafka,
-		Stats: p.statkeeper.GetAndResetAllStats(),
-	}, nil
+			Type:  protocols.Kafka,
+			Stats: stats,
+		}, func() {
+			for _, s := range stats {
+				s.Close()
+			}
+		}
 }
 
 // IsBuildModeSupported returns always true, as kafka module is supported by all modes.

--- a/pkg/network/protocols/kafka/stats.go
+++ b/pkg/network/protocols/kafka/stats.go
@@ -6,10 +6,14 @@
 package kafka
 
 import (
+	"errors"
+
+	"github.com/DataDog/sketches-go/ddsketch"
+
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/types"
 	"github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/sketches-go/ddsketch"
 )
 
 const (
@@ -18,11 +22,6 @@ const (
 
 	// FetchAPIKey is the API key for fetch requests
 	FetchAPIKey = 1
-
-	// RelativeAccuracy defines the acceptable error in quantile values calculated by DDSketch.
-	// For example, if the actual value at p50 is 100, with a relative accuracy of 0.01 the value calculated
-	// will be between 99 and 101
-	RelativeAccuracy = 0.01
 )
 
 // Key is an identifier for a group of Kafka transactions
@@ -65,12 +64,20 @@ type RequestStat struct {
 	StaticTags         uint64
 }
 
-func (r *RequestStat) initSketch() (err error) {
-	r.Latencies, err = ddsketch.NewDefaultDDSketch(RelativeAccuracy)
-	if err != nil {
-		log.Debugf("error recording kafka transaction latency: could not create new ddsketch: %v", err)
+func (r *RequestStat) initSketch() error {
+	latencies := protocols.SketchesPool.Get()
+	if latencies == nil {
+		return errors.New("error recording kafka transaction latency: could not create new ddsketch")
 	}
-	return
+	r.Latencies = latencies
+	return nil
+}
+
+func (r *RequestStat) close() {
+	if r.Latencies != nil {
+		r.Latencies.Clear()
+		protocols.SketchesPool.Put(r.Latencies)
+	}
 }
 
 // CombineWith merges the data in 2 RequestStats objects
@@ -151,4 +158,13 @@ func (r *RequestStats) AddRequest(errorCode int32, count int, staticTags uint64,
 
 func isValidKafkaErrorCode(errorCode int32) bool {
 	return errorCode >= -1 && errorCode <= 119
+}
+
+// Close releases internal stats resources.
+func (r *RequestStats) Close() {
+	for _, stats := range r.ErrorCodeToStat {
+		if stats != nil {
+			stats.close()
+		}
+	}
 }

--- a/pkg/network/protocols/kafka/stats.go
+++ b/pkg/network/protocols/kafka/stats.go
@@ -143,6 +143,7 @@ func (r *RequestStats) AddRequest(errorCode int32, count int, staticTags uint64,
 
 	if stats.Latencies == nil {
 		if err := stats.initSketch(); err != nil {
+			log.Warnf("could not add request latency to ddsketch: %v", err)
 			return
 		}
 

--- a/pkg/network/protocols/kafka/stats_test.go
+++ b/pkg/network/protocols/kafka/stats_test.go
@@ -84,3 +84,31 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	assert.GreaterOrEqual(t, val, expectedValue-acceptableError)
 	assert.LessOrEqual(t, val, expectedValue+acceptableError)
 }
+
+func benchmarkRequestStatsPool(b *testing.B, reqNum int) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		stats := NewRequestStats()
+		for j := 0; j < reqNum; j++ {
+			stats.AddRequest(1, 1, 1, 1)
+		}
+		stats.Close()
+	}
+}
+
+func BenchmarkRequestStatsPool_10Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 10)
+}
+
+func BenchmarkRequestStatsPool_100Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 100)
+}
+
+func BenchmarkRequestStatsPool_1000Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 1000)
+}
+
+func BenchmarkRequestStatsPool_10000Reqs(b *testing.B) {
+	benchmarkRequestStatsPool(b, 10000)
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We leverage object pool instead of reallocating ddsketch object for kafka

### Motivation

Follow up for another protocol after #34080

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Benchmark results:
```
main:
BenchmarkRequestStatsPool_10Reqs
BenchmarkRequestStatsPool_10Reqs-16       	 1000000	      1316 ns/op	     592 B/op	       9 allocs/op
BenchmarkRequestStatsPool_100Reqs
BenchmarkRequestStatsPool_100Reqs-16      	  153340	      8860 ns/op	    1808 B/op	      13 allocs/op
BenchmarkRequestStatsPool_1000Reqs
BenchmarkRequestStatsPool_1000Reqs-16     	   24699	     52517 ns/op	    1808 B/op	      13 allocs/op
BenchmarkRequestStatsPool_10000Reqs
BenchmarkRequestStatsPool_10000Reqs-16    	    3877	    317198 ns/op	    1808 B/op	      13 allocs/op

branch:
BenchmarkRequestStatsPool_10Reqs
BenchmarkRequestStatsPool_10Reqs-16       	 1924906	       700.7 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_100Reqs
BenchmarkRequestStatsPool_100Reqs-16      	  325545	      3820 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_1000Reqs
BenchmarkRequestStatsPool_1000Reqs-16     	   37941	     30833 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_10000Reqs
BenchmarkRequestStatsPool_10000Reqs-16    	    3649	    294629 ns/op	      65 B/op	       1 allocs/op
```