### PR TITLE
Source config from core agent for ddprofiling

### DIFF
--- a/comp/otelcol/converter/impl/autoconfigure.go
+++ b/comp/otelcol/converter/impl/autoconfigure.go
@@ -7,12 +7,9 @@
 package converterimpl
 
 import (
-	"regexp"
 	"strings"
 
 	"go.opentelemetry.io/collector/confmap"
-
-	"github.com/DataDog/datadog-agent/comp/core/config"
 )
 
 var ddAutoconfiguredSuffix = "dd-autoconfigured"
@@ -121,85 +118,5 @@ func addComponentToPipeline(conf *confmap.Conf, comp component, pipelineName str
 		pipelineMap[comp.Type] = pipelineOfTypeSlice
 	}
 
-	*conf = *confmap.NewFromStringMap(stringMapConf)
-}
-
-// addCoreAgentConfig enhances the configuration with information about the core agent.
-// For example, if api key is not found in otel config, it can be retrieved from core
-// agent config instead.
-func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
-	if coreCfg == nil {
-		return
-	}
-	stringMapConf := conf.ToStringMap()
-	exporters, ok := stringMapConf["exporters"]
-	if !ok {
-		return
-	}
-	exporterMap, ok := exporters.(map[string]any)
-	if !ok {
-		return
-	}
-	reg, err := regexp.Compile(secretRegex)
-	if err != nil {
-		return
-	}
-	for exporter := range exporterMap {
-		if componentName(exporter) == "datadog" {
-			datadog, ok := exporterMap[exporter]
-			if !ok {
-				return
-			}
-			datadogMap, ok := datadog.(map[string]any)
-			if !ok {
-				// datadog section is there, but there is nothing in it. We
-				// need to add it so we can add to it.
-				exporterMap[exporter] = make(map[string]any)
-				datadogMap = exporterMap[exporter].(map[string]any)
-			}
-			api, ok := datadogMap["api"]
-			// ok can be true if api section is there but contains nothing (api == nil).
-			// In which case, we need to add it so we can add to it.
-			if !ok || api == nil {
-				datadogMap["api"] = make(map[string]any, 2)
-				api = datadogMap["api"]
-			}
-			apiMap, ok := api.(map[string]any)
-			if !ok {
-				return
-			}
-
-			// api::site
-			apiSite := apiMap["site"]
-			if (apiSite == nil || apiSite == "") && coreCfg.Get("site") != nil {
-				apiMap["site"] = coreCfg.Get("site")
-			} else if (apiSite == nil || apiSite == "") && coreCfg.Get("site") == nil {
-				// if site is nil or empty string, and core config site is unset, set default
-				// site. Site defaults to an empty string in helm chart:
-				// https://github.com/DataDog/helm-charts/blob/datadog-3.86.0/charts/datadog/templates/_otel_agent_config.yaml#L24.
-				apiMap["site"] = "datadoghq.com"
-			}
-
-			// api::key
-			var match bool
-			apiKey, ok := apiMap["key"]
-			if ok {
-				var key string
-				if keyString, okString := apiKey.(string); okString {
-					key = keyString
-				}
-				if ok && key != "" {
-					match = reg.Match([]byte(key))
-					if !match {
-						continue
-					}
-				}
-			}
-			// TODO: add logic to either fail or log message if api key not found
-			if (apiKey == nil || apiKey == "" || match) && coreCfg.Get("api_key") != nil {
-				apiMap["key"] = coreCfg.Get("api_key")
-			}
-		}
-	}
 	*conf = *confmap.NewFromStringMap(stringMapConf)
 }

--- a/comp/otelcol/converter/impl/converter_test.go
+++ b/comp/otelcol/converter/impl/converter_test.go
@@ -312,6 +312,12 @@ func TestConvert(t *testing.T) {
 			expectedResult: "dd-core-cfg/env/no-override/config-result.yaml",
 			agentConfig:    "dd-core-cfg/env/no-override/acfg.yaml",
 		},
+		{
+			name:           "dd-core-cfg/env/empty-profiler-options",
+			provided:       "dd-core-cfg/env/empty-profiler-options/config.yaml",
+			expectedResult: "dd-core-cfg/env/empty-profiler-options/config-result.yaml",
+			agentConfig:    "dd-core-cfg/env/empty-profiler-options/acfg.yaml",
+		},
 	}
 
 	for _, tc := range tests {

--- a/comp/otelcol/converter/impl/converter_test.go
+++ b/comp/otelcol/converter/impl/converter_test.go
@@ -217,6 +217,12 @@ func TestConvert(t *testing.T) {
 			agentConfig:    "dd-core-cfg/apikey/no-api-key-section/acfg.yaml",
 		},
 		{
+			name:           "dd-core-cfg/apikey/no-api-no-add",
+			provided:       "dd-core-cfg/apikey/no-api-no-add/config.yaml",
+			expectedResult: "dd-core-cfg/apikey/no-api-no-add/config-result.yaml",
+			agentConfig:    "dd-core-cfg/apikey/no-api-no-add/acfg.yaml",
+		},
+		{
 			name:           "dd-core-cfg/apikey/multiple-dd-exporter",
 			provided:       "dd-core-cfg/apikey/multiple-dd-exporter/config.yaml",
 			expectedResult: "dd-core-cfg/apikey/multiple-dd-exporter/config-result.yaml",
@@ -287,6 +293,24 @@ func TestConvert(t *testing.T) {
 			provided:       "dd-core-cfg/none/config.yaml",
 			expectedResult: "dd-core-cfg/none/config-result.yaml",
 			agentConfig:    "dd-core-cfg/none/acfg.yaml",
+		},
+		{
+			name:           "dd-core-cfg/env/no-profiler-options",
+			provided:       "dd-core-cfg/env/no-profiler-options/config.yaml",
+			expectedResult: "dd-core-cfg/env/no-profiler-options/config-result.yaml",
+			agentConfig:    "dd-core-cfg/env/no-profiler-options/acfg.yaml",
+		},
+		{
+			name:           "dd-core-cfg/env/no-env",
+			provided:       "dd-core-cfg/env/no-env/config.yaml",
+			expectedResult: "dd-core-cfg/env/no-env/config-result.yaml",
+			agentConfig:    "dd-core-cfg/env/no-env/acfg.yaml",
+		},
+		{
+			name:           "dd-core-cfg/env/no-override",
+			provided:       "dd-core-cfg/env/no-override/config.yaml",
+			expectedResult: "dd-core-cfg/env/no-override/config-result.yaml",
+			agentConfig:    "dd-core-cfg/env/no-override/acfg.yaml",
 		},
 	}
 

--- a/comp/otelcol/converter/impl/coreconfig.go
+++ b/comp/otelcol/converter/impl/coreconfig.go
@@ -25,6 +25,8 @@ func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
 	addEnv(conf, coreCfg)
 }
 
+// test 
+
 // addEnv adds the env from core agent config to the profiler_options env setting,
 // if it is unset.
 func addEnv(conf *confmap.Conf, coreCfg config.Component) {

--- a/comp/otelcol/converter/impl/coreconfig.go
+++ b/comp/otelcol/converter/impl/coreconfig.go
@@ -133,7 +133,7 @@ func addAPIKeySite(conf *confmap.Conf, coreCfg config.Component, compType string
 				if keyString, okString := apiKey.(string); okString {
 					key = keyString
 				}
-				if ok && key != "" {
+				if key != "" {
 					match = reg.Match([]byte(key))
 					if !match {
 						continue

--- a/comp/otelcol/converter/impl/coreconfig.go
+++ b/comp/otelcol/converter/impl/coreconfig.go
@@ -49,7 +49,7 @@ func addEnv(conf *confmap.Conf, coreCfg config.Component) {
 				extensionMap[extension] = ddprofilingMap
 			}
 			profilerOptions, ok := ddprofilingMap["profiler_options"]
-			if !ok {
+			if !ok || profilerOptions == nil {
 				profilerOptions = make(map[string]any)
 				ddprofilingMap["profiler_options"] = profilerOptions
 			}

--- a/comp/otelcol/converter/impl/coreconfig.go
+++ b/comp/otelcol/converter/impl/coreconfig.go
@@ -25,8 +25,6 @@ func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
 	addEnv(conf, coreCfg)
 }
 
-// test 
-
 // addEnv adds the env from core agent config to the profiler_options env setting,
 // if it is unset.
 func addEnv(conf *confmap.Conf, coreCfg config.Component) {

--- a/comp/otelcol/converter/impl/coreconfig.go
+++ b/comp/otelcol/converter/impl/coreconfig.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package converterimpl provides the implementation of the otel-agent converter.
+package converterimpl
+
+import (
+	"regexp"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"go.opentelemetry.io/collector/confmap"
+)
+
+// addCoreAgentConfig enhances the configuration with information about the core agent.
+// For example, if api key is not found in otel config, it can be retrieved from core
+// agent config instead.
+func addCoreAgentConfig(conf *confmap.Conf, coreCfg config.Component) {
+	if coreCfg == nil {
+		return
+	}
+	addAPIKeySite(conf, coreCfg, "exporters", "datadog")
+	addAPIKeySite(conf, coreCfg, "extensions", "ddprofiling")
+
+
+}
+
+// addAPIKeySite adds the API key and site from core config to github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config.APIConfig.
+func addAPIKeySite(conf *confmap.Conf, coreCfg config.Component, compType string , compName string) {
+	stringMapConf := conf.ToStringMap()
+	components, ok := stringMapConf[compType]
+	if !ok {
+		return
+	}
+	componentMap, ok := components.(map[string]any)
+	if !ok {
+		return
+	}
+	reg, err := regexp.Compile(secretRegex)
+	if err != nil {
+		return
+	}
+	for component := range componentMap {
+		if componentName(component) == compName {
+			datadog, ok := componentMap[component]
+			if !ok {
+				return
+			}
+			datadogMap, ok := datadog.(map[string]any)
+			if !ok {
+				// datadog section is there, but there is nothing in it. We
+				// need to add it so we can add to it.
+				componentMap[component] = make(map[string]any)
+				datadogMap = componentMap[component].(map[string]any)
+			}
+			api, ok := datadogMap["api"]
+			// ok can be true if api section is there but contains nothing (api == nil).
+			// In which case, we need to add it so we can add to it.
+			if !ok || api == nil {
+				datadogMap["api"] = make(map[string]any, 2)
+				api = datadogMap["api"]
+			}
+			apiMap, ok := api.(map[string]any)
+			if !ok {
+				return
+			}
+
+			// api::site
+			apiSite := apiMap["site"]
+			if (apiSite == nil || apiSite == "") && coreCfg.Get("site") != nil {
+				apiMap["site"] = coreCfg.Get("site")
+			} else if (apiSite == nil || apiSite == "") && coreCfg.Get("site") == nil {
+				// if site is nil or empty string, and core config site is unset, set default
+				// site. Site defaults to an empty string in helm chart:
+				// https://github.com/DataDog/helm-charts/blob/datadog-3.86.0/charts/datadog/templates/_otel_agent_config.yaml#L24.
+				apiMap["site"] = "datadoghq.com"
+			}
+
+			// api::key
+			var match bool
+			apiKey, ok := apiMap["key"]
+			if ok {
+				var key string
+				if keyString, okString := apiKey.(string); okString {
+					key = keyString
+				}
+				if ok && key != "" {
+					match = reg.Match([]byte(key))
+					if !match {
+						continue
+					}
+				}
+			}
+			// TODO: add logic to either fail or log message if api key not found
+			if (apiKey == nil || apiKey == "" || match) && coreCfg.Get("api_key") != nil {
+				apiMap["key"] = coreCfg.Get("api_key")
+			}
+		}
+	}
+	*conf = *confmap.NewFromStringMap(stringMapConf)
+}

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/api-section/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/api-section/config-result.yaml
@@ -23,9 +23,14 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling: 
+    api: 
+      key: ggggg77777
+      site: datadoghq.eu
+
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/api-section/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/api-section/config.yaml
@@ -21,9 +21,12 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/key-site-section/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/key-site-section/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key: ggggg77777
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/key-site-section/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/key-site-section/config.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key:
+      site:
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/no-api-section/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/no-api-section/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key: ggggg77777
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/no-api-section/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/no-api-section/config.yaml
@@ -20,9 +20,10 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/no-overrides/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/all/no-overrides/config.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key: abc123
+      site: us1.datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/api-set-no-key/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/api-set-no-key/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: ggggg77777
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/api-set-no-key/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/api-set-no-key/config.yaml
@@ -22,9 +22,12 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/empty-string/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/empty-string/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: ggggg77777
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/empty-string/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/empty-string/config.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: ""
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/multiple-dd-exporter/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/multiple-dd-exporter/config-result.yaml
@@ -25,9 +25,18 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling/1:
+    api:
+      key: ggggg77777
+      site: datadoghq.com
+  ddprofiling/2:
+    api: 
+      key: ggggg77777
+      site: datadoghq.com
+
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling/1, ddprofiling/2]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/multiple-dd-exporter/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/multiple-dd-exporter/config.yaml
@@ -27,9 +27,17 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling/1:
+    api: 
+      key:
+      site: datadoghq.com
+  ddprofiling/2:
+    api: 
+      key:
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling/1, ddprofiling/2]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-key-section/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-key-section/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling: 
+    api:
+      key: ggggg77777
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-key-section/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-key-section/config-result.yaml
@@ -24,9 +24,6 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling: 
-    api:
-      key: ggggg77777
-      site: datadoghq.com
 
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-key-section/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-key-section/config.yaml
@@ -20,9 +20,10 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-no-add/acfg.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-no-add/acfg.yaml
@@ -1,0 +1,1 @@
+api_key: ggggg77777

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-no-add/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-no-add/config-result.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,19 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-no-add/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/no-api-no-add/config.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,19 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/secret/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/secret/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling: 
+    api:
+      key: ggggg77777
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/secret/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/secret/config.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: "ENC[my-secret]"
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/unset/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/unset/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: ggggg77777
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/unset/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/apikey/unset/config.yaml
@@ -21,9 +21,11 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling: 
+    api:
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/empty-profiler-options/acfg.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/empty-profiler-options/acfg.yaml
@@ -1,0 +1,1 @@
+env: test_env

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/empty-profiler-options/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/empty-profiler-options/config-result.yaml
@@ -1,0 +1,41 @@
+receivers:
+  otlp:
+  prometheus/user-defined:
+    config:
+      scrape_configs:
+        - job_name: 'datadog-agent'
+          scrape_interval: 60s
+          static_configs:
+            - targets: ['0.0.0.0:8888']
+
+processors:
+  infraattributes/user-defined:
+
+exporters:
+  nop:
+
+extensions:
+  pprof/user-defined:
+  health_check/user-defined:
+  zpages/user-defined:
+    endpoint: "localhost:55679"
+  ddflare/user-defined:
+  ddprofiling:
+    profiler_options:
+      env: test_env
+    
+service:
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [infraattributes/user-defined]
+      exporters: [nop]
+    metrics:
+      receivers: [prometheus/user-defined]
+      processors: [infraattributes/user-defined]
+      exporters: [nop]
+    logs:
+      receivers: [otlp]
+      processors: [infraattributes/user-defined]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/empty-profiler-options/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/empty-profiler-options/config.yaml
@@ -1,0 +1,40 @@
+receivers:
+  otlp:
+  prometheus/user-defined:
+    config:
+      scrape_configs:
+        - job_name: 'datadog-agent'
+          scrape_interval: 60s
+          static_configs:
+            - targets: ['0.0.0.0:8888']
+
+processors:
+  infraattributes/user-defined:
+
+exporters:
+  nop:
+
+extensions:
+  pprof/user-defined:
+  health_check/user-defined:
+  zpages/user-defined:
+    endpoint: "localhost:55679"
+  ddflare/user-defined:
+  ddprofiling:
+    profiler_options:
+    
+service:
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [infraattributes/user-defined]
+      exporters: [nop]
+    metrics:
+      receivers: [prometheus/user-defined]
+      processors: [infraattributes/user-defined]
+      exporters: [nop]
+    logs:
+      receivers: [otlp]
+      processors: [infraattributes/user-defined]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-env/acfg.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-env/acfg.yaml
@@ -1,0 +1,1 @@
+env: test_env

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-env/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-env/config-result.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,22 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    profiler_options:
+      service: test_svc
+      env: test_env
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-env/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-env/config.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,21 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    profiler_options:
+      service: test_svc
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-override/acfg.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-override/acfg.yaml
@@ -1,0 +1,1 @@
+env: test_env

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-override/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-override/config-result.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,21 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    profiler_options:
+      env: user-provided
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-override/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-override/config.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,21 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    profiler_options:
+      env: user-provided
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-profiler-options/acfg.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-profiler-options/acfg.yaml
@@ -1,0 +1,1 @@
+env: test_env

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-profiler-options/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-profiler-options/config-result.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,21 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    profiler_options:
+      env: test_env
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-profiler-options/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/env/no-profiler-options/config.yaml
@@ -12,10 +12,7 @@ processors:
   infraattributes/user-defined:
 
 exporters:
-  datadog:
-    api: 
-      key: ggggg77777
-      site: datadoghq.eu
+  nop:
 
 extensions:
   pprof/user-defined:
@@ -24,19 +21,19 @@ extensions:
     endpoint: "localhost:55679"
   ddflare/user-defined:
   ddprofiling:
-
+    
 service:
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     metrics:
       receivers: [prometheus/user-defined]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]
     logs:
       receivers: [otlp]
       processors: [infraattributes/user-defined]
-      exporters: [datadog]
+      exporters: [nop]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/none/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/none/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key:
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/none/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/none/config.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key:  
+      site:
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/api-set-no-site/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/api-set-no-site/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: ggggg77777
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/api-set-no-site/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/api-set-no-site/config.yaml
@@ -22,9 +22,12 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling: 
+    api:
+      key: ggggg77777
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/empty-string/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/empty-string/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: ggggg77777
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/empty-string/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/empty-string/config.yaml
@@ -23,9 +23,14 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key: ggggg77777
+      site: ""
+
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/multiple-dd-exporter/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/multiple-dd-exporter/config-result.yaml
@@ -25,9 +25,17 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling/1:
+    api:
+      key: abcde12345
+      site: datadoghq.eu
+  ddprofiling/2:
+    api: 
+      key: abcde12345
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling/1, ddprofiling/2]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/multiple-dd-exporter/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/multiple-dd-exporter/config.yaml
@@ -25,9 +25,15 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling/1:
+    api: 
+      key: abcde12345
+  ddprofiling/2:
+    api: 
+      key: abcde12345
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling/1, ddprofiling/2]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/no-api-site-section/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/no-api-site-section/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: ggggg77777
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/no-api-site-section/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/no-api-site-section/config.yaml
@@ -22,9 +22,12 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api: 
+      key: ggggg77777
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset-core-mptystr-col/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset-core-mptystr-col/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: abcde12345
+      site: datadoghq.com
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset-core-mptystr-col/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset-core-mptystr-col/config.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: abcde12345
+      site: ""
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset/config-result.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: abcde12345
+      site: datadoghq.eu
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]

--- a/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/dd-core-cfg/site/unset/config.yaml
@@ -23,9 +23,13 @@ extensions:
   zpages/user-defined:
     endpoint: "localhost:55679"
   ddflare/user-defined:
+  ddprofiling:
+    api:
+      key: abcde12345
+      site:
 
 service:
-  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
+  extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined, ddprofiling]
   pipelines:
     traces:
       receivers: [otlp]


### PR DESCRIPTION
### What does this PR do?
This PR sources api key, site and env from core agent config when this is unset in ddprofiling extension.

Note that api::key and api::site are only sourced if the api section is present in the ddprofiling extension. The reason is that api section shouldn't be set in otel-agent path, as it is not required (sent to trace agent comp, no agentless upload), so we use the presence of the api section to determine if its oss or otel-agent path

### Motivation
OTAGENT-262

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->