### PR TITLE
trivy: de-duplicate `ScanFilesystem` and remove need for imgMeta

### DIFF
--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -312,7 +312,12 @@ func (c *Collector) ScanContainerdImageFromFilesystem(ctx context.Context, imgMe
 		}
 	}()
 
-	return c.scanFilesystem(ctx, imagePath, imgMeta, scanOptions)
+	report, err := c.ScanFilesystem(ctx, imagePath, scanOptions)
+	if err != nil {
+		return nil, fmt.Errorf("unable to scan image %s, err: %w", imgMeta.ID, err)
+	}
+
+	return report, err
 }
 
 func extractLayersFromOverlayFSMounts(mounts []mount.Mount) []string {

--- a/pkg/util/trivy/trivy.go
+++ b/pkg/util/trivy/trivy.go
@@ -262,8 +262,8 @@ func (c *Collector) getCache() (CacheWithCleaner, error) {
 	return c.persistentCache, nil
 }
 
-// scanFilesystem scans the specified directory and logs detailed scan steps.
-func (c *Collector) scanFilesystem(ctx context.Context, path string, imgMeta *workloadmeta.ContainerImageMetadata, scanOptions sbom.ScanOptions) (sbom.Report, error) {
+// ScanFilesystem scans the specified directory and logs detailed scan steps.
+func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions sbom.ScanOptions) (sbom.Report, error) {
 	// For filesystem scans, it is required to walk the filesystem to get the persistentCache key so caching does not add any value.
 	// TODO: Cache directly the trivy report for container images
 	cache := newMemoryCache()
@@ -275,18 +275,10 @@ func (c *Collector) scanFilesystem(ctx context.Context, path string, imgMeta *wo
 
 	trivyReport, err := c.scan(ctx, fsArtifact, applier.NewApplier(cache))
 	if err != nil {
-		if imgMeta != nil {
-			return nil, fmt.Errorf("unable to marshal report to sbom format for image %s, err: %w", imgMeta.ID, err)
-		}
 		return nil, fmt.Errorf("unable to marshal report to sbom format, err: %w", err)
 	}
 
 	return c.buildReport(trivyReport, cache.blobID), nil
-}
-
-// ScanFilesystem scans file-system
-func (c *Collector) ScanFilesystem(ctx context.Context, path string, scanOptions sbom.ScanOptions) (sbom.Report, error) {
-	return c.scanFilesystem(ctx, path, nil, scanOptions)
 }
 
 func (c *Collector) fixupCacheKeyForImgMeta(ctx context.Context, artifact artifact.Artifact, imgMeta *workloadmeta.ContainerImageMetadata, cache CacheWithCleaner) error {


### PR DESCRIPTION
### What does this PR do?

This PR removes the image meta argument from `ScanFilesystem` allowing to have one single implementation directly usable for host scanning and containerd overlayfs direct scanning. The error message improvement provided by the img meta has been moved to the containerd caller.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->