### PR TITLE
[DJM scripts] Use hostname for Spark & Yarn integrations URLs

### DIFF
--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -147,10 +147,14 @@ func setupCommonEmrHostTags(s *common.Setup) (bool, string, error) {
 func setupResourceManager(s *common.Setup, clusterName string) {
 	var sparkIntegration common.IntegrationConfig
 	var yarnIntegration common.IntegrationConfig
-
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Infof("Failed to get hostname, defaulting to localhost: %v", err)
+		hostname = "localhost"
+	}
 	sparkIntegration.Instances = []any{
 		common.IntegrationConfigInstanceSpark{
-			SparkURL:         "http://127.0.0.1:8088",
+			SparkURL:         "http://" + hostname + ":8088",
 			SparkClusterMode: "spark_yarn_mode",
 			ClusterName:      clusterName,
 			StreamingMetrics: false,
@@ -158,7 +162,7 @@ func setupResourceManager(s *common.Setup, clusterName string) {
 	}
 	yarnIntegration.Instances = []any{
 		common.IntegrationConfigInstanceYarn{
-			ResourceManagerURI: "http://127.0.0.1:8088",
+			ResourceManagerURI: "http://" + hostname + ":8088",
 			ClusterName:        clusterName,
 		},
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?


This PR switches to using the hostname reported by `os.Hostname()` for the Spark and Yarn integrations URLs.

### Motivation

We realized that using `"http://127.0.0.1:8088"` or `"http://localhost:8088"` triggered some long warning messages in the agent status command output on some EMR / Spark versions. These warnings/errors are without impact on the DJM functionalities but cause customer confusion.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->