### PR TITLE
autoinstrumentation: stop using service-name from pod owner

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -26,7 +26,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -418,29 +417,6 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 		decision.message = insufficientResourcesMessage
 	}
 	return requirements, decision
-}
-
-// Returns the name of Kubernetes resource that owns the pod
-func getServiceNameFromPod(pod *corev1.Pod) (string, error) {
-	ownerReferences := pod.ObjectMeta.OwnerReferences
-	if len(ownerReferences) != 1 {
-		return "", fmt.Errorf("pod should be owned by one resource; current owners: %v+", ownerReferences)
-	}
-
-	switch owner := ownerReferences[0]; owner.Kind {
-	case "StatefulSet":
-		fallthrough
-	case "Job":
-		fallthrough
-	case "CronJob":
-		fallthrough
-	case "DaemonSet":
-		return owner.Name, nil
-	case "ReplicaSet":
-		return kubernetes.ParseDeploymentForReplicaSet(owner.Name), nil
-	}
-
-	return "", nil
 }
 
 func containsInitContainer(pod *corev1.Pod, initContainerName string) bool {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1553,9 +1553,8 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			}
 		}
 
-		enableAPMInstrumentation  = wConfig("apm_config.instrumentation.enabled", true)
-		disableAPMInstrumentation = wConfig("apm_config.instrumentation.enabled", false)
-		disableNamespaces         = func(ns ...string) func() {
+		enableAPMInstrumentation = wConfig("apm_config.instrumentation.enabled", true)
+		disableNamespaces        = func(ns ...string) func() {
 			return wConfig("apm_config.instrumentation.disabled_namespaces", ns)
 		}
 		enabledNamespaces = func(ns ...string) func() {
@@ -2125,10 +2124,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Envs: []corev1.EnvVar{
 					{
-						Name:  "DD_SERVICE",
-						Value: "user-deployment",
-					},
-					{
 						Name:  "DD_TRACE_ENABLED",
 						Value: "false",
 					},
@@ -2168,10 +2163,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_ID",
 					Value: uuid,
-				},
-				{
-					Name:  "DD_SERVICE",
-					Value: "user-deployment",
 				},
 				{
 					Name:  "DD_TRACE_ENABLED",
@@ -2221,77 +2212,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			setupConfig:               funcs{enableAPMInstrumentation},
 		},
 		{
-			name: "Single Step Instrumentation: default service name for ReplicaSet",
-			pod: common.FakePodSpec{
-				ParentKind: "replicaset",
-				ParentName: "test-deployment-123",
-			}.Create(),
-			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...), corev1.EnvVar{
-				Name:  "DD_SERVICE",
-				Value: "test-deployment",
-			},
-				corev1.EnvVar{
-					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
-					Value: "k8s_single_step",
-				},
-				corev1.EnvVar{
-					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
-					Value: installTime,
-				},
-				corev1.EnvVar{
-					Name:  "DD_INSTRUMENTATION_INSTALL_ID",
-					Value: uuid,
-				},
-			),
-			expectedInjectedLibraries: defaultLibraries,
-			expectedSecurityContext:   &corev1.SecurityContext{},
-			wantErr:                   false,
-			wantWebhookInitErr:        false,
-			setupConfig:               funcs{enableAPMInstrumentation},
-		},
-		{
-			name: "Single Step Instrumentation: default service name for StatefulSet",
-			pod: common.FakePodSpec{
-				ParentKind: "statefulset",
-				ParentName: "test-statefulset-123",
-			}.Create(),
-			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...), corev1.EnvVar{
-				Name:  "DD_SERVICE",
-				Value: "test-statefulset-123",
-			},
-				corev1.EnvVar{
-					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
-					Value: "k8s_single_step",
-				},
-				corev1.EnvVar{
-					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
-					Value: installTime,
-				},
-				corev1.EnvVar{
-					Name:  "DD_INSTRUMENTATION_INSTALL_ID",
-					Value: uuid,
-				},
-			),
-			expectedInjectedLibraries: defaultLibraries,
-			expectedSecurityContext:   &corev1.SecurityContext{},
-			wantErr:                   false,
-			wantWebhookInitErr:        false,
-			setupConfig:               funcs{enableAPMInstrumentation},
-		},
-		{
-			name: "Single Step Instrumentation: default service name (disabled)",
-			pod: common.FakePodSpec{
-				ParentKind: "replicaset",
-				ParentName: "test-deployment-123",
-			}.Create(),
-			expectedEnvs:              nil,
-			expectedInjectedLibraries: map[string]string{},
-			expectedSecurityContext:   &corev1.SecurityContext{},
-			wantErr:                   false,
-			wantWebhookInitErr:        false,
-			setupConfig:               funcs{disableAPMInstrumentation},
-		},
-		{
 			name: "Single Step Instrumentation: disabled namespaces should not be instrumented",
 			pod: common.FakePodSpec{
 				ParentKind: "replicaset",
@@ -2317,10 +2237,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				ParentName: "test-app-123",
 			}.Create(),
 			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...),
-				corev1.EnvVar{
-					Name:  "DD_SERVICE",
-					Value: "test-app",
-				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_single_step",
@@ -2500,10 +2416,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
 				{
-					Name:  "DD_SERVICE",
-					Value: "test-app",
-				},
-				{
 					Name:  "DD_RUNTIME_METRICS_ENABLED",
 					Value: "true",
 				},
@@ -2568,10 +2480,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
 				{
-					Name:  "DD_SERVICE",
-					Value: "test-app",
-				},
-				{
 					Name:  "DD_RUNTIME_METRICS_ENABLED",
 					Value: "true",
 				},
@@ -2634,10 +2542,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					Value: "k8s_single_step",
 				},
 				corev1.EnvVar{
-					Name:  "DD_SERVICE",
-					Value: "test-app",
-				},
-				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
 					Value: installTime,
 				},
@@ -2669,10 +2573,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_single_step",
-				},
-				corev1.EnvVar{
-					Name:  "DD_SERVICE",
-					Value: "test-app",
 				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
@@ -2708,10 +2608,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					Value: "k8s_single_step",
 				},
 				corev1.EnvVar{
-					Name:  "DD_SERVICE",
-					Value: "test-app",
-				},
-				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
 					Value: installTime,
 				},
@@ -2743,10 +2639,6 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_single_step",
-				},
-				corev1.EnvVar{
-					Name:  "DD_SERVICE",
-					Value: "test-app",
 				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
@@ -32,10 +32,6 @@ type basicLibConfigInjector struct{}
 
 func (basicLibConfigInjector) mutatePod(pod *corev1.Pod) error {
 	libConfig := basicConfig()
-	if name, err := getServiceNameFromPod(pod); err == nil {
-		// Set service name if it can be derived from a pod
-		libConfig.ServiceName = &name
-	}
 	for _, env := range libConfig.ToEnvs() {
 		_ = mutatecommon.InjectEnv(pod, env)
 	}

--- a/releasenotes-dca/notes/autoinstrumentation-no-implicit-service-name-4ffe707332e79793.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-no-implicit-service-name-4ffe707332e79793.yaml
@@ -4,7 +4,7 @@ upgrade:
     The autoinstrumentation webhook will no longer choose a service name based on the name
     of the deployment.
 
-    This would override the service name as it was set in a Dockerfile via ``ENV DD_SERVICE``
+    This would override a service name set in a Dockerfile with ``ENV DD_SERVICE``
     and caused issues. If you need to set the service name from via kubernetes, please see
     the `Unified Service Tagging <https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging>`
     documentation for alternative methods.

--- a/releasenotes-dca/notes/autoinstrumentation-no-implicit-service-name-4ffe707332e79793.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-no-implicit-service-name-4ffe707332e79793.yaml
@@ -1,0 +1,10 @@
+---
+upgrade:
+  - |
+    The autoinstrumentation webhook will no longer choose a service name based on the name
+    of the deployment.
+
+    This would override the service name as it was set in a Dockerfile via ``ENV DD_SERVICE``
+    and caused issues. If you need to set the service name from via kubernetes, please see
+    the `Unified Service Tagging <https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging>`
+    documentation for other ways to set this.

--- a/releasenotes-dca/notes/autoinstrumentation-no-implicit-service-name-4ffe707332e79793.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-no-implicit-service-name-4ffe707332e79793.yaml
@@ -7,4 +7,4 @@ upgrade:
     This would override the service name as it was set in a Dockerfile via ``ENV DD_SERVICE``
     and caused issues. If you need to set the service name from via kubernetes, please see
     the `Unified Service Tagging <https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging>`
-    documentation for other ways to set this.
+    documentation for alternative methods.


### PR DESCRIPTION
### What does this PR do?

This PR removes the behavior of using the deployment/stateful-set name for as `DD_SERVICE`.

### Motivation

Customers normally set service name from annotations, or in their docker env itself, or they can also do it the new workload targeting feature with `ddTraceConfigs`. All of those ways _are explicit_ and this one is implicit. Inferred service naming should be the responsibility of the language libraries themselves and has been the source of user confusion on in the past since this will override any `DD_SERVICE` in a container image and there is no way to turn it off.

### Describe how you validated your changes

- Unit tests.

### Possible Drawbacks / Trade-offs

- There are customers relying on this behavior but they do not know that they are.

### Additional Notes

This is part of parent ticket: https://datadoghq.atlassian.net/browse/INPLAT-458 and will involve further communications to users impacted.

cc @sarjyusuf 