### PR TITLE
fix(fleet): Avoid race condition in E2E tests

### DIFF
--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -159,10 +159,10 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 	// shorten timeout for tests
 	s.host.Run("sudo mkdir -p /etc/systemd/system/datadog-agent-exp.service.d/")
 	defer s.host.Run("sudo rm -rf /etc/systemd/system/datadog-agent-exp.service.d/")
-	s.host.Run(`echo -e "[Unit]\nJobTimeoutSec=5" | sudo tee /etc/systemd/system/datadog-agent-exp.service.d/override.conf > /dev/null`)
+	s.host.Run(`echo -e "[Unit]\nJobTimeoutSec=15" | sudo tee /etc/systemd/system/datadog-agent-exp.service.d/override.conf > /dev/null`)
 	s.host.Run(`sudo systemctl daemon-reload`)
 
-	s.host.AssertUnitProperty("datadog-agent-exp.service", "JobTimeoutUSec", "5s")
+	s.host.AssertUnitProperty("datadog-agent-exp.service", "JobTimeoutUSec", "15s")
 
 	timestamp := s.host.LastJournaldTimestamp()
 	s.host.Run(`sudo systemctl start datadog-agent-exp --no-block`)


### PR DESCRIPTION
### What does this PR do?
Sometimes the process agent takes 5s to stop, which conflicts with the 5s unit timeout we set and makes the test flaky.

### Motivation

### Describe how you validated your changes
E2E.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->