### PR TITLE
[CWS] Improve variables output in security-agent status

### DIFF
--- a/pkg/security/agent/status_provider.go
+++ b/pkg/security/agent/status_provider.go
@@ -9,8 +9,10 @@ package agent
 import (
 	"embed"
 	"io"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/core/status"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 )
 
 //go:embed status_templates
@@ -73,7 +75,34 @@ func (s statusProvider) populateStatus(stats map[string]interface{}) {
 				base["selfTests"] = selfTests
 			}
 			base["policiesStatus"] = cfStatus.PoliciesStatus
-			base["seclVariables"] = cfStatus.SECLVariables
+
+			var globals []*api.SECLVariableState
+			for _, global := range cfStatus.SECLVariables {
+				if !strings.Contains(global.Name, ".") {
+					globals = append(globals, global)
+				}
+			}
+			base["seclGlobalVariables"] = globals
+
+			scopedVariables := make(map[string]map[string][]*api.SECLVariableState)
+			for _, scoped := range cfStatus.SECLVariables {
+				split := strings.SplitN(scoped.Name, ".", 3)
+				if len(split) < 3 {
+					continue
+				}
+				scope, name, key := split[0], split[1], split[2]
+				if scope != "" {
+					if _, found := scopedVariables[scope]; !found {
+						scopedVariables[scope] = make(map[string][]*api.SECLVariableState)
+					}
+
+					scopedVariables[scope][key] = append(scopedVariables[scope][key], &api.SECLVariableState{
+						Name:  name,
+						Value: scoped.Value,
+					})
+				}
+			}
+			base["seclScopedVariables"] = scopedVariables
 		}
 	}
 

--- a/pkg/security/agent/status_templates/runtimesecurity.tmpl
+++ b/pkg/security/agent/status_templates/runtimesecurity.tmpl
@@ -45,14 +45,29 @@
 
   SECL Variables
   ==============
-  
-  {{ range $variable := .seclVariables }}
+
+  Global variables:
+  {{ range $variable := .seclGlobalVariables }}
     - {{ $variable.Name }}: {{ $variable.Value }}
-  {{ end }}
-  {{if not .seclVariables}}
-    No SECL variables found
-  {{end}}
-  
+  {{- end }}
+  {{- if not .seclGlobalVariables }}
+      No variable found
+  {{- end }}
+
+  Scoped variables:
+  {{ range $scope, $vars := .seclScopedVariables }}
+    {{ $scope }}:
+    {{ range $key, $variables := $vars }}
+      {{ $key }}:
+      {{- range $variable := $variables }}
+        - {{ $variable.Name }}: {{ $variable.Value }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if not .seclScopedVariables }}
+      No variable found
+  {{- end }}
+
   {{- with .environment }}
 
   Environment

--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -192,7 +192,11 @@ func (a *APIServer) GetStatus(_ context.Context, _ *api.GetStatusParams) (*api.S
 		apiStatus.SelfTests = a.selfTester.GetStatus()
 	}
 	apiStatus.PoliciesStatus = a.policiesStatus
-	apiStatus.SECLVariables = a.GetSECLVariables()
+
+	seclVariables := a.GetSECLVariables()
+	for _, seclVariable := range seclVariables {
+		apiStatus.SECLVariables = append(apiStatus.SECLVariables, seclVariable)
+	}
 
 	p, ok := a.probe.PlatformProbe.(*probe.EBPFProbe)
 	if ok {

--- a/pkg/security/module/server_windows.go
+++ b/pkg/security/module/server_windows.go
@@ -54,7 +54,12 @@ func (a *APIServer) GetStatus(_ context.Context, _ *api.GetStatusParams) (*api.S
 	}
 
 	apiStatus.PoliciesStatus = a.policiesStatus
-	apiStatus.SECLVariables = a.GetSECLVariables()
+
+	seclVariables := a.GetSECLVariables()
+	for _, seclVariable := range seclVariables {
+		apiStatus.SECLVariables = append(apiStatus.SECLVariables, seclVariable)
+	}
+
 	return apiStatus, nil
 }
 

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/events"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/rconfig"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/autosuppression"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/bundled"
@@ -72,6 +74,7 @@ type RuleEngine struct {
 type APIServer interface {
 	ApplyRuleIDs([]rules.RuleID)
 	ApplyPolicyStates([]*monitor.PolicyState)
+	GetSECLVariables() map[string]*api.SECLVariableState
 }
 
 // NewRuleEngine returns a new rule engine
@@ -372,6 +375,54 @@ func (e *RuleEngine) LoadPolicies(providers []rules.PolicyProvider, sendLoadedRe
 func (e *RuleEngine) notifyAPIServer(ruleIDs []rules.RuleID, policies []*monitor.PolicyState) {
 	e.apiServer.ApplyRuleIDs(ruleIDs)
 	e.apiServer.ApplyPolicyStates(policies)
+}
+
+// GetSECLVariables returns the set of SECL variables along with theirs values
+func (e *RuleEngine) GetSECLVariables() map[string]*api.SECLVariableState {
+	rs := e.currentRuleSet.Load().(*rules.RuleSet)
+	var seclVariables = make(map[string]*api.SECLVariableState)
+	for name, value := range rs.GetVariables() {
+		if strings.HasPrefix(name, "process.") {
+			scopedVariable := value.(eval.ScopedVariable)
+			if !scopedVariable.IsMutable() {
+				continue
+			}
+
+			e.probe.Walk(func(entry *model.ProcessCacheEntry) {
+				entry.Retain()
+				defer entry.Release()
+
+				event := e.probe.PlatformProbe.NewEvent()
+				event.ProcessCacheEntry = entry
+				ctx := eval.NewContext(event)
+				scopedName := fmt.Sprintf("%s.%d", name, entry.Pid)
+				value, found := scopedVariable.GetValue(ctx)
+				if !found {
+					return
+				}
+
+				scopedValue := fmt.Sprintf("%v", value)
+				seclVariables[scopedName] = &api.SECLVariableState{
+					Name:  scopedName,
+					Value: scopedValue,
+				}
+			})
+		} else if strings.HasPrefix(name, "container.") {
+			continue // skip container variables for now
+		} else { // global variables
+			value, found := value.(eval.Variable).GetValue()
+			if !found {
+				continue
+			}
+
+			scopedValue := fmt.Sprintf("%v", value)
+			seclVariables[name] = &api.SECLVariableState{
+				Name:  name,
+				Value: scopedValue,
+			}
+		}
+	}
+	return seclVariables
 }
 
 func (e *RuleEngine) gatherDefaultPolicyProviders() []rules.PolicyProvider {

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -27,11 +27,11 @@ func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]
 	}
 
 	variables := map[string]SECLVariable{
-		"pid": NewScopedIntVariable(func(_ *Context) int {
-			return os.Getpid()
+		"pid": NewScopedIntVariable(func(_ *Context) (int, bool) {
+			return os.Getpid(), true
 		}, nil),
-		"str": NewScopedStringVariable(func(_ *Context) string {
-			return "aaa"
+		"str": NewScopedStringVariable(func(_ *Context) (string, bool) {
+			return "aaa", true
 		}, nil),
 	}
 
@@ -481,8 +481,8 @@ func TestPartial(t *testing.T) {
 
 	variables := make(map[string]SECLVariable)
 	variables["var"] = NewScopedBoolVariable(
-		func(_ *Context) bool {
-			return false
+		func(_ *Context) (bool, bool) {
+			return false, true
 		},
 		func(_ *Context, _ interface{}) error {
 			return nil

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -30,12 +30,13 @@ type SECLVariable interface {
 
 // Variable is the interface implemented by variables
 type Variable interface {
-	GetValue() interface{}
+	GetValue() (interface{}, bool)
 }
 
 // ScopedVariable is the interface implemented by scoped variables
 type ScopedVariable interface {
-	GetValue(ctx *Context) interface{}
+	GetValue(ctx *Context) (interface{}, bool)
+	IsMutable() bool
 }
 
 // MutableVariable is the interface by variables whose value can be changed
@@ -63,28 +64,34 @@ func (v *settableVariable) Append(_ *Context, _ interface{}) error {
 	return errAppendNotSupported
 }
 
+// IsMutable returns whether the variable is settable
+func (v *settableVariable) IsMutable() bool {
+	return v.setFnc != nil
+}
+
 // ScopedIntVariable describes a scoped integer variable
 type ScopedIntVariable struct {
 	settableVariable
-	intFnc func(ctx *Context) int
+	intFnc func(ctx *Context) (int, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (i *ScopedIntVariable) GetEvaluator() interface{} {
 	return &IntEvaluator{
 		EvalFnc: func(ctx *Context) int {
-			return i.intFnc(ctx)
+			i, _ := i.intFnc(ctx)
+			return i
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (i *ScopedIntVariable) GetValue(ctx *Context) interface{} {
+func (i *ScopedIntVariable) GetValue(ctx *Context) (interface{}, bool) {
 	return i.intFnc(ctx)
 }
 
 // NewScopedIntVariable returns a new integer variable
-func NewScopedIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
+func NewScopedIntVariable(intFnc func(ctx *Context) (int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntVariable {
 	return &ScopedIntVariable{
 		settableVariable: settableVariable{
 			setFnc: setFnc,
@@ -96,7 +103,7 @@ func NewScopedIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Contex
 // ScopedStringVariable describes a string variable
 type ScopedStringVariable struct {
 	settableVariable
-	strFnc func(ctx *Context) string
+	strFnc func(ctx *Context) (string, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
@@ -104,18 +111,19 @@ func (s *ScopedStringVariable) GetEvaluator() interface{} {
 	return &StringEvaluator{
 		ValueType: VariableValueType,
 		EvalFnc: func(ctx *Context) string {
-			return s.strFnc(ctx)
+			v, _ := s.strFnc(ctx)
+			return v
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (s *ScopedStringVariable) GetValue(ctx *Context) interface{} {
+func (s *ScopedStringVariable) GetValue(ctx *Context) (interface{}, bool) {
 	return s.strFnc(ctx)
 }
 
 // NewScopedStringVariable returns a new scoped string variable
-func NewScopedStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
+func NewScopedStringVariable(strFnc func(ctx *Context) (string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringVariable {
 	return &ScopedStringVariable{
 		strFnc: strFnc,
 		settableVariable: settableVariable{
@@ -127,25 +135,26 @@ func NewScopedStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *
 // ScopedBoolVariable describes a boolean variable
 type ScopedBoolVariable struct {
 	settableVariable
-	boolFnc func(ctx *Context) bool
+	boolFnc func(ctx *Context) (bool, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (b *ScopedBoolVariable) GetEvaluator() interface{} {
 	return &BoolEvaluator{
 		EvalFnc: func(ctx *Context) bool {
-			return b.boolFnc(ctx)
+			v, _ := b.boolFnc(ctx)
+			return v
 		},
 	}
 }
 
 // GetValue returns the variable value
-func (b *ScopedBoolVariable) GetValue(ctx *Context) interface{} {
+func (b *ScopedBoolVariable) GetValue(ctx *Context) (interface{}, bool) {
 	return b.boolFnc(ctx)
 }
 
 // NewScopedBoolVariable returns a new boolean variable
-func NewScopedBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
+func NewScopedBoolVariable(boolFnc func(ctx *Context) (bool, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedBoolVariable {
 	return &ScopedBoolVariable{
 		boolFnc: boolFnc,
 		settableVariable: settableVariable{
@@ -157,18 +166,21 @@ func NewScopedBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Con
 // ScopedStringArrayVariable describes a scoped string array variable
 type ScopedStringArrayVariable struct {
 	settableVariable
-	strFnc func(ctx *Context) []string
+	strFnc func(ctx *Context) ([]string, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (s *ScopedStringArrayVariable) GetEvaluator() interface{} {
 	return &StringArrayEvaluator{
-		EvalFnc: s.strFnc,
+		EvalFnc: func(ctx *Context) []string {
+			v, _ := s.strFnc(ctx)
+			return v
+		},
 	}
 }
 
 // GetValue returns the variable value
-func (s *ScopedStringArrayVariable) GetValue(ctx *Context) interface{} {
+func (s *ScopedStringArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
 	return s.strFnc(ctx)
 }
 
@@ -185,11 +197,12 @@ func (s *ScopedStringArrayVariable) Append(ctx *Context, value interface{}) erro
 	if val, ok := value.(string); ok {
 		value = []string{val}
 	}
-	return s.Set(ctx, append(s.strFnc(ctx), value.([]string)...))
+	values, _ := s.strFnc(ctx)
+	return s.Set(ctx, append(values, value.([]string)...))
 }
 
 // NewScopedStringArrayVariable returns a new scoped string array variable
-func NewScopedStringArrayVariable(strFnc func(ctx *Context) []string, setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
+func NewScopedStringArrayVariable(strFnc func(ctx *Context) ([]string, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedStringArrayVariable {
 	return &ScopedStringArrayVariable{
 		strFnc: strFnc,
 		settableVariable: settableVariable{
@@ -201,18 +214,21 @@ func NewScopedStringArrayVariable(strFnc func(ctx *Context) []string, setFnc fun
 // ScopedIntArrayVariable describes a scoped integer array variable
 type ScopedIntArrayVariable struct {
 	settableVariable
-	intFnc func(ctx *Context) []int
+	intFnc func(ctx *Context) ([]int, bool)
 }
 
 // GetEvaluator returns the variable SECL evaluator
 func (v *ScopedIntArrayVariable) GetEvaluator() interface{} {
 	return &IntArrayEvaluator{
-		EvalFnc: v.intFnc,
+		EvalFnc: func(ctx *Context) []int {
+			s, _ := v.intFnc(ctx)
+			return s
+		},
 	}
 }
 
 // GetValue returns the variable value
-func (v *ScopedIntArrayVariable) GetValue(ctx *Context) interface{} {
+func (v *ScopedIntArrayVariable) GetValue(ctx *Context) (interface{}, bool) {
 	return v.intFnc(ctx)
 }
 
@@ -229,11 +245,12 @@ func (v *ScopedIntArrayVariable) Append(ctx *Context, value interface{}) error {
 	if val, ok := value.(int); ok {
 		value = []int{val}
 	}
-	return v.Set(ctx, append(v.intFnc(ctx), value.([]int)...))
+	values, _ := v.intFnc(ctx)
+	return v.Set(ctx, append(values, value.([]int)...))
 }
 
 // NewScopedIntArrayVariable returns a new integer array variable
-func NewScopedIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
+func NewScopedIntArrayVariable(intFnc func(ctx *Context) ([]int, bool), setFnc func(ctx *Context, value interface{}) error) *ScopedIntArrayVariable {
 	return &ScopedIntArrayVariable{
 		intFnc: intFnc,
 		settableVariable: settableVariable{
@@ -244,16 +261,18 @@ func NewScopedIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx 
 
 // IntVariable describes a global integer variable
 type IntVariable struct {
+	set   bool
 	Value int
 }
 
 // GetValue returns the variable value
-func (m *IntVariable) GetValue() interface{} {
-	return m.Value
+func (m *IntVariable) GetValue() (interface{}, bool) {
+	return m.Value, m.set
 }
 
 // Set the variable with the specified value
 func (m *IntVariable) Set(_ *Context, value interface{}) error {
+	m.set = true
 	m.Value = value.(int)
 	return nil
 }
@@ -262,6 +281,7 @@ func (m *IntVariable) Set(_ *Context, value interface{}) error {
 func (m *IntVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
+		m.set = true
 		m.Value += value
 	default:
 		return errAppendNotSupported
@@ -280,6 +300,7 @@ func (m *IntVariable) GetEvaluator() interface{} {
 
 // BoolVariable describes a mutable boolean variable
 type BoolVariable struct {
+	set   bool
 	Value bool
 }
 
@@ -298,13 +319,14 @@ func NewIntVariable() *IntVariable {
 }
 
 // GetValue returns the variable value
-func (m *BoolVariable) GetValue() interface{} {
-	return m.Value
+func (m *BoolVariable) GetValue() (interface{}, bool) {
+	return m.Value, m.set
 }
 
 // Set the variable with the specified value
 func (m *BoolVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(bool)
+	m.set = true
 	return nil
 }
 
@@ -321,6 +343,7 @@ func NewBoolVariable() *BoolVariable {
 // StringVariable describes a mutable string variable
 type StringVariable struct {
 	Value string
+	set   bool
 }
 
 // GetEvaluator returns the variable SECL evaluator
@@ -334,8 +357,8 @@ func (m *StringVariable) GetEvaluator() interface{} {
 }
 
 // GetValue returns the variable value
-func (m *StringVariable) GetValue() interface{} {
-	return m.Value
+func (m *StringVariable) GetValue() (interface{}, bool) {
+	return m.Value, m.set
 }
 
 // Append a value to the string
@@ -343,6 +366,7 @@ func (m *StringVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
 		m.Value += value
+		m.set = true
 	default:
 		return errAppendNotSupported
 	}
@@ -352,6 +376,7 @@ func (m *StringVariable) Append(_ *Context, value interface{}) error {
 // Set the variable with the specified value
 func (m *StringVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(string)
+	m.set = true
 	return nil
 }
 
@@ -366,8 +391,9 @@ type StringArrayVariable struct {
 }
 
 // GetValue returns the variable value
-func (m *StringArrayVariable) GetValue() interface{} {
-	return m.LRU.Keys()
+func (m *StringArrayVariable) GetValue() (interface{}, bool) {
+	keys := m.LRU.Keys()
+	return keys, len(keys) != 0
 }
 
 // Set the variable with the specified value
@@ -379,6 +405,7 @@ func (m *StringArrayVariable) Set(_ *Context, values interface{}) error {
 	for _, v := range values.([]string) {
 		m.LRU.Set(v, true, ttlcache.DefaultTTL)
 	}
+
 	return nil
 }
 
@@ -426,8 +453,9 @@ type IntArrayVariable struct {
 }
 
 // GetValue returns the variable value
-func (m *IntArrayVariable) GetValue() interface{} {
-	return m.LRU.Keys()
+func (m *IntArrayVariable) GetValue() (interface{}, bool) {
+	keys := m.LRU.Keys()
+	return keys, len(keys) != 0
 }
 
 // Set the variable with the specified value
@@ -581,39 +609,44 @@ func (v *ScopedVariables) NewSECLVariable(name string, value interface{}, opts V
 
 	switch value.(type) {
 	case int:
-		return NewScopedIntVariable(func(ctx *Context) int {
+		return NewScopedIntVariable(func(ctx *Context) (int, bool) {
 			if v := getVariable(ctx); v != nil {
-				return v.GetValue().(int)
+				value, set := v.GetValue()
+				return value.(int), set
 			}
-			return 0
+			return 0, false
 		}, setVariable), nil
 	case bool:
-		return NewScopedBoolVariable(func(ctx *Context) bool {
+		return NewScopedBoolVariable(func(ctx *Context) (bool, bool) {
 			if v := getVariable(ctx); v != nil {
-				return v.GetValue().(bool)
+				value, set := v.GetValue()
+				return value.(bool), set
 			}
-			return false
+			return false, false
 		}, setVariable), nil
 	case string:
-		return NewScopedStringVariable(func(ctx *Context) string {
+		return NewScopedStringVariable(func(ctx *Context) (string, bool) {
 			if v := getVariable(ctx); v != nil {
-				return v.GetValue().(string)
+				value, set := v.GetValue()
+				return value.(string), set
 			}
-			return ""
+			return "", false
 		}, setVariable), nil
 	case []string:
-		return NewScopedStringArrayVariable(func(ctx *Context) []string {
+		return NewScopedStringArrayVariable(func(ctx *Context) ([]string, bool) {
 			if v := getVariable(ctx); v != nil {
-				return v.GetValue().([]string)
+				value, set := v.GetValue()
+				return value.([]string), set
 			}
-			return nil
+			return nil, false
 		}, setVariable), nil
 	case []int:
-		return NewScopedIntArrayVariable(func(ctx *Context) []int {
+		return NewScopedIntArrayVariable(func(ctx *Context) ([]int, bool) {
 			if v := getVariable(ctx); v != nil {
-				return v.GetValue().([]int)
+				value, set := v.GetValue()
+				return value.([]int), set
 			}
-			return nil
+			return nil, false
 
 		}, setVariable), nil
 	default:

--- a/pkg/security/secl/model/variables.go
+++ b/pkg/security/secl/model/variables.go
@@ -13,12 +13,12 @@ import (
 var (
 	// SECLVariables set of variables
 	SECLVariables = map[string]eval.SECLVariable{
-		"process.pid": eval.NewScopedIntVariable(func(ctx *eval.Context) int {
+		"process.pid": eval.NewScopedIntVariable(func(ctx *eval.Context) (int, bool) {
 			pc := ctx.Event.(*Event).ProcessContext
 			if pc == nil {
-				return 0
+				return 0, false
 			}
-			return int(pc.Process.Pid)
+			return int(pc.Process.Pid), true
 		}, nil),
 	}
 )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

Having the ability to show the variables states makes it easier
to write rules using variables.

### Describe how you validated your changes

- Create a few rules with global and scope variables (only the "process" scope is supported right now).
- Run `security-agent status` and check the variables are properly displayed with the right value

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

Sample output:
```
  SECL Variables
  ==============

  Global variables:
  
      No variable found

  Scoped variables:
  
    process:
    
      974315:
        - foo: [974315]
```
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->