### PR TITLE
[AGENTRUN-140] reduce log level of uninitialized TLSConfig

### DIFF
--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -167,7 +167,7 @@ func GetTLSClientConfig() *tls.Config {
 	tokenLock.RLock()
 	defer tokenLock.RUnlock()
 	if initSource == uninitialized {
-		log.Errorf("GetTLSClientConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function)")
+		log.Warnf("GetTLSClientConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function)")
 	}
 	return clientTLSConfig.Clone()
 }
@@ -177,7 +177,7 @@ func GetTLSServerConfig() *tls.Config {
 	tokenLock.RLock()
 	defer tokenLock.RUnlock()
 	if initSource == uninitialized {
-		log.Errorf("GetTLSServerConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function), generating a self-signed certificate")
+		log.Warnf("GetTLSServerConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function), generating a self-signed certificate")
 		config, err := generateSelfSignedCert()
 		if err != nil {
 			log.Error(err.Error())

--- a/pkg/api/util/util.go
+++ b/pkg/api/util/util.go
@@ -167,7 +167,7 @@ func GetTLSClientConfig() *tls.Config {
 	tokenLock.RLock()
 	defer tokenLock.RUnlock()
 	if initSource == uninitialized {
-		log.Warnf("GetTLSClientConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function)")
+		log.Warn("GetTLSClientConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function)")
 	}
 	return clientTLSConfig.Clone()
 }
@@ -177,7 +177,7 @@ func GetTLSServerConfig() *tls.Config {
 	tokenLock.RLock()
 	defer tokenLock.RUnlock()
 	if initSource == uninitialized {
-		log.Warnf("GetTLSServerConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function), generating a self-signed certificate")
+		log.Warn("GetTLSServerConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function), generating a self-signed certificate")
 		config, err := generateSelfSignedCert()
 		if err != nil {
 			log.Error(err.Error())


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR reduces the log level of the following log:
```
GetTLSServerConfig/GetTLSClientConfig was called before being initialized (through SetAuthToken or CreateAndSetAuthToken function), generating a self-signed certificate
```

### Motivation
Error level logs should represent non-recoverable errors that prevent the Agent from operating normally. This error does not prevent the Agent from functioning correctly, so to avoid unnecessary concern, it should be downgraded to a warning level.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This PR does not introduce any changes in the Agent behavior.