### PR TITLE
Force disable ipc server in jmx and check commands

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -293,7 +293,8 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 // Ideally, the server wouldn't start up at all, but this workaround has been
 // in place for some times.
 func disableCmdPort() {
-	os.Setenv("DD_CMD_PORT", "0") // 0 indicates the OS should pick an unused port
+	os.Setenv("DD_CMD_PORT", "0")       // 0 indicates the OS should pick an unused port
+	os.Setenv("DD_AGENT_IPC_PORT", "0") // force disable the IPC server
 }
 
 // runJmxCommandConsole sets up the common utils necessary for JMX, and executes the command

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -772,5 +772,6 @@ func populateMemoryProfileConfig(cliParams *cliParams, initConfig map[string]int
 // Ideally, the server wouldn't start up at all, but this workaround has been
 // in place for some time.
 func disableCmdPort() {
-	os.Setenv("DD_CMD_PORT", "0") // 0 indicates the OS should pick an unused port
+	os.Setenv("DD_CMD_PORT", "0")       // 0 indicates the OS should pick an unused port
+	os.Setenv("DD_AGENT_IPC_PORT", "0") // force disable the IPC server
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Force disable the IPC server in JMX and check subcommands.

### Motivation
Just like the CMD server, it shouldn't start in those commands.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Bug was reported internally and confirmed that setting the port to 0 fixed it.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
~I'll try to understand why the api servers are even started, and possibly make a follow-up PR to remove that entirely.~
Actually it makes sense, JMX uses the API to get its configuration, so the commands spin up a server to provide it.
Ideally only the specific endpoints needed should be started though.