### PR TITLE
reordering fixes

### DIFF
--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -65,10 +65,6 @@ install_method:
     echo "$install_info_content" > $CONFIG_DIR/install_info
 fi
 
-if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
-    ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
-fi
-
 set +e 
 generate_install_id()
 {
@@ -97,9 +93,15 @@ if [ ! -f "$CONFIG_DIR/install.json" ]; then
     install_time=$(date +%s)
     install_signature=$(generate_install_signature "$install_id" "$install_type" "$install_time")
     echo "$install_signature" > $CONFIG_DIR/install.json
-    chown -R dd-agent:dd-agent ${CONFIG_DIR}
 fi
 set -e
+
+if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then
+    ${INSTALL_DIR}/embedded/bin/python "${INSTALL_DIR}/python-scripts/post.py" "${INSTALL_DIR}" || true
+fi
+if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
+    ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
+fi
 
 # Set proper rights to the dd-agent user
 chown -R dd-agent:dd-agent ${CONFIG_DIR}
@@ -127,22 +129,10 @@ if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
 fi
 
 # Make the system-probe and security-agent binaries and eBPF programs owned by root
-if [ -f "$INSTALL_DIR/embedded/bin/system-probe" ]; then
-    chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
-fi
-
-if [ -f "$INSTALL_DIR/embedded/bin/security-agent" ]; then
-    chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
-fi
-
-if [ -d "$INSTALL_DIR/embedded/share/system-probe/ebpf" ]; then
-    chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
-fi
-
-if [ -d "$INSTALL_DIR/embedded/share/system-probe/java" ]; then
-    chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
-
-fi
+chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
+chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
 
 # Enable and restart the agent service here on Debian platforms
 # On RHEL, this is done in the posttrans script
@@ -151,9 +141,6 @@ echo "Enabling service $SERVICE_NAME"
 if command -v systemctl >/dev/null 2>&1; then
     # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
     SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
-    SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-process || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with systemctl"
-    SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-trace || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with systemctl"
-    SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME-security || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with systemctl"
 elif command -v initctl >/dev/null 2>&1; then
     # Nothing to do, this is defined directly in the upstart job file
     :
@@ -162,6 +149,7 @@ elif command -v update-rc.d >/dev/null 2>&1; then
     update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
     update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
     update-rc.d $SERVICE_NAME-security defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with update-rc.d"
+    update-rc.d $SERVICE_NAME-system-probe defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-system-probe with update-rc.d"
 else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
 fi
@@ -184,10 +172,6 @@ else
     # No datadog.yaml file is present. This is probably a clean install made with the
     # step-by-step instructions/an automation tool, and the config file will be added next.
     echo "No datadog.yaml file detected, not starting the agent"
-fi
-
-if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then
-    ${INSTALL_DIR}/embedded/bin/python "${INSTALL_DIR}/python-scripts/post.py" "${INSTALL_DIR}" || true
 fi
 
 exit 0

--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -129,10 +129,22 @@ if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
 fi
 
 # Make the system-probe and security-agent binaries and eBPF programs owned by root
-chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
-chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
+# Those files are not present on datadog-heroku-agent dpkg package, hence the presence check
+if [ -f "$INSTALL_DIR/embedded/bin/system-probe" ]; then
+    chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
+fi
+
+if [ -f "$INSTALL_DIR/embedded/bin/security-agent" ]; then
+    chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
+fi
+
+if [ -d "$INSTALL_DIR/embedded/share/system-probe/ebpf" ]; then
+    chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
+fi
+
+if [ -d "$INSTALL_DIR/embedded/share/system-probe/java" ]; then
+    chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
+fi
 
 # Enable and restart the agent service here on Debian platforms
 # On RHEL, this is done in the posttrans script

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -26,53 +26,8 @@ if ! getent passwd dd-agent >/dev/null; then
     fi
 fi
 
-# Set proper rights to the dd-agent user
-chown -R dd-agent:dd-agent ${CONFIG_DIR}
-chown -R dd-agent:dd-agent ${LOG_DIR}
-chown -R dd-agent:dd-agent ${INSTALL_DIR}
-
-# Make system-probe configs read-only
-chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
-if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
-fi
-
-# Make security-agent config read-only
-chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
-if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
-    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
-fi
-
-if [ -d "$CONFIG_DIR/compliance.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/compliance.d || true
-fi
-
-if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
-    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
-fi
-
-# Make the system-probe and security-agent binaries and eBPF programs owned by root
-chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
-chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
-chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
-
-if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then
-    ${INSTALL_DIR}/embedded/bin/python "${INSTALL_DIR}/python-scripts/post.py" "${INSTALL_DIR}" || true
-fi
-
 KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE|Rocky|AlmaLinux|Oracle)"
 DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || grep -Eo $KNOWN_DISTRIBUTION /etc/Eos-release 2>/dev/null || grep -m1 -Eo $KNOWN_DISTRIBUTION /etc/os-release 2>/dev/null || uname -s)
-
-echo "Enabling service $SERVICE_NAME"
-if command -v systemctl >/dev/null 2>&1; then
-    systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
-elif command -v initctl >/dev/null 2>&1; then
-    # start/stop policy is already defined in the upstart job file
-    :
-else
-    echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
-fi
 
 # Only install selinux policy on a few known distributions
 INSTALL_SELINUX_POLICY="false"
@@ -158,10 +113,6 @@ install_method:
     echo "$install_info_content" >$CONFIG_DIR/install_info
 fi
 
-if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
-    ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
-fi
-
 set +e
 generate_install_id() {
     # Try generating a UUID based on /proc/sys/kernel/random/uuid
@@ -188,9 +139,56 @@ if [ ! -f "$CONFIG_DIR/install.json" ]; then
     install_time=$(date +%s)
     install_signature=$(generate_install_signature "$install_id" "$install_type" "$install_time")
     echo "$install_signature" >$CONFIG_DIR/install.json
-    chown -R dd-agent:dd-agent ${CONFIG_DIR}
 fi
 set -e
+
+if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then
+    ${INSTALL_DIR}/embedded/bin/python "${INSTALL_DIR}/python-scripts/post.py" "${INSTALL_DIR}" || true
+fi
+if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
+    ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
+fi
+
+# Set proper rights to the dd-agent user
+chown -R dd-agent:dd-agent ${CONFIG_DIR}
+chown -R dd-agent:dd-agent ${LOG_DIR}
+chown -R dd-agent:dd-agent ${INSTALL_DIR}
+
+# Make system-probe configs read-only
+chmod 0440 ${CONFIG_DIR}/system-probe.yaml.example || true
+if [ -f "$CONFIG_DIR/system-probe.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/system-probe.yaml || true
+fi
+
+# Make security-agent config read-only
+chmod 0440 ${CONFIG_DIR}/security-agent.yaml.example || true
+if [ -f "$CONFIG_DIR/security-agent.yaml" ]; then
+    chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
+fi
+
+if [ -d "$CONFIG_DIR/compliance.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/compliance.d || true
+fi
+
+if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
+    chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
+fi
+
+# Make the system-probe and security-agent binaries and eBPF programs owned by root
+chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
+chown root:root ${INSTALL_DIR}/embedded/bin/security-agent
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/ebpf
+chown -R root:root ${INSTALL_DIR}/embedded/share/system-probe/java
+
+echo "Enabling service $SERVICE_NAME"
+if command -v systemctl >/dev/null 2>&1; then
+    systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
+elif command -v initctl >/dev/null 2>&1; then
+    # start/stop policy is already defined in the upstart job file
+    :
+else
+    echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
+fi
 
 # TODO: Use a configcheck command on the agent to determine if it's safe to restart,
 # and avoid restarting when a check conf is invalid


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Important fixes
- fixed an issue where a recursive chown command incorrectly set dd-agent ownership in /etc/datadog-agent. Ownership is now correctly enforced after file creation, preventing accidental permission changes. Check config file ownership when installing version 7.63 RPM to confirm the fix.
- enablement of services is completed at the end, to avoid a host restart triggering starts of an unfinished install agent

Reordering rpm posttrans & dpkg postinst to match the following behaviour
1. user/group creation
2. installation metadate
(rpm only) 3. SE Linux
4. fips/python postinst 
5. change in ownership
6. enablement of services to work on host restart
7. start of services

Side fixes
- no need to enable all systemd services in dpkg, the datadog-agent one is enough as the others get started by it. This is already [the case in rpm ](https://github.com/DataDog/datadog-agent/blob/main/omnibus/package-scripts/agent-rpm/posttrans#L69) and in [OCI agent code](https://github.com/DataDog/datadog-agent/blob/main/pkg/fleet/installer/packages/datadog_agent.go#L140-L143)
- added missing system-probe enablement on upstart, I didn't check but probably enabling all other services than datadog-agent can also be skipped on upstart, adding it for completion

### Motivation
Preparing convergence of postinst (oci/deb/rpm)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->