### PR TITLE
Bump version of `github.com/docker/distribution`

### DIFF
--- a/pkg/trace/go.mod
+++ b/pkg/trace/go.mod
@@ -6,9 +6,6 @@ go 1.23.0
 // See https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md
 // for more details.
 
-// Internal deps fix version
-replace github.com/docker/distribution => github.com/docker/distribution v2.8.1+incompatible
-
 require (
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.61.0
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.61.0


### PR DESCRIPTION
### What does this PR do?

Bumps `github.com/docker/distribution` from `v2.8.1+incompatible` to `v2.8.3+incompatible`.

### Motivation

* Fix DataDog/image-vuln-scans#976

### Describe how you validated your changes

```console
$ docker run --rm aquasec/trivy image --scanners vuln docker.io/datadog/agent-dev:lenaic-cve-2023-2253-py3
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->