### PR TITLE
[compliance] Avoid dependency on k8s.io/client-go/discovery

### DIFF
--- a/cmd/cluster-agent/subcommands/start/compliance.go
+++ b/cmd/cluster-agent/subcommands/start/compliance.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"os"
 
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -120,9 +119,10 @@ func startCompliance(senderManager sender.SenderManager, wmeta workloadmeta.Comp
 }
 
 func wrapKubernetesClient(apiCl *apiserver.APIClient, isLeader func() bool) compliance.KubernetesProvider {
-	return func(_ context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
+	return func(_ context.Context) (dynamic.Interface, compliance.KubernetesGroupsAndResourcesProvider, error) {
 		if isLeader() {
-			return apiCl.DynamicCl, apiCl.Cl.Discovery(), nil
+			discoveryCl := apiCl.Cl.Discovery()
+			return apiCl.DynamicCl, discoveryCl.ServerGroupsAndResources, nil
 		}
 		return nil, nil, compliance.ErrIncompatibleEnvironment
 	}

--- a/cmd/security-agent/subcommands/check/resolver_cluster_agent.go
+++ b/cmd/security-agent/subcommands/check/resolver_cluster_agent.go
@@ -12,17 +12,18 @@ import (
 	"context"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
-func complianceKubernetesProvider(_ctx context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
+func complianceKubernetesProvider(_ctx context.Context) (dynamic.Interface, compliance.KubernetesGroupsAndResourcesProvider, error) {
 	ctx, cancel := context.WithTimeout(_ctx, 2*time.Second)
 	defer cancel()
 	apiCl, err := apiserver.WaitForAPIClient(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
-	return apiCl.DynamicCl, apiCl.Cl.Discovery(), nil
+	return apiCl.DynamicCl, apiCl.Cl.Discovery().ServerGroupsAndResources, nil
 }

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -20,7 +20,6 @@ import (
 	docker "github.com/docker/docker/client"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
@@ -113,7 +112,7 @@ func (s *suite) Run() {
 				options.DockerProvider = func(context.Context) (docker.CommonAPIClient, error) { return s.dockerClient, nil }
 			}
 			if s.kubeClient != nil {
-				options.KubernetesProvider = func(context.Context) (dynamic.Interface, discovery.DiscoveryInterface, error) {
+				options.KubernetesProvider = func(context.Context) (dynamic.Interface, compliance.KubernetesGroupsAndResourcesProvider, error) {
 					return s.kubeClient, nil, nil
 				}
 			}


### PR DESCRIPTION
### What does this PR do?

Avoids the dependency on `k8s.io/client-go/discovery` in the security-agent.
This dependency increases a lot the binary size (around 17 MB which represent a 25% of the security-agent).
It was only used to call `ServerGroupsAndResources()` so we can define a function with the same contract to avoid importing the whole package: `type KubernetesGroupsAndResourcesProvider func() ([]*kubemetav1.APIGroup, []*kubemetav1.APIResourceList, error)`



### Describe how you validated your changes

@paulcacheux Ran the security regression tests
