### PR TITLE
Fix pointer to strings and slices in Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -144,17 +144,13 @@ func collectSubLocationExpressions(location ditypes.LocationExpression) []ditype
 	queue := []ditypes.LocationExpression{location}
 	var top ditypes.LocationExpression
 
-	for {
-		if len(queue) == 0 {
-			break
-		}
+	for len(queue) == 0 {
 		top = queue[0]
 		queue = queue[1:]
 		queue = append(queue, top.IncludedExpressions...)
 		if top.Opcode != ditypes.OpPopPointerAddress {
 			collectedExpressions = append(collectedExpressions, top)
 		}
-
 		top.IncludedExpressions = []ditypes.LocationExpression{}
 	}
 	return collectedExpressions

--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -228,6 +228,9 @@ func generateSliceHeader(slice *ditypes.Parameter, out io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("could not generate header text for underlying slice element type: %w", err)
 	}
+	if slice == nil || len(slice.ParameterPieces) == 0 || slice.ParameterPieces[1] == nil {
+		return fmt.Errorf("could not read slice length parameter")
+	}
 	excludePopPointerAddressExpressions(&slice.ParameterPieces[1].LocationExpressions)
 	err = generateParametersTextViaLocationExpressions([]*ditypes.Parameter{slice.ParameterPieces[1]}, lenHeaderBuf)
 	if err != nil {
@@ -267,6 +270,9 @@ func generateStringHeader(stringParam *ditypes.Parameter, out io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("could not execute template for generating string header: %w", err)
 	}
+	if stringParam == nil || len(stringParam.ParameterPieces) == 0 || stringParam.ParameterPieces[1] == nil {
+		return fmt.Errorf("could not read string length parameter")
+	}
 	excludePopPointerAddressExpressions(&stringParam.ParameterPieces[1].LocationExpressions)
 	err = generateParametersTextViaLocationExpressions([]*ditypes.Parameter{stringParam.ParameterPieces[1]}, out)
 	if err != nil {
@@ -279,6 +285,9 @@ func generateStringHeader(stringParam *ditypes.Parameter, out io.Writer) error {
 }
 
 func excludePopPointerAddressExpressions(expressions *[]ditypes.LocationExpression) {
+	if expressions == nil {
+		return
+	}
 	filteredExpressions := []ditypes.LocationExpression{}
 	for i := range *expressions {
 		if (*expressions)[i].Opcode != ditypes.OpPopPointerAddress {

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -87,10 +87,7 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					)
 					_, ok := seenPointers[elementParam.ID]
 					if !ok {
-						targetExpressions = append(targetExpressions,
-							ditypes.CopyLocationExpression(),
-							ditypes.PopLocationExpression(1, 8),
-						)
+						targetExpressions = append(targetExpressions, ditypes.PopPointerAddressCompoundLocationExpression())
 						seenPointers[elementParam.ID] = true
 					}
 				} else {
@@ -108,10 +105,7 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					)
 					_, ok := seenPointers[elementParam.ID]
 					if !ok {
-						targetExpressions = append(targetExpressions,
-							ditypes.CopyLocationExpression(),
-							ditypes.PopLocationExpression(1, 8),
-						)
+						targetExpressions = append(targetExpressions, ditypes.PopPointerAddressCompoundLocationExpression())
 						seenPointers[elementParam.ID] = true
 					}
 				} else if elementParam.Kind == uint(reflect.Struct) {
@@ -137,6 +131,7 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 						continue
 					}
 
+					stringLength.LocationExpressions = append(stringLength.LocationExpressions, targetExpressions...)
 					if stringLength.Location != nil {
 						stringLength.LocationExpressions = append(stringLength.LocationExpressions,
 							ditypes.DirectReadLocationExpression(stringLength),
@@ -174,6 +169,7 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					sliceLength.LocationExpressions = append(sliceLength.LocationExpressions,
 						ditypes.PrintStatement("%s", "Reading the length of slice"),
 					)
+					sliceLength.LocationExpressions = append(sliceLength.LocationExpressions, targetExpressions...)
 					if sliceLength.Location != nil {
 						sliceLength.LocationExpressions = append(sliceLength.LocationExpressions,
 							ditypes.DirectReadLocationExpression(sliceLength),

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -77,7 +77,13 @@ func (s SpecialKind) String() string {
 }
 
 func (l LocationExpression) String() string {
-	return fmt.Sprintf("%s (%d, %d, %d)", l.Opcode.String(), l.Arg1, l.Arg2, l.Arg3)
+	return fmt.Sprintf("Opcode: %s Args: [%d, %d, %d] Label: %s Collection ID: %s\n",
+		l.Opcode.String(),
+		l.Arg1,
+		l.Arg2,
+		l.Arg3,
+		l.Label,
+		l.CollectionIdentifier)
 }
 
 // LocationExpressionOpcode uniquely identifies each location expression operation
@@ -417,14 +423,7 @@ type BPFProgram struct {
 //nolint:all
 func PrintLocationExpressions(expressions []LocationExpression) {
 	for i := range expressions {
-		fmt.Printf("Opcode: %s Args: [%d, %d, %d] Label: %s Collection ID: %s\n",
-			expressions[i].Opcode.String(),
-			expressions[i].Arg1,
-			expressions[i].Arg2,
-			expressions[i].Arg3,
-			expressions[i].Label,
-			expressions[i].CollectionIdentifier,
-		)
+		fmt.Println(expressions[i].String())
 	}
 }
 

--- a/pkg/dynamicinstrumentation/testutil/e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/e2e_test.go
@@ -11,6 +11,8 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
+	"math/rand"
 	"os"
 	"os/exec"
 	"reflect"
@@ -51,11 +53,12 @@ func TestGoDI(t *testing.T) {
 		t.Skip("ringbuffers not supported on this kernel")
 	}
 
+	serviceName := "go-di-sample-service-" + randomLabel()
 	sampleServicePath := BuildSampleService(t)
 	cmd := exec.Command(sampleServicePath)
 	cmd.Env = []string{
 		"DD_DYNAMIC_INSTRUMENTATION_ENABLED=true",
-		"DD_SERVICE=go-di-sample-service",
+		fmt.Sprintf("DD_SERVICE=%s", serviceName),
 		"DD_DYNAMIC_INSTRUMENTATION_OFFLINE=true",
 	}
 
@@ -123,7 +126,10 @@ func TestGoDI(t *testing.T) {
 			matches:           []bool{},
 			unexpectedResults: []ditypes.CapturedValueMap{},
 		}
-		err = cfgTemplate.Execute(buf, configDataType{functionWithoutPackagePrefix})
+		err = cfgTemplate.Execute(buf, configDataType{
+			ServiceName:  serviceName,
+			FunctionName: functionWithoutPackagePrefix,
+		})
 		require.NoError(t, err)
 		eventOutputWriter.expectedResult = expectedCaptureValue
 
@@ -199,11 +205,14 @@ func scrubPointerValue(capture *ditypes.CapturedValue) {
 	scrubPointerValues(capture.Fields)
 }
 
-type configDataType struct{ FunctionName string }
+type configDataType struct {
+	ServiceName  string
+	FunctionName string
+}
 
 var configTemplateText = `
 {
-    "go-di-sample-service": {
+    "{{.ServiceName}}": {
         "e504163d-f367-4522-8905-fe8bc34eb975": {
             "id": "e504163d-f367-4522-8905-fe8bc34eb975",
             "version": 0,
@@ -241,3 +250,12 @@ var configTemplateText = `
     }
 }
 `
+
+func randomLabel() string {
+	length := 6
+	randomString := make([]byte, length)
+	for i := 0; i < length; i++ {
+		randomString[i] = byte(65 + rand.Intn(25))
+	}
+	return string(randomString)
+}

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -259,6 +259,48 @@ var pointerCaptures = fixtures{
 		},
 	}}},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_struct_pointer": {"x": {Type: "*struct"}},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_pointer": {"z": {
+		Type: "*string",
+		Fields: fieldMap{
+			"arg_0": capturedValue("string", "abc"),
+		},
+	}},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_pointer_to_struct_with_a_string": {
+		"s": &ditypes.CapturedValue{
+			Type: "*struct",
+			Fields: fieldMap{
+				"arg_0": &ditypes.CapturedValue{
+					Type: "struct",
+					Fields: fieldMap{
+						"arg_0": capturedValue("int", "5"),
+						"arg_1": capturedValue("string", "abcdef"),
+					},
+				},
+			},
+		},
+	},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_pointer_to_struct_with_a_slice": {
+		"s": &ditypes.CapturedValue{
+			Type: "*struct",
+			Fields: fieldMap{
+				"arg_0": &ditypes.CapturedValue{
+					Type: "struct",
+					Fields: fieldMap{
+						"arg_0": capturedValue("int", "5"),
+						"arg_1": &ditypes.CapturedValue{
+							Type: "[]uint8",
+							Fields: fieldMap{
+								"[0]uint8": capturedValue("uint8", "2"),
+								"[1]uint8": capturedValue("uint8", "3"),
+								"[2]uint8": capturedValue("uint8", "4"),
+							},
+						},
+						"arg_2": capturedValue("uint64", "5"),
+					},
+				},
+			},
+		},
+	},
 }
 
 // mergeMaps combines multiple fixture maps into a single map

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -107,6 +107,9 @@ func reportCaptureError(defs []*ditypes.Parameter) ditypes.Captures {
 func convertArgs(defs []*ditypes.Parameter, captures []*ditypes.Param) map[string]*ditypes.CapturedValue {
 	args := make(map[string]*ditypes.CapturedValue)
 	for idx, capture := range captures {
+		if capture == nil {
+			continue
+		}
 		var (
 			argName   string
 			defPieces []*ditypes.Parameter


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where lengths of strings and slices were not correctly being captured if they were under a pointer reference. A complication of this was the capturing of pointer addresses in the output buffer which is done for the sake of checking if pointers are nil. The instructions for capturing the address were getting included in the capturing of slice/string length. 

To solve this issue, this PR adds a mechanism for identifying these instructions in the form of "compound instructions". This involves having instructions which represent a combination of instructions. For now, the only example of this is the PopPointerAddress instruction that's added in this PR. The instruction is filtered and removed from the length capturing expressions.

This PR also fixes a couple nil pointer dereferences and fixes one source of flakiness in e2e tests.

### Motivation

Strings/Slices weren't captured correctly when under a pointer reference.

### Describe how you validated your changes

Run e2e tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
