### PR TITLE
service discovery: Remove invalid assertion in TestPorts

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -306,7 +306,13 @@ func TestPorts(t *testing.T) {
 			continue
 		}
 
-		assert.NotContains(t, startEvent.Ports, port)
+		// Do not assert about this since this check can spuriously fail since
+		// the test infrastructure opens a listening TCP socket on an ephimeral
+		// port, and since we mix the different protocols we could find that on
+		// the unexpected port list.
+		if slices.Contains(startEvent.Ports, port) {
+			t.Logf("unexpected port %v also found", port)
+		}
 	}
 }
 


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Do not assert that no client ports are present in the list of ports received from the endpoint, since this check can spuriously fail since the test infrastructure opens a listening TCP socket on an ephimeral port, and since we mix the different protocols in one list (TCPv4/v5, UDPv4/v6) we could happen to find that on the unexpected port list.

To keep the assertion, we would have to change the endpoint to return information about the protocols also, so that we can make an accurate comparison. For now, just demote the assertion to a log.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-50

### Describe how you validated your changes

It's a test case.

Ran it locally a couple of hundred times and saw that the new log hits once in a while (previously it used to fail once in a while).

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->