### PR TITLE
[EBPF] gpu: add probes for cudaEventQuery

### DIFF
--- a/pkg/gpu/compile.go
+++ b/pkg/gpu/compile.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
-//go:generate $GOPATH/bin/include_headers pkg/gpu/ebpf/c/runtime/gpu.c pkg/ebpf/bytecode/build/runtime/gpu.c pkg/ebpf/c pkg/gpu/ebpf/c/runtime pkg/gpu/ebpf/c
+//go:generate $GOPATH/bin/include_headers pkg/gpu/ebpf/c/runtime/gpu.c pkg/ebpf/bytecode/build/runtime/gpu.c pkg/ebpf/c pkg/gpu/ebpf/c/runtime pkg/gpu/ebpf/c pkg/network/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/gpu.c pkg/ebpf/bytecode/runtime/gpu.go runtime
 
 func getRuntimeCompiledGPUMonitoring(config *config.Config) (runtime.CompiledOutput, error) {

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -295,6 +295,8 @@ int BPF_UPROBE(uprobe__cudaEventDestroy, __u64 event) {
     key.pid = pid_tgid >> 32;
 
     log_debug("cudaEventDestroy: pid_tgid=%llu, event=%llu", pid_tgid, event);
+
+    // If this deletion doesn't get triggered, the map cleaner will clean these entries up
     bpf_map_delete_elem(&cuda_event_to_stream, &key);
 
     return 0;

--- a/pkg/gpu/ebpf/c/types.h
+++ b/pkg/gpu/ebpf/c/types.h
@@ -64,4 +64,9 @@ typedef struct {
     __u32 pid;
 } cuda_event_key_t;
 
+typedef struct {
+    __u64 stream;
+    __u64 last_access_ktime_ns;
+} cuda_event_value_t;
+
 #endif

--- a/pkg/gpu/ebpf/c/types.h
+++ b/pkg/gpu/ebpf/c/types.h
@@ -59,4 +59,9 @@ typedef struct {
     int device;
 } cuda_set_device_event_t;
 
+typedef struct {
+    __u64 event;
+    __u32 pid;
+} cuda_event_key_t;
+
 #endif

--- a/pkg/gpu/ebpf/kprobe_types.go
+++ b/pkg/gpu/ebpf/kprobe_types.go
@@ -27,6 +27,9 @@ type CudaMemEventType C.cuda_memory_event_type_t
 
 type CudaSetDeviceEvent C.cuda_set_device_event_t
 
+type CudaEventKey C.cuda_event_key_t
+type CudaEventValue C.cuda_event_value_t
+
 const CudaEventTypeKernelLaunch CudaEventType = C.cuda_kernel_launch
 const CudaEventTypeMemory CudaEventType = C.cuda_memory_event
 const CudaEventTypeSync CudaEventType = C.cuda_sync

--- a/pkg/gpu/ebpf/kprobe_types_linux.go
+++ b/pkg/gpu/ebpf/kprobe_types_linux.go
@@ -46,6 +46,16 @@ type CudaSetDeviceEvent struct {
 	Pad_cgo_0 [4]byte
 }
 
+type CudaEventKey struct {
+	Event     uint64
+	Pid       uint32
+	Pad_cgo_0 [4]byte
+}
+type CudaEventValue struct {
+	Stream          uint64
+	Access_ktime_ns uint64
+}
+
 const CudaEventTypeKernelLaunch CudaEventType = 0x0
 const CudaEventTypeMemory CudaEventType = 0x1
 const CudaEventTypeSync CudaEventType = 0x2

--- a/pkg/gpu/ebpf/kprobe_types_linux_test.go
+++ b/pkg/gpu/ebpf/kprobe_types_linux_test.go
@@ -31,3 +31,11 @@ func TestCgoAlignment_CudaMemEvent(t *testing.T) {
 func TestCgoAlignment_CudaSetDeviceEvent(t *testing.T) {
 	ebpftest.TestCgoAlignment[CudaSetDeviceEvent](t)
 }
+
+func TestCgoAlignment_CudaEventKey(t *testing.T) {
+	ebpftest.TestCgoAlignment[CudaEventKey](t)
+}
+
+func TestCgoAlignment_CudaEventValue(t *testing.T) {
+	ebpftest.TestCgoAlignment[CudaEventValue](t)
+}

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -57,6 +57,8 @@ const (
 	cudaAllocCacheMap     bpfMapName = "cuda_alloc_cache"
 	cudaSyncCacheMap      bpfMapName = "cuda_sync_cache"
 	cudaSetDeviceCacheMap bpfMapName = "cuda_set_device_cache"
+	cudaEventStreamMap    bpfMapName = "cuda_event_to_stream"
+	cudaEventCacheMap     bpfMapName = "cuda_event_cache"
 )
 
 // probeFuncName stores the ebpf hook function name
@@ -71,6 +73,9 @@ const (
 	cudaFreeProbe          probeFuncName = "uprobe__cudaFree"
 	cudaSetDeviceProbe     probeFuncName = "uprobe__cudaSetDevice"
 	cudaSetDeviceRetProbe  probeFuncName = "uretprobe__cudaSetDevice"
+	cudaEventRecordProbe   probeFuncName = "uprobe__cudaEventRecord"
+	cudaEventQueryProbe    probeFuncName = "uprobe__cudaEventQuery"
+	cudaEventQueryRetProbe probeFuncName = "uretprobe__cudaEventQuery"
 )
 
 // ProbeDependencies holds the dependencies for the probe
@@ -263,6 +268,8 @@ func (p *Probe) setupManager(buf io.ReaderAt, opts manager.Options) error {
 			{Name: cudaAllocCacheMap},
 			{Name: cudaSyncCacheMap},
 			{Name: cudaSetDeviceCacheMap},
+			{Name: cudaEventStreamMap},
+			{Name: cudaEventCacheMap},
 		}}, "gpu", &ebpftelemetry.ErrorsTelemetryModifier{})
 
 	if opts.MapSpecEditors == nil {
@@ -331,6 +338,9 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaFreeProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaSetDeviceRetProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventRecordProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryRetProbe}},
 						},
 					},
 				},

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -370,6 +370,7 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 		SharedLibsLibset:               sharedlibraries.LibsetGPU,
 		ScanProcessesInterval:          cfg.ScanProcessesInterval,
 		EnablePeriodicScanNewProcesses: true,
+		EnableDetailedLogging:          true,
 	}
 }
 

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -64,7 +64,6 @@ const (
 	cudaSyncCacheMap       bpfMapName = "cuda_sync_cache"
 	cudaSetDeviceCacheMap  bpfMapName = "cuda_set_device_cache"
 	cudaEventStreamMap     bpfMapName = "cuda_event_to_stream"
-	cudaEventSyncCacheMap  bpfMapName = "cuda_event_sync_cache"
 	cudaEventQueryCacheMap bpfMapName = "cuda_event_query_cache"
 )
 
@@ -280,7 +279,6 @@ func (p *Probe) setupManager(buf io.ReaderAt, opts manager.Options) error {
 			{Name: cudaSyncCacheMap},
 			{Name: cudaSetDeviceCacheMap},
 			{Name: cudaEventStreamMap},
-			{Name: cudaEventSyncCacheMap},
 			{Name: cudaEventQueryCacheMap},
 		}}, "gpu", &ebpftelemetry.ErrorsTelemetryModifier{})
 

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -59,30 +59,33 @@ var (
 type bpfMapName = string
 
 const (
-	cudaEventsRingbuf     bpfMapName = "cuda_events"
-	cudaAllocCacheMap     bpfMapName = "cuda_alloc_cache"
-	cudaSyncCacheMap      bpfMapName = "cuda_sync_cache"
-	cudaSetDeviceCacheMap bpfMapName = "cuda_set_device_cache"
-	cudaEventStreamMap    bpfMapName = "cuda_event_to_stream"
-	cudaEventCacheMap     bpfMapName = "cuda_event_cache"
+	cudaEventsRingbuf      bpfMapName = "cuda_events"
+	cudaAllocCacheMap      bpfMapName = "cuda_alloc_cache"
+	cudaSyncCacheMap       bpfMapName = "cuda_sync_cache"
+	cudaSetDeviceCacheMap  bpfMapName = "cuda_set_device_cache"
+	cudaEventStreamMap     bpfMapName = "cuda_event_to_stream"
+	cudaEventSyncCacheMap  bpfMapName = "cuda_event_sync_cache"
+	cudaEventQueryCacheMap bpfMapName = "cuda_event_query_cache"
 )
 
 // probeFuncName stores the ebpf hook function name
 type probeFuncName = string
 
 const (
-	cudaLaunchKernelProbe  probeFuncName = "uprobe__cudaLaunchKernel"
-	cudaMallocProbe        probeFuncName = "uprobe__cudaMalloc"
-	cudaMallocRetProbe     probeFuncName = "uretprobe__cudaMalloc"
-	cudaStreamSyncProbe    probeFuncName = "uprobe__cudaStreamSynchronize"
-	cudaStreamSyncRetProbe probeFuncName = "uretprobe__cudaStreamSynchronize"
-	cudaFreeProbe          probeFuncName = "uprobe__cudaFree"
-	cudaSetDeviceProbe     probeFuncName = "uprobe__cudaSetDevice"
-	cudaSetDeviceRetProbe  probeFuncName = "uretprobe__cudaSetDevice"
-	cudaEventRecordProbe   probeFuncName = "uprobe__cudaEventRecord"
-	cudaEventQueryProbe    probeFuncName = "uprobe__cudaEventQuery"
-	cudaEventQueryRetProbe probeFuncName = "uretprobe__cudaEventQuery"
-	cudaEventDestroyProbe  probeFuncName = "uprobe__cudaEventDestroy"
+	cudaLaunchKernelProbe        probeFuncName = "uprobe__cudaLaunchKernel"
+	cudaMallocProbe              probeFuncName = "uprobe__cudaMalloc"
+	cudaMallocRetProbe           probeFuncName = "uretprobe__cudaMalloc"
+	cudaStreamSyncProbe          probeFuncName = "uprobe__cudaStreamSynchronize"
+	cudaStreamSyncRetProbe       probeFuncName = "uretprobe__cudaStreamSynchronize"
+	cudaFreeProbe                probeFuncName = "uprobe__cudaFree"
+	cudaSetDeviceProbe           probeFuncName = "uprobe__cudaSetDevice"
+	cudaSetDeviceRetProbe        probeFuncName = "uretprobe__cudaSetDevice"
+	cudaEventRecordProbe         probeFuncName = "uprobe__cudaEventRecord"
+	cudaEventQueryProbe          probeFuncName = "uprobe__cudaEventQuery"
+	cudaEventQueryRetProbe       probeFuncName = "uretprobe__cudaEventQuery"
+	cudaEventSynchronizeProbe    probeFuncName = "uprobe__cudaEventSynchronize"
+	cudaEventSynchronizeRetProbe probeFuncName = "uretprobe__cudaEventSynchronize"
+	cudaEventDestroyProbe        probeFuncName = "uprobe__cudaEventDestroy"
 )
 
 // ProbeDependencies holds the dependencies for the probe
@@ -277,7 +280,8 @@ func (p *Probe) setupManager(buf io.ReaderAt, opts manager.Options) error {
 			{Name: cudaSyncCacheMap},
 			{Name: cudaSetDeviceCacheMap},
 			{Name: cudaEventStreamMap},
-			{Name: cudaEventCacheMap},
+			{Name: cudaEventSyncCacheMap},
+			{Name: cudaEventQueryCacheMap},
 		}}, "gpu", &ebpftelemetry.ErrorsTelemetryModifier{})
 
 	if opts.MapSpecEditors == nil {
@@ -353,6 +357,8 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventRecordProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryRetProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeRetProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventDestroyProbe}},
 						},
 					},

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -76,6 +76,7 @@ const (
 	cudaEventRecordProbe   probeFuncName = "uprobe__cudaEventRecord"
 	cudaEventQueryProbe    probeFuncName = "uprobe__cudaEventQuery"
 	cudaEventQueryRetProbe probeFuncName = "uretprobe__cudaEventQuery"
+	cudaEventDestroyProbe  probeFuncName = "uprobe__cudaEventDestroy"
 )
 
 // ProbeDependencies holds the dependencies for the probe
@@ -341,6 +342,7 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventRecordProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventQueryRetProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventDestroyProbe}},
 						},
 					},
 				},

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -15,10 +15,12 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/maps"
 
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
 	consumerstestutil "github.com/DataDog/datadog-agent/pkg/eventmonitor/consumers/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
+	"github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 
@@ -76,6 +78,7 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 
 	var handlerStream, handlerGlobal *StreamHandler
 	require.Eventually(t, func() bool {
+		handlerStream, handlerGlobal = nil, nil // Ensure we see both handlers in the same iteration
 		for key, h := range probe.consumer.streamHandlers {
 			if key.pid == uint32(cmd.Process.Pid) {
 				if key.stream == 0 {
@@ -86,8 +89,36 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 			}
 		}
 
-		return handlerStream != nil && handlerGlobal != nil && len(handlerStream.kernelSpans) > 0 && len(handlerGlobal.allocations) > 0
+		return len(probe.consumer.streamHandlers) == 2 && handlerStream != nil && handlerGlobal != nil && len(handlerStream.kernelSpans) > 0 && len(handlerGlobal.allocations) > 0
 	}, 3*time.Second, 100*time.Millisecond, "stream and global handlers not found: existing is %v", probe.consumer.streamHandlers)
+
+	// Check that we're receiving the events we expect
+	telemetryMock, ok := probe.deps.Telemetry.(telemetry.Mock)
+	require.True(t, ok)
+
+	eventMetrics, err := telemetryMock.GetCountMetric("gpu__consumer", "events")
+	require.NoError(t, err)
+
+	actualEvents := make(map[string]int)
+	for _, m := range eventMetrics {
+		if evType, ok := m.Tags()["event_type"]; ok {
+			actualEvents[evType] = int(m.Value())
+		}
+	}
+
+	expectedEvents := map[string]int{
+		ebpf.CudaEventTypeKernelLaunch.String(): 1,
+		ebpf.CudaEventTypeSetDevice.String():    1,
+		ebpf.CudaEventTypeMemory.String():       2,
+		ebpf.CudaEventTypeSync.String():         2, // One from cudaStreamSynchronize and another from cudaEventQuery
+	}
+
+	for evName, value := range expectedEvents {
+		require.Equal(t, value, actualEvents[evName], "event %s count mismatch", evName)
+		delete(actualEvents, evName)
+	}
+
+	require.Empty(t, actualEvents, "unexpected events: %v", actualEvents)
 
 	// Check device assignments
 	require.Contains(t, probe.consumer.sysCtx.selectedDeviceByPIDAndTID, cmd.Process.Pid)

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -110,7 +110,7 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 		ebpf.CudaEventTypeKernelLaunch.String(): 1,
 		ebpf.CudaEventTypeSetDevice.String():    1,
 		ebpf.CudaEventTypeMemory.String():       2,
-		ebpf.CudaEventTypeSync.String():         2, // One from cudaStreamSynchronize and another from cudaEventQuery
+		ebpf.CudaEventTypeSync.String():         3, // cudaStreamSynchronize, cudaEventQuery and cudaEventSynchronize
 	}
 
 	for evName, value := range expectedEvents {

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -45,6 +45,10 @@ cudaError_t cudaEventQuery(cudaEvent_t event) {
     return 0;
 }
 
+cudaError_t cudaEventSynchronize(cudaEvent_t event) {
+    return 0;
+}
+
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
     cudaEvent_t event = 42;
@@ -75,6 +79,7 @@ int main(int argc, char **argv) {
 
     cudaEventRecord(event, stream);
     cudaEventQuery(event);
+    cudaEventSynchronize(event);
 
     // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -14,6 +14,7 @@ typedef struct {
 
 typedef int cudaError_t;
 typedef uint64_t cudaStream_t;
+typedef uint64_t cudaEvent_t;
 
 cudaError_t cudaLaunchKernel(const void *func, dim3 gridDim, dim3 blockDim, void **args, size_t sharedMem, cudaStream_t stream) {
     return 0;
@@ -36,8 +37,17 @@ cudaError_t cudaSetDevice(int device) {
     return 0;
 }
 
+cudaError_t cudaEventRecord(cudaEvent_t event, cudaStream_t stream) {
+    return 0;
+}
+
+cudaError_t cudaEventQuery(cudaEvent_t event) {
+    return 0;
+}
+
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
+    cudaEvent_t event = 42;
 
     if (argc != 3) {
         fprintf(stderr, "Usage: %s <wait-to-start-sec> <device-index>\n", argv[0]);
@@ -63,12 +73,15 @@ int main(int argc, char **argv) {
     cudaFree(ptr);
     cudaStreamSynchronize(stream);
 
+    cudaEventRecord(event, stream);
+    cudaEventQuery(event);
+
     // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)
 
     //this line is used as a market by patternScanner to indicate the end of the program
     fprintf(stderr, "CUDA calls made.\n");
-    pause();  // Wait for signal to finish the process
+    pause(); // Wait for signal to finish the process
 
     return 0;
 }

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -49,6 +49,10 @@ cudaError_t cudaEventSynchronize(cudaEvent_t event) {
     return 0;
 }
 
+cudaError_t cudaEventDestroy(cudaEvent_t event) {
+    return 0;
+}
+
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
     cudaEvent_t event = 42;
@@ -80,6 +84,8 @@ int main(int argc, char **argv) {
     cudaEventRecord(event, stream);
     cudaEventQuery(event);
     cudaEventSynchronize(event);
+
+    cudaEventDestroy(event);
 
     // we don't exit to avoid flakiness when the process is terminated before it was hooked for gpu monitoring
     // the expected usage is to send a kill signal to the process (or stop the container that is running it)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -356,7 +356,7 @@ def ninja_test_ebpf_programs(nw: NinjaWriter, build_dir):
 def ninja_gpu_ebpf_programs(nw: NinjaWriter, co_re_build_dir: Path | str):
     gpu_headers_dir = Path("pkg/gpu/ebpf/c")
     gpu_c_dir = gpu_headers_dir / "runtime"
-    gpu_flags = f"-I{gpu_headers_dir} -I{gpu_c_dir}"
+    gpu_flags = f"-I{gpu_headers_dir} -I{gpu_c_dir} -Ipkg/network/ebpf/c"
     gpu_programs = ["gpu"]
 
     for prog in gpu_programs:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds extra probes for `cudaEventQuery`. Because the event itself doesn't have the stream ID attached, we need to also probe `cudaEventRecord` to ensure we can retrieve the stream ID when we see the corresponding `cudaEventQuery` call.

There are two extra maps being added, both of them LRU maps to avoid requiring cleanups as we are not tracking `cudaEventDestroy` calls for simplicity.

### Motivation

A temporary way to ensure we don't miss synchronization events done via the CUDA events system.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests included, will also validate on `venomoth` where we saw this issue.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
