### PR TITLE
Prevent deadlocking in nodetreemodel

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -337,10 +337,16 @@ func (c *ntmConfig) SetKnown(key string) {
 	c.addToSchema(key, model.SourceSchema)
 }
 
-// IsKnown returns whether a key is known
+// IsKnown returns whether a key is in the set of "known keys", which is a legacy feature from Viper
 func (c *ntmConfig) IsKnown(key string) bool {
 	c.RLock()
 	defer c.RUnlock()
+	return c.isKnownKey(key)
+}
+
+// isKnownKey returns whether the key is known.
+// Must be called with the lock read-locked.
+func (c *ntmConfig) isKnownKey(key string) bool {
 	key = strings.ToLower(key)
 	_, found := c.knownKeys[key]
 	return found
@@ -350,9 +356,8 @@ func (c *ntmConfig) IsKnown(key string) bool {
 // Only a single warning will be logged per unknown key.
 //
 // Must be called with the lock read-locked.
-// The lock can be released and re-locked.
 func (c *ntmConfig) checkKnownKey(key string) {
-	if c.IsKnown(key) {
+	if c.isKnownKey(key) {
 		return
 	}
 

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -85,7 +85,7 @@ var legacyConvertArrayToMap = func(c *mapstructure.DecoderConfig) {
 // Else the viper/legacy version is used.
 func UnmarshalKey(cfg model.Reader, key string, target interface{}, opts ...UnmarshalKeyOption) error {
 	nodetreemodel := os.Getenv("DD_CONF_NODETREEMODEL")
-	if nodetreemodel == "enabled" || nodetreemodel == "unmarshal" {
+	if nodetreemodel == "enable" || nodetreemodel == "unmarshal" {
 		return unmarshalKeyReflection(cfg, key, target, opts...)
 	}
 


### PR DESCRIPTION

### What does this PR do?

Change `checkKnownKey` to call the non-locking `isKnownKey` in order to avoid deadlocking.

### Motivation

The method `checkKnownKey` must be called with a locked mutex, so it should avoid calling `IsKnown` which also locks.

Fix the spelling of the env var value that is used to enable nodetreemodel for `UnmarshalKey`, it should be "enable" instead of "enabled". That makes it consistent with the [constructor in setup](https://github.com/DataDog/datadog-agent/blob/e974b94c0dd94daee402a4cc1f57741685414657/pkg/config/setup/config.go#L265).

### Describe how you validated your changes

Manually ran the agent with `DD_CONF_NODETREEMODEL == "enable"` and noticed that it would usually (~70% of the time) deadlock; even Ctrl+C would not stop it. With this fix it does not deadlock and Ctrl+C is able to shutdown cleanly.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->