### PR TITLE
Turn "Failed to create envConfMap" into an warning.

### DIFF
--- a/comp/otelcol/ddflareextension/impl/extension.go
+++ b/comp/otelcol/ddflareextension/impl/extension.go
@@ -146,7 +146,7 @@ func NewExtension(ctx context.Context, cfg *Config, telemetry component.Telemetr
 	}
 	envConfMap, err := newEnvConfMap(ctx, cfg.configProviderSettings)
 	if err != nil {
-		ext.telemetry.Logger.Error("Failed to create envConfMap", zap.Error(err))
+		ext.telemetry.Logger.Warn(fmt.Sprintf("Cannot report environment variables to fleet automation: %v", err))
 	}
 	ext.envConfMap = envConfMap
 


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Turn `"Failed to create envConfMap"` into a warning to not display the full stack trace.

### Motivation

This can happen when building ocb.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Build ocb and show the message is not an error but an warning.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->