### PR TITLE
[GPU]: Additional fields for GPUEntity in WMS

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -197,7 +197,7 @@ func (c *collector) fillAttributes(gpuDeviceInfo *workloadmeta.GPU, device nvml.
 			log.Warnf("failed to get device attributes for device index %d: %v", gpuDeviceInfo.Index, nvml.ErrorString(ret))
 		}
 	} else {
-		gpuDeviceInfo.MaxClockRates[workloadmeta.SM] = maxSMClock
+		gpuDeviceInfo.MaxClockRates[workloadmeta.GPUSM] = maxSMClock
 	}
 
 	maxMemoryClock, ret := device.GetMaxClockInfo(nvml.CLOCK_MEM)
@@ -206,7 +206,7 @@ func (c *collector) fillAttributes(gpuDeviceInfo *workloadmeta.GPU, device nvml.
 			log.Warnf("failed to get device attributes for device index %d: %v", gpuDeviceInfo.Index, nvml.ErrorString(ret))
 		}
 	} else {
-		gpuDeviceInfo.MaxClockRates[workloadmeta.Memory] = maxMemoryClock
+		gpuDeviceInfo.MaxClockRates[workloadmeta.GPUMemory] = maxMemoryClock
 	}
 }
 

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1359,11 +1359,15 @@ func (e EventBundle) Acknowledge() {
 // the inithook for additional start-time configutation.
 type InitHelper func(context.Context, Component, config.Component) error
 
+// GPUClockType is an enum to access different clock rates of the GPU Device through the MaxClockRates array field of the GPU.
 type GPUClockType int
 
 const (
+	// SM Clock, use nvml.CLOCK_SM to get the value
 	SM GPUClockType = iota
+	// Memory Clock, use nvml.CLOCK_MEM to get the value
 	Memory
+	// COUNT is the total number of clock types in this enum
 	COUNT
 )
 

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1363,12 +1363,12 @@ type InitHelper func(context.Context, Component, config.Component) error
 type GPUClockType int
 
 const (
-	// SM Clock, use nvml.CLOCK_SM to get the value
-	SM GPUClockType = iota
-	// Memory Clock, use nvml.CLOCK_MEM to get the value
-	Memory
-	// COUNT is the total number of clock types in this enum
-	COUNT
+	// GPUSM represents SM Clock, use nvml.CLOCK_SM to get the value
+	GPUSM GPUClockType = iota
+	// GPUMemory represents Memory Clock, use nvml.CLOCK_MEM to get the value
+	GPUMemory
+	// GPUCOUNT is the total number of clock types in this enum
+	GPUCOUNT
 )
 
 // GPU represents a GPU resource.
@@ -1410,7 +1410,7 @@ type GPU struct {
 	TotalMemoryMB uint64
 
 	// MaxClockRates contains the maximum clock rates for SM and Memory
-	MaxClockRates [COUNT]uint32
+	MaxClockRates [GPUCOUNT]uint32
 
 	// MemoryBusWidth is the width of the memory bus in bits.
 	MemoryBusWidth uint32
@@ -1488,8 +1488,8 @@ func (g GPU) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Streaming Multiprocessor Count:", g.SMCount)
 	_, _ = fmt.Fprintln(&sb, "Total Memory (in MB):", g.TotalMemoryMB)
 	_, _ = fmt.Fprintln(&sb, "Memory Bus Width:", g.MemoryBusWidth)
-	_, _ = fmt.Fprintln(&sb, "Max SM Clock Rate:", g.MaxClockRates[SM])
-	_, _ = fmt.Fprintln(&sb, "Max Memory Clock Rate:", g.MaxClockRates[Memory])
+	_, _ = fmt.Fprintln(&sb, "Max SM Clock Rate:", g.MaxClockRates[GPUSM])
+	_, _ = fmt.Fprintln(&sb, "Max Memory Clock Rate:", g.MaxClockRates[GPUMemory])
 	if g.MigEnabled {
 		_, _ = fmt.Fprintln(&sb, "----------- MIG Device -----------")
 		_, _ = fmt.Fprintln(&sb, "MIG Enabled: true")

--- a/comp/core/workloadmeta/def/types_test.go
+++ b/comp/core/workloadmeta/def/types_test.go
@@ -162,9 +162,12 @@ func TestMergeGPU(t *testing.T) {
 		EntityMeta: EntityMeta{
 			Name: "gpu-1",
 		},
-		Vendor:     "nvidia",
-		Device:     "",
-		ActivePIDs: []int{123, 456},
+		Vendor:         "nvidia",
+		DriverVersion:  "460.32.03",
+		Device:         "",
+		ActivePIDs:     []int{123, 456},
+		TotalMemoryMB:  4096,
+		MemoryBusWidth: 256,
 	}
 	gpu2 := GPU{
 		EntityID: EntityID{
@@ -174,9 +177,12 @@ func TestMergeGPU(t *testing.T) {
 		EntityMeta: EntityMeta{
 			Name: "gpu-1",
 		},
-		Vendor:     "nvidia",
-		Device:     "tesla",
-		ActivePIDs: []int{654},
+		Vendor:         "nvidia",
+		DriverVersion:  "460.32.03",
+		Device:         "tesla",
+		ActivePIDs:     []int{654},
+		TotalMemoryMB:  4096,
+		MemoryBusWidth: 256,
 	}
 
 	err := gpu1.Merge(&gpu2)

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -62,6 +62,7 @@ var DefaultGPUArch = nvml.DeviceArchitecture(nvml.DEVICE_ARCH_HOPPER)
 // DefaultGPUAttributes is the attributes for the default device returned by the mock
 var DefaultGPUAttributes = nvml.DeviceAttributes{
 	MultiprocessorCount: 10,
+	MemorySizeMB:        4096,
 }
 
 // DefaultProcessInfo is the list of processes running on the default device returned by the mock
@@ -100,6 +101,19 @@ func GetDeviceMock(deviceIdx int) *nvmlmock.Device {
 		GetMemoryInfoFunc: func() (nvml.Memory, nvml.Return) {
 			return nvml.Memory{Total: DefaultTotalMemory, Free: 500}, nvml.SUCCESS
 		},
+		GetMemoryBusWidthFunc: func() (uint32, nvml.Return) {
+			return 256, nvml.SUCCESS
+		},
+		GetMaxClockInfoFunc: func(clockType nvml.ClockType) (uint32, nvml.Return) {
+			switch clockType {
+			case nvml.CLOCK_SM:
+				return 1000, nvml.SUCCESS
+			case nvml.CLOCK_MEM:
+				return 2000, nvml.SUCCESS
+			default:
+				return 0, nvml.ERROR_NOT_SUPPORTED
+			}
+		},
 	}
 }
 
@@ -132,6 +146,9 @@ func GetBasicNvmlMock() *nvmlmock.Interface {
 		},
 		DeviceGetMemoryInfoFunc: func(nvml.Device) (nvml.Memory, nvml.Return) {
 			return nvml.Memory{Total: DefaultTotalMemory, Free: 500}, nvml.SUCCESS
+		},
+		SystemGetDriverVersionFunc: func() (string, nvml.Return) {
+			return "470.57.02", nvml.SUCCESS
 		},
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Added additional fields to the GPUEntity in WMS
- DriverVersion
- TotalMemory (in mb)
- MemoryBusWidth (in bits)
- Max Clock Rate for SM and Memory

### Motivation

Use WMS as the source for the hostgpu inventory payload (will come in a separate PR)

### Describe how you validated your changes
Added those fields to the existing UT 

### Possible Drawbacks / Trade-offs

### Additional Notes
