### PR TITLE
Normalize module path returned by `get_go_module`

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -813,7 +813,7 @@ def get_go_module(path):
     while path != '/':
         go_mod_path = os.path.join(path, 'go.mod')
         if os.path.isfile(go_mod_path):
-            return os.path.relpath(path)
+            return normpath(os.path.relpath(path))
         path = os.path.dirname(path)
     raise Exception(f"No go.mod file found for package at {path}")
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Normalize the path returned by the `get_go_module` function.

### Motivation

On Windows the returned path would contain backslashes, meaning that in the following piece of code the condition to decide whether to skip the tests of a given module was always true as the `modules.yml` file uses posix paths:
https://github.com/DataDog/datadog-agent/blob/653f4b30592fb011563bca29fed874ef41688ecc/tasks/gotest.py#L735-L743

This was causing Windows CI jobs not to run the unit tests for non-root Go modules on dev branches.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->