### PR TITLE
(fleet) avoid re-initializing the config of packages on install

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -679,6 +679,14 @@ func (i *installerImpl) configurePackage(ctx context.Context, pkg string) (err e
 	if runtime.GOOS == "windows" {
 		return nil
 	}
+	state, err := i.configs.GetState(pkg)
+	if err != nil {
+		return fmt.Errorf("could not get config repository state: %w", err)
+	}
+	// If a config is already set, no need to initialize it
+	if state.Stable != "" {
+		return nil
+	}
 	tmpDir, err := i.configs.MkdirTemp()
 	if err != nil {
 		return fmt.Errorf("could not create temporary directory: %w", err)


### PR DESCRIPTION
We were setting an empty config on fresh installs regardless of wether a config was already present. This PR checks for the presence of a config before doing that.

### Describe how you validated your changes

- manual testing