### PR TITLE
inv tidy: comment out godebug lines before running the tidy operation on go 1.24

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -321,7 +321,6 @@ def tidy_all(ctx):
 @contextmanager
 def comment_out_godebug(ctx):
     go_version_output = ctx.run('go version')
-    # result is like "go version go1.23.6 linux/amd64"
     running_go_version = go_version_output.stdout.split(' ')[2]
     should_comment_out = running_go_version.startswith("go1.24")
 


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We now have some godebug statements in the main go.mod that are not all supported by go 1.24. To allow uses to tidy with recent go versions we comment out those lines before running the tidy and uncomment them after.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->