### PR TITLE
[podman] Use sqlite3 driver

### DIFF
--- a/pkg/util/podman/sqlite_db_client.go
+++ b/pkg/util/podman/sqlite_db_client.go
@@ -59,7 +59,7 @@ func NewSQLDBClient(dbPath string) *SQLDBClient {
 // Note: original function comes from https://github.com/containers/podman/blob/e71ec6f1d94d2d97fb3afe08aae0d8adaf8bddf0/libpod/sqlite_state.go#L57-L96
 // It was adapted as we don't need to write any information to the DB.
 func (client *SQLDBClient) getDBCon() (*sql.DB, error) {
-	conn, err := sql.Open("sqlite", filepath.Join(client.DBPath, sqliteOptions))
+	conn, err := sql.Open("sqlite3", filepath.Join(client.DBPath, sqliteOptions))
 	if err != nil {
 		return nil, fmt.Errorf("opening sqlite database: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

Changes the driver used by Podman from "sqlite" to "sqlite3".
Upstream uses "sqlite3". I should have changed this in my previous PR https://github.com/DataDog/datadog-agent/pull/34358 but forgot.
This was working because Trivy registers "sqlite".

### Describe how you validated your changes
Same as https://github.com/DataDog/datadog-agent/pull/34358