### PR TITLE
APM: add docs for apm_config.receiver_timeout

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1483,6 +1483,17 @@ api_key:
   #
   # trace_buffer: 0
 
+  ## @param receiver_timeout - integer - optional - default: 5
+  ## @env DD_APM_RECEIVER_TIMEOUT - integer - optional - default: 5
+  ##
+  ## WARNING: This config should generally not be changed unless directed to by Datadog Support for debugging purposes.
+  ## Issues that may present as timeouts are frequently due to resource constraints and increasing this value is unlikely
+  ## to help.
+  ##
+  ## Specifies the timeout in number of seconds for trace-agent endpoints.
+  #
+  # receiver_timeout: 5
+
   ## @param probabilistic_sampler - object - optional
   ## Enables and configures the Probabilistic Sampler, compatible with the
   ## OTel Probabilistic Sampler Processor ( https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/probabilisticsamplerprocessor#probabilistic-sampling-processor )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Just adds docs in the config template for receiver_timeout.
In VERY rare circumstances adjusting this value can help out certain customer setups, however there is a strong warning included that adjusting this value generally won't "just help" with connection issues.

### Motivation
We had a customer who found this value and successfully used it to avoid their issue however this parameter was undocumented. While most (read: 99.99%) of customers should never need to adjust this, having docs is still nice for that rare case :)

### Describe how you validated your changes
N/A - no behavior change here
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
Some customers may ignore this warning, adjust this value and make an issue they're having worse. This is unlikely, and in that case customers should be in contact with support (and can just revert to the default)

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->