### PR TITLE
Fix agent's version-manifests

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -261,6 +261,15 @@ elsif do_package
   dependency "init-scripts-agent"
 end
 
+# version manifest is based on the built softwares.
+# When packaging, we only build 2, which causes very incomplete manifests
+# to be generated. However, we build correct ones during the build stage, which
+# gets extracted in the correct location in the "package-artifacts" recipe.
+# By disabling manifest generation during packaging jobs, we ensure the manifest we
+# will package is the correct one
+disable_version_manifest do_package
+
+
 if linux_target?
   extra_package_file "#{output_config_dir}/etc/datadog-agent/"
   extra_package_file '/usr/bin/dd-agent'

--- a/release.json
+++ b/release.json
@@ -26,7 +26,7 @@
     },
     "nightly-a7": {
         "OMNIBUS_SOFTWARE_VERSION": "d4a12d8a009e1c497e5e740e1ea5c8d23d6864ca",
-        "OMNIBUS_RUBY_VERSION": "chouquette/version_manifest",
+        "OMNIBUS_RUBY_VERSION": "f614b2ccc11250b836f346007da49226e198b28e",
         "JMXFETCH_VERSION": "0.49.6",
         "JMXFETCH_HASH": "f06bdac1f8ec41daf9b9839ac883f1865a068b04810ea82197b8a6afb9369cb9",
         "MACOS_BUILD_VERSION": "master",

--- a/release.json
+++ b/release.json
@@ -26,7 +26,7 @@
     },
     "nightly-a7": {
         "OMNIBUS_SOFTWARE_VERSION": "d4a12d8a009e1c497e5e740e1ea5c8d23d6864ca",
-        "OMNIBUS_RUBY_VERSION": "chouquette/version_manifest49ba11883cdf5692a39095d1a036a1ef59a25210",
+        "OMNIBUS_RUBY_VERSION": "chouquette/version_manifest",
         "JMXFETCH_VERSION": "0.49.6",
         "JMXFETCH_HASH": "f06bdac1f8ec41daf9b9839ac883f1865a068b04810ea82197b8a6afb9369cb9",
         "MACOS_BUILD_VERSION": "master",

--- a/release.json
+++ b/release.json
@@ -26,7 +26,7 @@
     },
     "nightly-a7": {
         "OMNIBUS_SOFTWARE_VERSION": "d4a12d8a009e1c497e5e740e1ea5c8d23d6864ca",
-        "OMNIBUS_RUBY_VERSION": "49ba11883cdf5692a39095d1a036a1ef59a25210",
+        "OMNIBUS_RUBY_VERSION": "chouquette/version_manifest49ba11883cdf5692a39095d1a036a1ef59a25210",
         "JMXFETCH_VERSION": "0.49.6",
         "JMXFETCH_HASH": "f06bdac1f8ec41daf9b9839ac883f1865a068b04810ea82197b8a6afb9369cb9",
         "MACOS_BUILD_VERSION": "master",

--- a/releasenotes/notes/fix_version_manifests-0f8a359ed1f58962.yaml
+++ b/releasenotes/notes/fix_version_manifests-0f8a359ed1f58962.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    version-manifest.json and version-manifest.txt files now correctly reflect the packages content.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix incorrect version manifest being generated and packaged.

### Motivation

The version-manifest.txt & version-manifest.json files we ship in our packages are broken since we started splitting build & packaging.
This is because omnibus will systematically generate those files based on the software that were build for the current project.
When packaging, we only have 2 softwares being built, and we end up overriding the manifests generated during the build jobs with incorrect ones.
This PR fixes this.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Will be verified manually once the pipeline for this PR completes

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->