### PR TITLE
Enable datadog_otel_components_ocb_build

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -57,29 +57,29 @@ docker_image_build_otel:
     - when: always
 
 
-# datadog_otel_components_ocb_build:
-#   stage: integration_test
-#   image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-#   tags: ["arch:amd64"]
-#   needs: ["go_deps"]
-#   artifacts:
-#     paths:
-#       - ocb-output.log
-#       - otelcol-custom.log
-#       - flare-info.log
-#     when: always
-#   before_script:
-#     - !reference [.retrieve_linux_go_deps]
-#   script:
-#     - echo "Building custom collector with datadog components"
-#     - test/otel/testdata/ocb_build_script.sh
-#     - echo "see artifacts for job logs"
-#   rules:
-#     - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
-#       when: never
-#     - if: $CI_COMMIT_MESSAGE =~ /.*\[skip cancel\].*/
-#       when: never
-#     - if: $CI_COMMIT_REF_NAME =~ /.*-skip-cancel$/
-#       when: never
-#     - when: always
-#   timeout: 15 minutes
+datadog_otel_components_ocb_build:
+  stage: integration_test
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_deps"]
+  artifacts:
+    paths:
+      - ocb-output.log
+      - otelcol-custom.log
+      - flare-info.log
+    when: always
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    - echo "Building custom collector with datadog components"
+    - test/otel/testdata/ocb_build_script.sh
+    - echo "see artifacts for job logs"
+  rules:
+    - if: $CI_PIPELINE_SOURCE =~ /^schedule.*$/
+      when: never
+    - if: $CI_COMMIT_MESSAGE =~ /.*\[skip cancel\].*/
+      when: never
+    - if: $CI_COMMIT_REF_NAME =~ /.*-skip-cancel$/
+      when: never
+    - when: always
+  timeout: 15 minutes

--- a/comp/otelcol/ddflareextension/impl/extension.go
+++ b/comp/otelcol/ddflareextension/impl/extension.go
@@ -77,6 +77,8 @@ func (ext *ddExtension) NotifyConfig(_ context.Context, conf *confmap.Conf) erro
 		}
 
 		ext.configStore.set(string(envBytes), string(enhancedBytes))
+	} else {
+		ext.configStore.set("", string(enhancedBytes))
 	}
 
 	extensionConfs, err := conf.Sub("extensions")

--- a/test/otel/testdata/ocb_build_script.sh
+++ b/test/otel/testdata/ocb_build_script.sh
@@ -65,6 +65,23 @@ dd_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort | sed 's/.//'
 	for mod in $dd_mods; do
 		echo "- github.com/DataDog/datadog-agent$mod => $current_dir$mod"
 	done
+
+
+
+# Use a forked version of the Datadog exporter
+#
+# This change adds a replace directive for the datadog exporter to point to a forked version: GitHub Comparison: https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/main...ogaca-dd:opentelemetry-collector-contrib:olivierg/tmp-fix-ocb
+#
+# Issues Fixed:
+# 	1.	Dependency Mismatch:
+# 	  -	connector/datadogconnector/go.mod does not reference the latest version of exporter/datadogexporter.
+# 	  -	This adjustment is necessary until opentelemetry-collector-contrib v0.121.0 is officially released.
+# 	2.	Compatibility Issue:
+# 	  -	opentelemetry-collector-contrib fails to compile due to recent changes in the Datadog Agent.
+# 	  -	The pkgconfigmodel package was renamed to viperconfig, breaking compatibility with the latest updates.
+echo "- github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter => github.com/ogaca-dd/opentelemetry-collector-contrib/exporter/datadogexporter v0.0.0-20250220150909-786462df4eca" >> /tmp/otel-ci/builder-config.yaml
+
+
 } >>"$WORK_DIR/builder-config.yaml"
 
 # Install and configure OCB


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR enables `datadog_otel_components_ocb_build` which was temporary disabled [here](https://github.com/DataDog/datadog-agent/pull/33370/files#diff-47284b3e9644546c944f76ad8dbfed47271ba434610aaf7de48eafb8c1d9998cL60)

### Motivation

### Describe how you validated your changes
Run unit tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->