### PR TITLE
Adjust Quality Gate Limits down

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "350.0 MiB"
+      upper_bound: "280.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "724.0 MiB"
+      upper_bound: "714.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_rss_bytes
-      upper_bound: "406.0 MiB"
+      upper_bound: "335.0 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

This commit captures the gains made in #33434, notably in -idle and -logs and also even in -all-features, although to a less degree given the amount of machinery turned on in that experiment.

