### PR TITLE
agent: sysprobe-check fail silently if sysprobe configuration is missing

### DIFF
--- a/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
+++ b/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
@@ -2,6 +2,10 @@
 
 sysprobe_cfg="/etc/datadog-agent/system-probe.yaml"
 
+if [[ ! -f $sysprobe_cfg ]]; then
+  exit 0
+fi
+
 if grep -Eq '^ *enable_tcp_queue_length *: *true' $sysprobe_cfg || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH" == "true" ]]; then
   if [ -f /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example ]; then
     mv /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example \

--- a/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
+++ b/Dockerfiles/agent/cont-init.d/60-sysprobe-check.sh
@@ -2,18 +2,14 @@
 
 sysprobe_cfg="/etc/datadog-agent/system-probe.yaml"
 
-if [[ ! -f $sysprobe_cfg ]]; then
-  exit 0
-fi
-
-if grep -Eq '^ *enable_tcp_queue_length *: *true' $sysprobe_cfg || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH" == "true" ]]; then
+if [ -f "$sysprobe_cfg" ] && grep -Eq '^ *enable_tcp_queue_length *: *true' "$sysprobe_cfg" || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_TCP_QUEUE_LENGTH" == "true" ]]; then
   if [ -f /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example ]; then
     mv /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.example \
        /etc/datadog-agent/conf.d/tcp_queue_length.d/conf.yaml.default
   fi
 fi
 
-if grep -Eq '^ *enable_oom_kill *: *true' $sysprobe_cfg || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL" == "true" ]]; then
+if [ -f "$sysprobe_cfg" ] && grep -Eq '^ *enable_oom_kill *: *true' "$sysprobe_cfg" || [[ "$DD_SYSTEM_PROBE_CONFIG_ENABLE_OOM_KILL" == "true" ]]; then
   if [ -f /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.example ]; then
     mv /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.example \
        /etc/datadog-agent/conf.d/oom_kill.d/conf.yaml.default
@@ -22,7 +18,11 @@ fi
 
 # Match the key gpu_monitoring.enabled: true using Python's YAML parser, which is included in the base image
 # and is more robust than using regexes.
-gpu_monitoring_enabled=$(python3 -c "import yaml, sys; data=yaml.safe_load(sys.stdin); print(bool(data.get('gpu_monitoring', {}).get('enabled')))" < $sysprobe_cfg)
+if [ -f "$sysprobe_cfg" ]; then
+  gpu_monitoring_enabled=$(python3 -c "import yaml, sys; data=yaml.safe_load(sys.stdin) or {}; print(bool(data.get('gpu_monitoring', {}).get('enabled')))" < "$sysprobe_cfg")
+else
+  gpu_monitoring_enabled="False"
+fi
 
 # Note gpu_monitoring_enabled is a Python boolean, so casing is important
 if [[ "$gpu_monitoring_enabled" == "True" ]] || [[ "$DD_GPU_MONITORING_ENABLED" == "true" ]]; then


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Aborts silently from `sysprobe-check` if the system-probe configuration is missing

### Motivation

Customer complaint.

They don't have system-probe enabled, but seeing the following log, twice per agent-pod
```
grep: /etc/datadog-agent/system-probe.yaml: No such file or directory
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->