### PR TITLE
[NDMII-3310] update rtloader to add  getAttrBool method

### DIFF
--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -129,6 +129,19 @@ DATADOG_AGENT_RTLOADER_API int get_class(rtloader_t *rtloader, const char *name,
 DATADOG_AGENT_RTLOADER_API int get_attr_string(rtloader_t *rtloader, rtloader_pyobject_t *py_class,
                                                const char *attr_name, char **value);
 
+/*! \fn int get_attr_bool(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *attr_name, bool *value)
+    \brief Attempts to get a bool attribute from the supplied python class, by name.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param py_class A rtloader_pyobject_t ** pointer to the class we wish to get the
+    attribute from.
+    \param attr_name A constant C-string with the name of the attribute to get.
+    \param value A bool * pointer C-bool output parameter with the attribute value.
+    \return An integer with the success of the operation. Zero for success, non-zero for failure.
+    \sa rtloader_pyobject_t, rtloader_t
+*/
+DATADOG_AGENT_RTLOADER_API int get_attr_bool(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *attr_name,
+                                             bool *value);
+
 /*! \fn int get_check(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *init_config, const char
    *instance, const char *check_id, const char *check_name, rtloader_pyobject_t **check) \brief Attempts to instantiate
    a datadog python check with the supplied configuration parameters. \param rtloader_t A rtloader_t * pointer to the

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -86,6 +86,15 @@ public:
     */
     virtual bool getAttrString(RtLoaderPyObject *obj, const char *attributeName, char *&value) const = 0;
 
+    //! Pure virtual getAttrBool member.
+    /*!
+      \param obj The python object we wish to get the string attribute by name from.
+      \param attributeName A C-string representation of the string attribute we wish to get by name.
+      \param value The output C-bool representation to the specified attribute, if we succeed.
+      \return A boolean indicating the success or not of the operation.
+    */
+    virtual bool getAttrBool(RtLoaderPyObject *obj, const char *attributeName, bool &value) const = 0;
+
     //! Pure virtual getCheck member.
     /*!
       \param py_class The python check class we wish to instantiate.

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -241,6 +241,11 @@ int get_attr_string(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const c
     return AS_TYPE(RtLoader, rtloader)->getAttrString(AS_TYPE(RtLoaderPyObject, py_class), attr_name, *value);
 }
 
+int get_attr_bool(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *attr_name, bool *value)
+{
+    return AS_TYPE(RtLoader, rtloader)->getAttrBool(AS_TYPE(RtLoaderPyObject, py_class), attr_name, *value);
+}
+
 int get_check(rtloader_t *rtloader, rtloader_pyobject_t *py_class, const char *init_config, const char *instance,
               const char *check_id, const char *check_name, rtloader_pyobject_t **check)
 {

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -352,7 +352,10 @@ func getFakeModuleWithBool() (bool, error) {
 	var value C.bool
 
 	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	state := C.ensure_gil(rtloader)
+	defer C.release_gil(rtloader, state)
 
 	// class
 	moduleStr := (*C.char)(helpers.TrackedCString("fake_check"))
@@ -371,9 +374,6 @@ func getFakeModuleWithBool() (bool, error) {
 	if ret != 1 {
 		return false, fmt.Errorf(C.GoString(C.get_error(rtloader)))
 	}
-
-	C.release_gil(rtloader, state)
-	runtime.UnlockOSThread()
 
 	return value == C.bool(true), nil
 }

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -345,3 +345,35 @@ func setModuleAttrString(module string, attr string, value string) {
 	C.release_gil(rtloader, state)
 	runtime.UnlockOSThread()
 }
+
+func getFakeModuleWithBool() (bool, error) {
+	var module *C.rtloader_pyobject_t
+	var class *C.rtloader_pyobject_t
+	var value C.bool
+
+	runtime.LockOSThread()
+	state := C.ensure_gil(rtloader)
+
+	// class
+	moduleStr := (*C.char)(helpers.TrackedCString("fake_check"))
+	defer C._free(unsafe.Pointer(moduleStr))
+
+	// attribute
+	attributeStr := (*C.char)(helpers.TrackedCString("foo"))
+	defer C._free(unsafe.Pointer(attributeStr))
+
+	ret := C.get_class(rtloader, moduleStr, &module, &class)
+	if ret != 1 || module == nil || class == nil {
+		return false, fmt.Errorf(C.GoString(C.get_error(rtloader)))
+	}
+
+	ret = C.get_attr_bool(rtloader, module, attributeStr, &value)
+	if ret != 1 {
+		return false, fmt.Errorf(C.GoString(C.get_error(rtloader)))
+	}
+
+	C.release_gil(rtloader, state)
+	runtime.UnlockOSThread()
+
+	return value == C.bool(true), nil
+}

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -288,13 +288,24 @@ fake_check.foo = False`,
 fake_check.foo = "bar"`,
 			success: false,
 			value:   false,
+		}, {
+			name: "Test with a None attribute",
+			code: `import fake_check
+fake_check.foo = None`,
+			success: false,
+			value:   false,
+		}, {
+			name:    "Test with a non-existing attribute",
+			code:    `import fake_check`,
+			success: false,
+			value:   false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := runString(tt.code); err != nil {
-				t.Fatalf("`TestGetAttrBool` error resetting was_canceled: %v", err)
+				t.Fatalf("`TestGetAttrBool` error running code for test case: %v", err)
 			}
 
 			res, err := getFakeModuleWithBool()

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -258,3 +258,57 @@ with open(r'%s', 'w') as f:
 	// Check for leaks
 	helpers.AssertMemoryUsage(t)
 }
+
+func TestGetAttrBool(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	tests := []struct {
+		name    string
+		code    string
+		success bool
+		value   bool
+	}{
+
+		{
+			name: "Test with a True attribute",
+			code: `import fake_check
+fake_check.foo = True`,
+			success: true,
+			value:   true,
+		}, {
+			name: "Test with a False attribute",
+			code: `import fake_check
+fake_check.foo = False`,
+			success: true,
+			value:   false,
+		}, {
+			name: "Test with a non-bool attribute",
+			code: `import fake_check
+fake_check.foo = "bar"`,
+			success: false,
+			value:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := runString(tt.code); err != nil {
+				t.Fatalf("`TestGetAttrBool` error resetting was_canceled: %v", err)
+			}
+
+			res, err := getFakeModuleWithBool()
+
+			if tt.success && err != nil {
+				t.Fatal(err)
+			}
+
+			if res != tt.value {
+				t.Fatalf("Expected %v, got %v", tt.value, res)
+			}
+		})
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -840,6 +840,34 @@ bool Three::getAttrString(RtLoaderPyObject *obj, const char *attributeName, char
     return res;
 }
 
+bool Three::getAttrBool(RtLoaderPyObject *obj, const char *attributeName, bool &value) const
+{
+    if (obj == NULL) {
+        return false;
+    }
+
+    bool res = false;
+    PyObject *py_attr = NULL;
+    PyObject *py_obj = reinterpret_cast<PyObject *>(obj);
+
+    py_attr = PyObject_GetAttrString(py_obj, attributeName);
+    if (py_attr != NULL) {
+        if (PyBool_Check(py_attr)) {
+            value = (py_attr == Py_True);
+            res = true;
+        } else {
+            setError("error attribute " + std::string(attributeName) + " has a different type than bool");
+            PyErr_Clear();
+        }
+    } else {
+        setError("error fetching attribute " + std::string(attributeName) + " does not exist");
+        PyErr_Clear();
+    }
+
+    Py_XDECREF(py_attr);
+    return res;
+}
+
 void Three::decref(RtLoaderPyObject *obj)
 {
     Py_XDECREF(reinterpret_cast<PyObject *>(obj));

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -57,6 +57,7 @@ public:
 
     bool getClass(const char *module, RtLoaderPyObject *&pyModule, RtLoaderPyObject *&pyClass);
     bool getAttrString(RtLoaderPyObject *obj, const char *attributeName, char *&value) const;
+    bool getAttrBool(RtLoaderPyObject *obj, const char *attributeName, bool &value) const;
     bool getCheck(RtLoaderPyObject *py_class, const char *init_config_str, const char *instance_str,
                   const char *check_id_str, const char *check_name, const char *agent_config_str,
                   RtLoaderPyObject *&check);


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a method `getAttrBool` in the rtloader, very similar to the existing `getAttrString` which allows to retrieve a bool attribute from a python class

### Motivation

This will be used in a following PR [draft for now](https://github.com/DataDog/datadog-agent/pull/34158) to get the `HA_SUPPORTED` python class attribute from datadog-agent code

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->