### PR TITLE
[AGENTRUN-162] Disable X25519Kyber768Draft00 in the agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,12 @@ go 1.23.0
 
 toolchain go1.23.6
 
+// Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
+// This was causing errors with AWS Network Firewall
+// See https://github.com/DataDog/datadog-agent/issues/34323 for details.
+// This will be revisited once we update to 1.24.x
+godebug tlskyber=0
+
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)
 // that retracts itself and the previous version.

--- a/releasenotes/notes/fix-kyber-firewall-1d38f83a241208f7.yaml
+++ b/releasenotes/notes/fix-kyber-firewall-1d38f83a241208f7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Disable the X25519Kyber768Draft00 key exchange mechanism to avoid issues with
+    firewalls not supporting it, in particular AWS Network Firewall.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
Fixes https://github.com/DataDog/datadog-agent/issues/34323.

### What does this PR do?
Disable X25519Kyber768Draft00 in the agent.

### Motivation
This is enabled by default in Go 1.23, which we started using in version 7.62.0, but this scheme breaks some firewalls, in particular AWS Network Firewall.
We disable it for now and will revisit this when updating to Go 1.24.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI is considered enough.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->