### PR TITLE
fix(create_rc): Copy the config of parent dir to the worktree

### DIFF
--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -44,6 +44,12 @@ def init_env(ctx, branch: str | None = None, commit: str | None = None):
                 code=1,
             )
 
+    # Copy the configuration file
+    ctx.run(f"cp {LOCAL_DIRECTORY}/.git/config {WORKTREE_DIRECTORY}/.git/config", hide=True)
+    ctx.run(
+        f"git -C '{WORKTREE_DIRECTORY}' branch --set-upstream-to=origin/{branch or 'main'} {branch or 'main'}",
+        hide=True,
+    )
     # If the state is not clean, clean it
     if ctx.run(f"git -C '{WORKTREE_DIRECTORY}' status --porcelain", hide=True).stdout.strip():
         print(f'{color_message("Info", Color.BLUE)}: Cleaning worktree directory', file=sys.stderr)

--- a/tasks/unit_tests/libs/common/worktree_tests.py
+++ b/tasks/unit_tests/libs/common/worktree_tests.py
@@ -64,6 +64,8 @@ class WorktreeMockContext(MockContext):
             re.match(r'git.*status --porcelain.*', command)
             or re.match(r'git.*reset --hard.*', command)
             or re.match(r'git.*clean -f.*', command)
+            or re.match(r'git.*branch --set-upstream-to.*', command)
+            or re.match(r'cp.*', command)
         ):
             return Result(stdout='')
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Copy the git config of the parent directory into the worktree
- Set the upstream branch value

### Motivation
Currently the `create_rc` job [fails](https://github.com/DataDog/datadog-agent/actions/runs/13494331824/job/37698196121) because of permission issue. This is because the setting of the clone is not aligned with the initial clone. This was working before with an [update](https://github.com/DataDog/datadog-agent/pull/32277/files#diff-16a766b7791cd0da5989d2649e1e9523008dbca7285e0e1e8949ec9c0a0989e3L402) of the `upstream`. I think this is unsafe and copy of the config "as is" is better.

### Describe how you validated your changes
https://github.com/DataDog/datadog-agent/actions/runs/13519621629/job/37775826749
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs


### Additional Notes
Another option could have been to create a real worktree (instead of a clone) for operations that need write access.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->