### PR TITLE
chore(tagger): remove unused DogstatsdCardinality method

### DIFF
--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -52,5 +52,4 @@ type Component interface {
 	ResetCaptureTagger()
 	EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo)
 	ChecksCardinality() types.TagCardinality
-	DogstatsdCardinality() types.TagCardinality
 }

--- a/comp/core/tagger/impl-noop/tagger.go
+++ b/comp/core/tagger/impl-noop/tagger.go
@@ -98,10 +98,6 @@ func (n *noopTagger) ChecksCardinality() types.TagCardinality {
 	return types.LowCardinality
 }
 
-func (n *noopTagger) DogstatsdCardinality() types.TagCardinality {
-	return types.LowCardinality
-}
-
 // NewComponent returns a new noop tagger component
 func NewComponent() tagger.Component {
 	return &noopTagger{}

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -456,10 +456,6 @@ func (t *remoteTagger) ChecksCardinality() types.TagCardinality {
 	return t.checksCardinality
 }
 
-func (t *remoteTagger) DogstatsdCardinality() types.TagCardinality {
-	return t.dogstatsdCardinality
-}
-
 // Subscribe currently returns a non-nil error indicating that the method is not supported
 // for remote tagger. Currently, there are no use cases for client subscribing to remote tagger events
 func (t *remoteTagger) Subscribe(string, *types.Filter) (types.Subscription, error) {

--- a/comp/core/tagger/impl/local_tagger.go
+++ b/comp/core/tagger/impl/local_tagger.go
@@ -248,7 +248,3 @@ func (t *localTagger) EnrichTags(tagset.TagsAccumulator, taggertypes.OriginInfo)
 func (t *localTagger) ChecksCardinality() types.TagCardinality {
 	return types.LowCardinality
 }
-
-func (t *localTagger) DogstatsdCardinality() types.TagCardinality {
-	return types.LowCardinality
-}

--- a/comp/core/tagger/impl/replay_tagger.go
+++ b/comp/core/tagger/impl/replay_tagger.go
@@ -156,7 +156,3 @@ func (t *replayTagger) EnrichTags(tagset.TagsAccumulator, taggertypes.OriginInfo
 func (t *replayTagger) ChecksCardinality() types.TagCardinality {
 	return types.LowCardinality
 }
-
-func (t *replayTagger) DogstatsdCardinality() types.TagCardinality {
-	return types.LowCardinality
-}

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -523,12 +523,6 @@ func (t *TaggerWrapper) ChecksCardinality() types.TagCardinality {
 	return t.checksCardinality
 }
 
-// DogstatsdCardinality defines the cardinality of tags we should send for metrics from
-// dogstatsd.
-func (t *TaggerWrapper) DogstatsdCardinality() types.TagCardinality {
-	return t.dogstatsdCardinality
-}
-
 // taggerCardinality converts tagger cardinality string to types.TagCardinality
 // It should be defaulted to DogstatsdCardinality if the string is empty or unknown
 func taggerCardinality(cardinality string,

--- a/comp/core/tagger/impl/tagger_test.go
+++ b/comp/core/tagger/impl/tagger_test.go
@@ -484,7 +484,6 @@ func TestGlobalTags(t *testing.T) {
 }
 
 func TestTaggerCardinality(t *testing.T) {
-	fakeTagger := TaggerWrapper{}
 	tests := []struct {
 		name        string
 		cardinality string
@@ -513,46 +512,40 @@ func TestTaggerCardinality(t *testing.T) {
 		{
 			name:        "empty",
 			cardinality: "",
-			want:        fakeTagger.DogstatsdCardinality(),
+			want:        types.LowCardinality,
 		},
 		{
 			name:        "unknown",
 			cardinality: "foo",
-			want:        fakeTagger.DogstatsdCardinality(),
+			want:        types.LowCardinality,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			l := logmock.New(t)
-			assert.Equal(t, tt.want, taggerCardinality(tt.cardinality, fakeTagger.DogstatsdCardinality(), l))
+			assert.Equal(t, tt.want, taggerCardinality(tt.cardinality, types.LowCardinality, l))
 		})
 	}
 }
 
 func TestDefaultCardinality(t *testing.T) {
-
 	for _, tt := range []struct {
-		name                     string
-		wantChecksCardinality    types.TagCardinality
-		wantDogstatsdCardinality types.TagCardinality
-		setup                    func(cfg config.Component)
+		name                  string
+		wantChecksCardinality types.TagCardinality
+		setup                 func(cfg config.Component)
 	}{
 		{
-			name:                     "successful parse config values, use config",
-			wantChecksCardinality:    types.HighCardinality,
-			wantDogstatsdCardinality: types.OrchestratorCardinality,
+			name:                  "successful parse config values, use config",
+			wantChecksCardinality: types.HighCardinality,
 			setup: func(cfg config.Component) {
 				cfg.SetWithoutSource("checks_tag_cardinality", types.HighCardinalityString)
-				cfg.SetWithoutSource("dogstatsd_tag_cardinality", types.OrchestratorCardinalityString)
 			},
 		},
 		{
-			name:                     "fail parse config values, use default",
-			wantChecksCardinality:    types.LowCardinality,
-			wantDogstatsdCardinality: types.LowCardinality,
+			name:                  "fail parse config values, use default",
+			wantChecksCardinality: types.LowCardinality,
 			setup: func(cfg config.Component) {
 				cfg.SetWithoutSource("checks_tag_cardinality", "foo")
-				cfg.SetWithoutSource("dogstatsd_tag_cardinality", "foo")
 			},
 		},
 	} {
@@ -573,7 +566,6 @@ func TestDefaultCardinality(t *testing.T) {
 			tagger, err := NewTaggerClient(params, cfg, wmeta, logComponent, noopTelemetry.GetCompatComponent())
 			assert.NoError(t, err)
 
-			assert.Equal(t, tt.wantDogstatsdCardinality, tagger.DogstatsdCardinality())
 			assert.Equal(t, tt.wantChecksCardinality, tagger.ChecksCardinality())
 		})
 	}

--- a/comp/core/tagger/mock/fake_tagger.go
+++ b/comp/core/tagger/mock/fake_tagger.go
@@ -174,8 +174,3 @@ func (f *FakeTagger) EnrichTags(tagset.TagsAccumulator, taggertypes.OriginInfo) 
 func (f *FakeTagger) ChecksCardinality() types.TagCardinality {
 	return types.LowCardinality
 }
-
-// DogstatsdCardinality noop
-func (f *FakeTagger) DogstatsdCardinality() types.TagCardinality {
-	return types.LowCardinality
-}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove the `tagger.DogstatsdCardinality()` method.

### Motivation

This method returns the current local configuration for `dogstatsd_tag_cardinality` but it appears to be unused.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by unit and E2E tests.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A