### PR TITLE
usm: postgres: Remove instruction count of `postgres_handle_parse_message` by 70%

### DIFF
--- a/pkg/network/ebpf/c/protocols/postgres/defs.h
+++ b/pkg/network/ebpf/c/protocols/postgres/defs.h
@@ -33,7 +33,8 @@
 #define POSTGRES_PING_BODY "-- ping"
 #define NULL_TERMINATOR '\0'
 
-#define POSTGRES_SKIP_STRING_ITERATIONS 8
+#define POSTGRES_SKIP_STRING_ITERATIONS 32
+#define POSTGRES_SKIP_STRING_READ_SIZE 4
 #define SKIP_STRING_FAILED 0
 
 // Regular format of postgres message: | byte tag | int32_t len | string payload |


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

By re-balancing inner and outer loop lengths, without affecting the overall functionality, we can shrink the instruction count by 70%. A negative impact on TLS version with 15% increment. However, the socket-filter version has 30K instruction count, while TLS has 3K. So the trade-off is reasonable

### Motivation

Reduce instruction count for postgre

### Describe how you validated your postgres_handle_parse_message
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->