### PR TITLE
autoinstrumentation: deprecate, dont hard disable v1

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
@@ -8,13 +8,10 @@
 package autoinstrumentation
 
 import (
-	"errors"
 	"fmt"
-)
 
-// ErrUnsupported is a sentinel error for an unsupported version
-// option of this webhook.
-var ErrUnsupported = errors.New("unsupported version")
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
 
 type version int
 
@@ -27,7 +24,8 @@ const (
 func instrumentationVersion(v string) (version, error) {
 	switch v {
 	case "v1":
-		return instrumentationVersionInvalid, ErrUnsupported
+		log.Warn("autoinstrumentation version=v1 is deprecated, defaulting to v2")
+		return instrumentationV2, nil
 	case "v2":
 		return instrumentationV2, nil
 	default:

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
@@ -23,11 +23,10 @@ func TestVersion(t *testing.T) {
 		usesInjector   bool
 	}{
 		{
-			name:           "v1 is invalid",
+			name:           "v1 is deprecated, defaults to v2",
 			version:        "v1",
-			expectsVersion: instrumentationVersionInvalid,
-			expectsErr:     true,
-			expectsPanic:   true,
+			expectsVersion: instrumentationV2,
+			usesInjector:   true,
 		},
 		{
 			name:           "v2 uses injector",

--- a/releasenotes-dca/notes/autoinstrumentation-disable-v1-1b1fbd0a41c34865.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-disable-v1-1b1fbd0a41c34865.yaml
@@ -1,3 +1,3 @@
 deprecations:
   - |
-    `DD_APM_INSTRUMENTATION_VERSION=v1` has been disabled and will error when used.
+    ``DD_APM_INSTRUMENTATION_VERSION=v1`` has been deprecated and will default to ``v2``.


### PR DESCRIPTION
### What does this PR do?

Fix so that we don't hard disable `v1` as a follow up to #34173. [INPLAT-488](https://datadoghq.atlassian.net/browse/INPLAT-488)

### Motivation

We don't know exactly who is using this yet so we are going to disable the behavior without erroring out the cluster agent (logging a warning instead). 

### Describe how you validated your changes

Unit tests for version selection.

[INPLAT-488]: https://datadoghq.atlassian.net/browse/INPLAT-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ