### PR TITLE
(fleet) Remove locking mechanism and add pre-remove hooks to the installer

### DIFF
--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -216,19 +216,19 @@ func (i *InstallerExec) Setup(ctx context.Context) (err error) {
 
 // AvailableDiskSpace returns the available disk space.
 func (i *InstallerExec) AvailableDiskSpace() (uint64, error) {
-	repositories := repository.NewRepositories(paths.PackagesPath)
+	repositories := repository.NewRepositories(paths.PackagesPath, nil)
 	return repositories.AvailableDiskSpace()
 }
 
 // State returns the state of a package.
 func (i *InstallerExec) State(pkg string) (repository.State, error) {
-	repositories := repository.NewRepositories(paths.PackagesPath)
+	repositories := repository.NewRepositories(paths.PackagesPath, nil)
 	return repositories.Get(pkg).GetState()
 }
 
 // States returns the states of all packages.
 func (i *InstallerExec) States() (map[string]repository.State, error) {
-	repositories := repository.NewRepositories(paths.PackagesPath)
+	repositories := repository.NewRepositories(paths.PackagesPath, nil)
 	states, err := repositories.GetStates()
 	log.Debugf("repositories states: %v", states)
 	return states, err
@@ -236,13 +236,13 @@ func (i *InstallerExec) States() (map[string]repository.State, error) {
 
 // ConfigState returns the state of a package's configuration.
 func (i *InstallerExec) ConfigState(pkg string) (repository.State, error) {
-	repositories := repository.NewRepositories(paths.ConfigsPath)
+	repositories := repository.NewRepositories(paths.ConfigsPath, nil)
 	return repositories.Get(pkg).GetState()
 }
 
 // ConfigStates returns the states of all packages' configurations.
 func (i *InstallerExec) ConfigStates() (map[string]repository.State, error) {
-	repositories := repository.NewRepositories(paths.ConfigsPath)
+	repositories := repository.NewRepositories(paths.ConfigsPath, nil)
 	states, err := repositories.GetStates()
 	log.Debugf("config repositories states: %v", states)
 	return states, err

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -98,8 +98,8 @@ func NewInstaller(env *env.Env) (Installer, error) {
 		env:        env,
 		db:         db,
 		downloader: oci.NewDownloader(env, env.HTTPClient()),
-		packages:   repository.NewRepositories(paths.PackagesPath),
-		configs:    repository.NewRepositories(paths.ConfigsPath),
+		packages:   repository.NewRepositories(paths.PackagesPath, packages.PreRemoveHooks),
+		configs:    repository.NewRepositories(paths.ConfigsPath, nil),
 
 		userConfigsDir: paths.DefaultUserConfigsDir,
 		packagesDir:    paths.PackagesPath,

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/fixtures"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 )
 
@@ -38,8 +39,8 @@ type testPackageManager struct {
 }
 
 func newTestPackageManager(t *testing.T, s *fixtures.Server, rootPath string) *testPackageManager {
-	packages := repository.NewRepositories(rootPath)
-	configs := repository.NewRepositories(t.TempDir())
+	packages := repository.NewRepositories(rootPath, packages.PreRemoveHooks)
+	configs := repository.NewRepositories(t.TempDir(), nil)
 	db, err := db.New(filepath.Join(rootPath, "packages.db"))
 	assert.NoError(t, err)
 	return &testPackageManager{

--- a/pkg/fleet/installer/packages/pre_remove_hooks.go
+++ b/pkg/fleet/installer/packages/pre_remove_hooks.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package packages
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+)
+
+// PreRemoveHooks contains the mapping between packages and their pre-remove hooks
+var PreRemoveHooks = map[string]repository.PreRemoveHook{}

--- a/pkg/fleet/installer/repository/repositories.go
+++ b/pkg/fleet/installer/repository/repositories.go
@@ -21,19 +21,22 @@ const (
 
 // Repositories manages multiple repositories.
 type Repositories struct {
-	rootPath string
+	rootPath       string
+	preRemoveHooks map[string]PreRemoveHook
 }
 
 // NewRepositories returns a new Repositories.
-func NewRepositories(rootPath string) *Repositories {
+func NewRepositories(rootPath string, preRemoveHooks map[string]PreRemoveHook) *Repositories {
 	return &Repositories{
-		rootPath: rootPath,
+		rootPath:       rootPath,
+		preRemoveHooks: preRemoveHooks,
 	}
 }
 
 func (r *Repositories) newRepository(pkg string) *Repository {
 	return &Repository{
-		rootPath: filepath.Join(r.rootPath, pkg),
+		rootPath:       filepath.Join(r.rootPath, pkg),
+		preRemoveHooks: r.preRemoveHooks,
 	}
 }
 
@@ -84,7 +87,8 @@ func (r *Repositories) Create(pkg string, version string, stableSourcePath strin
 // Delete deletes the repository for the given package name.
 func (r *Repositories) Delete(_ context.Context, pkg string) error {
 	repository := r.newRepository(pkg)
-	err := os.RemoveAll(repository.rootPath)
+
+	err := repository.Delete()
 	if err != nil {
 		return fmt.Errorf("could not delete repository for package %s: %w", pkg, err)
 	}

--- a/pkg/fleet/installer/repository/repositories_test.go
+++ b/pkg/fleet/installer/repository/repositories_test.go
@@ -15,7 +15,7 @@ import (
 
 func newTestRepositories(t *testing.T) *Repositories {
 	rootPath := t.TempDir()
-	repositories := NewRepositories(rootPath)
+	repositories := NewRepositories(rootPath, nil)
 	return repositories
 }
 
@@ -52,7 +52,7 @@ func TestRepositoriesReopen(t *testing.T) {
 	err = repositories.Create("repo2", "v1", t.TempDir())
 	assert.NoError(t, err)
 
-	repositories = NewRepositories(repositories.rootPath)
+	repositories = NewRepositories(repositories.rootPath, nil)
 
 	state, err := repositories.GetStates()
 	assert.NoError(t, err)
@@ -69,7 +69,7 @@ func TestLoadRepositories(t *testing.T) {
 	os.Mkdir(path.Join(rootDir, "run"), 0755)
 	os.Mkdir(path.Join(rootDir, "tmp"), 0755)
 
-	repositories, err := NewRepositories(rootDir).loadRepositories()
+	repositories, err := NewRepositories(rootDir, nil).loadRepositories()
 	assert.NoError(t, err)
 	assert.Len(t, repositories, 1)
 	assert.Contains(t, repositories, "datadog-agent")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes the package locking mechanism from the installer since it is not used and adds a new hook that is run before package files on disk are deleted.

### Motivation

Pre-requisiste for dotnet SSI 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

These changes are validated with unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
https://datadoghq.atlassian.net/browse/INPLAT-432