### PR TITLE
use telemetry for runtime compilation

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill.go
@@ -13,6 +13,7 @@ package oomkill
 
 import (
 	"fmt"
+
 	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -22,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/maps"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -75,7 +75,7 @@ func loadOOMKillCOREProbe() (*Probe, error) {
 }
 
 func loadOOMKillRuntimeCompiledProbe(cfg *ebpf.Config) (*Probe, error) {
-	buf, err := runtime.OomKill.Compile(cfg, getCFlags(cfg), statsd.Client)
+	buf, err := runtime.OomKill.Compile(cfg, getCFlags(cfg))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/oomkill/oom_kill_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -38,7 +37,7 @@ func TestOOMKillCompile(t *testing.T) {
 
 		cfg := testConfig()
 		cfg.BPFDebug = true
-		out, err := runtime.OomKill.Compile(cfg, []string{"-g"}, statsd.Client)
+		out, err := runtime.OomKill.Compile(cfg, []string{"-g"})
 		require.NoError(t, err)
 		_ = out.Close()
 	})

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
@@ -13,6 +13,7 @@ package tcpqueuelength
 
 import (
 	"fmt"
+
 	"golang.org/x/sys/unix"
 
 	manager "github.com/DataDog/ebpf-manager"
@@ -22,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	ebpfmaps "github.com/DataDog/datadog-agent/pkg/ebpf/maps"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -171,7 +171,7 @@ func loadTCPQueueLengthCOREProbe(cfg *ebpf.Config) (*Tracer, error) {
 }
 
 func loadTCPQueueLengthRuntimeCompiledProbe(cfg *ebpf.Config) (*Tracer, error) {
-	compiledOutput, err := runtime.TcpQueueLength.Compile(cfg, []string{"-g"}, statsd.Client)
+	compiledOutput, err := runtime.TcpQueueLength.Compile(cfg, []string{"-g"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/ebpftest"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
@@ -34,7 +33,7 @@ func TestTCPQueueLengthCompile(t *testing.T) {
 
 		cfg := ebpf.NewConfig()
 		cfg.BPFDebug = true
-		out, err := runtime.TcpQueueLength.Compile(cfg, []string{"-g"}, statsd.Client)
+		out, err := runtime.TcpQueueLength.Compile(cfg, []string{"-g"})
 		require.NoError(t, err)
 		_ = out.Close()
 	})

--- a/pkg/collector/corechecks/servicediscovery/module/network_ebpf.go
+++ b/pkg/collector/corechecks/servicediscovery/module/network_ebpf.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	ebpfmaps "github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	kprobeconfig "github.com/DataDog/datadog-agent/pkg/network/tracer/connection/kprobe"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -87,7 +86,7 @@ func getAssetName(module string, debug bool) string {
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/discovery-net.c pkg/ebpf/bytecode/runtime/discovery-net.go runtime
 
 func runtimeCompile(cfg *discoveryConfig) (runtime.CompiledOutput, error) {
-	return runtime.DiscoveryNet.Compile(&cfg.Config, getCFlags(cfg), statsd.Client)
+	return runtime.DiscoveryNet.Compile(&cfg.Config, getCFlags(cfg))
 }
 
 func getCFlags(cfg *discoveryConfig) []string {

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -11,13 +11,12 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -45,16 +44,14 @@ type CompileOptions struct {
 	AdditionalFlags []string
 	// ModifyCallback is a callback function that is allowed to modify the contents before compilation
 	ModifyCallback func(in io.Reader, out io.Writer) error
-	// StatsdClient is a statsd client to use for telemetry
-	StatsdClient statsd.ClientInterface
 	// UseKernelHeaders enables the inclusion of kernel headers from the host
 	UseKernelHeaders bool
 }
 
 // Compile compiles the asset to an object file, writes it to the configured output directory, and
 // then opens and returns the compiled output
-func (a *asset) Compile(config *ebpf.Config, additionalFlags []string, client statsd.ClientInterface) (CompiledOutput, error) {
-	return a.compile(config, CompileOptions{AdditionalFlags: additionalFlags, StatsdClient: client, UseKernelHeaders: true})
+func (a *asset) Compile(config *ebpf.Config, additionalFlags []string) (CompiledOutput, error) {
+	return a.compile(config, CompileOptions{AdditionalFlags: additionalFlags, UseKernelHeaders: true})
 }
 
 // CompileWithOptions is the same as Compile, but takes an options struct with additional choices.
@@ -85,7 +82,7 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 		kernelHeaders = kernel.GetKernelHeaders(headerOpts)
 		if len(kernelHeaders) == 0 {
 			a.tm.compilationResult = headerFetchErr
-			return nil, fmt.Errorf("unable to find kernel headers")
+			return nil, errors.New("unable to find kernel headers")
 		}
 	}
 
@@ -180,7 +177,7 @@ func (a *asset) verify(source ProtectedFile) error {
 		return fmt.Errorf("hash file %s: %w", source.Name(), err)
 	}
 	if sum != a.hash {
-		return fmt.Errorf("file content hash does not match expected value")
+		return errors.New("file content hash does not match expected value")
 	}
 	return nil
 }

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -82,7 +82,7 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 			YumReposDir:     config.YumReposDir,
 			ZypperReposDir:  config.ZypperReposDir,
 		}
-		kernelHeaders = kernel.GetKernelHeaders(headerOpts, opts.StatsdClient)
+		kernelHeaders = kernel.GetKernelHeaders(headerOpts)
 		if len(kernelHeaders) == 0 {
 			a.tm.compilationResult = headerFetchErr
 			return nil, fmt.Errorf("unable to find kernel headers")

--- a/pkg/ebpf/bytecode/runtime/asset.go
+++ b/pkg/ebpf/bytecode/runtime/asset.go
@@ -69,9 +69,7 @@ func (a *asset) compile(config *ebpf.Config, opts CompileOptions) (CompiledOutpu
 	a.tm.compilationEnabled = true
 	defer func() {
 		a.tm.compilationDuration = time.Since(start)
-		if opts.StatsdClient != nil {
-			a.tm.SubmitTelemetry(a.filename, opts.StatsdClient)
-		}
+		a.tm.SubmitTelemetry(a.filename)
 	}()
 
 	var kernelHeaders []string

--- a/pkg/ebpf/bytecode/runtime/generated_asset.go
+++ b/pkg/ebpf/bytecode/runtime/generated_asset.go
@@ -45,9 +45,7 @@ func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, addition
 	a.tm.compilationEnabled = true
 	defer func() {
 		a.tm.compilationDuration = time.Since(start)
-		if client != nil {
-			a.tm.SubmitTelemetry(a.filename, client)
-		}
+		a.tm.SubmitTelemetry(a.filename)
 	}()
 
 	opts := kernel.HeaderOptions{

--- a/pkg/ebpf/bytecode/runtime/generated_asset.go
+++ b/pkg/ebpf/bytecode/runtime/generated_asset.go
@@ -56,7 +56,7 @@ func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, addition
 		YumReposDir:     config.YumReposDir,
 		ZypperReposDir:  config.ZypperReposDir,
 	}
-	kernelHeaders := kernel.GetKernelHeaders(opts, client)
+	kernelHeaders := kernel.GetKernelHeaders(opts)
 	if len(kernelHeaders) == 0 {
 		a.tm.compilationResult = headerFetchErr
 		return nil, fmt.Errorf("unable to find kernel headers")

--- a/pkg/ebpf/bytecode/runtime/generated_asset.go
+++ b/pkg/ebpf/bytecode/runtime/generated_asset.go
@@ -8,12 +8,11 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/DataDog/datadog-go/v5/statsd"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -38,7 +37,7 @@ func newGeneratedAsset(filename string) *generatedAsset {
 
 // Compile compiles the provided c code to an object file, writes it to the configured output directory, and
 // then opens and returns the compiled output
-func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, additionalFlags []string, client statsd.ClientInterface) (CompiledOutput, error) {
+func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, additionalFlags []string) (CompiledOutput, error) {
 	log.Debugf("starting runtime compilation of %s", a.filename)
 
 	start := time.Now()
@@ -59,7 +58,7 @@ func (a *generatedAsset) Compile(config *ebpf.Config, inputCode string, addition
 	kernelHeaders := kernel.GetKernelHeaders(opts)
 	if len(kernelHeaders) == 0 {
 		a.tm.compilationResult = headerFetchErr
-		return nil, fmt.Errorf("unable to find kernel headers")
+		return nil, errors.New("unable to find kernel headers")
 	}
 
 	outputDir := config.RuntimeCompilerOutputDir

--- a/pkg/ebpf/bytecode/runtime/helpers_test.go
+++ b/pkg/ebpf/bytecode/runtime/helpers_test.go
@@ -37,7 +37,7 @@ func TestGetAvailableHelpers(t *testing.T) {
 		YumReposDir:     cfg.YumReposDir,
 		ZypperReposDir:  cfg.ZypperReposDir,
 	}
-	kernelHeaders := kernel.GetKernelHeaders(opts, nil)
+	kernelHeaders := kernel.GetKernelHeaders(opts)
 	fns, err := getAvailableHelpers(kernelHeaders)
 	require.NoError(t, err)
 	assert.NotEmpty(t, fns, "number of available helpers")

--- a/pkg/ebpf/bytecode/runtime/telemetry.go
+++ b/pkg/ebpf/bytecode/runtime/telemetry.go
@@ -8,19 +8,22 @@
 package runtime
 
 import (
-	"errors"
-	"fmt"
-	"strings"
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/DataDog/nikos/types"
 
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+var rcTelemetry = struct {
+	success telemetry.Counter
+	error   telemetry.Counter
+}{
+	success: telemetry.NewCounter("ebpf__runtime_compilation__compile", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "result"}, "gauge of runtime compilation compile successes"),
+	error:   telemetry.NewCounter("ebpf__runtime_compilation__compile", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "result"}, "gauge of runtime compilation compile errors"),
+}
 
 // CompilationResult enumerates runtime compilation success & failure modes
 type CompilationResult int
@@ -30,9 +33,9 @@ const (
 	compilationSuccess
 	kernelVersionErr
 	verificationError
-	outputDirErr
+	_
 	outputFileErr
-	newCompilerErr //nolint:deadcode,unused
+	_
 	compilationErr
 	resultReadErr
 	headerFetchErr
@@ -54,7 +57,7 @@ func newCompilationTelemetry() CompilationTelemetry {
 	}
 }
 
-// CompilationEnabled returns whether or not runtime compilation has been enabled
+// CompilationEnabled returns whether runtime compilation has been enabled
 func (tm *CompilationTelemetry) CompilationEnabled() bool {
 	return tm.compilationEnabled
 }
@@ -70,46 +73,44 @@ func (tm *CompilationTelemetry) CompilationDurationNS() int64 {
 }
 
 // SubmitTelemetry sends telemetry using the provided statsd client
-func (tm *CompilationTelemetry) SubmitTelemetry(filename string, statsdClient statsd.ClientInterface) {
-	if !tm.compilationEnabled {
+func (tm *CompilationTelemetry) SubmitTelemetry(filename string) {
+	if !tm.compilationEnabled || tm.compilationResult == notAttempted {
 		return
 	}
 
-	var platform string
-	if target, err := types.NewTarget(); err == nil {
-		// Prefer platform information from nikos over platform info from the host package, since this
-		// is what kernel header downloading uses
-		platform = strings.ToLower(target.Distro.Display)
-	} else {
-		log.Warnf("failed to retrieve host platform information from nikos: %s", err)
-		platform, err = kernel.Platform()
-		if err != nil {
-			log.Warnf("failed to retrieve host platform information: %s", err)
-			return
-		}
+	platform, err := kernel.Platform()
+	if err != nil {
+		log.Warnf("failed to retrieve host platform information: %s", err)
+		return
+	}
+	platformVersion, err := kernel.PlatformVersion()
+	if err != nil {
+		log.Warnf("failed to get platform version: %s", err)
+		return
+	}
+	kernelVersion, err := kernel.Release()
+	if err != nil {
+		log.Warnf("failed to get kernel version: %s", err)
+		return
+	}
+	arch, err := kernel.Machine()
+	if err != nil {
+		log.Warnf("failed to get kernel architecture: %s", err)
+		return
 	}
 
 	tags := []string{
-		fmt.Sprintf("asset:%s", filename),
-		fmt.Sprintf("agent_version:%s", version.AgentVersion),
-		fmt.Sprintf("platform:%s", platform),
+		platform,
+		platformVersion,
+		kernelVersion,
+		arch,
+		filename,
+		model.RuntimeCompilationResult(tm.compilationResult).String(),
 	}
 
-	if tm.compilationResult != notAttempted {
-		var resultTag string
-		if tm.compilationResult == compilationSuccess || tm.compilationResult == compiledOutputFound {
-			resultTag = "success"
-		} else {
-			resultTag = "failure"
-		}
-
-		rcTags := append(tags,
-			fmt.Sprintf("result:%s", resultTag),
-			fmt.Sprintf("reason:%s", model.RuntimeCompilationResult(tm.compilationResult).String()),
-		)
-
-		if err := statsdClient.Count("datadog.system_probe.runtime_compilation.attempted", 1.0, rcTags, 1.0); err != nil && !errors.Is(err, statsd.ErrNoClient) {
-			log.Warnf("error submitting runtime compilation metric to statsd: %s", err)
-		}
+	if tm.compilationResult == compilationSuccess || tm.compilationResult == compiledOutputFound {
+		rcTelemetry.success.Inc(tags...)
+	} else {
+		rcTelemetry.error.Inc(tags...)
 	}
 }

--- a/pkg/ebpf/bytecode/runtime/telemetry.go
+++ b/pkg/ebpf/bytecode/runtime/telemetry.go
@@ -21,8 +21,8 @@ var rcTelemetry = struct {
 	success telemetry.Counter
 	error   telemetry.Counter
 }{
-	success: telemetry.NewCounter("ebpf__runtime_compilation__compile", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "result"}, "gauge of runtime compilation compile successes"),
-	error:   telemetry.NewCounter("ebpf__runtime_compilation__compile", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "result"}, "gauge of runtime compilation compile errors"),
+	success: telemetry.NewCounter("ebpf__runtime_compilation__compile", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "result"}, "counter of runtime compilation compile successes"),
+	error:   telemetry.NewCounter("ebpf__runtime_compilation__compile", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "result"}, "counter of runtime compilation compile errors"),
 }
 
 // CompilationResult enumerates runtime compilation success & failure modes

--- a/pkg/ebpf/ebpf.go
+++ b/pkg/ebpf/ebpf.go
@@ -49,8 +49,8 @@ func coreLoader(cfg *Config) (*coreAssetLoader, error) {
 			success telemetry.Counter
 			error   telemetry.Counter
 		}{
-			success: telemetry.NewCounter("ebpf__core__load", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "btf_type"}, "gauge of CO-RE load successes"),
-			error:   telemetry.NewCounter("ebpf__core__load", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "error_type"}, "gauge of CO-RE load errors"),
+			success: telemetry.NewCounter("ebpf__core__load", "success", []string{"platform", "platform_version", "kernel", "arch", "asset", "btf_type"}, "count of CO-RE load successes"),
+			error:   telemetry.NewCounter("ebpf__core__load", "error", []string{"platform", "platform_version", "kernel", "arch", "asset", "error_type"}, "count of CO-RE load errors"),
 		},
 	}
 	return core.loader, nil

--- a/pkg/gpu/compile.go
+++ b/pkg/gpu/compile.go
@@ -11,14 +11,13 @@ package gpu
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate $GOPATH/bin/include_headers pkg/gpu/ebpf/c/runtime/gpu.c pkg/ebpf/bytecode/build/runtime/gpu.c pkg/ebpf/c pkg/gpu/ebpf/c/runtime pkg/gpu/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/gpu.c pkg/ebpf/bytecode/runtime/gpu.go runtime
 
 func getRuntimeCompiledGPUMonitoring(config *config.Config) (runtime.CompiledOutput, error) {
-	return runtime.Gpu.Compile(&config.Config, getCFlags(config), statsd.Client)
+	return runtime.Gpu.Compile(&config.Config, getCFlags(config))
 }
 
 func getCFlags(config *config.Config) []string {

--- a/pkg/network/tracer/compile.go
+++ b/pkg/network/tracer/compile.go
@@ -10,14 +10,13 @@ package tracer
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/runtime/conntrack.c pkg/ebpf/bytecode/build/runtime/conntrack.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/conntrack.c pkg/ebpf/bytecode/runtime/conntrack.go runtime
 
 func getRuntimeCompiledConntracker(config *config.Config) (runtime.CompiledOutput, error) {
-	return runtime.Conntrack.Compile(&config.Config, getCFlags(config), statsd.Client)
+	return runtime.Conntrack.Compile(&config.Config, getCFlags(config))
 }
 
 func getCFlags(config *config.Config) []string {

--- a/pkg/network/tracer/connection/kprobe/compile.go
+++ b/pkg/network/tracer/connection/kprobe/compile.go
@@ -11,14 +11,13 @@ package kprobe
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/tracer.c pkg/ebpf/bytecode/build/runtime/tracer.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/tracer.c pkg/ebpf/bytecode/runtime/tracer.go runtime
 
 func getRuntimeCompiledTracer(config *config.Config) (runtime.CompiledOutput, error) {
-	return runtime.Tracer.Compile(&config.Config, getCFlags(config), statsd.Client)
+	return runtime.Tracer.Compile(&config.Config, getCFlags(config))
 }
 
 func getCFlags(config *config.Config) []string {

--- a/pkg/network/tracer/offsetguess_test.go
+++ b/pkg/network/tracer/offsetguess_test.go
@@ -28,7 +28,6 @@ import (
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer/offsetguess"
 	tracertestutil "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 )
@@ -137,7 +136,7 @@ func TestOffsetGuess(t *testing.T) {
 
 func testOffsetGuess(t *testing.T) {
 	cfg := testConfig()
-	buf, err := runtime.OffsetguessTest.Compile(&cfg.Config, getCFlags(cfg), statsd.Client)
+	buf, err := runtime.OffsetguessTest.Compile(&cfg.Config, getCFlags(cfg))
 	require.NoError(t, err)
 	defer buf.Close()
 

--- a/pkg/network/usm/compile.go
+++ b/pkg/network/usm/compile.go
@@ -11,14 +11,13 @@ package usm
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/runtime/usm.c pkg/ebpf/bytecode/build/runtime/usm.c pkg/ebpf/c pkg/ebpf/c/protocols pkg/network/ebpf/c/runtime pkg/network/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/usm.c pkg/ebpf/bytecode/runtime/usm.go runtime
 
 func getRuntimeCompiledUSM(config *config.Config) (runtime.CompiledOutput, error) {
-	return runtime.Usm.Compile(&config.Config, getCFlags(config), statsd.Client)
+	return runtime.Usm.Compile(&config.Config, getCFlags(config))
 }
 
 func getCFlags(config *config.Config) []string {

--- a/pkg/network/usm/sharedlibraries/compile.go
+++ b/pkg/network/usm/sharedlibraries/compile.go
@@ -10,14 +10,13 @@ package sharedlibraries
 import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 )
 
 //go:generate $GOPATH/bin/include_headers pkg/network/ebpf/c/runtime/shared-libraries.c pkg/ebpf/bytecode/build/runtime/shared-libraries.c pkg/ebpf/c pkg/network/ebpf/c/runtime pkg/network/ebpf/c
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/shared-libraries.c pkg/ebpf/bytecode/runtime/shared-libraries.go runtime
 
 func getRuntimeCompiledSharedLibraries(config *ebpf.Config) (runtime.CompiledOutput, error) {
-	return runtime.SharedLibraries.Compile(config, getCFlags(config), statsd.Client)
+	return runtime.SharedLibraries.Compile(config, getCFlags(config))
 }
 
 func getCFlags(config *ebpf.Config) []string {

--- a/pkg/security/ebpf/compile.go
+++ b/pkg/security/ebpf/compile.go
@@ -9,8 +9,6 @@
 package ebpf
 
 import (
-	"github.com/DataDog/datadog-go/v5/statsd"
-
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
@@ -21,7 +19,7 @@ import (
 //go:generate $GOPATH/bin/integrity pkg/ebpf/bytecode/build/runtime/runtime-security.c pkg/ebpf/bytecode/runtime/runtime-security.go runtime
 //go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/model/bpf_maps_generator -runtime-path ../../ebpf/bytecode/build/runtime/runtime-security.c -output ../../security/secl/model/consts_map_names_linux.go -pkg-name model
 
-func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFentry, useRingBuffer bool, client statsd.ClientInterface) (bytecode.AssetReader, error) {
+func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFentry, useRingBuffer bool) (bytecode.AssetReader, error) {
 	var cflags []string
 
 	if useFentry {
@@ -46,5 +44,5 @@ func getRuntimeCompiledPrograms(config *config.Config, useSyscallWrapper, useFen
 
 	cflags = append(cflags, "-g")
 
-	return runtime.RuntimeSecurity.Compile(&config.Config, cflags, client)
+	return runtime.RuntimeSecurity.Compile(&config.Config, cflags)
 }

--- a/pkg/security/ebpf/compile_test.go
+++ b/pkg/security/ebpf/compile_test.go
@@ -24,7 +24,7 @@ func TestLoaderCompile(t *testing.T) {
 		require.NoError(t, err)
 		cfg, err := config.NewConfig()
 		require.NoError(t, err)
-		out, err := getRuntimeCompiledPrograms(cfg, false, false, false, nil)
+		out, err := getRuntimeCompiledPrograms(cfg, false, false, false)
 		require.NoError(t, err)
 		_ = out.Close()
 	})

--- a/pkg/security/ebpf/compile_unsupported.go
+++ b/pkg/security/ebpf/compile_unsupported.go
@@ -9,13 +9,12 @@
 package ebpf
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
-	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
-func getRuntimeCompiledPrograms(_ *config.Config, _, _, _ bool, _ statsd.ClientInterface) (bytecode.AssetReader, error) {
-	return nil, fmt.Errorf("runtime compilation unsupported")
+func getRuntimeCompiledPrograms(_ *config.Config, _, _, _ bool) (bytecode.AssetReader, error) {
+	return nil, errors.New("runtime compilation unsupported")
 }

--- a/pkg/security/ebpf/loader.go
+++ b/pkg/security/ebpf/loader.go
@@ -11,11 +11,11 @@ package ebpf
 import (
 	"strings"
 
+	manager "github.com/DataDog/ebpf-manager"
+
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	"github.com/DataDog/datadog-go/v5/statsd"
-	manager "github.com/DataDog/ebpf-manager"
 )
 
 // ProbeLoader defines an eBPF ProbeLoader
@@ -25,17 +25,15 @@ type ProbeLoader struct {
 	useSyscallWrapper bool
 	useRingBuffer     bool
 	useFentry         bool
-	statsdClient      statsd.ClientInterface
 }
 
 // NewProbeLoader returns a new Loader
-func NewProbeLoader(config *config.Config, useSyscallWrapper, useRingBuffer bool, useFentry bool, statsdClient statsd.ClientInterface) *ProbeLoader {
+func NewProbeLoader(config *config.Config, useSyscallWrapper, useRingBuffer bool, useFentry bool) *ProbeLoader {
 	return &ProbeLoader{
 		config:            config,
 		useSyscallWrapper: useSyscallWrapper,
 		useRingBuffer:     useRingBuffer,
 		useFentry:         useFentry,
-		statsdClient:      statsdClient,
 	}
 }
 
@@ -52,7 +50,7 @@ func (l *ProbeLoader) Load() (bytecode.AssetReader, bool, error) {
 	var err error
 	var runtimeCompiled bool
 	if l.config.RuntimeCompilationEnabled {
-		l.bytecodeReader, err = getRuntimeCompiledPrograms(l.config, l.useSyscallWrapper, l.useFentry, l.useRingBuffer, l.statsdClient)
+		l.bytecodeReader, err = getRuntimeCompiledPrograms(l.config, l.useSyscallWrapper, l.useFentry, l.useRingBuffer)
 		if err != nil {
 			seclog.Warnf("error compiling runtime-security probe, falling back to pre-compiled: %s", err)
 		} else {

--- a/pkg/security/ebpf/tests/helpers_test.go
+++ b/pkg/security/ebpf/tests/helpers_test.go
@@ -14,11 +14,11 @@ import (
 	"testing"
 	"time"
 
-	secebpf "github.com/DataDog/datadog-agent/pkg/security/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
-	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/cilium/ebpf"
 	"github.com/safchain/baloum/pkg/baloum"
+
+	secebpf "github.com/DataDog/datadog-agent/pkg/security/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 )
 
 type testLogger struct {
@@ -62,7 +62,7 @@ func newVM(t *testing.T) *baloum.VM {
 		t.Fatal(err)
 	}
 
-	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, false, false, &statsd.NoOpClient{})
+	loader := secebpf.NewProbeLoader(&config.Config{}, useSyscallWrapper, false, false)
 	reader, _, err := loader.Load()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -370,7 +370,7 @@ func (p *EBPFProbe) VerifyEnvironment() *multierror.Error {
 }
 
 func (p *EBPFProbe) initEBPFManager() error {
-	loader := ebpf.NewProbeLoader(p.config.Probe, p.useSyscallWrapper, p.useRingBuffers, p.useFentry, p.statsdClient)
+	loader := ebpf.NewProbeLoader(p.config.Probe, p.useSyscallWrapper, p.useRingBuffers, p.useFentry)
 	defer loader.Close()
 
 	bytecodeReader, runtimeCompiled, err := loader.Load()

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -32,8 +32,8 @@ var headerTelemetry = struct {
 	success telemetry.Counter
 	error   telemetry.Counter
 }{
-	success: telemetry.NewCounter("ebpf__runtime_compilation__header_download", "success", []string{"platform", "platform_version", "kernel", "arch", "result"}, "gauge of kernel header download successes"),
-	error:   telemetry.NewCounter("ebpf__runtime_compilation__header_download", "error", []string{"platform", "platform_version", "kernel", "arch", "result"}, "gauge of kernel header download errors"),
+	success: telemetry.NewCounter("ebpf__runtime_compilation__header_download", "success", []string{"platform", "platform_version", "kernel", "arch", "result"}, "count of kernel header download successes"),
+	error:   telemetry.NewCounter("ebpf__runtime_compilation__header_download", "error", []string{"platform", "platform_version", "kernel", "arch", "result"}, "count of kernel header download errors"),
 }
 
 const sysfsHeadersPath = "/sys/kernel/kheaders.tar.xz"

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -19,17 +19,22 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 
-	"github.com/DataDog/datadog-go/v5/statsd"
-	"github.com/DataDog/nikos/types"
 	"golang.org/x/exp/maps"
 
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/archive"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+var headerTelemetry = struct {
+	success telemetry.Counter
+	error   telemetry.Counter
+}{
+	success: telemetry.NewCounter("ebpf__runtime_compilation__header_download", "success", []string{"platform", "platform_version", "kernel", "arch", "result"}, "gauge of kernel header download successes"),
+	error:   telemetry.NewCounter("ebpf__runtime_compilation__header_download", "error", []string{"platform", "platform_version", "kernel", "arch", "result"}, "gauge of kernel header download errors"),
+}
 
 const sysfsHeadersPath = "/sys/kernel/kheaders.tar.xz"
 const kernelModulesPath = "/lib/modules/%s/build"
@@ -73,6 +78,7 @@ const (
 	headersNotFoundDownloadDisabled
 )
 
+// IsSuccess returns whether the headers were fetched successfully
 func (r headerFetchResult) IsSuccess() bool {
 	return customHeadersFound <= r && r <= downloadSuccess
 }
@@ -128,7 +134,7 @@ func initProvider(opts HeaderOptions) {
 // Any subsequent calls to GetKernelHeaders will return the result of the first call. This is because
 // kernel header downloading can be a resource intensive process, so we don't want to retry it an unlimited
 // number of times.
-func GetKernelHeaders(opts HeaderOptions, client statsd.ClientInterface) []string {
+func GetKernelHeaders(opts HeaderOptions) []string {
 	providerMu.Lock()
 	defer providerMu.Unlock()
 
@@ -149,9 +155,7 @@ func GetKernelHeaders(opts HeaderOptions, client statsd.ClientInterface) []strin
 	}
 
 	headers, result, err := HeaderProvider.getKernelHeaders(hv)
-	if client != nil {
-		submitTelemetry(result, client)
-	}
+	submitTelemetry(result)
 
 	HeaderProvider.kernelHeaders = headers
 	HeaderProvider.result = result
@@ -215,7 +219,7 @@ func (h *headerProvider) getKernelHeaders(hv Version) ([]string, headerFetchResu
 	log.Debugf("unable to find downloaded kernel headers: no valid headers found")
 
 	if !h.downloadEnabled {
-		return nil, headersNotFoundDownloadDisabled, fmt.Errorf("no valid matching kernel header directories found. To download kernel headers, set system_probe_config.enable_kernel_header_download to true")
+		return nil, headersNotFoundDownloadDisabled, errors.New("no valid matching kernel header directories found. To download kernel headers, set system_probe_config.enable_kernel_header_download to true")
 	}
 
 	return h.downloadHeaders(hv)
@@ -233,7 +237,7 @@ func (h *headerProvider) downloadHeaders(hv Version) ([]string, headerFetchResul
 	if dirs := validateHeaderDirs(hv, getDownloadedHeaderDirs(h.headerDownloadDir), true); len(dirs) > 0 {
 		return dirs, downloadSuccess, nil
 	}
-	return nil, validationFailure, fmt.Errorf("downloaded headers are not valid")
+	return nil, validationFailure, errors.New("downloaded headers are not valid")
 }
 
 // validateHeaderDirs checks all the given directories and returns the directories containing kernel
@@ -357,7 +361,7 @@ func parseHeaderVersion(r io.Reader) (Version, error) {
 	if err := scanner.Err(); err != nil {
 		return 0, err
 	}
-	return 0, fmt.Errorf("no kernel version found")
+	return 0, errors.New("no kernel version found")
 }
 
 func getDefaultHeaderDirs() []string {
@@ -408,7 +412,7 @@ func getSysfsHeaderDirs(v Version) ([]string, error) {
 		}
 		defer func() { _ = unloadKHeadersModule() }()
 		if !sysfsHeadersExist() {
-			return nil, fmt.Errorf("unable to find sysfs kernel headers")
+			return nil, errors.New("unable to find sysfs kernel headers")
 		}
 	}
 
@@ -445,41 +449,43 @@ func unloadKHeadersModule() error {
 	return nil
 }
 
-func submitTelemetry(result headerFetchResult, client statsd.ClientInterface) {
+func submitTelemetry(result headerFetchResult) {
 	if result == notAttempted {
 		return
 	}
 
-	var platform string
-	if target, err := types.NewTarget(); err == nil {
-		platform = strings.ToLower(target.Distro.Display)
-	} else {
-		log.Warnf("failed to retrieve host platform information from nikos: %s", err)
-		platform, err = Platform()
-		if err != nil {
-			log.Warnf("failed to retrieve host platform information: %s", err)
-			return
-		}
+	platform, err := Platform()
+	if err != nil {
+		log.Warnf("failed to retrieve host platform information: %s", err)
+		return
+	}
+	platformVersion, err := PlatformVersion()
+	if err != nil {
+		log.Warnf("failed to get platform version: %s", err)
+		return
+	}
+	kernelVersion, err := Release()
+	if err != nil {
+		log.Warnf("failed to get kernel version: %s", err)
+		return
+	}
+	arch, err := Machine()
+	if err != nil {
+		log.Warnf("failed to get kernel architecture: %s", err)
+		return
 	}
 
 	tags := []string{
-		fmt.Sprintf("agent_version:%s", version.AgentVersion),
-		fmt.Sprintf("platform:%s", platform),
+		platform,
+		platformVersion,
+		kernelVersion,
+		arch,
+		kernelHeaderFetchResultName[int(result)],
 	}
 
-	var resultTag string
 	if result.IsSuccess() {
-		resultTag = "success"
+		headerTelemetry.success.Inc(tags...)
 	} else {
-		resultTag = "failure"
-	}
-
-	khdTags := append(tags,
-		fmt.Sprintf("result:%s", resultTag),
-		fmt.Sprintf("reason:%s", kernelHeaderFetchResultName[int(result)]),
-	)
-
-	if err := client.Count("datadog.system_probe.kernel_header_fetch.attempted", 1.0, khdTags, 1); err != nil && !errors.Is(err, statsd.ErrNoClient) {
-		log.Warnf("error submitting kernel header downloading metric to statsd: %s", err)
+		headerTelemetry.error.Inc(tags...)
 	}
 }

--- a/pkg/util/kernel/find_headers_test.go
+++ b/pkg/util/kernel/find_headers_test.go
@@ -21,7 +21,7 @@ func TestGetKernelHeaders(t *testing.T) {
 	}
 
 	opts := HeaderOptions{}
-	dirs := GetKernelHeaders(opts, nil)
+	dirs := GetKernelHeaders(opts)
 	assert.NotZero(t, len(dirs), "expected to find header directories")
 	t.Log(dirs)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes usage of statsd for runtime compilation and kernel header downloading to use internal telemetry.

### Motivation

We don't need to be submitting these statsd metrics on customer hosts. We track customer telemetry via data submitted with NPM/USM payloads.

### Describe how you validated your changes

Telemetry change only. Existing tests cover runtime compilation and kernel header downloading functionality.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->