### PR TITLE
[CWS] fix container id parsing from cgroup for eks fargate

### DIFF
--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -46,18 +46,13 @@ type controlGroup struct {
 	path string
 }
 
-func getProcControlGroupsFromFile(path string) ([]controlGroup, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
+func getProcControlGroupsFromData(data []byte) ([]controlGroup, error) {
 	var cgroups []controlGroup
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		t := scanner.Text()
 		parts := strings.Split(t, ":")
-		var ID int
-		ID, err = strconv.Atoi(parts[0])
+		ID, err := strconv.Atoi(parts[0])
 		if err != nil {
 			continue
 		}
@@ -69,17 +64,25 @@ func getProcControlGroupsFromFile(path string) ([]controlGroup, error) {
 		cgroups = append(cgroups, c)
 	}
 	return cgroups, nil
-
 }
 
-func getContainerIDFromProcFS(cgroupPath string) (containerutils.ContainerID, error) {
-	cgroups, err := getProcControlGroupsFromFile(cgroupPath)
+func getContainerIDFromCgroupData(data []byte) (containerutils.ContainerID, error) {
+	cgroups, err := getProcControlGroupsFromData(data)
 	if err != nil {
 		return "", err
 	}
 
 	for _, cgroup := range cgroups {
-		if cid, _ := containerutils.FindContainerID(containerutils.CGroupID(cgroup.path)); cid != "" {
+		str := cgroup.path
+		if strings.Contains(cgroup.path, "kubepods") {
+			els := strings.Split(str, "/")
+			if len(els) > 0 {
+				str = els[len(els)-1]
+			}
+		}
+		if cid, _ := containerutils.FindContainerID(containerutils.CGroupID(str)); cid != "" {
+			return cid, nil
+		} else if cid, _ = containerutils.FindContainerID(containerutils.CGroupID(str)); cid != "" {
 			return cid, nil
 		}
 	}
@@ -87,11 +90,19 @@ func getContainerIDFromProcFS(cgroupPath string) (containerutils.ContainerID, er
 }
 
 func getCurrentProcContainerID() (containerutils.ContainerID, error) {
-	return getContainerIDFromProcFS("/proc/self/cgroup")
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+	return getContainerIDFromCgroupData(data)
 }
 
 func getProcContainerID(pid int) (containerutils.ContainerID, error) {
-	return getContainerIDFromProcFS(fmt.Sprintf("/proc/%d/cgroup", pid))
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return "", err
+	}
+	return getContainerIDFromCgroupData(data)
 }
 
 func getNSID() uint64 {

--- a/pkg/security/ptracer/utils.go
+++ b/pkg/security/ptracer/utils.go
@@ -82,7 +82,7 @@ func getContainerIDFromCgroupData(data []byte) (containerutils.ContainerID, erro
 		}
 		if cid, _ := containerutils.FindContainerID(containerutils.CGroupID(str)); cid != "" {
 			return cid, nil
-		} else if cid, _ = containerutils.FindContainerID(containerutils.CGroupID(str)); cid != "" {
+		} else if cid, _ = containerutils.FindContainerID(containerutils.CGroupID(cgroup.path)); cid != "" {
 			return cid, nil
 		}
 	}

--- a/pkg/security/ptracer/utils_test.go
+++ b/pkg/security/ptracer/utils_test.go
@@ -33,4 +33,15 @@ func TestContainerID(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, containerutils.ContainerID("7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981"), cid)
 	})
+
+	t.Run("from-cgroup-ecs", func(t *testing.T) {
+		cgroupContent := `11:devices:/ecs/8a28a84664034325be01ca46b33d1dd3/8a28a84664034325be01ca46b33d1dd3-4092616770
+		10:memory:/ecs/8a28a84664034325be01ca46b33d1dd3/8a28a84664034325be01ca46b33d1dd3-4092616770
+		9:blkio:/ecs/8a28a84664034325be01ca46b33d1dd3/8a28a84664034325be01ca46b33d1dd3-4092616770
+		1:name=systemd:/ecs/8a28a84664034325be01ca46b33d1dd3/8a28a84664034325be01ca46b33d1dd3-4092616770`
+		cid, err := getContainerIDFromCgroupData([]byte(cgroupContent))
+
+		assert.NoError(t, err)
+		assert.Equal(t, containerutils.ContainerID("8a28a84664034325be01ca46b33d1dd3-4092616770"), cid)
+	})
 }

--- a/pkg/security/ptracer/utils_test.go
+++ b/pkg/security/ptracer/utils_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package ptracer
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainerID(t *testing.T) {
+	t.Run("from-cgroup-eks", func(t *testing.T) {
+		cgroupContent := `11:memory:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		10:perf_event:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		9:pids:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		8:cpuset:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		7:freezer:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		6:hugetlb:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		5:devices:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		4:cpu,cpuacct:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		3:blkio:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		2:net_cls,net_prio:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		1:name=systemd:/ecs/409b8b89ccd746bdb9b5e03418406d96/409b8b89ccd746bdb9b5e03418406d96-3057940393/kubepods/besteffort/podc00eb3e2-d6c0-4eb6-9e58-fe539629263f/7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981
+		`
+		cid, err := getContainerIDFromCgroupData([]byte(cgroupContent))
+
+		assert.NoError(t, err)
+		assert.Equal(t, containerutils.ContainerID("7022ec9d5774c69f38feddd6460373c4681ef72a4e03bc6f2d374387e9bde981"), cid)
+	})
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix container ID parsing on EKS Fargate.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->