### PR TITLE
Handle nil as the zero value for node values

### DIFF
--- a/pkg/config/nodetreemodel/node.go
+++ b/pkg/config/nodetreemodel/node.go
@@ -45,6 +45,10 @@ func NewNodeTree(v interface{}, source model.Source) (Node, error) {
 		return newInnerNode(children), nil
 	case []interface{}:
 		return newLeafNode(it, source), nil
+	case nil:
+		// nil as a value acts as the zero value, and the cast library will correctly
+		// convert it to zero values for the types we handle
+		return newLeafNode(nil, source), nil
 	}
 	if isScalar(v) {
 		return newLeafNode(v, source), nil


### PR DESCRIPTION
### What does this PR do?

Handle nil values in the config yaml by converting them to zero values for each type

### Motivation

Prevents a segfault in the config parser

### Describe how you validated your changes

Behavior change covered by unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
