### PR TITLE
Update E2E test to reduce flakiness in ECS-EC2 of hte process checks running in the core agent

### DIFF
--- a/test/new-e2e/tests/process/ecs_test.go
+++ b/test/new-e2e/tests/process/ecs_test.go
@@ -122,6 +122,9 @@ func (s *ECSEC2CoreAgentSuite) TestProcessCheckInCoreAgent() {
 		requireProcessNotCollected(c, payloads, "process-agent")
 	}, 2*time.Minute, 10*time.Second)
 
+	// Flush the server to ensure payloads are received from the process checks that are running on the core agent
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		payloads, err := s.Env().FakeIntake.Client().GetProcesses()
 		assert.NoError(c, err, "failed to get process payloads from fakeintake")

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
@@ -205,6 +206,21 @@ func filterProcess(name string, processes []*agentmodel.Process) []*agentmodel.P
 		}
 	}
 	return found
+}
+
+// filterPayloadsSince filters payloads that were collected since the given time. Also returns the
+// time of the last payload.
+func filterPayloadsSince(payloads []*aggregator.ProcessPayload, since time.Time) ([]*aggregator.ProcessPayload, time.Time) {
+	var filtered []*aggregator.ProcessPayload
+	lastCollectedTime := since
+	for _, payload := range payloads {
+		if payload.GetCollectedTime().After(since) {
+			filtered = append(filtered, payload)
+		}
+		lastCollectedTime = payload.GetCollectedTime()
+	}
+
+	return filtered, lastCollectedTime
 }
 
 // processHasData asserts that the given process has the expected data populated

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
 	agentmodel "github.com/DataDog/agent-payload/v5/process"
 	"github.com/stretchr/testify/assert"
@@ -206,21 +205,6 @@ func filterProcess(name string, processes []*agentmodel.Process) []*agentmodel.P
 		}
 	}
 	return found
-}
-
-// filterPayloadsSince filters payloads that were collected since the given time. Also returns the
-// time of the last payload.
-func filterPayloadsSince(payloads []*aggregator.ProcessPayload, since time.Time) ([]*aggregator.ProcessPayload, time.Time) {
-	var filtered []*aggregator.ProcessPayload
-	lastCollectedTime := since
-	for _, payload := range payloads {
-		if payload.GetCollectedTime().After(since) {
-			filtered = append(filtered, payload)
-		}
-		lastCollectedTime = payload.GetCollectedTime()
-	}
-
-	return filtered, lastCollectedTime
 }
 
 // processHasData asserts that the given process has the expected data populated


### PR DESCRIPTION
### What does this PR do?
This is to try and reduce the flakiness of the ECS-EC2 Core Agent Test. We expect the process agent to not be running, so this moves the assert eventually into it's own section and checks only the latest payloads to ensure the process-agent has shutdown and stopped running. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->