### PR TITLE
fix(ssi): set configs before injection

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -184,6 +184,12 @@ func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interfac
 		}
 	}
 
+	// Inject the tracer configs. We do this before lib injection to ensure DD_SERVICE is set if the user configures it
+	// in the target.
+	for _, envVar := range target.envVars {
+		mutatecommon.InjectEnv(pod, envVar)
+	}
+
 	// Inject the libraries.
 	err := m.core.injectTracers(pod, extracted)
 	if err != nil {
@@ -195,11 +201,6 @@ func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interfac
 		Name:  AppliedTargetEnvVar,
 		Value: target.json,
 	})
-
-	// Inject the tracer configs.
-	for _, envVar := range target.envVars {
-		mutatecommon.InjectEnv(pod, envVar)
-	}
 
 	// Add the annotations to the pod.
 	mutatecommon.AddAnnotation(pod, AppliedTargetAnnotation, target.json)

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -22,7 +22,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -147,7 +146,7 @@ func TestMutatePod(t *testing.T) {
 		},
 		"service name is applied when set in tracer configs": {
 			configPath: "testdata/filter_simple_service.yaml",
-			in: common.FakePodSpec{
+			in: mutatecommon.FakePodSpec{
 				Labels:     map[string]string{"language": "python"},
 				NS:         "application",
 				ParentKind: "replicaset",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -157,7 +157,7 @@ func TestMutatePod(t *testing.T) {
 			},
 			expectedInitContainerImages: []string{
 				"registry/apm-inject:0",
-				"registry/dd-lib-python-init:v2",
+				defaultLibInfo(python).image,
 			},
 			expectedEnv: map[string]string{
 				"DD_SERVICE": "best-service",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_service.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_service.yaml
@@ -1,0 +1,14 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "Python Apps"
+        podSelector:
+          matchLabels:
+            language: "python"
+        ddTraceVersions:
+          python: "v2"
+        ddTraceConfigs:
+          - name: "DD_SERVICE"
+            value: "best-service"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit resolves an issue where we set the service name to the deployment name in the injector by moving the tracer configs up in the list of mutations.

### Motivation
These are the final things @stanistan and I noticed when testing and discussing the final steps for workload selection.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The additional unit tests. 

### DD_SERVICE
I used `injector-dev` to spin up a deployment named `python-app`. I set the following `ddTraceConfigs`:
```
            ddTraceConfigs:
              - name: "DD_SERVICE"
                value: "best-service"
```

I ensured the service was actually named `best-service` in my sandbox:
<img width="1073" alt="Screenshot 2025-02-19 at 4 32 36 PM" src="https://github.com/user-attachments/assets/006456d0-f999-44e1-846a-8f7589248921" />


### Possible Drawbacks / Trade-offs
If the customer doesn't select tracer versions for a target, we will use language detection if we have it available. This could be confusing, but we feel like it's more desirable then getting all tracers we ever configure.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
[INPLAT-491](https://datadoghq.atlassian.net/browse/INPLAT-491)

[INPLAT-491]: https://datadoghq.atlassian.net/browse/INPLAT-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ