### PR TITLE
remove global for statsd client in system-probe

### DIFF
--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -9,11 +9,13 @@ package module
 import (
 	"errors"
 
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
+	"go.uber.org/fx"
+
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
-	"go.uber.org/fx"
 )
 
 // ErrNotEnabled is a special error type that should be returned by a Factory
@@ -35,4 +37,5 @@ type FactoryDependencies struct {
 	Tagger      tagger.Component
 	Telemetry   telemetry.Component
 	Compression logscompression.Component
+	Statsd      ddgostatsd.ClientInterface
 }

--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/gorilla/mux"
 
 	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
@@ -65,7 +66,7 @@ func withModule(name sysconfigtypes.ModuleName, fn func()) {
 // * Initialization using the provided Factory;
 // * Registering the HTTP endpoints of each module;
 // * Register the gRPC server;
-func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []Factory, wmeta workloadmeta.Component, tagger tagger.Component, telemetry telemetry.Component, compression logscompression.Component) error {
+func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []Factory, wmeta workloadmeta.Component, tagger tagger.Component, telemetry telemetry.Component, compression logscompression.Component, statsd ddgostatsd.ClientInterface) error {
 	var enabledModulesFactories []Factory
 	for _, factory := range factories {
 		if !cfg.ModuleIsEnabled(factory.Name) {
@@ -88,6 +89,7 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []Facto
 				Tagger:      tagger,
 				Telemetry:   telemetry,
 				Compression: compression,
+				Statsd:      statsd,
 			}
 			module, err = factory.Fn(cfg, deps)
 		})

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"runtime"
 
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	gorilla "github.com/gorilla/mux"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/debug"
@@ -31,7 +32,7 @@ import (
 )
 
 // StartServer starts the HTTP and gRPC servers for the system-probe, which registers endpoints from all enabled modules.
-func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmeta workloadmeta.Component, tagger tagger.Component, settings settings.Component, compression logscompression.Component) error {
+func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmeta workloadmeta.Component, tagger tagger.Component, settings settings.Component, compression logscompression.Component, statsd ddgostatsd.ClientInterface) error {
 	conn, err := server.NewListener(cfg.SocketAddress)
 	if err != nil {
 		return err
@@ -39,7 +40,7 @@ func StartServer(cfg *sysconfigtypes.Config, telemetry telemetry.Component, wmet
 
 	mux := gorilla.NewRouter()
 
-	err = module.Register(cfg, mux, modules.All, wmeta, tagger, telemetry, compression)
+	err = module.Register(cfg, mux, modules.All, wmeta, tagger, telemetry, compression, statsd)
 	if err != nil {
 		return fmt.Errorf("failed to create system probe: %s", err)
 	}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -112,9 +112,6 @@ func load() (*types.Config, error) {
 		DebugPort:        cfg.GetInt(spNS("debug_port")),
 		HealthPort:       cfg.GetInt(spNS("health_port")),
 		TelemetryEnabled: cfg.GetBool(spNS("telemetry_enabled")),
-
-		StatsdHost: pkgconfigsetup.GetBindHost(pkgconfigsetup.Datadog()),
-		StatsdPort: cfg.GetInt("dogstatsd_port"),
 	}
 
 	npmEnabled := cfg.GetBool(netNS("enabled"))

--- a/cmd/system-probe/config/types/config.go
+++ b/cmd/system-probe/config/types/config.go
@@ -29,9 +29,6 @@ type Config struct {
 	DebugPort        int
 	HealthPort       int
 	TelemetryEnabled bool
-
-	StatsdHost string
-	StatsdPort int
 }
 
 // ModuleIsEnabled returns a bool indicating if the given module name is enabled.

--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -35,6 +35,7 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	}
 
 	opts := eventmonitor.Opts{}
+	opts.StatsdClient = deps.Statsd
 	opts.ProbeOpts.EnvsVarResolutionEnabled = emconfig.EnvVarsResolutionEnabled
 	opts.ProbeOpts.Tagger = deps.Tagger
 	secmoduleOpts := secmodule.Opts{}

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -64,7 +64,7 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 		log.Info("enabling universal service monitoring (USM)")
 	}
 
-	t, err := tracer.NewTracer(ncfg, deps.Telemetry)
+	t, err := tracer.NewTracer(ncfg, deps.Telemetry, deps.Statsd)
 
 	return &networkTracer{tracer: t}, err
 }

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
@@ -50,7 +51,7 @@ import (
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
-	compstatsd "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient/rcclientimpl"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
@@ -59,9 +60,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
-	processstatsd "github.com/DataDog/datadog-agent/pkg/process/statsd"
 	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 	"github.com/DataDog/datadog-agent/pkg/util/coredump"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -99,7 +100,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				fx.Supply(log.ForDaemon("SYS-PROBE", "log_file", common.DefaultLogFile)),
 				fx.Supply(rcclient.Params{AgentName: "system-probe", AgentVersion: version.AgentVersion, IsSystemProbe: true}),
 				fx.Supply(option.None[secrets.Component]()),
-				compstatsd.Module(),
+				statsd.Module(),
 				config.Module(),
 				telemetryimpl.Module(),
 				sysprobeconfigimpl.Module(),
@@ -146,6 +147,9 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 				}),
 				settingsimpl.Module(),
 				logscompressionfx.Module(),
+				fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
+					return statsd.CreateForHostPort(pkgconfigsetup.GetBindHost(config), config.GetInt("dogstatsd_port"))
+				}),
 			)
 		},
 	}
@@ -155,7 +159,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 }
 
 // run starts the main loop.
-func run(log log.Component, _ config.Component, statsd compstatsd.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, wmeta workloadmeta.Component, tagger tagger.Component, _ pid.Component, _ healthprobe.Component, _ autoexit.Component, settings settings.Component, compression logscompression.Component) error {
+func run(log log.Component, _ config.Component, statsd ddgostatsd.ClientInterface, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, wmeta workloadmeta.Component, tagger tagger.Component, _ pid.Component, _ healthprobe.Component, _ autoexit.Component, settings settings.Component, compression logscompression.Component) error {
 	defer func() {
 		stopSystemProbe()
 	}()
@@ -178,7 +182,7 @@ func run(log log.Component, _ config.Component, statsd compstatsd.Component, tel
 			stopCh <- nil
 		case <-signals.ErrorStopper:
 			_ = log.Critical("system-probe has encountered an error, shutting down...")
-			stopCh <- fmt.Errorf("shutting down because of an error")
+			stopCh <- errors.New("shutting down because of an error")
 		case sig := <-signalCh:
 			log.Infof("Received signal '%s', shutting down...", sig)
 			stopCh <- nil
@@ -241,7 +245,7 @@ func StartSystemProbeWithDefaults(ctxChan <-chan context.Context) (<-chan error,
 
 func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 	return fxutil.OneShot(
-		func(log log.Component, _ config.Component, statsd compstatsd.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, wmeta workloadmeta.Component, tagger tagger.Component, _ healthprobe.Component, settings settings.Component, compression logscompression.Component) error {
+		func(log log.Component, _ config.Component, statsd ddgostatsd.ClientInterface, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, rcclient rcclient.Component, wmeta workloadmeta.Component, tagger tagger.Component, _ healthprobe.Component, settings settings.Component, compression logscompression.Component) error {
 			defer StopSystemProbeWithDefaults()
 			err := startSystemProbe(log, statsd, telemetry, sysprobeconfig, rcclient, wmeta, tagger, settings, compression)
 			if err != nil {
@@ -274,7 +278,7 @@ func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 		rcclientimpl.Module(),
 		config.Module(),
 		telemetryimpl.Module(),
-		compstatsd.Module(),
+		statsd.Module(),
 		sysprobeconfigimpl.Module(),
 		fx.Provide(func(config config.Component, sysprobeconfig sysprobeconfig.Component) healthprobe.Options {
 			return healthprobe.Options{
@@ -315,6 +319,9 @@ func runSystemProbe(ctxChan <-chan context.Context, errChan chan error) error {
 		}),
 		settingsimpl.Module(),
 		logscompressionfx.Module(),
+		fx.Provide(func(config config.Component, statsd statsd.Component) (ddgostatsd.ClientInterface, error) {
+			return statsd.CreateForHostPort(pkgconfigsetup.GetBindHost(config), config.GetInt("dogstatsd_port"))
+		}),
 	)
 }
 
@@ -324,7 +331,7 @@ func StopSystemProbeWithDefaults() {
 }
 
 // startSystemProbe Initializes the system-probe process
-func startSystemProbe(log log.Component, statsd compstatsd.Component, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, _ rcclient.Component, wmeta workloadmeta.Component, tagger tagger.Component, settings settings.Component, compression logscompression.Component) error {
+func startSystemProbe(log log.Component, statsd ddgostatsd.ClientInterface, telemetry telemetry.Component, sysprobeconfig sysprobeconfig.Component, _ rcclient.Component, wmeta workloadmeta.Component, tagger tagger.Component, settings settings.Component, compression logscompression.Component) error {
 	var err error
 	cfg := sysprobeconfig.SysProbeObject()
 
@@ -355,10 +362,6 @@ func startSystemProbe(log log.Component, statsd compstatsd.Component, telemetry 
 
 	setupInternalProfiling(settings, sysprobeconfig, configPrefix, log)
 
-	if err := processstatsd.Configure(cfg.StatsdHost, cfg.StatsdPort, statsd.CreateForHostPort); err != nil {
-		return log.Criticalf("error configuring statsd: %s", err)
-	}
-
 	if isValidPort(cfg.DebugPort) {
 		if cfg.TelemetryEnabled {
 			http.Handle("/telemetry", telemetry.Handler())
@@ -384,7 +387,7 @@ func startSystemProbe(log log.Component, statsd compstatsd.Component, telemetry 
 		}()
 	}
 
-	if err = api.StartServer(cfg, telemetry, wmeta, tagger, settings, compression); err != nil {
+	if err = api.StartServer(cfg, telemetry, wmeta, tagger, settings, compression, statsd); err != nil {
 		return log.Criticalf("error while starting api server, exiting: %v", err)
 	}
 	return nil

--- a/pkg/eventmonitor/eventmonitor.go
+++ b/pkg/eventmonitor/eventmonitor.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/eventmonitor/config"
-	procstatsd "github.com/DataDog/datadog-agent/pkg/process/statsd"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -220,7 +219,7 @@ func (m *EventMonitor) GetStats() map[string]interface{} {
 // NewEventMonitor instantiates an event monitoring system-probe module
 func NewEventMonitor(config *config.Config, secconfig *secconfig.Config, opts Opts) (*EventMonitor, error) {
 	if opts.StatsdClient == nil {
-		opts.StatsdClient = procstatsd.Client
+		opts.StatsdClient = &statsd.NoOpClient{}
 	}
 
 	if opts.ProbeOpts.StatsdClient == nil {

--- a/pkg/network/nettop/main.go
+++ b/pkg/network/nettop/main.go
@@ -38,7 +38,7 @@ func main() {
 	fmt.Printf("-- Config: %+v --\n", cfg)
 	cfg.BPFDebug = true
 
-	t, err := tracer.NewTracer(cfg, nil)
+	t, err := tracer.NewTracer(cfg, nil, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 	"go4.org/intern"
@@ -106,8 +107,8 @@ type Tracer struct {
 }
 
 // NewTracer creates a Tracer
-func NewTracer(config *config.Config, telemetryComponent telemetryComponent.Component) (*Tracer, error) {
-	tr, err := newTracer(config, telemetryComponent)
+func NewTracer(config *config.Config, telemetryComponent telemetryComponent.Component, statsd statsd.ClientInterface) (*Tracer, error) {
+	tr, err := newTracer(config, telemetryComponent, statsd)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +122,7 @@ func NewTracer(config *config.Config, telemetryComponent telemetryComponent.Comp
 
 // newTracer is an internal function used by tests primarily
 // (and NewTracer above)
-func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Component) (_ *Tracer, reterr error) {
+func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Component, statsd statsd.ClientInterface) (_ *Tracer, reterr error) {
 	// check if current platform is using old kernel API because it affects what kprobe are we going to enable
 	currKernelVersion, err := kernel.HostVersion()
 	if err != nil {
@@ -182,7 +183,7 @@ func newTracer(cfg *config.Config, telemetryComponent telemetryComponent.Compone
 	}
 
 	tr.reverseDNS = newReverseDNS(cfg, telemetryComponent)
-	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer)
+	tr.usmMonitor = newUSMMonitor(cfg, tr.ebpfTracer, statsd)
 
 	// Set up the connection_protocol map cleaner if protocol classification is enabled
 	if cfg.ProtocolClassificationEnabled || usmconfig.IsUSMSupportedAndEnabled(cfg) {
@@ -852,7 +853,7 @@ func (t *Tracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
 	return nil, nil
 }
 
-func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
+func newUSMMonitor(c *config.Config, tracer connection.Tracer, statsd statsd.ClientInterface) *usm.Monitor {
 	if !usmconfig.IsUSMSupportedAndEnabled(c) {
 		// If USM is not supported, or if USM is not enabled, we should not start the USM monitor.
 		return nil
@@ -864,7 +865,7 @@ func newUSMMonitor(c *config.Config, tracer connection.Tracer) *usm.Monitor {
 		log.Warnf("couldn't get %q map: %s", probes.ConnectionProtocolMap, err)
 	}
 
-	monitor, err := usm.NewMonitor(c, connectionProtocolMap)
+	monitor, err := usm.NewMonitor(c, connectionProtocolMap, statsd)
 	if err != nil {
 		log.Errorf("usm initialization failed: %s", err)
 		return nil

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -704,7 +704,7 @@ func (s *TracerSuite) TestGatewayLookupEnabled() {
 
 	cfg := testConfig()
 	cfg.EnableGatewayLookup = true
-	tr, err := newTracer(cfg, nil)
+	tr, err := newTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 	t.Cleanup(tr.Stop)
@@ -763,7 +763,7 @@ func (s *TracerSuite) TestGatewayLookupSubnetLookupError() {
 	cfg := testConfig()
 	cfg.EnableGatewayLookup = true
 	// create the tracer without starting it
-	tr, err := newTracer(cfg, nil)
+	tr, err := newTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 	t.Cleanup(tr.Stop)
@@ -829,7 +829,7 @@ func (s *TracerSuite) TestGatewayLookupCrossNamespace() {
 
 	cfg := testConfig()
 	cfg.EnableGatewayLookup = true
-	tr, err := newTracer(cfg, nil)
+	tr, err := newTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 	t.Cleanup(tr.Stop)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -88,7 +88,7 @@ func setupTracer(t testing.TB, cfg *config.Config) *Tracer {
 		cfg.ProtocolClassificationEnabled = false
 	}
 
-	tr, err := NewTracer(cfg, nil)
+	tr, err := NewTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 

--- a/pkg/network/tracer/tracer_unsupported.go
+++ b/pkg/network/tracer/tracer_unsupported.go
@@ -12,6 +12,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
+
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -22,7 +24,7 @@ import (
 type Tracer struct{}
 
 // NewTracer is not implemented on this OS for Tracer
-func NewTracer(_ *config.Config, _ telemetry.Component) (*Tracer, error) {
+func NewTracer(_ *config.Config, _ telemetry.Component, _ statsd.ClientInterface) (*Tracer, error) {
 	return nil, ebpf.ErrNotImplemented
 }
 

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -21,6 +21,8 @@ import (
 
 	"golang.org/x/sys/windows"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
+
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -67,7 +69,7 @@ type Tracer struct {
 }
 
 // NewTracer returns an initialized tracer struct
-func NewTracer(config *config.Config, telemetry telemetry.Component) (*Tracer, error) {
+func NewTracer(config *config.Config, telemetry telemetry.Component, _ statsd.ClientInterface) (*Tracer, error) {
 	if err := driver.Start(); err != nil {
 		return nil, fmt.Errorf("error starting driver: %s", err)
 	}
@@ -75,7 +77,7 @@ func NewTracer(config *config.Config, telemetry telemetry.Component) (*Tracer, e
 
 	if err != nil && errors.Is(err, syscall.ERROR_FILE_NOT_FOUND) {
 		log.Debugf("could not create driver interface: %v", err)
-		return nil, fmt.Errorf("The Windows driver was not installed, reinstall the Datadog Agent with network performance monitoring enabled")
+		return nil, errors.New("The Windows driver was not installed, reinstall the Datadog Agent with network performance monitoring enabled")
 	} else if err != nil {
 		return nil, fmt.Errorf("could not create windows driver controller: %v", err)
 	}

--- a/pkg/network/usm/debugger/cmd/usm_debugger.go
+++ b/pkg/network/usm/debugger/cmd/usm_debugger.go
@@ -37,7 +37,7 @@ func main() {
 	cleanupFn := setupBytecode()
 	defer cleanupFn()
 
-	monitor, err := usm.NewMonitor(getConfiguration(), nil)
+	monitor, err := usm.NewMonitor(getConfiguration(), nil, nil)
 	checkError(err)
 
 	err = monitor.Start()

--- a/pkg/network/usm/monitor.go
+++ b/pkg/network/usm/monitor.go
@@ -14,6 +14,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/cilium/ebpf"
 	"go.uber.org/atomic"
 
@@ -29,7 +30,6 @@ import (
 	usmstate "github.com/DataDog/datadog-agent/pkg/network/usm/state"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
-	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -54,10 +54,12 @@ type Monitor struct {
 	lastUpdateTime *atomic.Int64
 
 	telemetryStopChannel chan struct{}
+
+	statsd statsd.ClientInterface
 }
 
 // NewMonitor returns a new Monitor instance
-func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map) (m *Monitor, err error) {
+func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map, statsd statsd.ClientInterface) (m *Monitor, err error) {
 	defer func() {
 		// capture error and wrap it
 		if err != nil {
@@ -103,6 +105,7 @@ func NewMonitor(c *config.Config, connectionProtocolMap *ebpf.Map) (m *Monitor, 
 		closeFilterFn:        closeFilterFn,
 		processMonitor:       processMonitor,
 		telemetryStopChannel: make(chan struct{}),
+		statsd:               statsd,
 	}
 
 	usmMonitor.lastUpdateTime = atomic.NewInt64(time.Now().Unix())
@@ -233,7 +236,7 @@ func (m *Monitor) DumpMaps(w io.Writer, maps ...string) error {
 }
 
 func (m *Monitor) startTelemetryReporter() {
-	telemetry.SetStatsdClient(statsd.Client)
+	telemetry.SetStatsdClient(m.statsd)
 	ticker := time.NewTicker(30 * time.Second)
 	go func() {
 		defer ticker.Stop()

--- a/pkg/network/usm/monitor_test.go
+++ b/pkg/network/usm/monitor_test.go
@@ -83,7 +83,7 @@ func TestMonitorProtocolFail(t *testing.T) {
 			cfg := utils.NewUSMEmptyConfig()
 			cfg.EnableHTTPMonitoring = true
 
-			monitor, err := NewMonitor(cfg, nil)
+			monitor, err := NewMonitor(cfg, nil, nil)
 			skipIfNotSupported(t, err)
 			require.NoError(t, err)
 			t.Cleanup(monitor.Stop)
@@ -480,7 +480,7 @@ func TestEmptyConfig(t *testing.T) {
 
 	// The monitor should not start, and not return an error when no protocols
 	// are enabled.
-	monitor, err := NewMonitor(cfg, nil)
+	monitor, err := NewMonitor(cfg, nil, nil)
 	require.Nil(t, monitor)
 	require.NoError(t, err)
 }

--- a/pkg/network/usm/monitor_tls_test.go
+++ b/pkg/network/usm/monitor_tls_test.go
@@ -899,7 +899,7 @@ const (
 )
 
 func setupUSMTLSMonitor(t *testing.T, cfg *config.Config, reinit bool) *Monitor {
-	usmMonitor, err := NewMonitor(cfg, nil)
+	usmMonitor, err := NewMonitor(cfg, nil, nil)
 	require.NoError(t, err)
 	require.NoError(t, usmMonitor.Start())
 	if cfg.EnableUSMEventStream && usmconfig.NeedProcessMonitor(cfg) {

--- a/pkg/network/usm/tests/tracer_classification_test.go
+++ b/pkg/network/usm/tests/tracer_classification_test.go
@@ -58,7 +58,7 @@ func setupTracer(t testing.TB, cfg *config.Config) *tracer.Tracer {
 		cfg.ProtocolClassificationEnabled = false
 	}
 
-	tr, err := tracer.NewTracer(cfg, nil)
+	tr, err := tracer.NewTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -190,7 +190,7 @@ func (s *USMSuite) TestProtocolClassification() {
 	cfg.EnablePostgresMonitoring = true
 	cfg.EnableGoTLSSupport = gotlstestutil.GoTLSSupported(t, cfg)
 	cfg.BypassEnabled = true
-	tr, err := tracer.NewTracer(cfg, nil)
+	tr, err := tracer.NewTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 
@@ -702,7 +702,7 @@ func TestFullMonitorWithTracer(t *testing.T) {
 	cfg.EnableIstioMonitoring = true
 	cfg.EnableGoTLSSupport = true
 
-	tr, err := tracer.NewTracer(cfg, nil)
+	tr, err := tracer.NewTracer(cfg, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(tr.Stop)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes usage of the global statsd client in system-probe in favor of one provided by the component framework.

### Motivation

- Reduction in globals
- The ability to provide alternate statsd client implementations depending on where the logic is running. This is helpful for process-agent logic which can run in the core agent or process-agent depending on configuration. (Separate PR for process-agent upcoming)

### Describe how you validated your changes

Existing tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->