### PR TITLE
autoinstrumentation: enable injection based on language detection

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -779,7 +779,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.fallback_to_file_provider", false)                                // to be enabled only in e2e tests
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.patcher.file_provider_path", "/etc/datadog-agent/patch/auto-instru.json") // to be used only in e2e tests
-	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", false)                                   // allows injecting libraries for languages detected by automatic language detection feature
+	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.inject_auto_detected_libraries", true)                                    // allows injecting libraries for languages detected by automatic language detection feature
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.cpu")
 	config.BindEnv("admission_controller.auto_instrumentation.init_resources.memory")
 	config.BindEnv("admission_controller.auto_instrumentation.init_security_context")

--- a/releasenotes-dca/notes/autoinstrumentation-language-detection-baa4fc35d33c9de1.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-language-detection-baa4fc35d33c9de1.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    When there are no pinned library versions in the autoinstrumentation webhook,
+    use detected languages to omit unnecessary libraries.


### PR DESCRIPTION
### What does this PR do?

This PR enables auto-instrumentation based on languages detected by default.

### Motivation

Following up on:
- #33484 
- #33936 

This is a piece of the rollout for kubernetes auto-instrumentation that will help ease the cost of startup time based on not using language-libraries that are not necessary.

### Describe how you validated your changes


### Possible Drawbacks / Trade-offs

### Additional Notes

Relevant investigation here: https://app.datadoghq.com/notebook/11338387/langauge-detection-investigation?notebookType=rte&range=2678400000&start=1737300263615&live=true