### PR TITLE
[Dynamic Instrumentation] DI proctracker should not inspect itself

### DIFF
--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -95,6 +95,11 @@ func (pt *ProcessTracker) handleProcessStop(pid uint32) {
 }
 
 func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
+	// Avoid self-inspection.
+	if int(pid) == os.Getpid() {
+		return
+	}
+
 	serviceName := getServiceName(pid)
 	if serviceName == "" {
 		// if the expected env vars are not set we don't inspect the binary

--- a/pkg/dynamicinstrumentation/proctracker/proctracker_test.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker_test.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package proctracker
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessNotAdded(t *testing.T) {
+	pt := ProcessTracker{
+		processes: make(map[pid]binaryID),
+	}
+
+	// Use the current process ID for testing
+	pid := uint32(os.Getpid())
+
+	// Simulate process start
+	pt.inspectBinary("", pid)
+
+	// Ensure the process ID is not added to pt.processes
+	pt.lock.RLock()
+	defer pt.lock.RUnlock()
+	_, exists := pt.processes[pid]
+	assert.False(t, exists, "process ID should not be added to pt.processes")
+}


### PR DESCRIPTION
### What does this PR do?

This pull request includes changes to the `pkg/dynamicinstrumentation/proctracker` package to prevent self-inspection of the process and to add a corresponding test. The most important changes include adding a check to avoid self-inspection and creating a test to ensure the process is not added to the tracker.

### Motivation

Go DI is still underdevelopment, and is currently only enabled when (1) the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable is set, and (2) there are Go applications running in the environment.

When we enable DI for another language, e.g. Python, by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED`, then Go DI will always instrument itself because of the system-probe itself.

### Describe how you validated your changes

* [`pkg/dynamicinstrumentation/proctracker/proctracker_test.go`](diffhunk://#diff-318304b7b2bef5940223bf7c75da57769eed2f49c92c4968ef131fec1e4c57aeR1-R26): Added a new test `TestProcessNotAdded` to verify that the current process ID is not added to the `processes` map in the `ProcessTracker`.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->