### PR TITLE
Submit device scan type

### DIFF
--- a/cmd/agent/subcommands/snmp/command.go
+++ b/cmd/agent/subcommands/snmp/command.go
@@ -27,6 +27,7 @@ import (
 	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
 	snmpscanfx "github.com/DataDog/datadog-agent/comp/snmpscan/fx"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/spf13/cobra"
@@ -288,7 +289,7 @@ func scanDevice(connParams *snmpparse.SNMPConfig, args argsType, snmpScanner snm
 	deviceID := namespace + ":" + connParams.IPAddress
 	// Start the scan
 	fmt.Printf("Launching scan for device: %s\n", deviceID)
-	err := snmpScanner.ScanDeviceAndSendData(connParams, namespace)
+	err := snmpScanner.ScanDeviceAndSendData(connParams, namespace, metadata.ManualScan)
 	if err != nil {
 		fmt.Printf("Unable to perform device scan for device %s : %e", deviceID, err)
 	}

--- a/comp/snmpscan/def/component.go
+++ b/comp/snmpscan/def/component.go
@@ -20,5 +20,5 @@ type Component interface {
 	RunDeviceScan(snmpConection *gosnmp.GoSNMP, deviceNamespace string, deviceID string) error
 	RunSnmpWalk(snmpConection *gosnmp.GoSNMP, firstOid string) error
 	SendPayload(payload metadata.NetworkDevicesMetadata) error
-	ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string) error
+	ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error
 }

--- a/comp/snmpscan/impl/devicescan.go
+++ b/comp/snmpscan/impl/devicescan.go
@@ -57,7 +57,7 @@ func gatherPDUs(snmp *gosnmp.GoSNMP) ([]*gosnmp.SnmpPDU, error) {
 	return pdus, nil
 }
 
-func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string) error {
+func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig, namespace string, scanType metadata.ScanType) error {
 	// Establish connection
 	snmp, err := snmpparse.NewSNMP(connParams, s.log)
 	if err != nil {
@@ -70,6 +70,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 		DeviceScanStatus: &metadata.ScanStatusMetadata{
 			DeviceID:   deviceID,
 			ScanStatus: metadata.ScanStatusInProgress,
+			ScanType:   scanType,
 		},
 		CollectTimestamp: time.Now().Unix(),
 		Namespace:        namespace,
@@ -83,6 +84,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			DeviceScanStatus: &metadata.ScanStatusMetadata{
 				DeviceID:   deviceID,
 				ScanStatus: metadata.ScanStatusError,
+				ScanType:   scanType,
 			},
 			CollectTimestamp: time.Now().Unix(),
 			Namespace:        namespace,
@@ -99,6 +101,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 			DeviceScanStatus: &metadata.ScanStatusMetadata{
 				DeviceID:   deviceID,
 				ScanStatus: metadata.ScanStatusError,
+				ScanType:   scanType,
 			},
 			CollectTimestamp: time.Now().Unix(),
 			Namespace:        namespace,
@@ -113,6 +116,7 @@ func (s snmpScannerImpl) ScanDeviceAndSendData(connParams *snmpparse.SNMPConfig,
 		DeviceScanStatus: &metadata.ScanStatusMetadata{
 			DeviceID:   deviceID,
 			ScanStatus: metadata.ScanStatusCompleted,
+			ScanType:   scanType,
 		},
 		CollectTimestamp: time.Now().Unix(),
 		Namespace:        namespace,

--- a/comp/snmpscan/impl/snmpscan.go
+++ b/comp/snmpscan/impl/snmpscan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
 	rcclienttypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
 	snmpscan "github.com/DataDog/datadog-agent/comp/snmpscan/def"
+	"github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpparse"
 )
 
@@ -75,6 +76,6 @@ func (s snmpScannerImpl) startDeviceScan(task rcclienttypes.AgentTaskConfig) err
 	if err != nil {
 		return err
 	}
-	return s.ScanDeviceAndSendData(instance, ns)
+	return s.ScanDeviceAndSendData(instance, ns, metadata.RCTriggeredScan)
 
 }

--- a/comp/snmpscan/mock/mock.go
+++ b/comp/snmpscan/mock/mock.go
@@ -43,6 +43,6 @@ func (m mock) RunSnmpWalk(_ *gosnmp.GoSNMP, _ string) error {
 func (m mock) SendPayload(_ metadata.NetworkDevicesMetadata) error {
 	return nil
 }
-func (m mock) ScanDeviceAndSendData(_ *snmpparse.SNMPConfig, _ string) error {
+func (m mock) ScanDeviceAndSendData(_ *snmpparse.SNMPConfig, _ string, _ metadata.ScanType) error {
 	return nil
 }

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -94,10 +94,18 @@ const (
 	ScanStatusError ScanStatus = "error"
 )
 
+type ScanType string
+
+const (
+	ManualScan      ScanType = "manual"
+	RCTriggeredScan ScanType = "rc_triggered"
+)
+
 // ScanStatusMetadata contains scan status metadata
 type ScanStatusMetadata struct {
 	DeviceID   string     `json:"device_id"`
 	ScanStatus ScanStatus `json:"scan_status"`
+	ScanType   ScanType   `json:"scan_type,omitempty"`
 }
 
 // InterfaceMetadata contains interface metadata

--- a/pkg/networkdevice/metadata/payload.go
+++ b/pkg/networkdevice/metadata/payload.go
@@ -94,10 +94,13 @@ const (
 	ScanStatusError ScanStatus = "error"
 )
 
+// ScanType type for the different possible scan types manual or rc_triggered
 type ScanType string
 
 const (
-	ManualScan      ScanType = "manual"
+	// ManualScan represents a manual scan
+	ManualScan ScanType = "manual"
+	// RCTriggeredScan represents a rc triggered scan
 	RCTriggeredScan ScanType = "rc_triggered"
 )
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Submit the device scan type with the device scan status. We have two possible types: manual or RC triggered.

### Motivation
The device scan can now be triggered by RC using the agent task. This PR differentiates between these two types.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The backend processes the received payload with the updated status.
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->