### PR TITLE
trivy: simplify docker image scanning to fallback on regular image scanning

### DIFF
--- a/pkg/sbom/collectors/docker/docker.go
+++ b/pkg/sbom/collectors/docker/docker.go
@@ -27,8 +27,6 @@ import (
 // 1000 is already a very large default value
 const resultChanSize = 1000
 
-type scannerFunc func(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, client client.ImageAPIClient, scanOptions sbom.ScanOptions) (sbom.Report, error)
-
 // scanRequest defines a scan request. This struct should be
 // hashable to be pushed in the work queue for processing.
 type scanRequest struct {
@@ -108,13 +106,7 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 		return sbom.ScanResult{Error: fmt.Errorf("image metadata not found for image id %s: %s", dockerScanRequest.ID(), err)}
 	}
 
-	var scanner scannerFunc
-	if c.opts.OverlayFsScan {
-		scanner = c.trivyCollector.ScanDockerImageFromGraphDriver
-	} else {
-		scanner = c.trivyCollector.ScanDockerImage
-	}
-	report, err := scanner(
+	report, err := c.trivyCollector.ScanDockerImage(
 		ctx,
 		imageMeta,
 		c.cl,

--- a/pkg/util/trivy/docker.go
+++ b/pkg/util/trivy/docker.go
@@ -83,8 +83,8 @@ func (c *fakeDockerContainer) Layers() (layers []ftypes.LayerPath) {
 	return c.fakeContainer.Layers()
 }
 
-// ScanDockerImageFromGraphDriver scans a docker image directly from the graph driver
-func (c *Collector) ScanDockerImageFromGraphDriver(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, client client.ImageAPIClient, scanOptions sbom.ScanOptions) (sbom.Report, error) {
+// ScanDockerImage scans a docker image by exporting it and scanning the tarball
+func (c *Collector) ScanDockerImage(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, client client.ImageAPIClient, scanOptions sbom.ScanOptions) (sbom.Report, error) {
 	fanalImage, cleanup, err := convertDockerImage(ctx, client, imgMeta)
 	if cleanup != nil {
 		defer cleanup()
@@ -94,7 +94,7 @@ func (c *Collector) ScanDockerImageFromGraphDriver(ctx context.Context, imgMeta 
 		return nil, fmt.Errorf("unable to convert docker image, err: %w", err)
 	}
 
-	if fanalImage.inspect.GraphDriver.Name == "overlay2" {
+	if scanOptions.OverlayFsScan && fanalImage.inspect.GraphDriver.Name == "overlay2" {
 		var layers []string
 		if layerDirs, ok := fanalImage.inspect.GraphDriver.Data["LowerDir"]; ok {
 			layers = append(layers, strings.Split(layerDirs, ":")...)
@@ -120,20 +120,6 @@ func (c *Collector) ScanDockerImageFromGraphDriver(ctx context.Context, imgMeta 
 		}
 
 		return c.scanOverlayFS(ctx, layers, fakeContainer, imgMeta, scanOptions)
-	}
-
-	return nil, fmt.Errorf("unsupported graph driver: %s", fanalImage.inspect.GraphDriver.Name)
-}
-
-// ScanDockerImage scans a docker image by exporting it and scanning the tarball
-func (c *Collector) ScanDockerImage(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, client client.ImageAPIClient, scanOptions sbom.ScanOptions) (sbom.Report, error) {
-	fanalImage, cleanup, err := convertDockerImage(ctx, client, imgMeta)
-	if cleanup != nil {
-		defer cleanup()
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("unable to convert docker image, err: %w", err)
 	}
 
 	return c.scanImage(ctx, fanalImage, imgMeta, scanOptions)


### PR DESCRIPTION
### What does this PR do?

This PR allows the docker sbom collector to fallback on regular image scan if overlayfs scan is enabled, and the overlay driver is not correct (contrary to today where it's going to fail).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->