### PR TITLE
[CWS] Fix: add missing EKS cluster name in inventory

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -232,7 +232,6 @@ func (ia *inventoryagent) fetchCoreAgentMetadata() {
 	ia.data["config_process_dd_url"] = scrub(ia.conf.GetString("process_config.process_dd_url"))
 	ia.data["config_proxy_http"] = scrub(ia.conf.GetString("proxy.http"))
 	ia.data["config_proxy_https"] = scrub(ia.conf.GetString("proxy.https"))
-	ia.data["config_eks_fargate"] = ia.conf.GetBool("eks_fargate")
 	ia.data["feature_fips_enabled"] = ia.conf.GetBool("fips.enabled")
 	ia.data["feature_logs_enabled"] = ia.conf.GetBool("logs_enabled")
 	ia.data["feature_imdsv2_enabled"] = ia.conf.GetBool("ec2_prefer_imdsv2")
@@ -246,6 +245,13 @@ func (ia *inventoryagent) fetchCoreAgentMetadata() {
 
 	// ECS Fargate
 	ia.fetchECSFargateAgentMetadata()
+
+	// EKS Fargate
+	eks_fargate := ia.conf.GetBool("eks_fargate")
+	ia.data["config_eks_fargate"] = eks_fargate
+	if eks_fargate {
+		ia.data["eks_fargate_cluster_name"] = ia.conf.GetString("cluster_name")
+	}
 }
 
 func (ia *inventoryagent) fetchSecurityAgentMetadata() {

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -247,9 +247,9 @@ func (ia *inventoryagent) fetchCoreAgentMetadata() {
 	ia.fetchECSFargateAgentMetadata()
 
 	// EKS Fargate
-	eks_fargate := ia.conf.GetBool("eks_fargate")
-	ia.data["config_eks_fargate"] = eks_fargate
-	if eks_fargate {
+	eksFargate := ia.conf.GetBool("eks_fargate")
+	ia.data["config_eks_fargate"] = eksFargate
+	if eksFargate {
 		ia.data["eks_fargate_cluster_name"] = ia.conf.GetString("cluster_name")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

It adds the EKS cluster name in the agent inventory, in order to use it in REDAPL to display it on setup page:

![image](https://github.com/user-attachments/assets/0168f7d6-7c9a-4dbb-b784-4df38cda10b8)

Its now sent as `eks_fargate_cluster_name`

### Motivation

Fix a bug where cluster name, even if set, was not displayed on serverless setup page.

### Describe how you validated your changes

Setup an agent with `DD_EKS_FARGATE=true` and `DD_CLUSTER_NAME=<your_cluster_name>` (even locally)
Then, launch `agent diagnose show-metadata inventory-agent|grep eks_fargate_cluster_name` to validate that you have the new metadata.

### Possible Drawbacks / Trade-offs

### Additional Notes

Needed by: https://github.com/DataDog/infrastructure-resources/pull/1891