### PR TITLE
Yet another static quality gates threshold update

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,43 +1,43 @@
 # Package gates
 static_quality_gate_agent_deb_amd64:
-  max_on_wire_size: "204.92 MiB"
-  max_on_disk_size: "817.79 MiB"
+  max_on_wire_size: "202.62 MiB"
+  max_on_disk_size: "801.8 MiB"
 
 static_quality_gate_agent_deb_arm64:
-  max_on_wire_size: "186.5 MiB"
-  max_on_disk_size: "808.76 MiB"
+  max_on_wire_size: "184.51 MiB"
+  max_on_disk_size: "793.14 MiB"
 
 static_quality_gate_agent_rpm_amd64:
-  max_on_wire_size: "208.12 MiB"
-  max_on_disk_size: "817.82 MiB"
+  max_on_wire_size: "205.03 MiB"
+  max_on_disk_size: "801.79 MiB"
 
 static_quality_gate_agent_rpm_arm64:
-  max_on_wire_size: "188.34 MiB"
-  max_on_disk_size: "808.76 MiB"
+  max_on_wire_size: "186.44 MiB"
+  max_on_disk_size: "793.09 MiB"
 
 static_quality_gate_agent_suse_amd64:
-  max_on_wire_size: "208.12 MiB"
-  max_on_disk_size: "817.82 MiB"
+  max_on_wire_size: "205.03 MiB"
+  max_on_disk_size: "801.81 MiB"
 
 static_quality_gate_agent_suse_arm64:
-  max_on_wire_size: "188.33 MiB"
-  max_on_disk_size: "808.86 MiB"
+  max_on_wire_size: "186.44 MiB"
+  max_on_disk_size: "793.14 MiB"
 
 static_quality_gate_dogstatsd_deb_amd64:
-  max_on_wire_size: "19.8 MiB"
-  max_on_disk_size: "47.7 MiB"
+  max_on_wire_size: "19.78 MiB"
+  max_on_disk_size: "47.67 MiB"
 
 static_quality_gate_dogstatsd_deb_arm64:
-  max_on_wire_size: "18.5 MiB"
-  max_on_disk_size: "46.3 MiB"
+  max_on_wire_size: "18.49 MiB"
+  max_on_disk_size: "46.27 MiB"
 
 static_quality_gate_dogstatsd_rpm_amd64:
-  max_on_wire_size: "19.8 MiB"
-  max_on_disk_size: "47.7 MiB"
+  max_on_wire_size: "19.79 MiB"
+  max_on_disk_size: "47.67 MiB"
 
 static_quality_gate_dogstatsd_suse_amd64:
-  max_on_wire_size: "19.8 MiB"
-  max_on_disk_size: "47.7 MiB"
+  max_on_wire_size: "19.79 MiB"
+  max_on_disk_size: "47.67 MiB"
 
 static_quality_gate_iot_agent_deb_amd64:
   max_on_wire_size: "24.8 MiB"
@@ -61,28 +61,28 @@ static_quality_gate_iot_agent_suse_amd64:
 
 # Docker images gate
 static_quality_gate_docker_agent_amd64:
-  max_on_wire_size: "308.43 MiB"
-  max_on_disk_size: "902.2 MiB"
+  max_on_wire_size: "304.21 MiB"
+  max_on_disk_size: "886.12 MiB"
 
 static_quality_gate_docker_agent_arm64:
-  max_on_wire_size: "294.23 MiB"
-  max_on_disk_size: "916.47 MiB"
+  max_on_wire_size: "290.47 MiB"
+  max_on_disk_size: "900.79 MiB"
 
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_wire_size: "383.54 MiB"
-  max_on_disk_size: "1100.37 MiB"
+  max_on_wire_size: "379.33 MiB"
+  max_on_disk_size: "1084.34 MiB"
 
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_wire_size: "365.31 MiB"
-  max_on_disk_size: "1103.33 MiB"
+  max_on_wire_size: "361.55 MiB"
+  max_on_disk_size: "1087.6 MiB"
 
 static_quality_gate_docker_dogstatsd_amd64:
-  max_on_wire_size: "27.29 MiB"
+  max_on_wire_size: "27.28 MiB"
   max_on_disk_size: "55.78 MiB"
 
 static_quality_gate_docker_dogstatsd_arm64:
   max_on_wire_size: "26.16 MiB"
-  max_on_disk_size: "54.47 MiB"
+  max_on_disk_size: "54.45 MiB"
 
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_wire_size: "116.28 MiB"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates static quality gates following recent wins in size

### Motivation

Will be [automated](https://docs.google.com/document/d/1WVhrOQgwFj36NWgMqXw9fFRWyr0ghZll2UBR5QY2mxE/edit?pli=1&tab=t.0#heading=h.l4rb38u3959o) soon 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->