### PR TITLE
ci(pipeline_source): Adapt rules following update on scheduled pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -380,6 +380,10 @@ variables:
 .if_deploy_on_rc_tag_on_beta_repo_branch: &if_deploy_on_rc_tag_on_beta_repo_branch
   if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH == "beta" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
 
+# Schedule on main branch come from conductor, pipeline source is `pipeline`, we use the conductor env variable for identification 
+.if_scheduled_main: &if_scheduled_main
+  if: $DDR_WORKFLOW_ID != null && $CI_COMMIT_BRANCH == "main"
+
 # Rule to trigger jobs only when a branch matches the mergequeue pattern.
 .if_mergequeue: &if_mergequeue
   if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
@@ -1079,6 +1083,10 @@ workflow:
         - test/new-e2e/tests/security-agent-functional/**/*
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
+
+.on_scheduled_main:
+  - <<: *if_scheduled_main
+    when: always
 
 .on_main_or_rc_and_no_skip_e2e:
   - <<: *if_disable_e2e_tests

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -380,9 +380,6 @@ variables:
 .if_deploy_on_rc_tag_on_beta_repo_branch: &if_deploy_on_rc_tag_on_beta_repo_branch
   if: ($DEPLOY_AGENT == "true" || $DDR_WORKFLOW_ID != null) && $BUCKET_BRANCH == "beta" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
 
-.if_scheduled_main: &if_scheduled_main
-  if: ($CI_PIPELINE_SOURCE == "schedule" || ($DDR_WORKFLOW_ID != null && $APPS =~ /^beta-build-/)) && $CI_COMMIT_BRANCH == "main"
-
 # Rule to trigger jobs only when a branch matches the mergequeue pattern.
 .if_mergequeue: &if_mergequeue
   if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
@@ -1082,15 +1079,6 @@ workflow:
         - test/new-e2e/tests/security-agent-functional/**/*
       compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
     when: on_success
-
-.on_scheduled_main:
-  - <<: *if_scheduled_main
-
-.on_scheduled_main_or_manual:
-  - <<: *if_scheduled_main
-    when: always
-  - when: manual
-    allow_failure: true
 
 .on_main_or_rc_and_no_skip_e2e:
   - <<: *if_disable_e2e_tests

--- a/.gitlab/.pre/cancel-prev-pipelines.yml
+++ b/.gitlab/.pre/cancel-prev-pipelines.yml
@@ -3,8 +3,6 @@ cancel-prev-pipelines:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   rules: # this should only run on dev branches
-    - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
-      when: never
     - if: $CI_COMMIT_TAG
       when: never
     - !reference [.except_main_or_release_branch]

--- a/.gitlab/benchmarks/macrobenchmarks.yml
+++ b/.gitlab/benchmarks/macrobenchmarks.yml
@@ -6,12 +6,10 @@ variables:
   tags: ["team:apm-k8s-tweaked-metal-datadog-agent", "specific:true"]
   timeout: 1h
   rules:
-    - if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
-      when: never
     - if: $CI_PIPELINE_SOURCE == "schedule"
       when: always
-    - when: manual
-      allow_failure: true
+    - !reference [.on_scheduled_main]
+    - !reference [.manual]
   # If you have a problem with Gitlab cache, see Troubleshooting section in Benchmarking Platform docs
   image: $BENCHMARKS_CI_IMAGE
   needs: ["setup_agent_version"]

--- a/.gitlab/check_merge/do_not_merge.yml
+++ b/.gitlab/check_merge/do_not_merge.yml
@@ -3,8 +3,6 @@ do-not-merge:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]
   rules: # this should only run on dev branches
-  - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
-    when: never
   - if: $CI_COMMIT_TAG
     when: never
   - !reference [.except_main_or_release_branch]

--- a/.gitlab/deps_build/deps_build.yml
+++ b/.gitlab/deps_build/deps_build.yml
@@ -83,8 +83,7 @@ build_clang_arm64:
 
 build_processed_btfhub_archive:
   rules:
-    - !reference [.except_mergequeue]
-    - !reference [.on_scheduled_main_or_manual]
+    - !reference [.manual]
   stage: deps_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/btf-gen$DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BTF_GEN_BUILDIMAGES
   tags: ["arch:amd64"]

--- a/.gitlab/deps_build/deps_build.yml
+++ b/.gitlab/deps_build/deps_build.yml
@@ -83,6 +83,7 @@ build_clang_arm64:
 
 build_processed_btfhub_archive:
   rules:
+    - !reference [.on_scheduled_main]
     - !reference [.manual]
   stage: deps_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/btf-gen$DATADOG_AGENT_BTF_GEN_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BTF_GEN_BUILDIMAGES

--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -196,18 +196,6 @@ dev_nightly-ot-a7:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx-arm64
         IMG_DESTINATIONS: agent-dev:nightly-ot-beta-${CI_COMMIT_REF_SLUG}-jmx
 
-# deploy nightly build to single-machine-performance
-single_machine_performance-nightly-amd64-a7:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules: !reference [.on_scheduled_main]
-  needs:
-    - docker_build_agent7
-  variables:
-    IMG_REGISTRIES: internal-aws-smp
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-    IMG_DESTINATIONS: 08450328-agent:nightly-${CI_COMMIT_BRANCH}-${CI_COMMIT_SHA}-7-amd64
-
 # deploys nightlies to agent-dev
 dev_nightly-dogstatsd:
   extends: .docker_publish_job_definition

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -118,7 +118,7 @@ notify_gitlab_ci_changes:
 notify_failure_summary_on_pipeline:
   extends: [.failure_summary_job, .notify-job]
   rules:
-    - if: $CI_PIPELINE_SOURCE != "push" && $CI_PIPELINE_SOURCE != "schedule"
+    - if: $CI_PIPELINE_SOURCE != "push" && $CI_PIPELINE_SOURCE != "api"
       when: never
     - !reference [.on_main_always]
   script:
@@ -129,9 +129,7 @@ notify_failure_summary_on_pipeline:
 notify_failure_summary_daily:
   extends: [.failure_summary_job, .notify-job]
   rules:
-    - if: $CI_COMMIT_BRANCH != "main" || $CI_PIPELINE_SOURCE != "schedule"
-      when: never
-    - !reference [.on_deploy_nightly_repo_branch_always]
+    - !reference [.on_scheduled_main]
   script:
     - !reference [.notify_setup]
     - weekday="$(date --utc '+%A')"
@@ -153,10 +151,7 @@ close_failing_tests_stale_issues:
   extends: .notify-job
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_arm64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   rules:
-    # Daily
-    - if: $CI_COMMIT_BRANCH != "main" || $CI_PIPELINE_SOURCE != "schedule"
-      when: never
-    - !reference [.on_deploy_nightly_repo_branch_always]
+    - !reference [.on_scheduled_main]
   needs: []
   tags: ["arch:arm64"]
   script:

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -118,6 +118,7 @@ notify_gitlab_ci_changes:
 notify_failure_summary_on_pipeline:
   extends: [.failure_summary_job, .notify-job]
   rules:
+    - !reference [.on_scheduled_main]
     - if: $CI_PIPELINE_SOURCE != "push" && $CI_PIPELINE_SOURCE != "api"
       when: never
     - !reference [.on_main_always]

--- a/tasks/libs/ciproviders/gitlab_api.py
+++ b/tasks/libs/ciproviders/gitlab_api.py
@@ -1042,7 +1042,7 @@ def get_preset_contexts(required_tests):
         ("BUCKET_BRANCH", ["nightly"]),  # ["dev", "nightly", "beta", "stable", "oldnightly"]
         ("CI_COMMIT_BRANCH", ["main"]),  # ["main", "mq-working-branch-main", "7.42.x", "any/name"]
         ("CI_COMMIT_TAG", [""]),  # ["", "1.2.3-rc.4", "6.6.6"]
-        ("CI_PIPELINE_SOURCE", ["pipeline"]),  # ["trigger", "pipeline", "schedule"]
+        ("CI_PIPELINE_SOURCE", ["push", "api"]),  # ["trigger", "pipeline", "schedule"]
         ("DEPLOY_AGENT", ["true"]),
         ("RUN_ALL_BUILDS", ["true"]),
         ("RUN_E2E_TESTS", ["auto"]),
@@ -1063,7 +1063,7 @@ def get_preset_contexts(required_tests):
     mq_contexts = [
         ("BUCKET_BRANCH", ["dev"]),
         ("CI_COMMIT_BRANCH", ["mq-working-branch-main"]),
-        ("CI_PIPELINE_SOURCE", ["pipeline"]),
+        ("CI_PIPELINE_SOURCE", ["api"]),
         ("DEPLOY_AGENT", ["false"]),
         ("RUN_ALL_BUILDS", ["false"]),
         ("RUN_E2E_TESTS", ["auto"]),
@@ -1082,6 +1082,7 @@ def get_preset_contexts(required_tests):
         ("RELEASE_VERSION_7", ["nightly-a7"]),
         ("BUCKET_BRANCH", ["dev"]),
         ("DEPLOY_AGENT", ["false"]),
+        ("CI_PIPELINE_SOURCE", ["pipeline"]),  # ["trigger", "pipeline", "schedule"]
         ("INTEGRATIONS_CORE_VERSION", ["foo/bar"]),
         ("RUN_KITCHEN_TESTS", ["false"]),
         ("RUN_E2E_TESTS", ["off"]),

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -14,6 +14,7 @@ import time
 import traceback
 from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from functools import wraps
 from subprocess import CalledProcessError, check_output
 from types import SimpleNamespace
@@ -685,3 +686,8 @@ def is_windows():
 
 def is_installed(binary) -> bool:
     return shutil.which(binary) is not None
+
+
+def is_conductor_scheduled_pipeline() -> bool:
+    pipeline_start = datetime.fromisoformat(os.environ['CI_PIPELINE_CREATED_AT'])
+    return pipeline_start.hour == 6 and pipeline_start.minute < 30

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 import sys
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import yaml
 from invoke import Context, task
@@ -127,6 +127,14 @@ def failure_summary_send_notifications(
     assert (
         daily_summary or weekly_summary and not (daily_summary and weekly_summary)
     ), "Exactly one of daily or weekly summary must be set"
+
+    pipeline_start = datetime.fromisoformat(os.environ['CI_PIPELINE_CREATED_AT'])
+    if not (pipeline_start.hour == 6 and pipeline_start.minute < 30):
+        print(
+            "Failure summary notifications are only sent if the pipeline started at 6:00 UTC, skipping",
+            file=sys.stderr,
+        )
+        return
 
     period = timedelta(days=1) if daily_summary else timedelta(weeks=1)
     failure_summary.send_summary_messages(ctx, weekly_summary, max_length, period, dry_run=dry_run)

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import re
 import sys
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import yaml
 from invoke import Context, task
@@ -17,7 +17,7 @@ from tasks.libs.ciproviders.gitlab_api import (
 )
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.datadog_api import send_metrics
-from tasks.libs.common.utils import gitlab_section
+from tasks.libs.common.utils import gitlab_section, is_conductor_scheduled_pipeline
 from tasks.libs.notify import alerts, failure_summary, pipeline_status
 from tasks.libs.notify.jira_failing_tests import close_issue, get_failing_tests_names, get_jira
 from tasks.libs.notify.utils import PROJECT_NAME, should_notify
@@ -128,10 +128,9 @@ def failure_summary_send_notifications(
         daily_summary or weekly_summary and not (daily_summary and weekly_summary)
     ), "Exactly one of daily or weekly summary must be set"
 
-    pipeline_start = datetime.fromisoformat(os.environ['CI_PIPELINE_CREATED_AT'])
-    if not (pipeline_start.hour == 6 and pipeline_start.minute < 30):
+    if not (is_conductor_scheduled_pipeline()):
         print(
-            "Failure summary notifications are only sent if the pipeline started at 6:00 UTC, skipping",
+            "Failure summary notifications are only sent during the conductor scheduled pipeline, skipping",
             file=sys.stderr,
         )
         return

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -404,7 +404,8 @@ class TestFailureSummarySendNotifications(unittest.TestCase):
     def test_ignore_non_scheduled_conductor(self, print_mock):
         notify.failure_summary_send_notifications(MockContext(), daily_summary=True)
         print_mock.assert_called_with(
-            "Failure summary notifications are only sent if the pipeline started at 6:00 UTC, skipping", file=sys.stderr
+            "Failure summary notifications are only sent during the conductor scheduled pipeline, skipping",
+            file=sys.stderr,
         )
 
     @patch.dict('os.environ', {'CI_PIPELINE_CREATED_AT': '2025-02-07T06:11:11.111Z'})

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -395,3 +396,20 @@ class TestJobOwners(unittest.TestCase):
                 ('@DataDog/team-everything', {'this_is_a_test', 'hello_world'}),
             ],
         )
+
+
+class TestFailureSummarySendNotifications(unittest.TestCase):
+    @patch.dict('os.environ', {'CI_PIPELINE_CREATED_AT': '2025-02-07T11:11:11.111Z'})
+    @patch('builtins.print')
+    def test_ignore_non_scheduled_conductor(self, print_mock):
+        notify.failure_summary_send_notifications(MockContext(), daily_summary=True)
+        print_mock.assert_called_with(
+            "Failure summary notifications are only sent if the pipeline started at 6:00 UTC, skipping", file=sys.stderr
+        )
+
+    @patch.dict('os.environ', {'CI_PIPELINE_CREATED_AT': '2025-02-07T06:11:11.111Z'})
+    @patch('tasks.notify.failure_summary', new=MagicMock())
+    @patch('builtins.print')
+    def test_sheduled_conductor(self, print_mock):
+        notify.failure_summary_send_notifications(MockContext(), daily_summary=True)
+        print_mock.assert_not_called()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Prevent usage of the `schedule` pipeline_source for the `main` branch as scheduled pipelines are now triggered by conductor.
- Add a condition on the task to send daily/weekly summary to identify the conductor-scheduled pipeline using the pipeline creation date.

### Motivation
As per `ddci` migration the `pipeline_source` will change for pushes. I thus checked other usages of the pipeline source and detected these must be changed
https://datadoghq.atlassian.net/browse/ACIX-534


### Describe how you validated your changes
Bad configuration is handled by gitlab-ci tests + UT
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->