### PR TITLE
(fleet) Pass context down to pre-remove hooks

### DIFF
--- a/pkg/fleet/installer/repository/repositories.go
+++ b/pkg/fleet/installer/repository/repositories.go
@@ -75,9 +75,9 @@ func (r *Repositories) Get(pkg string) *Repository {
 }
 
 // Create creates a new repository for the given package name.
-func (r *Repositories) Create(pkg string, version string, stableSourcePath string) error {
+func (r *Repositories) Create(ctx context.Context, pkg string, version string, stableSourcePath string) error {
 	repository := r.newRepository(pkg)
-	err := repository.Create(version, stableSourcePath)
+	err := repository.Create(ctx, version, stableSourcePath)
 	if err != nil {
 		return fmt.Errorf("could not create repository for package %s: %w", pkg, err)
 	}
@@ -85,10 +85,10 @@ func (r *Repositories) Create(pkg string, version string, stableSourcePath strin
 }
 
 // Delete deletes the repository for the given package name.
-func (r *Repositories) Delete(_ context.Context, pkg string) error {
+func (r *Repositories) Delete(ctx context.Context, pkg string) error {
 	repository := r.newRepository(pkg)
 
-	err := repository.Delete()
+	err := repository.Delete(ctx)
 	if err != nil {
 		return fmt.Errorf("could not delete repository for package %s: %w", pkg, err)
 	}
@@ -118,13 +118,13 @@ func (r *Repositories) GetState(pkg string) (State, error) {
 }
 
 // Cleanup cleans up the repositories.
-func (r *Repositories) Cleanup() error {
+func (r *Repositories) Cleanup(ctx context.Context) error {
 	repositories, err := r.loadRepositories()
 	if err != nil {
 		return fmt.Errorf("could not load repositories: %w", err)
 	}
 	for _, repo := range repositories {
-		err := repo.Cleanup()
+		err := repo.Cleanup(ctx)
 		if err != nil {
 			return fmt.Errorf("could not clean up repository: %w", err)
 		}

--- a/pkg/fleet/installer/repository/repositories_test.go
+++ b/pkg/fleet/installer/repository/repositories_test.go
@@ -6,6 +6,7 @@
 package repository
 
 import (
+	"context"
 	"os"
 	"path"
 	"testing"
@@ -30,12 +31,12 @@ func TestRepositoriesEmpty(t *testing.T) {
 func TestRepositories(t *testing.T) {
 	repositories := newTestRepositories(t)
 
-	err := repositories.Create("repo1", "v1", t.TempDir())
+	err := repositories.Create(context.Background(), "repo1", "v1", t.TempDir())
 	assert.NoError(t, err)
 	repository := repositories.Get("repo1")
-	err = repository.SetExperiment("v2", t.TempDir())
+	err = repository.SetExperiment(context.Background(), "v2", t.TempDir())
 	assert.NoError(t, err)
-	err = repositories.Create("repo2", "v1.0", t.TempDir())
+	err = repositories.Create(context.Background(), "repo2", "v1.0", t.TempDir())
 	assert.NoError(t, err)
 
 	state, err := repositories.GetStates()
@@ -47,9 +48,9 @@ func TestRepositories(t *testing.T) {
 
 func TestRepositoriesReopen(t *testing.T) {
 	repositories := newTestRepositories(t)
-	err := repositories.Create("repo1", "v1", t.TempDir())
+	err := repositories.Create(context.Background(), "repo1", "v1", t.TempDir())
 	assert.NoError(t, err)
-	err = repositories.Create("repo2", "v1", t.TempDir())
+	err = repositories.Create(context.Background(), "repo2", "v1", t.TempDir())
 	assert.NoError(t, err)
 
 	repositories = NewRepositories(repositories.rootPath, nil)

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -7,6 +7,7 @@
 package repository
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -28,7 +29,7 @@ var (
 // PreRemoveHook are called before a package is removed.  It returns a boolean
 // indicating if the package files can be deleted safely and an error if an error happened
 // when running the hook.
-type PreRemoveHook func(string) (bool, error)
+type PreRemoveHook func(context.Context, string) (bool, error)
 
 // Repository contains the stable and experimental package of a single artifact managed by the updater.
 //
@@ -104,7 +105,7 @@ func (r *Repository) GetState() (State, error) {
 // 2. Create the root directory.
 // 3. Move the stable source to the repository.
 // 4. Create the stable link.
-func (r *Repository) Create(name string, stableSourcePath string) error {
+func (r *Repository) Create(ctx context.Context, name string, stableSourcePath string) error {
 	err := os.MkdirAll(r.rootPath, 0755)
 	if err != nil {
 		return fmt.Errorf("could not create packages root directory: %w", err)
@@ -129,7 +130,7 @@ func (r *Repository) Create(name string, stableSourcePath string) error {
 		}
 	}
 
-	err = repository.cleanup()
+	err = repository.cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup repository: %w", err)
 	}
@@ -150,7 +151,7 @@ func (r *Repository) Create(name string, stableSourcePath string) error {
 // 1. Remove the stable and experiment links.
 // 2. Cleanup the repository to remove all package versions after running the pre-remove hooks.
 // 3. Remove the root directory.
-func (r *Repository) Delete() error {
+func (r *Repository) Delete(ctx context.Context) error {
 	// Remove symlinks first so that cleanup will attempt to remove all package versions
 	repositoryFiles, err := readRepository(r.rootPath, r.preRemoveHooks)
 	if err != nil {
@@ -170,7 +171,7 @@ func (r *Repository) Delete() error {
 	}
 
 	// Delete all package versions
-	err = r.Cleanup()
+	err = r.Cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup repository for package %w", err)
 	}
@@ -197,12 +198,12 @@ func (r *Repository) Delete() error {
 // 1. Cleanup the repository.
 // 2. Move the experiment source to the repository.
 // 3. Set the experiment link to the experiment package.
-func (r *Repository) SetExperiment(name string, sourcePath string) error {
+func (r *Repository) SetExperiment(ctx context.Context, name string, sourcePath string) error {
 	repository, err := readRepository(r.rootPath, r.preRemoveHooks)
 	if err != nil {
 		return err
 	}
-	err = repository.cleanup()
+	err = repository.cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup repository: %w", err)
 	}
@@ -224,12 +225,12 @@ func (r *Repository) SetExperiment(name string, sourcePath string) error {
 // 1. Cleanup the repository.
 // 2. Set the stable link to the experiment package. The experiment link stays in place.
 // 3. Cleanup the repository to remove the previous stable package.
-func (r *Repository) PromoteExperiment() error {
+func (r *Repository) PromoteExperiment(ctx context.Context) error {
 	repository, err := readRepository(r.rootPath, r.preRemoveHooks)
 	if err != nil {
 		return err
 	}
-	err = repository.cleanup()
+	err = repository.cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup repository: %w", err)
 	}
@@ -246,7 +247,7 @@ func (r *Repository) PromoteExperiment() error {
 	if err != nil {
 		return fmt.Errorf("could not set stable: %w", err)
 	}
-	err = repository.cleanup()
+	err = repository.cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup repository: %w", err)
 	}
@@ -258,12 +259,12 @@ func (r *Repository) PromoteExperiment() error {
 // 1. Cleanup the repository.
 // 2. Sets the experiment link to the stable link.
 // 3. Cleanup the repository to remove the previous experiment package.
-func (r *Repository) DeleteExperiment() error {
+func (r *Repository) DeleteExperiment(ctx context.Context) error {
 	repository, err := readRepository(r.rootPath, r.preRemoveHooks)
 	if err != nil {
 		return err
 	}
-	err = repository.cleanup()
+	err = repository.cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup repository: %w", err)
 	}
@@ -277,7 +278,7 @@ func (r *Repository) DeleteExperiment() error {
 	if err != nil {
 		return fmt.Errorf("could not set experiment to stable: %w", err)
 	}
-	err = repository.cleanup()
+	err = repository.cleanup(ctx)
 	if err != nil {
 		return fmt.Errorf("could not cleanup repository: %w", err)
 	}
@@ -285,12 +286,12 @@ func (r *Repository) DeleteExperiment() error {
 }
 
 // Cleanup calls the cleanup function of the repository
-func (r *Repository) Cleanup() error {
+func (r *Repository) Cleanup(ctx context.Context) error {
 	repository, err := readRepository(r.rootPath, r.preRemoveHooks)
 	if err != nil {
 		return err
 	}
-	return repository.cleanup()
+	return repository.cleanup(ctx)
 }
 
 type repositoryFiles struct {
@@ -366,7 +367,7 @@ func movePackageFromSource(packageName string, rootPath string, sourcePath strin
 	return targetPath, nil
 }
 
-func (r *repositoryFiles) cleanup() error {
+func (r *repositoryFiles) cleanup(ctx context.Context) error {
 	// migrate old repositories that are missing the experiment link
 	if r.stable.Exists() && !r.experiment.Exists() {
 		err := r.setExperimentToStable()
@@ -396,7 +397,7 @@ func (r *repositoryFiles) cleanup() error {
 		pkgName := filepath.Base(r.rootPath)
 
 		if pkgHook, hasHook := r.preRemoveHooks[pkgName]; hasHook {
-			canDelete, err := pkgHook(pkgRepositoryPath)
+			canDelete, err := pkgHook(ctx, pkgRepositoryPath)
 			if err != nil {
 				log.Errorf("Pre-remove hook for package %s returned an error: %v", pkgRepositoryPath, err)
 			}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR propagates context down to the repository.cleanup() function so that it can be used for tracing.

### Motivation

Improve observability of pre-remove hooks

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

These functions are covered by unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->