### PR TITLE
feat(notify): Add information about skipped job on the initial PR

### DIFF
--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -38,6 +38,7 @@ notify:
   timeout: 15 minutes # Added to prevent a stuck job blocking the resource_group defined above
   script:
     - !reference [.notify_setup]
+    - !reference [.setup_agent_github_app]
     - invoke -e notify.send-message -p $CI_PIPELINE_ID
     - invoke -e notify.check-consistent-failures -p $CI_PIPELINE_ID
 

--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -6,7 +6,7 @@ from tasks.libs.ciproviders.gitlab_api import get_commit, get_pipeline
 from tasks.libs.common.git import get_default_branch
 from tasks.libs.common.utils import Color, color_message
 from tasks.libs.notify.utils import DEPLOY_PIPELINES_CHANNEL, PIPELINES_CHANNEL, PROJECT_NAME, get_pipeline_type
-from tasks.libs.pipeline.data import get_failed_jobs
+from tasks.libs.pipeline.data import get_failed_jobs, get_jobs_skipped_on_pr
 from tasks.libs.pipeline.notifications import (
     base_message,
     get_failed_tests,
@@ -52,8 +52,9 @@ def send_message(pipeline_id, dry_run):
     elif pipeline_type == "trigger":
         header = f"{header_icon} :arrow_forward: datadog-agent triggered"
 
-    message = SlackMessage(jobs=failed_jobs)
-    message.base_message = base_message(PROJECT_NAME, pipeline, commit, header, state)
+    skipped_jobs, pr_pipeline_url = get_jobs_skipped_on_pr(pipeline, failed_jobs)
+    message = SlackMessage(jobs=failed_jobs, skipped=skipped_jobs)
+    message.base_message = base_message(PROJECT_NAME, pipeline, commit, header, state, pr_pipeline_url)
 
     for job in failed_jobs.all_non_infra_failures():
         for test in get_failed_tests(PROJECT_NAME, job):

--- a/tasks/libs/pipeline/notifications.py
+++ b/tasks/libs/pipeline/notifications.py
@@ -137,7 +137,7 @@ def get_pr_from_commit(commit_title: str, project_name: str) -> tuple[str, str] 
     project_name: the GitHub project from which the PR originates, in the "org/repo" format
     """
 
-    parsed_pr_id_found = re.search(r'.*\(#([0-9]*)\)$', commit_title)
+    parsed_pr_id_found = re.search(r'.*#([0-9]+)', commit_title)
     if not parsed_pr_id_found:
         return None
 
@@ -146,14 +146,15 @@ def get_pr_from_commit(commit_title: str, project_name: str) -> tuple[str, str] 
     return parsed_pr_id, f"{GITHUB_BASE_URL}/{project_name}/pull/{parsed_pr_id}"
 
 
-def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCommit, header: str, state: str):
+def base_message(
+    project_name: str, pipeline: ProjectPipeline, commit: ProjectCommit, header: str, state: str, pr_pipeline_url: str
+) -> str:
     commit_title = commit.title
     pipeline_url = pipeline.web_url
     pipeline_id = pipeline.id
     commit_ref_name = pipeline.ref
-    commit_url_gitlab = commit.web_url
     commit_url_github = f"{GITHUB_BASE_URL}/{project_name}/commit/{commit.id}"
-    commit_short_sha = commit.id[-8:]
+    commit_short_sha = commit.id[:7]
     author = commit.author_name
     finish = datetime.fromisoformat(pipeline.finished_at) if pipeline.finished_at else datetime.now(timezone.utc)
     delta = finish - datetime.fromisoformat(pipeline.started_at)
@@ -167,9 +168,9 @@ def base_message(project_name: str, pipeline: ProjectPipeline, commit: ProjectCo
         enhanced_commit_title = enhanced_commit_title.replace(
             f"#{parsed_pr_id}", f"<{pr_url_github}/s|#{parsed_pr_id}>"
         )
-
+    pr_pipelline_link = f"(:gitlab:<{pr_pipeline_url}|pr pipeline>)" if pr_pipeline_url else ""
     return f"""{header} pipeline <{pipeline_url}|{pipeline_id}> for {commit_ref_name} {state} {duration}.
-{enhanced_commit_title} (<{commit_url_gitlab}|{commit_short_sha}>)(:github: <{commit_url_github}|link>) by {author}"""
+{enhanced_commit_title} {pr_pipelline_link}(:github: <{commit_url_github}|{commit_short_sha}>) by {author}"""
 
 
 def warn_new_commits(release_managers, team, branch, next_rc):

--- a/tasks/libs/types/types.py
+++ b/tasks/libs/types/types.py
@@ -109,13 +109,13 @@ class SlackMessage:
     TEST_SECTION_HEADER = "Failed tests:"
     MAX_JOBS_PER_TEST = 2
 
-    def __init__(self, base: str = "", jobs: FailedJobs = None, skipped: list = None):
+    def __init__(self, base: str = "", jobs: FailedJobs = None, skipped: list | None = None):
         jobs = jobs if jobs else FailedJobs()
         self.base_message = base
         self.failed_jobs = jobs
         self.failed_tests = defaultdict(list)
         self.coda = ""
-        self.skipped_jobs = skipped if skipped else []
+        self.skipped_jobs = skipped or []
 
     def add_test_failure(self, test, job):
         self.failed_tests[test.key].append(job)

--- a/tasks/libs/types/types.py
+++ b/tasks/libs/types/types.py
@@ -109,12 +109,13 @@ class SlackMessage:
     TEST_SECTION_HEADER = "Failed tests:"
     MAX_JOBS_PER_TEST = 2
 
-    def __init__(self, base: str = "", jobs: FailedJobs = None):
+    def __init__(self, base: str = "", jobs: FailedJobs = None, skipped: list = None):
         jobs = jobs if jobs else FailedJobs()
         self.base_message = base
         self.failed_jobs = jobs
         self.failed_tests = defaultdict(list)
         self.coda = ""
+        self.skipped_jobs = skipped if skipped else []
 
     def add_test_failure(self, test, job):
         self.failed_tests[test.key].append(job)
@@ -133,7 +134,8 @@ class SlackMessage:
             jobs_info = []
             for job in jobs:
                 num_retries = len(job.retry_summary) - 1
-                job_info = f"<{job.web_url}|{job.name}>"
+                emoji = " :job-skipped-on-pr:" if job.name in self.skipped_jobs else ""
+                job_info = f"<{job.web_url}|{job.name}>{emoji}"
                 if num_retries > 0:
                     job_info += f" ({num_retries} retries)"
 

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -33,6 +33,7 @@ def get_github_slack_map():
 
 class TestSendMessage(unittest.TestCase):
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
     @patch('builtins.print')
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
@@ -54,6 +55,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.assert_called()
 
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('tasks.libs.notify.pipeline_status.get_failed_jobs')
@@ -209,6 +211,7 @@ class TestSendMessage(unittest.TestCase):
         self.assertNotIn("@DataDog/agent-delivery", owners)
 
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('builtins.print')
@@ -233,6 +236,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.assert_called()
 
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
     @patch.dict('os.environ', {'DEPLOY_AGENT': 'true', 'SLACK_DATADOG_AGENT_BOT_TOKEN': 'hihan'})
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
@@ -258,6 +262,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.assert_called()
 
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('builtins.print')
@@ -283,6 +288,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.jobs.get.assert_called()
 
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
     @patch.dict(
         'os.environ',

--- a/tasks/unit_tests/pipeline_lib_tests.py
+++ b/tasks/unit_tests/pipeline_lib_tests.py
@@ -1,10 +1,10 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from gitlab.v4.objects import ProjectJob
 
 from tasks.libs.pipeline import notifications
-from tasks.libs.pipeline.data import get_job_failure_context
+from tasks.libs.pipeline.data import get_job_failure_context, get_jobs_skipped_on_pr
 from tasks.libs.types.types import FailedJobReason, FailedJobType
 
 
@@ -83,3 +83,156 @@ class TestFailedJobs(unittest.TestCase):
         fail_type, _fail_reason = get_job_failure_context(job, log)
 
         self.assertEqual(fail_type, FailedJobType.JOB_FAILURE)
+
+
+class TestGetSkippedJobsOnPr(unittest.TestCase):
+    @patch('tasks.libs.pipeline.data.get_gitlab_repo')
+    @patch('tasks.libs.pipeline.data.GithubAPI', autospec=True)
+    def test_nothing_skipped(self, gh_mock, gl_mock):
+        gh, commit, pr, agent, pipeline, pr_job, job, failed_jobs = 8 * [MagicMock()]
+        pr.head.ref = 'branch'
+        commit.get_pulls.return_value = [pr]
+        gh._repository.get_commit.return_value = commit
+        pr_job.name = 'bakery'
+        pr_job.status = 'success'
+        job.full_name = 'bakery'
+        pipeline.jobs.list.return_value = [job]
+        pipeline.bridges.list.return_value = []
+        pipeline.web_url = 'https://pipeline.url'
+        agent.pipelines.list.return_value = [pipeline]
+        gl_mock.return_value = agent
+        gh_mock.return_value = gh
+        failed_jobs.all_mandatory_failures.return_value = [job]
+        skipped, url = get_jobs_skipped_on_pr(MagicMock(), failed_jobs)
+        self.assertEqual(skipped, [])
+        self.assertEqual(url, 'https://pipeline.url')
+
+    @patch('tasks.libs.pipeline.data.get_gitlab_repo')
+    @patch('tasks.libs.pipeline.data.GithubAPI', autospec=True)
+    def test_job_skipped(self, gh_mock, gl_mock):
+        gh, commit, pr, agent, pipeline, pr_job, job, failed_jobs = 8 * [MagicMock()]
+        pr.head.ref = 'branch'
+        commit.get_pulls.return_value = [pr]
+        gh._repository.get_commit.return_value = commit
+        pr_job.name = 'bakery'
+        pr_job.status = 'skipped'
+        job.name = 'bake'
+        job.full_name = 'bakery'
+        pipeline.jobs.list.return_value = [job]
+        pipeline.bridges.list.return_value = []
+        pipeline.web_url = 'https://pipeline.url'
+        agent.pipelines.list.return_value = [pipeline]
+        gl_mock.return_value = agent
+        gh_mock.return_value = gh
+        failed_jobs.all_mandatory_failures.return_value = [job]
+        skipped, url = get_jobs_skipped_on_pr(MagicMock(), failed_jobs)
+        self.assertEqual(skipped, ['bake'])
+        self.assertEqual(url, 'https://pipeline.url')
+
+    @patch('tasks.libs.pipeline.data.get_gitlab_repo')
+    @patch('tasks.libs.pipeline.data.GithubAPI', autospec=True)
+    def test_not_generated(self, gh_mock, gl_mock):
+        gh, commit, pr, agent, pipeline, pr_job, job, failed_jobs = 8 * [MagicMock()]
+        pr.head.ref = 'branch'
+        commit.get_pulls.return_value = [pr]
+        gh._repository.get_commit.return_value = commit
+        pr_job.name = 'bakery [gluten free]'
+        pr_job.status = 'success'
+        job.full_name = 'bakery [pastry]'
+        job.name = 'bakery'
+        pipeline.jobs.list.return_value = [job]
+        pipeline.bridges.list.return_value = []
+        pipeline.web_url = 'https://pipeline.url'
+        agent.pipelines.list.return_value = [pipeline]
+        gl_mock.return_value = agent
+        gh_mock.return_value = gh
+        failed_jobs.all_mandatory_failures.return_value = [job]
+        skipped, url = get_jobs_skipped_on_pr(MagicMock(), failed_jobs)
+        self.assertEqual(skipped, ['bakery'])
+        self.assertEqual(url, 'https://pipeline.url')
+
+    @patch('tasks.libs.pipeline.data.get_gitlab_repo')
+    @patch('tasks.libs.pipeline.data.GithubAPI', autospec=True)
+    def test_no_pr(self, gh_mock, gl_mock):
+        gh, commit, pr, agent, pipeline, pr_job, job, failed_jobs = 8 * [MagicMock()]
+        pr.head.ref = 'branch'
+        commit.get_pulls.return_value = []
+        gh._repository.get_commit.return_value = commit
+        pr_job.name = 'bakery'
+        pr_job.status = 'skipped'
+        job.full_name = 'bakery'
+        pipeline.jobs.list.return_value = []
+        pipeline.bridges.list.return_value = []
+        pipeline.web_url = 'https://pipeline.url'
+        agent.pipelines.list.return_value = [pipeline]
+        gl_mock.return_value = agent
+        gh_mock.return_value = gh
+        failed_jobs.all_mandatory_failures.return_value = [job]
+        skipped, url = get_jobs_skipped_on_pr(MagicMock(), failed_jobs)
+        self.assertEqual(skipped, [])
+        self.assertEqual(url, '')
+
+    @patch('builtins.print')
+    @patch('tasks.libs.pipeline.data.get_gitlab_repo')
+    @patch('tasks.libs.pipeline.data.GithubAPI', autospec=True)
+    def test_too_many_pr(self, gh_mock, gl_mock, print_mock):
+        gh, commit, pr, agent, pipeline, pr_job, job, failed_jobs = 8 * [MagicMock()]
+        pr.head.ref = 'branch'
+        commit.get_pulls.return_value = [pr, pr]
+        gh._repository.get_commit.return_value = commit
+        pr_job.name = 'bakery'
+        pr_job.status = 'skipped'
+        job.full_name = 'bakery'
+        pipeline.jobs.list.return_value = []
+        pipeline.bridges.list.return_value = []
+        pipeline.web_url = 'https://pipeline.url'
+        agent.pipelines.list.return_value = [pipeline]
+        gl_mock.return_value = agent
+        gh_mock.return_value = gh
+        failed_jobs.all_mandatory_failures.return_value = [job]
+        skipped, url = get_jobs_skipped_on_pr(MagicMock(), failed_jobs)
+        self.assertEqual(skipped, [])
+        self.assertEqual(url, '')
+        print_mock.assert_called_once()
+
+    @patch('tasks.libs.pipeline.data.get_gitlab_repo')
+    @patch('tasks.libs.pipeline.data.GithubAPI', autospec=True)
+    def test_no_pipeline(self, gh_mock, gl_mock):
+        gh, commit, pr, agent, pipeline, pr_job, job, failed_jobs = 8 * [MagicMock()]
+        pr.head.ref = 'branch'
+        commit.get_pulls.return_value = [pr]
+        gh._repository.get_commit.return_value = commit
+        pr_job.name = 'bakery'
+        pr_job.status = 'success'
+        job.full_name = 'bakery'
+        pipeline.jobs.list.return_value = [job]
+        pipeline.bridges.list.return_value = []
+        pipeline.web_url = 'https://pipeline.url'
+        agent.pipelines.list.return_value = []
+        gl_mock.return_value = agent
+        gh_mock.return_value = gh
+        failed_jobs.all_mandatory_failures.return_value = [job]
+        skipped, url = get_jobs_skipped_on_pr(MagicMock(), failed_jobs)
+        self.assertEqual(skipped, [])
+        self.assertEqual(url, '')
+
+    @patch('tasks.libs.pipeline.data.get_gitlab_repo')
+    @patch('tasks.libs.pipeline.data.GithubAPI', autospec=True)
+    def test_no_failure(self, gh_mock, gl_mock):
+        gh, commit, pr, agent, pipeline, pr_job, job, failed_jobs = 8 * [MagicMock()]
+        pr.head.ref = 'branch'
+        commit.get_pulls.return_value = [pr]
+        gh._repository.get_commit.return_value = commit
+        pr_job.name = 'bakery'
+        pr_job.status = 'skipped'
+        job.full_name = 'bakery'
+        pipeline.jobs.list.return_value = [job]
+        pipeline.bridges.list.return_value = []
+        pipeline.web_url = 'https://pipeline.url'
+        agent.pipelines.list.return_value = [pipeline]
+        gl_mock.return_value = agent
+        gh_mock.return_value = gh
+        failed_jobs.all_mandatory_failures.return_value = []
+        skipped, url = get_jobs_skipped_on_pr(MagicMock(), failed_jobs)
+        self.assertEqual(skipped, [])
+        self.assertEqual(url, 'https://pipeline.url')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Add an emoji on failed job notification when the job was not run on the initial PR
- Replace the gitlab commit link by the PR pipeline link, if any
- Change the matching regex for PR link. It was broken by a recent devflow change and I made it more robust

Before:
![image](https://github.com/user-attachments/assets/20d3bdd5-4458-48be-bf69-3478c6a3b1f1)

After:
![image](https://github.com/user-attachments/assets/1881245b-6363-4c9f-a4bb-bae59eb412bb)


### Motivation
To improve the rules we use to run e2e test we need to know if we could have detected a failure on main earlier.
https://datadoghq.atlassian.net/browse/ACIX-244

### Describe how you validated your changes
Manual tests and UT
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->