### PR TITLE
Replace default options for e2e provisioners where unneeded

### DIFF
--- a/test/new-e2e/tests/agent-configuration/config-refresh/api_key_refresh_test.go
+++ b/test/new-e2e/tests/agent-configuration/config-refresh/api_key_refresh_test.go
@@ -16,7 +16,6 @@ import (
 	secrets "github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-configuration/secretsutils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,9 +27,7 @@ type linuxAPIKeyRefreshSuite struct {
 
 func TestLinuxAPIKeyFreshSuite(t *testing.T) {
 	suite := &linuxAPIKeyRefreshSuite{descriptor: os.UbuntuDefault}
-	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)),
-	)))
+	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner()))
 }
 
 func (v *linuxAPIKeyRefreshSuite) TestIntakeRefreshAPIKey() {

--- a/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_nix_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -22,7 +21,5 @@ type linuxHealthSuite struct {
 func TestLinuxHealthSuite(t *testing.T) {
 	t.Parallel()
 	suite := &linuxHealthSuite{baseHealthSuite{descriptor: os.UbuntuDefault}}
-	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)),
-	)))
+	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner()))
 }

--- a/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/health/health_win_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/test-infra-definitions/components/os"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/ec2"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -22,7 +21,5 @@ type windowsHealthSuite struct {
 func TestWindowsHealthSuite(t *testing.T) {
 	t.Parallel()
 	suite := &windowsHealthSuite{baseHealthSuite{descriptor: os.WindowsDefault}}
-	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner(
-		awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)),
-	)))
+	e2e.Run(t, suite, e2e.WithProvisioner(awshost.Provisioner()))
 }


### PR DESCRIPTION
### What does this PR do?

Replace `awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(suite.descriptor)))` with just `awshost.Provisioner()` as that's just the default value.

### Motivation

Simplify setup of e2e tests.

### Describe how you validated your changes

Changes are test only.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->