### PR TITLE
[incident 35594] Create AWS token only once on installer tests

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -792,6 +792,7 @@ new-e2e-eks-cleanup-on-failure:
 celian:
   image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
   tags: ["arch:amd64"]
+  stage: e2e
   needs: []
   before_script:
     # - !reference [.retrieve_linux_go_e2e_deps]

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -794,34 +794,34 @@ celian:
   tags: ["arch:amd64"]
   stage: e2e
   needs: []
-  before_script:
-    # - !reference [.retrieve_linux_go_e2e_deps]
-    # Setup AWS Credentials
-    - mkdir -p ~/.aws
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E profile >> ~/.aws/config || exit $?
-    - export AWS_PROFILE=agent-qa-ci
-    # Now all `aws` commands target the agent-qa profile
-    # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
-    # SSH Key retrieval for AWS
-    # - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
-    # - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
-    # # SSH Key retrieval for Azure
-    # - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
-    # - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
-    # # SSH Key retrieval for GCP
-    # - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
-    # - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
-    # # Use S3 backend
-    # - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
-    # # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
-    # # The app is called `agent-e2e-tests`
-    # - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
-    # - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
-    # - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
-    # - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
+  # before_script:
+  #   # - !reference [.retrieve_linux_go_e2e_deps]
+  #   # Setup AWS Credentials
+  #   - mkdir -p ~/.aws
+  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E profile >> ~/.aws/config || exit $?
+  #   - export AWS_PROFILE=agent-qa-ci
+  #   # Now all `aws` commands target the agent-qa profile
+  #   # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
+  #   # SSH Key retrieval for AWS
+  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
+  #   - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
+  #   # SSH Key retrieval for Azure
+  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
+  #   - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
+  #   # SSH Key retrieval for GCP
+  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
+  #   - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
+  #   # Use S3 backend
+  #   - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
+  #   # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
+  #   # The app is called `agent-e2e-tests`
+  #   - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
+  #   - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
+  #   - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
+  #   - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
   script:
     - echo Trying to assume role
-    # - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/roleoutput
+    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/roleoutput
     - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/dd.gitlabRunner_datadogAgent --external-id dd.gitlabRunner_datadogAgent --role-session-name RoleSession > /tmp/role.json
     - wc -c /tmp/role.json
     - set +e

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -11,8 +11,18 @@
     - !reference [.retrieve_linux_go_e2e_deps]
     # Setup AWS Credentials
     - mkdir -p ~/.aws
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E profile >> ~/.aws/config || exit $?
-    - export AWS_PROFILE=agent-qa-ci
+    - |
+      if [ "$E2E_FORCE_ASSUME_ROLE" = "true" ]; then
+        # INCIDENT(35594): Assume role for installer test to fetch only once credentials and avoid rate limits
+        echo Assuming ddbuild-agent-ci role
+        roleoutput="$(aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession)"
+        export AWS_ACCESS_KEY_ID="$(echo "$roleoutput" | jq -r '.Credentials.AccessKeyId')"
+        export AWS_SECRET_ACCESS_KEY="$(echo "$roleoutput" | jq -r '.Credentials.SecretAccessKey')"
+        export AWS_SESSION_TOKEN="$(echo "$roleoutput" | jq -r '.Credentials.SessionToken')"
+      else
+        $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E profile >> ~/.aws/config || exit $?
+        export AWS_PROFILE=agent-qa-ci
+      fi
     # Now all `aws` commands target the agent-qa profile
     # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
     # SSH Key retrieval for AWS
@@ -464,6 +474,7 @@ new-e2e-installer-script:
     TARGETS: ./tests/installer/script
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
+    E2E_FORCE_ASSUME_ROLE: "true"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -485,6 +496,7 @@ new-e2e-installer:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
+    E2E_FORCE_ASSUME_ROLE: "true"
 
 new-e2e-installer-windows:
   extends: .new_e2e_template
@@ -545,6 +557,7 @@ new-e2e-installer-ansible:
     TARGETS: ./tests/installer/unix
     TEAM: fleet
     FLEET_INSTALL_METHOD: "ansible"
+    E2E_FORCE_ASSUME_ROLE: "true"
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -796,8 +796,7 @@ celian:
   needs: []
   script:
     - echo Trying to assume role
-    # - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/role.json
-    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/dd.gitlabRunner_datadogAgent --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/role.json
+    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/role.json
     - wc -c /tmp/role.json
     - set +e
     - |

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -803,22 +803,22 @@ celian:
     # Now all `aws` commands target the agent-qa profile
     # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
     # SSH Key retrieval for AWS
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
-    - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
-    # SSH Key retrieval for Azure
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
-    - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
-    # SSH Key retrieval for GCP
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
-    - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
-    # Use S3 backend
-    - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
-    # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
-    # The app is called `agent-e2e-tests`
-    - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
-    - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
-    - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
-    - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
+    # - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
+    # - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
+    # # SSH Key retrieval for Azure
+    # - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
+    # - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
+    # # SSH Key retrieval for GCP
+    # - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
+    # - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
+    # # Use S3 backend
+    # - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
+    # # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
+    # # The app is called `agent-e2e-tests`
+    # - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
+    # - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
+    # - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
+    # - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
   script:
     - echo Trying to assume role
     - set +e

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -821,9 +821,10 @@ celian:
     # - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
   script:
     - echo Trying to assume role
-    - set +e
-    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/roleoutput
+    # - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/roleoutput
+    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/dd.gitlabRunner_datadogAgent --external-id dd.gitlabRunner_datadogAgent --role-session-name RoleSession > /tmp/role.json
     - wc -c /tmp/role.json
+    - set +e
     - |
       export AWS_ACCESS_KEY_ID=$(cat /tmp/role.json | jq -r '.Credentials.AccessKeyId')
       export AWS_SECRET_ACCESS_KEY=$(cat /tmp/role.json | jq -r '.Credentials.SecretAccessKey')

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -797,7 +797,7 @@ celian:
   script:
     - echo Trying to assume role
     # - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/role.json
-    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/dd.gitlabRunner_datadogAgent --external-id dd.gitlabRunner_datadogAgent --role-session-name RoleSession > /tmp/role.json
+    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/dd.gitlabRunner_datadogAgent --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/role.json
     - wc -c /tmp/role.json
     - set +e
     - |

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -796,7 +796,7 @@ celian:
   needs: []
   script:
     - echo Trying to assume role
-    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/roleoutput
+    # - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/role.json
     - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/dd.gitlabRunner_datadogAgent --external-id dd.gitlabRunner_datadogAgent --role-session-name RoleSession > /tmp/role.json
     - wc -c /tmp/role.json
     - set +e

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -794,31 +794,6 @@ celian:
   tags: ["arch:amd64"]
   stage: e2e
   needs: []
-  # before_script:
-  #   # - !reference [.retrieve_linux_go_e2e_deps]
-  #   # Setup AWS Credentials
-  #   - mkdir -p ~/.aws
-  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E profile >> ~/.aws/config || exit $?
-  #   - export AWS_PROFILE=agent-qa-ci
-  #   # Now all `aws` commands target the agent-qa profile
-  #   # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
-  #   # SSH Key retrieval for AWS
-  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
-  #   - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
-  #   # SSH Key retrieval for Azure
-  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
-  #   - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
-  #   # SSH Key retrieval for GCP
-  #   - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
-  #   - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
-  #   # Use S3 backend
-  #   - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
-  #   # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
-  #   # The app is called `agent-e2e-tests`
-  #   - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
-  #   - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
-  #   - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
-  #   - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
   script:
     - echo Trying to assume role
     - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/roleoutput
@@ -833,3 +808,30 @@ celian:
       echo "$AWS_ACCESS_KEY_ID" | wc -c
       echo "$AWS_SECRET_ACCESS_KEY" | wc -c
       echo "$AWS_SESSION_TOKEN" | wc -c
+    - set -e
+    - echo Rest of the setup
+    # Now all `aws` commands target the agent-qa profile
+    # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
+    # SSH Key retrieval for AWS
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
+    - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
+    # SSH Key retrieval for Azure
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
+    - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
+    # SSH Key retrieval for GCP
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
+    - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
+    # Use S3 backend
+    - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
+    # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
+    # The app is called `agent-e2e-tests`
+    - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
+    - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
+    - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
+    - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
+    # Setup GCP credentials. https://www.pulumi.com/registry/packages/gcp/installation-configuration/
+    # The service account is called `agent-e2e-tests`
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_GCP credentials_json > ~/gcp-credentials.json || exit $?
+    - export GOOGLE_APPLICATION_CREDENTIALS=~/gcp-credentials.json
+    # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
+    - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -12,17 +12,12 @@
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - |
-      if [ "$E2E_FORCE_ASSUME_ROLE" = "true" ]; then
-        # INCIDENT(35594): Assume role for installer test to fetch only once credentials and avoid rate limits
-        echo Assuming ddbuild-agent-ci role
-        roleoutput="$(aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession)"
-        export AWS_ACCESS_KEY_ID="$(echo "$roleoutput" | jq -r '.Credentials.AccessKeyId')"
-        export AWS_SECRET_ACCESS_KEY="$(echo "$roleoutput" | jq -r '.Credentials.SecretAccessKey')"
-        export AWS_SESSION_TOKEN="$(echo "$roleoutput" | jq -r '.Credentials.SessionToken')"
-      else
-        $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E profile >> ~/.aws/config || exit $?
-        export AWS_PROFILE=agent-qa-ci
-      fi
+      # Assume role to fetch only once credentials and avoid rate limits
+      echo Assuming ddbuild-agent-ci role
+      roleoutput="$(aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession)"
+      export AWS_ACCESS_KEY_ID="$(echo "$roleoutput" | jq -r '.Credentials.AccessKeyId')"
+      export AWS_SECRET_ACCESS_KEY="$(echo "$roleoutput" | jq -r '.Credentials.SecretAccessKey')"
+      export AWS_SESSION_TOKEN="$(echo "$roleoutput" | jq -r '.Credentials.SessionToken')"
     # Now all `aws` commands target the agent-qa profile
     # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
     # SSH Key retrieval for AWS
@@ -474,7 +469,6 @@ new-e2e-installer-script:
     TARGETS: ./tests/installer/script
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
-    E2E_FORCE_ASSUME_ROLE: "true"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -496,7 +490,6 @@ new-e2e-installer:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
-    E2E_FORCE_ASSUME_ROLE: "true"
 
 new-e2e-installer-windows:
   extends: .new_e2e_template
@@ -557,7 +550,6 @@ new-e2e-installer-ansible:
     TARGETS: ./tests/installer/unix
     TEAM: fleet
     FLEET_INSTALL_METHOD: "ansible"
-    E2E_FORCE_ASSUME_ROLE: "true"
 
 new-e2e-ndm-netflow:
   extends: .new_e2e_template
@@ -801,49 +793,3 @@ new-e2e-eks-cleanup-on-failure:
     - !reference [.except_mergequeue]
     - when: always
   allow_failure: true
-
-celian:
-  image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
-  tags: ["arch:amd64"]
-  stage: e2e
-  needs: []
-  script:
-    - echo Trying to assume role
-    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/role.json
-    - wc -c /tmp/role.json
-    - set +e
-    - |
-      export AWS_ACCESS_KEY_ID=$(cat /tmp/role.json | jq -r '.Credentials.AccessKeyId')
-      export AWS_SECRET_ACCESS_KEY=$(cat /tmp/role.json | jq -r '.Credentials.SecretAccessKey')
-      export AWS_SESSION_TOKEN=$(cat /tmp/role.json | jq -r '.Credentials.SessionToken')
-    - |
-      echo "$AWS_ACCESS_KEY_ID" | wc -c
-      echo "$AWS_SECRET_ACCESS_KEY" | wc -c
-      echo "$AWS_SESSION_TOKEN" | wc -c
-    - set -e
-    - echo Rest of the setup
-    # Now all `aws` commands target the agent-qa profile
-    # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
-    # SSH Key retrieval for AWS
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
-    - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
-    # SSH Key retrieval for Azure
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
-    - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
-    # SSH Key retrieval for GCP
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
-    - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
-    # Use S3 backend
-    - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
-    # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
-    # The app is called `agent-e2e-tests`
-    - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
-    - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
-    - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
-    - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
-    # Setup GCP credentials. https://www.pulumi.com/registry/packages/gcp/installation-configuration/
-    # The service account is called `agent-e2e-tests`
-    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_GCP credentials_json > ~/gcp-credentials.json || exit $?
-    - export GOOGLE_APPLICATION_CREDENTIALS=~/gcp-credentials.json
-    # Generate external links to CI VISIBILITY, used by artifacts:reports:annotations
-    - inv -e gitlab.generate-ci-visibility-links --output=$EXTERNAL_LINKS_PATH

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -788,3 +788,46 @@ new-e2e-eks-cleanup-on-failure:
     - !reference [.except_mergequeue]
     - when: always
   allow_failure: true
+
+celian:
+  image: registry.ddbuild.io/ci/test-infra-definitions/runner$TEST_INFRA_DEFINITIONS_BUILDIMAGES_SUFFIX:$TEST_INFRA_DEFINITIONS_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: []
+  before_script:
+    # - !reference [.retrieve_linux_go_e2e_deps]
+    # Setup AWS Credentials
+    - mkdir -p ~/.aws
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E profile >> ~/.aws/config || exit $?
+    - export AWS_PROFILE=agent-qa-ci
+    # Now all `aws` commands target the agent-qa profile
+    # TODO: ADXT-768: Create new secret with different ssh key for the different cloud providers
+    # SSH Key retrieval for AWS
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AWS_PUBLIC_KEY_PATH || exit $?
+    - touch $E2E_AWS_PRIVATE_KEY_PATH && chmod 600 $E2E_AWS_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AWS_PRIVATE_KEY_PATH || exit $?
+    # SSH Key retrieval for Azure
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_AZURE_PUBLIC_KEY_PATH || exit $?
+    - touch $E2E_AZURE_PRIVATE_KEY_PATH && chmod 600 $E2E_AZURE_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_AZURE_PRIVATE_KEY_PATH || exit $?
+    # SSH Key retrieval for GCP
+    - $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_public_key_rsa > $E2E_GCP_PUBLIC_KEY_PATH || exit $?
+    - touch $E2E_GCP_PRIVATE_KEY_PATH && chmod 600 $E2E_GCP_PRIVATE_KEY_PATH && $CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_QA_E2E ssh_key_rsa > $E2E_GCP_PRIVATE_KEY_PATH || exit $?
+    # Use S3 backend
+    - pulumi login "s3://dd-pulumi-state?region=us-east-1&awssdk=v2&profile=$AWS_PROFILE"
+    # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
+    # The app is called `agent-e2e-tests`
+    - ARM_CLIENT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE client_id) || exit $?; export ARM_CLIENT_ID
+    - ARM_CLIENT_SECRET=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE token) || exit $?; export ARM_CLIENT_SECRET
+    - ARM_TENANT_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE tenant_id) || exit $?; export ARM_TENANT_ID
+    - ARM_SUBSCRIPTION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $E2E_AZURE subscription_id) || exit $?; export ARM_SUBSCRIPTION_ID
+  script:
+    - echo Trying to assume role
+    - set +e
+    - aws sts assume-role --role-arn arn:aws:iam::669783387624:role/ddbuild-agent-ci --external-id ddbuild-agent-ci --role-session-name RoleSession > /tmp/roleoutput
+    - wc -c /tmp/role.json
+    - |
+      export AWS_ACCESS_KEY_ID=$(cat /tmp/role.json | jq -r '.Credentials.AccessKeyId')
+      export AWS_SECRET_ACCESS_KEY=$(cat /tmp/role.json | jq -r '.Credentials.SecretAccessKey')
+      export AWS_SESSION_TOKEN=$(cat /tmp/role.json | jq -r '.Credentials.SessionToken')
+    - |
+      echo "$AWS_ACCESS_KEY_ID" | wc -c
+      echo "$AWS_SECRET_ACCESS_KEY" | wc -c
+      echo "$AWS_SESSION_TOKEN" | wc -c

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -6,8 +6,10 @@
 package installscript
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
@@ -70,6 +72,32 @@ func TestScripts(t *testing.T) {
 			t.FailNow()
 		}
 	}
+
+	// We should be able to do that by calling aws sts assume-role and then registering the access key and access key id in the AWS_ACCESS_KEY*  environment variables
+	// We just need to make sure that these credentials will live long enough because they will not be refreshed automatically in the middle of the test
+	roleArn := os.Getenv("AWS_ROLE_ARN")
+	if roleArn == "" {
+		t.Log("AWS_ROLE_ARN env var is not set, this test requires it to be set to work")
+		t.FailNow()
+	}
+
+	sessionName := fmt.Sprintf("e2e-test-session-%d", time.Now().Unix())
+	assumeRoleCmd := fmt.Sprintf("aws sts assume-role --role-arn %s --role-session-name %s", roleArn, sessionName)
+	output, err := exec.Command("sh", "-c", assumeRoleCmd).Output()
+	require.NoError(t, err, "failed to assume role")
+
+	var creds struct {
+		Credentials struct {
+			AccessKeyId     string `json:"AccessKeyId"`
+			SecretAccessKey string `json:"SecretAccessKey"`
+			SessionToken    string `json:"SessionToken"`
+		} `json:"Credentials"`
+	}
+	require.NoError(t, json.Unmarshal(output, &creds), "failed to unmarshal assume role output")
+
+	os.Setenv("AWS_ACCESS_KEY_ID", creds.Credentials.AccessKeyId)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", creds.Credentials.SecretAccessKey)
+	os.Setenv("AWS_SESSION_TOKEN", creds.Credentials.SessionToken)
 
 	var flavors []e2eos.Descriptor
 	for _, flavor := range amd64Flavors {

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -6,10 +6,8 @@
 package installscript
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"testing"
@@ -66,38 +64,38 @@ func shouldSkipFlavor(flavors []e2eos.Descriptor, flavor e2eos.Descriptor) bool 
 }
 
 func TestScripts(t *testing.T) {
+	// // We should be able to do that by calling aws sts assume-role and then registering the access key and access key id in the AWS_ACCESS_KEY*  environment variables
+	// // We just need to make sure that these credentials will live long enough because they will not be refreshed automatically in the middle of the test
+	// roleArn := os.Getenv("AWS_ROLE_ARN")
+	// if roleArn == "" {
+	// 	t.Log("AWS_ROLE_ARN env var is not set, this test requires it to be set to work")
+	// 	t.FailNow()
+	// }
+
+	// sessionName := fmt.Sprintf("e2e-test-session-%d", time.Now().Unix())
+	// assumeRoleCmd := fmt.Sprintf("aws sts assume-role --role-arn %s --role-session-name %s", roleArn, sessionName)
+	// output, err := exec.Command("sh", "-c", assumeRoleCmd).Output()
+	// require.NoError(t, err, "failed to assume role")
+
+	// var creds struct {
+	// 	Credentials struct {
+	// 		AccessKeyId     string `json:"AccessKeyId"`
+	// 		SecretAccessKey string `json:"SecretAccessKey"`
+	// 		SessionToken    string `json:"SessionToken"`
+	// 	} `json:"Credentials"`
+	// }
+	// require.NoError(t, json.Unmarshal(output, &creds), "failed to unmarshal assume role output")
+
+	// os.Setenv("AWS_ACCESS_KEY_ID", creds.Credentials.AccessKeyId)
+	// os.Setenv("AWS_SECRET_ACCESS_KEY", creds.Credentials.SecretAccessKey)
+	// os.Setenv("AWS_SESSION_TOKEN", creds.Credentials.SessionToken)
+
 	if _, ok := os.LookupEnv("E2E_PIPELINE_ID"); !ok {
 		if _, ok := os.LookupEnv("CI_COMMIT_SHA"); !ok {
 			t.Log("CI_COMMIT_SHA & E2E_PIPELINE_ID env var are not set, this test requires one of these two variables to be set to work")
 			t.FailNow()
 		}
 	}
-
-	// We should be able to do that by calling aws sts assume-role and then registering the access key and access key id in the AWS_ACCESS_KEY*  environment variables
-	// We just need to make sure that these credentials will live long enough because they will not be refreshed automatically in the middle of the test
-	roleArn := os.Getenv("AWS_ROLE_ARN")
-	if roleArn == "" {
-		t.Log("AWS_ROLE_ARN env var is not set, this test requires it to be set to work")
-		t.FailNow()
-	}
-
-	sessionName := fmt.Sprintf("e2e-test-session-%d", time.Now().Unix())
-	assumeRoleCmd := fmt.Sprintf("aws sts assume-role --role-arn %s --role-session-name %s", roleArn, sessionName)
-	output, err := exec.Command("sh", "-c", assumeRoleCmd).Output()
-	require.NoError(t, err, "failed to assume role")
-
-	var creds struct {
-		Credentials struct {
-			AccessKeyId     string `json:"AccessKeyId"`
-			SecretAccessKey string `json:"SecretAccessKey"`
-			SessionToken    string `json:"SessionToken"`
-		} `json:"Credentials"`
-	}
-	require.NoError(t, json.Unmarshal(output, &creds), "failed to unmarshal assume role output")
-
-	os.Setenv("AWS_ACCESS_KEY_ID", creds.Credentials.AccessKeyId)
-	os.Setenv("AWS_SECRET_ACCESS_KEY", creds.Credentials.SecretAccessKey)
-	os.Setenv("AWS_SESSION_TOKEN", creds.Credentials.SessionToken)
 
 	var flavors []e2eos.Descriptor
 	for _, flavor := range amd64Flavors {

--- a/test/new-e2e/tests/installer/script/all_scripts_test.go
+++ b/test/new-e2e/tests/installer/script/all_scripts_test.go
@@ -64,32 +64,6 @@ func shouldSkipFlavor(flavors []e2eos.Descriptor, flavor e2eos.Descriptor) bool 
 }
 
 func TestScripts(t *testing.T) {
-	// // We should be able to do that by calling aws sts assume-role and then registering the access key and access key id in the AWS_ACCESS_KEY*  environment variables
-	// // We just need to make sure that these credentials will live long enough because they will not be refreshed automatically in the middle of the test
-	// roleArn := os.Getenv("AWS_ROLE_ARN")
-	// if roleArn == "" {
-	// 	t.Log("AWS_ROLE_ARN env var is not set, this test requires it to be set to work")
-	// 	t.FailNow()
-	// }
-
-	// sessionName := fmt.Sprintf("e2e-test-session-%d", time.Now().Unix())
-	// assumeRoleCmd := fmt.Sprintf("aws sts assume-role --role-arn %s --role-session-name %s", roleArn, sessionName)
-	// output, err := exec.Command("sh", "-c", assumeRoleCmd).Output()
-	// require.NoError(t, err, "failed to assume role")
-
-	// var creds struct {
-	// 	Credentials struct {
-	// 		AccessKeyId     string `json:"AccessKeyId"`
-	// 		SecretAccessKey string `json:"SecretAccessKey"`
-	// 		SessionToken    string `json:"SessionToken"`
-	// 	} `json:"Credentials"`
-	// }
-	// require.NoError(t, json.Unmarshal(output, &creds), "failed to unmarshal assume role output")
-
-	// os.Setenv("AWS_ACCESS_KEY_ID", creds.Credentials.AccessKeyId)
-	// os.Setenv("AWS_SECRET_ACCESS_KEY", creds.Credentials.SecretAccessKey)
-	// os.Setenv("AWS_SESSION_TOKEN", creds.Credentials.SessionToken)
-
 	if _, ok := os.LookupEnv("E2E_PIPELINE_ID"); !ok {
 		if _, ok := os.LookupEnv("CI_COMMIT_SHA"); !ok {
 			t.Log("CI_COMMIT_SHA & E2E_PIPELINE_ID env var are not set, this test requires one of these two variables to be set to work")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

INCIDENT 35594

Creates the AWS token once and pass it to stacks to avoid rate limits

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->