### PR TITLE
[CWS] simplify signature of `GetFamilyAddress`

### DIFF
--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -188,7 +188,7 @@ func NewRuntimeSecurityClient() (*RuntimeSecurityClient, error) {
 		return nil, errors.New("runtime_security_config.socket must be set")
 	}
 
-	family, _ := config.GetFamilyAddress(socketPath)
+	family := config.GetFamilyAddress(socketPath)
 	if runtime.GOOS == "windows" && family == "unix" {
 		return nil, fmt.Errorf("unix sockets are not supported on Windows")
 	}

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -647,9 +647,9 @@ func parseHashAlgorithmStringSlice(algorithms []string) []model.HashAlgorithm {
 }
 
 // GetFamilyAddress returns the address famility to use for system-probe <-> security-agent communication
-func GetFamilyAddress(path string) (string, string) {
+func GetFamilyAddress(path string) string {
 	if strings.HasPrefix(path, "/") {
-		return "unix", path
+		return "unix"
 	}
-	return "tcp", path
+	return "tcp"
 }

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -83,7 +83,7 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		}
 	}
 
-	family, address := config.GetFamilyAddress(cfg.SocketPath)
+	family := config.GetFamilyAddress(cfg.SocketPath)
 
 	apiServer, err := NewAPIServer(cfg, evm.Probe, opts.MsgSender, evm.StatsdClient, selfTester, compression)
 	if err != nil {
@@ -102,7 +102,7 @@ func NewCWSConsumer(evm *eventmonitor.EventMonitor, cfg *config.RuntimeSecurityC
 		apiServer:     apiServer,
 		rateLimiter:   events.NewRateLimiter(cfg, evm.StatsdClient),
 		sendStatsChan: make(chan chan bool, 1),
-		grpcServer:    NewGRPCServer(family, address),
+		grpcServer:    NewGRPCServer(family, cfg.SocketPath),
 		selfTester:    selfTester,
 		selfTestRetry: atomic.NewInt32(0),
 		reloader:      NewReloader(),

--- a/pkg/security/probe/probe_ebpfless.go
+++ b/pkg/security/probe/probe_ebpfless.go
@@ -515,10 +515,7 @@ func (p *EBPFLessProbe) handleNewClient(conn net.Conn, ch chan clientMsg) {
 
 // Start the probe
 func (p *EBPFLessProbe) Start() error {
-	family, address := config.GetFamilyAddress(p.config.RuntimeSecurity.EBPFLessSocket)
-	_ = family
-
-	tcpAddr, err := net.ResolveTCPAddr("tcp4", address)
+	tcpAddr, err := net.ResolveTCPAddr("tcp4", p.config.RuntimeSecurity.EBPFLessSocket)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

In preparation for https://github.com/DataDog/datadog-agent/pull/34596, this PR cleans up the  `GetFamilyAddress` function, removing the returned address (since it's the input but unchanged) and cleans up the different users.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->