### PR TITLE
fix(ssi): disabled webhooks should not mutate

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -109,6 +109,7 @@ func TestAutoInstrumentation(t *testing.T) {
 					Name: "foo",
 					Labels: map[string]string{
 						"admission.datadoghq.com/enabled": "true",
+						"app":                             "billing-service",
 					},
 					Namespace: "foo",
 				},
@@ -155,11 +156,11 @@ func TestAutoInstrumentation(t *testing.T) {
 			response := f(request)
 
 			// Check if the patch is expected.
-			emptyPatch := []byte("null")
+			emptyPatch := "null"
 			if tt.expectPatch {
-				assert.NotEqual(t, string(emptyPatch), string(response.Patch))
+				assert.NotEqual(t, emptyPatch, string(response.Patch))
 			} else {
-				assert.Equal(t, string(emptyPatch), string(response.Patch))
+				assert.Equal(t, emptyPatch, string(response.Patch))
 			}
 		})
 	}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -8,17 +8,27 @@
 package webhook
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -61,4 +71,96 @@ func TestNewController(t *testing.T) {
 	)
 
 	assert.IsType(t, &ControllerV1beta1{}, controller)
+}
+
+func TestAutoInstrumentation(t *testing.T) {
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		config      string
+		expectPatch bool
+	}{
+		{
+			name:   "disabled webhooks should not patch",
+			config: "testdata/all_disabled.yaml",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"admission.datadoghq.com/enabled": "true",
+					},
+					Namespace: "foo",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			expectPatch: false,
+		},
+		{
+			name:   "disabled webhooks should not patch, even with targets",
+			config: "testdata/all_disabled_targets.yaml",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"admission.datadoghq.com/enabled": "true",
+					},
+					Namespace: "foo",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "foo",
+						},
+					},
+				},
+			},
+			expectPatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock config.
+			mockConfig := configmock.NewFromFile(t, tt.config)
+
+			// Create a mock meta.
+			wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+				fx.Supply(coreconfig.Params{}),
+				fx.Provide(func() log.Component { return logmock.New(t) }),
+				coreconfig.MockModule(),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+			))
+
+			// Create APM webhook.
+			apm, err := generateAutoInstrumentationWebhook(wmeta, mockConfig)
+			assert.NoError(t, err)
+
+			// Create request.
+			podJSON, err := json.Marshal(tt.pod)
+			assert.NoError(t, err)
+			t.Log(string(podJSON))
+			request := &admission.Request{
+				Object:    podJSON,
+				Namespace: tt.pod.Namespace,
+			}
+
+			// Send request.
+			f := apm.WebhookFunc()
+			response := f(request)
+
+			// Check if the patch is expected.
+			emptyPatch := []byte("null")
+			if tt.expectPatch {
+				assert.NotEqual(t, string(emptyPatch), string(response.Patch))
+			} else {
+				assert.Equal(t, string(emptyPatch), string(response.Patch))
+			}
+		})
+	}
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -132,9 +131,9 @@ func TestAutoInstrumentation(t *testing.T) {
 
 			// Create a mock meta.
 			wmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
-				fx.Supply(coreconfig.Params{}),
+				fx.Supply(config.Params{}),
 				fx.Provide(func() log.Component { return logmock.New(t) }),
-				coreconfig.MockModule(),
+				config.MockModule(),
 				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
 			))
 

--- a/pkg/clusteragent/admission/controllers/webhook/testdata/all_disabled.yaml
+++ b/pkg/clusteragent/admission/controllers/webhook/testdata/all_disabled.yaml
@@ -1,0 +1,9 @@
+---
+apm_config:
+  instrumentation:
+    enabled: false
+admission_controller:
+  inject_config:
+    enabled: false
+  inject_tags:
+    enabled: false

--- a/pkg/clusteragent/admission/controllers/webhook/testdata/all_disabled_targets.yaml
+++ b/pkg/clusteragent/admission/controllers/webhook/testdata/all_disabled_targets.yaml
@@ -1,0 +1,14 @@
+---
+apm_config:
+  instrumentation:
+    enabled: false
+    targets:
+      - name: "Billing Service"
+        podSelector:
+          matchLabels:
+            app: "billing-service"
+admission_controller:
+  inject_config:
+    enabled: false
+  inject_tags:
+    enabled: false

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -102,11 +102,17 @@ func (m *NamespaceMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Inter
 
 // ShouldMutatePod implements the common.MutationFilter interface for the auto-instrumentation injector.
 func (m *NamespaceMutator) ShouldMutatePod(pod *corev1.Pod) bool {
+	if !m.config.Instrumentation.Enabled {
+		return false
+	}
 	return m.filter.ShouldMutatePod(pod)
 }
 
 // IsNamespaceEligible implements the common.MutationFilter interface for the auto-instrumentation injector.
 func (m *NamespaceMutator) IsNamespaceEligible(ns string) bool {
+	if !m.config.Instrumentation.Enabled {
+		return false
+	}
 	return m.filter.IsNamespaceEligible(ns)
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -33,6 +33,7 @@ const (
 
 // TargetMutator is an autoinstrumentation mutator that filters pods based on the target based workload selection.
 type TargetMutator struct {
+	enabled                           bool
 	core                              *mutatorCore
 	targets                           []targetInternal
 	disabledNamespaces                map[string]bool
@@ -124,6 +125,7 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component) (*TargetMuta
 	}
 
 	m := &TargetMutator{
+		enabled:                           config.Instrumentation.Enabled,
 		targets:                           internalTargets,
 		disabledNamespaces:                disabledNamespacesMap,
 		securityClientLibraryPodMutators:  config.securityClientLibraryPodMutators,
@@ -140,6 +142,12 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component) (*TargetMuta
 
 // MutatePod mutates the pod if it matches the target based workload selection or has the appropriate annotations.
 func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interface) (bool, error) {
+	// Return if the mutator is disabled.
+	if !m.enabled {
+		log.Debug("Target mutator is disabled, not mutating")
+		return false, nil
+	}
+
 	log.Debugf("Mutating pod in target mutator %q", mutatecommon.PodString(pod))
 
 	// Sanitize input.
@@ -211,11 +219,20 @@ func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interfac
 // ShouldMutatePod determines if a pod would be mutated by the target mutator. It is used by other webhook mutators as
 // a filter.
 func (m *TargetMutator) ShouldMutatePod(pod *corev1.Pod) bool {
+	// Return if the mutator is disabled.
+	if !m.enabled {
+		return false
+	}
 	return m.getTarget(pod) != nil
 }
 
 // IsNamespaceEligible returns true if a namespace is eligible for injection/mutation.
 func (m *TargetMutator) IsNamespaceEligible(namespace string) bool {
+	// Return if the mutator is disabled.
+	if !m.enabled {
+		return false
+	}
+
 	// If the namespace is disabled, we don't need to check the targets.
 	if _, ok := m.disabledNamespaces[namespace]; ok {
 		return false


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit resolves a bug where even when the tags from labels and config webhook were disabled, the auto instrumentation webhook would still mutate them.

### Motivation
As part of [Kubernetes SSI | Workload Selection 🎯](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing), we split the webhook logic and ensured that the autoinstrumentation webhook would apply all mutators it needed.

There are two config variables used for enabling the webhook:
* `admission_controller.auto_instrumentation.enabled` low level to control enabling/disabling the webhook
* `apm_config.instrumentation.enabled` the customer exposed config for enabling/disabling mutation

Because we chain together the mutators, our mutator does not apply because `apm_config.instrumentation.enabled` is set to false and our mutator checks `filter.IsNamespaceEnabled`. But the other mutators do apply because of they check `filter.ShouldMutatePod`. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The additional unit tests should cover this scenario.

### Possible Drawbacks / Trade-offs
We could also change what it means to have the autoinstrumentation webhook enabled and have it tied directly to `apm_config.instrumentation.enabled`. That broke tests and made me nervous.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I feel good about the test added. I feel less confident in the fix and I'd love feedback on it