### PR TITLE
Add support for kube_autoscaler_kind tag on Pods currently only supports DatadogPodAutoscaler

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -46,6 +46,11 @@ const (
 	dockerLabelService = "com.datadoghq.tags.service"
 
 	autodiscoveryLabelTagsKey = "com.datadoghq.ad.tags"
+
+	// Datadog Autoscaling annotation
+	// (from pkg/clusteragent/autoscaling/workload/model/const.go)
+	// no importing due to packages it pulls
+	datadogAutoscalingIDAnnotation = "autoscaling.datadoghq.com/autoscaler-id"
 )
 
 var (
@@ -357,6 +362,11 @@ func (c *WorkloadMetaCollector) extractTagsFromPodEntity(pod *workloadmeta.Kuber
 	// gpu requested vendor as tags
 	for _, gpuVendor := range pod.GPUVendorList {
 		tagList.AddLow(tags.KubeGPUVendor, gpuVendor)
+	}
+
+	// autoscaler presence
+	if pod.Annotations[datadogAutoscalingIDAnnotation] != "" {
+		tagList.AddLow(tags.KubeAutoscalerKind, "datadogpodautoscaler")
 	}
 
 	kubeServiceDisabled := false

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -815,6 +815,34 @@ func TestHandleKubePod(t *testing.T) {
 			},
 		},
 		{
+			name: "datadog autoscaling tag",
+			pod: workloadmeta.KubernetesPod{
+				EntityID: podEntityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      podName,
+					Namespace: podNamespace,
+					Annotations: map[string]string{
+						datadogAutoscalingIDAnnotation: "datadogpodautoscaler",
+					},
+				},
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:       podSource,
+					EntityID:     podTaggerEntityID,
+					HighCardTags: []string{},
+					OrchestratorCardTags: []string{
+						fmt.Sprintf("pod_name:%s", podName),
+					},
+					LowCardTags: []string{
+						fmt.Sprintf("kube_namespace:%s", podNamespace),
+						"kube_autoscaler_kind:datadogpodautoscaler",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
 			name: "disable kube_service",
 			pod: workloadmeta.KubernetesPod{
 				EntityID: podEntityID,
@@ -2458,7 +2486,8 @@ func TestHandlePodWithDeletedContainer(t *testing.T) {
 	collector.children = map[types.EntityID]map[types.EntityID]struct{}{
 		// Notice that here we set the container that belonged to the pod
 		// but that no longer exists
-		podTaggerEntityID: {containerToBeDeletedTaggerEntityID: struct{}{}}}
+		podTaggerEntityID: {containerToBeDeletedTaggerEntityID: struct{}{}},
+	}
 
 	eventBundle := workloadmeta.EventBundle{
 		Events: []workloadmeta.Event{

--- a/comp/core/tagger/tags/tags.go
+++ b/comp/core/tagger/tags/tags.go
@@ -88,6 +88,8 @@ const (
 	KubeAppPartOf = "kube_app_part_of"
 	// KubeAppManagedBy is the tag for the "app.kubernetes.io/managed-by" Kubernetes label
 	KubeAppManagedBy = "kube_app_managed_by"
+	// KubeAutoscalerKind is the tag reflecting if a pod is managed by an Autoscaler
+	KubeAutoscalerKind = "kube_autoscaler_kind"
 
 	// GPU related tags
 

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -250,7 +250,7 @@ func TestPatcherApplyRecommendations(t *testing.T) {
 			},
 		},
 		{
-			name: "no update on empty recommendations",
+			name: "only autoscaler id on empty recommendations",
 			pod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1",
@@ -271,7 +271,8 @@ func TestPatcherApplyRecommendations(t *testing.T) {
 					}},
 				},
 			},
-			wantErr: false,
+			wantErr:      false,
+			wantInjected: true,
 			wantPod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns1",
@@ -281,6 +282,9 @@ func TestPatcherApplyRecommendations(t *testing.T) {
 						APIVersion: "foo.com/v1",
 						Name:       "test",
 					}},
+					Annotations: map[string]string{
+						model.AutoscalerIDAnnotation: "ns1/autoscaler1",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{


### PR DESCRIPTION
### What does this PR do?

Add the `kube_autoscaler_kind` tag on Pods to allow filtering autoscaled pods. Currently only support Pods autoscaled by `DatadogPodAutoscaler`

### Motivation

Allow filtering of autoscaled Pods.

### Describe how you validated your changes

Non-regression: `kube_autoscaler_kind` tag is not added to existing Pods.
When an Autoscaler is defined targeting a workload, the `kube_autoscaler_kind` is set to `datadogpodautoscaler` (regardless of any Autoscaler setting).

### Possible Drawbacks / Trade-offs

### Additional Notes