### PR TITLE
revert enabling sysprobe on sysvinit systems

### DIFF
--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -161,7 +161,6 @@ elif command -v update-rc.d >/dev/null 2>&1; then
     update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
     update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
     update-rc.d $SERVICE_NAME-security defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with update-rc.d"
-    update-rc.d $SERVICE_NAME-system-probe defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-system-probe with update-rc.d"
 else
     echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
 fi


### PR DESCRIPTION
This PR reverts one of the changes made in https://github.com/DataDog/datadog-agent/pull/34305 that added a "missing" sysprobe entry for sysvinit systems.

We don't actually support the probe on such systems because the kernels are too old. This would just lead to a warning so removing it.