### PR TITLE
Update lading in Regression Detector to 0.25.6

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.5
+  version: 0.25.6
 
 target:
 


### PR DESCRIPTION
### What does this PR do?

This commit updates the lading component of the Regression Detector to its most [recent release](https://github.com/DataDog/lading/releases/tag/v0.25.6)
