### PR TITLE
[CWS] optimized mount resolver storage

### DIFF
--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -476,7 +476,7 @@ func TestMountResolver(t *testing.T) {
 
 func TestMountGetParentPath(t *testing.T) {
 	mr := &Resolver{
-		mounts: map[uint32]*model.Mount{
+		mounts: newMountStorageFromMap(mountStorageSplit, map[uint32]*model.Mount{
 			1: {
 				MountID:       1,
 				MountPointStr: "/",
@@ -502,7 +502,7 @@ func TestMountGetParentPath(t *testing.T) {
 				},
 				MountPointStr: "/c",
 			},
-		},
+		}),
 	}
 
 	parentPath, _, _, err := mr.getMountPath(4, 44, 1)
@@ -512,7 +512,7 @@ func TestMountGetParentPath(t *testing.T) {
 
 func TestMountLoop(t *testing.T) {
 	mr := &Resolver{
-		mounts: map[uint32]*model.Mount{
+		mounts: newMountStorageFromMap(mountStorageSplit, map[uint32]*model.Mount{
 			1: {
 				MountID:       1,
 				MountPointStr: "/",
@@ -538,7 +538,7 @@ func TestMountLoop(t *testing.T) {
 				},
 				MountPointStr: "/c",
 			},
-		},
+		}),
 	}
 
 	parentPath, _, _, err := mr.getMountPath(3, 44, 1)
@@ -548,22 +548,22 @@ func TestMountLoop(t *testing.T) {
 
 func BenchmarkGetParentPath(b *testing.B) {
 	mr := &Resolver{
-		mounts: make(map[uint32]*model.Mount),
+		mounts: newMountStorage(mountStorageSplit),
 	}
 
-	mr.mounts[1] = &model.Mount{
+	mr.mounts.insert(&model.Mount{
 		MountID:       1,
 		MountPointStr: "/",
-	}
+	})
 
 	for i := uint32(1); i != 100; i++ {
-		mr.mounts[i+1] = &model.Mount{
+		mr.mounts.insert(&model.Mount{
 			MountID: i + 1,
 			ParentPathKey: model.PathKey{
 				MountID: i,
 			},
 			MountPointStr: fmt.Sprintf("/%d", i+1),
-		}
+		})
 	}
 
 	b.ResetTimer()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR splits the storage for mount resolvers between an array for low integer MountIDs and a map for the rest. The goal of this is to help iteration and deletion by reducing the amount of map operations when most of mount IDs are actually fairly low

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->