### PR TITLE
Revert "[AGENTCFG-79] Remove usage of Viper from comp/logs/agent/config/parser.go"

### DIFF
--- a/comp/logs/agent/config/go.mod
+++ b/comp/logs/agent/config/go.mod
@@ -11,9 +11,9 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.61.0
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/util/pointer v0.61.0
+	github.com/DataDog/viper v1.14.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/fx v1.23.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -37,7 +37,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.62.3 // indirect
-	github.com/DataDog/viper v1.14.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -73,6 +72,7 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // This section was automatically added by 'invoke modules.add-all-replace' command, do not edit manually

--- a/comp/logs/agent/config/integration_config.go
+++ b/comp/logs/agent/config/integration_config.go
@@ -81,41 +81,17 @@ type LogsConfig struct {
 	// ChannelTagsMutex guards ChannelTags.
 	ChannelTagsMutex sync.Mutex
 
-	Service        string
-	Source         string
-	SourceCategory string
-
-	Tags            TagsField
-	ProcessingRules []*ProcessingRule `mapstructure:"log_processing_rules" json:"log_processing_rules" yaml:"log_processing_rules"`
+	Service         string
+	Source          string
+	SourceCategory  string
+	Tags            []string
+	ProcessingRules []*ProcessingRule `mapstructure:"log_processing_rules" json:"log_processing_rules"`
 	// ProcessRawMessage is used to process the raw message instead of only the content part of the message.
 	ProcessRawMessage *bool `mapstructure:"process_raw_message" json:"process_raw_message"`
 
 	AutoMultiLine               *bool   `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection"`
 	AutoMultiLineSampleSize     int     `mapstructure:"auto_multi_line_sample_size" json:"auto_multi_line_sample_size"`
 	AutoMultiLineMatchThreshold float64 `mapstructure:"auto_multi_line_match_threshold" json:"auto_multi_line_match_threshold"`
-}
-
-// TagsField is a custom type for unmarshalling comma-separated string values or typical yaml fields into a slice of strings.
-type TagsField []string
-
-// UnmarshalYAML is a custom unmarshalling function is needed for string array fields to split comma-separated values.
-func (t *TagsField) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	if err := unmarshal(&str); err == nil {
-		// note that we are intentionally avoiding the trimming of any spaces whilst splitting the string
-		*t = strings.Split(str, ",")
-		return nil
-	}
-
-	var raw []interface{}
-	if err := unmarshal(&raw); err == nil {
-		for _, item := range raw {
-			if str, ok := item.(string); ok {
-				*t = append(*t, str)
-			}
-		}
-	}
-	return fmt.Errorf("invalid tags format")
 }
 
 // Dump dumps the contents of this struct to a string, for debugging purposes.

--- a/comp/logs/agent/config/parser.go
+++ b/comp/logs/agent/config/parser.go
@@ -6,15 +6,12 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
-	yaml "gopkg.in/yaml.v3"
+	"github.com/DataDog/viper"
 )
-
-type yamlLogsConfigsWrapper struct {
-	Logs []*LogsConfig
-}
 
 // ParseJSON parses the data formatted in JSON
 // returns an error if the parsing failed.
@@ -27,13 +24,23 @@ func ParseJSON(data []byte) ([]*LogsConfig, error) {
 	return configs, nil
 }
 
+const yaml = "yaml"
+const logsPath = "logs"
+
 // ParseYAML parses the data formatted in YAML,
 // returns an error if the parsing failed.
 func ParseYAML(data []byte) ([]*LogsConfig, error) {
-	var yamlConfigsWrapper yamlLogsConfigsWrapper
-	err := yaml.Unmarshal(data, &yamlConfigsWrapper)
+	var configs []*LogsConfig
+	var err error
+	v := viper.New()
+	v.SetConfigType(yaml)
+	err = v.ReadConfig(bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("could not decode YAML logs config: %v", err)
 	}
-	return yamlConfigsWrapper.Logs, nil
+	err = v.UnmarshalKey(logsPath, &configs)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse YAML logs config: %v", err)
+	}
+	return configs, nil
 }

--- a/comp/logs/agent/config/parser_test.go
+++ b/comp/logs/agent/config/parser_test.go
@@ -6,10 +6,10 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"regexp"
+	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseJSONWithValidFormatShouldSucceed(t *testing.T) {
@@ -27,7 +27,7 @@ func TestParseJSONWithValidFormatShouldSucceed(t *testing.T) {
 	config = configs[0]
 	assert.Equal(t, "any_source", config.Source)
 	assert.Equal(t, "any_service", config.Service)
-	assert.EqualValues(t, []string{"a", "b:d"}, config.Tags)
+	assert.Equal(t, []string{"a", "b:d"}, config.Tags)
 
 	configs, err = ParseJSON([]byte(`[{"source":"any_source","service":"any_service","log_processing_rules":[{"type":"multi_line","name":"numbers","pattern":"[0-9]"}]}]`))
 	assert.Nil(t, err)
@@ -55,6 +55,56 @@ func TestParseJSONWithInvalidFormatShouldFail(t *testing.T) {
 	}
 }
 
+func TestParseYAMLWithValidFormatShouldSucceed(t *testing.T) {
+	data := []byte(`
+logs:
+  - type: file
+    path: /var/log/app.log
+    tags: a, b:c
+  - type: udp
+    source: foo
+    service: bar
+  - type: docker
+    log_processing_rules:
+      - type: include_at_match
+        name: numbers
+        pattern: ^[0-9]+$
+`)
+
+	configs, err := ParseYAML(data)
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(configs))
+
+	var config *LogsConfig
+	var tag string
+	var rule *ProcessingRule
+
+	config = configs[0]
+	assert.Equal(t, FileType, config.Type)
+	assert.Equal(t, "/var/log/app.log", config.Path)
+	assert.Equal(t, 2, len(config.Tags))
+
+	tag = config.Tags[0]
+	assert.Equal(t, "a", strings.TrimSpace(tag))
+
+	tag = config.Tags[1]
+	assert.Equal(t, "b:c", strings.TrimSpace(tag))
+
+	config = configs[1]
+	assert.Equal(t, UDPType, config.Type)
+	assert.Equal(t, "foo", config.Source)
+	assert.Equal(t, "bar", config.Service)
+
+	config = configs[2]
+	assert.Equal(t, DockerType, config.Type)
+	assert.Equal(t, 1, len(config.ProcessingRules))
+
+	rule = config.ProcessingRules[0]
+	assert.Equal(t, IncludeAtMatch, rule.Type)
+	assert.Equal(t, "numbers", rule.Name)
+	assert.Equal(t, "^[0-9]+$", rule.Pattern)
+}
+
 func TestParseYAMLWithInvalidFormatShouldFail(t *testing.T) {
 	invalidFormats := []string{`
 foo:
@@ -70,186 +120,6 @@ foo:
 
 	for _, format := range invalidFormats {
 		configs, _ := ParseYAML([]byte(format))
-		require.Equal(t, 0, len(configs))
-	}
-}
-
-func TestParseYAMLWithValidFormatShouldSucceed(t *testing.T) {
-	tests := []struct {
-		name   string
-		yaml   []byte
-		assert func(t *testing.T, configs []*LogsConfig, err error)
-	}{
-		{
-			name: "Test 0: Parse with file logs and multiple tags",
-			yaml: []byte(`
-logs:
-  - type: file
-    path: /var/log/app.log
-    tags: a, b:c
-    container_mode: false
-    auto_multi_line_detection: false
-    auto_multi_line_match_threshold: 3.0
-    port: 8080
-`),
-			assert: func(t *testing.T, configs []*LogsConfig, err error) {
-				assert.Nil(t, err)
-				require.Equal(t, len(configs), 1)
-				config := configs[0]
-				assert.Equal(t, "file", config.Type)
-				assert.Equal(t, "/var/log/app.log", config.Path)
-				require.Equal(t, len(config.Tags), 2)
-				assert.Equal(t, "a", config.Tags[0])
-				assert.Equal(t, " b:c", config.Tags[1])
-			},
-		},
-		{
-			name: "Test 0.5: Same as Test 0, but without string separation",
-			yaml: []byte(`
-logs:
-  - type: file
-    path: /var/log/app.log
-    tags: a,b:c
-    container_mode: false
-    auto_multi_line_detection: false
-    auto_multi_line_match_threshold: 3.0
-    port: 8080
-`),
-			assert: func(t *testing.T, configs []*LogsConfig, err error) {
-				assert.Nil(t, err)
-				require.Equal(t, len(configs), 1)
-				config := configs[0]
-				assert.Equal(t, "file", config.Type)
-				assert.Equal(t, "/var/log/app.log", config.Path)
-				require.Equal(t, len(config.Tags), 2)
-				assert.Equal(t, "a", config.Tags[0])
-				assert.Equal(t, "b:c", config.Tags[1])
-			},
-		},
-		{
-			name: "Test 1: Parse with simple include_at_match processing rule",
-			yaml: []byte(`
-logs:
-  - type: file
-    path: /my/test/file.log
-    service: cardpayment
-    source: java
-    log_processing_rules:
-    - type: include_at_match
-      name: include_datadoghq_users
-      pattern: \w+@datadoghq.com
-`),
-			assert: func(t *testing.T, configs []*LogsConfig, err error) {
-				assert.Nil(t, err)
-				require.Equal(t, len(configs), 1)
-				config := configs[0]
-				assert.Equal(t, "file", config.Type)
-				assert.Equal(t, "/my/test/file.log", config.Path)
-				assert.Equal(t, "cardpayment", config.Service)
-				assert.Equal(t, "java", config.Source)
-				require.Equal(t, len(config.ProcessingRules), 1)
-				assert.Equal(t, "include_at_match", config.ProcessingRules[0].Type)
-				assert.Equal(t, "include_datadoghq_users", config.ProcessingRules[0].Name)
-				assert.Equal(t, `\w+@datadoghq.com`, config.ProcessingRules[0].Pattern)
-				_, err = regexp.Compile(config.ProcessingRules[0].Pattern)
-				assert.Nil(t, err, "Pattern should be a valid regex")
-			},
-		},
-		{
-			name: "Test 2: Parse with another pattern and include_at_match processing rule",
-			yaml: []byte(`
-logs:
-  - type: file
-    path: /my/test/file.log
-    service: cardpayment
-    source: java
-    log_processing_rules:
-    - type: include_at_match
-      name: include_datadoghq_users
-      pattern: abc|123
-`),
-			assert: func(t *testing.T, configs []*LogsConfig, err error) {
-				assert.Nil(t, err)
-				require.Equal(t, len(configs), 1)
-				config := configs[0]
-				assert.Equal(t, "file", config.Type)
-				assert.Equal(t, "/my/test/file.log", config.Path)
-				assert.Equal(t, "cardpayment", config.Service)
-				assert.Equal(t, "java", config.Source)
-				require.Equal(t, len(config.ProcessingRules), 1)
-				assert.Equal(t, "include_at_match", config.ProcessingRules[0].Type)
-				assert.Equal(t, "include_datadoghq_users", config.ProcessingRules[0].Name)
-				assert.Equal(t, `abc|123`, config.ProcessingRules[0].Pattern)
-				_, err = regexp.Compile(config.ProcessingRules[0].Pattern)
-				assert.Nil(t, err, "Pattern should be a valid regex")
-			},
-		},
-		{
-			name: "Test 3: Parse with multi-line processing rule",
-			yaml: []byte(`
-logs:
-  - type: file
-    path: /var/log/pg_log.log
-    service: database
-    source: postgresql
-    log_processing_rules:
-    - type: multi_line
-      name: new_log_start_with_date
-      pattern: \d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])
-`),
-			assert: func(t *testing.T, configs []*LogsConfig, err error) {
-				assert.Nil(t, err)
-				require.Equal(t, len(configs), 1)
-				config := configs[0]
-				assert.Equal(t, "file", config.Type)
-				assert.Equal(t, "/var/log/pg_log.log", config.Path)
-				assert.Equal(t, "database", config.Service)
-				assert.Equal(t, "postgresql", config.Source)
-				require.Equal(t, len(config.ProcessingRules), 1)
-				assert.Equal(t, "multi_line", config.ProcessingRules[0].Type)
-				assert.Equal(t, "new_log_start_with_date", config.ProcessingRules[0].Name)
-				assert.Equal(t, `\d{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])`, config.ProcessingRules[0].Pattern)
-				_, err = regexp.Compile(config.ProcessingRules[0].Pattern)
-				assert.Nil(t, err, "Pattern should be a valid regex")
-			},
-		},
-		{
-			name: "Test 4: Parse with mask_sequences processing rule",
-			yaml: []byte(`
-logs:
- - type: file
-   path: /my/test/file.log
-   service: cardpayment
-   source: java
-   log_processing_rules:
-      - type: mask_sequences
-        name: mask_credit_cards
-        replace_placeholder: "[masked_credit_card]"
-        pattern: (?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})
-`),
-			assert: func(t *testing.T, configs []*LogsConfig, err error) {
-				assert.Nil(t, err)
-				require.Equal(t, len(configs), 1)
-				config := configs[0]
-				assert.Equal(t, "file", config.Type)
-				assert.Equal(t, "/my/test/file.log", config.Path)
-				assert.Equal(t, "cardpayment", config.Service)
-				assert.Equal(t, "java", config.Source)
-				require.Equal(t, len(config.ProcessingRules), 1)
-				assert.Equal(t, "mask_sequences", config.ProcessingRules[0].Type)
-				assert.Equal(t, "mask_credit_cards", config.ProcessingRules[0].Name)
-				assert.Equal(t, "[masked_credit_card]", config.ProcessingRules[0].ReplacePlaceholder)
-				assert.Equal(t, `(?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})`, config.ProcessingRules[0].Pattern)
-				_, err = regexp.Compile(config.ProcessingRules[0].Pattern)
-				assert.Nil(t, err, "Pattern should be a valid regex")
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configs, err := ParseYAML(tt.yaml)
-			tt.assert(t, configs, err)
-		})
+		assert.Equal(t, 0, len(configs))
 	}
 }

--- a/comp/logs/agent/config/processing_rules.go
+++ b/comp/logs/agent/config/processing_rules.go
@@ -23,7 +23,7 @@ const (
 type ProcessingRule struct {
 	Type               string
 	Name               string
-	ReplacePlaceholder string `mapstructure:"replace_placeholder" json:"replace_placeholder" yaml:"replace_placeholder"`
+	ReplacePlaceholder string `mapstructure:"replace_placeholder" json:"replace_placeholder"`
 	Pattern            string
 	// TODO: should be moved out
 	Regex       *regexp.Regexp

--- a/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
+++ b/comp/metadata/inventorychecks/inventorychecksimpl/inventorychecks_test.go
@@ -249,7 +249,7 @@ func TestGetPayload(t *testing.T) {
 				assert.Equal(t, expectedSourceStatus, actualSource[0]["state"])
 				assert.Equal(t, "awesome_cache", actualSource[0]["service"])
 				assert.Equal(t, "redis", actualSource[0]["source"])
-				assert.Equal(t, logConfig.TagsField{"env:prod"}, actualSource[0]["tags"])
+				assert.Equal(t, []string{"env:prod"}, actualSource[0]["tags"])
 			} else {
 				assert.Len(t, p.LogsMetadata, 0)
 			}

--- a/pkg/logs/launchers/container/tailerfactory/file_test.go
+++ b/pkg/logs/launchers/container/tailerfactory/file_test.go
@@ -14,7 +14,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
@@ -24,7 +23,7 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
-	config "github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/util/containersorpods"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -318,7 +317,7 @@ func TestMakeK8sSource(t *testing.T) {
 			require.Equal(t, wildcard, child.Config.Path)
 			require.Equal(t, "src", child.Config.Source)
 			require.Equal(t, "svc", child.Config.Service)
-			assert.EqualValues(t, config.TagsField{"tag!"}, child.Config.Tags)
+			require.Equal(t, []string{"tag!"}, child.Config.Tags)
 			require.Equal(t, *child.Config.AutoMultiLine, true)
 			require.Equal(t, child.Config.AutoMultiLineSampleSize, 123)
 			require.Equal(t, child.Config.AutoMultiLineMatchThreshold, 0.123)


### PR DESCRIPTION
Reverts DataDog/datadog-agent#34065 which broke the `new-e2e-alp` [test](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/821030241) on main