### PR TITLE
Update memory allotment for `quality_gate_idle`

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -9,7 +9,7 @@ erratic: false
 target:
   name: datadog-agent
   cpu_allotment: 4
-  memory_allotment: 250 MiB
+  memory_allotment: 300 MiB
 
   environment:
     DD_API_KEY: 00000001


### PR DESCRIPTION
### What does this PR do?

Raises `memory_allotment` for `quality_gate_idle` from `250 MiB` to `300 MiB`

### Motivation

Turns out enabling internal profiling causes the agent to exceed the cgroup limit and gets oomkilled, causing us to lose profiles. `memory_allotment` value is used to set cgroup.memory.max

### Describe how you validated your changes

Confirmed that this change does not significantly impact agent behavior in this [notebook](https://app.datadoghq.com/notebook/11582059/caleb-investigate-impact-of-cgroup-limit?cols=host%2Cservice&storage=hot)

