### PR TITLE
[SVLS] Fix serverless integration tests - updates QEMU

### DIFF
--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -48,9 +48,9 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
+          image: tonistiigi/binfmt:qemu-v9.2.2-52 #v3.6.0 latest
           platforms: amd64,arm64
 
       - name: Set up Docker Buildx

--- a/pkg/aggregator/demultiplexer_serverless.go
+++ b/pkg/aggregator/demultiplexer_serverless.go
@@ -50,7 +50,7 @@ func InitAndStartServerlessDemultiplexer(keysPerDomain map[string][]string, forw
 	forwarder := forwarder.NewSyncForwarder(pkgconfigsetup.Datadog(), logger, keysPerDomain, forwarderTimeout)
 	h, _ := hostname.Get(context.Background())
 	config := pkgconfigsetup.Datadog()
-	config.SetWithoutSource("serializer_compressor_kind", "gzip")
+	config.SetWithoutSource("serializer_compressor_kind", "none")
 	serializer := serializer.NewSerializer(forwarder, nil, selector.FromConfig(config), pkgconfigsetup.Datadog(), logger, h)
 	metricSamplePool := metrics.NewMetricSamplePool(MetricSamplePoolBatchSize, utils.IsTelemetryEnabled(pkgconfigsetup.Datadog()))
 	tagsStore := tags.NewStore(pkgconfigsetup.Datadog().GetBool("aggregator_use_tags_store"), "timesampler")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This updates QEMU to the latest release. Previously, the Ubuntu runner update caused an issue with QEMU where we were receiving a gcc segmentation fault and test were failing, leading to blocked builds. Updating to the newest version fixes the build failure.

It also reverts a change which was hidden by this failure, where gzip compression breaks distribution metrics in the serverless context

https://github.com/docker/setup-qemu-action/releases/tag/v3.6.0

### Motivation
Failed builds and https://github.com/actions/runner-images/issues/11662#issuecomment-2688922107
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->