### PR TITLE
dynamicinstrumentation: do not store full dwarf data in `ProcessInfo`

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -59,7 +59,6 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 	}
 
 	procInfo.TypeMap = typeMap
-	procInfo.DwarfData = dwarfData
 
 	fieldIDs := make([]bininspect.FieldIdentifier, 0)
 	for _, funcParams := range typeMap.Functions {

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -74,10 +74,20 @@ entryLoop:
 				continue entryLoop
 			}
 
+			cuLineReader, err := dwarfData.LineReader(entry)
+			if err != nil {
+				log.Errorf("could not get file line reader for compile unit: %v", err)
+				continue entryLoop
+			}
+			var files []*dwarf.LineFile
+			if cuLineReader != nil {
+				files = cuLineReader.Files()
+			}
+
 			for i := range ranges {
-				result.DeclaredFiles = append(result.DeclaredFiles, &ditypes.LowPCEntry{
+				result.DeclaredFiles = append(result.DeclaredFiles, &ditypes.DwarfFilesEntry{
 					LowPC: ranges[i][0],
-					Entry: entry,
+					Files: files,
 				})
 			}
 		}
@@ -177,7 +187,7 @@ entryLoop:
 	slices.SortFunc(result.FunctionsByPC, func(a, b *ditypes.FuncByPCEntry) int {
 		return cmp.Compare(b.LowPC, a.LowPC)
 	})
-	slices.SortFunc(result.DeclaredFiles, func(a, b *ditypes.LowPCEntry) int {
+	slices.SortFunc(result.DeclaredFiles, func(a, b *ditypes.DwarfFilesEntry) int {
 		return cmp.Compare(b.LowPC, a.LowPC)
 	})
 

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -24,7 +24,7 @@ type TypeMap struct {
 	// DeclaredFiles places DWARF compile unit entries in order by its
 	// low program counter which is necessary for resolving declared file
 	// for the sake of stack traces
-	DeclaredFiles []*LowPCEntry
+	DeclaredFiles []*DwarfFilesEntry
 }
 
 // Parameter represents a function parameter as read from DWARF info
@@ -383,10 +383,10 @@ func (l Location) String() string {
 	return fmt.Sprintf("Location{InReg: %t, StackOffset: %d, Register: %d}", l.InReg, l.StackOffset, l.Register)
 }
 
-// LowPCEntry is a helper type used to sort DWARF entries by their low program counter
-type LowPCEntry struct {
+// DwarfFilesEntry represents the list of files used in a DWARF compile unit
+type DwarfFilesEntry struct {
 	LowPC uint64
-	Entry *dwarf.Entry
+	Files []*dwarf.LineFile
 }
 
 // BPFProgram represents a bpf program that's created for a single probe

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -19,7 +19,7 @@ type TypeMap struct {
 
 	// FunctionsByPC places DWARF subprogram (function) entries in order by
 	// its low program counter which is necessary for resolving stack traces
-	FunctionsByPC []*LowPCEntry
+	FunctionsByPC []*FuncByPCEntry
 
 	// DeclaredFiles places DWARF compile unit entries in order by its
 	// low program counter which is necessary for resolving declared file
@@ -409,4 +409,12 @@ func PrintLocationExpressions(expressions []LocationExpression) {
 			expressions[i].CollectionIdentifier,
 		)
 	}
+}
+
+// FuncByPCEntry represents useful data associated with a function entry in DWARF
+type FuncByPCEntry struct {
+	LowPC      uint64
+	Fn         string
+	FileNumber int64
+	Line       int64
 }

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -10,7 +10,6 @@
 package ditypes
 
 import (
-	"debug/dwarf"
 	"fmt"
 	"io"
 	"strconv"
@@ -133,8 +132,7 @@ type ProcessInfo struct {
 	RuntimeID   string
 	BinaryPath  string
 
-	TypeMap   *TypeMap
-	DwarfData *dwarf.Data
+	TypeMap *TypeMap
 
 	ConfigurationUprobe    *link.Link
 	ProbesByID             ProbesByID

--- a/pkg/dynamicinstrumentation/uploader/stack_trace.go
+++ b/pkg/dynamicinstrumentation/uploader/stack_trace.go
@@ -64,17 +64,11 @@ func pcToLine(procInfo *ditypes.ProcessInfo, pc uint64) (*funcInfo, error) {
 	}
 	funcEntry := typeMap.FunctionsByPC[functionIndex]
 
-	compileUnitIndex, _ := slices.BinarySearchFunc(typeMap.DeclaredFiles, &ditypes.LowPCEntry{LowPC: pc}, func(a, b *ditypes.LowPCEntry) int {
+	compileUnitIndex, _ := slices.BinarySearchFunc(typeMap.DeclaredFiles, &ditypes.DwarfFilesEntry{LowPC: pc}, func(a, b *ditypes.DwarfFilesEntry) int {
 		return cmp.Compare(b.LowPC, a.LowPC)
 	})
 
-	compileUnitEntry := typeMap.DeclaredFiles[compileUnitIndex].Entry
-
-	cuLineReader, err := procInfo.DwarfData.LineReader(compileUnitEntry)
-	if err != nil {
-		return nil, fmt.Errorf("could not get file line reader for compile unit: %w", err)
-	}
-	files := cuLineReader.Files()
+	files := typeMap.DeclaredFiles[compileUnitIndex].Files
 	if len(files) < int(funcEntry.FileNumber) {
 		return nil, fmt.Errorf("invalid file number in dwarf function entry associated with compile unit")
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR refactors the dwarf management in dynamic instrumentation code, with the end goal of not storing the full dwarf data for all processes continuously.

The first commit moves the computation of "function + file number + line" to the loading part instead of in `pcToLine` allowing to not store a full `dwarf.Entry` but just the interesting data

The second commit moves the computation of the list of files to the loading part instead of in `pcToLine`, allowing to do it only once, and to not store a full `dwarf.Entry` for each compilation unit

The last commit removes the dwarf data field from the process info struct now that all users have disappeared.

Benchmarks:
- [profile list 
](https://ddstaging.datadoghq.com/profiling/explorer?query=service%3Asystem-probe%20kube_cluster_name%3Astripe%20host%3Ai-06f0b451aae18f19d&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&fromUser=false&my_code=disabled&profile_type=heap-live-size&refresh_mode=sliding&stream_sort=timestamp%2Cdesc&viz=stream&from_ts=1739964547505&to_ts=1739968147505&live=true)
- [dashboard with metrics](https://ddstaging.datadoghq.com/dashboard/kfn-zy2-t98/agent-system-probe-overview?fromUser=true&refresh_mode=sliding&tpl_var_host%5B0%5D=i-06f0b451aae18f19d&from_ts=1739964508192&to_ts=1739968108192&live=true)
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->