### PR TITLE
pkg/ebpf: split amd64 and arm64 embed files and remove `copy_bundled_ebpf_files`

### DIFF
--- a/pkg/ebpf/bytecode/asset_reader_bindata.go
+++ b/pkg/ebpf/bytecode/asset_reader_bindata.go
@@ -9,25 +9,26 @@ package bytecode
 
 import (
 	"bytes"
-	"embed"
+	"errors"
 	"io"
 	"path"
+	"runtime"
 )
-
-// Note that these files are placed in the build directory by the tasks/system_probe.py:copy_bundled_ebpf_files
-// function, called by the tasks that build the object files. This function copies those files from the
-// architecture-specific build directory as we cannot use variables in these directives
-
-//go:embed build/runtime-security.o
-//go:embed build/runtime-security-syscall-wrapper.o
-//go:embed build/runtime-security-fentry.o
-//go:embed build/runtime-security-offset-guesser.o
-var bindata embed.FS
 
 // GetReader returns a new AssetReader for the specified bundled asset
 func GetReader(dir, name string) (AssetReader, error) {
 	dir = "build"
-	assetPath := path.Join(dir, name)
+	var arch string
+	switch runtime.GOARCH {
+	case "amd64":
+		arch = "x86_64"
+	case "arm64":
+		arch = "arm64"
+	default:
+		return nil, errors.New("unsupported architecture")
+	}
+
+	assetPath := path.Join(dir, arch, name)
 
 	content, err := bindata.ReadFile(assetPath)
 	if err != nil {

--- a/pkg/ebpf/bytecode/asset_reader_bindata_amd64.go
+++ b/pkg/ebpf/bytecode/asset_reader_bindata_amd64.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build ebpf_bindata && amd64
+
+package bytecode
+
+import (
+	"embed"
+)
+
+//go:embed build/x86_64/runtime-security.o
+//go:embed build/x86_64/runtime-security-syscall-wrapper.o
+//go:embed build/x86_64/runtime-security-fentry.o
+//go:embed build/x86_64/runtime-security-offset-guesser.o
+var bindata embed.FS

--- a/pkg/ebpf/bytecode/asset_reader_bindata_arm64.go
+++ b/pkg/ebpf/bytecode/asset_reader_bindata_arm64.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build ebpf_bindata && arm64
+
+package bytecode
+
+import (
+	"embed"
+)
+
+//go:embed build/arm64/runtime-security.o
+//go:embed build/arm64/runtime-security-syscall-wrapper.o
+//go:embed build/arm64/runtime-security-fentry.o
+//go:embed build/arm64/runtime-security-offset-guesser.o
+var bindata embed.FS

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1527,9 +1527,6 @@ def build_object_files(
         ebpf_compiler=ebpf_compiler,
     )
 
-    if bundle_ebpf:
-        copy_bundled_ebpf_files(ctx, arch=arch)
-
     validate_object_file_metadata(ctx, build_dir, verbose=False)
 
     if not is_windows:
@@ -1566,22 +1563,6 @@ def build_object_files(
                 ctx.run(f"{sudo} find ./ -maxdepth 1 -type f -name '*.c' {cp_cmd('runtime')}")
 
 
-def copy_bundled_ebpf_files(
-    ctx,
-    arch: str | Arch = CURRENT_ARCH,
-):
-    # If we're bundling eBPF files, we need to copy the ebpf files to the right location,
-    # as we cannot use the go:embed directive with variables that depend on the build architecture
-    arch = Arch.from_str(arch)
-    ebpf_build_dir = get_ebpf_build_dir(arch)
-
-    # Parse the files to copy from the go:embed directive, to avoid having duplicate places
-    # where the files are listed
-    ctx.run(
-        f"grep -E '^//go:embed' pkg/ebpf/bytecode/asset_reader_bindata.go | sed -E 's#//go:embed build/##' | xargs -I@ cp -v {ebpf_build_dir}/@ pkg/ebpf/bytecode/build/"
-    )
-
-
 def build_cws_object_files(
     ctx,
     major_version='7',
@@ -1603,9 +1584,6 @@ def build_cws_object_files(
         with_unit_test=with_unit_test,
         ebpf_compiler=ebpf_compiler,
     )
-
-    if bundle_ebpf:
-        copy_bundled_ebpf_files(ctx, arch=arch)
 
 
 def clean_object_files(ctx, major_version='7', kernel_release=None, debug=False, strip_object_files=False):


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR splits the go:embed files used for ebpf bindata to one per architecture, removing the need for `copy_bundled_ebpf_files`. This should hopefully make it clearer where those files are and prevent issues in the future.

### Motivation

### Describe how you validated your changes
Only affects ebpf_bindata which is not the distributed version, so no impact.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->