### PR TITLE
[APM] Fix GOMAXPROCS calculation

### DIFF
--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -162,7 +162,7 @@ func prepGoRuntime(tracecfg *tracecfg.AgentConfig) {
 		if mp, ok := os.LookupEnv("GOMAXPROCS"); ok {
 			log.Infof("GOMAXPROCS manually set to %v", mp)
 		} else if tracecfg.MaxCPU > 0 {
-			allowedCores := int(tracecfg.MaxCPU / 100)
+			allowedCores := int(tracecfg.MaxCPU)
 			if allowedCores < 1 {
 				allowedCores = 1
 			}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This is a fix for a fallback mechanism on how GOMAXPROCS are calculated.

When setting up the configuration, `MaxCPU` is set to `apm_config.max_cpu_percent` / 100.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

This is covered by existing tests, which ensure the `MaxCPU` is already a _ratio_, not a percentage (already divided by 100):  https://github.com/DataDog/datadog-agent/blob/96b09b66576fa7a5dbbd16232e9fbc0cbf42e48d/comp/trace/config/config_test.go#L1981-L2009

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->