### PR TITLE
usm: postgres: Use object pool for latencies

### DIFF
--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -233,10 +233,15 @@ func (p *protocol) GetStats() (*protocols.ProtocolStats, func()) {
 	p.eventsConsumer.Sync()
 	p.kernelTelemetry.Log()
 
+	stats := p.statskeeper.GetAndResetAllStats()
 	return &protocols.ProtocolStats{
-		Type:  protocols.Postgres,
-		Stats: p.statskeeper.GetAndResetAllStats(),
-	}, nil
+			Type:  protocols.Postgres,
+			Stats: stats,
+		}, func() {
+			for _, stat := range stats {
+				stat.Close()
+			}
+		}
 }
 
 // IsBuildModeSupported returns always true, as postgres module is supported by all modes.

--- a/pkg/network/protocols/postgres/statskeeper.go
+++ b/pkg/network/protocols/postgres/statskeeper.go
@@ -56,6 +56,7 @@ func (s *StatKeeper) Process(tx *EventWrapper) {
 	}
 	if requestStats.Latencies == nil {
 		if err := requestStats.initSketch(); err != nil {
+			log.Warnf("could not add request latency to ddsketch: %v", err)
 			return
 		}
 		if err := requestStats.Latencies.Add(requestStats.FirstLatencySample); err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We leverage object pool instead of reallocating ddsketch object for postgres

### Motivation

Follow up for another protocol after #34080

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Benchmark results:
```
main:
BenchmarkRequestStatsPool_10Reqs
BenchmarkRequestStatsPool_10Reqs-16       	 1000000	      1316 ns/op	     592 B/op	       9 allocs/op
BenchmarkRequestStatsPool_100Reqs
BenchmarkRequestStatsPool_100Reqs-16      	  153340	      8860 ns/op	    1808 B/op	      13 allocs/op
BenchmarkRequestStatsPool_1000Reqs
BenchmarkRequestStatsPool_1000Reqs-16     	   24699	     52517 ns/op	    1808 B/op	      13 allocs/op
BenchmarkRequestStatsPool_10000Reqs
BenchmarkRequestStatsPool_10000Reqs-16    	    3877	    317198 ns/op	    1808 B/op	      13 allocs/op

branch:
BenchmarkRequestStatsPool_10Reqs
BenchmarkRequestStatsPool_10Reqs-16       	 1924906	       700.7 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_100Reqs
BenchmarkRequestStatsPool_100Reqs-16      	  325545	      3820 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_1000Reqs
BenchmarkRequestStatsPool_1000Reqs-16     	   37941	     30833 ns/op	      64 B/op	       1 allocs/op
BenchmarkRequestStatsPool_10000Reqs
BenchmarkRequestStatsPool_10000Reqs-16    	    3649	    294629 ns/op	      65 B/op	       1 allocs/op
```