### PR TITLE
Revert "Revert "(fleet) bundle the installer in the agent""

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -216,6 +216,7 @@
 /cmd/agent/dist/conf.d/sbom.d/          @DataDog/container-integrations
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/ndm-core
 /cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-agent
+/cmd/agent/installer.go                 @DataDog/fleet
 /cmd/agent/install*.sh                  @DataDog/container-ecosystems @DataDog/agent-delivery
 /cmd/cluster-agent/                     @DataDog/container-platform
 /cmd/cluster-agent-cloudfoundry/        @DataDog/agent-integrations

--- a/cmd/agent/installer.go
+++ b/cmd/agent/installer.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build bundle_installer && !windows && !darwin
+
+package main
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/installer/command"
+	"github.com/DataDog/datadog-agent/cmd/installer/subcommands"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registerAgent([]string{"datadog-installer"}, func() *cobra.Command {
+		return command.MakeCommand(subcommands.InstallerSubcommands())
+	})
+}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -17,6 +17,7 @@ from tasks.flavor import AgentFlavor
 # ALL_TAGS lists all available build tags.
 # Used to remove unknown tags from provided tag lists.
 ALL_TAGS = {
+    "bundle_installer",
     "clusterchecks",
     "consul",
     "containerd",
@@ -63,6 +64,7 @@ ALL_TAGS = {
 
 # AGENT_TAGS lists the tags needed when building the agent.
 AGENT_TAGS = {
+    "bundle_installer",
     "consul",
     "containerd",
     "no_dynamic_plugins",
@@ -92,6 +94,7 @@ AGENT_TAGS = {
 # AGENT_HEROKU_TAGS lists the tags for Heroku agent build
 AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
     {
+        "bundle_installer",
         "containerd",
         "no_dynamic_plugins",
         "cri",


### PR DESCRIPTION
Reverts DataDog/datadog-agent#34410

Re-applies https://github.com/DataDog/datadog-agent/pull/34326 (failure was just a flake)