### PR TITLE
chore(autoinstrumentation): disable autoinstrumentation-v1

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -48,6 +48,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 		wantErr                 bool
 		config                  func(c model.Config)
 		expectedLdPreload       string
+		expectedLibConfigEnvs   map[string]string
 	}{
 		{
 			name: "no libs, no injection",
@@ -210,7 +211,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 					},
 				},
 				libs: []libInfo{
-					java.libInfo("", "gcr.io/datadoghq/dd-lib-python-init:v1"),
+					python.libInfo("", "gcr.io/datadoghq/dd-lib-python-init:v1"),
 				},
 				source: libInfoSourceSingleStepLangaugeDetection,
 			},
@@ -218,6 +219,45 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				c.SetWithoutSource("apm_config.instrumentation.injector_image_tag", "0.16-1")
 			},
 			expectedLdPreload: "/foo/bar:/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
+		},
+		{
+			name: "all-lib.config",
+			pod: common.FakePodSpec{
+				Annotations: map[string]string{
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+				},
+			}.Create(),
+			libInfo: extractedPodLibInfo{
+				libs: []libInfo{
+					python.libInfo("", "gcr.io/datadoghq/dd-lib-python-init:v1"),
+				},
+			},
+			expectedInjectorImage: "gcr.io/datadoghq/apm-inject:0",
+			expectedLibConfigEnvs: map[string]string{
+				"DD_RUNTIME_METRICS_ENABLED": "true",
+				"DD_TRACE_RATE_LIMIT":        "50",
+				"DD_TRACE_SAMPLE_RATE":       "0.30",
+			},
+		},
+		{
+			name: "app-container.config",
+			pod: common.FakePodSpec{
+				Annotations: map[string]string{
+					"admission.datadoghq.com/python-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/java-lib.config.v1":   `{"version":1,"runtime_metrics_enabled":false,"tracing_rate_limit":60,"tracing_sampling_rate":0.3}`,
+				},
+			}.Create(),
+			libInfo: extractedPodLibInfo{
+				libs: []libInfo{
+					python.libInfo("", "gcr.io/datadoghq/dd-lib-python-init:v1"),
+				},
+			},
+			expectedInjectorImage: "gcr.io/datadoghq/apm-inject:0",
+			expectedLibConfigEnvs: map[string]string{
+				"DD_RUNTIME_METRICS_ENABLED": "true",
+				"DD_TRACE_RATE_LIMIT":        "50",
+				"DD_TRACE_SAMPLE_RATE":       "0.30",
+			},
 		},
 	}
 
@@ -363,7 +403,6 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			}
 
 			requireEnv(t, "DD_INJECT_SENDER_TYPE", true, "k8s")
-
 			requireEnv(t, "DD_INSTRUMENTATION_INSTALL_TYPE", true, tt.expectedInstallType)
 
 			if tt.libInfo.languageDetection == nil {
@@ -373,247 +412,10 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGES_DETECTED", true, tt.expectedLangsDetected)
 				requireEnv(t, "DD_INSTRUMENTATION_LANGUAGE_DETECTION_INJECTION_ENABLED", true, strconv.FormatBool(tt.libInfo.languageDetection.injectionEnabled))
 			}
-		})
-	}
-}
 
-func TestInjectAutoInstruConfig(t *testing.T) {
-	tests := []struct {
-		name           string
-		pod            *corev1.Pod
-		libsToInject   []libInfo
-		expectedEnvKey string
-		expectedEnvVal string
-		wantErr        bool
-	}{
-		{
-			name: "nominal case: java",
-			pod:  common.FakePod("java-pod"),
-			libsToInject: []libInfo{
-				{
-					lang:  "java",
-					image: "gcr.io/datadoghq/dd-lib-java-init:v1",
-				},
-			},
-			expectedEnvKey: "JAVA_TOOL_OPTIONS",
-			expectedEnvVal: " -javaagent:/datadog-lib/dd-java-agent.jar -XX:OnError=/datadog-lib/java/continuousprofiler/tmp/dd_crash_uploader.sh -XX:ErrorFile=/datadog-lib/java/continuousprofiler/tmp/hs_err_pid_%p.log",
-			wantErr:        false,
-		},
-		{
-			name: "JAVA_TOOL_OPTIONS not empty",
-			pod:  common.FakePodWithEnvValue("java-pod", "JAVA_TOOL_OPTIONS", "predefined"),
-			libsToInject: []libInfo{
-				{
-					lang:  "java",
-					image: "gcr.io/datadoghq/dd-lib-java-init:v1",
-				},
-			},
-			expectedEnvKey: "JAVA_TOOL_OPTIONS",
-			expectedEnvVal: "predefined -javaagent:/datadog-lib/dd-java-agent.jar -XX:OnError=/datadog-lib/java/continuousprofiler/tmp/dd_crash_uploader.sh -XX:ErrorFile=/datadog-lib/java/continuousprofiler/tmp/hs_err_pid_%p.log",
-			wantErr:        false,
-		},
-		{
-			name: "JAVA_TOOL_OPTIONS set via ValueFrom",
-			pod:  common.FakePodWithEnvFieldRefValue("java-pod", "JAVA_TOOL_OPTIONS", "path"),
-			libsToInject: []libInfo{
-				{
-					lang:  "java",
-					image: "gcr.io/datadoghq/dd-lib-java-init:v1",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "nominal case: js",
-			pod:  common.FakePod("js-pod"),
-			libsToInject: []libInfo{
-				{
-					lang:  "js",
-					image: "gcr.io/datadoghq/dd-lib-js-init:v1",
-				},
-			},
-			expectedEnvKey: "NODE_OPTIONS",
-			expectedEnvVal: " --require=/datadog-lib/node_modules/dd-trace/init",
-			wantErr:        false,
-		},
-		{
-			name: "NODE_OPTIONS not empty",
-			pod:  common.FakePodWithEnvValue("js-pod", "NODE_OPTIONS", "predefined"),
-			libsToInject: []libInfo{
-				{
-					lang:  "js",
-					image: "gcr.io/datadoghq/dd-lib-js-init:v1",
-				},
-			},
-			expectedEnvKey: "NODE_OPTIONS",
-			expectedEnvVal: "predefined --require=/datadog-lib/node_modules/dd-trace/init",
-			wantErr:        false,
-		},
-		{
-			name: "NODE_OPTIONS set via ValueFrom",
-			pod:  common.FakePodWithEnvFieldRefValue("js-pod", "NODE_OPTIONS", "path"),
-			libsToInject: []libInfo{
-				{
-					lang:  "js",
-					image: "gcr.io/datadoghq/dd-lib-js-init:v1",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "nominal case: python",
-			pod:  common.FakePod("python-pod"),
-			libsToInject: []libInfo{
-				{
-					lang:  "python",
-					image: "gcr.io/datadoghq/dd-lib-python-init:v1",
-				},
-			},
-			expectedEnvKey: "PYTHONPATH",
-			expectedEnvVal: "/datadog-lib/",
-			wantErr:        false,
-		},
-		{
-			name: "PYTHONPATH not empty",
-			pod:  common.FakePodWithEnvValue("python-pod", "PYTHONPATH", "predefined"),
-			libsToInject: []libInfo{
-				{
-					lang:  "python",
-					image: "gcr.io/datadoghq/dd-lib-python-init:v1",
-				},
-			},
-			expectedEnvKey: "PYTHONPATH",
-			expectedEnvVal: "/datadog-lib/:predefined",
-			wantErr:        false,
-		},
-		{
-			name: "PYTHONPATH set via ValueFrom",
-			pod:  common.FakePodWithEnvFieldRefValue("python-pod", "PYTHONPATH", "path"),
-			libsToInject: []libInfo{
-				{
-					lang:  "python",
-					image: "gcr.io/datadoghq/dd-lib-python-init:v1",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "Unknown language",
-			pod:  common.FakePod("unknown-pod"),
-			libsToInject: []libInfo{
-				{
-					lang:  "unknown",
-					image: "gcr.io/datadoghq/dd-lib-unknown-init:v1",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "nominal case: dotnet",
-			pod:  common.FakePod("dotnet-pod"),
-			libsToInject: []libInfo{
-				{
-					lang:  "dotnet",
-					image: "gcr.io/datadoghq/dd-lib-dotnet-init:v1",
-				},
-			},
-			expectedEnvKey: "CORECLR_PROFILER",
-			expectedEnvVal: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-			wantErr:        false,
-		},
-		{
-			name: "CORECLR_ENABLE_PROFILING not empty",
-			pod:  common.FakePodWithEnvValue("dotnet-pod", "CORECLR_PROFILER", "predefined"),
-			libsToInject: []libInfo{
-				{
-					lang:  "dotnet",
-					image: "gcr.io/datadoghq/dd-lib-dotnet-init:v1",
-				},
-			},
-			expectedEnvKey: "CORECLR_PROFILER",
-			expectedEnvVal: "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-			wantErr:        false,
-		},
-		{
-			name: "CORECLR_ENABLE_PROFILING set via ValueFrom",
-			pod:  common.FakePodWithEnvFieldRefValue("dotnet-pod", "CORECLR_PROFILER", "path"),
-			libsToInject: []libInfo{
-				{
-					lang:  dotnet,
-					image: "gcr.io/datadoghq/dd-lib-dotnet-init:v1",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "nominal case: ruby",
-			pod:  common.FakePod("ruby-pod"),
-			libsToInject: []libInfo{
-				{
-					lang:  ruby,
-					image: "gcr.io/datadoghq/dd-lib-ruby-init:v1",
-				},
-			},
-			expectedEnvKey: "RUBYOPT",
-			expectedEnvVal: " -r/datadog-lib/auto_inject",
-			wantErr:        false,
-		},
-		{
-			name: "RUBYOPT not empty",
-			pod:  common.FakePodWithEnvValue("ruby-pod", "RUBYOPT", "predefined"),
-			libsToInject: []libInfo{
-				{
-					lang:  "ruby",
-					image: "gcr.io/datadoghq/dd-lib-ruby-init:v1",
-				},
-			},
-			expectedEnvKey: "RUBYOPT",
-			expectedEnvVal: "predefined -r/datadog-lib/auto_inject",
-			wantErr:        false,
-		},
-		{
-			name: "RUBYOPT set via ValueFrom",
-			pod:  common.FakePodWithEnvFieldRefValue("ruby-pod", "RUBYOPT", "path"),
-			libsToInject: []libInfo{
-				{
-					lang:  "ruby",
-					image: "gcr.io/datadoghq/dd-lib-ruby-init:v1",
-				},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			wmeta := fxutil.Test[workloadmeta.Component](t,
-				core.MockBundle(),
-				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-			)
-
-			mockConfig := configmock.New(t)
-			mockConfig.SetWithoutSource("apm_config.instrumentation.version", "v1")
-
-			config, err := NewConfig(mockConfig)
-			require.NoError(t, err)
-
-			mutator, err := NewNamespaceMutator(config, wmeta)
-			require.NoError(t, err)
-
-			err = mutator.core.injectTracers(tt.pod, extractedPodLibInfo{
-				libs:   tt.libsToInject,
-				source: libInfoSourceLibInjection,
-			})
-			if tt.wantErr {
-				require.Error(t, err, "expected injectAutoInstruConfig to error")
-			} else {
-				require.NoError(t, err, "expected injectAutoInstruConfig to succeed")
+			for k, v := range tt.expectedLibConfigEnvs {
+				requireEnv(t, k, true, v)
 			}
-
-			if err != nil {
-				return
-			}
-
-			assertLibReq(t, tt.pod, tt.libsToInject[0].lang, tt.libsToInject[0].image, tt.expectedEnvKey, tt.expectedEnvVal)
 		})
 	}
 }
@@ -1783,7 +1585,7 @@ func injectAllEnvs() []corev1.EnvVar {
 	}
 }
 
-func TestInjectAutoInstrumentation(t *testing.T) {
+func TestInjectAutoInstrumentationV1(t *testing.T) {
 	var (
 		mockConfig model.Config
 		wConfig    = func(k string, v any) func() {
@@ -3333,14 +3135,14 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 			wmeta := common.FakeStoreWithDeployment(t, tt.langDetectionDeployments)
 
 			mockConfig = configmock.New(t)
-			mockConfig.SetWithoutSource("apm_config.instrumentation.version", "v1")
 			if tt.setupConfig != nil {
 				for _, f := range tt.setupConfig {
 					f()
 				}
 			}
 
-			webhook, errInitAPMInstrumentation := maybeWebhook(wmeta, mockConfig)
+			// N.B. Force v1 for these tests!
+			webhook, errInitAPMInstrumentation := maybeWebhook(wmeta, mockConfig, instrumentationV1)
 			if tt.wantWebhookInitErr {
 				require.Error(t, errInitAPMInstrumentation)
 				return
@@ -3605,11 +3407,15 @@ func TestShouldInject(t *testing.T) {
 	}
 }
 
-func maybeWebhook(wmeta workloadmeta.Component, ddConfig config.Component) (*Webhook, error) {
+func maybeWebhook(wmeta workloadmeta.Component, ddConfig config.Component, versionOverride version) (*Webhook, error) {
 	config, err := NewConfig(ddConfig)
 	if err != nil {
 		return nil, err
 	}
+
+	// N.B. keeping this around to continue to have tests for v1,
+	// even though it is disabled
+	config.version = versionOverride
 
 	mutator, err := NewNamespaceMutator(config, wmeta)
 	if err != nil {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
@@ -8,8 +8,13 @@
 package autoinstrumentation
 
 import (
+	"errors"
 	"fmt"
 )
+
+// ErrUnsupported is a sentinel error for an unsupported version
+// option of this webhook.
+var ErrUnsupported = errors.New("unsupported version")
 
 type version int
 
@@ -22,7 +27,7 @@ const (
 func instrumentationVersion(v string) (version, error) {
 	switch v {
 	case "v1":
-		return instrumentationV1, nil
+		return instrumentationVersionInvalid, ErrUnsupported
 	case "v2":
 		return instrumentationV2, nil
 	default:

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
@@ -23,9 +23,11 @@ func TestVersion(t *testing.T) {
 		usesInjector   bool
 	}{
 		{
-			name:           "v1 is valid",
+			name:           "v1 is invalid",
 			version:        "v1",
-			expectsVersion: instrumentationV1,
+			expectsVersion: instrumentationVersionInvalid,
+			expectsErr:     true,
+			expectsPanic:   true,
 		},
 		{
 			name:           "v2 uses injector",
@@ -56,7 +58,5 @@ func TestVersion(t *testing.T) {
 				require.NotPanics(t, usesInjector)
 			}
 		})
-
 	}
-
 }

--- a/releasenotes-dca/notes/autoinstrumentation-disable-v1-1b1fbd0a41c34865.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-disable-v1-1b1fbd0a41c34865.yaml
@@ -1,0 +1,3 @@
+deprecations:
+  - |
+    `DD_APM_INSTRUMENTATION_VERSION=v1` has been disabled and will error when used.


### PR DESCRIPTION
### What does this PR do?

Disables autoinstrumentation v1. https://datadoghq.atlassian.net/browse/INPLAT-488

### Motivation

This has been the default behavior since `7.57` and has an undocumented env var to switch behaviors for debugging. We want to remove this behavior entirely for `7.64`. 

### Describe how you validated your changes

Validated changes by adding tests by updating the tests for the version being an error. Updated tests for v1 to bypass the configuration check so that we have them for future work. 

### Possible Drawbacks / Trade-offs

We could have logged a warning but there is behavior in v1 and how libraries are loaded that can cause a possible crash in environments. We don't know about them via telemetry and we won't address them, so it should be impossible to use v1 going forward.

### Additional Notes

- Follow up ticket for removing the code, configuration and fixing the tests to happen for `7.65` https://datadoghq.atlassian.net/browse/INPLAT-489