### PR TITLE
[OTAGENT-313] move otel-agent cfgs to its own subcmd under config

### DIFF
--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -231,7 +231,7 @@ func getConfigValue(_ log.Component, config config.Component, cliParams *cliPara
 
 func otelAgentCfg(_ log.Component, config config.Component, cliParams *cliParams) error {
 	if !config.GetBool("otelcollector.enabled") {
-		return errors.New("otel-agent is not present")
+		return errors.New("otel-agent is not enabled")
 	}
 	if !config.GetBool("otelcollector.converter.enabled") {
 		return errors.New("otel-agent converter must be enabled to get otel-agent's runtime configs")

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -103,7 +103,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 
 	otelCmd := &cobra.Command{
 		Use:   "otel-agent",
-		Short: "Otel-agnet, prints out the read-only runtime configs of otel-agent if otel-agent is present and converted is enabled",
+		Short: "Otel-agent, prints out the read-only runtime configs of otel-agent if otel-agent is present and converted is enabled",
 		Long:  ``,
 		RunE:  oneShotRunE(otelAgentCfg),
 	}

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -103,7 +103,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 
 	otelCmd := &cobra.Command{
 		Use:   "otel-agent",
-		Short: "Otel-agent, prints out the read-only runtime configs of otel-agent if otel-agent is present and converted is enabled",
+		Short: "Otel-agent, prints out the read-only runtime configs of otel-agent if otel-agent is present and converter is enabled",
 		Long:  ``,
 		RunE:  oneShotRunE(otelAgentCfg),
 	}

--- a/pkg/cli/subcommands/config/command.go
+++ b/pkg/cli/subcommands/config/command.go
@@ -8,9 +8,8 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"net/http"
-	"strings"
 
 	"go.uber.org/fx"
 
@@ -102,6 +101,14 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 	cmd.AddCommand(getCmd)
 	getCmd.Flags().BoolVarP(&cliParams.source, "source", "s", false, "print every source and its value")
 
+	otelCmd := &cobra.Command{
+		Use:   "otel-agent",
+		Short: "Otel-agnet, prints out the read-only runtime configs of otel-agent if otel-agent is present and converted is enabled",
+		Long:  ``,
+		RunE:  oneShotRunE(otelAgentCfg),
+	}
+	cmd.AddCommand(otelCmd)
+
 	return cmd
 }
 
@@ -121,46 +128,9 @@ func showRuntimeConfiguration(_ log.Component, config config.Component, cliParam
 		return err
 	}
 
-	if config.GetBool("otelcollector.enabled") && config.GetBool("otelcollector.converter.enabled") {
-		runtimeConfig, err = insertOTelCollectorConfig(config.GetString("otelcollector.extension_url"), runtimeConfig, c.HTTPClient())
-		if err != nil {
-			return err
-		}
-	}
-
 	fmt.Println(runtimeConfig)
 
 	return nil
-}
-
-func insertOTelCollectorConfig(extensionURL string, runtimeConfig string, httpClient *http.Client) (string, error) {
-	resp, err := util.DoGet(httpClient, extensionURL, util.CloseConnection)
-	if err != nil {
-		return runtimeConfig, err
-	}
-	var extensionResp ddflareextensiontypes.Response
-	if err = json.Unmarshal(resp, &extensionResp); err != nil {
-		return runtimeConfig, err
-	}
-	otelRuntimeCfg := extensionResp.RuntimeConfig
-	var sb strings.Builder
-	for _, cfg := range strings.Split(runtimeConfig, "\n") {
-		sb.WriteString(cfg)
-		sb.WriteString("\n")
-		if cfg == "otelcollector:" {
-			sb.WriteString("  config:")
-			sb.WriteString("\n")
-			for _, otcfg := range strings.Split(otelRuntimeCfg, "\n") {
-				if otcfg == "" {
-					continue
-				}
-				sb.WriteString("    ")
-				sb.WriteString(otcfg)
-				sb.WriteString("\n")
-			}
-		}
-	}
-	return sb.String(), nil
 }
 
 func listRuntimeConfigurableValue(_ log.Component, config config.Component, cliParams *cliParams) error {
@@ -256,5 +226,35 @@ func getConfigValue(_ log.Component, config config.Component, cliParams *cliPara
 		}
 	}
 
+	return nil
+}
+
+func otelAgentCfg(_ log.Component, config config.Component, cliParams *cliParams) error {
+	if !config.GetBool("otelcollector.enabled") {
+		return errors.New("otel-agent is not present")
+	}
+	if !config.GetBool("otelcollector.converter.enabled") {
+		return errors.New("otel-agent converter must be enabled to get otel-agent's runtime configs")
+	}
+
+	err := util.SetAuthToken(config)
+	if err != nil {
+		return err
+	}
+
+	c, err := cliParams.GlobalParams.SettingsClient()
+	if err != nil {
+		return err
+	}
+
+	resp, err := util.DoGet(c.HTTPClient(), config.GetString("otelcollector.extension_url"), util.CloseConnection)
+	if err != nil {
+		return err
+	}
+	var extensionResp ddflareextensiontypes.Response
+	if err = json.Unmarshal(resp, &extensionResp); err != nil {
+		return err
+	}
+	fmt.Println(extensionResp.RuntimeConfig)
 	return nil
 }

--- a/test/new-e2e/tests/otel/otel-agent/minimal_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/minimal_test.go
@@ -102,51 +102,51 @@ func (s *minimalTestSuite) TestOTelAgentStatus() {
 }
 
 func (s *minimalTestSuite) TestCoreAgentConfigCmd() {
-	const expectedCfg = `    service:
-      extensions:
-      - pprof/dd-autoconfigured
-      - zpages/dd-autoconfigured
-      - health_check/dd-autoconfigured
-      - ddflare/dd-autoconfigured
-      pipelines:
-        logs:
-          exporters:
-          - datadog
-          processors:
-          - batch
-          - infraattributes/dd-autoconfigured
-          receivers:
-          - otlp
-        metrics:
-          exporters:
-          - datadog
-          processors:
-          - batch
-          - infraattributes/dd-autoconfigured
-          receivers:
-          - otlp
-          - datadog/connector
-        metrics/dd-autoconfigured/datadog:
-          exporters:
-          - datadog
-          processors: []
-          receivers:
-          - prometheus/dd-autoconfigured
-        traces:
-          exporters:
-          - datadog/connector
-          processors:
-          - batch
-          - infraattributes/dd-autoconfigured
-          receivers:
-          - otlp
-        traces/send:
-          exporters:
-          - datadog
-          processors:
-          - batch
-          - infraattributes/dd-autoconfigured
-          receivers:
-          - otlp`
+	const expectedCfg = `service:
+  extensions:
+  - pprof/dd-autoconfigured
+  - zpages/dd-autoconfigured
+  - health_check/dd-autoconfigured
+  - ddflare/dd-autoconfigured
+  pipelines:
+    logs:
+      exporters:
+      - datadog
+      processors:
+      - batch
+      - infraattributes/dd-autoconfigured
+      receivers:
+      - otlp
+    metrics:
+      exporters:
+      - datadog
+      processors:
+      - batch
+      - infraattributes/dd-autoconfigured
+      receivers:
+      - otlp
+      - datadog/connector
+    metrics/dd-autoconfigured/datadog:
+      exporters:
+      - datadog
+      processors: []
+      receivers:
+      - prometheus/dd-autoconfigured
+    traces:
+      exporters:
+      - datadog/connector
+      processors:
+      - batch
+      - infraattributes/dd-autoconfigured
+      receivers:
+      - otlp
+    traces/send:
+      exporters:
+      - datadog
+      processors:
+      - batch
+      - infraattributes/dd-autoconfigured
+      receivers:
+      - otlp`
 	utils.TestCoreAgentConfigCmd(s, expectedCfg)
 }

--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -274,11 +274,11 @@ func TestCoreAgentConfigCmd(s OTelTestSuite, expectedCfg string) {
 	require.NoError(s.T(), err)
 	agent := getAgentPod(s)
 
-	s.T().Log("Calling config command in core agent")
-	stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agent.Name, "agent", []string{"agent", "config"})
+	s.T().Log("Calling 'config otel-agent' command in core agent")
+	stdout, stderr, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agent.Name, "agent", []string{"agent", "config", "otel-agent"})
 	require.NoError(s.T(), err, "Failed to execute config")
 	require.Empty(s.T(), stderr)
 	require.NotNil(s.T(), stdout)
-	s.T().Log("Full output of config command in core agent\n", stdout)
+	s.T().Log("Full output of 'config otel-agent' command in core agent\n", stdout)
 	assert.Contains(s.T(), stdout, expectedCfg)
 }


### PR DESCRIPTION
### What does this PR do?
Move otel-agent's runtime configs from `agent config` to `agent config otel-agent`

### Motivation
Avoid mixing otel-agent configs with core agent configs. Also make sure `agent config` has no error when failing to get otel-agent's configs.

### Describe how you validated your changes
otel-agent e2e test