### PR TITLE
autoinstrumentation: pin minor library versions

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -67,6 +67,52 @@ func defaultLibrariesFor(languages ...string) map[string]string {
 	return out
 }
 
+func TestDefaultLibVersions(t *testing.T) {
+	// N.B. This test uses js since there are many major versions.
+	tests := []struct {
+		in, out string
+	}{
+		{
+			in:  "v5",
+			out: defaultLibImageVersions[js],
+		},
+		{
+			in:  "5",
+			out: defaultLibImageVersions[js],
+		},
+		{
+			in:  "default",
+			out: defaultLibImageVersions[js],
+		},
+		{
+			in:  "v1",
+			out: "registry/dd-lib-js-init:v1",
+		},
+		{
+			in:  "v1.0",
+			out: "registry/dd-lib-js-init:v1.0",
+		},
+		{
+			in:  "5.0",
+			out: "registry/dd-lib-js-init:5.0",
+		},
+		{
+			in:  "v5.0",
+			out: "registry/dd-lib-js-init:v5.0",
+		},
+		{
+			in:  "latest",
+			out: "registry/dd-lib-js-init:latest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s->%s", tt.in, tt.out), func(t *testing.T) {
+			require.Equal(t, tt.out, js.libImageName("registry", tt.in))
+		})
+	}
+}
+
 func TestInjectAutoInstruConfigV2(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -40,7 +40,7 @@ var (
 	defaultLibraries = map[string]string{
 		"java":   "v1.46",
 		"python": "v2.21",
-		"ruby":   "v2",
+		"ruby":   "v2.10",
 		"dotnet": "v3.10",
 		"js":     "v5.37",
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -39,7 +39,7 @@ const commonRegistry = "gcr.io/datadoghq"
 var (
 	defaultLibraries = map[string]string{
 		"java":   "v1.46",
-		"python": "v2",
+		"python": "v2.21",
 		"ruby":   "v2",
 		"dotnet": "v3",
 		"js":     "v5.37",
@@ -49,9 +49,9 @@ var (
 	defaultLibImageVersions = map[language]string{
 		java:   "registry/dd-lib-java-init:" + defaultLibraries["java"],
 		js:     "registry/dd-lib-js-init:" + defaultLibraries["js"],
-		python: "registry/dd-lib-python-init:v2",
-		dotnet: "registry/dd-lib-dotnet-init:v3",
-		ruby:   "registry/dd-lib-ruby-init:v2",
+		python: "registry/dd-lib-python-init:" + defaultLibraries["python"],
+		dotnet: "registry/dd-lib-dotnet-init:" + defaultLibraries["dotnet"],
+		ruby:   "registry/dd-lib-ruby-init:" + defaultLibraries["ruby"],
 	}
 )
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1041,8 +1041,8 @@ func TestExtractLibInfo(t *testing.T) {
 			containerRegistry: "registry",
 			expectedLibsToInject: []libInfo{
 				{
-					lang:  "php",
-					image: "registry/dd-lib-php-init:v1",
+					lang:  php,
+					image: "registry/dd-lib-php-init:v1.6",
 				},
 			},
 		},

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -660,36 +660,21 @@ func assertLibReq(t *testing.T, pod *corev1.Pod, lang language, image, envKey, e
 }
 
 func TestExtractLibInfo(t *testing.T) {
-	defaultLibImageVersions := map[string]string{
-		"java":   "registry/dd-lib-java-init:v1",
-		"js":     "registry/dd-lib-js-init:v5",
-		"python": "registry/dd-lib-python-init:v2",
-		"dotnet": "registry/dd-lib-dotnet-init:v3",
-		"ruby":   "registry/dd-lib-ruby-init:v2",
+	// TODO: Add new entry when a new language is supported
+	defaultLibImageVersions := map[language]string{
+		java:   "registry/dd-lib-java-init:v1.46",
+		js:     "registry/dd-lib-js-init:v5",
+		python: "registry/dd-lib-python-init:v2",
+		dotnet: "registry/dd-lib-dotnet-init:v3",
+		ruby:   "registry/dd-lib-ruby-init:v2",
 	}
 
-	// TODO: Add new entry when a new language is supported
-	allLatestDefaultLibs := []libInfo{
-		{
-			lang:  "java",
-			image: defaultLibImageVersions["java"],
-		},
-		{
-			lang:  "js",
-			image: defaultLibImageVersions["js"],
-		},
-		{
-			lang:  "python",
-			image: defaultLibImageVersions["python"],
-		},
-		{
-			lang:  "dotnet",
-			image: defaultLibImageVersions["dotnet"],
-		},
-		{
-			lang:  "ruby",
-			image: defaultLibImageVersions["ruby"],
-		},
+	var allLatestDefaultLibs []libInfo
+	for k, v := range defaultLibImageVersions {
+		allLatestDefaultLibs = append(allLatestDefaultLibs, libInfo{
+			lang:  k,
+			image: v,
+		})
 	}
 
 	var mockConfig model.Config
@@ -708,7 +693,7 @@ func TestExtractLibInfo(t *testing.T) {
 			expectedLibsToInject: []libInfo{
 				{
 					lang:  "java",
-					image: "registry/dd-lib-java-init:v1",
+					image: "registry/dd-lib-java-init:v1.46",
 				},
 			},
 		},
@@ -719,7 +704,7 @@ func TestExtractLibInfo(t *testing.T) {
 			expectedLibsToInject: []libInfo{
 				{
 					lang:  "java",
-					image: "registry/dd-lib-java-init:v1",
+					image: "registry/dd-lib-java-init:v1.46",
 				},
 			},
 		},
@@ -730,7 +715,7 @@ func TestExtractLibInfo(t *testing.T) {
 			expectedLibsToInject: []libInfo{
 				{
 					lang:  "java",
-					image: fmt.Sprintf("%s/dd-lib-java-init:v1", commonRegistry),
+					image: fmt.Sprintf("%s/dd-lib-java-init:v1.46", commonRegistry),
 				},
 			},
 		},
@@ -792,10 +777,7 @@ func TestExtractLibInfo(t *testing.T) {
 			},
 			containerRegistry: "registry",
 			expectedLibsToInject: []libInfo{
-				{
-					lang:  "java",
-					image: "registry/dd-lib-java-init:v1",
-				},
+				java.libInfo("", defaultLibImageVersions[java]),
 				{
 					lang:  "js",
 					image: "registry/dd-lib-js-init:v1",
@@ -824,11 +806,7 @@ func TestExtractLibInfo(t *testing.T) {
 			},
 			containerRegistry: "registry",
 			expectedLibsToInject: []libInfo{
-				{
-					ctrName: "java-app",
-					lang:    "java",
-					image:   "registry/dd-lib-java-init:v1",
-				},
+				java.libInfo("java-app", defaultLibImageVersions[java]),
 				{
 					ctrName: "node-app",
 					lang:    "js",
@@ -955,7 +933,7 @@ func TestExtractLibInfo(t *testing.T) {
 			expectedLibsToInject: []libInfo{
 				{
 					lang:  "java",
-					image: "registry/dd-lib-java-init:v1",
+					image: "registry/dd-lib-java-init:v1.46",
 				},
 			},
 		},
@@ -1027,10 +1005,7 @@ func TestExtractLibInfo(t *testing.T) {
 			pod:               common.FakePodWithAnnotation("admission.datadoghq.com/java-lib.version", "v1"),
 			containerRegistry: "registry",
 			expectedLibsToInject: []libInfo{
-				{
-					lang:  "java",
-					image: "registry/dd-lib-java-init:v1",
-				},
+				java.libInfo("", defaultLibImageVersions[java]),
 			},
 			setupConfig: func() {
 				mockConfig.SetWithoutSource("apm_config.instrumentation.enabled", true)
@@ -1814,7 +1789,7 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 	installTime := strconv.FormatInt(time.Now().Unix(), 10)
 
 	defaultLibraries := map[string]string{
-		"java":   "v1",
+		"java":   "v1.46",
 		"python": "v2",
 		"ruby":   "v2",
 		"dotnet": "v3",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -36,6 +36,37 @@ import (
 
 const commonRegistry = "gcr.io/datadoghq"
 
+var (
+	defaultLibraries = map[string]string{
+		"java":   "v1.46",
+		"python": "v2",
+		"ruby":   "v2",
+		"dotnet": "v3",
+		"js":     "v5.37",
+	}
+
+	// TODO: Add new entry when a new language is supported
+	defaultLibImageVersions = map[language]string{
+		java:   "registry/dd-lib-java-init:" + defaultLibraries["java"],
+		js:     "registry/dd-lib-js-init:" + defaultLibraries["js"],
+		python: "registry/dd-lib-python-init:v2",
+		dotnet: "registry/dd-lib-dotnet-init:v3",
+		ruby:   "registry/dd-lib-ruby-init:v2",
+	}
+)
+
+func defaultLibInfo(l language) libInfo {
+	return libInfo{lang: l, image: defaultLibImageVersions[l]}
+}
+
+func defaultLibrariesFor(languages ...string) map[string]string {
+	out := map[string]string{}
+	for _, l := range languages {
+		out[l] = defaultLibraries[l]
+	}
+	return out
+}
+
 func TestInjectAutoInstruConfigV2(t *testing.T) {
 	tests := []struct {
 		name                    string
@@ -660,15 +691,6 @@ func assertLibReq(t *testing.T, pod *corev1.Pod, lang language, image, envKey, e
 }
 
 func TestExtractLibInfo(t *testing.T) {
-	// TODO: Add new entry when a new language is supported
-	defaultLibImageVersions := map[language]string{
-		java:   "registry/dd-lib-java-init:v1.46",
-		js:     "registry/dd-lib-js-init:v5",
-		python: "registry/dd-lib-python-init:v2",
-		dotnet: "registry/dd-lib-dotnet-init:v3",
-		ruby:   "registry/dd-lib-ruby-init:v2",
-	}
-
 	var allLatestDefaultLibs []libInfo
 	for k, v := range defaultLibImageVersions {
 		allLatestDefaultLibs = append(allLatestDefaultLibs, libInfo{
@@ -1787,22 +1809,6 @@ func TestInjectAutoInstrumentation(t *testing.T) {
 
 	uuid := uuid.New().String()
 	installTime := strconv.FormatInt(time.Now().Unix(), 10)
-
-	defaultLibraries := map[string]string{
-		"java":   "v1.46",
-		"python": "v2",
-		"ruby":   "v2",
-		"dotnet": "v3",
-		"js":     "v5",
-	}
-
-	defaultLibrariesFor := func(languages ...string) map[string]string {
-		out := map[string]string{}
-		for _, l := range languages {
-			out[l] = defaultLibraries[l]
-		}
-		return out
-	}
 
 	tests := []struct {
 		name                      string

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -41,7 +41,7 @@ var (
 		"java":   "v1.46",
 		"python": "v2.21",
 		"ruby":   "v2",
-		"dotnet": "v3",
+		"dotnet": "v3.10",
 		"js":     "v5.37",
 	}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -169,7 +169,7 @@ const defaultVersionMagicString = "default"
 // If this language does not appear in supportedLanguages, it will not be injected.
 var languageVersions = map[language]*ver.Version{
 	java:   ver.Must(ver.NewVersion("v1.46")), // https://datadoghq.atlassian.net/browse/APMON-1064
-	dotnet: ver.Must(ver.NewVersion("v3")),    // https://datadoghq.atlassian.net/browse/APMON-1390
+	dotnet: ver.Must(ver.NewVersion("v3.10")), // https://datadoghq.atlassian.net/browse/APMON-1390
 	python: ver.Must(ver.NewVersion("v2.21")), // https://datadoghq.atlassian.net/browse/APMON-1068
 	ruby:   ver.Must(ver.NewVersion("v2")),    // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     ver.Must(ver.NewVersion("v5.37")), // https://datadoghq.atlassian.net/browse/APMON-1065

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -171,7 +171,7 @@ var languageVersions = map[language]*ver.Version{
 	java:   ver.Must(ver.NewVersion("v1.46")), // https://datadoghq.atlassian.net/browse/APMON-1064
 	dotnet: ver.Must(ver.NewVersion("v3.10")), // https://datadoghq.atlassian.net/browse/APMON-1390
 	python: ver.Must(ver.NewVersion("v2.21")), // https://datadoghq.atlassian.net/browse/APMON-1068
-	ruby:   ver.Must(ver.NewVersion("v2")),    // https://datadoghq.atlassian.net/browse/APMON-1066
+	ruby:   ver.Must(ver.NewVersion("v2.10")), // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     ver.Must(ver.NewVersion("v5.37")), // https://datadoghq.atlassian.net/browse/APMON-1065
 	php:    ver.Must(ver.NewVersion("v1")),    // https://datadoghq.atlassian.net/browse/APMON-1128
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -170,7 +170,7 @@ const defaultVersionMagicString = "default"
 var languageVersions = map[language]*ver.Version{
 	java:   ver.Must(ver.NewVersion("v1.46")), // https://datadoghq.atlassian.net/browse/APMON-1064
 	dotnet: ver.Must(ver.NewVersion("v3")),    // https://datadoghq.atlassian.net/browse/APMON-1390
-	python: ver.Must(ver.NewVersion("v2")),    // https://datadoghq.atlassian.net/browse/APMON-1068
+	python: ver.Must(ver.NewVersion("v2.21")), // https://datadoghq.atlassian.net/browse/APMON-1068
 	ruby:   ver.Must(ver.NewVersion("v2")),    // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     ver.Must(ver.NewVersion("v5.37")), // https://datadoghq.atlassian.net/browse/APMON-1065
 	php:    ver.Must(ver.NewVersion("v1")),    // https://datadoghq.atlassian.net/browse/APMON-1128

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -173,7 +173,7 @@ var languageVersions = map[language]*ver.Version{
 	python: ver.Must(ver.NewVersion("v2.21")), // https://datadoghq.atlassian.net/browse/APMON-1068
 	ruby:   ver.Must(ver.NewVersion("v2.10")), // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     ver.Must(ver.NewVersion("v5.37")), // https://datadoghq.atlassian.net/browse/APMON-1065
-	php:    ver.Must(ver.NewVersion("v1")),    // https://datadoghq.atlassian.net/browse/APMON-1128
+	php:    ver.Must(ver.NewVersion("v1.6")),  // https://datadoghq.atlassian.net/browse/APMON-1128
 }
 
 func (l language) defaultLibVersion() string {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -172,7 +172,7 @@ var languageVersions = map[language]*ver.Version{
 	dotnet: ver.Must(ver.NewVersion("v3")),    // https://datadoghq.atlassian.net/browse/APMON-1390
 	python: ver.Must(ver.NewVersion("v2")),    // https://datadoghq.atlassian.net/browse/APMON-1068
 	ruby:   ver.Must(ver.NewVersion("v2")),    // https://datadoghq.atlassian.net/browse/APMON-1066
-	js:     ver.Must(ver.NewVersion("v5")),    // https://datadoghq.atlassian.net/browse/APMON-1065
+	js:     ver.Must(ver.NewVersion("v5.37")), // https://datadoghq.atlassian.net/browse/APMON-1065
 	php:    ver.Must(ver.NewVersion("v1")),    // https://datadoghq.atlassian.net/browse/APMON-1128
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -450,11 +450,7 @@ func TestGetTargetLibraries(t *testing.T) {
 			},
 			expected: &targetInternal{
 				libVersions: []libInfo{
-					{
-						ctrName: "",
-						lang:    js,
-						image:   "registry/dd-lib-js-init:v5",
-					},
+					defaultLibInfo(js),
 				},
 			},
 		},
@@ -511,11 +507,7 @@ func TestGetTargetLibraries(t *testing.T) {
 			},
 			expected: &targetInternal{
 				libVersions: []libInfo{
-					{
-						ctrName: "",
-						lang:    java,
-						image:   "registry/dd-lib-java-init:v1.46",
-					},
+					defaultLibInfo(java),
 				},
 			},
 		},
@@ -599,26 +591,11 @@ func TestGetTargetLibraries(t *testing.T) {
 			},
 			expected: &targetInternal{
 				libVersions: []libInfo{
-					{
-						lang:  java,
-						image: "registry/dd-lib-java-init:v1.46",
-					},
-					{
-						lang:  js,
-						image: "registry/dd-lib-js-init:v5",
-					},
-					{
-						lang:  python,
-						image: "registry/dd-lib-python-init:v2",
-					},
-					{
-						lang:  dotnet,
-						image: "registry/dd-lib-dotnet-init:v3",
-					},
-					{
-						lang:  ruby,
-						image: "registry/dd-lib-ruby-init:v2",
-					},
+					defaultLibInfo(java),
+					defaultLibInfo(js),
+					defaultLibInfo(python),
+					defaultLibInfo(dotnet),
+					defaultLibInfo(ruby),
 				},
 			},
 		},

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -514,7 +514,7 @@ func TestGetTargetLibraries(t *testing.T) {
 					{
 						ctrName: "",
 						lang:    java,
-						image:   "registry/dd-lib-java-init:v1",
+						image:   "registry/dd-lib-java-init:v1.46",
 					},
 				},
 			},
@@ -600,29 +600,24 @@ func TestGetTargetLibraries(t *testing.T) {
 			expected: &targetInternal{
 				libVersions: []libInfo{
 					{
-						ctrName: "",
-						lang:    java,
-						image:   "registry/dd-lib-java-init:v1",
+						lang:  java,
+						image: "registry/dd-lib-java-init:v1.46",
 					},
 					{
-						ctrName: "",
-						lang:    js,
-						image:   "registry/dd-lib-js-init:v5",
+						lang:  js,
+						image: "registry/dd-lib-js-init:v5",
 					},
 					{
-						ctrName: "",
-						lang:    python,
-						image:   "registry/dd-lib-python-init:v2",
+						lang:  python,
+						image: "registry/dd-lib-python-init:v2",
 					},
 					{
-						ctrName: "",
-						lang:    dotnet,
-						image:   "registry/dd-lib-dotnet-init:v3",
+						lang:  dotnet,
+						image: "registry/dd-lib-dotnet-init:v3",
 					},
 					{
-						ctrName: "",
-						lang:    ruby,
-						image:   "registry/dd-lib-ruby-init:v2",
+						lang:  ruby,
+						image: "registry/dd-lib-ruby-init:v2",
 					},
 				},
 			},

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -88,7 +88,7 @@ func TestMutatePod(t *testing.T) {
 			},
 			expectedInitContainerImages: []string{
 				"registry/apm-inject:0",
-				"registry/dd-lib-python-init:v2",
+				defaultLibInfo(python).image,
 			},
 			expectedEnv: map[string]string{
 				"DD_INJECT_SENDER_TYPE":           "k8s",
@@ -120,7 +120,7 @@ func TestMutatePod(t *testing.T) {
 			},
 			expectedInitContainerImages: []string{
 				"registry/apm-inject:0",
-				"registry/dd-lib-python-init:v2",
+				defaultLibInfo(python).image,
 			},
 			expectedEnv: map[string]string{
 				"DD_PROFILING_ENABLED":            "true",
@@ -384,11 +384,7 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 			},
 			expected: &targetInternal{
 				libVersions: []libInfo{
-					{
-						ctrName: "",
-						lang:    python,
-						image:   "registry/dd-lib-python-init:v2",
-					},
+					defaultLibInfo(python),
 				},
 			},
 		},
@@ -484,11 +480,7 @@ func TestGetTargetLibraries(t *testing.T) {
 			},
 			expected: &targetInternal{
 				libVersions: []libInfo{
-					{
-						ctrName: "",
-						lang:    python,
-						image:   "registry/dd-lib-python-init:v2",
-					},
+					defaultLibInfo(python),
 				},
 			},
 		},


### PR DESCRIPTION
### What does this PR do?

This PR adds behavior to pin injected libraries (by default) to minor versions instead of major versions. These should be updated with each release of the cluster-agent.

### Motivation

- We currently pin major versions of the language libraries in the cluster-agent so that by default a user will get a "stable" release.

- Major tags get updated as we roll through minor updates in the libraries so major v2 could be v2.1 or v2.2, etc and it's possible that bugs are introduced this way _and_ a cluster running this webhook could be running significantly different versions of tracing libraries without doing any real changes.

- We still want the clusters tracing libraries to receive updates for bug fixes (patch releases) so that would be fine here as well.

- One additional wrinkle here is that when a cluster is set up we specify "major versions" in the `libVersions` section by default, so our version picker chooses the "more specific" pinned minor version that is set. 

### Describe how you validated your changes

Validated by updating tests to make sure that we are _by default_ choosing the minor version when a major version is specified.

### Alternatives

This originally used `hashicorp/go-version` but we couldn't disambiguate between `v2` and `v2.0` as something because [this field](https://github.com/hashicorp/go-version/blob/v1.7.0/version.go#L41) is not exposed in the interface. 
