### PR TITLE
trivy: improve `filepath.Rel` call when root is `/` in walker

### DIFF
--- a/pkg/util/trivy/walker.go
+++ b/pkg/util/trivy/walker.go
@@ -78,7 +78,11 @@ func (w *FSWalker) WalkDirFunc(root string, fn walker.WalkFunc, opt walker.Optio
 		}
 
 		if !strings.HasPrefix(filePath, "/") {
-			filePath = root + "/" + filePath
+			if strings.HasSuffix(root, "/") {
+				filePath = root + filePath
+			} else {
+				filePath = root + "/" + filePath
+			}
 		}
 
 		relPath, err := filepath.Rel(root, filePath)


### PR DESCRIPTION
### What does this PR do?

When `root = /, filepath = a/b/c`, the current code transforms filepath into `//a/b/c` which needs a call to clean to before being able to compute the relativity in `filepath.Rel`. This PR fixes this by transforming filepath into `/a/b/c` ahead of time skipping most allocations.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->