### PR TITLE
[FA] Remove old tuf cleanup

### DIFF
--- a/omnibus/package-scripts/agent-deb/preinst
+++ b/omnibus/package-scripts/agent-deb/preinst
@@ -35,13 +35,6 @@ if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/
     fi
 fi
 
-# For versions < 6.10 using the custom datadog-pip, TUF and in-toto files were kept in TUF_REPO_DIR.
-# They were not being cleaned by these versions, so let's do that now on install/upgrade
-TUF_REPO_DIR=$INSTALL_DIR/repositories
-if [ -d $TUF_REPO_DIR ]; then
-    rm -rf $TUF_REPO_DIR
-fi
-
 # Remove any unpacked BTF files
 find "$INSTALL_DIR/embedded/share/system-probe/ebpf/co-re/btf" -name "*.btf*" -type f -delete || true
 # And remove empty directories

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -29,13 +29,6 @@ if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/
     fi
 fi
 
-# For versions < 6.10 using the custom datadog-pip, TUF and in-toto files were kept in TUF_REPO_DIR.
-# They were not being cleaned by these versions, so let's do that now on install/upgrade
-TUF_REPO_DIR=$INSTALL_DIR/repositories
-if [ -d $TUF_REPO_DIR ]; then
-    rm -rf $TUF_REPO_DIR
-fi
-
 # RPM Agents < 5.18.0 expect the preinst script of the _new_ package to stop the agent service on upgrade (which is defined with an init.d script on Agent 5)
 # So let's stop the Agent 5 service here until we don't want to support upgrades from Agents < 5.18.0 anymore
 if [ -f "/etc/init.d/datadog-agent" ]; then


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove old cleanup code to simplify the package installation scripts.
This cleanup code was introduced for agent 6.10 (original [PR](https://github.com/DataDog/datadog-agent/pull/3025)) when we switch the `datadog-agent integration install` command to `datadog_checks_downloader`.

Agent versions <6.10 populate the `/etc/datadog-agent/repositories` folder with TUF files to verify package signatures.
From agent 6.10, we don't use this path to store the TUF files (https://github.com/DataDog/integrations-core/blob/6.10.x/datadog_checks_downloader/datadog_checks/downloader/download.py#L52)

### Motivation

Simplify the package installation scripts

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

Here’s an example of the edge case that could occur on Agent versions (<6.10 - released on 2019-02-28):

1. A host is running Agent <6.10.
2. A user installs a new integration with datadog-agent integration install.
3. The Agent is upgraded again to another version still <6.10.
4. The user attempts to install another new integration using datadog-agent integration install, which triggers an error.


Additional Notes:

* Because only integrations compatible with the older datadog-checks-base package can be installed, and their signatures have generally been invalid for over two years, this scenario is highly unlikely in practice.
* If it does occur, there is a workaround for step 4: disable signature verification via the CLI option.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->