### PR TITLE
[ACIX-548] Migrated trace agent integration tests on agent6

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -135,6 +135,7 @@ docker_image_build_otel       @DataDog/opentelemetry
 datadog_otel_components_ocb_build  @DataDog/opentelemetry
 agent_integration_tests       @DataDog/container-integrations
 docker_integration_tests      @DataDog/container-integrations
+trace_agent_integration_tests @DataDog/agent-apm
 
 # Functional test
 serverless_cold_start_performance-deb_x64      @DataDog/serverless

--- a/.gitlab/integration_test/include.yml
+++ b/.gitlab/integration_test/include.yml
@@ -4,3 +4,4 @@
 
 include:
   - .gitlab/integration_test/windows.yml
+  - .gitlab/integration_test/linux.yml

--- a/.gitlab/integration_test/linux.yml
+++ b/.gitlab/integration_test/linux.yml
@@ -1,0 +1,18 @@
+.integration_tests_deb:
+  stage: integration_test
+  needs: ["go_deps", "go_tools_deps"]
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  tags: ["docker-in-docker:amd64"]
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
+
+trace_agent_integration_tests:
+  extends: .integration_tests_deb
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  timeout: 50m
+  retry: 2
+  script:
+    - inv -e trace-agent.integration-tests --race

--- a/.gitlab/integration_test/linux.yml
+++ b/.gitlab/integration_test/linux.yml
@@ -4,14 +4,14 @@
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  tags: ["docker-in-docker:amd64"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.retrieve_linux_go_tools_deps]
 
 trace_agent_integration_tests:
   extends: .integration_tests_deb
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
   timeout: 50m
   retry: 2
   script:

--- a/tasks/go_test.py
+++ b/tasks/go_test.py
@@ -32,7 +32,6 @@ from tasks.libs.datadog_api import create_count, send_metrics
 from tasks.libs.junit_upload_core import enrich_junitxml, produce_junit_tar
 from tasks.modules import GoModule
 from tasks.test_core import ModuleTestResult, process_input_args, process_module_results, test_core
-from tasks.trace_agent import integration_tests as trace_integration_tests
 
 PROFILE_COV = "coverage.out"
 TMP_PROFILE_COV_PREFIX = "coverage.out.rerun"
@@ -491,7 +490,6 @@ def integration_tests(ctx, install_deps=False, race=False, remote_docker=False, 
         lambda: agent_integration_tests(ctx, install_deps, race, remote_docker),
         lambda: dsd_integration_tests(ctx, install_deps, race, remote_docker),
         lambda: dca_integration_tests(ctx, install_deps, race, remote_docker),
-        lambda: trace_integration_tests(ctx, install_deps, race),
     ]
     for t in tests:
         try:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Migrates trace agent integration tests from circle ci to gitlab on agent 6.

Like this [PR](https://github.com/DataDog/datadog-agent/pull/34008) but for agent 6. The test is not run anymore on circle ci but on gitlab.

[Job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/816120736).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->