### PR TITLE
[incident-35594] Added delay to installer pulumi stacks

### DIFF
--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -82,6 +82,7 @@ func TestScripts(t *testing.T) {
 		flavor.Architecture = e2eos.ARM64Arch
 		flavors = append(flavors, flavor)
 	}
+	iteration := 0
 	for _, f := range flavors {
 		for _, test := range scriptTestsWithSkippedFlavors {
 			flavor := f // capture range variable for parallel tests closure
@@ -92,6 +93,9 @@ func TestScripts(t *testing.T) {
 			suite := test.t(flavor, flavor.Architecture)
 			t.Run(suite.Name(), func(t *testing.T) {
 				t.Parallel()
+
+				// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
+				time.Sleep(time.Duration(iteration) * STACK_CREATION_DELAY)
 
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
@@ -104,8 +108,7 @@ func TestScripts(t *testing.T) {
 				)
 			})
 
-			// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
-			time.Sleep(STACK_CREATION_DELAY)
+			iteration++
 		}
 	}
 }

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -94,6 +94,9 @@ func TestScripts(t *testing.T) {
 			t.Run(suite.Name(), func(t *testing.T) {
 				t.Parallel()
 
+				// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
+				time.Sleep(time.Duration(iteration) * stackCreationDelay)
+
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
 					awshost.WithoutAgent(),
@@ -104,9 +107,6 @@ func TestScripts(t *testing.T) {
 					e2e.WithStackName(suite.Name()),
 				)
 			})
-
-			// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
-			time.Sleep(stackCreationDelay)
 
 			iteration++
 		}

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 )
 
+const STACK_CREATION_DELAY = 5 * time.Second
+
 type installerScriptTests func(os e2eos.Descriptor, arch e2eos.Architecture) installerScriptSuite
 
 type installerScriptTestsWithSkippedFlavors struct {
@@ -101,6 +103,9 @@ func TestScripts(t *testing.T) {
 					e2e.WithStackName(suite.Name()),
 				)
 			})
+
+			// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
+			time.Sleep(STACK_CREATION_DELAY)
 		}
 	}
 }

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 )
 
-const STACK_CREATION_DELAY = 5 * time.Second
+const stackCreationDelay = 5 * time.Second
 
 type installerScriptTests func(os e2eos.Descriptor, arch e2eos.Architecture) installerScriptSuite
 
@@ -95,7 +95,7 @@ func TestScripts(t *testing.T) {
 				t.Parallel()
 
 				// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
-				time.Sleep(time.Duration(iteration) * STACK_CREATION_DELAY)
+				time.Sleep(time.Duration(iteration) * stackCreationDelay)
 
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 )
 
-const stackCreationDelay = 1 * time.Minute
+const stackCreationDelay = 5 * time.Second
 
 type installerScriptTests func(os e2eos.Descriptor, arch e2eos.Architecture) installerScriptSuite
 

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -94,9 +94,6 @@ func TestScripts(t *testing.T) {
 			t.Run(suite.Name(), func(t *testing.T) {
 				t.Parallel()
 
-				// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
-				time.Sleep(time.Duration(iteration) * stackCreationDelay)
-
 				opts := []awshost.ProvisionerOption{
 					awshost.WithEC2InstanceOptions(ec2.WithOSArch(flavor, flavor.Architecture)),
 					awshost.WithoutAgent(),
@@ -107,6 +104,9 @@ func TestScripts(t *testing.T) {
 					e2e.WithStackName(suite.Name()),
 				)
 			})
+
+			// INCIDENT(35594): To avoid rate limits, we need to wait between stack creation (aws imds rate limits)
+			time.Sleep(stackCreationDelay)
 
 			iteration++
 		}

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
 )
 
-const stackCreationDelay = 5 * time.Second
+const stackCreationDelay = 1 * time.Minute
 
 type installerScriptTests func(os e2eos.Descriptor, arch e2eos.Architecture) installerScriptSuite
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

INCIDENT-35594

This adds a delay between stack creation to avoid rate limits.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->