### PR TITLE
[AGENTRUN-115] Get the hostname from running agent if possible in hostname command

### DIFF
--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -70,11 +70,8 @@ func printHostname(_ log.Component, config config.Component, params *cliParams) 
 }
 
 func getHostname(config config.Component, params *cliParams) (string, error) {
-	var hname string
-	var err error
-
 	if !params.forceLocal {
-		hname, err = getRemoteHostname(config)
+		hname, err := getRemoteHostname(config)
 		if err == nil {
 			return hname, nil
 		}

--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -58,6 +59,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 func getHostname(_ log.Component, config config.Component, params *cliParams) error {
+	return getHostnameWithWriter(nil, config, params, os.Stdout)
+}
+
+func getHostnameWithWriter(_ log.Component, config config.Component, params *cliParams, writer io.Writer) error {
 	var hname string
 	var err error
 
@@ -76,7 +81,7 @@ func getHostname(_ log.Component, config config.Component, params *cliParams) er
 		}
 	}
 
-	fmt.Println(hname)
+	fmt.Fprintln(writer, hname)
 	return nil
 }
 
@@ -86,16 +91,16 @@ func getRemoteHostname(config config.Component) (string, error) {
 		return "", err
 	}
 
-	res, err := endpoint.DoGet()
+	hname, err := endpoint.DoGet()
 	if err != nil {
 		return "", err
 	}
 
-	var hname string
-	err = json.Unmarshal(res, &hname)
+	var hostname string
+	err = json.Unmarshal(hname, &hostname)
 	if err != nil {
 		return "", err
 	}
 
-	return hname, nil
+	return hostname, nil
 }

--- a/cmd/agent/subcommands/hostname/command.go
+++ b/cmd/agent/subcommands/hostname/command.go
@@ -59,10 +59,10 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 func getHostname(_ log.Component, config config.Component, params *cliParams) error {
-	return getHostnameWithWriter(nil, config, params, os.Stdout)
+	return getHostnameWithWriter(config, params, os.Stdout)
 }
 
-func getHostnameWithWriter(_ log.Component, config config.Component, params *cliParams, writer io.Writer) error {
+func getHostnameWithWriter(config config.Component, params *cliParams, writer io.Writer) error {
 	var hname string
 	var err error
 

--- a/cmd/agent/subcommands/hostname/command_test.go
+++ b/cmd/agent/subcommands/hostname/command_test.go
@@ -6,13 +6,24 @@
 package hostname
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -24,4 +35,82 @@ func TestCommand(t *testing.T) {
 		func(_ *cliParams, _ core.BundleParams, secretParams secrets.Params) {
 			require.Equal(t, false, secretParams.Enabled)
 		})
+}
+
+func hostnameHandler(hostname string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/agent/hostname" || r.Method != http.MethodGet {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+		if hostname == "" {
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		hname, err := json.Marshal(hostname)
+		if err != nil {
+			http.Error(w, "Internal Server Error (marshalling)", http.StatusInternalServerError)
+			return
+		}
+		w.Write(hname)
+	})
+}
+
+func TestGetHostnameRemote(t *testing.T) {
+	testCases := []struct {
+		name           string
+		forceLocal     bool
+		remoteHostname string
+	}{
+		{
+			name:           "remote",
+			forceLocal:     false,
+			remoteHostname: "remotehostname",
+		},
+		{
+			name:           "forceLocal",
+			forceLocal:     true,
+			remoteHostname: "remotehostname",
+		},
+		{
+			name:           "remoteFallbackLocal",
+			forceLocal:     false,
+			remoteHostname: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := config.NewMock(t)
+			logger := logmock.New(t)
+			cliParams := &cliParams{
+				GlobalParams: &command.GlobalParams{},
+				forceLocal:   tc.forceLocal,
+			}
+
+			server := httptest.NewTLSServer(hostnameHandler(tc.remoteHostname))
+			t.Cleanup(server.Close)
+
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			localHostname := "localhostname"
+			config.Set("hostname", localHostname, model.SourceFile)
+			config.Set("cmd_host", serverURL.Hostname(), model.SourceFile)
+			config.Set("cmd_port", serverURL.Port(), model.SourceFile)
+
+			config.Set("auth_token_file_path", path.Join(t.TempDir(), "auth_token"), model.SourceFile)
+			apiutil.CreateAndSetAuthToken(config)
+
+			var buff bytes.Buffer
+			err = getHostnameWithWriter(logger, config, cliParams, &buff)
+			require.NoError(t, err)
+
+			expectedHostname := localHostname
+			if !tc.forceLocal && tc.remoteHostname != "" {
+				expectedHostname = tc.remoteHostname
+			}
+			require.Equal(t, expectedHostname, strings.TrimSpace(buff.String()))
+		})
+	}
 }

--- a/releasenotes/notes/hostname-subcommand-remote-736b0ca4a7793321.yaml
+++ b/releasenotes/notes/hostname-subcommand-remote-736b0ca4a7793321.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The hostname subcommand of the agent now tries reaching out to the running agent,
+    and fallback to computing the hostname locally if the agent is not running.
+    You can use the `--local` option to force the local computation.

--- a/releasenotes/notes/hostname-subcommand-remote-736b0ca4a7793321.yaml
+++ b/releasenotes/notes/hostname-subcommand-remote-736b0ca4a7793321.yaml
@@ -8,6 +8,6 @@
 ---
 enhancements:
   - |
-    The hostname subcommand of the agent now tries reaching out to the running agent,
-    and fallback to computing the hostname locally if the agent is not running.
+    The hostname subcommand for the Agent now tries to reach out to the running Agent,
+    and falls back to computing the hostname locally if the Agent is not running.
     You can use the `--local` option to force the local computation.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Change the hostname subcommand to try reaching out to the running agent before falling back to local computation of the hostname. 

### Motivation
The command should give the same hostname as the running agent, in case of transient error (eg. network) it is currently not the case. 
Reaching out to the running agent is a more correct behavior, and in the worst case we fallback to the local computation and print a warning.
This should help avoid some issues we've seen in support cases and flaky end-to-end tests.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Local testing:
```
$ DD_HOSTNAME=myname ./bin/agent/agent hostname
COMP-VWFVT21J6N
$ DD_HOSTNAME=myname ./bin/agent/agent hostname --local
myname
```

Also added unit tests to ensure the behavior is correct.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->