### PR TITLE
fix(trigger_release): Don't follow manual pipeline

### DIFF
--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -46,6 +46,9 @@ trigger_auto_staging_release_on_failure:
   variables:
     AUTO_RELEASE: "false"
     TARGET_REPO: staging
+    # The jobs in the downstream pipeline will all be manual, so following
+    # the created pipeline would likely cause this job to timeout
+    NO_FOLLOW: "--no-follow"
   rules:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+){0,1}$/
       when: never


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Prevent failures of the `trigger_auto_staging_release_on_failure` job

### Motivation
Since #33779, we introduced default job to generate the `agent-release-management` pipeline when any previous job failed.
As the pipeline is manual and depends on a trigger job with `depend` [strategy](https://github.com/DataDog/agent-release-management/blob/main/.gitlab-ci.yml#L149), when this job is triggered it hits the global timeout. We won't change the strategy to keep reflecting the job execution when the auto_release is used (cf [here](https://github.com/DataDog/agent-release-management/pull/125)).
As a consequence the only solution is to prevent following the child pipeline in this situation.

### Describe how you validated your changes
n/a
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
cc @FlorentClarret 
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->