### PR TITLE
convert pointer *uint64 to uint64 when generating go struct from eBPF struct

### DIFF
--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -67,7 +67,6 @@ func processFile(rdr io.Reader, out io.Writer) error {
 	convertPointerToUint64Regex := regexp.MustCompile(`\*_Ctype_struct_(\w+)`)
 	b = convertPointerToUint64Regex.ReplaceAll(b, []byte("uint64"))
 
-	// Convert *byte pointers to uint64 (original void * in C)
 	// Convert *byte and *uint64 pointers to uint64 (original void * in C)
 	convertBytePointerToUint64Regex := regexp.MustCompile(`(\s+)(\*(byte|uint64))`)
 	b = convertBytePointerToUint64Regex.ReplaceAll(b, []byte("${1}uint64"))

--- a/pkg/ebpf/cgo/genpost.go
+++ b/pkg/ebpf/cgo/genpost.go
@@ -68,7 +68,8 @@ func processFile(rdr io.Reader, out io.Writer) error {
 	b = convertPointerToUint64Regex.ReplaceAll(b, []byte("uint64"))
 
 	// Convert *byte pointers to uint64 (original void * in C)
-	convertBytePointerToUint64Regex := regexp.MustCompile(`(\s+)(\*byte)`)
+	// Convert *byte and *uint64 pointers to uint64 (original void * in C)
+	convertBytePointerToUint64Regex := regexp.MustCompile(`(\s+)(\*(byte|uint64))`)
 	b = convertBytePointerToUint64Regex.ReplaceAll(b, []byte("${1}uint64"))
 
 	b, err = format.Source(b)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adjusts `cgo` to convert `*uint64` pointers of eBPF structure to `uint64` in golang structure.

### Motivation
```
**eBPF**:
typedef struct {
    void *ctx;
    void *buf;
    size_t *size_out_param;
} ssl_read_ex_args_t;
```

**Go**:
`type SslReadExArgs C.ssl_read_ex_args_t`

**Generated**:
```
type SslReadExArgs struct {
	Ctx       uint64
	Buf       uint64
	Out_param *uint64
}
```
**Expected**:
```
type SslReadExArgs struct {
	Ctx       uint64
	Buf       uint64
	Out_param uint64
}
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->