### PR TITLE
[podman] Change sqlite backend

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1486,6 +1486,7 @@ core,github.com/mattn/go-colorable,MIT,Copyright (c) 2016 Yasuhiro Matsumoto
 core,github.com/mattn/go-isatty,MIT,Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
 core,github.com/mattn/go-runewidth,MIT,Copyright (c) 2016 Yasuhiro Matsumoto
 core,github.com/mattn/go-shellwords,MIT,Copyright (c) 2017 Yasuhiro Matsumoto
+core,github.com/mattn/go-sqlite3,MIT,Copyright (c) 2014 Yasuhiro Matsumoto
 core,github.com/mdlayher/netlink,MIT,Copyright (C) 2016-2022 Matt Layher
 core,github.com/mdlayher/netlink/nlenc,MIT,Copyright (C) 2016-2022 Matt Layher
 core,github.com/mdlayher/socket,MIT,Copyright (C) 2021 Matt Layher

--- a/go.mod
+++ b/go.mod
@@ -479,6 +479,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
+	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/shirou/gopsutil/v4 v4.25.1
 	go.opentelemetry.io/collector/component/componenttest v0.120.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1318,8 +1318,9 @@ github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-shellwords v1.0.2/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.12 h1:M2zGm7EW6UQJvDeQxo4T51eKPurbeFbe8WtebGE2xrk=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
 github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=

--- a/pkg/util/podman/sqlite_db_client.go
+++ b/pkg/util/podman/sqlite_db_client.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 
 	// SQLite backend for database/sql
-	_ "modernc.org/sqlite"
+	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )


### PR DESCRIPTION
### What does this PR do?

Changes the SQLite backend used by Podman from `modernc.org/sqlite` to `github.com/mattn/go-sqlite3`.

Reasons for the Change:
- Alignment with Podman upstream: When this functionality was introduced, `modernc.org/sqlite` was chosen due to unrelated integration test failures. However, those issues no longer exist, so switching to `go-sqlite3` ensures consistency with the upstream implementation. More details can be found in this PR: DataDog/datadog-agent#24373.
- Reduction in binary size (https://github.com/DataDog/datadog-agent/pull/34358#issuecomment-2678468439): This change reduces the binary size in the dogstatsd binary. However, the impact is less noticeable for the agents because some Trivy-related code in the Core Agent still depends on `modernc.org/sqlite`.

The part of the code that uses this is not highly performance-sensitive, as it only executes a simple query to retrieve the pods on a node, so changing the library shouldn't really change much.

### Describe how you validated your changes

I ran the agent in a version of Podman that uses SQLite and followed the instructions in the original PR: https://github.com/DataDog/datadog-agent/pull/24373

We don't have e2e tests for Podman, so I'll mark this to be tested during QA.