### PR TITLE
Probabilistic Sampler Trace Sampling Rules

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -308,6 +308,17 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if core.IsSet("apm_config.probabilistic_sampler.sampling_percentage") {
 		c.ProbabilisticSamplerSamplingPercentage = float32(core.GetFloat64("apm_config.probabilistic_sampler.sampling_percentage"))
 	}
+	if k := "apm_config.probabilistic_sampler.trace_sampling_rules"; core.IsConfigured(k) {
+		rules, ok := core.Get(k).([]interface{})
+		if ok {
+			c.ProbabilisticSamplerTraceSamplingRules = make([]config.ProbabilisticSamplerRule, len(rules))
+			if err := structure.UnmarshalKey(core, k, &c.ProbabilisticSamplerTraceSamplingRules); err != nil {
+				log.Errorf("Unmarshalling probabilistic_sampler.trace_sampling_rules: %v", err)
+			}
+		} else {
+			log.Errorf("Bad format for probabilistic_sampler.trace_sampling_rules, expected a list of maps, got %T", core.Get("apm_config.probabilistic_sampler.trace_sampling_rules"))
+		}
+	}
 	if core.IsSet("apm_config.probabilistic_sampler.hash_seed") {
 		c.ProbabilisticSamplerHashSeed = uint32(core.GetInt("apm_config.probabilistic_sampler.hash_seed"))
 	}

--- a/comp/trace/config/testdata/full.yaml
+++ b/comp/trace/config/testdata/full.yaml
@@ -46,6 +46,18 @@ apm_config:
   target_traces_per_second: 5
   max_events_per_second: 50
   max_remote_traces_per_second: 9999
+  probabilistic_sampler:
+    enabled: true
+    sampling_percentage: 1.13
+    trace_sampling_rules:
+    - service: "^example-service.*"
+      operation_name: "^example-operation-name.*"
+      percentage: 30
+      attributes:
+        key1: "^value1-.*"
+        key2: "^value2-.*"
+    - resource_name: "^GET /api/v1/.*"
+      percentage: 12.34
   ignore_resources:
     - /health
     - /500

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1489,6 +1489,19 @@ api_key:
     ## hash_seed: A seed used for the hash algorithm. This must match other agents and OTel
     ##            collectors using the probabilistic sampler to ensure consistent sampling.
     #  hash_seed: 0
+    #
+    ## @env DD_APM_PROBABILISTIC_SAMPLER_TRACE_SAMPLING_RULES - list of objects - optional
+    ## service, operation_name, resource_name, and span attributes can be used in a rule.
+    ## Within a single rule, conditions are combined using AND, while multiple rules are combined using OR.
+    # trace_sampling_rules:
+    # - service: "^example-service.*"
+    #   operation_name: "^example-operation-name.*"
+    #   percentage: 30
+    #   attributes:
+    #   - key1: "^value1.*"
+    #   - key2: "^value2.*"
+    # - resource_name: "^GET /api/v1/.*"
+    #   percentage: 12.34
 
   ## @param error_tracking_standalone - object - optional
   ## Enables Error Tracking Standalone

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -112,8 +112,16 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnv("apm_config.enable_rare_sampler", "DD_APM_ENABLE_RARE_SAMPLER")
 	config.BindEnv("apm_config.disable_rare_sampler", "DD_APM_DISABLE_RARE_SAMPLER") // Deprecated
 	config.BindEnv("apm_config.max_remote_traces_per_second", "DD_APM_MAX_REMOTE_TPS")
-	config.BindEnv("apm_config.probabilistic_sampler.enabled", "DD_APM_PROBABILISTIC_SAMPLER_ENABLED")
-	config.BindEnv("apm_config.probabilistic_sampler.sampling_percentage", "DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE")
+	config.BindEnvAndSetDefault("apm_config.probabilistic_sampler.enabled", false, "DD_APM_PROBABILISTIC_SAMPLER_ENABLED")
+	config.BindEnvAndSetDefault("apm_config.probabilistic_sampler.sampling_percentage", float32(100), "DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE")
+	config.BindEnv("apm_config.probabilistic_sampler.trace_sampling_rules", "DD_APM_PROBABILISTIC_SAMPLER_TRACE_SAMPLING_RULES")
+	config.ParseEnvAsSlice("apm_config.probabilistic_sampler.trace_sampling_rules", func(in string) []interface{} {
+		var out []interface{}
+		if err := json.Unmarshal([]byte(in), &out); err != nil {
+			log.Warnf(`"apm_config.probabilistic_sampler.trace_sampling_rules" can not be parsed: %s`, err)
+		}
+		return out
+	})
 	config.BindEnv("apm_config.probabilistic_sampler.hash_seed", "DD_APM_PROBABILISTIC_SAMPLER_HASH_SEED")
 	config.BindEnvAndSetDefault("apm_config.error_tracking_standalone.enabled", false, "DD_APM_ERROR_TRACKING_STANDALONE_ENABLED")
 

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -168,7 +168,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig, telemetryCollector 
 		Statsd:                statsd,
 		Timing:                timing,
 	}
-	agnt.SamplerMetrics.Add(agnt.PrioritySampler, agnt.ErrorsSampler, agnt.NoPrioritySampler, agnt.RareSampler)
+	agnt.SamplerMetrics.Add(agnt.PrioritySampler, agnt.ErrorsSampler, agnt.NoPrioritySampler, agnt.RareSampler, agnt.ProbabilisticSampler)
 	agnt.Receiver = api.NewHTTPReceiver(conf, dynConf, in, agnt, telemetryCollector, statsd, timing)
 	agnt.OTLPReceiver = api.NewOTLPReceiver(in, conf, statsd, timing)
 	agnt.RemoteConfigHandler = remoteconfighandler.New(conf, agnt.PrioritySampler, agnt.RareSampler, agnt.ErrorsSampler)

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -1084,7 +1084,7 @@ func TestSampling(t *testing.T) {
 			SamplerMetrics:       sampler.NewMetrics(statsd),
 			conf:                 cfg,
 		}
-		a.SamplerMetrics.Add(a.NoPrioritySampler, a.ErrorsSampler, a.PrioritySampler, a.RareSampler)
+		a.SamplerMetrics.Add(a.NoPrioritySampler, a.ErrorsSampler, a.PrioritySampler, a.RareSampler, a.ProbabilisticSampler)
 		if ac.errorsSampled {
 			a.ErrorsSampler = sampler.NewErrorsSampler(sampledCfg)
 		}
@@ -1134,6 +1134,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1153,6 +1155,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1172,6 +1176,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1191,6 +1197,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1210,6 +1218,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1229,6 +1239,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1248,6 +1260,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1267,6 +1281,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1286,6 +1302,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1305,6 +1323,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1324,6 +1344,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1343,6 +1365,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 				{
@@ -1357,6 +1381,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1376,6 +1402,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1398,6 +1426,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1417,6 +1447,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1436,6 +1468,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1455,6 +1489,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1474,6 +1510,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1493,6 +1531,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1512,6 +1552,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1531,6 +1573,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1550,6 +1594,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(1), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1569,6 +1615,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1588,6 +1636,8 @@ func TestSampling(t *testing.T) {
 						statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 						statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+						statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 					},
 				},
 			},
@@ -1650,6 +1700,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, int64(1), []string{"sampler:error", "target_service:serv1"}, gomock.Any()).Times(1)
@@ -1660,6 +1712,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 		"userdrop-error-manual-dm-unsampled": {
@@ -1675,6 +1729,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -1685,6 +1741,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 		"userdrop-error-agent-dm-sampled": {
@@ -1700,6 +1758,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, int64(1), []string{"sampler:error", "target_service:serv1"}, gomock.Any()).Times(1)
@@ -1710,6 +1770,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 		"userkeep-error-no-dm-sampled": {
@@ -1725,6 +1787,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, int64(1), []string{"sampler:priority", "sampling_priority:manual_keep", "target_service:serv1"}, gomock.Any()).Times(1)
@@ -1735,6 +1799,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 		"userkeep-error-agent-dm-sampled": {
@@ -1750,6 +1816,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, int64(1), []string{"sampler:priority", "sampling_priority:manual_keep", "target_service:serv1"}, gomock.Any()).Times(1)
@@ -1760,6 +1828,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 		"autodrop-error-sampled": {
@@ -1775,6 +1845,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, int64(1), []string{"sampler:error", "target_service:serv1"}, gomock.Any()).Times(1)
@@ -1785,6 +1857,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 		"autodrop-not-sampled": {
@@ -1800,6 +1874,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
@@ -1810,6 +1886,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 		"autokeep-dm-sampled": {
@@ -1825,6 +1903,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 			expectStatsdWithFeature: func(statsdClient *mockStatsd.MockClientInterface) {
 				statsdClient.EXPECT().Count(sampler.MetricSamplerKept, int64(1), []string{"sampler:probabilistic", "target_service:serv1"}, gomock.Any()).Times(1)
@@ -1835,6 +1915,8 @@ func TestSampleTrace(t *testing.T) {
 				statsdClient.EXPECT().Count(sampler.MetricsRareHits, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Count(sampler.MetricsRareMisses, int64(0), nil, gomock.Any()).Times(1)
 				statsdClient.EXPECT().Gauge(sampler.MetricsRareShrinks, float64(0), nil, gomock.Any()).Times(1)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRulesEvaluations, int64(0), nil, gomock.Any()).Times(0)
+				statsdClient.EXPECT().Count(sampler.MetricsProbabilisticSamplerSamplingRuleMatches, int64(0), nil, gomock.Any()).Times(0)
 			},
 		},
 	}
@@ -1845,15 +1927,16 @@ func TestSampleTrace(t *testing.T) {
 			statsd := mockStatsd.NewMockClientInterface(ctrl)
 			metrics := sampler.NewMetrics(statsd)
 			a := &Agent{
-				NoPrioritySampler: sampler.NewNoPrioritySampler(cfg),
-				ErrorsSampler:     sampler.NewErrorsSampler(cfg),
-				PrioritySampler:   sampler.NewPrioritySampler(cfg, &sampler.DynamicConfig{}),
-				RareSampler:       sampler.NewRareSampler(config.New()),
-				EventProcessor:    newEventProcessor(cfg, statsd),
-				SamplerMetrics:    metrics,
-				conf:              cfg,
+				NoPrioritySampler:    sampler.NewNoPrioritySampler(cfg),
+				ErrorsSampler:        sampler.NewErrorsSampler(cfg),
+				PrioritySampler:      sampler.NewPrioritySampler(cfg, &sampler.DynamicConfig{}),
+				RareSampler:          sampler.NewRareSampler(config.New()),
+				ProbabilisticSampler: sampler.NewProbabilisticSampler(cfg),
+				EventProcessor:       newEventProcessor(cfg, statsd),
+				SamplerMetrics:       metrics,
+				conf:                 cfg,
 			}
-			a.SamplerMetrics.Add(a.NoPrioritySampler, a.ErrorsSampler, a.PrioritySampler, a.RareSampler)
+			a.SamplerMetrics.Add(a.NoPrioritySampler, a.ErrorsSampler, a.PrioritySampler, a.RareSampler, a.ProbabilisticSampler)
 			tt.expectStatsd(statsd)
 			keep, _ := a.traceSampling(now, info.NewReceiverStats().GetTagStats(info.Tags{}), &tt.trace)
 			metrics.Report()

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -284,6 +284,22 @@ type SymDBProxyConfig struct {
 	AdditionalEndpoints map[string][]string `json:"-"` // Never marshal this field
 }
 
+// ProbabilisticSamplerRule is used for applying sampling percentage to spans that match
+// the service name, operation name, resource, and/or tags.
+type ProbabilisticSamplerRule struct {
+	// Service specifies the regex pattern that a span service name must match.
+	Service string `mapstructure:"service"`
+	// OperationName specifies the regex pattern that a span operation name must match.
+	OperationName string `mapstructure:"operation_name"`
+	// ResourceName specifies the regex pattern that a span resource must match.
+	ResourceName string `mapstructure:"resource_name"`
+	// Attributes specifies the map of key-value patterns that span attributes must match.
+	Attributes map[string]string `mapstructure:"attributes"`
+	// Percentage specifies the sampling percentage that should be applied to spans that match
+	// service and/or name of the rule.
+	Percentage float32 `mapstructure:"percentage"`
+}
+
 // AgentConfig handles the interpretation of the configuration (with default
 // behaviors) in one place. It is also a simple structure to share across all
 // the Agent components, with 100% safe and reliable values.
@@ -335,6 +351,7 @@ type AgentConfig struct {
 	ProbabilisticSamplerEnabled            bool
 	ProbabilisticSamplerHashSeed           uint32
 	ProbabilisticSamplerSamplingPercentage float32
+	ProbabilisticSamplerTraceSamplingRules []ProbabilisticSamplerRule
 
 	// Error Tracking Standalone
 	ErrorTrackingStandalone bool

--- a/pkg/trace/sampler/probabilistic.go
+++ b/pkg/trace/sampler/probabilistic.go
@@ -8,12 +8,18 @@ package sampler
 import (
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"hash/fnv"
+	"math"
+	"regexp"
 	"strconv"
+	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 const (
@@ -25,6 +31,11 @@ const (
 
 	// probRateKey indicates the percentage sampling rate configured for the probabilistic sampler
 	probRateKey = "_dd.prob_sr"
+
+	// MetricsProbabilisticSamplerSamplingRulesEvaluations is the metric name for the number of probabilistic sampler rules evaluated.
+	MetricsProbabilisticSamplerSamplingRulesEvaluations = "datadog.trace_agent.sampler.probabilistic.sampling_rule.evaluations"
+	// MetricsProbabilisticSamplerSamplingRuleMatches is the metric name for the number of probabilistic sampler rules that matched.
+	MetricsProbabilisticSamplerSamplingRuleMatches = "datadog.trace_agent.sampler.probabilistic.sampling_rule.matches"
 )
 
 // ProbabilisticSampler is a sampler that overrides all other samplers,
@@ -34,6 +45,11 @@ type ProbabilisticSampler struct {
 	hashSeed                 []byte
 	scaledSamplingPercentage uint32
 	samplingPercentage       float64
+	// If any rules don't match the span, it fallbacks to the `samplingPercentage`.
+	// traceSamplingRules is a list of rules that can be used to override the `samplingPercentage`.
+	traceSamplingRules       probabilisticSamplerRules
+	samplingRuleMetrics      map[string]probabilisticSamplerRuleMetrics
+	samplingRuleMetricsMutex sync.Mutex
 	// fullTraceIDMode looks at the full 128-bit trace ID to make the sampling decision
 	// This can be useful when trying to run this probabilistic sampler alongside the
 	// OTEL probabilistic sampler processor which always looks at the full 128-bit trace id.
@@ -42,19 +58,190 @@ type ProbabilisticSampler struct {
 	fullTraceIDMode bool
 }
 
+type probabilisticSamplerRule struct {
+	service          *regexp.Regexp
+	operationName    *regexp.Regexp
+	resourceName     *regexp.Regexp
+	attributes       map[string]*regexp.Regexp
+	scaledPercentage uint32
+	percentage       float64
+}
+
+// String returns a string representation of the probabilisticSamplerRule.
+func (r *probabilisticSamplerRule) String() string {
+	var b strings.Builder
+	if r.service != nil {
+		b.WriteString(fmt.Sprintf("service=%s, ", r.service.String()))
+	}
+	if r.operationName != nil {
+		b.WriteString(fmt.Sprintf("operation_name=%s, ", r.operationName.String()))
+	}
+	if r.resourceName != nil {
+		b.WriteString(fmt.Sprintf("resource_name=%s, ", r.resourceName.String()))
+	}
+	if len(r.attributes) > 0 {
+		b.WriteString("attributes=[")
+		for k, v := range r.attributes {
+			b.WriteString(fmt.Sprintf("%s=%s, ", k, v.String()))
+		}
+		b.WriteString("], ")
+	}
+	b.WriteString(fmt.Sprintf("percentage=%f", r.percentage))
+	return b.String()
+}
+
+func (r *probabilisticSamplerRule) evaluate(root *trace.Span) (matched, evaluated bool) {
+	if r.service != nil {
+		evaluated = true
+		if !r.service.MatchString(root.Service) {
+			return false, true
+		}
+	}
+	if r.operationName != nil {
+		evaluated = true
+		if !r.operationName.MatchString(root.Name) {
+			return false, true
+		}
+	}
+	if r.resourceName != nil {
+		evaluated = true
+		if !r.resourceName.MatchString(root.Resource) {
+			return false, true
+		}
+	}
+	for tagKey, tagRegex := range r.attributes {
+		if tagRegex == nil {
+			continue
+		}
+		if root.Meta != nil {
+			evaluated = true
+			if v, ok := root.Meta[tagKey]; ok && tagRegex.MatchString(v) {
+				continue
+			}
+		}
+		if root.Metrics != nil {
+			evaluated = true
+			v, ok := root.Metrics[tagKey]
+			// sampling on numbers with floating point is not supported,
+			// thus 'math.Floor(v) != v'
+			if !ok || math.Floor(v) != v || !tagRegex.MatchString(strconv.FormatFloat(v, 'g', -1, 64)) {
+				return false, true
+			}
+		}
+	}
+	return true, evaluated
+}
+
+func compileProbabilisticSamplerRules(rules []config.ProbabilisticSamplerRule) (probabilisticSamplerRules, error) {
+	compiledRules := make(probabilisticSamplerRules, len(rules))
+	for i, rule := range rules {
+		var err error
+		if rule.Service != "" {
+			compiledRules[i].service, err = regexp.Compile(rule.Service)
+			if err != nil {
+				return nil, fmt.Errorf("service regex: %w", err)
+			}
+		}
+		if rule.OperationName != "" {
+			compiledRules[i].operationName, err = regexp.Compile(rule.OperationName)
+			if err != nil {
+				return nil, fmt.Errorf("name regex: %w", err)
+			}
+		}
+		if rule.ResourceName != "" {
+			compiledRules[i].resourceName, err = regexp.Compile(rule.ResourceName)
+			if err != nil {
+				return nil, fmt.Errorf("resource regex: %w", err)
+			}
+		}
+		compiledRules[i].attributes = make(map[string]*regexp.Regexp, len(rule.Attributes))
+		for k, v := range rule.Attributes {
+			compiledRules[i].attributes[k], err = regexp.Compile(v)
+			if err != nil {
+				return nil, fmt.Errorf("tag regex: key=%s, value=%s: %w", k, v, err)
+			}
+		}
+		compiledRules[i].scaledPercentage = uint32(rule.Percentage * percentageScaleFactor)
+		compiledRules[i].percentage = float64(rule.Percentage) / 100.
+	}
+	return compiledRules, nil
+}
+
+type probabilisticSamplerRules []probabilisticSamplerRule
+
+// String returns a string representation of the probabilisticSamplerRules.
+func (rs probabilisticSamplerRules) String() string {
+	rules := make([]string, len(rs))
+	for i, rule := range rs {
+		rules[i] = fmt.Sprintf("rule %d: %s", i, rule.String())
+	}
+	return strings.Join(rules, ", ")
+}
+
+type probabilisticSamplerRuleMetrics struct {
+	evaluations int64
+	matches     int64
+}
+
 // NewProbabilisticSampler returns a new ProbabilisticSampler that deterministically samples
 // a given percentage of incoming spans based on their trace ID
 func NewProbabilisticSampler(conf *config.AgentConfig) *ProbabilisticSampler {
 	hashSeedBytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(hashSeedBytes, conf.ProbabilisticSamplerHashSeed)
 	_, fullTraceIDMode := conf.Features["probabilistic_sampler_full_trace_id"]
+	rules, err := compileProbabilisticSamplerRules(conf.ProbabilisticSamplerTraceSamplingRules)
+	if err == nil && len(rules) > 0 {
+		log.Infof("Compiled probabilistic sampler trace sampling rules: %s", rules.String())
+	} else {
+		log.Errorf("Compiling probabilistic sampler trace sampling rules: %v", err)
+	}
 	return &ProbabilisticSampler{
 		enabled:                  conf.ProbabilisticSamplerEnabled,
 		hashSeed:                 hashSeedBytes,
 		scaledSamplingPercentage: uint32(conf.ProbabilisticSamplerSamplingPercentage * percentageScaleFactor),
 		samplingPercentage:       float64(conf.ProbabilisticSamplerSamplingPercentage) / 100.,
+		traceSamplingRules:       rules,
+		samplingRuleMetrics:      make(map[string]probabilisticSamplerRuleMetrics),
 		fullTraceIDMode:          fullTraceIDMode,
 	}
+}
+
+func (ps *ProbabilisticSampler) percentage(root *trace.Span) (uint32, float64) {
+	var matched, evaluated bool
+	defer func() {
+		if !evaluated {
+			return
+		}
+		ps.samplingRuleMetricsMutex.Lock()
+		metrics := ps.samplingRuleMetrics[root.Service]
+		metrics.evaluations++
+		if matched {
+			metrics.matches++
+		}
+		ps.samplingRuleMetrics[root.Service] = metrics
+		ps.samplingRuleMetricsMutex.Unlock()
+	}()
+	for _, rule := range ps.traceSamplingRules {
+		matched, evaluated = rule.evaluate(root)
+		if matched && evaluated {
+			return rule.scaledPercentage, rule.percentage
+		}
+	}
+	return ps.scaledSamplingPercentage, ps.samplingPercentage
+}
+
+func (ps *ProbabilisticSampler) report(statsd statsd.ClientInterface) {
+	if !ps.enabled || len(ps.traceSamplingRules) == 0 {
+		return
+	}
+	ps.samplingRuleMetricsMutex.Lock()
+	defer ps.samplingRuleMetricsMutex.Unlock()
+	for service, metrics := range ps.samplingRuleMetrics {
+		tags := []string{"rule_type:trace", "target_service:" + service}
+		_ = statsd.Count(MetricsProbabilisticSamplerSamplingRulesEvaluations, metrics.evaluations, tags, 1)
+		_ = statsd.Count(MetricsProbabilisticSamplerSamplingRuleMatches, metrics.matches, tags, 1)
+	}
+	ps.samplingRuleMetrics = make(map[string]probabilisticSamplerRuleMetrics)
 }
 
 // Sample a trace given the chunk's root span, returns true if the trace should be kept
@@ -79,9 +266,10 @@ func (ps *ProbabilisticSampler) Sample(root *trace.Span) bool {
 	_, _ = hasher.Write(ps.hashSeed)
 	_, _ = hasher.Write(tid)
 	hash := hasher.Sum32()
-	keep := hash&bitMaskHashBuckets < ps.scaledSamplingPercentage
+	scaledSamplingPercentage, samplingPercentage := ps.percentage(root)
+	keep := hash&bitMaskHashBuckets < scaledSamplingPercentage
 	if keep {
-		setMetric(root, probRateKey, ps.samplingPercentage)
+		setMetric(root, probRateKey, samplingPercentage)
 	}
 	return keep
 }

--- a/pkg/trace/sampler/probabilistic.go
+++ b/pkg/trace/sampler/probabilistic.go
@@ -235,13 +235,14 @@ func (ps *ProbabilisticSampler) report(statsd statsd.ClientInterface) {
 		return
 	}
 	ps.samplingRuleMetricsMutex.Lock()
-	defer ps.samplingRuleMetricsMutex.Unlock()
-	for service, metrics := range ps.samplingRuleMetrics {
+	ruleMetrics := ps.samplingRuleMetrics
+	ps.samplingRuleMetrics = make(map[string]probabilisticSamplerRuleMetrics)
+	ps.samplingRuleMetricsMutex.Unlock()
+	for service, metrics := range ruleMetrics {
 		tags := []string{"rule_type:trace", "target_service:" + service}
 		_ = statsd.Count(MetricsProbabilisticSamplerSamplingRulesEvaluations, metrics.evaluations, tags, 1)
 		_ = statsd.Count(MetricsProbabilisticSamplerSamplingRuleMatches, metrics.matches, tags, 1)
 	}
-	ps.samplingRuleMetrics = make(map[string]probabilisticSamplerRuleMetrics)
 }
 
 // Sample a trace given the chunk's root span, returns true if the trace should be kept

--- a/releasenotes/notes/add-probabilistic-trace-sampling-rules-37a1d56b390e1418.yaml
+++ b/releasenotes/notes/add-probabilistic-trace-sampling-rules-37a1d56b390e1418.yaml
@@ -1,0 +1,19 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add a new feature called ``DD_APM_PROBABILISTIC_SAMPLER_TRACE_SAMPLING_RULES``.
+    This feature is available when ``DD_APM_PROBABILISTIC_SAMPLER_ENABLED=true``.
+    It allows to define regular expression for the service, operation_name,
+    resource_name, and attributes of the root span.
+    If any span matches a defined rule, the sampling percentage specifie in that
+    rule will override ``DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE``.
+    Multiple rules can be configured—within a single rule, conditions are
+    combined using AND, while multiple rules are combined using OR.
+    See https://github.com/DataDog/datadog-agent/pull/34232 for example configs.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Add `DD_APM_PROBABILISTIC_SAMPLER_TRACE_SAMPLING_RULES` for env var, `apm_config.probabilistic_sampler.trace_sampling_rules` for `datadog.yaml`.
- Add two trace agent metrics for debugging.
  - `datadog.trace_agent.sampler.probabilistic.sampling_rule.matches`
  - `datadog.trace_agent.sampler.probabilistic.sampling_rule.evaluations`

Example

```dockerfile
ENV DD_APM_PROBABILISTIC_SAMPLER_TRACE_SAMPLING_RULES='[{"service":"^example-service.*","operation_name":"^example-operation-name.*","percentage":30,"attributes":{"key1":"^value1-.*","key2":"^value2-.*"}},{"resource_name":"^GET \/api\/v1\/.*","percentage":12.34}]'
```

```yaml
apm_config:
  probabilistic_sampler:
    trace_sampling_rules:
    - service: "^example-service.*"
      operation_name: "^example-operation-name.*"
      percentage: 30
      attributes:
      - key1: "^value1.*"
      - key2: "^value2.*"
    - resource_name: "^GET /api/v1/.*"
      percentage: 12.34
```

### Motivation

In the Datadog Tracer config, there is a feature called `DD_TRACE_SAMPLING_RULES`.
When using the OTel SDK and OTLP Ingestion, flexible sampling rules like `DD_TRACE_SAMPLING_RULES` should be helpful.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Set
- `DD_APM_PROBABILISTIC_SAMPLER_ENABLED=true`
- `DD_APM_PROBABILISTIC_SAMPLER_TRACE_SAMPLING_RULES=[{"service":"note-client","percentage":30},{"service":"note-server","percentage":60}]`


```bash
docker compose exec -it agent agent config | grep -A70 apm_config
apm_config:
  # ...skip...
  probabilistic_sampler:
    enabled: true
    trace_sampling_rules:
      - percentage: 30
        service: note-client
      - percentage: 60
        service: note-server
    sampling_percentage: 100
```

a. `exclude_null(avg:datadog.trace_agent.sampler.probabilistic.sampling_rule.matches{*} by {env,host,target_service,version}.as_count())`
b. `exclude_null(avg:datadog.trace_agent.sampler.probabilistic.sampling_rule.evaluations{*} by {env,host,target_service,version}.as_count())`
c. `exclude_null(avg:datadog.trace_agent.sampler.kept{sampler:probabilistic} by {env,host,target_service,version}.as_count())`
d. `exclude_null(avg:datadog.trace_agent.sampler.seen{sampler:probabilistic} by {env,host,target_service,version}.as_count())`

`a / b * 100`

- `note-envoy` -> 0% no rules are set for this service.
- `note-server` -> 100%
- `note-client` -> 100%

![2025-02-26_17-58-43](https://github.com/user-attachments/assets/852a393b-b876-466a-b4c9-1c0de927f1c3)

`c / d * 100`

- `note-envoy` -> 100% because`DD_APM_PROBABILISTIC_SAMPLER_SAMPLING_PERCENTAGE=100` by default.
- `note-server` -> 60%
- `note-client` -> 30%

![2025-02-26_17-59-12](https://github.com/user-attachments/assets/7ced73a9-cc50-4b0b-9fea-5656f0168ee9)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->