### PR TITLE
[Dynamic Instrumentation] Introducing Exploration Testing

### DIFF
--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -153,25 +153,26 @@ func (pt *ProcessTracker) inspectBinaryForRegistration(exePath string, pid uint3
 		return
 	}
 	noStructs := make(map[bininspect.FieldIdentifier]bininspect.StructLookupFunction)
-	var functionsConfig = map[string]bininspect.FunctionConfiguration{
-		ditypes.RemoteConfigCallback: {
-			IncludeReturnLocations: false,
-			ParamLookupFunction:    remoteConfigCallback,
-		},
-	}
+	//var functionsConfig = map[string]bininspect.FunctionConfiguration{
+	//	ditypes.RemoteConfigCallback: {
+	//		IncludeReturnLocations: false,
+	//		ParamLookupFunction:    remoteConfigCallback,
+	//	},
+	//}
+	noFuncs := make(map[string]bininspect.FunctionConfiguration)
 
 	var ddtracegoVersion = ditypes.DDTraceGoVersionV1
-	_, err = bininspect.InspectNewProcessBinary(elfFile, functionsConfig, noStructs)
+	_, err = bininspect.InspectNewProcessBinary(elfFile, noFuncs, noStructs)
 	if err != nil {
 		log.Errorf("error reading binary for %d %s: %s, %s", pid, serviceName, binPath, err)
 
 		// Since dd-trace-go v2 has a different import path (therefore different symbol name) for the remote config callback, we need to handle both cases.
-		functionsConfig[ditypes.RemoteConfigCallbackV2] = bininspect.FunctionConfiguration{
+		noFuncs[ditypes.RemoteConfigCallbackV2] = bininspect.FunctionConfiguration{
 			IncludeReturnLocations: false,
 			ParamLookupFunction:    remoteConfigCallback,
 		}
-		delete(functionsConfig, ditypes.RemoteConfigCallback)
-		_, err = bininspect.InspectNewProcessBinary(elfFile, functionsConfig, noStructs)
+		delete(noFuncs, ditypes.RemoteConfigCallback)
+		_, err = bininspect.InspectNewProcessBinary(elfFile, noFuncs, noStructs)
 		if err != nil {
 			log.Errorf("error reading binary for %d %s: %s, %s", pid, serviceName, binPath, err)
 			return

--- a/pkg/dynamicinstrumentation/testutil/exploration_e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/exploration_e2e_test.go
@@ -1,0 +1,1515 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package testutil
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"debug/dwarf"
+	"debug/elf"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/features"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation"
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/diagnostics"
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/diconfig"
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
+	consumerstestutil "github.com/DataDog/datadog-agent/pkg/eventmonitor/consumers/testutil"
+)
+
+type ProcessState int
+
+const (
+	StateNew ProcessState = iota
+	StateAnalyzing
+	StateRunning
+	StateExited
+)
+
+func (s ProcessState) String() string {
+	switch s {
+	case StateNew:
+		return "NEW"
+	case StateAnalyzing:
+		return "ANALYZING"
+	case StateRunning:
+		return "RUNNING"
+	case StateExited:
+		return "EXITED"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+type ProcessInfo struct {
+	PID        int
+	BinaryPath string
+	ParentPID  int
+	State      ProcessState
+	Children   []*ProcessInfo
+	StartTime  time.Time
+	Analyzed   bool
+}
+
+type ProcessTracker struct {
+	t                *testing.T
+	ctx              context.Context
+	mu               sync.RWMutex
+	processes        map[int]*ProcessInfo
+	mainPID          int
+	stopChan         chan struct{}
+	analyzedBinaries map[string]bool
+	analyzedPIDs     map[int]bool
+	done             chan struct{}
+}
+
+type ProbeManager struct {
+	t               *testing.T
+	installedProbes sync.Map // maps pid -> map[string]struct{}
+	dataReceived    sync.Map // maps pid -> map[string]bool
+	mu              sync.Mutex
+}
+
+type BinaryInfo struct {
+	path     string
+	hasDebug bool
+}
+
+type FunctionInfo struct {
+	PackageName  string
+	FunctionName string
+	FullName     string
+	ProbeId      string
+}
+
+func NewFunctionInfo(packageName, functionName, fullName string) FunctionInfo {
+	return FunctionInfo{
+		PackageName:  packageName,
+		FunctionName: functionName,
+		FullName:     fullName,
+		ProbeId:      uuid.NewString(),
+	}
+}
+
+type rcConfig struct {
+	ID        string
+	Version   int
+	ProbeType string `json:"type"`
+	Language  string
+	Where     struct {
+		TypeName   string `json:"typeName"`
+		MethodName string `json:"methodName"`
+		SourceFile string
+		Lines      []string
+	}
+	Tags            []string
+	Template        string
+	CaptureSnapshot bool
+	EvaluatedAt     string
+	Capture         struct {
+		MaxReferenceDepth int `json:"maxReferenceDepth"`
+		MaxFieldCount     int `json:"maxFieldCount"`
+	}
+}
+
+type ConfigAccumulator struct {
+	configs map[string]map[string]rcConfig
+	tmpl    *template.Template
+	mu      sync.RWMutex
+}
+
+type RepoInfo struct {
+	Packages   map[string]bool // Package names found in repo
+	RepoPath   string          // Path to the repo
+	CommitHash string          // Current commit hash (optional)
+}
+
+type explorationEventOutputTestWriter struct {
+	t              *testing.T
+	expectedResult map[string]*ditypes.CapturedValue
+}
+
+func (e *explorationEventOutputTestWriter) Write(p []byte) (n int, err error) {
+	var snapshot ditypes.SnapshotUpload
+	if err := json.Unmarshal(p, &snapshot); err != nil {
+		e.t.Error("failed to unmarshal snapshot", err)
+	}
+	funcName := snapshot.Debugger.ProbeInSnapshot.Type + "." + snapshot.Debugger.ProbeInSnapshot.Method
+	e.t.Logf("Received snapshot for function: %s", funcName)
+	return len(p), nil
+}
+
+var (
+	analyzedBinaries     []BinaryInfo
+	waitForAttach        bool = true
+	bufferPool                = sync.Pool{New: func() interface{} { return new(bytes.Buffer) }}
+	seenBinaries              = make(map[string]struct{})
+	g_configsAccumulator *ConfigAccumulator
+	g_RepoInfo           *RepoInfo
+	g_ConfigManager      *diconfig.ReaderConfigManager
+	g_cmd                *exec.Cmd
+	DEBUG                bool = true
+	TRACE                bool = false
+	NUMBER_OF_PROBES     int  = 100
+	processedPids        map[int]bool
+
+	explorationTestConfigTemplateText = `
+    {{- range $index, $target := .}}
+    {{- if $index}},{{end}}
+    "{{$target.ProbeId}}": {
+        "id": "{{$target.ProbeId}}",
+        "version": 0,
+        "type": "LOG_PROBE",
+        "language": "go",
+        "where": {
+            "typeName": "{{$target.PackageName}}",
+            "methodName": "{{$target.FunctionName}}"
+        },
+        "tags": [],
+        "template": "Executed {{$target.PackageName}}.{{$target.FunctionName}}, it took {@duration}ms",
+        "segments": [
+            {
+                "str": "Executed {{$target.PackageName}}.{{$target.FunctionName}}, it took "
+            },
+            {
+                "dsl": "@duration",
+                "json": {
+                    "ref": "@duration"
+                }
+            },
+            {
+                "str": "ms"
+            }
+        ],
+        "captureSnapshot": false,
+        "capture": {
+            "maxReferenceDepth": 10
+        },
+        "sampling": {
+            "snapshotsPerSecond": 5000
+        },
+        "evaluateAt": "EXIT"
+    }
+    {{- end}}
+`
+)
+
+func getProcessArgs(pid int) ([]string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil {
+		return nil, err
+	}
+	args := strings.Split(string(data), "\x00")
+	if len(args) > 0 && args[len(args)-1] == "" {
+		args = args[:len(args)-1]
+	}
+	return args, nil
+}
+
+func getProcessCwd(pid int) (string, error) {
+	cwd, err := os.Readlink(fmt.Sprintf("/proc/%d/cwd", pid))
+	if err != nil {
+		return "", err
+	}
+	return cwd, nil
+}
+
+func getProcessEnv(pid int) ([]string, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/environ", pid))
+	if err != nil {
+		return nil, err
+	}
+	env := strings.Split(string(data), "\x00")
+	if len(env) > 0 && env[len(env)-1] == "" {
+		env = env[:len(env)-1]
+	}
+	return env, nil
+}
+
+func extractDDService(env []string) (string, error) {
+	for _, entry := range env {
+		if strings.HasPrefix(entry, "DD_SERVICE=") {
+			return strings.TrimPrefix(entry, "DD_SERVICE="), nil
+		}
+	}
+	return "", fmt.Errorf("DD_SERVICE not found")
+}
+
+func hasDWARFInfo(binaryPath string) (bool, error) {
+	f, err := elf.Open(binaryPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to open binary: %w", err)
+	}
+	defer f.Close()
+
+	debugSections := false
+	for _, section := range f.Sections {
+		if strings.HasPrefix(section.Name, ".debug_") {
+			fmt.Printf("Found debug section: %s (size: %d)\n", section.Name, section.Size)
+			debugSections = true
+		}
+	}
+
+	dwarfData, err := f.DWARF()
+	if err != nil {
+		return debugSections, fmt.Errorf("DWARF read error: %w", err)
+	}
+
+	reader := dwarfData.Reader()
+	entry, err := reader.Next()
+	if err != nil {
+		return debugSections, fmt.Errorf("DWARF entry read error: %w", err)
+	}
+	if entry != nil {
+		fmt.Printf("Found DWARF entry of type: %v\n", entry.Tag)
+		return true, nil
+	}
+	return false, nil
+}
+
+func listAllFunctions(filePath string) ([]FunctionInfo, error) {
+	var functions []FunctionInfo
+	var errors []string
+
+	ef, err := elf.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file: %v", err)
+	}
+	defer ef.Close()
+
+	dwarfData, err := ef.DWARF()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DWARF data: %v", err)
+	}
+
+	reader := dwarfData.Reader()
+	for {
+		entry, err := reader.Next()
+		if err != nil {
+			return nil, fmt.Errorf("error reading DWARF entry: %v", err)
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag == dwarf.TagSubprogram {
+			funcName, ok := entry.Val(dwarf.AttrName).(string)
+			if !ok || funcName == "" {
+				continue
+			}
+			info := extractPackageAndFunction(funcName)
+			if info.FunctionName == "" {
+				errors = append(errors, fmt.Sprintf("could not extract function name from %q", funcName))
+				continue
+			}
+			functions = append(functions, info)
+		}
+	}
+
+	if len(functions) == 0 {
+		if len(errors) > 0 {
+			return nil, fmt.Errorf("failed to extract any functions. Errors: %s", strings.Join(errors, "; "))
+		}
+		return nil, fmt.Errorf("no functions found in the binary")
+	}
+	return functions, nil
+}
+
+func extractPackageAndFunction(fullName string) FunctionInfo {
+	if fullName == "" {
+		return FunctionInfo{}
+	}
+	parenIndex := strings.Index(fullName, "(")
+	lastDot := -1
+	if parenIndex != -1 {
+		lastDot = strings.LastIndex(fullName[:parenIndex], ".")
+	} else {
+		lastDot = strings.LastIndex(fullName, ".")
+	}
+	if lastDot == -1 {
+		return FunctionInfo{}
+	}
+	pkgPath := fullName[:lastDot]
+	funcPart := fullName[lastDot+1:]
+	return NewFunctionInfo(pkgPath, funcPart, fullName)
+}
+
+func shouldProfileFunction(name string) bool {
+	if strings.HasPrefix(name, "*ZN") ||
+		strings.HasPrefix(name, "_") ||
+		strings.Contains(name, "_sanitizer") ||
+		strings.Contains(name, "runtime.") {
+		return false
+	}
+	parts := strings.Split(name, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	pkgPath := parts[0]
+	if len(parts) > 2 {
+		pkgPath = strings.Join(parts[:len(parts)-1], "/")
+	}
+	for repoPkg := range g_RepoInfo.Packages {
+		if strings.Contains(pkgPath, repoPkg) {
+			return true
+		}
+	}
+	return false
+}
+
+func filterFunctions(funcs []FunctionInfo) []FunctionInfo {
+	var validFuncs []FunctionInfo
+	for _, f := range funcs {
+		fullName := fmt.Sprintf("%s.%s", f.PackageName, f.FunctionName)
+		if shouldProfileFunction(fullName) {
+			validFuncs = append(validFuncs, f)
+		}
+	}
+	if len(validFuncs) == 0 {
+		return nil
+	}
+	sort.Slice(validFuncs, func(i, j int) bool {
+		fullNameI := fmt.Sprintf("%s.%s", validFuncs[i].PackageName, validFuncs[i].FunctionName)
+		fullNameJ := fmt.Sprintf("%s.%s", validFuncs[j].PackageName, validFuncs[j].FunctionName)
+		return fullNameI < fullNameJ
+	})
+	if len(validFuncs) <= NUMBER_OF_PROBES {
+		return validFuncs
+	}
+	return validFuncs[:NUMBER_OF_PROBES]
+}
+
+func ExtractFunctions(binaryPath string) ([]FunctionInfo, error) {
+	file, err := elf.Open(binaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open binary: %v", err)
+	}
+	defer file.Close()
+
+	dwarfData, err := file.DWARF()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load DWARF data: %v", err)
+	}
+
+	var functions []FunctionInfo
+	reader := dwarfData.Reader()
+	for {
+		entry, err := reader.Next()
+		if err != nil {
+			return nil, fmt.Errorf("error reading DWARF: %v", err)
+		}
+		if entry == nil {
+			break
+		}
+		if entry.Tag == dwarf.TagSubprogram {
+			funcName, _ := entry.Val(dwarf.AttrName).(string)
+			var packageName string
+			if compDir, ok := entry.Val(dwarf.AttrCompDir).(string); ok {
+				packageName = compDir
+			}
+			if funcName != "" {
+				functions = append(functions, FunctionInfo{
+					PackageName:  packageName,
+					FunctionName: funcName,
+				})
+			}
+		}
+	}
+	return functions, nil
+}
+
+func hasDWARF(binaryPath string) (bool, error) {
+	file, err := elf.Open(binaryPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to open binary: %v", err)
+	}
+	defer file.Close()
+
+	_, err = file.DWARF()
+	if err != nil {
+		if err.Error() == "no DWARF data" {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check DWARF data: %v", err)
+	}
+	return true, nil
+}
+
+func fingerprintGoBinary(binaryPath string) (string, error) {
+	f, err := elf.Open(binaryPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sections := make([]*elf.Section, len(f.Sections))
+	copy(sections, f.Sections)
+	sort.Slice(sections, func(i, j int) bool {
+		return sections[i].Name < sections[j].Name
+	})
+
+	hash := sha256.New()
+	for _, sec := range sections {
+		if sec.Type == elf.SHT_NOBITS || sec.Name == ".note.go.buildid" {
+			continue
+		}
+		if _, err := io.WriteString(hash, sec.Name); err != nil {
+			return "", err
+		}
+		data, err := sec.Data()
+		if err != nil {
+			return "", err
+		}
+		if _, err := hash.Write(data); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func isAlreadyProcessed(binaryPath string) (bool, error) {
+	fingerprint, err := fingerprintGoBinary(binaryPath)
+	if err != nil {
+		return false, err
+	}
+	if _, exists := seenBinaries[fingerprint]; exists {
+		return true, nil
+	}
+	seenBinaries[fingerprint] = struct{}{}
+	return false, nil
+}
+
+func getBinaryPath(pid int) (string, error) {
+	exePath := fmt.Sprintf("/proc/%d/exe", pid)
+	binaryPath, err := filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve executable path: %v", err)
+	}
+	return binaryPath, nil
+}
+
+func getParentPID(pid int) int {
+	ppidStr, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(ppidStr))
+	if len(fields) < 4 {
+		return 0
+	}
+	ppid, _ := strconv.Atoi(fields[3])
+	return ppid
+}
+
+func findAncestors(pid int, tree map[int]bool) {
+	for pid > 1 {
+		if tree[pid] {
+			return
+		}
+		tree[pid] = true
+		ppid := getParentPID(pid)
+		if ppid <= 1 {
+			return
+		}
+		pid = ppid
+	}
+}
+
+func LogDebug(t *testing.T, format string, args ...any) {
+	if DEBUG {
+		t.Logf(format, args...)
+	}
+}
+
+func NewProbeManager(t *testing.T) *ProbeManager {
+	return &ProbeManager{t: t}
+}
+
+func (pm *ProbeManager) Install(pid int, function string) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	v, _ := pm.installedProbes.LoadOrStore(pid, make(map[string]struct{}))
+	probes := v.(map[string]struct{})
+	probes[function] = struct{}{}
+	pm.t.Logf("Installing probe: PID=%d Function=%s", pid, function)
+	return nil
+}
+
+func (pm *ProbeManager) Remove(pid int, function string) error {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	if v, ok := pm.installedProbes.Load(pid); ok {
+		probes := v.(map[string]struct{})
+		delete(probes, function)
+		pm.t.Logf("Removing probe: PID=%d Function=%s", pid, function)
+	}
+	return nil
+}
+
+func (pm *ProbeManager) CollectData(pid int, function string) (bool, error) {
+	if v, ok := pm.dataReceived.Load(pid); ok {
+		dataMap := v.(map[string]bool)
+		return dataMap[function], nil
+	}
+	return false, nil
+}
+
+func NewProcessTracker(t *testing.T, ctx context.Context) *ProcessTracker {
+	return &ProcessTracker{
+		t:                t,
+		ctx:              ctx,
+		processes:        make(map[int]*ProcessInfo),
+		stopChan:         make(chan struct{}),
+		analyzedBinaries: make(map[string]bool),
+		analyzedPIDs:     make(map[int]bool),
+		done:             make(chan struct{}),
+	}
+}
+
+func (pt *ProcessTracker) markAnalyzed(pid int, path string) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	pt.analyzedPIDs[pid] = true
+	pt.analyzedBinaries[path] = true
+}
+
+func (pt *ProcessTracker) addProcess(pid int, parentPID int) *ProcessInfo {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+
+	if proc, exists := pt.processes[pid]; exists {
+		return proc
+	}
+
+	binaryPath, _ := getBinaryPath(pid)
+
+	proc := &ProcessInfo{
+		PID:        pid,
+		ParentPID:  parentPID,
+		BinaryPath: binaryPath,
+		State:      StateNew,
+		StartTime:  time.Now(),
+		Analyzed:   false,
+	}
+	pt.processes[pid] = proc
+	if parent, exists := pt.processes[parentPID]; exists {
+		parent.Children = append(parent.Children, proc)
+	}
+	pt.LogTrace("New process: PID=%d, Parent=%d, Binary=%s", pid, parentPID, binaryPath)
+	return proc
+}
+
+func (pt *ProcessTracker) analyzeBinary(pid int, info *ProcessInfo) error {
+	if info == nil {
+		return fmt.Errorf("nil process info")
+	}
+	pt.mu.Lock()
+	info.State = StateAnalyzing
+	pt.mu.Unlock()
+
+	if err := InspectBinary(pt.t, info.BinaryPath, pid); err != nil {
+		pt.mu.Lock()
+		info.State = StateNew
+		pt.mu.Unlock()
+		return fmt.Errorf("binary analysis failed: %v", err)
+	}
+	pt.mu.Lock()
+	info.State = StateRunning
+	pt.mu.Unlock()
+	return nil
+}
+
+func (pt *ProcessTracker) scanProcessTree() error {
+	if err := syscall.Kill(-g_cmd.Process.Pid, syscall.SIGSTOP); err != nil {
+		if err != unix.ESRCH {
+			pt.LogTrace("⚠️ Failed to stop PID %d: %v", -g_cmd.Process.Pid, err)
+		}
+		return nil
+	}
+	defer func() {
+		if err := syscall.Kill(-g_cmd.Process.Pid, syscall.SIGCONT); err != nil {
+			if err != unix.ESRCH {
+				pt.LogTrace("⚠️ Failed to resume PID %d: %v", -g_cmd.Process.Pid, err)
+			}
+		}
+	}()
+	allPids := make(map[int]bool)
+	if entries, err := os.ReadDir("/proc"); err == nil {
+		for _, entry := range entries {
+			if pid, err := strconv.Atoi(entry.Name()); err == nil {
+				allPids[pid] = true
+			}
+		}
+	}
+	ourProcessTree := make(map[int]bool)
+	ourPid := os.Getpid()
+	findAncestors(ourPid, ourProcessTree)
+
+	var toAnalyze []struct {
+		pid  int
+		path string
+		ppid int
+	}
+	for pid := range allPids {
+		pt.mu.RLock()
+		if pt.analyzedPIDs[pid] {
+			pt.mu.RUnlock()
+			continue
+		}
+		pt.mu.RUnlock()
+		if ourProcessTree[pid] {
+			continue
+		}
+		binaryPath, err := getBinaryPath(pid)
+		if err != nil {
+			continue
+		}
+
+		if binaryPath == "" {
+			continue
+		}
+		ppid := getParentPID(pid)
+		if ourProcessTree[ppid] {
+			continue
+		}
+		shouldAnalyze := false
+		if strings.HasSuffix(binaryPath, ".test") {
+			shouldAnalyze = true
+			pt.LogTrace("Found test binary: %s (PID=%d)", binaryPath, pid)
+		} else if strings.Contains(binaryPath, "/go-build") && strings.Contains(binaryPath, "/exe/") {
+			shouldAnalyze = true
+			pt.LogTrace("Found build binary: %s (PID=%d)", binaryPath, pid)
+		} else {
+			parentPath, err := getBinaryPath(ppid)
+			if err == nil && strings.HasSuffix(parentPath, ".test") {
+				shouldAnalyze = true
+				pt.LogTrace("Found child of test: %s (PID=%d, Parent=%d)", binaryPath, pid, ppid)
+			}
+		}
+		if shouldAnalyze {
+			if _, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err == nil {
+				toAnalyze = append(toAnalyze, struct {
+					pid  int
+					path string
+					ppid int
+				}{pid, binaryPath, ppid})
+				if pt.processes[pid] == nil {
+					pt.addProcess(pid, ppid)
+				}
+			}
+		}
+	}
+	if len(toAnalyze) > 0 {
+		pt.LogTrace("🔍 Found %d processes to analyze:", len(toAnalyze))
+		for _, p := range toAnalyze {
+			pt.LogTrace("  PID=%d PPID=%d Path=%s", p.pid, p.ppid, p.path)
+		}
+	}
+	var activePids []int
+	for _, p := range toAnalyze {
+		activePids = append(activePids, p.pid)
+	}
+	batchSize := 2
+	for i := 0; i < len(toAnalyze); i += batchSize {
+		end := i + batchSize
+		if end > len(toAnalyze) {
+			end = len(toAnalyze)
+		}
+		var wg sync.WaitGroup
+		for _, p := range toAnalyze[i:end] {
+			wg.Add(1)
+			go func(pid int, path string) {
+				defer wg.Done()
+				if _, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err != nil {
+					return
+				}
+				pt.LogTrace("Stopping process for analysis: PID=%d Path=%s", pid, path)
+				pt.mu.RLock()
+				proc := pt.processes[pid]
+				pt.mu.RUnlock()
+				if proc == nil {
+					return
+				}
+				if err := pt.analyzeBinary(pid, proc); err != nil {
+					pt.LogTrace("Analysis failed: %v", err)
+				} else {
+					proc.Analyzed = true
+					pt.markAnalyzed(pid, path)
+				}
+			}(p.pid, p.path)
+		}
+		wg.Wait()
+		time.Sleep(10 * time.Microsecond)
+	}
+	return nil
+}
+
+func (pt *ProcessTracker) logProcessTree() {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+	pt.t.Log("\n🌳 Process Tree:")
+	var printNode func(proc *ProcessInfo, prefix string)
+	printNode = func(proc *ProcessInfo, prefix string) {
+		state := "➡️"
+		switch proc.State {
+		case StateAnalyzing:
+			state = "🔍"
+		case StateRunning:
+			state = "▶️"
+		case StateExited:
+			state = "⏹️"
+		}
+		analyzed := ""
+		if proc.Analyzed {
+			analyzed = "✓"
+		}
+		pt.LogTrace("%s%s [PID=%d] %s%s (Parent=%d)",
+			prefix, state, proc.PID, filepath.Base(proc.BinaryPath), analyzed, proc.ParentPID)
+		for _, child := range proc.Children {
+			printNode(child, prefix+"  ")
+		}
+	}
+	if main, exists := pt.processes[pt.mainPID]; exists {
+		printNode(main, "")
+	}
+}
+
+// isGoBinary determines if a binary was built with Go
+func isGoBinary(t *testing.T, binaryPath string) bool {
+	// Method 1: Check for Go build info (most reliable)
+	cmd := exec.Command("go", "version", "-m", binaryPath)
+	output, err := cmd.CombinedOutput()
+	if err == nil && strings.Contains(string(output), "go") {
+		return true
+	}
+
+	// Method 2: Fallback to checking ELF headers for Go-specific sections
+	file, err := elf.Open(binaryPath)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	// Look for Go-specific sections
+	for _, section := range file.Sections {
+		if section.Name == ".gopclntab" || section.Name == ".go.buildinfo" {
+			return true
+		}
+	}
+
+	// Method 3: Fallback to string search for common Go signatures
+	data, err := os.ReadFile(binaryPath)
+	if err != nil {
+		return false
+	}
+
+	// Check for common Go runtime strings
+	goSignatures := [][]byte{
+		[]byte("runtime.findrunnable"),
+		[]byte("runtime.main"),
+		[]byte("golang.org"),
+		[]byte("go.builtin"),
+	}
+
+	for _, sig := range goSignatures {
+		if bytes.Contains(data, sig) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func traceChildProcesses(t *testing.T, parentPid int) {
+	if processedPids == nil {
+		processedPids = make(map[int]bool)
+	}
+
+	t.Logf("Starting ptrace monitor for children of PID %d", parentPid)
+	//startTime := time.Now()
+
+	// Keep track of processes we're tracing
+	tracedPids := make(map[int]bool)
+
+	// Create a ticker for finding new processes to trace
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	// Track when parent exits
+	parentAlive := true
+	var parentExitTime time.Time
+
+	for {
+		// Check parent status
+		if parentAlive && !isProcessAlive(parentPid) {
+			parentAlive = false
+			parentExitTime = time.Now()
+			t.Logf("Parent process %d is no longer alive, will stop monitoring after grace period", parentPid)
+		}
+
+		// Exit after grace period if parent is gone and we're not tracing anything
+		if !parentAlive && len(tracedPids) == 0 && time.Since(parentExitTime) > 3*time.Second {
+			t.Logf("Parent gone and no processes being traced, stopping monitor")
+			return
+		}
+
+		// Look for new child processes to trace
+		select {
+		case <-ticker.C:
+			// Find new children that aren't being traced yet
+			children := findAllChildren(parentPid)
+			for _, pid := range children {
+				// Skip if already processed or being traced
+				if processedPids[pid] || tracedPids[pid] {
+					continue
+				}
+
+				// Try to trace this process
+				if err := syscall.PtraceAttach(pid); err != nil {
+					// Process might have exited or can't be traced, skip
+					continue
+				}
+
+				// Wait for the process to stop
+				var status syscall.WaitStatus
+				if _, err := syscall.Wait4(pid, &status, 0, nil); err != nil {
+					// Failed to wait, detach and skip
+					syscall.PtraceDetach(pid)
+					continue
+				}
+
+				// Check if it's a Go binary before proceeding
+				binaryPath, err := getBinaryPath(pid)
+				if err != nil || !isGoBinary(t, binaryPath) {
+					// Not a Go binary or can't get path, detach and mark as processed
+					processedPids[pid] = true
+					syscall.PtraceDetach(pid)
+					continue
+				}
+
+				t.Logf("Successfully attached to new Go process: PID=%d (%s)", pid, binaryPath)
+
+				// Set options to trace child processes
+				if err := syscall.PtraceSetOptions(pid,
+					syscall.PTRACE_O_TRACECLONE|
+						syscall.PTRACE_O_TRACEFORK|
+						syscall.PTRACE_O_TRACEVFORK|
+						syscall.PTRACE_O_TRACEEXEC); err != nil {
+					t.Logf("Failed to set ptrace options for %d: %v", pid, err)
+					syscall.PtraceDetach(pid)
+					continue
+				}
+
+				// Process is now halted, inspect the binary
+				t.Logf("Inspecting halted Go binary: PID=%d (%s)", pid, binaryPath)
+				InspectBinary(t, binaryPath, pid)
+				processedPids[pid] = true
+
+				// Add to traced processes and continue
+				tracedPids[pid] = true
+
+				// Resume the process
+				if err := syscall.PtraceCont(pid, 0); err != nil {
+					t.Logf("Failed to continue process %d: %v", pid, err)
+					delete(tracedPids, pid)
+					continue
+				}
+
+				t.Logf("Process %d resumed after inspection", pid)
+			}
+
+		default:
+			// Non-blocking check for events from traced processes
+			for pid := range tracedPids {
+				var status syscall.WaitStatus
+				wpid, err := syscall.Wait4(pid, &status, syscall.WNOHANG, nil)
+
+				if wpid == 0 {
+					// No events from this process yet
+					continue
+				}
+
+				if err != nil {
+					// Error waiting for process, remove from traced
+					t.Logf("Error waiting for process %d: %v", pid, err)
+					delete(tracedPids, pid)
+					continue
+				}
+
+				if status.Exited() {
+					t.Logf("Traced process %d exited", pid)
+					delete(tracedPids, pid)
+					continue
+				}
+
+				if status.Stopped() {
+					signal := status.StopSignal()
+
+					if signal == syscall.SIGTRAP {
+						eventType := ((status.StopSignal() >> 8) & 0xff)
+
+						switch eventType {
+						case syscall.PTRACE_EVENT_FORK, syscall.PTRACE_EVENT_VFORK, syscall.PTRACE_EVENT_CLONE:
+							// A new process is being created
+							newPid, err := syscall.PtraceGetEventMsg(pid)
+							if err != nil {
+								t.Logf("Failed to get new PID: %v", err)
+							} else {
+								childPid := int(newPid)
+								t.Logf("Process %d created new process: PID=%d", pid, childPid)
+
+								// Child will automatically stop, we'll handle it when finding children
+							}
+
+						case syscall.PTRACE_EVENT_EXEC:
+							t.Logf("Process %d executed a new program", pid)
+
+							// Re-check if it's a Go binary after exec
+							binaryPath, err := getBinaryPath(pid)
+							if err == nil && isGoBinary(t, binaryPath) {
+								t.Logf("Inspecting Go binary after exec: PID=%d (%s)", pid, binaryPath)
+								InspectBinary(t, binaryPath, pid)
+							}
+						}
+					}
+
+					// Continue the process with the appropriate signal
+					var sigToDeliver syscall.Signal
+					if signal != syscall.SIGTRAP {
+						sigToDeliver = signal
+					}
+
+					if err := syscall.PtraceCont(pid, int(sigToDeliver)); err != nil {
+						t.Logf("Failed to continue process %d: %v", pid, err)
+						delete(tracedPids, pid)
+					}
+				}
+			}
+
+			// Sleep a tiny bit to avoid burning CPU
+			time.Sleep(1 * time.Millisecond)
+		}
+	}
+}
+
+// Helper function for non-blocking wait
+func nonBlockingWait4(pid int, status *syscall.WaitStatus, options int, rusage *syscall.Rusage, done chan struct{}) (int, error) {
+	// Try a non-blocking wait first
+	wpid, err := syscall.Wait4(pid, status, options|syscall.WNOHANG, rusage)
+	if wpid != 0 || err != nil {
+		return wpid, err
+	}
+
+	// If no processes are ready, wait a bit and try again
+	select {
+	case <-done:
+		// Context is done, return gracefully
+		return 0, nil
+	case <-time.After(10 * time.Millisecond):
+		return 0, nil
+	}
+}
+
+// Find all children of a PID recursively
+func findAllChildren(parentPid int) []int {
+	result := []int{}
+
+	// Read all processes in /proc
+	procEntries, err := os.ReadDir("/proc")
+	if err != nil {
+		return result
+	}
+
+	for _, entry := range procEntries {
+		// Check if this is a process directory (numeric name)
+		pid := 0
+		_, err := fmt.Sscanf(entry.Name(), "%d", &pid)
+		if err != nil || pid == 0 {
+			continue
+		}
+
+		// Check if this is a child of our parent
+		statusPath := fmt.Sprintf("/proc/%d/status", pid)
+		statusContent, err := os.ReadFile(statusPath)
+		if err != nil {
+			continue
+		}
+
+		// Find the PPid line
+		statusText := string(statusContent)
+		var ppid int
+		for _, line := range strings.Split(statusText, "\n") {
+			if strings.HasPrefix(line, "PPid:") {
+				fmt.Sscanf(line, "PPid:\t%d", &ppid)
+				break
+			}
+		}
+
+		// Add this and any children to our result
+		if ppid == parentPid {
+			result = append(result, pid)
+			// Recursively find children of this child
+			childResults := findAllChildren(pid)
+			result = append(result, childResults...)
+		}
+	}
+
+	return result
+}
+
+func isProcessAlive(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+
+	// On Unix, FindProcess always succeeds, so we need to send signal 0
+	// to test if the process actually exists
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+func (pt *ProcessTracker) StartTracking(command string, args []string, dir string) error {
+	cmd := exec.CommandContext(pt.ctx, command, args...)
+	g_cmd = cmd
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Env = append(os.Environ(),
+		"PWD="+dir,
+		"DD_DYNAMIC_INSTRUMENTATION_ENABLED=true",
+		"DD_SERVICE=go-di-exploration-test-service")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start command: %v", err)
+	}
+
+	pt.mainPID = cmd.Process.Pid
+	pt.addProcess(pt.mainPID, os.Getpid())
+
+	//go traceChildProcesses(pt.t, cmd.Process.Pid)
+
+	go func() {
+		initialTicker := time.NewTicker(10 * time.Millisecond)
+		defer initialTicker.Stop()
+		logTicker := time.NewTicker(10 * time.Second)
+		defer logTicker.Stop()
+		for {
+			select {
+			case <-pt.stopChan:
+				return
+			case <-initialTicker.C:
+				if err := pt.scanProcessTree(); err != nil {
+					pt.LogTrace("⚠️ Error scanning: %v", err)
+				}
+			case <-logTicker.C:
+			}
+		}
+	}()
+
+	err := cmd.Wait()
+	close(pt.stopChan)
+	pt.LogTrace("Analyzed %d binaries.", len(analyzedBinaries))
+	for _, binary := range analyzedBinaries {
+		pt.LogTrace("Analyzed %s (debug info: %v)", binary.path, binary.hasDebug)
+	}
+	return err
+}
+
+func (pt *ProcessTracker) Cleanup() {
+	// Cleanup logic if needed.
+}
+
+func (pt *ProcessTracker) LogTrace(format string, args ...any) {
+	if TRACE {
+		pt.t.Logf(format, args...)
+	}
+}
+
+func NewConfigAccumulator() (*ConfigAccumulator, error) {
+	tmpl, err := template.New("config_template").Parse(explorationTestConfigTemplateText)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+	return &ConfigAccumulator{
+		configs: make(map[string]map[string]rcConfig),
+		tmpl:    tmpl,
+	}, nil
+}
+
+func (ca *ConfigAccumulator) AddTargets(targets []FunctionInfo, serviceName string) error {
+	ca.mu.Lock()
+	defer ca.mu.Unlock()
+
+	buf := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufferPool.Put(buf)
+
+	buf.WriteString("{")
+	if err := ca.tmpl.Execute(buf, targets); err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+	buf.WriteString("}")
+
+	var newConfigs map[string]rcConfig
+	if err := json.NewDecoder(buf).Decode(&newConfigs); err != nil {
+		return fmt.Errorf("failed to decode generated configs: %w", err)
+	}
+	if ca.configs[serviceName] == nil {
+		ca.configs[serviceName] = make(map[string]rcConfig)
+	}
+	for probeID, config := range newConfigs {
+		ca.configs[serviceName][probeID] = config
+	}
+	return nil
+}
+
+func (ca *ConfigAccumulator) WriteConfigs() error {
+	ca.mu.RLock()
+	defer ca.mu.RUnlock()
+
+	buf := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufferPool.Put(buf)
+
+	if err := json.NewEncoder(buf).Encode(ca.configs); err != nil {
+		return fmt.Errorf("failed to marshal configs: %w", err)
+	}
+	return g_ConfigManager.ConfigWriter.WriteSync(buf.Bytes())
+}
+
+func InspectBinary(t *testing.T, binaryPath string, pid int) error {
+	allFuncs, err := listAllFunctions(binaryPath)
+	if err != nil {
+		analyzedBinaries = append(analyzedBinaries, BinaryInfo{
+			path:     binaryPath,
+			hasDebug: false,
+		})
+		return nil
+	}
+
+	targets := filterFunctions(allFuncs)
+	args, err := getProcessArgs(pid)
+	if err != nil {
+		return fmt.Errorf("failed to process args: %v", err)
+	}
+	cwd, err := getProcessCwd(pid)
+	if err != nil {
+		return fmt.Errorf("failed to get Cwd: %v", err)
+	}
+	env, err := getProcessEnv(pid)
+	if err != nil {
+		return fmt.Errorf("failed to get Env: %v", err)
+	}
+	serviceName, err := extractDDService(env)
+	if err != nil {
+		return fmt.Errorf("failed to get Env: %v, binaryPath: %s", err, binaryPath)
+	}
+
+	LogDebug(t, "\n=======================================")
+	LogDebug(t, "🔍 SERVICE NAME: %s", serviceName)
+	LogDebug(t, "🔍 ANALYZING BINARY: %s", binaryPath)
+	LogDebug(t, "🔍 ENV: %v", env)
+	LogDebug(t, "🔍 ARGS: %v", args)
+	LogDebug(t, "🔍 CWD: %s", cwd)
+	LogDebug(t, "🔍 Elected %d target functions:", len(targets))
+	for _, f := range targets {
+		LogDebug(t, "  → Package: %s, Function: %s, FullName: %s", f.PackageName, f.FunctionName, f.FullName)
+	}
+	LogDebug(t, "=======================================")
+
+	if _, err := os.Stat(binaryPath); err != nil {
+		return fmt.Errorf("(1) binary inspection failed: %v", err)
+	}
+
+	analyzedBinaries = append(analyzedBinaries, BinaryInfo{
+		path:     binaryPath,
+		hasDebug: len(targets) > 0,
+	})
+	LogDebug(t, "✅ Analysis complete for: %s", binaryPath)
+	LogDebug(t, "=======================================\n")
+
+	g_ConfigManager.ProcTracker.HandleProcessStartSync(uint32(pid))
+	t.Logf("About to request instrumentations for binary: %s, pid: %d.", binaryPath, pid)
+
+	if err := g_configsAccumulator.AddTargets(targets, serviceName); err != nil {
+		t.Logf("Error adding target: %v, binaryPath: %s", err, binaryPath)
+		return fmt.Errorf("add targets failed: %v, binary: %s", err, binaryPath)
+	}
+	if err = g_configsAccumulator.WriteConfigs(); err != nil {
+		t.Logf("Error writing configs: %v, binaryPath: %s", err, binaryPath)
+		return fmt.Errorf("error adding configs: %v, binary: %s", err, binaryPath)
+	}
+	time.Sleep(2 * time.Second)
+	t.Logf("Requested to instrument %d functions for binary: %s, pid: %d.", len(targets), binaryPath, pid)
+	for _, f := range targets {
+		t.Logf("      -> requested instrumentation for %v", f)
+	}
+	if waitForAttach && os.Getenv("DEBUG") == "true" {
+		pid := os.Getpid()
+		t.Logf("Waiting to attach for PID: %d", pid)
+		time.Sleep(30 * time.Second)
+		waitForAttach = false
+	}
+	return nil
+}
+
+// TestExplorationGoDI is the entrypoint of the integration test of Go DI. The idea is to
+// test Go DI in exploratory manner. In high level, here are the steps this test takes:
+// 1. Clones protobuf and applies patches.
+// 2. Figuring out the 1st party packages involved with the cloned project (to avoid instrumenting 3rd party/std libs)
+// 3. Compiles the test
+// 4. Runs the test in a supervised environment, spawning processes as a group.
+// 5. Periodically pauses and resumes the process group to analyze each binary unique.
+// 6. Invoke Go DI to put probes in top X functions defined by `NUMBER_OF_RROBES` const.
+//
+//	The goal is to exercise as many code paths as possible of the Go DI code base.
+func TestExplorationGoDI(t *testing.T) {
+	require.NoError(t, rlimit.RemoveMemlock(), "Failed to remove memlock limit")
+	if features.HaveMapType(ebpf.RingBuf) != nil {
+		t.Skip("Ringbuffers not supported on this kernel")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	diagnostics.Diagnostics = diagnostics.NewDiagnosticManager()
+	t.Cleanup(diagnostics.StopGlobalDiagnostics)
+
+	eventOutputWriter := &explorationEventOutputTestWriter{t: t}
+	opts := &dynamicinstrumentation.DIOptions{
+		RateLimitPerProbePerSecond: 0.0,
+		ReaderWriterOptions: dynamicinstrumentation.ReaderWriterOptions{
+			CustomReaderWriters: true,
+			SnapshotWriter:      eventOutputWriter,
+			DiagnosticWriter:    os.Stderr,
+		},
+	}
+
+	var (
+		GoDI *dynamicinstrumentation.GoDI
+		err  error
+	)
+	GoDI, err = dynamicinstrumentation.RunDynamicInstrumentation(ctx, consumerstestutil.NewTestProcessConsumer(t), opts)
+	require.NoError(t, err)
+	t.Cleanup(GoDI.Close)
+
+	cm, ok := GoDI.ConfigManager.(*diconfig.ReaderConfigManager)
+	require.True(t, ok, "Config manager is of wrong type")
+	g_ConfigManager = cm
+
+	g_configsAccumulator, err = NewConfigAccumulator()
+	if err != nil {
+		t.Fatal("Failed to create ConfigAccumulator")
+	}
+
+	tempDir := initializeTempDir(t, "/tmp/protobuf-integration-1060272402")
+	modulePath := filepath.Join(tempDir, "src", "google.golang.org", "protobuf")
+
+	t.Log("Setting up test environment...")
+	g_RepoInfo = cloneProtobufRepo(t, modulePath, "30f628eeb303f2c29be7a381bf78aa3e3aabd317")
+	copyPatches(t, "exploration_tests/patches/protobuf", modulePath)
+
+	t.Log("Starting process tracking...")
+	tracker := NewProcessTracker(t, ctx)
+	err = tracker.StartTracking("./test.bash", nil, modulePath)
+	require.NoError(t, err)
+}
+
+func initializeTempDir(t *testing.T, predefinedTempDir string) string {
+	if predefinedTempDir != "" {
+		return predefinedTempDir
+	}
+	tempDir, err := os.MkdirTemp("", "protobuf-integration-")
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(tempDir, 0755))
+	t.Log("tempDir:", tempDir)
+	return tempDir
+}
+
+func ScanRepoPackages(repoPath string) (*RepoInfo, error) {
+	info := &RepoInfo{
+		Packages: make(map[string]bool),
+		RepoPath: repoPath,
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, ".git")); err == nil {
+		if hash, err := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD").Output(); err == nil {
+			info.CommitHash = strings.TrimSpace(string(hash))
+		}
+	}
+	err := filepath.Walk(repoPath, func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if f.IsDir() {
+			dirname := filepath.Base(path)
+			if dirname == ".git" ||
+				dirname == ".cache" ||
+				dirname == "vendor" ||
+				dirname == "testdata" ||
+				strings.HasPrefix(dirname, ".") ||
+				strings.HasPrefix(dirname, "tmp") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") ||
+			strings.HasSuffix(path, ".pb.go") {
+			return nil
+		}
+		relPath, err := filepath.Rel(repoPath, path)
+		if err != nil || strings.Contains(relPath, "..") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(content))
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if strings.HasPrefix(line, "package ") {
+				pkgDir := filepath.Dir(relPath)
+				if pkgDir != "." {
+					info.Packages[pkgDir] = true
+				}
+				break
+			}
+		}
+		return nil
+	})
+	if len(info.Packages) == 0 {
+		return nil, fmt.Errorf("no packages found in repository at %s", repoPath)
+	}
+	return info, err
+}
+
+func cloneProtobufRepo(t *testing.T, modulePath string, commitHash string) *RepoInfo {
+	if _, err := os.Stat(modulePath); os.IsNotExist(err) {
+		cmd := exec.Command("git", "clone", "https://github.com/protocolbuffers/protobuf-go", modulePath)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		require.NoError(t, cmd.Run(), "Failed to clone repository")
+	}
+	if commitHash != "" {
+		cmd := exec.Command("git", "checkout", commitHash)
+		cmd.Dir = modulePath
+		require.NoError(t, cmd.Run(), "Failed to checkout commit hash")
+	}
+	info, err := ScanRepoPackages(modulePath)
+	require.NoError(t, err, "Failed to scan repo packages")
+
+	var pkgs []string
+	for pkg := range info.Packages {
+		if strings.Contains(pkg, "/tmp") {
+			continue
+		}
+		pkgs = append(pkgs, pkg)
+	}
+	sort.Strings(pkgs)
+	t.Logf("📦 Found %d packages in protobuf repo:", len(pkgs))
+
+	groups := make(map[string][]string)
+	for _, pkg := range pkgs {
+		parts := strings.SplitN(pkg, "/", 2)
+		topLevel := parts[0]
+		groups[topLevel] = append(groups[topLevel], pkg)
+	}
+
+	var topLevels []string
+	for k := range groups {
+		topLevels = append(topLevels, k)
+	}
+	sort.Strings(topLevels)
+	for _, topLevel := range topLevels {
+		t.Logf("  %s/", topLevel)
+		for _, pkg := range groups[topLevel] {
+			t.Logf("    → %s", pkg)
+		}
+	}
+	return info
+}
+
+func copyPatches(t *testing.T, src, dst string) {
+	require.NoError(t, copyDir(src, dst), "Failed to copy patches")
+}
+
+func copyDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			if err = copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err = copyFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func copyFile(srcFile, dstFile string) error {
+	src, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+	if err = os.MkdirAll(filepath.Dir(dstFile), 0755); err != nil {
+		return err
+	}
+	dst, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+	_, err = io.Copy(dst, src)
+	return err
+}

--- a/pkg/dynamicinstrumentation/testutil/exploration_tests/patches/protobuf/integration_test.go
+++ b/pkg/dynamicinstrumentation/testutil/exploration_tests/patches/protobuf/integration_test.go
@@ -1,0 +1,595 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/internal/version"
+)
+
+var (
+	regenerate   = flag.Bool("regenerate", false, "regenerate files")
+	buildRelease = flag.Bool("buildRelease", false, "build release binaries")
+
+	protobufVersion = "27.0"
+
+	golangVersions = func() []string {
+		// Version policy: oldest supported version of Go, plus the version before that.
+		// This matches the version policy of the Google Cloud Client Libraries:
+		// https://cloud.google.com/go/getting-started/supported-go-versions
+		return []string{
+			"1.21.13",
+			"1.22.6",
+			"1.23.0",
+		}
+	}()
+	golangLatest = golangVersions[len(golangVersions)-1]
+
+	staticcheckVersion = "2024.1.1"
+	staticcheckSHA256s = map[string]string{
+		"darwin/amd64": "b67380b84b81d5765b478b7ad888dd7ce53b2c0861103bafa946ac84dc9244ce",
+		"darwin/arm64": "09cb10e4199f7c6356c2ed5dc45e877c3087ef775d84d39338b52e1a94866074",
+		"linux/386":    "0225fd8b5cf6c762f9c0aedf1380ed4df576d1d54fb68691be895889e10faf0b",
+		"linux/amd64":  "6e9398fcaff2b36e1d15e84a647a3a14733b7c2dd41187afa2c182a4c3b32180",
+	}
+
+	// purgeTimeout determines the maximum age of unused sub-directories.
+	purgeTimeout = 30 * 24 * time.Hour // 1 month
+
+	// Variables initialized by mustInitDeps.
+	modulePath   string
+	protobufPath string
+)
+
+func TestIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	if os.Getenv("GO_BUILDER_NAME") != "" {
+		// To start off, run on longtest builders, not longtest-race ones.
+		if race() {
+			t.Skip("skipping integration test in race mode on builders")
+		}
+		// When on a builder, run even if it's not explicitly requested
+		// provided our caller isn't already running it.
+		if os.Getenv("GO_PROTOBUF_INTEGRATION_TEST_RUNNING") == "1" {
+			t.Skip("protobuf integration test is already running, skipping nested invocation")
+		}
+		os.Setenv("GO_PROTOBUF_INTEGRATION_TEST_RUNNING", "1")
+	} else if flag.Lookup("test.run").Value.String() != "^TestIntegration$" {
+		t.Skip("not running integration test if not explicitly requested via test.bash")
+	}
+
+	mustInitDeps(t)
+	mustHandleFlags(t)
+
+	// Report dirt in the working tree quickly, rather than after
+	// going through all the presubmits.
+	//
+	// Fail the test late, so we can test uncommitted changes with -failfast.
+	// gitDiff := mustRunCommand(t, "git", "diff", "HEAD")
+	// if strings.TrimSpace(gitDiff) != "" {
+	//  fmt.Printf("WARNING: working tree contains uncommitted changes:\n%v\n", gitDiff)
+	// }
+	// gitUntracked := mustRunCommand(t, "git", "ls-files", "--others", "--exclude-standard")
+	// if strings.TrimSpace(gitUntracked) != "" {
+	//  fmt.Printf("WARNING: working tree contains untracked files:\n%v\n", gitUntracked)
+	// }
+
+	// Do the relatively fast checks up-front.
+	t.Run("GeneratedGoFiles", func(t *testing.T) {
+		diff := mustRunCommand(t, "go", "run", "-tags", "protolegacy", "./internal/cmd/generate-types")
+		if strings.TrimSpace(diff) != "" {
+			t.Fatalf("stale generated files:\n%v", diff)
+		}
+		diff = mustRunCommand(t, "go", "run", "-tags", "protolegacy", "./internal/cmd/generate-protos")
+		if strings.TrimSpace(diff) != "" {
+			t.Fatalf("stale generated files:\n%v", diff)
+		}
+	})
+	t.Run("FormattedGoFiles", func(t *testing.T) {
+		files := strings.Split(strings.TrimSpace(mustRunCommand(t, "git", "ls-files", "*.go")), "\n")
+		diff := mustRunCommand(t, append([]string{"gofmt", "-d"}, files...)...)
+		if strings.TrimSpace(diff) != "" {
+			t.Fatalf("unformatted source files:\n%v", diff)
+		}
+	})
+	t.Run("CopyrightHeaders", func(t *testing.T) {
+		files := strings.Split(strings.TrimSpace(mustRunCommand(t, "git", "ls-files", "*.go", "*.proto")), "\n")
+		mustHaveCopyrightHeader(t, files)
+	})
+
+	var wg sync.WaitGroup
+	sema := make(chan bool, (runtime.NumCPU()+1)/2)
+	for i := range golangVersions {
+		goVersion := golangVersions[i]
+		goLabel := "Go" + goVersion
+		runGo := func(label string, cmd command, args ...string) {
+			wg.Add(1)
+			sema <- true
+			go func() {
+				defer wg.Done()
+				defer func() { <-sema }()
+				t.Run(goLabel+"/"+label, func(t *testing.T) {
+					args[0] += goVersion
+					cmd.mustRun(t, args...)
+				})
+			}()
+		}
+
+		runGo("Normal", command{}, "go", "test", "-race", "./...")
+		runGo("Reflect", command{}, "go", "test", "-race", "-tags", "protoreflect", "./...")
+		if goVersion == golangLatest {
+			runGo("ProtoLegacyRace", command{}, "go", "test", "-race", "-tags", "protolegacy", "./...")
+			runGo("ProtoLegacy", command{}, "go", "test", "-tags", "protolegacy", "./...")
+			runGo("ProtocGenGo", command{Dir: "cmd/protoc-gen-go/testdata"}, "go", "test")
+			runGo("Conformance", command{Dir: "internal/conformance"}, "go", "test", "-execute")
+
+			// Only run the 32-bit compatibility tests for Linux;
+			// avoid Darwin since 10.15 dropped support i386 code execution.
+			// if runtime.GOOS == "linux" {
+			//  runGo("Arch32Bit", command{Env: append(os.Environ(), "GOARCH=386")}, "go", "test", "./...")
+			// }
+		}
+	}
+	wg.Wait()
+
+	t.Run("GoStaticCheck", func(t *testing.T) {
+		checks := []string{
+			"all",     // start with all checks enabled
+			"-SA1019", // disable deprecated usage check
+			"-S*",     // disable code simplification checks
+			"-ST*",    // disable coding style checks
+			"-U*",     // disable unused declaration checks
+		}
+		out := mustRunCommand(t, "staticcheck", "-checks="+strings.Join(checks, ","), "-fail=none", "./...")
+
+		// Filter out findings from certain paths.
+		var findings []string
+		for _, finding := range strings.Split(strings.TrimSpace(out), "\n") {
+			switch {
+			case strings.HasPrefix(finding, "internal/testprotos/legacy/"):
+			default:
+				findings = append(findings, finding)
+			}
+		}
+		if len(findings) > 0 {
+			t.Fatalf("staticcheck findings:\n%v", strings.Join(findings, "\n"))
+		}
+	})
+	// t.Run("CommittedGitChanges", func(t *testing.T) {
+	//  if strings.TrimSpace(gitDiff) != "" {
+	//      t.Fatalf("uncommitted changes")
+	//  }
+	// })
+	// t.Run("TrackedGitFiles", func(t *testing.T) {
+	//  if strings.TrimSpace(gitUntracked) != "" {
+	//      t.Fatalf("untracked files")
+	//  }
+	// })
+}
+
+func mustInitDeps(t *testing.T) {
+	check := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Determine the directory to place the test directory.
+	repoRoot, err := os.Getwd()
+	check(err)
+	testDir := filepath.Join(repoRoot, ".cache")
+	check(os.MkdirAll(testDir, 0775))
+
+	// Delete the current directory if non-empty,
+	// which only occurs if a dependency failed to initialize properly.
+	var workingDir string
+	finishedDirs := map[string]bool{}
+	defer func() {
+		if workingDir != "" {
+			os.RemoveAll(workingDir) // best-effort
+		}
+	}()
+	startWork := func(name string) string {
+		workingDir = filepath.Join(testDir, name)
+		return workingDir
+	}
+	finishWork := func() {
+		finishedDirs[workingDir] = true
+		workingDir = ""
+	}
+
+	// Delete other sub-directories that are no longer relevant.
+	defer func() {
+		now := time.Now()
+		fis, _ := os.ReadDir(testDir)
+		for _, fi := range fis {
+			dir := filepath.Join(testDir, fi.Name())
+			if finishedDirs[dir] {
+				os.Chtimes(dir, now, now) // best-effort
+				continue
+			}
+			fii, err := fi.Info()
+			check(err)
+			if now.Sub(fii.ModTime()) < purgeTimeout {
+				continue
+			}
+			fmt.Printf("delete %v\n", fi.Name())
+			os.RemoveAll(dir) // best-effort
+		}
+	}()
+
+	// The bin directory contains symlinks to each tool by version.
+	// It is safe to delete this directory and run the test script from scratch.
+	binPath := startWork("bin")
+	check(os.RemoveAll(binPath))
+	check(os.Mkdir(binPath, 0775))
+	check(os.Setenv("PATH", binPath+":"+os.Getenv("PATH")))
+	registerBinary := func(name, path string) {
+		check(os.Symlink(path, filepath.Join(binPath, name)))
+	}
+	finishWork()
+
+	// Get the protobuf toolchain.
+	protobufPath = startWork("protobuf-" + protobufVersion)
+	if _, err := os.Stat(protobufPath); err != nil {
+		fmt.Printf("download %v\n", filepath.Base(protobufPath))
+		checkoutVersion := protobufVersion
+		if isCommit := strings.Trim(protobufVersion, "0123456789abcdef") == ""; !isCommit {
+			// release tags have "v" prefix
+			checkoutVersion = "v" + protobufVersion
+		}
+		command{Dir: testDir}.mustRun(t, "git", "clone", "https://github.com/protocolbuffers/protobuf", "protobuf-"+protobufVersion)
+		command{Dir: protobufPath}.mustRun(t, "git", "checkout", checkoutVersion)
+
+		if os.Getenv("GO_BUILDER_NAME") != "" {
+			// If this is running on the Go build infrastructure,
+			// use pre-built versions of these binaries that the
+			// builders are configured to provide in $PATH.
+			protocPath, err := exec.LookPath("protoc")
+			check(err)
+			confTestRunnerPath, err := exec.LookPath("conformance_test_runner")
+			check(err)
+			check(os.MkdirAll(filepath.Join(protobufPath, "bazel-bin", "conformance"), 0775))
+			check(os.Symlink(protocPath, filepath.Join(protobufPath, "bazel-bin", "protoc")))
+			check(os.Symlink(confTestRunnerPath, filepath.Join(protobufPath, "bazel-bin", "conformance", "conformance_test_runner")))
+		} else {
+			// In other environments, download and build the protobuf toolchain.
+			// We avoid downloading the pre-compiled binaries since they do not contain
+			// the conformance test runner.
+			fmt.Printf("build %v\n", filepath.Base(protobufPath))
+			env := os.Environ()
+			args := []string{
+				"bazel", "build",
+				":protoc",
+				"//conformance:conformance_test_runner",
+			}
+			if runtime.GOOS == "darwin" {
+				// Adding this environment variable appears to be necessary for macOS builds.
+				env = append(env, "CC=clang")
+				// And this flag.
+				args = append(args,
+					"--macos_minimum_os=13.0",
+					"--host_macos_minimum_os=13.0",
+				)
+			}
+			command{
+				Dir: protobufPath,
+				Env: env,
+			}.mustRun(t, args...)
+		}
+	}
+	check(os.Setenv("PROTOBUF_ROOT", protobufPath)) // for generate-protos
+	registerBinary("conform-test-runner", filepath.Join(protobufPath, "bazel-bin", "conformance", "conformance_test_runner"))
+	registerBinary("protoc", filepath.Join(protobufPath, "bazel-bin", "protoc"))
+	finishWork()
+
+	// Download each Go toolchain version.
+	for _, v := range golangVersions {
+		goDir := startWork("go" + v)
+		if _, err := os.Stat(goDir); err != nil {
+			fmt.Printf("download %v\n", filepath.Base(goDir))
+			url := fmt.Sprintf("https://dl.google.com/go/go%v.%v-%v.tar.gz", v, runtime.GOOS, runtime.GOARCH)
+			downloadArchive(check, goDir, url, "go", "") // skip SHA256 check as we fetch over https from a trusted domain
+		}
+		registerBinary("go"+v, filepath.Join(goDir, "bin", "go"))
+		finishWork()
+	}
+	registerBinary("go", filepath.Join(testDir, "go"+golangLatest, "bin", "go"))
+	registerBinary("gofmt", filepath.Join(testDir, "go"+golangLatest, "bin", "gofmt"))
+
+	// Download the staticcheck tool.
+	checkDir := startWork("staticcheck-" + staticcheckVersion)
+	if _, err := os.Stat(checkDir); err != nil {
+		fmt.Printf("download %v\n", filepath.Base(checkDir))
+		url := fmt.Sprintf("https://github.com/dominikh/go-tools/releases/download/%v/staticcheck_%v_%v.tar.gz", staticcheckVersion, runtime.GOOS, runtime.GOARCH)
+		downloadArchive(check, checkDir, url, "staticcheck", staticcheckSHA256s[runtime.GOOS+"/"+runtime.GOARCH])
+	}
+	registerBinary("staticcheck", filepath.Join(checkDir, "staticcheck"))
+	finishWork()
+
+	// GitHub actions sets GOROOT, which confuses invocations of the Go toolchain.
+	// Explicitly clear GOROOT, so each toolchain uses their default GOROOT.
+	check(os.Unsetenv("GOROOT"))
+
+	// Set a cache directory outside the test directory.
+	check(os.Setenv("GOCACHE", filepath.Join(repoRoot, ".gocache")))
+}
+
+func downloadFile(check func(error), dstPath, srcURL string, perm fs.FileMode) {
+	resp, err := http.Get(srcURL)
+	check(err)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		check(fmt.Errorf("GET %q: non-200 OK status code: %v body: %q", srcURL, resp.Status, body))
+	}
+
+	check(os.MkdirAll(filepath.Dir(dstPath), 0775))
+	f, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	check(err)
+
+	_, err = io.Copy(f, resp.Body)
+	check(err)
+
+	check(f.Close())
+}
+
+func downloadArchive(check func(error), dstPath, srcURL, skipPrefix, wantSHA256 string) {
+	check(os.RemoveAll(dstPath))
+
+	resp, err := http.Get(srcURL)
+	check(err)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		check(fmt.Errorf("GET %q: non-200 OK status code: %v body: %q", srcURL, resp.Status, body))
+	}
+
+	var r io.Reader = resp.Body
+	if wantSHA256 != "" {
+		b, err := io.ReadAll(resp.Body)
+		check(err)
+		r = bytes.NewReader(b)
+
+		if gotSHA256 := fmt.Sprintf("%x", sha256.Sum256(b)); gotSHA256 != wantSHA256 {
+			check(fmt.Errorf("checksum validation error:\ngot  %v\nwant %v", gotSHA256, wantSHA256))
+		}
+	}
+
+	zr, err := gzip.NewReader(r)
+	check(err)
+
+	tr := tar.NewReader(zr)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			return
+		}
+		check(err)
+
+		// Skip directories or files outside the prefix directory.
+		if len(skipPrefix) > 0 {
+			if !strings.HasPrefix(h.Name, skipPrefix) {
+				continue
+			}
+			if len(h.Name) > len(skipPrefix) && h.Name[len(skipPrefix)] != '/' {
+				continue
+			}
+		}
+
+		path := strings.TrimPrefix(strings.TrimPrefix(h.Name, skipPrefix), "/")
+		path = filepath.Join(dstPath, filepath.FromSlash(path))
+		mode := os.FileMode(h.Mode & 0777)
+		switch h.Typeflag {
+		case tar.TypeReg:
+			b, err := io.ReadAll(tr)
+			check(err)
+			check(os.WriteFile(path, b, mode))
+		case tar.TypeDir:
+			check(os.Mkdir(path, mode))
+		}
+	}
+}
+
+func mustHandleFlags(t *testing.T) {
+	if *regenerate {
+		t.Run("Generate", func(t *testing.T) {
+			fmt.Print(mustRunCommand(t, "go", "generate", "./internal/cmd/generate-types"))
+			fmt.Print(mustRunCommand(t, "go", "generate", "./internal/cmd/generate-protos"))
+			files := strings.Split(strings.TrimSpace(mustRunCommand(t, "git", "ls-files", "*.go")), "\n")
+			mustRunCommand(t, append([]string{"gofmt", "-w"}, files...)...)
+		})
+	}
+	if *buildRelease {
+		t.Run("BuildRelease", func(t *testing.T) {
+			v := version.String()
+			for _, goos := range []string{"linux", "darwin", "windows"} {
+				for _, goarch := range []string{"386", "amd64", "arm64"} {
+					// Avoid Darwin since 10.15 dropped support for i386.
+					if goos == "darwin" && goarch == "386" {
+						continue
+					}
+
+					binPath := filepath.Join("bin", fmt.Sprintf("protoc-gen-go.%v.%v.%v", v, goos, goarch))
+
+					// Build the binary.
+					cmd := command{Env: append(os.Environ(), "GOOS="+goos, "GOARCH="+goarch)}
+					cmd.mustRun(t, "go", "build", "-trimpath", "-ldflags", "-s -w -buildid=", "-o", binPath, "./cmd/protoc-gen-go")
+
+					// Archive and compress the binary.
+					in, err := os.ReadFile(binPath)
+					if err != nil {
+						t.Fatal(err)
+					}
+					out := new(bytes.Buffer)
+					suffix := ""
+					comment := fmt.Sprintf("protoc-gen-go VERSION=%v GOOS=%v GOARCH=%v", v, goos, goarch)
+					switch goos {
+					case "windows":
+						suffix = ".zip"
+						zw := zip.NewWriter(out)
+						zw.SetComment(comment)
+						fw, _ := zw.Create("protoc-gen-go.exe")
+						fw.Write(in)
+						zw.Close()
+					default:
+						suffix = ".tar.gz"
+						gz, _ := gzip.NewWriterLevel(out, gzip.BestCompression)
+						gz.Comment = comment
+						tw := tar.NewWriter(gz)
+						tw.WriteHeader(&tar.Header{
+							Name: "protoc-gen-go",
+							Mode: int64(0775),
+							Size: int64(len(in)),
+						})
+						tw.Write(in)
+						tw.Close()
+						gz.Close()
+					}
+					if err := os.WriteFile(binPath+suffix, out.Bytes(), 0664); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+		})
+	}
+	if *regenerate || *buildRelease {
+		t.SkipNow()
+	}
+}
+
+var copyrightRegex = []*regexp.Regexp{
+	regexp.MustCompile(`^// Copyright \d\d\d\d The Go Authors\. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file\.
+`),
+	// Generated .pb.go files from main protobuf repo.
+	regexp.MustCompile(`^// Protocol Buffers - Google's data interchange format
+// Copyright \d\d\d\d Google Inc\.  All rights reserved\.
+`),
+}
+
+func mustHaveCopyrightHeader(t *testing.T, files []string) {
+	var bad []string
+File:
+	for _, file := range files {
+		if strings.HasSuffix(file, "internal/testprotos/conformance/editions/test_messages_edition2023.pb.go") {
+			// TODO(lassefolger) the underlying proto file is checked into
+			// the protobuf repo without a copyright header. Fix is pending but
+			// might require a release.
+			continue
+		}
+		b, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, re := range copyrightRegex {
+			if loc := re.FindIndex(b); loc != nil && loc[0] == 0 {
+				continue File
+			}
+		}
+		bad = append(bad, file)
+	}
+	if len(bad) > 0 {
+		t.Fatalf("files with missing/bad copyright headers:\n  %v", strings.Join(bad, "\n  "))
+	}
+}
+
+// Add in command struct:
+type command struct {
+	Dir string
+	Env []string
+}
+
+func (c command) mustRun(t *testing.T, args ...string) string {
+	t.Helper()
+	stdout := new(bytes.Buffer)
+	stderr := new(bytes.Buffer)
+
+	var cmdArgs []string
+	if len(args) > 1 && strings.HasPrefix(args[0], "go") && args[1] == "test" {
+		for i, arg := range args {
+			cmdArgs = append(cmdArgs, arg)
+			if i == 1 { // right after "test"
+				cmdArgs = append(cmdArgs,
+					"-ldflags=-w=false -s=false",
+					"-gcflags=all=-l",
+					"-count=1",
+					"-timeout=30m",
+				)
+			}
+		}
+	} else {
+		cmdArgs = args
+	}
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
+	cmd.Dir = "."
+	if c.Dir != "" {
+		cmd.Dir = c.Dir
+	}
+	cmd.Env = os.Environ()
+	if c.Env != nil {
+		cmd.Env = c.Env
+	}
+	cmd.Env = append(cmd.Env,
+		fmt.Sprintf("PWD=%s", cmd.Dir),
+		fmt.Sprintf("DD_SERVICE=go-di-exploration-test-%d", rand.Int()),
+	)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("executing (%v): %v\n%s%s", strings.Join(args, " "), err, stdout.String(), stderr.String())
+	}
+
+	return stdout.String()
+}
+
+func mustRunCommand(t *testing.T, args ...string) string {
+	t.Helper()
+	return command{}.mustRun(t, args...)
+}
+
+// race is an approximation of whether the race detector is on.
+// It's used to skip the integration test on builders, without
+// preventing the integration test from running under the race
+// detector as a '//go:build !race' build constraint would.
+func race() bool {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return false
+	}
+	for _, setting := range bi.Settings {
+		if setting.Key == "-race" {
+			return setting.Value == "true"
+		}
+	}
+	return false
+}

--- a/pkg/dynamicinstrumentation/testutil/exploration_tests/patches/protobuf/test.bash
+++ b/pkg/dynamicinstrumentation/testutil/exploration_tests/patches/protobuf/test.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright 2018 The Go Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+go test google.golang.org/protobuf -run='^TestIntegration$' -v -timeout=60m -count=1 -failfast "$@"
+exit $?

--- a/pkg/dynamicinstrumentation/testutil/exploration_tests/patches/protobuf/testing/prototest/message.go
+++ b/pkg/dynamicinstrumentation/testutil/exploration_tests/patches/protobuf/testing/prototest/message.go
@@ -1,0 +1,911 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package prototest exercises protobuf reflection.
+package prototest
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// TODO: Test invalid field descriptors or oneof descriptors.
+// TODO: This should test the functionality that can be provided by fast-paths.
+
+// Message tests a message implementation.
+type Message struct {
+	// Resolver is used to determine the list of extension fields to test with.
+	// If nil, this defaults to using protoregistry.GlobalTypes.
+	Resolver interface {
+		FindExtensionByName(field protoreflect.FullName) (protoreflect.ExtensionType, error)
+		FindExtensionByNumber(message protoreflect.FullName, field protoreflect.FieldNumber) (protoreflect.ExtensionType, error)
+		RangeExtensionsByMessage(message protoreflect.FullName, f func(protoreflect.ExtensionType) bool)
+	}
+
+	// UnmarshalOptions are respected for every Unmarshal call this package
+	// does. The Resolver and AllowPartial fields are overridden.
+	UnmarshalOptions proto.UnmarshalOptions
+}
+
+//nolint:all
+//go:noinline
+func blabla_blabla(x bool) {}
+
+// Test performs tests on a [protoreflect.MessageType] implementation.
+func (test Message) Test(t testing.TB, mt protoreflect.MessageType) {
+	testType(t, mt)
+
+	// for {
+	// 	blabla_blabla(true)
+	// 	time.Sleep(1 * time.Second)
+	// }
+
+	md := mt.Descriptor()
+	m1 := mt.New()
+	for i := 0; i < md.Fields().Len(); i++ {
+		fd := md.Fields().Get(i)
+		testField(t, m1, fd)
+	}
+	if test.Resolver == nil {
+		test.Resolver = protoregistry.GlobalTypes
+	}
+	var extTypes []protoreflect.ExtensionType
+	test.Resolver.RangeExtensionsByMessage(md.FullName(), func(e protoreflect.ExtensionType) bool {
+		extTypes = append(extTypes, e)
+		return true
+	})
+	for _, xt := range extTypes {
+		testField(t, m1, xt.TypeDescriptor())
+	}
+	for i := 0; i < md.Oneofs().Len(); i++ {
+		testOneof(t, m1, md.Oneofs().Get(i))
+	}
+	testUnknown(t, m1)
+
+	// Test round-trip marshal/unmarshal.
+	m2 := mt.New().Interface()
+	populateMessage(m2.ProtoReflect(), 1, nil)
+	for _, xt := range extTypes {
+		m2.ProtoReflect().Set(xt.TypeDescriptor(), newValue(m2.ProtoReflect(), xt.TypeDescriptor(), 1, nil))
+	}
+	b, err := proto.MarshalOptions{
+		AllowPartial: true,
+	}.Marshal(m2)
+	if err != nil {
+		t.Errorf("Marshal() = %v, want nil\n%v", err, prototext.Format(m2))
+	}
+	m3 := mt.New().Interface()
+	unmarshalOpts := test.UnmarshalOptions
+	unmarshalOpts.AllowPartial = true
+	unmarshalOpts.Resolver = test.Resolver
+	if err := unmarshalOpts.Unmarshal(b, m3); err != nil {
+		t.Errorf("Unmarshal() = %v, want nil\n%v", err, prototext.Format(m2))
+	}
+	if !proto.Equal(m2, m3) {
+		t.Errorf("round-trip marshal/unmarshal did not preserve message\nOriginal:\n%v\nNew:\n%v", prototext.Format(m2), prototext.Format(m3))
+	}
+}
+
+func testType(t testing.TB, mt protoreflect.MessageType) {
+	m := mt.New().Interface()
+	want := reflect.TypeOf(m)
+	if got := reflect.TypeOf(m.ProtoReflect().Interface()); got != want {
+		t.Errorf("type mismatch: reflect.TypeOf(m) != reflect.TypeOf(m.ProtoReflect().Interface()): %v != %v", got, want)
+	}
+	if got := reflect.TypeOf(m.ProtoReflect().New().Interface()); got != want {
+		t.Errorf("type mismatch: reflect.TypeOf(m) != reflect.TypeOf(m.ProtoReflect().New().Interface()): %v != %v", got, want)
+	}
+	if got := reflect.TypeOf(m.ProtoReflect().Type().Zero().Interface()); got != want {
+		t.Errorf("type mismatch: reflect.TypeOf(m) != reflect.TypeOf(m.ProtoReflect().Type().Zero().Interface()): %v != %v", got, want)
+	}
+	if mt, ok := mt.(protoreflect.MessageFieldTypes); ok {
+		testFieldTypes(t, mt)
+	}
+}
+
+func testFieldTypes(t testing.TB, mt protoreflect.MessageFieldTypes) {
+	descName := func(d protoreflect.Descriptor) protoreflect.FullName {
+		if d == nil {
+			return "<nil>"
+		}
+		return d.FullName()
+	}
+	typeName := func(mt protoreflect.MessageType) protoreflect.FullName {
+		if mt == nil {
+			return "<nil>"
+		}
+		return mt.Descriptor().FullName()
+	}
+	adjustExpr := func(idx int, expr string) string {
+		expr = strings.Replace(expr, "fd.", "md.Fields().Get(i).", -1)
+		expr = strings.Replace(expr, "(fd)", "(md.Fields().Get(i))", -1)
+		expr = strings.Replace(expr, "mti.", "mt.Message(i).", -1)
+		expr = strings.Replace(expr, "(i)", fmt.Sprintf("(%d)", idx), -1)
+		return expr
+	}
+	checkEnumDesc := func(idx int, gotExpr, wantExpr string, got, want protoreflect.EnumDescriptor) {
+		if got != want {
+			t.Errorf("descriptor mismatch: %v != %v: %v != %v", adjustExpr(idx, gotExpr), adjustExpr(idx, wantExpr), descName(got), descName(want))
+		}
+	}
+	checkMessageDesc := func(idx int, gotExpr, wantExpr string, got, want protoreflect.MessageDescriptor) {
+		if got != want {
+			t.Errorf("descriptor mismatch: %v != %v: %v != %v", adjustExpr(idx, gotExpr), adjustExpr(idx, wantExpr), descName(got), descName(want))
+		}
+	}
+	checkMessageType := func(idx int, gotExpr, wantExpr string, got, want protoreflect.MessageType) {
+		if got != want {
+			t.Errorf("type mismatch: %v != %v: %v != %v", adjustExpr(idx, gotExpr), adjustExpr(idx, wantExpr), typeName(got), typeName(want))
+		}
+	}
+
+	fds := mt.Descriptor().Fields()
+	m := mt.New()
+	for i := 0; i < fds.Len(); i++ {
+		fd := fds.Get(i)
+		switch {
+		case fd.IsList():
+			if fd.Enum() != nil {
+				checkEnumDesc(i,
+					"mt.Enum(i).Descriptor()", "fd.Enum()",
+					mt.Enum(i).Descriptor(), fd.Enum())
+			}
+			if fd.Message() != nil {
+				checkMessageDesc(i,
+					"mt.Message(i).Descriptor()", "fd.Message()",
+					mt.Message(i).Descriptor(), fd.Message())
+				checkMessageType(i,
+					"mt.Message(i)", "m.NewField(fd).List().NewElement().Message().Type()",
+					mt.Message(i), m.NewField(fd).List().NewElement().Message().Type())
+			}
+		case fd.IsMap():
+			mti := mt.Message(i)
+			if m := mti.New(); m != nil {
+				checkMessageDesc(i,
+					"m.Descriptor()", "fd.Message()",
+					m.Descriptor(), fd.Message())
+			}
+			if m := mti.Zero(); m != nil {
+				checkMessageDesc(i,
+					"m.Descriptor()", "fd.Message()",
+					m.Descriptor(), fd.Message())
+			}
+			checkMessageDesc(i,
+				"mti.Descriptor()", "fd.Message()",
+				mti.Descriptor(), fd.Message())
+			if mti := mti.(protoreflect.MessageFieldTypes); mti != nil {
+				if fd.MapValue().Enum() != nil {
+					checkEnumDesc(i,
+						"mti.Enum(fd.MapValue().Index()).Descriptor()", "fd.MapValue().Enum()",
+						mti.Enum(fd.MapValue().Index()).Descriptor(), fd.MapValue().Enum())
+				}
+				if fd.MapValue().Message() != nil {
+					checkMessageDesc(i,
+						"mti.Message(fd.MapValue().Index()).Descriptor()", "fd.MapValue().Message()",
+						mti.Message(fd.MapValue().Index()).Descriptor(), fd.MapValue().Message())
+					checkMessageType(i,
+						"mti.Message(fd.MapValue().Index())", "m.NewField(fd).Map().NewValue().Message().Type()",
+						mti.Message(fd.MapValue().Index()), m.NewField(fd).Map().NewValue().Message().Type())
+				}
+			}
+		default:
+			if fd.Enum() != nil {
+				checkEnumDesc(i,
+					"mt.Enum(i).Descriptor()", "fd.Enum()",
+					mt.Enum(i).Descriptor(), fd.Enum())
+			}
+			if fd.Message() != nil {
+				checkMessageDesc(i,
+					"mt.Message(i).Descriptor()", "fd.Message()",
+					mt.Message(i).Descriptor(), fd.Message())
+				checkMessageType(i,
+					"mt.Message(i)", "m.NewField(fd).Message().Type()",
+					mt.Message(i), m.NewField(fd).Message().Type())
+			}
+		}
+	}
+}
+
+// testField exercises set/get/has/clear of a field.
+func testField(t testing.TB, m protoreflect.Message, fd protoreflect.FieldDescriptor) {
+	name := fd.FullName()
+	num := fd.Number()
+
+	switch {
+	case fd.IsList():
+		testFieldList(t, m, fd)
+	case fd.IsMap():
+		testFieldMap(t, m, fd)
+	case fd.Message() != nil:
+	default:
+		if got, want := m.NewField(fd), fd.Default(); !valueEqual(got, want) {
+			t.Errorf("Message.NewField(%v) = %v, want default value %v", name, formatValue(got), formatValue(want))
+		}
+		if fd.Kind() == protoreflect.FloatKind || fd.Kind() == protoreflect.DoubleKind {
+			testFieldFloat(t, m, fd)
+		}
+	}
+
+	// Set to a non-zero value, the zero value, different non-zero values.
+	for _, n := range []seed{1, 0, minVal, maxVal} {
+		v := newValue(m, fd, n, nil)
+		m.Set(fd, v)
+		wantHas := true
+		if n == 0 {
+			if !fd.HasPresence() {
+				wantHas = false
+			}
+			if fd.IsExtension() {
+				wantHas = true
+			}
+			if fd.Cardinality() == protoreflect.Repeated {
+				wantHas = false
+			}
+			if fd.ContainingOneof() != nil {
+				wantHas = true
+			}
+		}
+		if !fd.HasPresence() && fd.Cardinality() != protoreflect.Repeated && fd.ContainingOneof() == nil && fd.Kind() == protoreflect.EnumKind && v.Enum() == 0 {
+			wantHas = false
+		}
+		if got, want := m.Has(fd), wantHas; got != want {
+			t.Errorf("after setting %q to %v:\nMessage.Has(%v) = %v, want %v", name, formatValue(v), num, got, want)
+		}
+		if got, want := m.Get(fd), v; !valueEqual(got, want) {
+			t.Errorf("after setting %q:\nMessage.Get(%v) = %v, want %v", name, num, formatValue(got), formatValue(want))
+		}
+		found := false
+		m.Range(func(d protoreflect.FieldDescriptor, got protoreflect.Value) bool {
+			if fd != d {
+				return true
+			}
+			found = true
+			if want := v; !valueEqual(got, want) {
+				t.Errorf("after setting %q:\nMessage.Range got value %v, want %v", name, formatValue(got), formatValue(want))
+			}
+			return true
+		})
+		if got, want := wantHas, found; got != want {
+			t.Errorf("after setting %q:\nMessageRange saw field: %v, want %v", name, got, want)
+		}
+	}
+
+	m.Clear(fd)
+	if got, want := m.Has(fd), false; got != want {
+		t.Errorf("after clearing %q:\nMessage.Has(%v) = %v, want %v", name, num, got, want)
+	}
+	switch {
+	case fd.IsList():
+		if got := m.Get(fd); got.List().Len() != 0 {
+			t.Errorf("after clearing %q:\nMessage.Get(%v) = %v, want empty list", name, num, formatValue(got))
+		}
+	case fd.IsMap():
+		if got := m.Get(fd); got.Map().Len() != 0 {
+			t.Errorf("after clearing %q:\nMessage.Get(%v) = %v, want empty map", name, num, formatValue(got))
+		}
+	case fd.Message() == nil:
+		if got, want := m.Get(fd), fd.Default(); !valueEqual(got, want) {
+			t.Errorf("after clearing %q:\nMessage.Get(%v) = %v, want default %v", name, num, formatValue(got), formatValue(want))
+		}
+	}
+
+	// Set to the default value.
+	switch {
+	case fd.IsList() || fd.IsMap():
+		m.Set(fd, m.Mutable(fd))
+		if got, want := m.Has(fd), (fd.IsExtension() && fd.Cardinality() != protoreflect.Repeated) || fd.ContainingOneof() != nil; got != want {
+			t.Errorf("after setting %q to default:\nMessage.Has(%v) = %v, want %v", name, num, got, want)
+		}
+	case fd.Message() == nil:
+		m.Set(fd, m.Get(fd))
+		if got, want := m.Get(fd), fd.Default(); !valueEqual(got, want) {
+			t.Errorf("after setting %q to default:\nMessage.Get(%v) = %v, want default %v", name, num, formatValue(got), formatValue(want))
+		}
+	}
+	m.Clear(fd)
+
+	// Set to the wrong type.
+	v := protoreflect.ValueOfString("")
+	if fd.Kind() == protoreflect.StringKind {
+		v = protoreflect.ValueOfInt32(0)
+	}
+	if !panics(func() {
+		m.Set(fd, v)
+	}) {
+		t.Errorf("setting %v to %T succeeds, want panic", name, v.Interface())
+	}
+}
+
+// testFieldMap tests set/get/has/clear of entries in a map field.
+func testFieldMap(t testing.TB, m protoreflect.Message, fd protoreflect.FieldDescriptor) {
+	name := fd.FullName()
+	num := fd.Number()
+
+	// New values.
+	m.Clear(fd) // start with an empty map
+	mapv := m.Get(fd).Map()
+	if mapv.IsValid() {
+		t.Errorf("after clearing field: message.Get(%v).IsValid() = true, want false", name)
+	}
+	if got, want := mapv.NewValue(), newMapValue(fd, mapv, 0, nil); !valueEqual(got, want) {
+		t.Errorf("message.Get(%v).NewValue() = %v, want %v", name, formatValue(got), formatValue(want))
+	}
+	if !panics(func() {
+		m.Set(fd, protoreflect.ValueOfMap(mapv))
+	}) {
+		t.Errorf("message.Set(%v, <invalid>) does not panic", name)
+	}
+	if !panics(func() {
+		mapv.Set(newMapKey(fd, 0), newMapValue(fd, mapv, 0, nil))
+	}) {
+		t.Errorf("message.Get(%v).Set(...) of invalid map does not panic", name)
+	}
+	mapv = m.Mutable(fd).Map() // mutable map
+	if !mapv.IsValid() {
+		t.Errorf("message.Mutable(%v).IsValid() = false, want true", name)
+	}
+	if got, want := mapv.NewValue(), newMapValue(fd, mapv, 0, nil); !valueEqual(got, want) {
+		t.Errorf("message.Mutable(%v).NewValue() = %v, want %v", name, formatValue(got), formatValue(want))
+	}
+
+	// Add values.
+	want := make(testMap)
+	for i, n := range []seed{1, 0, minVal, maxVal} {
+		if got, want := m.Has(fd), i > 0; got != want {
+			t.Errorf("after inserting %d elements to %q:\nMessage.Has(%v) = %v, want %v", i, name, num, got, want)
+		}
+
+		k := newMapKey(fd, n)
+		v := newMapValue(fd, mapv, n, nil)
+		mapv.Set(k, v)
+		want.Set(k, v)
+		if got, want := m.Get(fd), protoreflect.ValueOfMap(want); !valueEqual(got, want) {
+			t.Errorf("after inserting %d elements to %q:\nMessage.Get(%v) = %v, want %v", i, name, num, formatValue(got), formatValue(want))
+		}
+	}
+
+	// Set values.
+	want.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		nv := newMapValue(fd, mapv, 10, nil)
+		mapv.Set(k, nv)
+		want.Set(k, nv)
+		if got, want := m.Get(fd), protoreflect.ValueOfMap(want); !valueEqual(got, want) {
+			t.Errorf("after setting element %v of %q:\nMessage.Get(%v) = %v, want %v", formatValue(k.Value()), name, num, formatValue(got), formatValue(want))
+		}
+		return true
+	})
+
+	// Clear values.
+	want.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		mapv.Clear(k)
+		want.Clear(k)
+		if got, want := m.Has(fd), want.Len() > 0; got != want {
+			t.Errorf("after clearing elements of %q:\nMessage.Has(%v) = %v, want %v", name, num, got, want)
+		}
+		if got, want := m.Get(fd), protoreflect.ValueOfMap(want); !valueEqual(got, want) {
+			t.Errorf("after clearing elements of %q:\nMessage.Get(%v) = %v, want %v", name, num, formatValue(got), formatValue(want))
+		}
+		return true
+	})
+	if mapv := m.Get(fd).Map(); mapv.IsValid() {
+		t.Errorf("after clearing all elements: message.Get(%v).IsValid() = true, want false %v", name, formatValue(protoreflect.ValueOfMap(mapv)))
+	}
+
+	// Non-existent map keys.
+	missingKey := newMapKey(fd, 1)
+	if got, want := mapv.Has(missingKey), false; got != want {
+		t.Errorf("non-existent map key in %q: Map.Has(%v) = %v, want %v", name, formatValue(missingKey.Value()), got, want)
+	}
+	if got, want := mapv.Get(missingKey).IsValid(), false; got != want {
+		t.Errorf("non-existent map key in %q: Map.Get(%v).IsValid() = %v, want %v", name, formatValue(missingKey.Value()), got, want)
+	}
+	mapv.Clear(missingKey) // noop
+
+	// Mutable.
+	if fd.MapValue().Message() == nil {
+		if !panics(func() {
+			mapv.Mutable(newMapKey(fd, 1))
+		}) {
+			t.Errorf("Mutable on %q succeeds, want panic", name)
+		}
+	} else {
+		k := newMapKey(fd, 1)
+		v := mapv.Mutable(k)
+		if got, want := mapv.Len(), 1; got != want {
+			t.Errorf("after Mutable on %q, Map.Len() = %v, want %v", name, got, want)
+		}
+		populateMessage(v.Message(), 1, nil)
+		if !valueEqual(mapv.Get(k), v) {
+			t.Errorf("after Mutable on %q, changing new mutable value does not change map entry", name)
+		}
+		mapv.Clear(k)
+	}
+}
+
+type testMap map[any]protoreflect.Value
+
+func (m testMap) Get(k protoreflect.MapKey) protoreflect.Value     { return m[k.Interface()] }
+func (m testMap) Set(k protoreflect.MapKey, v protoreflect.Value)  { m[k.Interface()] = v }
+func (m testMap) Has(k protoreflect.MapKey) bool                   { return m.Get(k).IsValid() }
+func (m testMap) Clear(k protoreflect.MapKey)                      { delete(m, k.Interface()) }
+func (m testMap) Mutable(k protoreflect.MapKey) protoreflect.Value { panic("unimplemented") }
+func (m testMap) Len() int                                         { return len(m) }
+func (m testMap) NewValue() protoreflect.Value                     { panic("unimplemented") }
+func (m testMap) Range(f func(protoreflect.MapKey, protoreflect.Value) bool) {
+	for k, v := range m {
+		if !f(protoreflect.ValueOf(k).MapKey(), v) {
+			return
+		}
+	}
+}
+func (m testMap) IsValid() bool { return true }
+
+// testFieldList exercises set/get/append/truncate of values in a list.
+func testFieldList(t testing.TB, m protoreflect.Message, fd protoreflect.FieldDescriptor) {
+	name := fd.FullName()
+	num := fd.Number()
+
+	m.Clear(fd) // start with an empty list
+	list := m.Get(fd).List()
+	if list.IsValid() {
+		t.Errorf("message.Get(%v).IsValid() = true, want false", name)
+	}
+	if !panics(func() {
+		m.Set(fd, protoreflect.ValueOfList(list))
+	}) {
+		t.Errorf("message.Set(%v, <invalid>) does not panic", name)
+	}
+	if !panics(func() {
+		list.Append(newListElement(fd, list, 0, nil))
+	}) {
+		t.Errorf("message.Get(%v).Append(...) of invalid list does not panic", name)
+	}
+	if got, want := list.NewElement(), newListElement(fd, list, 0, nil); !valueEqual(got, want) {
+		t.Errorf("message.Get(%v).NewElement() = %v, want %v", name, formatValue(got), formatValue(want))
+	}
+	list = m.Mutable(fd).List() // mutable list
+	if !list.IsValid() {
+		t.Errorf("message.Get(%v).IsValid() = false, want true", name)
+	}
+	if got, want := list.NewElement(), newListElement(fd, list, 0, nil); !valueEqual(got, want) {
+		t.Errorf("message.Mutable(%v).NewElement() = %v, want %v", name, formatValue(got), formatValue(want))
+	}
+
+	// Append values.
+	var want protoreflect.List = &testList{}
+	for i, n := range []seed{1, 0, minVal, maxVal} {
+		if got, want := m.Has(fd), i > 0; got != want {
+			t.Errorf("after appending %d elements to %q:\nMessage.Has(%v) = %v, want %v", i, name, num, got, want)
+		}
+		v := newListElement(fd, list, n, nil)
+		want.Append(v)
+		list.Append(v)
+
+		if got, want := m.Get(fd), protoreflect.ValueOfList(want); !valueEqual(got, want) {
+			t.Errorf("after appending %d elements to %q:\nMessage.Get(%v) = %v, want %v", i+1, name, num, formatValue(got), formatValue(want))
+		}
+	}
+
+	// Set values.
+	for i := 0; i < want.Len(); i++ {
+		v := newListElement(fd, list, seed(i+10), nil)
+		want.Set(i, v)
+		list.Set(i, v)
+		if got, want := m.Get(fd), protoreflect.ValueOfList(want); !valueEqual(got, want) {
+			t.Errorf("after setting element %d of %q:\nMessage.Get(%v) = %v, want %v", i, name, num, formatValue(got), formatValue(want))
+		}
+	}
+
+	// Truncate.
+	for want.Len() > 0 {
+		n := want.Len() - 1
+		want.Truncate(n)
+		list.Truncate(n)
+		if got, want := m.Has(fd), want.Len() > 0; got != want {
+			t.Errorf("after truncating %q to %d:\nMessage.Has(%v) = %v, want %v", name, n, num, got, want)
+		}
+		if got, want := m.Get(fd), protoreflect.ValueOfList(want); !valueEqual(got, want) {
+			t.Errorf("after truncating %q to %d:\nMessage.Get(%v) = %v, want %v", name, n, num, formatValue(got), formatValue(want))
+		}
+	}
+
+	// AppendMutable.
+	if fd.Message() == nil {
+		if !panics(func() {
+			list.AppendMutable()
+		}) {
+			t.Errorf("AppendMutable on %q succeeds, want panic", name)
+		}
+	} else {
+		v := list.AppendMutable()
+		if got, want := list.Len(), 1; got != want {
+			t.Errorf("after AppendMutable on %q, list.Len() = %v, want %v", name, got, want)
+		}
+		populateMessage(v.Message(), 1, nil)
+		if !valueEqual(list.Get(0), v) {
+			t.Errorf("after AppendMutable on %q, changing new mutable value does not change list item 0", name)
+		}
+		want.Truncate(0)
+	}
+}
+
+type testList struct {
+	a []protoreflect.Value
+}
+
+func (l *testList) Append(v protoreflect.Value)       { l.a = append(l.a, v) }
+func (l *testList) AppendMutable() protoreflect.Value { panic("unimplemented") }
+func (l *testList) Get(n int) protoreflect.Value      { return l.a[n] }
+func (l *testList) Len() int                          { return len(l.a) }
+func (l *testList) Set(n int, v protoreflect.Value)   { l.a[n] = v }
+func (l *testList) Truncate(n int)                    { l.a = l.a[:n] }
+func (l *testList) NewElement() protoreflect.Value    { panic("unimplemented") }
+func (l *testList) IsValid() bool                     { return true }
+
+// testFieldFloat exercises some interesting floating-point scalar field values.
+func testFieldFloat(t testing.TB, m protoreflect.Message, fd protoreflect.FieldDescriptor) {
+	name := fd.FullName()
+	num := fd.Number()
+
+	for _, v := range []float64{math.Inf(-1), math.Inf(1), math.NaN(), math.Copysign(0, -1)} {
+		var val protoreflect.Value
+		if fd.Kind() == protoreflect.FloatKind {
+			val = protoreflect.ValueOfFloat32(float32(v))
+		} else {
+			val = protoreflect.ValueOfFloat64(float64(v))
+		}
+		m.Set(fd, val)
+		// Note that Has is true for -0.
+		if got, want := m.Has(fd), true; got != want {
+			t.Errorf("after setting %v to %v: Message.Has(%v) = %v, want %v", name, v, num, got, want)
+		}
+		if got, want := m.Get(fd), val; !valueEqual(got, want) {
+			t.Errorf("after setting %v: Message.Get(%v) = %v, want %v", name, num, formatValue(got), formatValue(want))
+		}
+	}
+}
+
+// testOneof tests the behavior of fields in a oneof.
+func testOneof(t testing.TB, m protoreflect.Message, od protoreflect.OneofDescriptor) {
+	for _, mutable := range []bool{false, true} {
+		for i := 0; i < od.Fields().Len(); i++ {
+			fda := od.Fields().Get(i)
+			if mutable {
+				// Set fields by requesting a mutable reference.
+				if !fda.IsMap() && !fda.IsList() && fda.Message() == nil {
+					continue
+				}
+				_ = m.Mutable(fda)
+			} else {
+				// Set fields explicitly.
+				m.Set(fda, newValue(m, fda, 1, nil))
+			}
+			if !od.IsSynthetic() {
+				// Synthetic oneofs are used to represent optional fields in
+				// proto3. While they show up in protoreflect, WhichOneof does
+				// not work on these (only on non-synthetic, explicit oneofs).
+				if got, want := m.WhichOneof(od), fda; got != want {
+					t.Errorf("after setting oneof field %q:\nWhichOneof(%q) = %v, want %v", fda.FullName(), fda.Name(), got, want)
+				}
+			}
+			for j := 0; j < od.Fields().Len(); j++ {
+				fdb := od.Fields().Get(j)
+				if got, want := m.Has(fdb), i == j; got != want {
+					t.Errorf("after setting oneof field %q:\nGet(%q) = %v, want %v", fda.FullName(), fdb.FullName(), got, want)
+				}
+			}
+		}
+	}
+}
+
+// testUnknown tests the behavior of unknown fields.
+func testUnknown(t testing.TB, m protoreflect.Message) {
+	var b []byte
+	b = protowire.AppendTag(b, 1000, protowire.VarintType)
+	b = protowire.AppendVarint(b, 1001)
+	m.SetUnknown(protoreflect.RawFields(b))
+	if got, want := []byte(m.GetUnknown()), b; !bytes.Equal(got, want) {
+		t.Errorf("after setting unknown fields:\nGetUnknown() = %v, want %v", got, want)
+	}
+}
+
+func formatValue(v protoreflect.Value) string {
+	switch v := v.Interface().(type) {
+	case protoreflect.List:
+		var buf bytes.Buffer
+		buf.WriteString("list[")
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				buf.WriteString(" ")
+			}
+			buf.WriteString(formatValue(v.Get(i)))
+		}
+		buf.WriteString("]")
+		return buf.String()
+	case protoreflect.Map:
+		var buf bytes.Buffer
+		buf.WriteString("map[")
+		var keys []protoreflect.MapKey
+		v.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+			keys = append(keys, k)
+			return true
+		})
+		sort.Slice(keys, func(i, j int) bool {
+			return keys[i].String() < keys[j].String()
+		})
+		for i, k := range keys {
+			if i > 0 {
+				buf.WriteString(" ")
+			}
+			buf.WriteString(formatValue(k.Value()))
+			buf.WriteString(":")
+			buf.WriteString(formatValue(v.Get(k)))
+		}
+		buf.WriteString("]")
+		return buf.String()
+	case protoreflect.Message:
+		b, err := prototext.Marshal(v.Interface())
+		if err != nil {
+			return fmt.Sprintf("<%v>", err)
+		}
+		return fmt.Sprintf("%v{%s}", v.Descriptor().FullName(), b)
+	case string:
+		return fmt.Sprintf("%q", v)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func valueEqual(a, b protoreflect.Value) bool {
+	ai, bi := a.Interface(), b.Interface()
+	switch ai.(type) {
+	case protoreflect.Message:
+		return proto.Equal(
+			a.Message().Interface(),
+			b.Message().Interface(),
+		)
+	case protoreflect.List:
+		lista, listb := a.List(), b.List()
+		if lista.Len() != listb.Len() {
+			return false
+		}
+		for i := 0; i < lista.Len(); i++ {
+			if !valueEqual(lista.Get(i), listb.Get(i)) {
+				return false
+			}
+		}
+		return true
+	case protoreflect.Map:
+		mapa, mapb := a.Map(), b.Map()
+		if mapa.Len() != mapb.Len() {
+			return false
+		}
+		equal := true
+		mapa.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+			if !valueEqual(v, mapb.Get(k)) {
+				equal = false
+				return false
+			}
+			return true
+		})
+		return equal
+	case []byte:
+		return bytes.Equal(a.Bytes(), b.Bytes())
+	case float32:
+		// NaNs are equal, but must be the same NaN.
+		return math.Float32bits(ai.(float32)) == math.Float32bits(bi.(float32))
+	case float64:
+		// NaNs are equal, but must be the same NaN.
+		return math.Float64bits(ai.(float64)) == math.Float64bits(bi.(float64))
+	default:
+		return ai == bi
+	}
+}
+
+// A seed is used to vary the content of a value.
+//
+// A seed of 0 is the zero value. Messages do not have a zero-value; a 0-seeded messages
+// is unpopulated.
+//
+// A seed of minVal or maxVal is the least or greatest value of the value type.
+type seed int
+
+const (
+	minVal seed = -1
+	maxVal seed = -2
+)
+
+// newSeed creates new seed values from a base, for example to create seeds for the
+// elements in a list. If the input seed is minVal or maxVal, so is the output.
+func newSeed(n seed, adjust ...int) seed {
+	switch n {
+	case minVal, maxVal:
+		return n
+	}
+	for _, a := range adjust {
+		n = 10*n + seed(a)
+	}
+	return n
+}
+
+// newValue returns a new value assignable to a field.
+//
+// The stack parameter is used to avoid infinite recursion when populating circular
+// data structures.
+func newValue(m protoreflect.Message, fd protoreflect.FieldDescriptor, n seed, stack []protoreflect.MessageDescriptor) protoreflect.Value {
+	switch {
+	case fd.IsList():
+		if n == 0 {
+			return m.New().Mutable(fd)
+		}
+		list := m.NewField(fd).List()
+		list.Append(newListElement(fd, list, 0, stack))
+		list.Append(newListElement(fd, list, minVal, stack))
+		list.Append(newListElement(fd, list, maxVal, stack))
+		list.Append(newListElement(fd, list, n, stack))
+		return protoreflect.ValueOfList(list)
+	case fd.IsMap():
+		if n == 0 {
+			return m.New().Mutable(fd)
+		}
+		mapv := m.NewField(fd).Map()
+		mapv.Set(newMapKey(fd, 0), newMapValue(fd, mapv, 0, stack))
+		mapv.Set(newMapKey(fd, minVal), newMapValue(fd, mapv, minVal, stack))
+		mapv.Set(newMapKey(fd, maxVal), newMapValue(fd, mapv, maxVal, stack))
+		mapv.Set(newMapKey(fd, n), newMapValue(fd, mapv, newSeed(n, 0), stack))
+		return protoreflect.ValueOfMap(mapv)
+	case fd.Message() != nil:
+		return populateMessage(m.NewField(fd).Message(), n, stack)
+	default:
+		return newScalarValue(fd, n)
+	}
+}
+
+func newListElement(fd protoreflect.FieldDescriptor, list protoreflect.List, n seed, stack []protoreflect.MessageDescriptor) protoreflect.Value {
+	if fd.Message() == nil {
+		return newScalarValue(fd, n)
+	}
+	return populateMessage(list.NewElement().Message(), n, stack)
+}
+
+func newMapKey(fd protoreflect.FieldDescriptor, n seed) protoreflect.MapKey {
+	kd := fd.MapKey()
+	return newScalarValue(kd, n).MapKey()
+}
+
+func newMapValue(fd protoreflect.FieldDescriptor, mapv protoreflect.Map, n seed, stack []protoreflect.MessageDescriptor) protoreflect.Value {
+	vd := fd.MapValue()
+	if vd.Message() == nil {
+		return newScalarValue(vd, n)
+	}
+	return populateMessage(mapv.NewValue().Message(), n, stack)
+}
+
+func newScalarValue(fd protoreflect.FieldDescriptor, n seed) protoreflect.Value {
+	switch fd.Kind() {
+	case protoreflect.BoolKind:
+		return protoreflect.ValueOfBool(n != 0)
+	case protoreflect.EnumKind:
+		vals := fd.Enum().Values()
+		var i int
+		switch n {
+		case minVal:
+			i = 0
+		case maxVal:
+			i = vals.Len() - 1
+		default:
+			i = int(n) % vals.Len()
+		}
+		return protoreflect.ValueOfEnum(vals.Get(i).Number())
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		switch n {
+		case minVal:
+			return protoreflect.ValueOfInt32(math.MinInt32)
+		case maxVal:
+			return protoreflect.ValueOfInt32(math.MaxInt32)
+		default:
+			return protoreflect.ValueOfInt32(int32(n))
+		}
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		switch n {
+		case minVal:
+			// Only use 0 for the zero value.
+			return protoreflect.ValueOfUint32(1)
+		case maxVal:
+			return protoreflect.ValueOfUint32(math.MaxInt32)
+		default:
+			return protoreflect.ValueOfUint32(uint32(n))
+		}
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+		switch n {
+		case minVal:
+			return protoreflect.ValueOfInt64(math.MinInt64)
+		case maxVal:
+			return protoreflect.ValueOfInt64(math.MaxInt64)
+		default:
+			return protoreflect.ValueOfInt64(int64(n))
+		}
+	case protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		switch n {
+		case minVal:
+			// Only use 0 for the zero value.
+			return protoreflect.ValueOfUint64(1)
+		case maxVal:
+			return protoreflect.ValueOfUint64(math.MaxInt64)
+		default:
+			return protoreflect.ValueOfUint64(uint64(n))
+		}
+	case protoreflect.FloatKind:
+		switch n {
+		case minVal:
+			return protoreflect.ValueOfFloat32(math.SmallestNonzeroFloat32)
+		case maxVal:
+			return protoreflect.ValueOfFloat32(math.MaxFloat32)
+		default:
+			return protoreflect.ValueOfFloat32(1.5 * float32(n))
+		}
+	case protoreflect.DoubleKind:
+		switch n {
+		case minVal:
+			return protoreflect.ValueOfFloat64(math.SmallestNonzeroFloat64)
+		case maxVal:
+			return protoreflect.ValueOfFloat64(math.MaxFloat64)
+		default:
+			return protoreflect.ValueOfFloat64(1.5 * float64(n))
+		}
+	case protoreflect.StringKind:
+		if n == 0 {
+			return protoreflect.ValueOfString("")
+		}
+		return protoreflect.ValueOfString(fmt.Sprintf("%d", n))
+	case protoreflect.BytesKind:
+		if n == 0 {
+			return protoreflect.ValueOfBytes(nil)
+		}
+		return protoreflect.ValueOfBytes([]byte{byte(n >> 24), byte(n >> 16), byte(n >> 8), byte(n)})
+	}
+	panic("unhandled kind")
+}
+
+func populateMessage(m protoreflect.Message, n seed, stack []protoreflect.MessageDescriptor) protoreflect.Value {
+	if n == 0 {
+		return protoreflect.ValueOfMessage(m)
+	}
+	md := m.Descriptor()
+	for _, x := range stack {
+		if md == x {
+			return protoreflect.ValueOfMessage(m)
+		}
+	}
+	stack = append(stack, md)
+	for i := 0; i < md.Fields().Len(); i++ {
+		fd := md.Fields().Get(i)
+		if fd.IsWeak() {
+			continue
+		}
+		m.Set(fd, newValue(m, fd, newSeed(n, i), stack))
+	}
+	return protoreflect.ValueOfMessage(m)
+}
+
+func panics(f func()) (didPanic bool) {
+	defer func() {
+		if err := recover(); err != nil {
+			didPanic = true
+		}
+	}()
+	f()
+	return false
+}


### PR DESCRIPTION
### What does this PR do?
Laid the groundwork of Exploration Testing ([DEBUG-3124](https://datadoghq.atlassian.net/jira/software/c/projects/DEBUG/boards/760?assignee=6172d61db9c549006f9adf14&selectedIssue=DEBUG-3124)), whereby:
  * We clone [protobuf](https://github.com/protocolbuffers/protobuf-go) and checkout into a consistent commit sha - [30f628eeb303f2c29be7a381bf78aa3e3aabd317](https://github.com/protocolbuffers/protobuf-go/tree/30f628eeb303f2c29be7a381bf78aa3e3aabd317).
  * Scan the packages tree of protobuf on disk and keep it aside for a quick lookup
  * Patch a few files in this repository to enable Exploration Testing (such as compiling protobuf's tests with debug information, forcing all subprocesses to inherit the env var `DD_SERVICE`, getting rid of several unnecessary steps, etc)
  * Run the integration tests of protobuf in supervised fashion, spawning them under the same process group and pausing the execution of the whole group every few milliseconds (by signaling `SIGSTOP` and resuming with `SIGCONT`), inspecting new subprocesses's binaries, extrapolate function names from the associated DWARF information and letting Go DI process them synchronously. A few helper functions were introduced in Go DI to enable that.
  
The idea of exploration testing is to exercise as many code paths of Go DI as possible, instrumenting as many functions as possible in automatic and exploratory fashion to reveal any crash/bugs/unsupported or faulty logic and be able to track our progress and avoid regressions.
The exploration test is not incorporated in the CI pipeline yet. For the time being It will be used locally to make sure we don't introduce regressions and that we enlarge our instrumentation diversity and support.

* To run the exploration tests locally, one should simply use the traditional `go test`.
e.g `sudo go test -tags=linux_bpf -gcflags="all=-N -l" -v -run TestExplorationGoDI -timeout=60m -count=1`
* There's dependency on bazel to run the exploration tests locally. Installation commands on linux ARM64 would be:
`curl -LO https://releases.bazel.build/7.2.1/release/bazel-7.2.1-linux-arm64`
`chmod +x bazel-7.2.1-linux-arm64`
`sudo mv bazel-7.2.1-linux-arm64 /usr/local/bin/bazel`
Verify installation by executing `bazel version` 

### Motivation

This PR strengthens our Go DI for the upcoming Private Beta, expected early next quarter. Two major roadblocks to the Private Beta are:
- Stability. We shall not crash System Probe. With the help of Exploration Testing, we can exercise a lot more code paths than our traditional e2e tests and reveal any nil dereference, race condition, faulty logic and more as demonstrated in this PR
- Producing snapshots of method argument values. To provide value to end users, we shall support common code constructs and be able to probe arbitrary functions and produce snapshots. Exploration Testing technique could help in this front too by giving us quantitative way to validate our incremental progress.

The scope of the private beta is outlined in [this internal RFC](https://docs.google.com/document/d/1RFtgVVYCc8DCyvNKFTfn1vl5gfBSDAl2dZ59KIyhdb4/edit?tab=t.0#heading=h.rnd972k0hiye).

### Describe how you validated your changes
I ran locally our e2e tests & exploration tests and verified the proposed changes improved our stability. In future PR, the exploration tests will be part of the CI pipeline and run every time a file in the dynamic instrumentation package is modified.

### Additional Notes

This PR is stacked on #34340

[DEBUG-3454]: https://datadoghq.atlassian.net/browse/DEBUG-3454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEBUG-3230]: https://datadoghq.atlassian.net/browse/DEBUG-3230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEBUG-3205]: https://datadoghq.atlassian.net/browse/DEBUG-3205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEBUG-3211]: https://datadoghq.atlassian.net/browse/DEBUG-3211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEBUG-3124]: https://datadoghq.atlassian.net/browse/DEBUG-3124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ