### PR TITLE
[OTAGENT-306] support new otel env convention in workload meta

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -62,9 +62,10 @@ var (
 	}
 
 	otelResourceAttributesMapping = map[string]string{
-		"service.name":           tags.Service,
-		"service.version":        tags.Version,
-		"deployment.environment": tags.Env,
+		"service.name":                tags.Service,
+		"service.version":             tags.Version,
+		"deployment.environment":      tags.Env,
+		"deployment.environment.name": tags.Env,
 	}
 
 	lowCardOrchestratorEnvKeys = map[string]string{

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -1743,6 +1743,42 @@ func TestHandleContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "OTel new env convention",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+				EnvVars: map[string]string{
+					// env as tags
+					"TEAM": "container-integrations",
+					"TIER": "node",
+
+					// otel standard tags
+					"OTEL_SERVICE_NAME":        svc,
+					"OTEL_RESOURCE_ATTRIBUTES": fmt.Sprintf("service.name=%s,service.version=%s,deployment.environment.name=%s", svc, version, env),
+				},
+			},
+			envAsTags: map[string]string{
+				"team": "owner_team",
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:   containerSource,
+					EntityID: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: append([]string{
+						"owner_team:container-integrations",
+					}, standardTags...),
+					StandardTags: standardTags,
+				},
+			},
+		},
+		{
 			name: "tags from environment with opentelemetry sdk with whitespace",
 			container: workloadmeta.Container{
 				EntityID: entityID,


### PR DESCRIPTION
### What does this PR do?
Support new otel env convention `deployment.environment.name` in workload meta

### Motivation
`deployment.environment.name` is now the preferred convention for env in OTel. `deployment.environment` is deprecated.

### Describe how you validated your changes
new unit tests