### PR TITLE
[Dynamic Instrumentation] Rename DI environment variable

### DIFF
--- a/cmd/system-probe/config/config_linux_test.go
+++ b/cmd/system-probe/config/config_linux_test.go
@@ -48,14 +48,14 @@ func TestNetworkProcessEventMonitoring(t *testing.T) {
 
 func TestDynamicInstrumentation(t *testing.T) {
 	mock.NewSystemProbe(t)
-	os.Setenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED", "true")
-	defer os.Unsetenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED")
+	os.Setenv("DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED", "true")
+	defer os.Unsetenv("DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED")
 
 	cfg, err := New("", "")
 	require.NoError(t, err)
 	assert.Equal(t, true, cfg.ModuleIsEnabled(DynamicInstrumentationModule))
 
-	os.Unsetenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED")
+	os.Unsetenv("DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED")
 	cfg, err = New("", "")
 	require.NoError(t, err)
 	assert.Equal(t, false, cfg.ModuleIsEnabled(DynamicInstrumentationModule))

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -176,7 +176,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "attach_kprobes_with_kprobe_events_abi"), false, "DD_ATTACH_KPROBES_WITH_KPROBE_EVENTS_ABI")
 
 	// User Tracer
-	cfg.BindEnvAndSetDefault(join(diNS, "enabled"), false, "DD_DYNAMIC_INSTRUMENTATION_ENABLED")
+	cfg.BindEnvAndSetDefault(join(diNS, "enabled"), false, "DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED")
 	cfg.BindEnvAndSetDefault(join(diNS, "offline_mode"), false, "DD_DYNAMIC_INSTRUMENTATION_OFFLINE_MODE")
 	cfg.BindEnvAndSetDefault(join(diNS, "probes_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_PROBES_FILE_PATH")
 	cfg.BindEnvAndSetDefault(join(diNS, "snapshot_output_file_path"), false, "DD_DYNAMIC_INSTRUMENTATION_SNAPSHOT_FILE_PATH")

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -198,7 +198,7 @@ func getServiceName(pid uint32) string {
 		if len(parts) == 2 && parts[0] == "DD_SERVICE" {
 			serviceName = parts[1]
 		}
-		if len(parts) == 2 && parts[0] == "DD_DYNAMIC_INSTRUMENTATION_ENABLED" {
+		if len(parts) == 2 && parts[0] == "DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED" {
 			diEnabled = parts[1] == "true"
 		}
 	}

--- a/pkg/dynamicinstrumentation/testutil/e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/e2e_test.go
@@ -57,7 +57,7 @@ func TestGoDI(t *testing.T) {
 	sampleServicePath := BuildSampleService(t)
 	cmd := exec.Command(sampleServicePath)
 	cmd.Env = []string{
-		"DD_DYNAMIC_INSTRUMENTATION_ENABLED=true",
+		"DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED=true",
 		fmt.Sprintf("DD_SERVICE=%s", serviceName),
 		"DD_DYNAMIC_INSTRUMENTATION_OFFLINE=true",
 	}

--- a/pkg/dynamicinstrumentation/testutil/sample/sample_service/sample_service.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/sample_service/sample_service.go
@@ -18,7 +18,7 @@ import (
 
 func main() {
 	tracerEnabled := os.Getenv("DD_SERVICE") != "" &&
-		os.Getenv("DD_DYNAMIC_INSTRUMENTATION_ENABLED") != "" &&
+		os.Getenv("DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED") != "" &&
 		os.Getenv("DD_DYNAMIC_INSTRUMENTATION_OFFLINE") == ""
 
 	log.Info("Starting sample process with tracerEnabled=", tracerEnabled)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This pull request updates the environment variable `DD_DYNAMIC_INSTRUMENTATION_ENABLED` to `DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED` across multiple files to ensure consistency and clarity in the codebase.

### Motivation

We have evidence that Go DI is enabled and causing performance issues in at least one environment where it is not supposed to. This might be resolved by #34495, but would occur in any environment where (1) the agent is installed, (2) a Go application is running, (3) DI is enabled for another language like Python. To solve this for now, we'll make this environment variable unique and call it `DD_DYNAMIC_INSTRUMENTATION_GO_ENABLED`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

* Updated the environment variable in `TestDynamicInstrumentation` in `cmd/system-probe/config/config_linux_test.go`.
* Modified the environment variable in `TestGoDI` in `pkg/dynamicinstrumentation/testutil/e2e_test.go`.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->