### PR TITLE
[CWS] Add missing CIDR for IPv6 loopback address

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -493,4 +493,6 @@ var DefaultPrivateIPCIDRs = []string{
 	"100.64.0.0/10",
 	// IETF RFC 4193
 	"fc00::/7",
+	// IPv6 loopback address
+	"::1/128",
 }

--- a/pkg/security/probe/field_handlers_test.go
+++ b/pkg/security/probe/field_handlers_test.go
@@ -72,6 +72,16 @@ func TestIsIPPublic(t *testing.T) {
 			ip:       "2001:0:0eab:dead::a0:abcd:4e",
 			expected: true,
 		},
+		{
+			name:     "IPv4 loopback address",
+			ip:       "127.0.0.1",
+			expected: false,
+		},
+		{
+			name:     "IPv6 loopback address",
+			ip:       "::1",
+			expected: false,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix the IPv6 loopback address not being included in the list of default private IP CIDRs.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->