### PR TITLE
Move autoscaling controller to CRD v1alpha2

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -125,6 +125,7 @@ core,github.com/DataDog/datadog-api-client-go/v2/api/datadogV2,Apache-2.0,"Copyr
 core,github.com/DataDog/datadog-go/v5/statsd,MIT,"Copyright (c) 2015 Datadog, Inc"
 core,github.com/DataDog/datadog-operator/api/datadoghq/common,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1,Apache-2.0,"Copyright 2016-present Datadog, Inc"
+core,github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 core,github.com/DataDog/dd-sensitive-data-scanner/sds-go/go,Apache-2.0,"Copyright 2024-present Datadog, Inc"
 core,github.com/DataDog/dd-trace-go/v2/appsec/events,Apache-2.0,"Copyright (c) 2016-Present, Datadog <info@datadoghq.com> | Copyright 2016 Datadog, Inc | Copyright 2016-Present Datadog, Inc"
 core,github.com/DataDog/dd-trace-go/v2/datastreams/options,Apache-2.0,"Copyright (c) 2016-Present, Datadog <info@datadoghq.com> | Copyright 2016 Datadog, Inc | Copyright 2016-Present Datadog, Inc"

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.62.3
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	// TODO: pin to an operator released version once there is a release that includes the api module
-	github.com/DataDog/datadog-operator/api v0.0.0-20250114151552-463ab54482b4
+	github.com/DataDog/datadog-operator/api v0.0.0-20250218182124-bd4ad0b8d2fd
 	github.com/DataDog/ebpf-manager v0.7.7
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.9
@@ -93,7 +93,7 @@ require (
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8
 	github.com/golang/mock v1.7.0-rc.1
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/DataDog/datadog-api-client-go/v2 v2.35.0/go.mod h1:d3tOEgUd2kfsr9uuHQ
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEUqFvRDw=
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/datadog-operator/api v0.0.0-20250114151552-463ab54482b4 h1:Lb06hh5dOz327LZZIfCu2/Kcxstf9ml7c0B2ZSm9Y5k=
-github.com/DataDog/datadog-operator/api v0.0.0-20250114151552-463ab54482b4/go.mod h1:Ef4llzn4c4p6FPZNjeYgIQFHa2va2JPC8Wf/kivrF2E=
+github.com/DataDog/datadog-operator/api v0.0.0-20250218182124-bd4ad0b8d2fd h1:ZCkas9vo9WVqmxXFo10S3rLfAB+Ls0EYldklc0MSHWs=
+github.com/DataDog/datadog-operator/api v0.0.0-20250218182124-bd4ad0b8d2fd/go.mod h1:Mc5PwgupcDXw3tCcQQLMPZLCqG0rS1vKXZrXi8qVRIo=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42 h1:RoH7VLzTnxHEugRPIgnGlxwDFszFGI7b3WZZUtWuPRM=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11 h1:6vwU//TjBIghQKMgIP9UyIRhN/LWS1y8tYzvRnu8JZw=
@@ -885,8 +885,9 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/clusteragent/autoscaling/controller_fake.go
+++ b/pkg/clusteragent/autoscaling/controller_fake.go
@@ -21,7 +21,7 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	core "k8s.io/client-go/testing"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 )
 
 var (

--- a/pkg/clusteragent/autoscaling/workload/config_retriever_settings_test.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_settings_test.go
@@ -14,10 +14,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	clock "k8s.io/utils/clock/testing"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
@@ -38,7 +40,7 @@ func TestConfigRetriverAutoscalingSettingsFollower(t *testing.T) {
 
 	// Object specs
 	object1Spec := &datadoghq.DatadogPodAutoscalerSpec{
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 		TargetRef: autoscalingv2.CrossVersionObjectReference{
 			APIVersion: "v1",
 			Kind:       "Deployment",
@@ -57,7 +59,9 @@ func TestConfigRetriverAutoscalingSettingsFollower(t *testing.T) {
 						{
 							Namespace: "ns",
 							Name:      "name1",
-							Spec:      object1Spec,
+							Specs: &model.AutoscalingSpecs{
+								V1Alpha2: object1Spec,
+							},
 						},
 					},
 				}),
@@ -82,7 +86,7 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 
 	// Object specs
 	object1Spec := &datadoghq.DatadogPodAutoscalerSpec{
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 		TargetRef: autoscalingv2.CrossVersionObjectReference{
 			APIVersion: "v1",
 			Kind:       "Deployment",
@@ -90,7 +94,7 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 		},
 	}
 	object2Spec := &datadoghq.DatadogPodAutoscalerSpec{
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 		TargetRef: autoscalingv2.CrossVersionObjectReference{
 			APIVersion: "v1",
 			Kind:       "Deployment",
@@ -98,16 +102,16 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 		},
 	}
 	object3Spec := &datadoghq.DatadogPodAutoscalerSpec{
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 		TargetRef: autoscalingv2.CrossVersionObjectReference{
 			APIVersion: "v1",
 			Kind:       "Deployment",
 			Name:       "deploy3",
 		},
-		Policy: &datadoghq.DatadogPodAutoscalerPolicy{
-			ApplyMode: datadoghq.DatadogPodAutoscalerNoneApplyMode,
-			Update: &datadoghq.DatadogPodAutoscalerUpdatePolicy{
-				Strategy: datadoghq.DatadogPodAutoscalerAutoUpdateStrategy,
+		ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+			Mode: datadoghq.DatadogPodAutoscalerApplyModePreview,
+			Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
+				Strategy: datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
 			},
 		},
 	}
@@ -118,12 +122,16 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 			{
 				Namespace: "ns",
 				Name:      "name1",
-				Spec:      object1Spec,
+				Specs: &model.AutoscalingSpecs{
+					V1Alpha2: object1Spec,
+				},
 			},
 			{
 				Namespace: "ns",
 				Name:      "name2",
-				Spec:      object2Spec,
+				Specs: &model.AutoscalingSpecs{
+					V1Alpha2: object2Spec,
+				},
 			},
 		},
 	}
@@ -133,7 +141,9 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 			{
 				Namespace: "ns",
 				Name:      "name3",
-				Spec:      object3Spec,
+				Specs: &model.AutoscalingSpecs{
+					V1Alpha2: object3Spec,
+				},
 			},
 		},
 	}
@@ -159,9 +169,9 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 	podAutoscalers := cr.store.GetAll()
 
 	// Set expected versions
-	object1Spec.RemoteVersion = pointer.Ptr[uint64](1)
-	object2Spec.RemoteVersion = pointer.Ptr[uint64](1)
-	object3Spec.RemoteVersion = pointer.Ptr[uint64](10)
+	object1Spec.RemoteVersion = pointer.Ptr[uint64](versionOffset + 1)
+	object2Spec.RemoteVersion = pointer.Ptr[uint64](versionOffset + 1)
+	object3Spec.RemoteVersion = pointer.Ptr[uint64](versionOffset + 10)
 	model.AssertPodAutoscalersEqual(t, []model.FakePodAutoscalerInternal{
 		{
 			Namespace:         "ns",
@@ -186,19 +196,19 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 	// Update to existing autoscalingsettings received
 	// Update the settings for object3
 	// Both adding and removing fields
-	object3Spec.Targets = []datadoghq.DatadogPodAutoscalerTarget{
+	object3Spec.Objectives = []datadoghqcommon.DatadogPodAutoscalerObjective{
 		{
-			Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-			PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
-				Name: v1.ResourceCPU,
-				Value: datadoghq.DatadogPodAutoscalerTargetValue{
-					Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+			Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+			PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
+				Name: corev1.ResourceCPU,
+				Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+					Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 					Utilization: pointer.Ptr[int32](80),
 				},
 			},
 		},
 	}
-	object3Spec.Policy = nil
+	object3Spec.ApplyPolicy = nil
 
 	stateCallbackCalled = 0
 	mockRCClient.triggerUpdate(
@@ -220,7 +230,7 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 	podAutoscalers = cr.store.GetAll()
 
 	// Set expected versions: only one change for for foo2
-	object3Spec.RemoteVersion = pointer.Ptr[uint64](11)
+	object3Spec.RemoteVersion = pointer.Ptr[uint64](versionOffset + 11)
 	model.AssertPodAutoscalersEqual(t, []model.FakePodAutoscalerInternal{
 		{
 			Namespace:         "ns",
@@ -279,6 +289,183 @@ func TestConfigRetriverAutoscalingSettingsLeader(t *testing.T) {
 			Namespace:         "ns",
 			Name:              "name3",
 			Spec:              object3Spec,
+			SettingsTimestamp: testTime,
+		},
+	}, podAutoscalers)
+}
+
+func TestConfigRetrieverAutoscalingSettingOldVersions(t *testing.T) {
+	testTime := time.Now()
+	cr, mockRCClient := newMockConfigRetriever(t, true, clock.NewFakeClock(testTime))
+
+	// Object specs from different versions
+	objectv1alpha1Spec := &datadoghqv1alpha1.DatadogPodAutoscalerSpec{
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
+		TargetRef: autoscalingv2.CrossVersionObjectReference{
+			APIVersion: "v1",
+			Kind:       "Deployment",
+			Name:       "deploy1",
+		},
+		Targets: []datadoghqcommon.DatadogPodAutoscalerObjective{
+			{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
+					Name: corev1.ResourceCPU,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
+						Utilization: pointer.Ptr[int32](80),
+					},
+				},
+			},
+		},
+		Policy: &datadoghqv1alpha1.DatadogPodAutoscalerPolicy{
+			ApplyMode: datadoghqv1alpha1.DatadogPodAutoscalerManualApplyMode,
+			Upscale: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+				Strategy: pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerMinChangeStrategySelect),
+			},
+		},
+	}
+
+	settingsList1 := model.AutoscalingSettingsList{
+		Settings: []model.AutoscalingSettings{
+			{
+				Namespace: "ns",
+				Name:      "name1",
+				// Old .Spec field
+				Spec: objectv1alpha1Spec,
+			},
+			{
+				Namespace: "ns",
+				Name:      "name2",
+				Specs: &model.AutoscalingSpecs{
+					V1Alpha1: objectv1alpha1Spec,
+				},
+			},
+		},
+	}
+
+	// New Autoscaling settings received
+	stateCallbackCalled := 0
+	mockRCClient.triggerUpdate(
+		data.ProductContainerAutoscalingSettings,
+		map[string]state.RawConfig{
+			"foo1": buildAutoscalingSettingsRawConfig(t, 1, settingsList1),
+		},
+		func(_ string, applyState state.ApplyStatus) {
+			stateCallbackCalled++
+			assert.Equal(t, applyState, state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+				Error: "",
+			})
+		},
+	)
+
+	assert.Equal(t, 1, stateCallbackCalled)
+	podAutoscalers := cr.store.GetAll()
+
+	// Expected v1alpha2 version output
+	objectv1alpha2Spec := &datadoghq.DatadogPodAutoscalerSpec{
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
+		TargetRef: autoscalingv2.CrossVersionObjectReference{
+			APIVersion: "v1",
+			Kind:       "Deployment",
+			Name:       "deploy1",
+		},
+		Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
+			{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
+					Name: corev1.ResourceCPU,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
+						Utilization: pointer.Ptr[int32](80),
+					},
+				},
+			},
+		},
+		ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+			Mode: datadoghq.DatadogPodAutoscalerApplyModePreview,
+			ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+				Strategy: pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerMinChangeStrategySelect),
+			},
+		},
+	}
+
+	// Copy with RemoteVersion set
+	expected := objectv1alpha2Spec.DeepCopy()
+	expected.RemoteVersion = pointer.Ptr[uint64](versionOffset + 1)
+	model.AssertPodAutoscalersEqual(t, []model.FakePodAutoscalerInternal{
+		{
+			Namespace:         "ns",
+			Name:              "name1",
+			Spec:              expected,
+			SettingsTimestamp: testTime,
+		},
+		{
+			Namespace:         "ns",
+			Name:              "name2",
+			Spec:              expected,
+			SettingsTimestamp: testTime,
+		},
+	}, podAutoscalers)
+
+	// Now the backend has upgraded to v2alpha1 keeping old v1alpha1 for old Cluster Agents
+	// v1alpha2 should be prioritized, creating a small diff to check output
+	objectv1alpha2Spec.TargetRef.Name = "deploy2"
+	settingsList1 = model.AutoscalingSettingsList{
+		Settings: []model.AutoscalingSettings{
+			{
+				Namespace: "ns",
+				Name:      "name1",
+				Specs: &model.AutoscalingSpecs{
+					V1Alpha1: objectv1alpha1Spec,
+					V1Alpha2: objectv1alpha2Spec,
+				},
+			},
+			{
+				Namespace: "ns",
+				Name:      "name2",
+				Spec:      objectv1alpha1Spec,
+				Specs: &model.AutoscalingSpecs{
+					V1Alpha2: objectv1alpha2Spec,
+				},
+			},
+		},
+	}
+
+	// New Autoscaling settings received (version 2)
+	stateCallbackCalled = 0
+	mockRCClient.triggerUpdate(
+		data.ProductContainerAutoscalingSettings,
+		map[string]state.RawConfig{
+			"foo1": buildAutoscalingSettingsRawConfig(t, 2, settingsList1),
+		},
+		func(_ string, applyState state.ApplyStatus) {
+			stateCallbackCalled++
+			assert.Equal(t, applyState, state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+				Error: "",
+			})
+		},
+	)
+
+	assert.Equal(t, 1, stateCallbackCalled)
+	podAutoscalers = cr.store.GetAll()
+
+	// Copy with RemoteVersion set
+	expected = objectv1alpha2Spec.DeepCopy()
+	expected.RemoteVersion = pointer.Ptr[uint64](versionOffset + 2)
+	model.AssertPodAutoscalersEqual(t, []model.FakePodAutoscalerInternal{
+		{
+			Namespace:         "ns",
+			Name:              "name1",
+			Spec:              expected,
+			SettingsTimestamp: testTime,
+		},
+		{
+			Namespace:         "ns",
+			Name:              "name2",
+			Spec:              expected,
 			SettingsTimestamp: testTime,
 		},
 	}, podAutoscalers)

--- a/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
@@ -15,9 +15,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	kubeAutoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/hashicorp/go-multierror"
+
+	kubeAutoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
@@ -170,9 +171,9 @@ func parseAutoscalingValues(timestamp time.Time, values *kubeAutoscaling.Workloa
 
 		var err error
 		if values.Horizontal.Manual != nil {
-			scalingValues.Horizontal, err = parseHorizontalScalingData(timestamp, values.Horizontal.Manual, datadoghq.DatadogPodAutoscalerManualValueSource)
+			scalingValues.Horizontal, err = parseHorizontalScalingData(timestamp, values.Horizontal.Manual, datadoghqcommon.DatadogPodAutoscalerManualValueSource)
 		} else if values.Horizontal.Auto != nil {
-			scalingValues.Horizontal, err = parseHorizontalScalingData(timestamp, values.Horizontal.Auto, datadoghq.DatadogPodAutoscalerAutoscalingValueSource)
+			scalingValues.Horizontal, err = parseHorizontalScalingData(timestamp, values.Horizontal.Auto, datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource)
 		}
 
 		if err != nil {
@@ -187,9 +188,9 @@ func parseAutoscalingValues(timestamp time.Time, values *kubeAutoscaling.Workloa
 
 		var err error
 		if values.Vertical.Manual != nil {
-			scalingValues.Vertical, err = parseAutoscalingVerticalData(timestamp, values.Vertical.Manual, datadoghq.DatadogPodAutoscalerManualValueSource)
+			scalingValues.Vertical, err = parseAutoscalingVerticalData(timestamp, values.Vertical.Manual, datadoghqcommon.DatadogPodAutoscalerManualValueSource)
 		} else if values.Vertical.Auto != nil {
-			scalingValues.Vertical, err = parseAutoscalingVerticalData(timestamp, values.Vertical.Auto, datadoghq.DatadogPodAutoscalerAutoscalingValueSource)
+			scalingValues.Vertical, err = parseAutoscalingVerticalData(timestamp, values.Vertical.Auto, datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource)
 		}
 
 		if err != nil {
@@ -200,7 +201,7 @@ func parseAutoscalingValues(timestamp time.Time, values *kubeAutoscaling.Workloa
 	return scalingValues, nil
 }
 
-func parseHorizontalScalingData(timestamp time.Time, data *kubeAutoscaling.WorkloadHorizontalData, source datadoghq.DatadogPodAutoscalerValueSource) (*model.HorizontalScalingValues, error) {
+func parseHorizontalScalingData(timestamp time.Time, data *kubeAutoscaling.WorkloadHorizontalData, source datadoghqcommon.DatadogPodAutoscalerValueSource) (*model.HorizontalScalingValues, error) {
 	horizontalValues := &model.HorizontalScalingValues{
 		Source: source,
 	}
@@ -222,7 +223,7 @@ func parseHorizontalScalingData(timestamp time.Time, data *kubeAutoscaling.Workl
 	return horizontalValues, nil
 }
 
-func parseAutoscalingVerticalData(timestamp time.Time, data *kubeAutoscaling.WorkloadVerticalData, source datadoghq.DatadogPodAutoscalerValueSource) (*model.VerticalScalingValues, error) {
+func parseAutoscalingVerticalData(timestamp time.Time, data *kubeAutoscaling.WorkloadVerticalData, source datadoghqcommon.DatadogPodAutoscalerValueSource) (*model.VerticalScalingValues, error) {
 	verticalValues := &model.VerticalScalingValues{
 		Source: source,
 	}
@@ -236,10 +237,10 @@ func parseAutoscalingVerticalData(timestamp time.Time, data *kubeAutoscaling.Wor
 	}
 
 	if containersNum := len(data.Resources); containersNum > 0 {
-		verticalValues.ContainerResources = make([]datadoghq.DatadogPodAutoscalerContainerResources, 0, containersNum)
+		verticalValues.ContainerResources = make([]datadoghqcommon.DatadogPodAutoscalerContainerResources, 0, containersNum)
 
 		for _, containerResources := range data.Resources {
-			convertedResources := datadoghq.DatadogPodAutoscalerContainerResources{
+			convertedResources := datadoghqcommon.DatadogPodAutoscalerContainerResources{
 				Name: containerResources.ContainerName,
 			}
 

--- a/pkg/clusteragent/autoscaling/workload/config_retriever_values_test.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_values_test.go
@@ -18,7 +18,7 @@ import (
 	clock "k8s.io/utils/clock/testing"
 
 	kubeAutoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
@@ -212,7 +212,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name1",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerManualValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerManualValueSource,
 					Replicas:  3,
 					Timestamp: testTime,
 				},
@@ -223,13 +223,13 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name2",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 					Replicas:  6,
 					Timestamp: testTime,
 				},
 				Vertical: &model.VerticalScalingValues{
-					Source: datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-					ContainerResources: []datadoghq.DatadogPodAutoscalerContainerResources{
+					Source: datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+					ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 						{
 							Name: "container1",
 							Requests: corev1.ResourceList{
@@ -239,7 +239,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 						},
 					},
 					Timestamp:     testTime,
-					ResourcesHash: "9d1474c7c20f3820",
+					ResourcesHash: "8fe97e46aa840723",
 				},
 			},
 		},
@@ -248,13 +248,13 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name3",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 					Replicas:  5,
 					Timestamp: testTime,
 				},
 				Vertical: &model.VerticalScalingValues{
-					Source: datadoghq.DatadogPodAutoscalerManualValueSource,
-					ContainerResources: []datadoghq.DatadogPodAutoscalerContainerResources{
+					Source: datadoghqcommon.DatadogPodAutoscalerManualValueSource,
+					ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 						{
 							Name: "container1",
 							Requests: corev1.ResourceList{
@@ -268,7 +268,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 						},
 					},
 					Timestamp:     testTime,
-					ResourcesHash: "e55f79588b87a881",
+					ResourcesHash: "f41ccab869dc36a7",
 				},
 			},
 		},
@@ -309,13 +309,13 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name2",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 					Replicas:  6,
 					Timestamp: testTime,
 				},
 				Vertical: &model.VerticalScalingValues{
-					Source: datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-					ContainerResources: []datadoghq.DatadogPodAutoscalerContainerResources{
+					Source: datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+					ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 						{
 							Name: "container1",
 							Requests: corev1.ResourceList{
@@ -325,7 +325,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 						},
 					},
 					Timestamp:     testTime,
-					ResourcesHash: "9d1474c7c20f3820",
+					ResourcesHash: "8fe97e46aa840723",
 				},
 			},
 		},
@@ -334,7 +334,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name3",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 					Replicas:  6,
 					Timestamp: testTime,
 				},
@@ -371,13 +371,13 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name2",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 					Replicas:  6,
 					Timestamp: testTime,
 				},
 				Vertical: &model.VerticalScalingValues{
-					Source: datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-					ContainerResources: []datadoghq.DatadogPodAutoscalerContainerResources{
+					Source: datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+					ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 						{
 							Name: "container1",
 							Requests: corev1.ResourceList{
@@ -386,7 +386,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 							},
 						},
 					},
-					ResourcesHash: "9d1474c7c20f3820",
+					ResourcesHash: "8fe97e46aa840723",
 					Timestamp:     testTime,
 				},
 			},
@@ -396,7 +396,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name3",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 					Replicas:  6,
 					Timestamp: testTime,
 				},
@@ -432,13 +432,13 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 			Name:      "name2",
 			ScalingValues: model.ScalingValues{
 				Horizontal: &model.HorizontalScalingValues{
-					Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+					Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 					Replicas:  6,
 					Timestamp: testTime,
 				},
 				Vertical: &model.VerticalScalingValues{
-					Source: datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-					ContainerResources: []datadoghq.DatadogPodAutoscalerContainerResources{
+					Source: datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+					ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 						{
 							Name: "container1",
 							Requests: corev1.ResourceList{
@@ -448,7 +448,7 @@ func TestConfigRetriverAutoscalingValuesLeader(t *testing.T) {
 						},
 					},
 					Timestamp:     testTime,
-					ResourcesHash: "9d1474c7c20f3820",
+					ResourcesHash: "8fe97e46aa840723",
 				},
 			},
 		},

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -23,7 +23,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/common"
@@ -153,10 +154,10 @@ func (hr *horizontalController) performScaling(ctx context.Context, podAutoscale
 
 func (hr *horizontalController) computeScaleAction(
 	autoscalerInternal *model.PodAutoscalerInternal,
-	source datadoghq.DatadogPodAutoscalerValueSource,
+	source datadoghqcommon.DatadogPodAutoscalerValueSource,
 	currentDesiredReplicas, targetDesiredReplicas int32,
 	minReplicas, maxReplicas int32,
-) (*datadoghq.DatadogPodAutoscalerHorizontalAction, time.Duration, error) {
+) (*datadoghqcommon.DatadogPodAutoscalerHorizontalAction, time.Duration, error) {
 	// Check if we scaling has been disabled explicitly
 	if currentDesiredReplicas == 0 {
 		return nil, 0, errors.New("scaling disabled as current replicas is set to 0")
@@ -196,7 +197,7 @@ func (hr *horizontalController) computeScaleAction(
 	// TODO: Should we apply scaling rules in this case?
 	if outsideBoundaries {
 		log.Debugf("Current replica count for autoscaler id: %s is outside of min/max constraints, scaling back to closest boundary: %d replicas", autoscalerInternal.ID(), targetDesiredReplicas)
-		return &datadoghq.DatadogPodAutoscalerHorizontalAction{
+		return &datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 			FromReplicas:        currentDesiredReplicas,
 			ToReplicas:          targetDesiredReplicas,
 			RecommendedReplicas: &originalTargetDesiredReplicas,
@@ -221,10 +222,10 @@ func (hr *horizontalController) computeScaleAction(
 	var rulesLimitReason string
 	var rulesLimitedReplicas int32
 	var rulesNextEvalAfter time.Duration
-	if scaleDirection == common.ScaleUp && autoscalerSpec.Policy != nil {
-		rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleUpPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.Policy.Upscale, currentDesiredReplicas, targetDesiredReplicas)
-	} else if scaleDirection == common.ScaleDown && autoscalerSpec.Policy != nil {
-		rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleDownPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.Policy.Downscale, currentDesiredReplicas, targetDesiredReplicas)
+	if scaleDirection == common.ScaleUp && autoscalerSpec.ApplyPolicy != nil {
+		rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleUpPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.ApplyPolicy.ScaleUp, currentDesiredReplicas, targetDesiredReplicas)
+	} else if scaleDirection == common.ScaleDown && autoscalerSpec.ApplyPolicy != nil {
+		rulesLimitedReplicas, rulesNextEvalAfter, rulesLimitReason = applyScaleDownPolicy(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), autoscalerSpec.ApplyPolicy.ScaleDown, currentDesiredReplicas, targetDesiredReplicas)
 	}
 	// If rules had any effect, use values from rules
 	if rulesLimitReason != "" {
@@ -237,25 +238,25 @@ func (hr *horizontalController) computeScaleAction(
 	// Stabilize recommendation
 	var stabilizationLimitReason string
 	var stabilizationLimitedReplicas int32
-	upscaleStabilizationSeconds := int32(0)
-	downscaleStabilizationSeconds := int32(0)
+	scaleUpStabilizationSeconds := int32(0)
+	scaleDownStabilizationSeconds := int32(0)
 
-	if policy := autoscalerInternal.Spec().Policy; policy != nil {
-		if upscalePolicy := policy.Upscale; upscalePolicy != nil {
-			upscaleStabilizationSeconds = int32(upscalePolicy.StabilizationWindowSeconds)
+	if policy := autoscalerInternal.Spec().ApplyPolicy; policy != nil {
+		if scaleUpPolicy := policy.ScaleUp; scaleUpPolicy != nil {
+			scaleUpStabilizationSeconds = int32(scaleUpPolicy.StabilizationWindowSeconds)
 		}
-		if downscalePolicy := policy.Downscale; downscalePolicy != nil {
-			downscaleStabilizationSeconds = int32(downscalePolicy.StabilizationWindowSeconds)
+		if scaleDownPolicy := policy.ScaleDown; scaleDownPolicy != nil {
+			scaleDownStabilizationSeconds = int32(scaleDownPolicy.StabilizationWindowSeconds)
 		}
 	}
 
-	stabilizationLimitedReplicas, stabilizationLimitReason = stabilizeRecommendations(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), currentDesiredReplicas, targetDesiredReplicas, upscaleStabilizationSeconds, downscaleStabilizationSeconds, scaleDirection)
+	stabilizationLimitedReplicas, stabilizationLimitReason = stabilizeRecommendations(scalingTimestamp, autoscalerInternal.HorizontalLastActions(), currentDesiredReplicas, targetDesiredReplicas, scaleUpStabilizationSeconds, scaleDownStabilizationSeconds, scaleDirection)
 	if stabilizationLimitReason != "" {
 		limitReason = stabilizationLimitReason
 		targetDesiredReplicas = stabilizationLimitedReplicas
 	}
 
-	horizontalAction := &datadoghq.DatadogPodAutoscalerHorizontalAction{
+	horizontalAction := &datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 		FromReplicas:        currentDesiredReplicas,
 		ToReplicas:          targetDesiredReplicas,
 		RecommendedReplicas: &originalTargetDesiredReplicas,
@@ -268,36 +269,36 @@ func (hr *horizontalController) computeScaleAction(
 	return horizontalAction, evalAfter, nil
 }
 
-func isScalingAllowed(autoscalerSpec *datadoghq.DatadogPodAutoscalerSpec, source datadoghq.DatadogPodAutoscalerValueSource, direction common.ScaleDirection) (bool, string) {
+func isScalingAllowed(autoscalerSpec *datadoghq.DatadogPodAutoscalerSpec, source datadoghqcommon.DatadogPodAutoscalerValueSource, direction common.ScaleDirection) (bool, string) {
 	// If we don't have spec, we cannot take decisions, should not happen.
 	if autoscalerSpec == nil {
 		return false, "pod autoscaling hasn't been initialized yet"
 	}
 
 	// By default, policy is to allow all
-	if autoscalerSpec.Policy == nil {
+	if autoscalerSpec.ApplyPolicy == nil {
 		return true, ""
 	}
 
 	// Default apply mode to All if not set
-	applyMode := autoscalerSpec.Policy.ApplyMode
+	applyMode := autoscalerSpec.ApplyPolicy.Mode
 	if applyMode == "" {
-		applyMode = datadoghq.DatadogPodAutoscalerAllApplyMode
+		applyMode = datadoghq.DatadogPodAutoscalerApplyModeApply
 	}
 
 	// We do have policies, checking if they allow this source
 	if !model.ApplyModeAllowSource(applyMode, source) {
-		return false, fmt.Sprintf("horizontal scaling disabled due to applyMode: %s not allowing recommendations from source: %s", autoscalerSpec.Policy.ApplyMode, source)
+		return false, fmt.Sprintf("horizontal scaling disabled due to applyMode: %s not allowing recommendations from source: %s", autoscalerSpec.ApplyPolicy.Mode, source)
 	}
 
 	// Check if scaling direction is allowed
-	if direction == common.ScaleUp && autoscalerSpec.Policy.Upscale != nil && autoscalerSpec.Policy.Upscale.Strategy != nil {
-		if *autoscalerSpec.Policy.Upscale.Strategy == datadoghq.DatadogPodAutoscalerDisabledStrategySelect {
+	if direction == common.ScaleUp && autoscalerSpec.ApplyPolicy.ScaleUp != nil && autoscalerSpec.ApplyPolicy.ScaleUp.Strategy != nil {
+		if *autoscalerSpec.ApplyPolicy.ScaleUp.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect {
 			return false, "upscaling disabled by strategy"
 		}
 	}
-	if direction == common.ScaleDown && autoscalerSpec.Policy.Downscale != nil && autoscalerSpec.Policy.Downscale.Strategy != nil {
-		if *autoscalerSpec.Policy.Downscale.Strategy == datadoghq.DatadogPodAutoscalerDisabledStrategySelect {
+	if direction == common.ScaleDown && autoscalerSpec.ApplyPolicy.ScaleDown != nil && autoscalerSpec.ApplyPolicy.ScaleDown.Strategy != nil {
+		if *autoscalerSpec.ApplyPolicy.ScaleDown.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect {
 			return false, "downscaling disabled by strategy"
 		}
 	}
@@ -308,15 +309,15 @@ func isScalingAllowed(autoscalerSpec *datadoghq.DatadogPodAutoscalerSpec, source
 
 func applyScaleUpPolicy(
 	currentTime time.Time,
-	events []datadoghq.DatadogPodAutoscalerHorizontalAction,
-	policy *datadoghq.DatadogPodAutoscalerScalingPolicy,
+	events []datadoghqcommon.DatadogPodAutoscalerHorizontalAction,
+	policy *datadoghqcommon.DatadogPodAutoscalerScalingPolicy,
 	currentDesiredReplicas, targetDesiredReplicas int32,
 ) (int32, time.Duration, string) {
 	if policy == nil {
 		return targetDesiredReplicas, 0, ""
 	}
 
-	strategy := datadoghq.DatadogPodAutoscalerMaxChangeStrategySelect
+	strategy := datadoghqcommon.DatadogPodAutoscalerMaxChangeStrategySelect
 	// If no strategy is defined, we default to the max policy for scale up
 	if policy.Strategy != nil {
 		strategy = *policy.Strategy
@@ -325,7 +326,7 @@ func applyScaleUpPolicy(
 	var maxReplicasFromRules int32
 	var selectStrategyFunc func(int32, int32) int32
 	minExpireIn := time.Hour // We don't support more than 1 hour of events
-	if strategy == datadoghq.DatadogPodAutoscalerMinChangeStrategySelect {
+	if strategy == datadoghqcommon.DatadogPodAutoscalerMinChangeStrategySelect {
 		maxReplicasFromRules = math.MaxInt32
 		selectStrategyFunc = min
 	} else {
@@ -336,20 +337,16 @@ func applyScaleUpPolicy(
 	for _, rule := range policy.Rules {
 		// We could find directly `periodStartReplicas` by looking at `FromReplicas` in the first matching event.
 		// TODO: In case of manual scaling (outside of DPA), we could consider it in the calculation, while it's currently not.
-		replicasAdded, replicasRemoved, numEvents, expireIn := accumulateReplicasChange(currentTime, events, rule.PeriodSeconds)
+		replicasAdded, replicasRemoved, expireIn := accumulateReplicasChange(currentTime, events, rule.PeriodSeconds)
 		minExpireIn = min(minExpireIn, expireIn)
-		if numEvents == 0 && rule.Match != nil && *rule.Match == datadoghq.DatadogPodAutoscalerIfScalingEventRuleMatch {
-			// Rule should be skipped as no scaling events were found in the window
-			continue
-		}
 
 		// When are computing the number of replicas at the start of the period, needed to compute % scaling.
 		// For that we consider the current number and apply the opposite of the events that happened in the period.
 		periodStartReplicas := currentDesiredReplicas - replicasAdded + replicasRemoved
 		var ruleMax int32
-		if rule.Type == datadoghq.DatadogPodAutoscalerPodsScalingRuleType {
+		if rule.Type == datadoghqcommon.DatadogPodAutoscalerPodsScalingRuleType {
 			ruleMax = periodStartReplicas + rule.Value
-		} else if rule.Type == datadoghq.DatadogPodAutoscalerPercentScalingRuleType {
+		} else if rule.Type == datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType {
 			// 1.x * start may yield the same number of replicas as periodStartReplicas, ceiling up to always always allow at least 1 replica
 			// otherwise it would block scaling up forever.
 			ruleMax = int32(math.Ceil(float64(periodStartReplicas) * (1 + float64(rule.Value)/100)))
@@ -376,15 +373,15 @@ func applyScaleUpPolicy(
 
 func applyScaleDownPolicy(
 	currentTime time.Time,
-	events []datadoghq.DatadogPodAutoscalerHorizontalAction,
-	policy *datadoghq.DatadogPodAutoscalerScalingPolicy,
+	events []datadoghqcommon.DatadogPodAutoscalerHorizontalAction,
+	policy *datadoghqcommon.DatadogPodAutoscalerScalingPolicy,
 	currentDesiredReplicas, targetDesiredReplicas int32,
 ) (int32, time.Duration, string) {
 	if policy == nil {
 		return targetDesiredReplicas, 0, ""
 	}
 
-	strategy := datadoghq.DatadogPodAutoscalerMaxChangeStrategySelect
+	strategy := datadoghqcommon.DatadogPodAutoscalerMaxChangeStrategySelect
 	// If no strategy is defined, we default to the max policy for scale up
 	if policy.Strategy != nil {
 		strategy = *policy.Strategy
@@ -393,7 +390,7 @@ func applyScaleDownPolicy(
 	var minReplicasFromRules int32
 	minExpireIn := time.Hour // We don't support more than 1 hour of events
 	var selectPolicyFn func(int32, int32) int32
-	if strategy == datadoghq.DatadogPodAutoscalerMinChangeStrategySelect {
+	if strategy == datadoghqcommon.DatadogPodAutoscalerMinChangeStrategySelect {
 		minReplicasFromRules = math.MinInt32
 		selectPolicyFn = max // For scaling down, the lowest change ('min' policy) produces a maximum value
 	} else {
@@ -404,20 +401,16 @@ func applyScaleDownPolicy(
 	for _, rule := range policy.Rules {
 		// We could find directly `periodStartReplicas` by looking at `FromReplicas` in the first matching event.
 		// TODO: In case of manual scaling (outside of DPA), we could consider it in the calculation, while it's currently not.
-		replicasAdded, replicasRemoved, numEvents, expireIn := accumulateReplicasChange(currentTime, events, rule.PeriodSeconds)
+		replicasAdded, replicasRemoved, expireIn := accumulateReplicasChange(currentTime, events, rule.PeriodSeconds)
 		minExpireIn = min(minExpireIn, expireIn)
-		if numEvents == 0 && rule.Match != nil && *rule.Match == datadoghq.DatadogPodAutoscalerIfScalingEventRuleMatch {
-			// Rule should be skipped as no scaling events were found in the window
-			continue
-		}
 
 		// When are computing the number of replicas at the start of the period, needed to compute % scaling.
 		// For that we consider the current number and apply the opposite of the events that happened in the period.
 		periodStartReplicas := currentDesiredReplicas - replicasAdded + replicasRemoved
 		var ruleMin int32
-		if rule.Type == datadoghq.DatadogPodAutoscalerPodsScalingRuleType {
+		if rule.Type == datadoghqcommon.DatadogPodAutoscalerPodsScalingRuleType {
 			ruleMin = periodStartReplicas - rule.Value
-		} else if rule.Type == datadoghq.DatadogPodAutoscalerPercentScalingRuleType {
+		} else if rule.Type == datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType {
 			// When casting, the decimal is truncated, so we always have at least 1 replica allowed
 			ruleMin = int32(float64(periodStartReplicas) * (1 - float64(rule.Value)/100))
 		}
@@ -440,18 +433,17 @@ func applyScaleDownPolicy(
 	return targetDesiredReplicas, 0, ""
 }
 
-func accumulateReplicasChange(currentTime time.Time, events []datadoghq.DatadogPodAutoscalerHorizontalAction, periodSeconds int32) (added, removed, numEvents int32, expireIn time.Duration) {
+func accumulateReplicasChange(currentTime time.Time, events []datadoghqcommon.DatadogPodAutoscalerHorizontalAction, periodSeconds int32) (added, removed int32, expireIn time.Duration) {
 	periodDuration := time.Duration(periodSeconds) * time.Second
 	earliestTimestamp := currentTime.Add(-periodDuration)
 
 	for _, event := range events {
 		if event.Time.Time.After(earliestTimestamp) {
-			if numEvents == 0 {
+			if expireIn == 0 {
 				// Record when the oldest event will be out of the window
 				expireIn = event.Time.Sub(earliestTimestamp)
 			}
 
-			numEvents++
 			diff := event.ToReplicas - event.FromReplicas
 			if diff > 0 {
 				added += diff
@@ -467,7 +459,7 @@ func accumulateReplicasChange(currentTime time.Time, events []datadoghq.DatadogP
 	return
 }
 
-func stabilizeRecommendations(currentTime time.Time, pastActions []datadoghq.DatadogPodAutoscalerHorizontalAction, currentReplicas int32, originalTargetDesiredReplicas int32, stabilizationWindowUpscaleSeconds int32, stabilizationWindowDownscaleSeconds int32, scaleDirection common.ScaleDirection) (int32, string) {
+func stabilizeRecommendations(currentTime time.Time, pastActions []datadoghqcommon.DatadogPodAutoscalerHorizontalAction, currentReplicas int32, originalTargetDesiredReplicas int32, stabilizationWindowScaleUpSeconds int32, stabilizationWindowScaleDownSeconds int32, scaleDirection common.ScaleDirection) (int32, string) {
 	limitReason := ""
 
 	if len(pastActions) == 0 {
@@ -475,10 +467,10 @@ func stabilizeRecommendations(currentTime time.Time, pastActions []datadoghq.Dat
 	}
 
 	upRecommendation := originalTargetDesiredReplicas
-	upCutoff := currentTime.Add(-time.Duration(stabilizationWindowUpscaleSeconds) * time.Second)
+	upCutoff := currentTime.Add(-time.Duration(stabilizationWindowScaleUpSeconds) * time.Second)
 
 	downRecommendation := originalTargetDesiredReplicas
-	downCutoff := currentTime.Add(-time.Duration(stabilizationWindowDownscaleSeconds) * time.Second)
+	downCutoff := currentTime.Add(-time.Duration(stabilizationWindowScaleDownSeconds) * time.Second)
 
 	for _, a := range pastActions {
 		if scaleDirection == common.ScaleUp && a.Time.Time.After(upCutoff) {

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -22,7 +22,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/common"
@@ -78,8 +79,8 @@ func (f *horizontalControllerFixture) runSync(fakePai *model.FakePodAutoscalerIn
 	return autoscalerInternal, res, err
 }
 
-func newHorizontalAction(time time.Time, fromReplicas, toReplicas, recommendedReplicas int32) datadoghq.DatadogPodAutoscalerHorizontalAction {
-	return datadoghq.DatadogPodAutoscalerHorizontalAction{
+func newHorizontalAction(time time.Time, fromReplicas, toReplicas, recommendedReplicas int32) datadoghqcommon.DatadogPodAutoscalerHorizontalAction {
+	return datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 		Time:                metav1.NewTime(time),
 		FromReplicas:        fromReplicas,
 		ToReplicas:          toReplicas,
@@ -89,7 +90,7 @@ func newHorizontalAction(time time.Time, fromReplicas, toReplicas, recommendedRe
 
 type horizontalScalingTestArgs struct {
 	fakePai          *model.FakePodAutoscalerInternal
-	dataSource       datadoghq.DatadogPodAutoscalerValueSource
+	dataSource       datadoghqcommon.DatadogPodAutoscalerValueSource
 	dataOffset       time.Duration
 	currentReplicas  int32
 	statusReplicas   int32
@@ -123,7 +124,7 @@ func (f *horizontalControllerFixture) testScalingDecision(args horizontalScaling
 
 	if scaleActionExpected && args.scaleError == nil {
 		// Update fakePai with the new expected state
-		action := &datadoghq.DatadogPodAutoscalerHorizontalAction{
+		action := &datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 			Time:                metav1.NewTime(f.clock.Now()),
 			FromReplicas:        args.currentReplicas,
 			ToReplicas:          args.scaleReplicas,
@@ -191,11 +192,11 @@ func TestHorizontalControllerSyncPrerequisites(t *testing.T) {
 			Kind:       expectedGVK.Kind,
 			APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
 		},
-		Policy: &datadoghq.DatadogPodAutoscalerPolicy{
-			Upscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
+		ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+			ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 				StabilizationWindowSeconds: 0,
 			},
-			Downscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
+			ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 				StabilizationWindowSeconds: 0,
 			},
 		},
@@ -244,51 +245,52 @@ func TestHorizontalControllerSyncPrerequisites(t *testing.T) {
 	}, autoscaler)
 
 	// Test case: Any scaling disabled by policy
-	fakePai.Spec.Policy = &datadoghq.DatadogPodAutoscalerPolicy{
-		ApplyMode: datadoghq.DatadogPodAutoscalerNoneApplyMode,
+	fakePai.Spec.ApplyPolicy = &datadoghq.DatadogPodAutoscalerApplyPolicy{
+		Mode: datadoghq.DatadogPodAutoscalerApplyModePreview,
 	}
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		currentReplicas: 5,
 		statusReplicas:  5,
 		recReplicas:     10,
 		scaleReplicas:   5,
-		scaleError:      testutil.NewErrorString("horizontal scaling disabled due to applyMode: None not allowing recommendations from source: Autoscaling"),
+		scaleError:      testutil.NewErrorString("horizontal scaling disabled due to applyMode: Preview not allowing recommendations from source: Autoscaling"),
 	})
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test case: Automatic scaling values disabled by policy
-	fakePai.Spec.Policy = &datadoghq.DatadogPodAutoscalerPolicy{
-		ApplyMode: datadoghq.DatadogPodAutoscalerManualApplyMode,
-	}
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-		currentReplicas: 5,
-		statusReplicas:  5,
-		recReplicas:     10,
-		scaleReplicas:   5,
-		scaleError:      testutil.NewErrorString("horizontal scaling disabled due to applyMode: Manual not allowing recommendations from source: Autoscaling"),
-	})
-	assert.Equal(t, autoscaling.NoRequeue, result)
-	assert.NoError(t, err)
+	// Tests disabled until we add back Manual capability in the CRD
+	// // Test case: Automatic scaling values disabled by policy
+	// fakePai.Spec.ApplyPolicy = &datadoghq.DatadogPodAutoscalerApplyPolicy{
+	// 	Mode: datadoghqcommon.DatadogPodAutoscalerManualApplyMode,
+	// }
+	// result, err = f.testScalingDecision(horizontalScalingTestArgs{
+	// 	fakePai:         fakePai,
+	// 	dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+	// 	currentReplicas: 5,
+	// 	statusReplicas:  5,
+	// 	recReplicas:     10,
+	// 	scaleReplicas:   5,
+	// 	scaleError:      testutil.NewErrorString("horizontal scaling disabled due to applyMode: Manual not allowing recommendations from source: Autoscaling"),
+	// })
+	// assert.Equal(t, autoscaling.NoRequeue, result)
+	// assert.NoError(t, err)
 
-	// Test case: Automatic scaling values disabled by policy, sending manual value, should scale
-	fakePai.Spec.Policy = &datadoghq.DatadogPodAutoscalerPolicy{
-		ApplyMode: datadoghq.DatadogPodAutoscalerManualApplyMode,
-	}
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerManualValueSource,
-		currentReplicas: 5,
-		statusReplicas:  5,
-		recReplicas:     10,
-		scaleReplicas:   10,
-	})
-	assert.Equal(t, autoscaling.NoRequeue, result)
-	assert.NoError(t, err)
+	// // Test case: Automatic scaling values disabled by policy, sending manual value, should scale
+	// fakePai.Spec.ApplyPolicy = &datadoghq.DatadogPodAutoscalerApplyPolicy{
+	// 	Mode: datadoghq.DatadogPodAutoscalerManualApplyMode,
+	// }
+	// result, err = f.testScalingDecision(horizontalScalingTestArgs{
+	// 	fakePai:         fakePai,
+	// 	dataSource:      datadoghqcommon.DatadogPodAutoscalerManualValueSource,
+	// 	currentReplicas: 5,
+	// 	statusReplicas:  5,
+	// 	recReplicas:     10,
+	// 	scaleReplicas:   10,
+	// })
+	// assert.Equal(t, autoscaling.NoRequeue, result)
+	// assert.NoError(t, err)
 }
 
 func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
@@ -317,7 +319,7 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 		},
 		ScalingValues: model.ScalingValues{
 			Horizontal: &model.HorizontalScalingValues{
-				Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 				Timestamp: f.clock.Now().Add(-defaultStepDuration),
 				Replicas:  5,
 			},
@@ -329,7 +331,7 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	// Step: same number of replicas, no action taken, only updating status
 	result, err := f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 5,
 		statusReplicas:  4,
@@ -344,7 +346,7 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 5,
 		statusReplicas:  4,
@@ -359,7 +361,7 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 7,
 		statusReplicas:  4,
@@ -374,7 +376,7 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 5,
 		statusReplicas:  4,
@@ -390,7 +392,7 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 5,
 		statusReplicas:  5,
@@ -404,13 +406,13 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	// Scaling should be limited by the new constraints
 	// Step is 30s later
 	f.clock.Step(defaultStepDuration)
-	fakePai.Spec.Constraints = &datadoghq.DatadogPodAutoscalerConstraints{
+	fakePai.Spec.Constraints = &datadoghqcommon.DatadogPodAutoscalerConstraints{
 		MinReplicas: pointer.Ptr[int32](2),
 		MaxReplicas: 8,
 	}
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  10,
 		statusReplicas:   10,
@@ -424,13 +426,13 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	// Step: Changes in recommended replicas but still outside of new range (max)
 	// Step is 30s later
 	f.clock.Step(defaultStepDuration)
-	fakePai.Spec.Constraints = &datadoghq.DatadogPodAutoscalerConstraints{
+	fakePai.Spec.Constraints = &datadoghqcommon.DatadogPodAutoscalerConstraints{
 		MinReplicas: pointer.Ptr[int32](2),
 		MaxReplicas: 8,
 	}
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  8,
 		statusReplicas:   8,
@@ -445,13 +447,13 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	// Scaling should be limited by the new constraints
 	// Step is 30s later
 	f.clock.Step(defaultStepDuration)
-	fakePai.Spec.Constraints = &datadoghq.DatadogPodAutoscalerConstraints{
+	fakePai.Spec.Constraints = &datadoghqcommon.DatadogPodAutoscalerConstraints{
 		MinReplicas: pointer.Ptr[int32](8),
 		MaxReplicas: 10,
 	}
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  6,
 		statusReplicas:   6,
@@ -465,13 +467,13 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	// Step: Changes in recommended replicas but still outside of new range (min)
 	// Step is 30s later
 	f.clock.Step(defaultStepDuration)
-	fakePai.Spec.Constraints = &datadoghq.DatadogPodAutoscalerConstraints{
+	fakePai.Spec.Constraints = &datadoghqcommon.DatadogPodAutoscalerConstraints{
 		MinReplicas: pointer.Ptr[int32](8),
 		MaxReplicas: 10,
 	}
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  8,
 		statusReplicas:   8,
@@ -483,7 +485,7 @@ func TestHorizontalControllerSyncScaleDecisions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
+func TestHorizontalControllerSyncScaleUpWithRules(t *testing.T) {
 	testTime := time.Now()
 	startTime := testTime.Add(-time.Hour)
 	defaultStepDuration := 30 * time.Second
@@ -497,7 +499,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 		Version: "v1",
 		Kind:    "Deployment",
 	}
-	// Rules used on Upscale
+	// Rules used on scale up
 	// Min of
 	// - 5 PODs every 1 minute
 	// - 20% change every 5 minutes
@@ -513,22 +515,22 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 				Kind:       expectedGVK.Kind,
 				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
 			},
-			Policy: &datadoghq.DatadogPodAutoscalerPolicy{
-				Upscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
-					Strategy: pointer.Ptr(datadoghq.DatadogPodAutoscalerMinChangeStrategySelect),
-					Rules: []datadoghq.DatadogPodAutoscalerScalingRule{
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+					Strategy: pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerMinChangeStrategySelect),
+					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPodsScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPodsScalingRuleType,
 							Value:         5,
 							PeriodSeconds: 60,
 						},
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPercentScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType,
 							Value:         20,
 							PeriodSeconds: 300,
 						},
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPercentScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType,
 							Value:         100,
 							PeriodSeconds: 1800,
 						},
@@ -538,7 +540,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 		},
 		ScalingValues: model.ScalingValues{
 			Horizontal: &model.HorizontalScalingValues{
-				Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 				Timestamp: f.clock.Now().Add(-defaultStepDuration),
 				Replicas:  100,
 			},
@@ -550,7 +552,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 	// Step: Increase of 4 replicas in 30s, should scale up without limits
 	result, err := f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 100,
 		statusReplicas:  100,
@@ -565,7 +567,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  104,
 		statusReplicas:   104,
@@ -580,7 +582,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 	// It goes 105 -> 109 -> 110 -> 114 -> 115 -> 119 -> 120 (6 steps)
 	args := horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 104,
 		statusReplicas:  104,
@@ -612,7 +614,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  120,
 		statusReplicas:   120,
@@ -625,7 +627,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 
 	// Step: To break the 100% limit we cheat and add a scaling event that should have been forbidden by the other rules
 	f.clock.Step(defaultStepDuration)
-	fakePai.HorizontalLastActions = append(fakePai.HorizontalLastActions, datadoghq.DatadogPodAutoscalerHorizontalAction{
+	fakePai.HorizontalLastActions = append(fakePai.HorizontalLastActions, datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 		Time:                metav1.NewTime(f.clock.Now()),
 		FromReplicas:        120,
 		ToReplicas:          198,
@@ -636,7 +638,7 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 	f.clock.Step(6 * time.Minute)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  198,
 		statusReplicas:   198,
@@ -649,11 +651,11 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 
 	// Changing strategy from MinChange to MaxChange, the 20% rule should now be the limiting factor (as we moved 6 minutes since large increase)
 	// 20% of 198 leads to 238
-	fakePai.Spec.Policy.Upscale.Strategy = pointer.Ptr(datadoghq.DatadogPodAutoscalerMaxChangeStrategySelect)
+	fakePai.Spec.ApplyPolicy.ScaleUp.Strategy = pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerMaxChangeStrategySelect)
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  200,
 		statusReplicas:   200,
@@ -663,62 +665,9 @@ func TestHorizontalControllerSyncUpscaleWithRules(t *testing.T) {
 	})
 	assert.Equal(t, autoscaling.Requeue.After(31*time.Second), result)
 	assert.NoError(t, err)
-
-	// Step: Add a rule IfScalingEvent to block scaling up during 1 minute after an event
-	f.clock.Step(time.Hour)
-	fakePai.Spec.Policy.Upscale.Strategy = pointer.Ptr(datadoghq.DatadogPodAutoscalerMinChangeStrategySelect)
-	fakePai.Spec.Policy.Upscale.Rules = append(fakePai.Spec.Policy.Upscale.Rules, datadoghq.DatadogPodAutoscalerScalingRule{
-		Type:          datadoghq.DatadogPodAutoscalerPodsScalingRuleType,
-		Value:         0,
-		PeriodSeconds: 60,
-		Match:         pointer.Ptr(datadoghq.DatadogPodAutoscalerIfScalingEventRuleMatch),
-	})
-
-	// Scaling allowed as no event occurred recently
-	f.clock.Step(defaultStepDuration)
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-		dataOffset:      defaultStepDuration,
-		currentReplicas: 238,
-		statusReplicas:  238,
-		recReplicas:     240,
-		scaleReplicas:   240,
-	})
-	assert.Equal(t, autoscaling.NoRequeue, result)
-	assert.NoError(t, err)
-
-	// Scaling not allowed by the 0-pod rule / 60s rule
-	f.clock.Step(defaultStepDuration)
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-		dataOffset:       defaultStepDuration,
-		currentReplicas:  240,
-		statusReplicas:   240,
-		recReplicas:      245,
-		scaleReplicas:    240,
-		scaleLimitReason: "desired replica count limited to 240 (originally 245) due to scaling policy",
-	})
-	assert.Equal(t, autoscaling.Requeue.After(31*time.Second), result)
-	assert.NoError(t, err)
-
-	// After 1 minute we should be able to scale again
-	f.clock.Step(defaultStepDuration)
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-		dataOffset:      defaultStepDuration,
-		currentReplicas: 240,
-		statusReplicas:  240,
-		recReplicas:     245,
-		scaleReplicas:   245,
-	})
-	assert.Equal(t, autoscaling.NoRequeue, result)
-	assert.NoError(t, err)
 }
 
-func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
+func TestHorizontalControllerSyncScaleDownWithRules(t *testing.T) {
 	testTime := time.Now()
 	startTime := testTime.Add(-time.Hour)
 	defaultStepDuration := 30 * time.Second
@@ -732,7 +681,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 		Version: "v1",
 		Kind:    "Deployment",
 	}
-	// Rules used on Downscale
+	// Rules used on scale down
 	// Min of
 	// - 5 PODs every 1 minute
 	// - 20% change every 5 minutes
@@ -748,22 +697,22 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 				Kind:       expectedGVK.Kind,
 				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
 			},
-			Policy: &datadoghq.DatadogPodAutoscalerPolicy{
-				Downscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
-					Strategy: pointer.Ptr(datadoghq.DatadogPodAutoscalerMinChangeStrategySelect),
-					Rules: []datadoghq.DatadogPodAutoscalerScalingRule{
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+					Strategy: pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerMinChangeStrategySelect),
+					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPodsScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPodsScalingRuleType,
 							Value:         5,
 							PeriodSeconds: 60,
 						},
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPercentScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType,
 							Value:         20,
 							PeriodSeconds: 300,
 						},
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPercentScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPercentScalingRuleType,
 							Value:         50,
 							PeriodSeconds: 1800,
 						},
@@ -773,7 +722,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 		},
 		ScalingValues: model.ScalingValues{
 			Horizontal: &model.HorizontalScalingValues{
-				Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 				Timestamp: f.clock.Now().Add(-defaultStepDuration),
 				Replicas:  100,
 			},
@@ -785,7 +734,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 	// Step: Decrease of 4 replicas in 30s, should scale down without limits
 	result, err := f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 100,
 		statusReplicas:  100,
@@ -800,7 +749,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  96,
 		statusReplicas:   96,
@@ -815,7 +764,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 	// It goes 95 -> 91 -> 90 -> 86 -> 85 -> 81 -> 80 (6 steps)
 	args := horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 96,
 		statusReplicas:  96,
@@ -847,7 +796,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  80,
 		statusReplicas:   80,
@@ -860,7 +809,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 
 	// Step: To break the 50% limit we cheat and add a scaling event that should have been forbidden by the other rules
 	f.clock.Step(defaultStepDuration)
-	fakePai.HorizontalLastActions = append(fakePai.HorizontalLastActions, datadoghq.DatadogPodAutoscalerHorizontalAction{
+	fakePai.HorizontalLastActions = append(fakePai.HorizontalLastActions, datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 		Time:                metav1.NewTime(f.clock.Now()),
 		FromReplicas:        80,
 		ToReplicas:          52,
@@ -871,7 +820,7 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 	f.clock.Step(6 * time.Minute)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  52,
 		statusReplicas:   52,
@@ -884,11 +833,11 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 
 	// Changing strategy from MinChange to MaxChange, the 20% rule should now be the limiting factor (as we moved 6 minutes since large decrease)
 	// 20% of 52 leads to 41.6 (41)
-	fakePai.Spec.Policy.Downscale.Strategy = pointer.Ptr(datadoghq.DatadogPodAutoscalerMaxChangeStrategySelect)
+	fakePai.Spec.ApplyPolicy.ScaleDown.Strategy = pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerMaxChangeStrategySelect)
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  50,
 		statusReplicas:   50,
@@ -897,59 +846,6 @@ func TestHorizontalControllerSyncDownscaleWithRules(t *testing.T) {
 		scaleLimitReason: "desired replica count limited to 41 (originally 40) due to scaling policy",
 	})
 	assert.Equal(t, autoscaling.Requeue.After(31*time.Second), result)
-	assert.NoError(t, err)
-
-	// Step: Add a rule IfScalingEvent to block scaling up during 1 minute after an event
-	f.clock.Step(time.Hour)
-	fakePai.Spec.Policy.Downscale.Strategy = pointer.Ptr(datadoghq.DatadogPodAutoscalerMinChangeStrategySelect)
-	fakePai.Spec.Policy.Downscale.Rules = append(fakePai.Spec.Policy.Downscale.Rules, datadoghq.DatadogPodAutoscalerScalingRule{
-		Type:          datadoghq.DatadogPodAutoscalerPodsScalingRuleType,
-		Value:         0,
-		PeriodSeconds: 60,
-		Match:         pointer.Ptr(datadoghq.DatadogPodAutoscalerIfScalingEventRuleMatch),
-	})
-
-	// Scaling allowed as no event occurred recently
-	f.clock.Step(defaultStepDuration)
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-		dataOffset:      defaultStepDuration,
-		currentReplicas: 41,
-		statusReplicas:  41,
-		recReplicas:     40,
-		scaleReplicas:   40,
-	})
-	assert.Equal(t, autoscaling.NoRequeue, result)
-	assert.NoError(t, err)
-
-	// Scaling not allowed by the 0-pod rule / 60s rule
-	f.clock.Step(defaultStepDuration)
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-		dataOffset:       defaultStepDuration,
-		currentReplicas:  40,
-		statusReplicas:   40,
-		recReplicas:      35,
-		scaleReplicas:    40,
-		scaleLimitReason: "desired replica count limited to 40 (originally 35) due to scaling policy",
-	})
-	assert.Equal(t, autoscaling.Requeue.After(31*time.Second), result)
-	assert.NoError(t, err)
-
-	// After 1 minute we should be able to scale again
-	f.clock.Step(defaultStepDuration)
-	result, err = f.testScalingDecision(horizontalScalingTestArgs{
-		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
-		dataOffset:      defaultStepDuration,
-		currentReplicas: 40,
-		statusReplicas:  40,
-		recReplicas:     35,
-		scaleReplicas:   35,
-	})
-	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 }
 
@@ -968,7 +864,7 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 		Kind:    "Deployment",
 	}
 
-	// Single rule on upscale and downscale
+	// Single rule on scale up and scale down
 	// Start at 100 replicas for ease of calculations
 	fakePai := &model.FakePodAutoscalerInternal{
 		Namespace: autoscalerNamespace,
@@ -979,24 +875,24 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 				Kind:       expectedGVK.Kind,
 				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
 			},
-			Constraints: &datadoghq.DatadogPodAutoscalerConstraints{
+			Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 				MinReplicas: pointer.Ptr[int32](90),
 				MaxReplicas: 120,
 			},
-			Policy: &datadoghq.DatadogPodAutoscalerPolicy{
-				Upscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
-					Rules: []datadoghq.DatadogPodAutoscalerScalingRule{
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPodsScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPodsScalingRuleType,
 							Value:         5,
 							PeriodSeconds: 300,
 						},
 					},
 				},
-				Downscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
-					Rules: []datadoghq.DatadogPodAutoscalerScalingRule{
+				ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
+					Rules: []datadoghqcommon.DatadogPodAutoscalerScalingRule{
 						{
-							Type:          datadoghq.DatadogPodAutoscalerPodsScalingRuleType,
+							Type:          datadoghqcommon.DatadogPodAutoscalerPodsScalingRuleType,
 							Value:         5,
 							PeriodSeconds: 300,
 						},
@@ -1006,7 +902,7 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 		},
 		ScalingValues: model.ScalingValues{
 			Horizontal: &model.HorizontalScalingValues{
-				Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 				Timestamp: f.clock.Now().Add(-defaultStepDuration),
 				Replicas:  100,
 			},
@@ -1015,11 +911,11 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 		HorizontalEventsRetention: 5 * time.Minute, // Matching rules
 	}
 
-	// Test upscale to 103 replicas (not limited)
+	// Test scale up to 103 replicas (not limited)
 	f.clock.Step(defaultStepDuration)
 	result, err := f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 100,
 		statusReplicas:  100,
@@ -1029,11 +925,11 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test downscale to 97 replicas (not limited)
+	// Test scale down to 97 replicas (not limited)
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 103,
 		statusReplicas:  103,
@@ -1043,11 +939,11 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test downscale to 92 replicas, limited to 95
+	// Test scale down to 92 replicas, limited to 95
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  97,
 		statusReplicas:   97,
@@ -1058,11 +954,11 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 	assert.Equal(t, autoscaling.Requeue.After(241*time.Second), result)
 	assert.NoError(t, err)
 
-	// Test upscale to 110 replicas, limited to 105
+	// Test scale up to 110 replicas, limited to 105
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  95,
 		statusReplicas:   95,
@@ -1078,7 +974,7 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 	f.clock.Step(10 * time.Minute)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  130,
 		statusReplicas:   130,
@@ -1092,10 +988,10 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 	// Setting Upscaling strategy to Disabled, should only allow downscaling
 	// Moving clock 10 minutes forward to avoid the 5 pods rule
 	f.clock.Step(10 * time.Minute)
-	fakePai.Spec.Policy.Upscale.Strategy = pointer.Ptr(datadoghq.DatadogPodAutoscalerDisabledStrategySelect)
+	fakePai.Spec.ApplyPolicy.ScaleUp.Strategy = pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 100,
 		statusReplicas:  100,
@@ -1106,11 +1002,11 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Verify downscale works as expected
+	// Verify scale down works as expected
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 100,
 		statusReplicas:  100,
@@ -1123,10 +1019,10 @@ func TestHorizontalControllerSyncScaleDecisionsWithRules(t *testing.T) {
 	// Setting Downscaling strategy to Disabled, nothing allowed
 	// Moving clock 10 minutes forward to avoid the 5 pods rule
 	f.clock.Step(10 * time.Minute)
-	fakePai.Spec.Policy.Downscale.Strategy = pointer.Ptr(datadoghq.DatadogPodAutoscalerDisabledStrategySelect)
+	fakePai.Spec.ApplyPolicy.ScaleDown.Strategy = pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 95,
 		statusReplicas:  95,
@@ -1143,18 +1039,18 @@ func TestStabilizeRecommendations(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		actions         []datadoghq.DatadogPodAutoscalerHorizontalAction
+		actions         []datadoghqcommon.DatadogPodAutoscalerHorizontalAction
 		currentReplicas int32
 		recReplicas     int32
 		expected        int32
 		expectedReason  string
-		upscaleWindow   int32
-		downscaleWindow int32
+		scaleUpWindow   int32
+		scaleDownWindow int32
 		scaleDirection  common.ScaleDirection
 	}{
 		{
-			name: "no downscale stabilization - constant upscale",
-			actions: []datadoghq.DatadogPodAutoscalerHorizontalAction{
+			name: "no scale down stabilization - constant scale up",
+			actions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 				newHorizontalAction(currentTime.Add(-60*time.Second), 4, 5, 6),
 				newHorizontalAction(currentTime.Add(-30*time.Second), 6, 4, 4),
 			},
@@ -1162,13 +1058,13 @@ func TestStabilizeRecommendations(t *testing.T) {
 			recReplicas:     8,
 			expected:        8,
 			expectedReason:  "",
-			upscaleWindow:   0,
-			downscaleWindow: 300,
+			scaleUpWindow:   0,
+			scaleDownWindow: 300,
 			scaleDirection:  common.ScaleUp,
 		},
 		{
-			name: "downscale stabilization",
-			actions: []datadoghq.DatadogPodAutoscalerHorizontalAction{
+			name: "scale down stabilization",
+			actions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 				newHorizontalAction(currentTime.Add(-60*time.Second), 8, 6, 6),
 				newHorizontalAction(currentTime.Add(-30*time.Second), 6, 5, 5),
 			},
@@ -1176,13 +1072,13 @@ func TestStabilizeRecommendations(t *testing.T) {
 			recReplicas:     4,
 			expected:        5,
 			expectedReason:  "desired replica count limited to 5 (originally 4) due to stabilization window",
-			upscaleWindow:   0,
-			downscaleWindow: 300,
+			scaleUpWindow:   0,
+			scaleDownWindow: 300,
 			scaleDirection:  common.ScaleDown,
 		},
 		{
-			name: "downscale stabilization, recommendation flapping",
-			actions: []datadoghq.DatadogPodAutoscalerHorizontalAction{
+			name: "scale down stabilization, recommendation flapping",
+			actions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 				newHorizontalAction(currentTime.Add(-90*time.Second), 8, 6, 6),
 				newHorizontalAction(currentTime.Add(-60*time.Second), 6, 9, 9),
 				newHorizontalAction(currentTime.Add(-30*time.Second), 9, 7, 7),
@@ -1191,13 +1087,13 @@ func TestStabilizeRecommendations(t *testing.T) {
 			recReplicas:     5,
 			expected:        7,
 			expectedReason:  "desired replica count limited to 7 (originally 5) due to stabilization window",
-			upscaleWindow:   0,
-			downscaleWindow: 300,
+			scaleUpWindow:   0,
+			scaleDownWindow: 300,
 			scaleDirection:  common.ScaleDown,
 		},
 		{
-			name: "upscale stabilization",
-			actions: []datadoghq.DatadogPodAutoscalerHorizontalAction{
+			name: "scale up stabilization",
+			actions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 				newHorizontalAction(currentTime.Add(-60*time.Second), 5, 6, 6),
 				newHorizontalAction(currentTime.Add(-30*time.Second), 6, 8, 8),
 			},
@@ -1205,13 +1101,13 @@ func TestStabilizeRecommendations(t *testing.T) {
 			recReplicas:     12,
 			expected:        8,
 			expectedReason:  "desired replica count limited to 8 (originally 12) due to stabilization window",
-			upscaleWindow:   300,
-			downscaleWindow: 0,
+			scaleUpWindow:   300,
+			scaleDownWindow: 0,
 			scaleDirection:  common.ScaleUp,
 		},
 		{
-			name: "upscale stabilization, recommendation flapping",
-			actions: []datadoghq.DatadogPodAutoscalerHorizontalAction{
+			name: "scale up stabilization, recommendation flapping",
+			actions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 				newHorizontalAction(currentTime.Add(-90*time.Second), 6, 8, 8),
 				newHorizontalAction(currentTime.Add(-60*time.Second), 8, 7, 7),
 				newHorizontalAction(currentTime.Add(-30*time.Second), 7, 9, 9),
@@ -1220,22 +1116,22 @@ func TestStabilizeRecommendations(t *testing.T) {
 			recReplicas:     12,
 			expected:        9,
 			expectedReason:  "desired replica count limited to 9 (originally 12) due to stabilization window",
-			upscaleWindow:   300,
-			downscaleWindow: 0,
+			scaleUpWindow:   300,
+			scaleDownWindow: 0,
 			scaleDirection:  common.ScaleUp,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recommendedReplicas, limitReason := stabilizeRecommendations(currentTime, tt.actions, tt.currentReplicas, tt.recReplicas, tt.upscaleWindow, tt.downscaleWindow, tt.scaleDirection)
+			recommendedReplicas, limitReason := stabilizeRecommendations(currentTime, tt.actions, tt.currentReplicas, tt.recReplicas, tt.scaleUpWindow, tt.scaleDownWindow, tt.scaleDirection)
 			assert.Equal(t, tt.expected, recommendedReplicas)
 			assert.Equal(t, tt.expectedReason, limitReason)
 		})
 	}
 }
 
-func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
+func TestHorizontalControllerSyncScaleDownWithStabilization(t *testing.T) {
 	testTime := time.Now()
 	startTime := testTime.Add(-time.Hour)
 	defaultStepDuration := 30 * time.Second
@@ -1259,26 +1155,26 @@ func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
 				Kind:       expectedGVK.Kind,
 				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
 			},
-			Constraints: &datadoghq.DatadogPodAutoscalerConstraints{
+			Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 				MinReplicas: pointer.Ptr[int32](90),
 				MaxReplicas: 120,
 			},
-			Policy: &datadoghq.DatadogPodAutoscalerPolicy{
-				Upscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					StabilizationWindowSeconds: 0,
 				},
-				Downscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
+				ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					StabilizationWindowSeconds: 300,
 				},
 			},
 		},
-		HorizontalLastActions: []datadoghq.DatadogPodAutoscalerHorizontalAction{
+		HorizontalLastActions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 			newHorizontalAction(f.clock.Now().Add(-60*time.Second), 90, 94, 94),
 			newHorizontalAction(f.clock.Now().Add(-30*time.Second), 94, 97, 97),
 		},
 		ScalingValues: model.ScalingValues{
 			Horizontal: &model.HorizontalScalingValues{
-				Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 				Timestamp: f.clock.Now().Add(-defaultStepDuration),
 				Replicas:  100,
 			},
@@ -1287,11 +1183,11 @@ func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
 		HorizontalEventsRetention: 5 * time.Minute,
 	}
 
-	// Test upscale to 100 replicas (not limited)
+	// Test scale up to 100 replicas (not limited)
 	f.clock.Step(defaultStepDuration)
 	result, err := f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 97,
 		statusReplicas:  97,
@@ -1301,11 +1197,11 @@ func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test downscale to 97 replicas, limited to 100
+	// Test scale down to 97 replicas, limited to 100
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  100,
 		statusReplicas:   100,
@@ -1316,11 +1212,11 @@ func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test downscale to 95 replicas, still limited to 100
+	// Test scale down to 95 replicas, still limited to 100
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  100,
 		statusReplicas:   100,
@@ -1331,12 +1227,12 @@ func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test downscale to 92 replicas (not limited)
+	// Test scale down to 92 replicas (not limited)
 	// Moving clock 4 minutes forward to get past stabilization window
 	f.clock.Step(4 * time.Minute)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 100,
 		statusReplicas:  100,
@@ -1346,11 +1242,11 @@ func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test upscale to 100 replicas (not limited)
+	// Test scale up to 100 replicas (not limited)
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 92,
 		statusReplicas:  92,
@@ -1361,7 +1257,7 @@ func TestHorizontalControllerSyncDownscaleWithStabilization(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestHorizontalControllerSyncUpscaleWithStabilization(t *testing.T) {
+func TestHorizontalControllerSyncScaleUpWithStabilization(t *testing.T) {
 	testTime := time.Now()
 	startTime := testTime.Add(-time.Hour)
 	defaultStepDuration := 30 * time.Second
@@ -1385,26 +1281,26 @@ func TestHorizontalControllerSyncUpscaleWithStabilization(t *testing.T) {
 				Kind:       expectedGVK.Kind,
 				APIVersion: expectedGVK.Group + "/" + expectedGVK.Version,
 			},
-			Constraints: &datadoghq.DatadogPodAutoscalerConstraints{
+			Constraints: &datadoghqcommon.DatadogPodAutoscalerConstraints{
 				MinReplicas: pointer.Ptr[int32](90),
 				MaxReplicas: 120,
 			},
-			Policy: &datadoghq.DatadogPodAutoscalerPolicy{
-				Upscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				ScaleUp: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					StabilizationWindowSeconds: 300,
 				},
-				Downscale: &datadoghq.DatadogPodAutoscalerScalingPolicy{
+				ScaleDown: &datadoghqcommon.DatadogPodAutoscalerScalingPolicy{
 					StabilizationWindowSeconds: 0,
 				},
 			},
 		},
-		HorizontalLastActions: []datadoghq.DatadogPodAutoscalerHorizontalAction{
+		HorizontalLastActions: []datadoghqcommon.DatadogPodAutoscalerHorizontalAction{
 			newHorizontalAction(f.clock.Now().Add(-60*time.Second), 120, 110, 110),
 			newHorizontalAction(f.clock.Now().Add(-30*time.Second), 110, 104, 104),
 		},
 		ScalingValues: model.ScalingValues{
 			Horizontal: &model.HorizontalScalingValues{
-				Source:    datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+				Source:    datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 				Timestamp: f.clock.Now().Add(-defaultStepDuration),
 				Replicas:  100,
 			},
@@ -1413,11 +1309,11 @@ func TestHorizontalControllerSyncUpscaleWithStabilization(t *testing.T) {
 		HorizontalEventsRetention: 5 * time.Minute,
 	}
 
-	// Test downscale to 100 replicas (not limited)
+	// Test scale down to 100 replicas (not limited)
 	f.clock.Step(defaultStepDuration)
 	result, err := f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 104,
 		statusReplicas:  104,
@@ -1427,11 +1323,11 @@ func TestHorizontalControllerSyncUpscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test upscale to 102 replicas, limited to 100
+	// Test scale up to 102 replicas, limited to 100
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  100,
 		statusReplicas:   100,
@@ -1442,11 +1338,11 @@ func TestHorizontalControllerSyncUpscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test upscale to 105 replicas, still limited to 100
+	// Test scale up to 105 replicas, still limited to 100
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:          fakePai,
-		dataSource:       datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:       datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:       defaultStepDuration,
 		currentReplicas:  100,
 		statusReplicas:   100,
@@ -1457,12 +1353,12 @@ func TestHorizontalControllerSyncUpscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test upscale to 102 replicas (not limited)
+	// Test scale up to 102 replicas (not limited)
 	// Moving clock 4 minutes forward to get past stabilization window
 	f.clock.Step(4 * time.Minute)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 100,
 		statusReplicas:  100,
@@ -1472,11 +1368,11 @@ func TestHorizontalControllerSyncUpscaleWithStabilization(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
-	// Test downscale to 100 replicas (not limited)
+	// Test scale down to 100 replicas (not limited)
 	f.clock.Step(defaultStepDuration)
 	result, err = f.testScalingDecision(horizontalScalingTestArgs{
 		fakePai:         fakePai,
-		dataSource:      datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 		dataOffset:      defaultStepDuration,
 		currentReplicas: 102,
 		statusReplicas:  102,

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
@@ -70,7 +71,7 @@ func newFixture(t *testing.T, testTime time.Time) *fixture {
 	}
 }
 
-func newFakePodAutoscaler(ns, name string, gen int64, creationTimestamp time.Time, spec datadoghq.DatadogPodAutoscalerSpec, status datadoghq.DatadogPodAutoscalerStatus) (obj *unstructured.Unstructured, dpa *datadoghq.DatadogPodAutoscaler) {
+func newFakePodAutoscaler(ns, name string, gen int64, creationTimestamp time.Time, spec datadoghq.DatadogPodAutoscalerSpec, status datadoghqcommon.DatadogPodAutoscalerStatus) (obj *unstructured.Unstructured, dpa *datadoghq.DatadogPodAutoscaler) {
 	dpa = &datadoghq.DatadogPodAutoscaler{
 		TypeMeta: podAutoscalerMeta,
 		ObjectMeta: metav1.ObjectMeta{
@@ -107,12 +108,12 @@ func TestLeaderCreateDeleteLocal(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		// Local owner means .Spec source of truth is K8S
-		Owner: datadoghq.DatadogPodAutoscalerLocalOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner,
 	}
 
 	defaultCreationTime := time.Time{}
 	// Read newly created DPA
-	dpa, dpaTyped := newFakePodAutoscaler("default", "dpa-0", 1, defaultCreationTime, dpaSpec, datadoghq.DatadogPodAutoscalerStatus{})
+	dpa, dpaTyped := newFakePodAutoscaler("default", "dpa-0", 1, defaultCreationTime, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
 
 	f.InformerObjects = append(f.InformerObjects, dpa)
 	f.Objects = append(f.Objects, dpaTyped)
@@ -159,7 +160,7 @@ func TestLeaderCreateDeleteRemote(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		// Remote owner means .Spec source of truth is Datadog App
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 	}
 
 	dpaInternal := model.FakePodAutoscalerInternal{
@@ -173,47 +174,47 @@ func TestLeaderCreateDeleteRemote(t *testing.T) {
 	expectedDPA := &datadoghq.DatadogPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DatadogPodAutoscaler",
-			APIVersion: "datadoghq.com/v1alpha1",
+			APIVersion: "datadoghq.com/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "dpa-0",
 			Namespace: "default",
 		},
 		Spec: dpaSpec,
-		Status: datadoghq.DatadogPodAutoscalerStatus{
-			Conditions: []datadoghq.DatadogPodAutoscalerCondition{
+		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
 				{
-					Type:               datadoghq.DatadogPodAutoscalerErrorCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerErrorCondition,
 					Status:             corev1.ConditionFalse,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerActiveCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerActiveCondition,
 					Status:             corev1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
 					Status:             corev1.ConditionFalse,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToApply,
+					Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
@@ -279,11 +280,11 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 			dpaSpec := datadoghq.DatadogPodAutoscalerSpec{
 				TargetRef: tt.targetRef,
 				// Local owner means .Spec source of truth is K8S
-				Owner: datadoghq.DatadogPodAutoscalerLocalOwner,
+				Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner,
 			}
 
 			// Create object in store
-			dpa, dpaTyped := newFakePodAutoscaler(currentNs, "dpa-dca", 1, testTime, dpaSpec, datadoghq.DatadogPodAutoscalerStatus{})
+			dpa, dpaTyped := newFakePodAutoscaler(currentNs, "dpa-dca", 1, testTime, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
 			f.InformerObjects = append(f.InformerObjects, dpa)
 			f.Objects = append(f.Objects, dpaTyped)
 
@@ -295,7 +296,7 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 			expectedDPAError := &datadoghq.DatadogPodAutoscaler{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "DatadogPodAutoscaler",
-					APIVersion: "datadoghq.com/v1alpha1",
+					APIVersion: "datadoghq.com/v1alpha2",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:              "dpa-dca",
@@ -312,41 +313,41 @@ func TestDatadogPodAutoscalerTargetingClusterAgentErrors(t *testing.T) {
 					},
 					Owner: "",
 				},
-				Status: datadoghq.DatadogPodAutoscalerStatus{
-					Conditions: []datadoghq.DatadogPodAutoscalerCondition{
+				Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+					Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
 						{
-							Type:               datadoghq.DatadogPodAutoscalerErrorCondition,
+							Type:               datadoghqcommon.DatadogPodAutoscalerErrorCondition,
 							Status:             corev1.ConditionTrue,
 							LastTransitionTime: metav1.NewTime(testTime),
 							Reason:             "Autoscaling target cannot be set to the cluster agent",
 						},
 						{
-							Type:               datadoghq.DatadogPodAutoscalerActiveCondition,
+							Type:               datadoghqcommon.DatadogPodAutoscalerActiveCondition,
 							Status:             corev1.ConditionTrue,
 							LastTransitionTime: metav1.NewTime(testTime),
 						},
 						{
-							Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
+							Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
 							Status:             corev1.ConditionUnknown,
 							LastTransitionTime: metav1.NewTime(testTime),
 						},
 						{
-							Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
+							Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
 							Status:             corev1.ConditionUnknown,
 							LastTransitionTime: metav1.NewTime(testTime),
 						},
 						{
-							Type:               datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
+							Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
 							Status:             corev1.ConditionFalse,
 							LastTransitionTime: metav1.NewTime(testTime),
 						},
 						{
-							Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
+							Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
 							Status:             corev1.ConditionUnknown,
 							LastTransitionTime: metav1.NewTime(testTime),
 						},
 						{
-							Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToApply,
+							Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply,
 							Status:             corev1.ConditionUnknown,
 							LastTransitionTime: metav1.NewTime(testTime),
 						},
@@ -377,7 +378,7 @@ func TestPodAutoscalerLocalOwnerObjectsLimit(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		// Local owner means .Spec source of truth is K8S
-		Owner: datadoghq.DatadogPodAutoscalerLocalOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner,
 	}
 
 	currentNs := common.GetMyNamespace()
@@ -390,9 +391,9 @@ func TestPodAutoscalerLocalOwnerObjectsLimit(t *testing.T) {
 	dpa2Time := testTime.Add(1 * time.Hour)
 
 	// Read newly created DPA
-	dpa, dpaTyped := newFakePodAutoscaler(currentNs, "dpa-0", 1, dpaTime, dpaSpec, datadoghq.DatadogPodAutoscalerStatus{})
-	dpa1, dpaTyped1 := newFakePodAutoscaler(currentNs, "dpa-1", 1, dpa1Time, dpaSpec, datadoghq.DatadogPodAutoscalerStatus{})
-	dpa2, dpaTyped2 := newFakePodAutoscaler(currentNs, "dpa-2", 1, dpa2Time, dpaSpec, datadoghq.DatadogPodAutoscalerStatus{})
+	dpa, dpaTyped := newFakePodAutoscaler(currentNs, "dpa-0", 1, dpaTime, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
+	dpa1, dpaTyped1 := newFakePodAutoscaler(currentNs, "dpa-1", 1, dpa1Time, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
+	dpa2, dpaTyped2 := newFakePodAutoscaler(currentNs, "dpa-2", 1, dpa2Time, dpaSpec, datadoghqcommon.DatadogPodAutoscalerStatus{})
 
 	f.InformerObjects = append(f.InformerObjects, dpa, dpa1)
 	f.Objects = append(f.Objects, dpaTyped, dpaTyped1)
@@ -428,7 +429,7 @@ func TestPodAutoscalerLocalOwnerObjectsLimit(t *testing.T) {
 	dpaStatusUpdate := &datadoghq.DatadogPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DatadogPodAutoscaler",
-			APIVersion: "datadoghq.com/v1alpha1",
+			APIVersion: "datadoghq.com/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "dpa-2",
@@ -445,41 +446,41 @@ func TestPodAutoscalerLocalOwnerObjectsLimit(t *testing.T) {
 			},
 			Owner: "",
 		},
-		Status: datadoghq.DatadogPodAutoscalerStatus{
-			Conditions: []datadoghq.DatadogPodAutoscalerCondition{
+		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
 				{
-					Type:               datadoghq.DatadogPodAutoscalerErrorCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerErrorCondition,
 					Status:             corev1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(testTime),
 					Reason:             fmt.Sprintf("Autoscaler disabled as maximum number per cluster reached (%d)", testMaxAutoscalerObjects),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerActiveCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerActiveCondition,
 					Status:             corev1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
 					Status:             corev1.ConditionFalse,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToApply,
+					Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
@@ -512,7 +513,7 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		// Remote owner means .Spec source of truth is Datadog App
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 	}
 
 	dpa1Spec := datadoghq.DatadogPodAutoscalerSpec{
@@ -522,7 +523,7 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		// Remote owner means .Spec source of truth is Datadog App
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 	}
 	dpa2Spec := datadoghq.DatadogPodAutoscalerSpec{
 		TargetRef: autoscalingv2.CrossVersionObjectReference{
@@ -531,7 +532,7 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 			APIVersion: "apps/v1",
 		},
 		// Remote owner means .Spec source of truth is Datadog App
-		Owner: datadoghq.DatadogPodAutoscalerRemoteOwner,
+		Owner: datadoghqcommon.DatadogPodAutoscalerRemoteOwner,
 	}
 
 	dpaInternal := model.FakePodAutoscalerInternal{
@@ -556,40 +557,40 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 	f.store.Set("default/dpa-2", dpaInternal2.Build(), controllerID)
 
 	// Should create object in Kubernetes
-	expectedStatus := datadoghq.DatadogPodAutoscalerStatus{
-		Conditions: []datadoghq.DatadogPodAutoscalerCondition{
+	expectedStatus := datadoghqcommon.DatadogPodAutoscalerStatus{
+		Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
 			{
-				Type:               datadoghq.DatadogPodAutoscalerErrorCondition,
+				Type:               datadoghqcommon.DatadogPodAutoscalerErrorCondition,
 				Status:             corev1.ConditionFalse,
 				LastTransitionTime: metav1.NewTime(testTime),
 			},
 			{
-				Type:               datadoghq.DatadogPodAutoscalerActiveCondition,
+				Type:               datadoghqcommon.DatadogPodAutoscalerActiveCondition,
 				Status:             corev1.ConditionTrue,
 				LastTransitionTime: metav1.NewTime(testTime),
 			},
 			{
-				Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
+				Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
 				Status:             corev1.ConditionUnknown,
 				LastTransitionTime: metav1.NewTime(testTime),
 			},
 			{
-				Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
+				Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
 				Status:             corev1.ConditionUnknown,
 				LastTransitionTime: metav1.NewTime(testTime),
 			},
 			{
-				Type:               datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
+				Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
 				Status:             corev1.ConditionFalse,
 				LastTransitionTime: metav1.NewTime(testTime),
 			},
 			{
-				Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
+				Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
 				Status:             corev1.ConditionUnknown,
 				LastTransitionTime: metav1.NewTime(testTime),
 			},
 			{
-				Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToApply,
+				Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply,
 				Status:             corev1.ConditionUnknown,
 				LastTransitionTime: metav1.NewTime(testTime),
 			},
@@ -626,7 +627,7 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 	expectedDPAError := &datadoghq.DatadogPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DatadogPodAutoscaler",
-			APIVersion: "datadoghq.com/v1alpha1",
+			APIVersion: "datadoghq.com/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "dpa-1",
@@ -643,41 +644,41 @@ func TestPodAutoscalerRemoteOwnerObjectsLimit(t *testing.T) {
 			},
 			Owner: "",
 		},
-		Status: datadoghq.DatadogPodAutoscalerStatus{
-			Conditions: []datadoghq.DatadogPodAutoscalerCondition{
+		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{
 				{
-					Type:               datadoghq.DatadogPodAutoscalerErrorCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerErrorCondition,
 					Status:             corev1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(testTime),
 					Reason:             fmt.Sprintf("Autoscaler disabled as maximum number per cluster reached (%d)", testMaxAutoscalerObjects),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerActiveCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerActiveCondition,
 					Status:             corev1.ConditionTrue,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition,
 					Status:             corev1.ConditionFalse,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
+					Type:               datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},
 				{
-					Type:               datadoghq.DatadogPodAutoscalerVerticalAbleToApply,
+					Type:               datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply,
 					Status:             corev1.ConditionUnknown,
 					LastTransitionTime: metav1.NewTime(testTime),
 				},

--- a/pkg/clusteragent/autoscaling/workload/local/recommendation_settings.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommendation_settings.go
@@ -11,7 +11,7 @@ package local
 import (
 	"fmt"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -22,12 +22,10 @@ const (
 	containerMemoryUsageMetricName = "container.memory.usage"
 )
 
-var (
-	resourceToMetric = map[corev1.ResourceName]string{
-		corev1.ResourceCPU:    containerCPUUsageMetricName,
-		corev1.ResourceMemory: containerMemoryUsageMetricName,
-	}
-)
+var resourceToMetric = map[corev1.ResourceName]string{
+	corev1.ResourceCPU:    containerCPUUsageMetricName,
+	corev1.ResourceMemory: containerMemoryUsageMetricName,
+}
 
 type resourceRecommenderSettings struct {
 	metricName    string
@@ -36,17 +34,17 @@ type resourceRecommenderSettings struct {
 	highWatermark float64
 }
 
-func newResourceRecommenderSettings(target datadoghq.DatadogPodAutoscalerTarget) (*resourceRecommenderSettings, error) {
-	if target.Type == datadoghq.DatadogPodAutoscalerContainerResourceTargetType {
-		return getOptionsFromContainerResource(target.ContainerResource)
+func newResourceRecommenderSettings(objective datadoghqcommon.DatadogPodAutoscalerObjective) (*resourceRecommenderSettings, error) {
+	if objective.Type == datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType {
+		return getOptionsFromContainerResource(objective.ContainerResource)
 	}
-	if target.Type == datadoghq.DatadogPodAutoscalerResourceTargetType {
-		return getOptionsFromPodResource(target.PodResource)
+	if objective.Type == datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType {
+		return getOptionsFromPodResource(objective.PodResource)
 	}
-	return nil, fmt.Errorf("Invalid target type: %s", target.Type)
+	return nil, fmt.Errorf("Invalid target type: %s", objective.Type)
 }
 
-func getOptionsFromPodResource(target *datadoghq.DatadogPodAutoscalerResourceTarget) (*resourceRecommenderSettings, error) {
+func getOptionsFromPodResource(target *datadoghqcommon.DatadogPodAutoscalerPodResourceObjective) (*resourceRecommenderSettings, error) {
 	if target == nil {
 		return nil, fmt.Errorf("nil target")
 	}
@@ -63,7 +61,7 @@ func getOptionsFromPodResource(target *datadoghq.DatadogPodAutoscalerResourceTar
 	return recSettings, nil
 }
 
-func getOptionsFromContainerResource(target *datadoghq.DatadogPodAutoscalerContainerResourceTarget) (*resourceRecommenderSettings, error) {
+func getOptionsFromContainerResource(target *datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective) (*resourceRecommenderSettings, error) {
 	if target == nil {
 		return nil, fmt.Errorf("nil target")
 	}
@@ -81,8 +79,8 @@ func getOptionsFromContainerResource(target *datadoghq.DatadogPodAutoscalerConta
 	return recSettings, nil
 }
 
-func validateTarget(targetType datadoghq.DatadogPodAutoscalerTargetValueType, name corev1.ResourceName, value datadoghq.DatadogPodAutoscalerTargetValue) error {
-	if targetType != datadoghq.DatadogPodAutoscalerUtilizationTargetValueType {
+func validateTarget(targetType datadoghqcommon.DatadogPodAutoscalerObjectiveValueType, name corev1.ResourceName, value datadoghqcommon.DatadogPodAutoscalerObjectiveValue) error {
+	if targetType != datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType {
 		return fmt.Errorf("invalid value type: %s", targetType)
 	}
 
@@ -98,7 +96,7 @@ func validateTarget(targetType datadoghq.DatadogPodAutoscalerTargetValueType, na
 	return nil
 }
 
-func validateUtilizationValue(value datadoghq.DatadogPodAutoscalerTargetValue) error {
+func validateUtilizationValue(value datadoghqcommon.DatadogPodAutoscalerObjectiveValue) error {
 	if value.Utilization == nil {
 		return fmt.Errorf("missing utilization value")
 	}

--- a/pkg/clusteragent/autoscaling/workload/local/recommendation_settings_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommendation_settings_test.go
@@ -11,24 +11,24 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
-	"github.com/google/go-cmp/cmp"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 func TestNewResourceRecommenderSettings(t *testing.T) {
 	tests := []struct {
-		name   string
-		target datadoghq.DatadogPodAutoscalerTarget
-		want   *resourceRecommenderSettings
-		err    error
+		name      string
+		objective datadoghqcommon.DatadogPodAutoscalerObjective
+		want      *resourceRecommenderSettings
+		err       error
 	}{
 		{
 			name: "Invalid resource type",
-			target: datadoghq.DatadogPodAutoscalerTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
 				Type: "something-invalid",
 			},
 			want: nil,
@@ -36,12 +36,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Pod resource - CPU target utilization",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 				},
@@ -55,12 +55,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Pod resource - memory utilization",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "memory",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 				},
@@ -74,35 +74,21 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Pod resource - nil target",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type:        datadoghq.DatadogPodAutoscalerResourceTargetType,
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type:        datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
 				PodResource: nil,
 			},
 			want: nil,
 			err:  fmt.Errorf("nil target"),
 		},
 		{
-			name: "Pod resource - invalid value type",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
-					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type: datadoghq.DatadogPodAutoscalerAbsoluteTargetValueType,
-					},
-				},
-			},
-			want: nil,
-			err:  fmt.Errorf("invalid value type: Absolute"),
-		},
-		{
 			name: "Pod resource - invalid name",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "some-resource",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 				},
@@ -112,12 +98,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Pod resource - nil utilization",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type: datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type: datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 					},
 				},
 			},
@@ -126,12 +112,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Pod resource - out of bounds utilization value",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(0)),
 					},
 				},
@@ -141,12 +127,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Container resource - CPU target utilization",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
-				ContainerResource: &datadoghq.DatadogPodAutoscalerContainerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+				ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 					Container: "container-foo",
@@ -162,12 +148,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Container resource - memory utilization",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
-				ContainerResource: &datadoghq.DatadogPodAutoscalerContainerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+				ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{
 					Name: "memory",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 					Container: "container-foo",
@@ -183,36 +169,21 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Container resource - nil target",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type:              datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type:              datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
 				ContainerResource: nil,
 			},
 			want: nil,
 			err:  fmt.Errorf("nil target"),
 		},
 		{
-			name: "Container resource - invalid value type",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
-				ContainerResource: &datadoghq.DatadogPodAutoscalerContainerResourceTarget{
-					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type: datadoghq.DatadogPodAutoscalerAbsoluteTargetValueType,
-					},
-					Container: "container-foo",
-				},
-			},
-			want: nil,
-			err:  fmt.Errorf("invalid value type: Absolute"),
-		},
-		{
 			name: "Container resource - invalid name",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
-				ContainerResource: &datadoghq.DatadogPodAutoscalerContainerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+				ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{
 					Name: "some-resource",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 				},
@@ -222,12 +193,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Container resource - nil utilization",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
-				ContainerResource: &datadoghq.DatadogPodAutoscalerContainerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+				ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type: datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type: datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 					},
 					Container: "container-foo",
 				},
@@ -237,12 +208,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 		},
 		{
 			name: "Container resource - out of bounds utilization value",
-			target: datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
-				ContainerResource: &datadoghq.DatadogPodAutoscalerContainerResourceTarget{
+			objective: datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+				ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(0)),
 					},
 					Container: "container-foo",
@@ -255,14 +226,12 @@ func TestNewResourceRecommenderSettings(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recommenderSettings, err := newResourceRecommenderSettings(tt.target)
+			recommenderSettings, err := newResourceRecommenderSettings(tt.objective)
 			if tt.err != nil {
 				assert.Error(t, err, tt.err.Error())
 			} else {
 				assert.NoError(t, err)
-				if diff := cmp.Diff(recommenderSettings, tt.want, cmp.AllowUnexported(resourceRecommenderSettings{})); diff != "" {
-					t.Error(diff)
-				}
+				assert.Empty(t, cmp.Diff(recommenderSettings, tt.want, cmp.AllowUnexported(resourceRecommenderSettings{})))
 			}
 		})
 	}

--- a/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
@@ -12,8 +12,9 @@ import (
 	"testing"
 	"time"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"github.com/stretchr/testify/assert"
+
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
@@ -57,7 +58,7 @@ func TestProcessScaleUp(t *testing.T) {
 	pai, found := store.Get("default/autoscaler1")
 	assert.True(t, found)
 	assert.Nil(t, pai.FallbackScalingValues().HorizontalError)
-	assert.Equal(t, datadoghq.DatadogPodAutoscalerLocalValueSource, pai.FallbackScalingValues().Horizontal.Source)
+	assert.Equal(t, datadoghqcommon.DatadogPodAutoscalerLocalValueSource, pai.FallbackScalingValues().Horizontal.Source)
 	assert.Equal(t, int32(2), pai.FallbackScalingValues().Horizontal.Replicas) // currently 1 replica, recommending scale up to 2
 	assert.Equal(t, (testTime - 30), pai.FallbackScalingValues().Horizontal.Timestamp.Unix())
 
@@ -115,7 +116,7 @@ func TestProcessScaleDown(t *testing.T) {
 	pai, found := store.Get("default/autoscaler1")
 	assert.True(t, found)
 	assert.Nil(t, pai.FallbackScalingValues().HorizontalError)
-	assert.Equal(t, datadoghq.DatadogPodAutoscalerLocalValueSource, pai.FallbackScalingValues().Horizontal.Source)
+	assert.Equal(t, datadoghqcommon.DatadogPodAutoscalerLocalValueSource, pai.FallbackScalingValues().Horizontal.Source)
 	assert.Equal(t, int32(2), pai.FallbackScalingValues().Horizontal.Replicas) // currently 3 replicas, recommending scale down to 2
 	assert.Equal(t, (testTime - 30), pai.FallbackScalingValues().Horizontal.Timestamp.Unix())
 

--- a/pkg/clusteragent/autoscaling/workload/local/recommender_testutils.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender_testutils.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"sync"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/loadstore"
@@ -68,13 +70,13 @@ func newAutoscaler() model.PodAutoscalerInternal {
 				APIVersion: "apps/v1",
 				Name:       "test-deployment",
 			},
-			Targets: []datadoghq.DatadogPodAutoscalerTarget{
+			Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
 				{
-					Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-					PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+					Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+					PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 						Name: "cpu",
-						Value: datadoghq.DatadogPodAutoscalerTargetValue{
-							Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+						Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+							Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 							Utilization: pointer.Ptr(int32(80)),
 						},
 					},

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
@@ -13,11 +13,11 @@ import (
 	"math"
 	"time"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
 	"k8s.io/utils/clock"
 
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/loadstore"
@@ -56,7 +56,7 @@ func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAuto
 
 	// Get current pods for the target
 	targetRef := dpai.Spec().TargetRef
-	targets := dpai.Spec().Targets
+	objectives := dpai.Spec().Objectives
 	targetGVK, targetErr := dpai.TargetGVK()
 	if targetErr != nil {
 		return nil, fmt.Errorf("Failed to get GVK for target: %s, %s", dpai.ID(), targetErr)
@@ -78,8 +78,8 @@ func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAuto
 
 	recommendedReplicas := model.HorizontalScalingValues{}
 
-	for _, target := range targets {
-		recSettings, err := newResourceRecommenderSettings(target)
+	for _, objective := range objectives {
+		recSettings, err := newResourceRecommenderSettings(objective)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get resource recommender settings: %s", err)
 		}
@@ -105,7 +105,7 @@ func (r replicaCalculator) calculateHorizontalRecommendations(dpai model.PodAuto
 		if rec > recommendedReplicas.Replicas {
 			recommendedReplicas.Replicas = rec
 			recommendedReplicas.Timestamp = ts
-			recommendedReplicas.Source = datadoghq.DatadogPodAutoscalerLocalValueSource
+			recommendedReplicas.Source = datadoghqcommon.DatadogPodAutoscalerLocalValueSource
 		}
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
@@ -14,10 +14,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
@@ -429,12 +431,12 @@ func TestCalculateUtilizationPodResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recSettings, err := newResourceRecommenderSettings(datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			recSettings, err := newResourceRecommenderSettings(datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 				},
@@ -795,12 +797,12 @@ func TestCalculateUtilizationContainerResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recSettings, err := newResourceRecommenderSettings(datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerContainerResourceTargetType,
-				ContainerResource: &datadoghq.DatadogPodAutoscalerContainerResourceTarget{
+			recSettings, err := newResourceRecommenderSettings(datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerContainerResourceObjectiveType,
+				ContainerResource: &datadoghqcommon.DatadogPodAutoscalerContainerResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 					Container: "container-name1",
@@ -858,12 +860,12 @@ func TestCalculateReplicas(t *testing.T) {
 
 	for _, tt := range test {
 		t.Run(tt.name, func(t *testing.T) {
-			recSettings, err := newResourceRecommenderSettings(datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			recSettings, err := newResourceRecommenderSettings(datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(tt.targetUtilization),
 					},
 				},
@@ -1505,12 +1507,12 @@ func TestRecommend(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			recSettings, err := newResourceRecommenderSettings(datadoghq.DatadogPodAutoscalerTarget{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+			recSettings, err := newResourceRecommenderSettings(datadoghqcommon.DatadogPodAutoscalerObjective{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 				},
@@ -1561,14 +1563,14 @@ func TestCalculateHorizontalRecommendationsScaleUp(t *testing.T) {
 			Name:       deploymentName,
 			APIVersion: "apps/v1",
 		},
-		Owner: datadoghq.DatadogPodAutoscalerLocalOwner,
-		Targets: []datadoghq.DatadogPodAutoscalerTarget{
+		Owner: datadoghqcommon.DatadogPodAutoscalerLocalOwner,
+		Objectives: []datadoghqcommon.DatadogPodAutoscalerObjective{
 			{
-				Type: datadoghq.DatadogPodAutoscalerResourceTargetType,
-				PodResource: &datadoghq.DatadogPodAutoscalerResourceTarget{
+				Type: datadoghqcommon.DatadogPodAutoscalerPodResourceObjectiveType,
+				PodResource: &datadoghqcommon.DatadogPodAutoscalerPodResourceObjective{
 					Name: "cpu",
-					Value: datadoghq.DatadogPodAutoscalerTargetValue{
-						Type:        datadoghq.DatadogPodAutoscalerUtilizationTargetValueType,
+					Value: datadoghqcommon.DatadogPodAutoscalerObjectiveValue{
+						Type:        datadoghqcommon.DatadogPodAutoscalerUtilizationObjectiveValueType,
 						Utilization: pointer.Ptr(int32(80)),
 					},
 				},
@@ -1578,15 +1580,15 @@ func TestCalculateHorizontalRecommendationsScaleUp(t *testing.T) {
 	dpa := &datadoghq.DatadogPodAutoscaler{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DatadogPodAutoscaler",
-			APIVersion: "datadoghq.com/v1alpha1",
+			APIVersion: "datadoghq.com/v1alpha2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      deploymentName,
 			Namespace: ns,
 		},
 		Spec: dpaSpec,
-		Status: datadoghq.DatadogPodAutoscalerStatus{
-			Conditions: []datadoghq.DatadogPodAutoscalerCondition{},
+		Status: datadoghqcommon.DatadogPodAutoscalerStatus{
+			Conditions: []datadoghqcommon.DatadogPodAutoscalerCondition{},
 		},
 	}
 	dpai := model.NewPodAutoscalerInternal(dpa)

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -14,7 +14,8 @@ import (
 	"slices"
 	"time"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
@@ -68,7 +69,7 @@ type PodAutoscalerInternal struct {
 	fallbackScalingValues ScalingValues
 
 	// horizontalLastActions is the last horizontal action successfully taken
-	horizontalLastActions []datadoghq.DatadogPodAutoscalerHorizontalAction
+	horizontalLastActions []datadoghqcommon.DatadogPodAutoscalerHorizontalAction
 
 	// horizontalLastLimitReason is stored separately as we don't want to keep no-action events in `horizontalLastActions`
 	// i.e. when targetReplicaCount after limits == currentReplicas but we want to surface the last limiting reason anyway.
@@ -78,7 +79,7 @@ type PodAutoscalerInternal struct {
 	horizontalLastActionError error
 
 	// verticalLastAction is the last action taken by the Vertical Pod Autoscaler
-	verticalLastAction *datadoghq.DatadogPodAutoscalerVerticalAction
+	verticalLastAction *datadoghqcommon.DatadogPodAutoscalerVerticalAction
 
 	// verticalLastActionError is the last error encountered on vertical scaling
 	verticalLastActionError error
@@ -147,8 +148,8 @@ func (p *PodAutoscalerInternal) UpdateFromPodAutoscaler(podAutoscaler *datadoghq
 	// Reset the target GVK as it might have changed
 	// Resolving the target GVK is done in the controller sync to ensure proper sync and error handling
 	p.targetGVK = schema.GroupVersionKind{}
-	// Compute the horizontal events retention again in case .Spec.Policy has changed
-	p.horizontalEventsRetention = getHorizontalEventsRetention(podAutoscaler.Spec.Policy, longestScalingRulePeriodAllowed)
+	// Compute the horizontal events retention again in case .Spec.ApplyPolicy has changed
+	p.horizontalEventsRetention = getHorizontalEventsRetention(podAutoscaler.Spec.ApplyPolicy, longestScalingRulePeriodAllowed)
 	// Compute recommender configuration again in case .Annotations has changed
 	p.updateCustomRecommenderConfiguration(podAutoscaler.Annotations)
 }
@@ -161,8 +162,8 @@ func (p *PodAutoscalerInternal) UpdateFromSettings(podAutoscalerSpec *datadoghq.
 	// Reset the target GVK as it might have changed
 	// Resolving the target GVK is done in the controller sync to ensure proper sync and error handling
 	p.targetGVK = schema.GroupVersionKind{}
-	// Compute the horizontal events retention again in case .Spec.Policy has changed
-	p.horizontalEventsRetention = getHorizontalEventsRetention(podAutoscalerSpec.Policy, longestScalingRulePeriodAllowed)
+	// Compute the horizontal events retention again in case .Spec.ApplyPolicy has changed
+	p.horizontalEventsRetention = getHorizontalEventsRetention(podAutoscalerSpec.ApplyPolicy, longestScalingRulePeriodAllowed)
 }
 
 // UpdateFromValues updates the PodAutoscalerInternal scaling values
@@ -196,7 +197,7 @@ func (p *PodAutoscalerInternal) RemoveLocalValues() {
 }
 
 // UpdateFromHorizontalAction updates the PodAutoscalerInternal from a new horizontal action
-func (p *PodAutoscalerInternal) UpdateFromHorizontalAction(action *datadoghq.DatadogPodAutoscalerHorizontalAction, err error) {
+func (p *PodAutoscalerInternal) UpdateFromHorizontalAction(action *datadoghqcommon.DatadogPodAutoscalerHorizontalAction, err error) {
 	if err != nil {
 		p.horizontalLastActionError = err
 		p.horizontalLastLimitReason = ""
@@ -220,7 +221,7 @@ func (p *PodAutoscalerInternal) UpdateFromHorizontalAction(action *datadoghq.Dat
 }
 
 // UpdateFromVerticalAction updates the PodAutoscalerInternal from a new vertical action
-func (p *PodAutoscalerInternal) UpdateFromVerticalAction(action *datadoghq.DatadogPodAutoscalerVerticalAction, err error) {
+func (p *PodAutoscalerInternal) UpdateFromVerticalAction(action *datadoghqcommon.DatadogPodAutoscalerVerticalAction, err error) {
 	if err != nil {
 		p.verticalLastActionError = err
 	} else if action != nil {
@@ -259,7 +260,7 @@ func (p *PodAutoscalerInternal) SetDeleted() {
 
 // UpdateFromStatus updates the PodAutoscalerInternal from an existing status.
 // It assumes the PodAutoscalerInternal is empty so it's not emptying existing data.
-func (p *PodAutoscalerInternal) UpdateFromStatus(status *datadoghq.DatadogPodAutoscalerStatus) {
+func (p *PodAutoscalerInternal) UpdateFromStatus(status *datadoghqcommon.DatadogPodAutoscalerStatus) {
 	if status.Horizontal != nil {
 		if status.Horizontal.Target != nil {
 			p.scalingValues.Horizontal = &HorizontalScalingValues{
@@ -295,19 +296,19 @@ func (p *PodAutoscalerInternal) UpdateFromStatus(status *datadoghq.DatadogPodAut
 	// We're only keeping error string, loosing type, but it's not important for what we do.
 	for _, cond := range status.Conditions {
 		switch {
-		case cond.Type == datadoghq.DatadogPodAutoscalerErrorCondition && cond.Status == corev1.ConditionTrue:
+		case cond.Type == datadoghqcommon.DatadogPodAutoscalerErrorCondition && cond.Status == corev1.ConditionTrue:
 			// Error condition could refer to a controller error or from a general Datadog error
 			// We're restoring this to error as it's the most generic
 			p.error = errors.New(cond.Reason)
-		case cond.Type == datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition && cond.Status == corev1.ConditionFalse:
+		case cond.Type == datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition && cond.Status == corev1.ConditionFalse:
 			p.scalingValues.HorizontalError = errors.New(cond.Reason)
-		case cond.Type == datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition && cond.Status == corev1.ConditionFalse:
+		case cond.Type == datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition && cond.Status == corev1.ConditionFalse:
 			p.horizontalLastActionError = errors.New(cond.Reason)
-		case cond.Type == datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition && cond.Status == corev1.ConditionTrue:
+		case cond.Type == datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition && cond.Status == corev1.ConditionTrue:
 			p.horizontalLastLimitReason = cond.Reason
-		case cond.Type == datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition && cond.Status == corev1.ConditionFalse:
+		case cond.Type == datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition && cond.Status == corev1.ConditionFalse:
 			p.scalingValues.VerticalError = errors.New(cond.Reason)
-		case cond.Type == datadoghq.DatadogPodAutoscalerVerticalAbleToApply && cond.Status == corev1.ConditionFalse:
+		case cond.Type == datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply && cond.Status == corev1.ConditionFalse:
 			p.verticalLastActionError = errors.New(cond.Reason)
 		}
 	}
@@ -373,7 +374,7 @@ func (p *PodAutoscalerInternal) FallbackScalingValues() ScalingValues {
 }
 
 // HorizontalLastActions returns the last horizontal actions taken
-func (p *PodAutoscalerInternal) HorizontalLastActions() []datadoghq.DatadogPodAutoscalerHorizontalAction {
+func (p *PodAutoscalerInternal) HorizontalLastActions() []datadoghqcommon.DatadogPodAutoscalerHorizontalAction {
 	return p.horizontalLastActions
 }
 
@@ -383,7 +384,7 @@ func (p *PodAutoscalerInternal) HorizontalLastActionError() error {
 }
 
 // VerticalLastAction returns the last action taken by the Vertical Pod Autoscaler
-func (p *PodAutoscalerInternal) VerticalLastAction() *datadoghq.DatadogPodAutoscalerVerticalAction {
+func (p *PodAutoscalerInternal) VerticalLastAction() *datadoghqcommon.DatadogPodAutoscalerVerticalAction {
 	return p.verticalLastAction
 }
 
@@ -441,8 +442,8 @@ func (p *PodAutoscalerInternal) CustomRecommenderConfiguration() *RecommenderCon
 //
 
 // BuildStatus builds the status of the PodAutoscaler from the internal state
-func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStatus *datadoghq.DatadogPodAutoscalerStatus) datadoghq.DatadogPodAutoscalerStatus {
-	status := datadoghq.DatadogPodAutoscalerStatus{}
+func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStatus *datadoghqcommon.DatadogPodAutoscalerStatus) datadoghqcommon.DatadogPodAutoscalerStatus {
+	status := datadoghqcommon.DatadogPodAutoscalerStatus{}
 
 	// Syncing current replicas
 	if p.currentReplicas != nil {
@@ -451,8 +452,8 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 
 	// Produce Horizontal status only if we have a desired number of replicas
 	if p.scalingValues.Horizontal != nil {
-		status.Horizontal = &datadoghq.DatadogPodAutoscalerHorizontalStatus{
-			Target: &datadoghq.DatadogPodAutoscalerHorizontalTargetStatus{
+		status.Horizontal = &datadoghqcommon.DatadogPodAutoscalerHorizontalStatus{
+			Target: &datadoghqcommon.DatadogPodAutoscalerHorizontalTargetStatus{
 				Source:      p.scalingValues.Horizontal.Source,
 				GeneratedAt: metav1.NewTime(p.scalingValues.Horizontal.Timestamp),
 				Replicas:    p.scalingValues.Horizontal.Replicas,
@@ -473,29 +474,29 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 	if p.scalingValues.Vertical != nil {
 		cpuReqSum, memReqSum := p.scalingValues.Vertical.SumCPUMemoryRequests()
 
-		status.Vertical = &datadoghq.DatadogPodAutoscalerVerticalStatus{
-			Target: &datadoghq.DatadogPodAutoscalerVerticalTargetStatus{
+		status.Vertical = &datadoghqcommon.DatadogPodAutoscalerVerticalStatus{
+			Target: &datadoghqcommon.DatadogPodAutoscalerVerticalTargetStatus{
 				Source:           p.scalingValues.Vertical.Source,
 				GeneratedAt:      metav1.NewTime(p.scalingValues.Vertical.Timestamp),
 				Version:          p.scalingValues.Vertical.ResourcesHash,
 				DesiredResources: p.scalingValues.Vertical.ContainerResources,
 				Scaled:           p.scaledReplicas,
-				PODCPURequest:    cpuReqSum,
-				PODMemoryRequest: memReqSum,
+				PodCPURequest:    cpuReqSum,
+				PodMemoryRequest: memReqSum,
 			},
 			LastAction: p.verticalLastAction,
 		}
 	}
 
 	// Building conditions
-	existingConditions := map[datadoghq.DatadogPodAutoscalerConditionType]*datadoghq.DatadogPodAutoscalerCondition{
-		datadoghq.DatadogPodAutoscalerErrorCondition:                     nil,
-		datadoghq.DatadogPodAutoscalerActiveCondition:                    nil,
-		datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition: nil,
-		datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition:     nil,
-		datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition:  nil,
-		datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition:   nil,
-		datadoghq.DatadogPodAutoscalerVerticalAbleToApply:                nil,
+	existingConditions := map[datadoghqcommon.DatadogPodAutoscalerConditionType]*datadoghqcommon.DatadogPodAutoscalerCondition{
+		datadoghqcommon.DatadogPodAutoscalerErrorCondition:                     nil,
+		datadoghqcommon.DatadogPodAutoscalerActiveCondition:                    nil,
+		datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition: nil,
+		datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition:     nil,
+		datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition:  nil,
+		datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition:   nil,
+		datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply:                nil,
 	}
 
 	if currentStatus != nil {
@@ -512,37 +513,37 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 	if p.error == nil {
 		globalError = p.scalingValues.Error
 	}
-	status.Conditions = append(status.Conditions, newConditionFromError(true, currentTime, globalError, datadoghq.DatadogPodAutoscalerErrorCondition, existingConditions))
+	status.Conditions = append(status.Conditions, newConditionFromError(true, currentTime, globalError, datadoghqcommon.DatadogPodAutoscalerErrorCondition, existingConditions))
 
 	// Building active condition, should handle multiple reasons, currently only disabled if target replicas = 0
 	if p.currentReplicas != nil && *p.currentReplicas == 0 {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "Target has been scaled to 0 replicas", currentTime, datadoghq.DatadogPodAutoscalerActiveCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "Target has been scaled to 0 replicas", currentTime, datadoghqcommon.DatadogPodAutoscalerActiveCondition, existingConditions))
 	} else {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, "", currentTime, datadoghq.DatadogPodAutoscalerActiveCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, "", currentTime, datadoghqcommon.DatadogPodAutoscalerActiveCondition, existingConditions))
 	}
 
 	// Building errors related to compute recommendations
-	var horizontalAbleToRecommend datadoghq.DatadogPodAutoscalerCondition
+	var horizontalAbleToRecommend datadoghqcommon.DatadogPodAutoscalerCondition
 	if p.scalingValues.HorizontalError != nil || p.scalingValues.Horizontal != nil {
-		horizontalAbleToRecommend = newConditionFromError(false, currentTime, p.scalingValues.HorizontalError, datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, existingConditions)
+		horizontalAbleToRecommend = newConditionFromError(false, currentTime, p.scalingValues.HorizontalError, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, existingConditions)
 	} else {
-		horizontalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", currentTime, datadoghq.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, existingConditions)
+		horizontalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToRecommendCondition, existingConditions)
 	}
 	status.Conditions = append(status.Conditions, horizontalAbleToRecommend)
 
-	var verticalAbleToRecommend datadoghq.DatadogPodAutoscalerCondition
+	var verticalAbleToRecommend datadoghqcommon.DatadogPodAutoscalerCondition
 	if p.scalingValues.VerticalError != nil || p.scalingValues.Vertical != nil {
-		verticalAbleToRecommend = newConditionFromError(false, currentTime, p.scalingValues.VerticalError, datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition, existingConditions)
+		verticalAbleToRecommend = newConditionFromError(false, currentTime, p.scalingValues.VerticalError, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, existingConditions)
 	} else {
-		verticalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", currentTime, datadoghq.DatadogPodAutoscalerVerticalAbleToRecommendCondition, existingConditions)
+		verticalAbleToRecommend = newCondition(corev1.ConditionUnknown, "", currentTime, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToRecommendCondition, existingConditions)
 	}
 	status.Conditions = append(status.Conditions, verticalAbleToRecommend)
 
 	// Horizontal: handle scaling limited condition
 	if p.horizontalLastLimitReason != "" {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, p.horizontalLastLimitReason, currentTime, datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionTrue, p.horizontalLastLimitReason, currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
 	} else {
-		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "", currentTime, datadoghq.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
+		status.Conditions = append(status.Conditions, newCondition(corev1.ConditionFalse, "", currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalScalingLimitedCondition, existingConditions))
 	}
 
 	// Building rollout errors
@@ -554,7 +555,7 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 	} else if len(p.horizontalLastActions) > 0 {
 		horizontalStatus = corev1.ConditionTrue
 	}
-	status.Conditions = append(status.Conditions, newCondition(horizontalStatus, horizontalReason, currentTime, datadoghq.DatadogPodAutoscalerHorizontalAbleToScaleCondition, existingConditions))
+	status.Conditions = append(status.Conditions, newCondition(horizontalStatus, horizontalReason, currentTime, datadoghqcommon.DatadogPodAutoscalerHorizontalAbleToScaleCondition, existingConditions))
 
 	var verticalReason string
 	rolloutStatus := corev1.ConditionUnknown
@@ -564,7 +565,7 @@ func (p *PodAutoscalerInternal) BuildStatus(currentTime metav1.Time, currentStat
 	} else if p.verticalLastAction != nil {
 		rolloutStatus = corev1.ConditionTrue
 	}
-	status.Conditions = append(status.Conditions, newCondition(rolloutStatus, verticalReason, currentTime, datadoghq.DatadogPodAutoscalerVerticalAbleToApply, existingConditions))
+	status.Conditions = append(status.Conditions, newCondition(rolloutStatus, verticalReason, currentTime, datadoghqcommon.DatadogPodAutoscalerVerticalAbleToApply, existingConditions))
 
 	return status
 }
@@ -579,7 +580,7 @@ func (p *PodAutoscalerInternal) updateCustomRecommenderConfiguration(annotations
 	p.customRecommenderConfiguration = annotation
 }
 
-func addHorizontalAction(currentTime time.Time, retention time.Duration, actions []datadoghq.DatadogPodAutoscalerHorizontalAction, action *datadoghq.DatadogPodAutoscalerHorizontalAction) []datadoghq.DatadogPodAutoscalerHorizontalAction {
+func addHorizontalAction(currentTime time.Time, retention time.Duration, actions []datadoghqcommon.DatadogPodAutoscalerHorizontalAction, action *datadoghqcommon.DatadogPodAutoscalerHorizontalAction) []datadoghqcommon.DatadogPodAutoscalerHorizontalAction {
 	if retention == 0 {
 		actions = actions[:0]
 		actions = append(actions, *action)
@@ -603,7 +604,7 @@ func addHorizontalAction(currentTime time.Time, retention time.Duration, actions
 	return actions
 }
 
-func newConditionFromError(trueOnError bool, currentTime metav1.Time, err error, conditionType datadoghq.DatadogPodAutoscalerConditionType, existingConditions map[datadoghq.DatadogPodAutoscalerConditionType]*datadoghq.DatadogPodAutoscalerCondition) datadoghq.DatadogPodAutoscalerCondition {
+func newConditionFromError(trueOnError bool, currentTime metav1.Time, err error, conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, existingConditions map[datadoghqcommon.DatadogPodAutoscalerConditionType]*datadoghqcommon.DatadogPodAutoscalerCondition) datadoghqcommon.DatadogPodAutoscalerCondition {
 	var condition corev1.ConditionStatus
 
 	var reason string
@@ -625,8 +626,8 @@ func newConditionFromError(trueOnError bool, currentTime metav1.Time, err error,
 	return newCondition(condition, reason, currentTime, conditionType, existingConditions)
 }
 
-func newCondition(status corev1.ConditionStatus, reason string, currentTime metav1.Time, conditionType datadoghq.DatadogPodAutoscalerConditionType, existingConditions map[datadoghq.DatadogPodAutoscalerConditionType]*datadoghq.DatadogPodAutoscalerCondition) datadoghq.DatadogPodAutoscalerCondition {
-	condition := datadoghq.DatadogPodAutoscalerCondition{
+func newCondition(status corev1.ConditionStatus, reason string, currentTime metav1.Time, conditionType datadoghqcommon.DatadogPodAutoscalerConditionType, existingConditions map[datadoghqcommon.DatadogPodAutoscalerConditionType]*datadoghqcommon.DatadogPodAutoscalerCondition) datadoghqcommon.DatadogPodAutoscalerCondition {
+	condition := datadoghqcommon.DatadogPodAutoscalerCondition{
 		Type:   conditionType,
 		Status: status,
 		Reason: reason,
@@ -642,22 +643,22 @@ func newCondition(status corev1.ConditionStatus, reason string, currentTime meta
 	return condition
 }
 
-func getHorizontalEventsRetention(policy *datadoghq.DatadogPodAutoscalerPolicy, longestLookbackAllowed time.Duration) time.Duration {
+func getHorizontalEventsRetention(policy *datadoghq.DatadogPodAutoscalerApplyPolicy, longestLookbackAllowed time.Duration) time.Duration {
 	var longestRetention time.Duration
 	if policy == nil {
 		return 0
 	}
 
-	if policy.Upscale != nil {
-		upscaleRetention := getLongestScalingRulesPeriod(policy.Upscale.Rules)
-		upscaleStabilizationWindow := time.Second * time.Duration(policy.Upscale.StabilizationWindowSeconds)
-		longestRetention = max(longestRetention, upscaleRetention, upscaleStabilizationWindow)
+	if policy.ScaleUp != nil {
+		scaleUpRetention := getLongestScalingRulesPeriod(policy.ScaleUp.Rules)
+		scaleUpStabilizationWindow := time.Second * time.Duration(policy.ScaleUp.StabilizationWindowSeconds)
+		longestRetention = max(longestRetention, scaleUpRetention, scaleUpStabilizationWindow)
 	}
 
-	if policy.Downscale != nil {
-		downscaleRetention := getLongestScalingRulesPeriod(policy.Downscale.Rules)
-		downscaleStabilizationWindow := time.Second * time.Duration(policy.Downscale.StabilizationWindowSeconds)
-		longestRetention = max(longestRetention, downscaleRetention, downscaleStabilizationWindow)
+	if policy.ScaleDown != nil {
+		scaleDownRetention := getLongestScalingRulesPeriod(policy.ScaleDown.Rules)
+		scaleDownStabilizationWindow := time.Second * time.Duration(policy.ScaleDown.StabilizationWindowSeconds)
+		longestRetention = max(longestRetention, scaleDownRetention, scaleDownStabilizationWindow)
 	}
 
 	if longestRetention > longestLookbackAllowed {
@@ -666,7 +667,7 @@ func getHorizontalEventsRetention(policy *datadoghq.DatadogPodAutoscalerPolicy, 
 	return longestRetention
 }
 
-func getLongestScalingRulesPeriod(rules []datadoghq.DatadogPodAutoscalerScalingRule) time.Duration {
+func getLongestScalingRulesPeriod(rules []datadoghqcommon.DatadogPodAutoscalerScalingRule) time.Duration {
 	var longest time.Duration
 	for _, rule := range rules {
 		periodDuration := time.Second * time.Duration(rule.PeriodSeconds)

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_test_utils.go
@@ -19,7 +19,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 )
 
 // FakePodAutoscalerInternal is a fake PodAutoscalerInternal object.
@@ -31,11 +32,11 @@ type FakePodAutoscalerInternal struct {
 	SettingsTimestamp              time.Time
 	CreationTimestamp              time.Time
 	ScalingValues                  ScalingValues
-	HorizontalLastActions          []datadoghq.DatadogPodAutoscalerHorizontalAction
+	HorizontalLastActions          []datadoghqcommon.DatadogPodAutoscalerHorizontalAction
 	HorizontalLastLimitReason      string
 	HorizontalLastActionError      error
 	HorizontalEventsRetention      time.Duration
-	VerticalLastAction             *datadoghq.DatadogPodAutoscalerVerticalAction
+	VerticalLastAction             *datadoghqcommon.DatadogPodAutoscalerVerticalAction
 	VerticalLastActionError        error
 	CurrentReplicas                *int32
 	ScaledReplicas                 *int32
@@ -71,7 +72,7 @@ func (f FakePodAutoscalerInternal) Build() PodAutoscalerInternal {
 }
 
 // AddHorizontalAction mimics the behavior of adding an horizontal event.
-func (f *FakePodAutoscalerInternal) AddHorizontalAction(currentTime time.Time, action *datadoghq.DatadogPodAutoscalerHorizontalAction) {
+func (f *FakePodAutoscalerInternal) AddHorizontalAction(currentTime time.Time, action *datadoghqcommon.DatadogPodAutoscalerHorizontalAction) {
 	f.HorizontalLastActions = addHorizontalAction(currentTime, f.HorizontalEventsRetention, f.HorizontalLastActions, action)
 }
 

--- a/pkg/clusteragent/autoscaling/workload/model/rc_schema.go
+++ b/pkg/clusteragent/autoscaling/workload/model/rc_schema.go
@@ -9,7 +9,9 @@ package model
 
 import (
 	kubeAutoscaling "github.com/DataDog/agent-payload/v5/autoscaling/kubernetes"
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+
+	datadoghqv1alpha1 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqv1alpha2 "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 )
 
 // ReccomendationError is an error encountered while computing a recommendation on Datadog side
@@ -35,5 +37,16 @@ type AutoscalingSettings struct {
 	Name string `json:"name"`
 
 	// Spec is the full spec of the PodAutoscaler
-	Spec *datadoghq.DatadogPodAutoscalerSpec `json:"spec"`
+	// WARNING: Legacy field, to be removed
+	Spec *datadoghqv1alpha1.DatadogPodAutoscalerSpec `json:"spec,omitempty"`
+
+	// Specs contains one version of the PodAutoscaler spec
+	// Has priority over the legacy field Spec
+	Specs *AutoscalingSpecs `json:"specs,omitempty"`
+}
+
+// AutoscalingSpecs contains the different versions of the PodAutoscaler spec
+type AutoscalingSpecs struct {
+	V1Alpha1 *datadoghqv1alpha1.DatadogPodAutoscalerSpec `json:"v1alpha1,omitempty"`
+	V1Alpha2 *datadoghqv1alpha2.DatadogPodAutoscalerSpec `json:"v1alpha2,omitempty"`
 }

--- a/pkg/clusteragent/autoscaling/workload/model/recommendations.go
+++ b/pkg/clusteragent/autoscaling/workload/model/recommendations.go
@@ -12,7 +12,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 )
 
 // ScalingValues represents the scaling values (horizontal and vertical) for a target
@@ -32,7 +32,7 @@ type ScalingValues struct {
 // HorizontalScalingValues holds the horizontal scaling values for a target
 type HorizontalScalingValues struct {
 	// Source is the source of the value
-	Source datadoghq.DatadogPodAutoscalerValueSource
+	Source datadoghqcommon.DatadogPodAutoscalerValueSource
 
 	// Timestamp is the time at which the data was generated
 	Timestamp time.Time
@@ -44,7 +44,7 @@ type HorizontalScalingValues struct {
 // VerticalScalingValues holds the vertical scaling values for a target
 type VerticalScalingValues struct {
 	// Source is the source of the value
-	Source datadoghq.DatadogPodAutoscalerValueSource
+	Source datadoghqcommon.DatadogPodAutoscalerValueSource
 
 	// Timestamp is the time at which the data was generated
 	Timestamp time.Time
@@ -53,7 +53,7 @@ type VerticalScalingValues struct {
 	ResourcesHash string
 
 	// ContainerResources holds the resources for a container
-	ContainerResources []datadoghq.DatadogPodAutoscalerContainerResources
+	ContainerResources []datadoghqcommon.DatadogPodAutoscalerContainerResources
 }
 
 // RecommenderConfiguration holds the configuration for a custom recommender

--- a/pkg/clusteragent/autoscaling/workload/model/utils.go
+++ b/pkg/clusteragent/autoscaling/workload/model/utils.go
@@ -8,18 +8,16 @@
 package model
 
 import (
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 )
 
 // ApplyModeAllowSource returns true if the given source is allowed by the given apply mode.
-func ApplyModeAllowSource(mode datadoghq.DatadogPodAutoscalerApplyMode, source datadoghq.DatadogPodAutoscalerValueSource) bool {
+func ApplyModeAllowSource(mode datadoghq.DatadogPodAutoscalerApplyMode, _ datadoghqcommon.DatadogPodAutoscalerValueSource) bool {
 	switch mode {
-	case datadoghq.DatadogPodAutoscalerNoneApplyMode:
-	case datadoghq.DatadogPodAutoscalerManualApplyMode:
-		return source == datadoghq.DatadogPodAutoscalerManualValueSource
-	case datadoghq.DatadogPodAutoscalerAllApplyMode:
+	case datadoghq.DatadogPodAutoscalerApplyModeApply:
 		return true
 	default:
+		return false
 	}
-	return false
 }

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/record"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
@@ -76,7 +76,7 @@ func (pa podPatcher) ApplyRecommendations(pod *corev1.Pod) (bool, error) {
 
 	// Check if we're allowed to patch the POD
 	strategy, reason := getVerticalPatchingStrategy(autoscaler)
-	if strategy == datadoghq.DatadogPodAutoscalerDisabledUpdateStrategy {
+	if strategy == datadoghqcommon.DatadogPodAutoscalerDisabledUpdateStrategy {
 		log.Debugf("Autoscaler %s has vertical patching disabled for POD %s/%s, reason: %s", autoscaler.ID(), pod.Namespace, pod.Name, reason)
 		return false, nil
 	}

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -19,7 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
@@ -42,9 +43,9 @@ func patcherTestStoreWithData() *store {
 		ScalingValues: model.ScalingValues{
 			VerticalError: errors.New("error on dd side"),
 			Vertical: &model.VerticalScalingValues{
-				Source:        datadoghq.DatadogPodAutoscalerAutoscalingValueSource,
+				Source:        datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
 				ResourcesHash: "version1",
-				ContainerResources: []datadoghq.DatadogPodAutoscalerContainerResources{
+				ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
 					{Name: "container1", Limits: corev1.ResourceList{"cpu": resource.MustParse("500m")}, Requests: corev1.ResourceList{"memory": resource.MustParse("256Mi")}},
 					{Name: "container2", Limits: corev1.ResourceList{"cpu": resource.MustParse("600m")}, Requests: corev1.ResourceList{"memory": resource.MustParse("512Mi")}},
 				},

--- a/pkg/clusteragent/autoscaling/workload/telemetry.go
+++ b/pkg/clusteragent/autoscaling/workload/telemetry.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
 	workqueuetelemetry "github.com/DataDog/datadog-agent/pkg/util/workqueue/telemetry"
-	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha1"
+	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
 	corev1 "k8s.io/api/core/v1"
 )
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -52,7 +52,6 @@ type KubeUtil struct {
 	kubeletClient          *kubeletClient
 	rawConnectionInfo      map[string]string // kept to pass to the python kubelet check
 	podListCacheDuration   time.Duration
-	filter                 *containers.Filter
 	waitOnMissingContainer time.Duration
 	podUnmarshaller        *podUnmarshaller
 	podResourcesClient     *PodResourcesClient
@@ -60,11 +59,6 @@ type KubeUtil struct {
 
 func (ku *KubeUtil) init() error {
 	var err error
-	ku.filter, err = containers.GetSharedMetricFilter()
-	if err != nil {
-		return err
-	}
-
 	ku.kubeletClient, err = getKubeletClient(context.Background())
 	if err != nil {
 		return err

--- a/releasenotes-dca/notes/autoscaling-v1alpha2-baac5496f3ac9d11.yaml
+++ b/releasenotes-dca/notes/autoscaling-v1alpha2-baac5496f3ac9d11.yaml
@@ -1,0 +1,3 @@
+upgrade:
+  - |
+    Datadog Autoscaling is upgraded to use DatadogPodAutoscaler CRD v1alpha2 instead of v1alpha1. Remote (created in Datadog) autoscalers are automatically migrated. In-cluster (Local) autoscalers need to be migrated manually.


### PR DESCRIPTION
### What does this PR do?

Move autoscaling controller to CRD v1alpha2

### Motivation

### Describe how you validated your changes

Non-regression with new Cluster Agent + CRD v1alpha2.
For existing CRs in v1alpha1:
- The `Remote` ones will be automatically converted
- The `Local` ones will be interpreted as `v1alpha2` dropping fields (notably old `targets` and `applyMode`).

### Possible Drawbacks / Trade-offs

### Additional Notes