### PR TITLE
Yet Another Static Quality Updates Threshold Updates 2

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,62 +1,62 @@
 # Package gates
 static_quality_gate_agent_deb_amd64:
-  max_on_wire_size: "202.62 MiB"
+  max_on_wire_size: "179.62 MiB"
   max_on_disk_size: "801.8 MiB"
 
 static_quality_gate_agent_deb_arm64:
-  max_on_wire_size: "184.51 MiB"
+  max_on_wire_size: "169.69 MiB"
   max_on_disk_size: "793.14 MiB"
 
 static_quality_gate_agent_rpm_amd64:
-  max_on_wire_size: "205.03 MiB"
+  max_on_wire_size: "181.73 MiB"
   max_on_disk_size: "801.79 MiB"
 
 static_quality_gate_agent_rpm_arm64:
-  max_on_wire_size: "186.44 MiB"
+  max_on_wire_size: "165.58 MiB"
   max_on_disk_size: "793.09 MiB"
 
 static_quality_gate_agent_suse_amd64:
-  max_on_wire_size: "205.03 MiB"
+  max_on_wire_size: "181.73 MiB"
   max_on_disk_size: "801.81 MiB"
 
 static_quality_gate_agent_suse_arm64:
-  max_on_wire_size: "186.44 MiB"
+  max_on_wire_size: "165.58 MiB"
   max_on_disk_size: "793.14 MiB"
 
 static_quality_gate_dogstatsd_deb_amd64:
-  max_on_wire_size: "19.78 MiB"
+  max_on_wire_size: "19.65 MiB"
   max_on_disk_size: "47.67 MiB"
 
 static_quality_gate_dogstatsd_deb_arm64:
-  max_on_wire_size: "18.49 MiB"
+  max_on_wire_size: "18.36 MiB"
   max_on_disk_size: "46.27 MiB"
 
 static_quality_gate_dogstatsd_rpm_amd64:
-  max_on_wire_size: "19.79 MiB"
+  max_on_wire_size: "19.65 MiB"
   max_on_disk_size: "47.67 MiB"
 
 static_quality_gate_dogstatsd_suse_amd64:
-  max_on_wire_size: "19.79 MiB"
+  max_on_wire_size: "19.65 MiB"
   max_on_disk_size: "47.67 MiB"
 
 static_quality_gate_iot_agent_deb_amd64:
-  max_on_wire_size: "24.8 MiB"
+  max_on_wire_size: "24.6 MiB"
   max_on_disk_size: "69.0 MiB"
 
 static_quality_gate_iot_agent_deb_arm64:
-  max_on_wire_size: "22.8 MiB"
+  max_on_wire_size: "22.59 MiB"
   max_on_disk_size: "66.4 MiB"
 
 static_quality_gate_iot_agent_rpm_amd64:
-  max_on_wire_size: "24.8 MiB"
+  max_on_wire_size: "24.62 MiB"
   max_on_disk_size: "69.0 MiB"
 
 static_quality_gate_iot_agent_rpm_arm64:
-  max_on_wire_size: "22.8 MiB"
+  max_on_wire_size: "22.61 MiB"
   max_on_disk_size: "66.4 MiB"
 
 static_quality_gate_iot_agent_suse_amd64:
-  max_on_wire_size: "24.8 MiB"
+  max_on_wire_size: "24.62 MiB"
   max_on_disk_size: "69.0 MiB"
 
 # Docker images gate


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates static quality gates thresholds

### Motivation

Will be done automatically very [soon](https://docs.google.com/document/d/1WVhrOQgwFj36NWgMqXw9fFRWyr0ghZll2UBR5QY2mxE/edit?pli=1&tab=t.0)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->