### PR TITLE
[OTAGENT-301] add fuzzy version match for ocb version check

### DIFF
--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -101,7 +101,7 @@ def versions_equal(version1, version2, fuzzy=False):
     idx = version1.find("/")
     if idx != -1:
         # version may be in the format of "v1.xx.0/v0.yyy.0"
-        version1 = version1[idx + 1:]
+        version1 = version1[idx + 1 :]
     # strip leading 'v' if present
     if version1.startswith("v"):
         version1 = version1[1:]

--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -140,10 +140,13 @@ def validate_manifest(manifest) -> list:
         if components:
             for component in components:
                 for module in component.values():
-                    if module.find(OCB_VERSION) == -1:
-                        raise YAMLValidationError(
-                            f"Component {module}) in manifest does not match required OCB version ({OCB_VERSION})"
-                        )
+                    module_info = module.split(" ")
+                    if len(module_info) == 2:
+                        _, module_version = module_info
+                        if not versions_equal(module_version, OCB_VERSION, True):
+                            raise YAMLValidationError(
+                                f"Component {module}) in manifest does not match required OCB version ({OCB_VERSION})"
+                            )
 
     # validate mandatory components are present
     missing_components = find_matching_components(manifest, MANDATORY_COMPONENTS, False)

--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -97,11 +97,11 @@ def find_matching_components(manifest, components_to_match: dict, present: bool)
     return res
 
 
-def versions_equal(version1, version2):
+def versions_equal(version1, version2, fuzzy=False):
     idx = version1.find("/")
     if idx != -1:
         # version may be in the format of "v1.xx.0/v0.yyy.0"
-        version1 = version1[idx + 1 :]
+        version1 = version1[idx + 1:]
     # strip leading 'v' if present
     if version1.startswith("v"):
         version1 = version1[1:]
@@ -110,8 +110,16 @@ def versions_equal(version1, version2):
     # Split the version strings by '.'
     parts1 = version1.split(".")
     parts2 = version2.split(".")
+
     # Compare the first two parts (major and minor versions)
-    return parts1[0] == parts2[0] and parts1[1] == parts2[1]
+    major_minor_match = parts1[0] == parts2[0] and parts1[1] == parts2[1]
+
+    if fuzzy:
+        # If fuzzy matching is enabled, check if major and minor match
+        return major_minor_match
+    else:
+        # Otherwise, check all parts for exact match
+        return major_minor_match and parts1 == parts2
 
 
 def validate_manifest(manifest) -> list:
@@ -120,7 +128,7 @@ def validate_manifest(manifest) -> list:
 
     # validate collector version matches ocb version
     manifest_version = manifest.get("dist", {}).get("otelcol_version")
-    if manifest_version and not versions_equal(manifest_version, OCB_VERSION):
+    if manifest_version and not versions_equal(manifest_version, OCB_VERSION, True):
         raise YAMLValidationError(
             f"Collector version ({manifest_version}) in manifest does not match required OCB version ({OCB_VERSION})"
         )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Allow patch version to differ as long as major and minor match (if `fuzzy=True`) in collector.generate invoke task
### Motivation
https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder#strict-versioning-checks

### Describe how you validated your changes
run locally
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
if OCB changes matching criteria, we will need to update.
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->