### PR TITLE
change default for process checks in core agent

### DIFF
--- a/cmd/agent/subcommands/flare/command_other_test.go
+++ b/cmd/agent/subcommands/flare/command_other_test.go
@@ -34,6 +34,7 @@ func NewSystemProbeTestServer(_ http.Handler) (*httptest.Server, error) {
 func InjectConnectionFailures(mockSysProbeConfig model.Config, _ model.Config) {
 	mockSysProbeConfig.SetWithoutSource("system_probe_config.enabled", true)
 	mockSysProbeConfig.SetWithoutSource("system_probe_config.sysprobe_socket", "/opt/datadog-agent/run/sysprobe-bad.sock")
+	mockSysProbeConfig.SetWithoutSource("network_config.enabled", true)
 }
 
 // CheckExpectedConnectionFailures checks the expected errors after simulated

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -146,6 +146,7 @@ func (c *commandTestSuite) TestReadProfileData() {
 	if runtime.GOOS != "darwin" {
 		mockSysProbeConfig.SetWithoutSource("system_probe_config.enabled", true)
 		mockSysProbeConfig.SetWithoutSource("system_probe_config.sysprobe_socket", c.sysprobeSocketPath)
+		mockSysProbeConfig.SetWithoutSource("network_config.enabled", true)
 	}
 
 	profiler := getProfiler(t, mockConfig, mockSysProbeConfig)
@@ -214,6 +215,7 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 	mockSysProbeConfig := configmock.NewSystemProbe(t)
 	mockSysProbeConfig.SetWithoutSource("system_probe_config.enabled", true)
 	mockSysProbeConfig.SetWithoutSource("system_probe_config.sysprobe_socket", c.sysprobeSocketPath)
+	mockSysProbeConfig.SetWithoutSource("network_config.enabled", true)
 
 	profiler := getProfiler(t, mockConfig, mockSysProbeConfig)
 	data, err := profiler.ReadProfileData(10, func(string, ...interface{}) error { return nil })

--- a/comp/core/profiler/impl/profiler.go
+++ b/comp/core/profiler/impl/profiler.go
@@ -260,9 +260,15 @@ func (profiler) securityAgentEnabled() bool {
 }
 
 func (p profiler) processAgentEnabled() bool {
-	return p.cfg.GetBool("process_config.enabled") ||
+	processChecksEnabled := p.cfg.GetBool("process_config.enabled") ||
 		p.cfg.GetBool("process_config.container_collection.enabled") ||
 		p.cfg.GetBool("process_config.process_collection.enabled")
+	processChecksInProcessAgent := !p.cfg.GetBool("process_config.run_in_core_agent.enabled") &&
+		processChecksEnabled
+	npmEnabled := p.sysProbeCfg.GetBool("network_config.enabled")
+	usmEnabled := p.sysProbeCfg.GetBool("service_monitoring_config.enabled")
+
+	return processChecksInProcessAgent || npmEnabled || usmEnabled
 }
 
 func (p profiler) apmEnabled() bool {

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -52,11 +52,11 @@ func createGenericConfig(t *testing.T) model.Config {
 	mockConfig.SetWithoutSource("process_config.expvar_port", port)
 	mockConfig.SetWithoutSource("security_agent.expvar_port", port)
 
+	mockConfig.SetWithoutSource("process_config.run_in_core_agent.enabled", false)
 	mockConfig.SetWithoutSource("process_config.enabled", false)
 	mockConfig.SetWithoutSource("process_config.container_collection.enabled", false)
 	mockConfig.SetWithoutSource("process_config.process_collection.enabled", false)
 	mockConfig.SetWithoutSource("apm_config.enabled", false)
-	mockConfig.SetWithoutSource("system_probe_config.enabled", false)
 
 	return mockConfig
 }
@@ -213,13 +213,44 @@ func TestTimeout(t *testing.T) {
 			expTimeout:      baseTimeout + 6*(10*time.Second),
 		},
 		{
+			name: "Process Agent Checks in Core Agent",
+			extraCfgs: map[string]interface{}{
+				"process_config.run_in_core_agent.enabled": true,
+			},
+			extraSysCfgs:    map[string]interface{}{},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 4*(10*time.Second),
+		},
+		{
+			name: "Process Agent Enabled, via NPM",
+			extraCfgs: map[string]interface{}{
+				"process_config.run_in_core_agent.enabled": true,
+			},
+			extraSysCfgs: map[string]interface{}{
+				"network_config.enabled": true,
+			},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 8*(10*time.Second),
+		},
+		{
+			name: "Process Agent Enabled, via USM",
+			extraCfgs: map[string]interface{}{
+				"process_config.run_in_core_agent.enabled": true,
+			},
+			extraSysCfgs: map[string]interface{}{
+				"service_monitoring_config.enabled": true,
+			},
+			profileDuration: 10 * time.Second,
+			expTimeout:      baseTimeout + 8*(10*time.Second),
+		},
+		{
 			name:      "SysProbe Enabled",
 			extraCfgs: map[string]interface{}{},
 			extraSysCfgs: map[string]interface{}{
 				"system_probe_config.enabled": true,
 			},
 			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 6*(10*time.Second),
+			expTimeout:      baseTimeout + 8*(10*time.Second), // config enables NPM, which enables process agent
 		},
 		{
 			name: "Everything Enabled",

--- a/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
+++ b/comp/core/workloadmeta/collectors/internal/remote/processcollector/process_collector_test.go
@@ -258,7 +258,8 @@ func TestCollection(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			overrides := map[string]interface{}{
-				"language_detection.enabled": true,
+				"language_detection.enabled":               true,
+				"process_config.run_in_core_agent.enabled": false,
 			}
 
 			// We do not inject any collectors here; we instantiate

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1556,9 +1556,9 @@ api_key:
   ## @param run_in_core_agent - custom object - optional
   ## Controls whether the process Agent or core Agent collects process and/or container information (Linux only).
   # run_in_core_agent:
-    ## @param enabled - boolean - optional - default: false
+    ## @param enabled - boolean - optional - default: true
     ## Enables process/container collection on the core Agent instead of the process Agent.
-    # enabled: false
+    # enabled: true
   {{ end }}
 
   ## @param process_collection - custom object - optional

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -117,7 +117,7 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnvAndSetDefault(config, "process_config.process_collection.enabled", false)
 
 	// This allows for the process check to run in the core agent but is for linux only
-	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", false)
+	procBindEnvAndSetDefault(config, "process_config.run_in_core_agent.enabled", runtime.GOOS == "linux")
 
 	config.BindEnv("process_config.process_dd_url",
 		"DD_PROCESS_CONFIG_PROCESS_DD_URL",

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -68,7 +68,7 @@ func TestProcessDefaultConfig(t *testing.T) {
 		},
 		{
 			key:          "process_config.run_in_core_agent.enabled",
-			defaultValue: false,
+			defaultValue: runtime.GOOS == "linux",
 		},
 		{
 			key:          "process_config.queue_size",

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -161,10 +161,10 @@ func provideExtraFiles(fb flaretypes.FlareBuilder) error {
 		fb.AddFile("status.log", []byte("unable to get the status of the agent, is it running?"))           //nolint:errcheck
 		fb.AddFile("config-check.log", []byte("unable to get loaded checks config, is the agent running?")) //nolint:errcheck
 	} else {
-		fb.AddFileFromFunc("tagger-list.json", getAgentTaggerList)                      //nolint:errcheck
-		fb.AddFileFromFunc("workload-list.log", getAgentWorkloadList)                   //nolint:errcheck
-		fb.AddFileFromFunc("process-agent_tagger-list.json", getProcessAgentTaggerList) //nolint:errcheck
+		fb.AddFileFromFunc("tagger-list.json", getAgentTaggerList)    //nolint:errcheck
+		fb.AddFileFromFunc("workload-list.log", getAgentWorkloadList) //nolint:errcheck
 		if !pkgconfigsetup.Datadog().GetBool("process_config.run_in_core_agent.enabled") {
+			fb.AddFileFromFunc("process-agent_tagger-list.json", getProcessAgentTaggerList) //nolint:errcheck
 			getChecksFromProcessAgent(fb, getProcessAPIAddressPort)
 		}
 	}

--- a/pkg/process/metadata/workloadmeta/collector/process_test.go
+++ b/pkg/process/metadata/workloadmeta/collector/process_test.go
@@ -171,10 +171,10 @@ func TestProcessCollector(t *testing.T) {
 // the remote process collector is enabled.
 func TestEnabled(t *testing.T) {
 	type testCase struct {
-		name                                                    string
-		processCollectionEnabled, remoteProcessCollectorEnabled bool
-		expectEnabled                                           bool
-		flavor                                                  string
+		name                                                                           string
+		processCollectionEnabled, remoteProcessCollectorEnabled, runInCoreAgentEnabled bool
+		expectEnabled                                                                  bool
+		flavor                                                                         string
 	}
 
 	testCases := []testCase{
@@ -182,6 +182,7 @@ func TestEnabled(t *testing.T) {
 			name:                          "process check enabled",
 			processCollectionEnabled:      true,
 			remoteProcessCollectorEnabled: false,
+			runInCoreAgentEnabled:         false,
 			flavor:                        flavor.ProcessAgent,
 			expectEnabled:                 false,
 		},
@@ -189,6 +190,7 @@ func TestEnabled(t *testing.T) {
 			name:                          "remote collector disabled",
 			processCollectionEnabled:      false,
 			remoteProcessCollectorEnabled: false,
+			runInCoreAgentEnabled:         false,
 			flavor:                        flavor.ProcessAgent,
 			expectEnabled:                 false,
 		},
@@ -196,8 +198,17 @@ func TestEnabled(t *testing.T) {
 			name:                          "collector enabled",
 			processCollectionEnabled:      false,
 			remoteProcessCollectorEnabled: true,
+			runInCoreAgentEnabled:         false,
 			flavor:                        flavor.ProcessAgent,
 			expectEnabled:                 true,
+		},
+		{
+			name:                          "collector enabled but in core agent",
+			processCollectionEnabled:      false,
+			remoteProcessCollectorEnabled: true,
+			runInCoreAgentEnabled:         true,
+			flavor:                        flavor.ProcessAgent,
+			expectEnabled:                 false,
 		},
 	}
 
@@ -208,6 +219,7 @@ func TestEnabled(t *testing.T) {
 			cfg := configmock.New(t)
 			cfg.SetWithoutSource("process_config.process_collection.enabled", tc.processCollectionEnabled)
 			cfg.SetWithoutSource("language_detection.enabled", tc.remoteProcessCollectorEnabled)
+			cfg.SetWithoutSource("process_config.run_in_core_agent.enabled", tc.runInCoreAgentEnabled)
 
 			assert.Equal(t, tc.expectEnabled, Enabled(cfg))
 		})

--- a/releasenotes/notes/process-check-in-core-agent-default-f1006c4863990a26.yaml
+++ b/releasenotes/notes/process-check-in-core-agent-default-f1006c4863990a26.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Process checks will now run in the core agent by default on Linux. Process Agent will only run if needed for other configured features.

--- a/releasenotes/notes/process-check-in-core-agent-default-f1006c4863990a26.yaml
+++ b/releasenotes/notes/process-check-in-core-agent-default-f1006c4863990a26.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Process checks will now run in the core agent by default on Linux. Process Agent will only run if needed for other configured features.
+    Process checks now run in the core Agent by default on Linux. Process Agent will only run if needed for other configured features.

--- a/test/new-e2e/tests/agent-configuration/config-refresh/fixtures/config.yaml.tmpl
+++ b/test/new-e2e/tests/agent-configuration/config-refresh/fixtures/config.yaml.tmpl
@@ -22,6 +22,8 @@ security_agent:
   cmd_port: {{.SecurityCmdPort}}
 
 process_config:
+  run_in_core_agent:
+    enabled: false
   process_collection:
     enabled: true
   cmd_port: {{.ProcessCmdPort}}

--- a/test/new-e2e/tests/agent-runtimes/ipc/fixtures/config.yaml.tmpl
+++ b/test/new-e2e/tests/agent-runtimes/ipc/fixtures/config.yaml.tmpl
@@ -14,6 +14,8 @@ security_agent:
   cmd_port: {{.SecurityCmdPort}}
 
 process_config:
+  run_in_core_agent:
+    enabled: false
   process_collection:
     enabled: true
   cmd_port: {{.ProcessCmdPort}}

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_common_test.go
@@ -7,6 +7,7 @@
 package flare
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -40,9 +41,12 @@ func (v *baseFlareSuite) TestFlareDefaultFiles() {
 	assertLogsFolderOnlyContainsLogFile(v.T(), flare)
 	assertEtcFolderOnlyContainsConfigFile(v.T(), flare)
 
-	assertFileContains(v.T(), flare, "process_check_output.json", "'process_config.process_collection.enabled' is disabled")
-	assertFileNotContains(v.T(), flare, "container_check_output.json", "'process_config.container_collection.enabled' is disabled")
-	assertFileNotContains(v.T(), flare, "process_discovery_check_output.json", "'process_config.process_discovery.enabled' is disabled")
+	if runtime.GOOS != "linux" {
+		assertFilesExist(v.T(), flare, []string{"process-agent_tagger-list.json"})
+		assertFileContains(v.T(), flare, "process_check_output.json", "'process_config.process_collection.enabled' is disabled")
+		assertFileNotContains(v.T(), flare, "container_check_output.json", "'process_config.container_collection.enabled' is disabled")
+		assertFileNotContains(v.T(), flare, "process_discovery_check_output.json", "'process_config.process_discovery.enabled' is disabled")
+	}
 }
 
 func (v *baseFlareSuite) TestLocalFlareDefaultFiles() {
@@ -72,9 +76,12 @@ func (v *baseFlareSuite) TestFlareProfiling() {
 	assert.Contains(v.T(), logs, "Setting runtime_block_profile_rate to 5000")
 	assert.Contains(v.T(), logs, "Getting a 31s profile snapshot from core.")
 	assert.Contains(v.T(), logs, "Getting a 31s profile snapshot from security-agent.")
-	assert.Contains(v.T(), logs, "Getting a 31s profile snapshot from process.")
-
 	assertFilesExist(v.T(), flare, profilingFiles)
+
+	if runtime.GOOS != "linux" {
+		assert.Contains(v.T(), logs, "Getting a 31s profile snapshot from process.")
+		assertFilesExist(v.T(), flare, profilingNonLinuxFiles)
+	}
 }
 
 func requestAgentFlareAndFetchFromFakeIntake(v *baseFlareSuite, flareArgs ...agentclient.AgentArgsOption) (flare.Flare, string) {

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_files.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_files.go
@@ -34,7 +34,6 @@ var nonLocalMetadataFlareFiles = []string{
 }
 
 var nonLocalFlareFiles = []string{
-	"process-agent_tagger-list.json",
 	"tagger-list.json",
 	"workload-list.log",
 	"agent_open_files.txt",
@@ -94,16 +93,19 @@ var profilingFiles = []string{
 	"profiles/core-block.pprof",
 	"profiles/core-cpu.pprof",
 	"profiles/core-mutex.pprof",
-	"profiles/process-1st-heap.pprof",
-	"profiles/process-2nd-heap.pprof",
-	"profiles/process-block.pprof",
-	"profiles/process-cpu.pprof",
-	"profiles/process-mutex.pprof",
 	"profiles/trace-1st-heap.pprof",
 	"profiles/trace-2nd-heap.pprof",
 	"profiles/trace-block.pprof",
 	"profiles/trace-cpu.pprof",
 	"profiles/trace-mutex.pprof",
+}
+
+var profilingNonLinuxFiles = []string{
+	"profiles/process-1st-heap.pprof",
+	"profiles/process-2nd-heap.pprof",
+	"profiles/process-block.pprof",
+	"profiles/process-cpu.pprof",
+	"profiles/process-mutex.pprof",
 }
 
 // untestedFiles contains some untested files that needs specific scenario which should be added later.

--- a/test/new-e2e/tests/agent-subcommands/flare/flare_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/flare/flare_nix_test.go
@@ -75,10 +75,6 @@ func (v *linuxFlareSuite) TestzzzFlareWithAllConfiguration() {
 	extraCustomConfigFiles := []string{"etc/confd/dist/test.yaml", "etc/confd/dist/test.yml", "etc/confd/dist/test.yml.test", "etc/confd/checksd/test.yml"}
 	assertFilesExist(v.T(), flare, extraCustomConfigFiles)
 
-	assertFileNotContains(v.T(), flare, "process_check_output.json", "'process_config.process_collection.enabled' is disabled")
-	assertFileContains(v.T(), flare, "container_check_output.json", "'process_config.container_collection.enabled' is disabled")
-	assertFileContains(v.T(), flare, "process_discovery_check_output.json", "'process_config.process_discovery.enabled' is disabled")
-
 	filesRegistredInPermissionsLog := append(systemProbeDummyFiles, "/etc/datadog-agent/auth_token")
 	assertFileContains(v.T(), flare, "permissions.log", filesRegistredInPermissionsLog...)
 }

--- a/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_common_test.go
@@ -97,7 +97,7 @@ func fetchAndCheckStatus(v *baseStatusSuite, expectedSections []expectedSection)
 	}, 2*time.Minute, 20*time.Second)
 }
 
-func (v *baseStatusSuite) TestDefaultInstallStatus() {
+func (v *baseStatusSuite) testDefaultInstallStatus(processAgentContain, processAgentNotContain []string) {
 	expectedSections := []expectedSection{
 		{
 			name:             `Agent \(.*\)`, // TODO: verify that the right version is output
@@ -176,7 +176,8 @@ func (v *baseStatusSuite) TestDefaultInstallStatus() {
 		{
 			name:             "Process Agent",
 			shouldBePresent:  true,
-			shouldNotContain: []string{"Status: Not running or unreachable"},
+			shouldContain:    processAgentContain,
+			shouldNotContain: processAgentNotContain,
 		},
 		{
 			name:            "Remote Configuration",

--- a/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_nix_test.go
@@ -79,3 +79,7 @@ func (v *linuxStatusSuite) TestChecksMetadataUnix() {
 
 	fetchAndCheckStatus(&v.baseStatusSuite, expectedSections)
 }
+
+func (v *linuxStatusSuite) TestDefaultInstallStatus() {
+	v.testDefaultInstallStatus([]string{"Status: Not running or unreachable"}, nil)
+}

--- a/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
+++ b/test/new-e2e/tests/agent-subcommands/status/status_win_test.go
@@ -65,3 +65,7 @@ func (v *windowsStatusSuite) TestChecksMetadataWindows() {
 
 	fetchAndCheckStatus(&v.baseStatusSuite, expectedSections)
 }
+
+func (v *windowsStatusSuite) TestDefaultInstallStatus() {
+	v.testDefaultInstallStatus(nil, []string{"Status: Not running or unreachable"})
+}

--- a/test/new-e2e/tests/fips-compliance/fixtures/system-probe.yaml
+++ b/test/new-e2e/tests/fips-compliance/fixtures/system-probe.yaml
@@ -1,2 +1,4 @@
+network_config:
+  enabled: true
 runtime_security_config:
   enabled: true

--- a/test/new-e2e/tests/installer/script/default_script_test.go
+++ b/test/new-e2e/tests/installer/script/default_script_test.go
@@ -10,12 +10,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
-	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
+	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client"
 )
 
 type installScriptDefaultSuite struct {
@@ -40,6 +41,7 @@ func (s *installScriptDefaultSuite) TestInstall() {
 		"DD_SITE=datadoghq.com",
 		"DD_APM_INSTRUMENTATION_LIBRARIES=java:1,python:2,js:5,dotnet:3",
 		"DD_APM_INSTRUMENTATION_ENABLED=host",
+		"DD_NETWORK_CONFIG_ENABLED=true", // necessary to get process-agent running
 		"DD_RUNTIME_SECURITY_CONFIG_ENABLED=true",
 		"DD_SBOM_CONTAINER_IMAGE_ENABLED=true",
 		"DD_SBOM_HOST_ENABLED=true",

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -47,7 +47,7 @@ func (s *packageAgentSuite) TestInstall() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
-	s.host.WaitForUnitActive(agentUnit, traceUnit, processUnit)
+	s.host.WaitForUnitActive(agentUnit, traceUnit)
 
 	state := s.host.State()
 	s.assertUnits(state, false)
@@ -73,8 +73,8 @@ func (s *packageAgentSuite) TestInstall() {
 func (s *packageAgentSuite) assertUnits(state host.State, oldUnits bool) {
 	state.AssertUnitsLoaded(agentUnit, traceUnit, processUnit, probeUnit, securityUnit)
 	state.AssertUnitsEnabled(agentUnit)
-	state.AssertUnitsRunning(agentUnit, traceUnit, processUnit)
-	state.AssertUnitsDead(probeUnit, securityUnit)
+	state.AssertUnitsRunning(agentUnit, traceUnit)
+	state.AssertUnitsDead(probeUnit, processUnit, securityUnit)
 
 	systemdPath := "/etc/systemd/system"
 	if oldUnits {
@@ -150,11 +150,10 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
-	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
 
 	s.host.SetupFakeAgentExp().
 		SetStopWithSigtermExit0("core-agent").
-		SetStopWithSigtermExit0("process-agent").
 		SetStopWithSigtermExit0("trace-agent")
 
 	// assert timeout is already set
@@ -174,8 +173,7 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		// first stop agent dependency
 		Unordered(host.SystemdEvents().
-			Stopped(traceUnit).
-			Stopped(processUnit),
+			Stopped(traceUnit),
 		).
 		// then agent
 		Stopping(agentUnit).
@@ -184,7 +182,6 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 		// start experiment dependency
 		Unordered(host.SystemdEvents().
 			Starting(agentUnitXP).
-			Started(processUnitXP).
 			Started(traceUnitXP).
 			SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible).
 			Skipped(securityUnitXP),
@@ -194,7 +191,6 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 		Timed(agentUnitXP).
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnitXP).
-			Stopped(processUnitXP).
 			Stopped(traceUnitXP),
 		).
 
@@ -202,7 +198,6 @@ func (s *packageAgentSuite) TestExperimentTimeout() {
 		Started(agentUnit).
 		Unordered(host.SystemdEvents().
 			Started(traceUnit).
-			Started(processUnit).
 			SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible).
 			Skipped(securityUnit),
 		),
@@ -213,14 +208,13 @@ func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
-	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
 
 	s.host.SetupFakeAgentExp().
 		SetStopWithSigkill("core-agent").
-		SetStopWithSigkill("process-agent").
 		SetStopWithSigkill("trace-agent")
 
-	for _, unit := range []string{traceUnitXP, processUnitXP, agentUnitXP} {
+	for _, unit := range []string{traceUnitXP, agentUnitXP} {
 		s.T().Logf("Testing timeoutStop of unit %s", unit)
 		s.host.AssertUnitProperty(unit, "TimeoutStopUSec", "1min 30s")
 		s.host.Run(fmt.Sprintf("sudo mkdir -p /etc/systemd/system/%s.d/", unit))
@@ -241,8 +235,7 @@ func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		// first stop agent dependency
 		Unordered(host.SystemdEvents().
-			Stopped(traceUnit).
-			Stopped(processUnit),
+			Stopped(traceUnit),
 		).
 		// then agent
 		Stopping(agentUnit).
@@ -251,7 +244,6 @@ func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 		// start experiment dependency
 		Unordered(host.SystemdEvents().
 			Starting(agentUnitXP).
-			Started(processUnitXP).
 			Started(traceUnitXP).
 			SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible).
 			Skipped(securityUnitXP),
@@ -261,13 +253,10 @@ func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 		Timed(agentUnitXP).
 		Unordered(host.SystemdEvents().
 			SigtermTimed(agentUnitXP).
-			SigtermTimed(processUnitXP).
 			SigtermTimed(traceUnitXP).
 			Sigkill(agentUnitXP).
-			Sigkill(processUnitXP).
 			Sigkill(traceUnitXP).
 			Stopped(agentUnitXP).
-			Stopped(processUnitXP).
 			Stopped(traceUnitXP),
 		).
 
@@ -275,7 +264,6 @@ func (s *packageAgentSuite) TestExperimentIgnoringSigterm() {
 		Started(agentUnit).
 		Unordered(host.SystemdEvents().
 			Started(traceUnit).
-			Started(processUnit).
 			SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible).
 			Skipped(securityUnit),
 		),
@@ -286,7 +274,7 @@ func (s *packageAgentSuite) TestExperimentExits() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
-	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
 
 	xpAgent := s.host.SetupFakeAgentExp()
 
@@ -304,8 +292,7 @@ func (s *packageAgentSuite) TestExperimentExits() {
 		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 			// first stop agent dependency
 			Unordered(host.SystemdEvents().
-				Stopped(traceUnit).
-				Stopped(processUnit),
+				Stopped(traceUnit),
 			).
 			// then agent
 			Stopping(agentUnit).
@@ -314,7 +301,6 @@ func (s *packageAgentSuite) TestExperimentExits() {
 			// start experiment dependency
 			Unordered(host.SystemdEvents().
 				Starting(agentUnitXP).
-				Started(processUnitXP).
 				Started(traceUnitXP).
 				SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible).
 				Skipped(securityUnitXP),
@@ -323,7 +309,6 @@ func (s *packageAgentSuite) TestExperimentExits() {
 			// failed agent XP unit
 			Failed(agentUnitXP).
 			Unordered(host.SystemdEvents().
-				Stopped(processUnitXP).
 				Stopped(traceUnitXP),
 			).
 
@@ -331,7 +316,6 @@ func (s *packageAgentSuite) TestExperimentExits() {
 			Started(agentUnit).
 			Unordered(host.SystemdEvents().
 				Started(traceUnit).
-				Started(processUnit).
 				SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible).
 				Skipped(securityUnit),
 			),
@@ -343,7 +327,7 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
-	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
 
 	s.host.SetupFakeAgentExp()
 
@@ -355,10 +339,8 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 		// ensure experiment is running
 		s.host.WaitForUnitActive(
 			"datadog-agent-trace-exp.service",
-			"datadog-agent-process-exp.service",
 		)
 		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Started(traceUnitXP))
-		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Started(processUnitXP))
 		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().Skipped(securityUnitXP))
 		s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().SkippedIf(probeUnitXP, s.installMethod != InstallMethodAnsible))
 
@@ -370,7 +352,6 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 			// stop order
 			Unordered(host.SystemdEvents().
 				Stopped(agentUnitXP).
-				Stopped(processUnitXP).
 				Stopped(traceUnitXP),
 			).
 
@@ -378,7 +359,6 @@ func (s *packageAgentSuite) TestExperimentStopped() {
 			Started(agentUnit).
 			Unordered(host.SystemdEvents().
 				Started(traceUnit).
-				Started(processUnit).
 				SkippedIf(probeUnit, s.installMethod != InstallMethodAnsible).
 				Skipped(securityUnit),
 			),
@@ -390,7 +370,7 @@ func (s *packageAgentSuite) TestRunPath() {
 	s.RunInstallScript(envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
-	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service", "datadog-agent-process.service")
+	s.host.WaitForUnitActive("datadog-agent.service", "datadog-agent-trace.service")
 
 	var rawConfig string
 	var err error

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -73,8 +73,8 @@ func (s *packageAgentSuite) TestInstall() {
 func (s *packageAgentSuite) assertUnits(state host.State, oldUnits bool) {
 	state.AssertUnitsLoaded(agentUnit, traceUnit, processUnit, probeUnit, securityUnit)
 	state.AssertUnitsEnabled(agentUnit)
-	state.AssertUnitsRunning(agentUnit, traceUnit)
-	state.AssertUnitsDead(probeUnit, processUnit, securityUnit)
+	state.AssertUnitsRunning(agentUnit, traceUnit) //cannot assert process-agent because it may be running or dead based on timing
+	state.AssertUnitsDead(probeUnit, securityUnit)
 
 	systemdPath := "/etc/systemd/system"
 	if oldUnits {

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -115,7 +115,6 @@ func (s *upgradeScenarioSuite) TestUpgradeSuccessful() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -131,7 +130,6 @@ func (s *upgradeScenarioSuite) TestUpgradeFromExistingExperiment() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -159,7 +157,6 @@ func (s *upgradeScenarioSuite) TestBackendFailure() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -183,7 +180,6 @@ func (s *upgradeScenarioSuite) TestExperimentFailure() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -209,7 +205,6 @@ func (s *upgradeScenarioSuite) TestExperimentCurrentVersion() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -240,7 +235,6 @@ func (s *upgradeScenarioSuite) TestStopWithoutExperiment() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -260,7 +254,6 @@ func (s *upgradeScenarioSuite) TestDoubleExperiments() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -289,7 +282,6 @@ func (s *upgradeScenarioSuite) TestPromoteWithoutExperiment() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -315,7 +307,6 @@ func (s *upgradeScenarioSuite) TestInstallerSuccessful() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -331,7 +322,6 @@ func (s *upgradeScenarioSuite) TestInstallerBackendFailure() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -359,7 +349,6 @@ func (s *upgradeScenarioSuite) TestInstallerAgentFailure() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -419,7 +408,6 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeSuccessful() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -448,7 +436,6 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -491,13 +478,11 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnit).
-			Stopped(traceUnit).
-			Stopped(processUnit),
+			Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents().
 			Starting(agentUnitXP).
 			Started(traceUnitXP).
-			Started(processUnitXP).
 			Started(securityUnitXP).
 			Started(probeUnitXP),
 		),
@@ -511,14 +496,12 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnitXP).
-			Stopped(processUnitXP).
 			Stopped(traceUnitXP).
 			Stopped(securityUnitXP).
 			Stopped(probeUnitXP),
 		).
 		Unordered(host.SystemdEvents().
 			Started(agentUnit).
-			Stopped(processUnit).
 			Stopped(traceUnit).
 			Started(securityUnit).
 			Started(probeUnit),
@@ -539,7 +522,6 @@ func (s *upgradeScenarioSuite) TestUpgradeConfigFromExistingExperiment() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -575,7 +557,6 @@ func (s *upgradeScenarioSuite) TestUpgradeConfigFailure() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -594,23 +575,19 @@ func (s *upgradeScenarioSuite) TestUpgradeConfigFailure() {
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents(). // Stable stops
 						Stopped(agentUnit).
-						Stopped(processUnit).
 						Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents(). // Experiment starts
 						Starting(agentUnitXP).
-						Started(processUnitXP).
 						Started(traceUnitXP),
 		).
 		Unordered(host.SystemdEvents(). // Experiment fails
 						Failed(agentUnitXP).
-						Stopped(processUnitXP).
 						Stopped(traceUnitXP),
 		).
 		Started(agentUnit). // Stable restarts
 		Unordered(host.SystemdEvents().
-			Started(traceUnit).
-			Started(processUnit),
+			Started(traceUnit),
 		),
 	)
 
@@ -655,7 +632,6 @@ func (s *upgradeScenarioSuite) TestRemoteInstallUninstall() {
 	s.host.WaitForUnitActive(
 		"datadog-agent.service",
 		"datadog-agent-trace.service",
-		"datadog-agent-process.service",
 		"datadog-installer.service",
 	)
 	s.host.WaitForFileExists(true, "/opt/datadog-packages/run/installer.sock")
@@ -787,13 +763,11 @@ func (s *upgradeScenarioSuite) assertSuccessfulAgentStartExperiment(timestamp ho
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnit).
-			Stopped(traceUnit).
-			Stopped(processUnit),
+			Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents().
 			Starting(agentUnitXP).
-			Started(traceUnitXP).
-			Started(processUnitXP),
+			Started(traceUnitXP),
 		),
 	)
 
@@ -808,12 +782,10 @@ func (s *upgradeScenarioSuite) assertSuccessfulAgentPromoteExperiment(timestamp 
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnitXP).
-			Stopped(processUnitXP).
 			Stopped(traceUnitXP),
 		).
 		Unordered(host.SystemdEvents().
 			Started(agentUnit).
-			Stopped(processUnit).
 			Stopped(traceUnit),
 		),
 	)
@@ -828,13 +800,11 @@ func (s *upgradeScenarioSuite) assertSuccessfulAgentStopExperiment(timestamp hos
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnitXP).
-			Stopped(processUnitXP).
 			Stopped(traceUnitXP),
 		).
 		Started(agentUnit).
 		Unordered(host.SystemdEvents().
-			Started(traceUnit).
-			Started(processUnit),
+			Started(traceUnit),
 		),
 	)
 
@@ -903,13 +873,11 @@ func (s *upgradeScenarioSuite) assertSuccessfulConfigStartExperiment(timestamp h
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnit).
-			Stopped(traceUnit).
-			Stopped(processUnit),
+			Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents().
 			Starting(agentUnitXP).
-			Started(traceUnitXP).
-			Started(processUnitXP),
+			Started(traceUnitXP),
 		),
 	)
 
@@ -924,12 +892,10 @@ func (s *upgradeScenarioSuite) assertSuccessfulConfigPromoteExperiment(timestamp
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnitXP).
-			Stopped(processUnitXP).
 			Stopped(traceUnitXP),
 		).
 		Unordered(host.SystemdEvents().
 			Started(agentUnit).
-			Stopped(processUnit).
 			Stopped(traceUnit),
 		),
 	)
@@ -944,13 +910,11 @@ func (s *upgradeScenarioSuite) assertSuccessfulConfigStopExperiment(timestamp ho
 	s.host.AssertSystemdEvents(timestamp, host.SystemdEvents().
 		Unordered(host.SystemdEvents().
 			Stopped(agentUnitXP).
-			Stopped(processUnitXP).
 			Stopped(traceUnitXP),
 		).
 		Started(agentUnit).
 		Unordered(host.SystemdEvents().
-			Started(traceUnit).
-			Started(processUnit),
+			Started(traceUnit),
 		),
 	)
 

--- a/test/new-e2e/tests/language-detection/etc/process_config.yaml
+++ b/test/new-e2e/tests/language-detection/etc/process_config.yaml
@@ -1,4 +1,6 @@
 process_config:
+  run_in_core_agent:
+    enabled: false
   process_collection:
     enabled: true
   intervals:

--- a/test/new-e2e/tests/language-detection/etc/process_config_no_check.yaml
+++ b/test/new-e2e/tests/language-detection/etc/process_config_no_check.yaml
@@ -1,4 +1,6 @@
 process_config:
+  run_in_core_agent:
+    enabled: false
   process_collection:
     enabled: false
   container_collection:

--- a/test/new-e2e/tests/process/config/helm-template.tmpl
+++ b/test/new-e2e/tests/process/config/helm-template.tmpl
@@ -7,13 +7,13 @@ datadog:
   networkMonitoring:
     enabled: {{.NetworkPerformanceMonitoring}}
 
-agents: 
+agents:
   containers:
     agent:
       env:
         - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
-          value: {{.RunInCoreAgent}}
+          value: "{{.RunInCoreAgent}}"
     processAgent:
       env:
         - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
-          value: {{.RunInCoreAgent}}
+          value: "{{.RunInCoreAgent}}"

--- a/test/new-e2e/tests/process/config/process_check.yaml
+++ b/test/new-e2e/tests/process/config/process_check.yaml
@@ -5,3 +5,6 @@ process_config:
     enabled: false
   process_discovery:
     enabled: false
+
+  run_in_core_agent:
+    enabled: false

--- a/test/new-e2e/tests/process/config/process_discovery_check.yaml
+++ b/test/new-e2e/tests/process/config/process_discovery_check.yaml
@@ -5,3 +5,6 @@ process_config:
     enabled: false
   process_discovery:
     enabled: true
+
+  run_in_core_agent:
+    enabled: false

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -29,6 +29,7 @@ func TestDockerTestSuite(t *testing.T) {
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", pulumi.StringPtr("false")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", pulumi.StringPtr("false")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", pulumi.StringPtr("false")),
 
 		dockeragentparams.WithExtraComposeManifest("fakeProcess", pulumi.String(fakeProcessCompose)),
 	}
@@ -66,6 +67,7 @@ func (s *dockerTestSuite) TestProcessDiscoveryCheck() {
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("false")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED", pulumi.StringPtr("false")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_DISCOVERY_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", pulumi.StringPtr("false")),
 
 		dockeragentparams.WithExtraComposeManifest("fakeProcess", pulumi.String(fakeProcessCompose)),
 	}
@@ -92,6 +94,7 @@ func (s *dockerTestSuite) TestProcessCheckWithIO() {
 	agentOpts := []dockeragentparams.Option{
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_PROCESS_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", pulumi.StringPtr("false")),
 	}
 	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithAgentOptions(agentOpts...)))
 
@@ -120,6 +123,7 @@ func (s *dockerTestSuite) TestProcessChecksWithNPM() {
 	agentOpts := []dockeragentparams.Option{
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED", pulumi.StringPtr("false")),
 		dockeragentparams.WithExtraComposeManifest("fakeProcess", pulumi.String(fakeProcessCompose)),
 	}
 	s.UpdateEnv(awsdocker.Provisioner(awsdocker.WithAgentOptions(agentOpts...)))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Re-apply of #33434 with fixed tests

### Motivation

### Describe how you validated your changes

Additional test failures were due to now faulty assumption that `process-agent` is always running.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->