### PR TITLE
Warn instead of error when failing to get v3 or v4 metaURI

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
@@ -186,7 +186,7 @@ func (c *collector) getResourceTags(ctx context.Context, entity *workloadmeta.EC
 	}
 
 	if metaURI == "" {
-		log.Errorf("failed to get client for metadata v3 or v4 API from task %q and the following containers: %v", entity.ID, entity.Containers)
+		log.Warnf("failed to get client for metadata v3 or v4 API from task %q and the following containers: %v", entity.ID, entity.Containers)
 		return rt
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set log level to warn instead of error when it fails to get client for metadata v3 or v4 API in `v1parser.go`.
### Motivation
I occasionally see error logs like this during my ECS service deployment:
```
2025-02-20 17:21:39 UTC \| PROCESS \| ERROR \| (comp/core/workloadmeta/collectors/internal/ecs/v1parser.go:189 in getResourceTags) \| failed to get client for metadata v3 or v4 API from task "arn:aws:ecs:us-east-2: 123456789012:task/redacted-cluster/***************************2c96b" and the following containers: [{ redacted-task {      }}]
```
It doesn't have any negative effect on the functionality. Resource tags can be collected successfully in retries when the container is ready to provide the metaURI endpoint. So I'm changing the log level to warn.

