### PR TITLE
Support for nil pointers in Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -223,6 +223,7 @@ func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[st
 		if err != nil {
 			return nil, fmt.Errorf("could not find pointer type: %w", err)
 		}
+		typeHeader.ID = randomLabel()
 		typeHeader.ParameterPieces = pointerElements
 	}
 

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -219,12 +219,15 @@ func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[st
 		}
 		typeHeader.ParameterPieces = arrayElements
 	} else if typeEntry.Tag == dwarf.TagPointerType {
+		// Get underlying type that the pointer points to
 		pointerElements, err := getPointerLayers(typeEntry.Offset, dwarfData, seenTypes)
 		if err != nil {
 			return nil, fmt.Errorf("could not find pointer type: %w", err)
 		}
-		typeHeader.ID = randomLabel()
 		typeHeader.ParameterPieces = pointerElements
+		// pointers have a unique ID so we only capture the address once when generating
+		// location expressions
+		typeHeader.ID = randomLabel()
 	}
 
 	return &typeHeader, nil
@@ -374,6 +377,8 @@ func getStructFields(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[s
 	return structFields, nil
 }
 
+// getPointerLayers is used to populate the underlying type of pointers. The returned slice of parameters
+// would contain a single element which represents the entire type tree that the pointer points to.
 func getPointerLayers(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[string]*seenTypeCounter) ([]*ditypes.Parameter, error) {
 	typeReader := dwarfData.Reader()
 	typeReader.Seek(offset)

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -98,9 +98,9 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 				// This is not directly assigned, expect the address for it on the stack
 				if elementParam.Kind == uint(reflect.Pointer) {
 					targetExpressions = append(targetExpressions,
+						ditypes.DereferenceLocationExpression(uint(elementParam.TotalSize)),
 						ditypes.CopyLocationExpression(),
 						ditypes.PopLocationExpression(1, 8),
-						ditypes.DereferenceLocationExpression(uint(elementParam.TotalSize)),
 					)
 				} else if elementParam.Kind == uint(reflect.Struct) {
 					// Structs don't provide context on location, or have values themselves

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -169,7 +169,6 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					if len(elementParam.ParameterPieces) != 3 {
 						continue
 					}
-					sliceIdentifier := randomLabel()
 					slicePointer := elementParam.ParameterPieces[0]
 					sliceLength := elementParam.ParameterPieces[1]
 					sliceLength.LocationExpressions = append(sliceLength.LocationExpressions,
@@ -193,7 +192,7 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					// Generate and collect the location expressions for collecting an individual
 					// element of this slice
 					sliceElementType := slicePointer.ParameterPieces[0]
-
+					sliceIdentifier := randomLabel()
 					labelName := randomLabel()
 
 					if slicePointer.Location != nil && sliceLength.Location != nil {
@@ -227,7 +226,6 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 						for i := 0; i < ditypes.SliceMaxLength; i++ {
 							GenerateLocationExpression(limitsInfo, sliceElementType)
 							expressionsToUseForEachSliceElement := collectAllLocationExpressions(sliceElementType, true)
-							labelName := randomLabel()
 							targetExpressions = append(targetExpressions,
 								ditypes.PrintStatement("%s", "Reading slice element "+fmt.Sprintf("%d", i)),
 								ditypes.JumpToLabelIfEqualToLimit(uint(i), sliceIdentifier, labelName),

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -84,6 +84,8 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 				} else if elementParam.Kind == uint(reflect.Pointer) {
 					targetExpressions = append(targetExpressions,
 						ditypes.DirectReadLocationExpression(elementParam),
+						ditypes.CopyLocationExpression(),
+						ditypes.PopLocationExpression(1, 8),
 					)
 				} else {
 					targetExpressions = append(targetExpressions,
@@ -96,6 +98,8 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 				// This is not directly assigned, expect the address for it on the stack
 				if elementParam.Kind == uint(reflect.Pointer) {
 					targetExpressions = append(targetExpressions,
+						ditypes.CopyLocationExpression(),
+						ditypes.PopLocationExpression(1, 8),
 						ditypes.DereferenceLocationExpression(uint(elementParam.TotalSize)),
 					)
 				} else if elementParam.Kind == uint(reflect.Struct) {

--- a/pkg/dynamicinstrumentation/eventparser/event_parser_test.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser_test.go
@@ -9,6 +9,7 @@ package eventparser
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
@@ -365,7 +366,7 @@ func TestParseParams(t *testing.T) {
 		},
 		{
 			Name:   "uint pointer ok",
-			Buffer: []byte{22, 8, 0, 7, 8, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Buffer: []byte{22, 8, 0, 7, 8, 0, 248, 60, 128, 0, 64, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ExpectedOutput: []*ditypes.Param{
 				{
 					Type: "*uint",
@@ -384,7 +385,7 @@ func TestParseParams(t *testing.T) {
 		},
 		{
 			Name:   "struct pointer ok",
-			Buffer: []byte{22, 8, 0, 25, 3, 0, 1, 1, 0, 2, 8, 0, 4, 2, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Buffer: []byte{22, 8, 0, 25, 2, 0, 7, 8, 0, 1, 1, 0, 248, 60, 128, 0, 64, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ExpectedOutput: []*ditypes.Param{
 				{
 					Type: "*struct",
@@ -393,26 +394,20 @@ func TestParseParams(t *testing.T) {
 					Fields: []*ditypes.Param{
 						{
 							Type: "struct",
-							Size: 3,
+							Size: 2,
 							Kind: byte(reflect.Struct),
 							Fields: []*ditypes.Param{
+								{
+									Kind:     byte(reflect.Uint),
+									ValueStr: "9",
+									Type:     "uint",
+									Size:     8,
+								},
 								{
 									Kind:     byte(reflect.Bool),
 									ValueStr: "true",
 									Type:     "bool",
 									Size:     1,
-								},
-								{
-									Kind:     byte(reflect.Int),
-									ValueStr: "1",
-									Type:     "int",
-									Size:     8,
-								},
-								{
-									Kind:     byte(reflect.Int16),
-									ValueStr: "2",
-									Type:     "int16",
-									Size:     2,
 								},
 							},
 						},
@@ -425,36 +420,11 @@ func TestParseParams(t *testing.T) {
 			Buffer: []byte{22, 8, 0, 25, 3, 0, 1, 1, 0, 2, 8, 0, 4, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ExpectedOutput: []*ditypes.Param{
 				{
-					Type: "*struct",
-					Size: 8,
-					Kind: byte(reflect.Pointer),
-					Fields: []*ditypes.Param{
-						{
-							Type: "struct",
-							Size: 3,
-							Kind: byte(reflect.Struct),
-							Fields: []*ditypes.Param{
-								{
-									Kind:     byte(reflect.Bool),
-									ValueStr: "false",
-									Type:     "bool",
-									Size:     1,
-								},
-								{
-									Kind:     byte(reflect.Int),
-									ValueStr: "0",
-									Type:     "int",
-									Size:     8,
-								},
-								{
-									Kind:     byte(reflect.Int16),
-									ValueStr: "0",
-									Type:     "int16",
-									Size:     2,
-								},
-							},
-						},
-					},
+					Type:     "*struct",
+					Size:     8,
+					Kind:     byte(reflect.Pointer),
+					ValueStr: "0x0",
+					Fields:   nil,
 				},
 			},
 		},
@@ -463,6 +433,11 @@ func TestParseParams(t *testing.T) {
 	for i := range testCases {
 		t.Run(testCases[i].Name, func(t *testing.T) {
 			result := readParams(testCases[i].Buffer)
+			for i := range result {
+				if strings.HasPrefix(result[i].Type, "*") && result[i].ValueStr != "0x0" {
+					result[i].ValueStr = ""
+				}
+			}
 			assert.Equal(t, testCases[i].ExpectedOutput, result)
 		})
 	}

--- a/pkg/dynamicinstrumentation/testutil/e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/e2e_test.go
@@ -193,7 +193,7 @@ func scrubPointerValues(captures ditypes.CapturedValueMap) {
 }
 
 func scrubPointerValue(capture *ditypes.CapturedValue) {
-	if capture.Type == "ptr" {
+	if strings.HasPrefix(capture.Type, "*") {
 		capture.Value = nil
 	}
 	scrubPointerValues(capture.Fields)

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -273,11 +273,11 @@ func mergeMaps(maps ...fixtures) fixtures {
 }
 
 var expectedCaptures = mergeMaps(
-	basicCaptures,
-	stringCaptures,
-	arrayCaptures,
-	structCaptures,
-	sliceCaptures,
+	// basicCaptures,
+	// stringCaptures,
+	// arrayCaptures,
+	// structCaptures,
+	// sliceCaptures,
 	pointerCaptures,
 	// mapCaptures,
 	// genericCaptures,

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -273,11 +273,11 @@ func mergeMaps(maps ...fixtures) fixtures {
 }
 
 var expectedCaptures = mergeMaps(
-	// basicCaptures,
-	// stringCaptures,
-	// arrayCaptures,
-	// structCaptures,
-	// sliceCaptures,
+	basicCaptures,
+	stringCaptures,
+	arrayCaptures,
+	structCaptures,
+	sliceCaptures,
 	pointerCaptures,
 	// mapCaptures,
 	// genericCaptures,

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -243,6 +243,24 @@ var structCaptures = fixtures{
 	}}},
 }
 
+var pointerCaptures = fixtures{
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_uint_pointer": {"x": {Type: "*uint", Fields: fieldMap{
+		"arg_0": capturedValue("uint", "1"),
+	}}},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_pointer": {"z": {Type: "*bool"}},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_pointer": {"x": {Type: "*struct", Fields: fieldMap{
+		"arg_0": &ditypes.CapturedValue{
+			Type: "struct",
+			Fields: fieldMap{
+				"arg_0": capturedValue("bool", "true"),
+				"arg_1": capturedValue("int", "1"),
+				"arg_2": capturedValue("int16", "2"),
+			},
+		},
+	}}},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_struct_pointer": {"x": {Type: "*struct"}},
+}
+
 // mergeMaps combines multiple fixture maps into a single map
 func mergeMaps(maps ...fixtures) fixtures {
 	result := make(fixtures)
@@ -260,6 +278,7 @@ var expectedCaptures = mergeMaps(
 	arrayCaptures,
 	structCaptures,
 	sliceCaptures,
+	pointerCaptures,
 	// mapCaptures,
 	// genericCaptures,
 	// multiParamCaptures,

--- a/pkg/dynamicinstrumentation/testutil/sample/pointers.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/pointers.go
@@ -95,6 +95,10 @@ func test_string_slice_pointer(a *[]string) {}
 func test_nil_pointer(z *bool) {}
 
 //nolint:all
+//go:noinline
+func test_pointer_to_pointer(u **int) {}
+
+//nolint:all
 func ExecutePointerFuncs() {
 	var u64F uint64 = 5
 	swp := structWithPointer{a: &u64F}
@@ -149,4 +153,9 @@ func ExecutePointerFuncs() {
 	test_string_slice_pointer(&stringSlice)
 
 	test_nil_pointer(nil)
+
+	u := 9
+	up := &u
+	upp := &up
+	test_pointer_to_pointer(upp)
 }


### PR DESCRIPTION
### What does this PR do?

Similar to #33996, this adds logic to DI to allow for nil values for pointers. It does so by adding 8 bytes of value for pointers in the output buffer between bpf and user space. If the address is 0, parsing of events knows not to expect a value for the underlying type that is being pointed to.

Also fixes a small bug in non-directly assigned slices.

### Motivation

This is a precursor change to set up for support of partial snapshots.

### Describe how you validated your changes

Added e2e test fixtures.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->