### PR TITLE
[build-tags] Delete unused `no_dynamic_plugins` in system-probe

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -172,7 +172,6 @@ SERVERLESS_TAGS = {"serverless", "otlp"}
 # SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
 SYSTEM_PROBE_TAGS = {
     "datadog.no_waf",
-    "no_dynamic_plugins",
     "ec2",
     "linux_bpf",
     "netcgo",


### PR DESCRIPTION
### What does this PR do?

This PR removes the `no_dynamic_plugins` build tag from system-probe. This tag is only intended for use with containerd, but since system-probe doesn’t use containerd it's not needed.

This change doesn’t introduce any functional improvement. It’s only for clarity.

### Describe how you validated your changes
Rely on CI.