### PR TITLE
Reduce the memory limit for `quality_gate_idle_all_features`

### DIFF
--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "680.0 MiB"
+      upper_bound: "675.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
### What does this PR do?

This commit updates our Quality Gate limits, capturing improvements observed from the 2025-02-26 and 2025-02-27 runs.