### PR TITLE
[NPM] Telemetry for Syn retransmits

### DIFF
--- a/pkg/network/ebpf/c/tracer/events.h
+++ b/pkg/network/ebpf/c/tracer/events.h
@@ -96,6 +96,11 @@ static __always_inline int cleanup_conn(void *ctx, conn_tuple_t *tup, struct soc
             conn.tcp_stats = *tst;
         } else {
             if (!cst_flushable) {
+                int *count = bpf_map_lookup_elem(&tcp_retransmits, &(conn.tup));
+                if (count) {
+                    increment_telemetry_count_times(tcp_syn_retransmit, *count);
+                    bpf_map_delete_elem(&tcp_retransmits, &(conn.tup));
+                }
                 return -1;
             }
         }

--- a/pkg/network/ebpf/c/tracer/telemetry.h
+++ b/pkg/network/ebpf/c/tracer/telemetry.h
@@ -28,10 +28,11 @@ enum telemetry_counter {
     tcp_finish_connect_failed_tuple,
     tcp_close_target_failures,
     tcp_done_connection_flush,
-    tcp_close_connection_flush
+    tcp_close_connection_flush,
+    tcp_syn_retransmit,
 };
 
-static __always_inline void increment_telemetry_count(enum telemetry_counter counter_name) {
+static __always_inline void __increment_telemetry_count(enum telemetry_counter counter_name, int times) {
     __u64 key = 0;
     telemetry_t *val = NULL;
     val = bpf_map_lookup_elem(&telemetry, &key);
@@ -41,48 +42,59 @@ static __always_inline void increment_telemetry_count(enum telemetry_counter cou
 
     switch (counter_name) {
     case tcp_failed_connect:
-        __sync_fetch_and_add(&val->tcp_failed_connect, 1);
+        __sync_fetch_and_add(&val->tcp_failed_connect, times);
         break;
     case unbatched_tcp_close:
-        __sync_fetch_and_add(&val->unbatched_tcp_close, 1);
+        __sync_fetch_and_add(&val->unbatched_tcp_close, times);
         break;
     case unbatched_udp_close:
-        __sync_fetch_and_add(&val->unbatched_udp_close, 1);
+        __sync_fetch_and_add(&val->unbatched_udp_close, times);
         break;
     case udp_send_processed:
-        __sync_fetch_and_add(&val->udp_sends_processed, 1);
+        __sync_fetch_and_add(&val->udp_sends_processed, times);
         break;
     case udp_send_missed:
-        __sync_fetch_and_add(&val->udp_sends_missed, 1);
+        __sync_fetch_and_add(&val->udp_sends_missed, times);
         break;
     case udp_dropped_conns:
-        __sync_fetch_and_add(&val->udp_dropped_conns, 1);
+        __sync_fetch_and_add(&val->udp_dropped_conns, times);
         break;
     case unsupported_tcp_failures:
-        __sync_fetch_and_add(&val->unsupported_tcp_failures, 1);
+        __sync_fetch_and_add(&val->unsupported_tcp_failures, times);
         break;
     case tcp_done_missing_pid:
-        __sync_fetch_and_add(&val->tcp_done_missing_pid, 1);
+        __sync_fetch_and_add(&val->tcp_done_missing_pid, times);
         break;
     case tcp_connect_failed_tuple:
-        __sync_fetch_and_add(&val->tcp_connect_failed_tuple, 1);
+        __sync_fetch_and_add(&val->tcp_connect_failed_tuple, times);
         break;
     case tcp_done_failed_tuple:
-        __sync_fetch_and_add(&val->tcp_done_failed_tuple, 1);
+        __sync_fetch_and_add(&val->tcp_done_failed_tuple, times);
         break;
     case tcp_finish_connect_failed_tuple:
-        __sync_fetch_and_add(&val->tcp_finish_connect_failed_tuple, 1);
+        __sync_fetch_and_add(&val->tcp_finish_connect_failed_tuple, times);
         break;
     case tcp_close_target_failures:
-        __sync_fetch_and_add(&val->tcp_close_target_failures, 1);
+        __sync_fetch_and_add(&val->tcp_close_target_failures, times);
         break;
     case tcp_done_connection_flush:
-        __sync_fetch_and_add(&val->tcp_done_connection_flush, 1);
+        __sync_fetch_and_add(&val->tcp_done_connection_flush, times);
         break;
     case tcp_close_connection_flush:
-        __sync_fetch_and_add(&val->tcp_close_connection_flush, 1);
+        __sync_fetch_and_add(&val->tcp_close_connection_flush, times);
+        break;
+    case tcp_syn_retransmit:
+        __sync_fetch_and_add(&val->tcp_syn_retransmit, times);
         break;
     }
+}
+
+static __always_inline void increment_telemetry_count(enum telemetry_counter counter_name) {
+    __increment_telemetry_count(counter_name, 1);
+}
+
+static __always_inline void increment_telemetry_count_times(enum telemetry_counter counter_name, int times) {
+    __increment_telemetry_count(counter_name, times);
 }
 
 __maybe_unused static __always_inline void sockaddr_to_addr(struct sockaddr *sa, u64 *addr_h, u64 *addr_l, u16 *port, u32 *metadata) {

--- a/pkg/network/ebpf/c/tracer/tracer.h
+++ b/pkg/network/ebpf/c/tracer/tracer.h
@@ -128,6 +128,7 @@ typedef struct {
     __u64 tcp_close_target_failures;
     __u64 tcp_done_connection_flush;
     __u64 tcp_close_connection_flush;
+    __u64 tcp_syn_retransmit;
 } telemetry_t;
 
 typedef struct {

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -73,6 +73,7 @@ type Telemetry struct {
 	Tcp_close_target_failures       uint64
 	Tcp_done_connection_flush       uint64
 	Tcp_close_connection_flush      uint64
+	Tcp_syn_retransmit              uint64
 }
 type PortBinding struct {
 	Netns     uint32

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -67,6 +67,7 @@ var EbpfTracerTelemetry = struct {
 	tcpCloseTargetFailures      *prometheus.Desc
 	tcpDoneConnectionFlush      *prometheus.Desc
 	tcpCloseConnectionFlush     *prometheus.Desc
+	tcpSynRetransmit            *prometheus.Desc
 	ongoingConnectPidCleaned    telemetry.Counter
 	PidCollisions               *telemetry.StatCounterWrapper
 	iterationDups               telemetry.Counter
@@ -89,6 +90,7 @@ var EbpfTracerTelemetry = struct {
 	lastTCPCloseTargetFailures      *atomic.Int64
 	lastTCPDoneConnectionFlush      *atomic.Int64
 	lastTCPCloseConnectionFlush     *atomic.Int64
+	lastTCPSynRetransmit            *atomic.Int64
 }{
 	telemetry.NewGauge(connTracerModuleName, "connections", []string{"ip_proto", "family"}, "Gauge measuring the number of active connections in the EBPF map"),
 	prometheus.NewDesc(connTracerModuleName+"__tcp_failed_connects", "Counter measuring the number of failed TCP connections in the EBPF map", nil, nil),
@@ -106,10 +108,12 @@ var EbpfTracerTelemetry = struct {
 	prometheus.NewDesc(connTracerModuleName+"__tcp_close_target_failures", "Counter measuring the number of failed TCP connections in tcp_close", nil, nil),
 	prometheus.NewDesc(connTracerModuleName+"__tcp_done_connection_flush", "Counter measuring the number of connection flushes performed in tcp_done", nil, nil),
 	prometheus.NewDesc(connTracerModuleName+"__tcp_close_connection_flush", "Counter measuring the number of connection flushes performed in tcp_close", nil, nil),
+	prometheus.NewDesc(connTracerModuleName+"__tcp_syn_retransmit", "Counter measuring the number of tcp retransmits of syn packets", nil, nil),
 	telemetry.NewCounter(connTracerModuleName, "ongoing_connect_pid_cleaned", []string{}, "Counter measuring the number of tcp_ongoing_connect_pid entries cleaned in userspace"),
 	telemetry.NewStatCounterWrapper(connTracerModuleName, "pid_collisions", []string{}, "Counter measuring number of process collisions"),
 	telemetry.NewCounter(connTracerModuleName, "iteration_dups", []string{}, "Counter measuring the number of connections iterated more than once"),
 	telemetry.NewCounter(connTracerModuleName, "iteration_aborts", []string{}, "Counter measuring how many times ebpf iteration of connection map was aborted"),
+	atomic.NewInt64(0),
 	atomic.NewInt64(0),
 	atomic.NewInt64(0),
 	atomic.NewInt64(0),
@@ -641,6 +645,10 @@ func (t *ebpfTracer) Collect(ch chan<- prometheus.Metric) {
 	delta = int64(ebpfTelemetry.Tcp_close_connection_flush) - EbpfTracerTelemetry.lastTCPCloseConnectionFlush.Load()
 	EbpfTracerTelemetry.lastTCPCloseConnectionFlush.Store(int64(ebpfTelemetry.Tcp_close_connection_flush))
 	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.tcpCloseConnectionFlush, prometheus.CounterValue, float64(delta))
+
+	delta = int64(ebpfTelemetry.Tcp_syn_retransmit) - EbpfTracerTelemetry.lastTCPSynRetransmit.Load()
+	EbpfTracerTelemetry.lastTCPSynRetransmit.Store(int64(ebpfTelemetry.Tcp_syn_retransmit))
+	ch <- prometheus.MustNewConstMetric(EbpfTracerTelemetry.tcpSynRetransmit, prometheus.CounterValue, float64(delta))
 }
 
 // DumpMaps (for debugging purpose) returns all maps content by default or selected maps from maps parameter.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

cleans up the retransmit map in the case that tcp & conn stat maps are empty. this likely means that syns were retransmitted on connections that never completed the handshake, so we can increment some telemetry on that as well.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->