### PR TITLE
Add apm-ecosystems as non-releasing-team

### DIFF
--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -24,6 +24,7 @@ NON_RELEASING_TEAMS = {
     'sdlc-security',
     'data-jobs-monitoring',
     'serverless-aws',
+    'apm-ecosystems-performance',
 }
 
 


### PR DESCRIPTION
### What does this PR do?

This PR adds the apm ecosystems team to the NON_RELEASING_TEAMS set.

### Motivation

We use NON_RELEASING_TEAMS to determine which teams present in the CODEOWNERS file do not contribute directly to the Agent release and do not need to be part of it. apm-ecosystems-performance team reached out to use to remove them there.