### PR TITLE
fix(fleet): Update cURL on Ubuntu to avoid SSL errors

### DIFF
--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -162,11 +162,21 @@ func (s *packageBaseSuite) SetupSuite() {
 	s.setupFakeIntake()
 	s.host = host.New(s.T(), s.Env().RemoteHost, s.os, s.arch)
 	s.disableUnattendedUpgrades()
+	s.updateCurlOnUbuntu()
 }
 
 func (s *packageBaseSuite) disableUnattendedUpgrades() {
 	if _, err := s.Env().RemoteHost.Execute("which apt"); err == nil {
 		s.Env().RemoteHost.MustExecute("sudo apt remove -y unattended-upgrades")
+	}
+}
+
+func (s *packageBaseSuite) updateCurlOnUbuntu() {
+	// There is an issue with the default cURL version on Ubuntu that causes sporadic
+	// SSL failures, and the fix is to update it.
+	// See https://stackoverflow.com/questions/72627218/openssl-error-messages-error0a000126ssl-routinesunexpected-eof-while-readin
+	if s.os.Flavor == e2eos.Ubuntu {
+		s.Env().RemoteHost.MustExecute("sudo apt update && sudo apt upgrade -y curl")
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
We see transient SSL errors on Ubuntu when running cURL commands. This PR fixes it by updating cURL (see https://stackoverflow.com/questions/72627218/openssl-error-messages-error0a000126ssl-routinesunexpected-eof-while-readin). 

### Motivation
No flaky

### Describe how you validated your changes
E2E

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->