### PR TITLE
Add purpose tag to pass through SMP

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -100,7 +100,7 @@ single-machine-performance-regression_detector:
     - echo "${BASELINE_SHA} | ${BASELINE_IMAGE}"
     - COMPARISON_IMAGE=${SMP_ECR_URL}/${SMP_AGENT_TEAM_ID}-agent:${CI_COMMIT_SHA}-7-amd64
     - echo "${CI_COMMIT_SHA} | ${COMPARISON_IMAGE}"
-    - SMP_TAGS="ci_pipeline_id=${CI_PIPELINE_ID},ci_job_id=${CI_JOB_ID},ci_commit_branch=${CI_COMMIT_BRANCH}"
+    - SMP_TAGS="ci_pipeline_id=${CI_PIPELINE_ID},ci_job_id=${CI_JOB_ID},ci_commit_branch=${CI_COMMIT_BRANCH},purpose=agent_ci"
     - echo "Tags passed through SMP are ${SMP_TAGS}"
     - RUST_LOG="info,aws_config::profile::credentials=error"
     - RUST_LOG_DEBUG="debug,aws_config::profile::credentials=error"


### PR DESCRIPTION
### What does this PR do?

Adds the tag `purpose=agent_ci` to logs from SMP experiments.

### Motivation

Better insight into the source of any arbitrary log seen in SMP. We already have `ci_pipeline_id` and `ci_job_id`. If these are present on a log we know the job that produced the log comes from agent CI, so we dont _really need_ it. However, since we tag our nightly runs with `purpose=quality_gates` it would be nice to have more uniform tagging across the board when investigating patterns across all SMP logs.
