### PR TITLE
(fleet) Change installer directories permissions on Windows

### DIFF
--- a/pkg/fleet/installer/paths/installer_paths.go
+++ b/pkg/fleet/installer/paths/installer_paths.go
@@ -8,6 +8,8 @@
 // Package paths defines commonly used paths throughout the installer
 package paths
 
+import "os"
+
 const (
 	// PackagesPath is the path to the packages directory.
 	PackagesPath = "/opt/datadog-packages"
@@ -24,3 +26,8 @@ const (
 	// RunPath is the default run path
 	RunPath = "/opt/datadog-packages/run"
 )
+
+// SetRepositoryPermissions sets the permissions on the repository directory
+func SetRepositoryPermissions(path string) error {
+	return os.Chmod(path, 0755)
+}

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -336,3 +336,18 @@ func getProgramDataDirForProduct(product string) (path string, err error) {
 	path = val
 	return
 }
+
+// SetRepositoryPermissions sets the permissions on the repository directory
+// It needs to be world readable so that user processes can load installed libraries
+func SetRepositoryPermissions(path string) error {
+	// Desired permissions:
+	// - OWNER: Administrators
+	// - GROUP: Administrators
+	// - SYSTEM: Full Control (propagates to children)
+	// - Administrators: Full Control (propagates to children)
+	// - Everyone: 0x1200A9 Read and execute (propagates to children)
+	// - PROTECTED: does not inherit permissions from parent
+	sddl := "O:BAG:BAD:PAI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;0x1200A9;;;WD)"
+
+	return treeResetNamedSecurityInfoWithSDDL(path, sddl)
+}

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -357,7 +358,7 @@ func movePackageFromSource(packageName string, rootPath string, sourcePath strin
 	if !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("could not stat target package: %w", err)
 	}
-	if err := os.Chmod(sourcePath, 0755); err != nil {
+	if err := paths.SetRepositoryPermissions(sourcePath); err != nil {
 		return "", fmt.Errorf("could not set permissions on package: %w", err)
 	}
 	err = os.Rename(sourcePath, targetPath)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes the folders where packages are installed world readable. This is consistent with what is done for linux and is required for single step instrumentation to reference libraries installed by the installer.

The top level directory keeps its traversal only permissions, that way the files in the temporary directories created by the installer remain private to the installer user like on linux.
 
### Motivation

Enable SSI for dotnet.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

This was validated manually + with [system tests](https://github.com/DataDog/system-tests/pull/3942).

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
https://datadoghq.atlassian.net/browse/INPLAT-432