### PR TITLE
[CTK-3757][CTK-3960] Update windows IO tests to use diskspeed for generating IO load

### DIFF
--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -122,6 +122,9 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
 	))
 
+	// Flush fake intake to remove payloads that won't have IO stats
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
 	}, 1*time.Minute, 5*time.Second)


### PR DESCRIPTION
### What does this PR do?
- Adds a setup step to install `choco` and `diskspd` for windows
- Makes the test checking for I/O check multiple time as all the I/O data we are looking for may not be in every payload due to the process possibly not performing I/O when the check runs.

### Motivation
- https://datadoghq.atlassian.net/browse/CTK-3757
- https://datadoghq.atlassian.net/browse/CTK-3960

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
The tests still need to be marked flaky for the time being as `choco` may rate limit us when trying to download the installer. This can be fixed once we have a CI cache. The following card tracks creating a CI Cache for agent-qa https://datadoghq.atlassian.net/browse/ADXT-950. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->