### PR TITLE
Updates static quality gates thresholds value

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,47 +1,47 @@
 # Package gates
 static_quality_gate_agent_deb_amd64:
-  max_on_wire_size: "210.72 MiB"
-  max_on_disk_size: "841.59 MiB"
+  max_on_wire_size: "204.92 MiB"
+  max_on_disk_size: "817.79 MiB"
 
 static_quality_gate_agent_deb_arm64:
-  max_on_wire_size: "192.1 MiB"
-  max_on_disk_size: "830.66 MiB"
+  max_on_wire_size: "186.5 MiB"
+  max_on_disk_size: "808.76 MiB"
 
 static_quality_gate_agent_rpm_amd64:
-  max_on_wire_size: "214.52 MiB"
-  max_on_disk_size: "841.52 MiB"
+  max_on_wire_size: "208.12 MiB"
+  max_on_disk_size: "817.82 MiB"
 
 static_quality_gate_agent_rpm_arm64:
-  max_on_wire_size: "193.64 MiB"
-  max_on_disk_size: "830.66 MiB"
+  max_on_wire_size: "188.34 MiB"
+  max_on_disk_size: "808.76 MiB"
 
 static_quality_gate_agent_suse_amd64:
-  max_on_wire_size: "214.52 MiB"
-  max_on_disk_size: "841.52 MiB"
+  max_on_wire_size: "208.12 MiB"
+  max_on_disk_size: "817.82 MiB"
 
 static_quality_gate_agent_suse_arm64:
-  max_on_wire_size: "194.03 MiB"
-  max_on_disk_size: "830.66 MiB"
+  max_on_wire_size: "188.33 MiB"
+  max_on_disk_size: "808.86 MiB"
 
 static_quality_gate_dogstatsd_deb_amd64:
-  max_on_wire_size: "20.6 MiB"
-  max_on_disk_size: "49.7 MiB"
+  max_on_wire_size: "19.8 MiB"
+  max_on_disk_size: "47.7 MiB"
 
 static_quality_gate_dogstatsd_deb_arm64:
-  max_on_wire_size: "19.1 MiB"
-  max_on_disk_size: "48.1 MiB"
+  max_on_wire_size: "18.5 MiB"
+  max_on_disk_size: "46.3 MiB"
 
 static_quality_gate_dogstatsd_rpm_amd64:
-  max_on_wire_size: "20.6 MiB"
-  max_on_disk_size: "49.7 MiB"
+  max_on_wire_size: "19.8 MiB"
+  max_on_disk_size: "47.7 MiB"
 
 static_quality_gate_dogstatsd_suse_amd64:
-  max_on_wire_size: "20.6 MiB"
-  max_on_disk_size: "49.7 MiB"
+  max_on_wire_size: "19.8 MiB"
+  max_on_disk_size: "47.7 MiB"
 
 static_quality_gate_iot_agent_deb_amd64:
   max_on_wire_size: "24.8 MiB"
-  max_on_disk_size: "69 MiB"
+  max_on_disk_size: "69.0 MiB"
 
 static_quality_gate_iot_agent_deb_arm64:
   max_on_wire_size: "22.8 MiB"
@@ -49,7 +49,7 @@ static_quality_gate_iot_agent_deb_arm64:
 
 static_quality_gate_iot_agent_rpm_amd64:
   max_on_wire_size: "24.8 MiB"
-  max_on_disk_size: "69 MiB"
+  max_on_disk_size: "69.0 MiB"
 
 static_quality_gate_iot_agent_rpm_arm64:
   max_on_wire_size: "22.8 MiB"
@@ -57,32 +57,32 @@ static_quality_gate_iot_agent_rpm_arm64:
 
 static_quality_gate_iot_agent_suse_amd64:
   max_on_wire_size: "24.8 MiB"
-  max_on_disk_size: "69 MiB"
+  max_on_disk_size: "69.0 MiB"
 
 # Docker images gate
 static_quality_gate_docker_agent_amd64:
-  max_on_wire_size: "317.43 MiB"
-  max_on_disk_size: "926.00 MiB"
+  max_on_wire_size: "308.43 MiB"
+  max_on_disk_size: "902.2 MiB"
 
 static_quality_gate_docker_agent_arm64:
-  max_on_wire_size: "302.43 MiB"
-  max_on_disk_size: "939.07 MiB"
+  max_on_wire_size: "294.23 MiB"
+  max_on_disk_size: "916.47 MiB"
 
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_wire_size: "392.54 MiB"
-  max_on_disk_size: "1124.07 MiB"
+  max_on_wire_size: "383.54 MiB"
+  max_on_disk_size: "1100.37 MiB"
 
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_wire_size: "373.21 MiB"
-  max_on_disk_size: "1125.63 MiB"
+  max_on_wire_size: "365.31 MiB"
+  max_on_disk_size: "1103.33 MiB"
 
 static_quality_gate_docker_dogstatsd_amd64:
-  max_on_wire_size: "28.29 MiB"
-  max_on_disk_size: "57.88 MiB"
+  max_on_wire_size: "27.29 MiB"
+  max_on_disk_size: "55.78 MiB"
 
 static_quality_gate_docker_dogstatsd_arm64:
-  max_on_wire_size: "27.06 MiB"
-  max_on_disk_size: "56.27 MiB"
+  max_on_wire_size: "26.16 MiB"
+  max_on_disk_size: "54.47 MiB"
 
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_wire_size: "116.28 MiB"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update static quality gates thresholds to save on recent wins

### Motivation

[Dashboard](https://app.datadoghq.com/dashboard/5np-man-vak/static-quality-gates?fromUser=false&refresh_mode=sliding&from_ts=1740314801116&to_ts=1740487601116&live=true)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->