### PR TITLE
`admission.datadoghq.com/%s-lib.config.v1` supports `DD_VERSION`

### DIFF
--- a/pkg/clusteragent/admission/common/lib_config.go
+++ b/pkg/clusteragent/admission/common/lib_config.go
@@ -19,8 +19,9 @@ type LibConfig struct {
 	Language string `yaml:"library_language" json:"library_language"`
 	Version  string `yaml:"library_version" json:"library_version"`
 
-	ServiceName *string `yaml:"service_name,omitempty" json:"service_name,omitempty"`
-	Env         *string `yaml:"env,omitempty" json:"env,omitempty"`
+	ServiceName    *string `yaml:"service_name,omitempty" json:"service_name,omitempty"`
+	Env            *string `yaml:"env,omitempty" json:"env,omitempty"`
+	ServiceVersion *string `yaml:"version,omitempty" json:"version,omitempty"`
 
 	Tracing        *bool `yaml:"tracing_enabled,omitempty" json:"tracing_enabled,omitempty"`
 	LogInjection   *bool `yaml:"log_injection_enabled,omitempty" json:"log_injection_enabled,omitempty"`
@@ -68,6 +69,12 @@ func (lc LibConfig) ToEnvs() []corev1.EnvVar {
 		envs = append(envs, corev1.EnvVar{
 			Name:  "DD_ENV",
 			Value: *lc.Env,
+		})
+	}
+	if lc.ServiceVersion != nil {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "DD_VERSION",
+			Value: *lc.ServiceVersion,
 		})
 	}
 	if val, defined := checkFormatVal(lc.Tracing); defined {

--- a/pkg/clusteragent/admission/common/lib_config_test.go
+++ b/pkg/clusteragent/admission/common/lib_config_test.go
@@ -19,6 +19,7 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 	type fields struct {
 		ServiceName         *string
 		Env                 *string
+		ServiceVersion      *string
 		Tracing             *bool
 		LogInjection        *bool
 		HealthMetrics       *bool
@@ -48,6 +49,7 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 			fields: fields{
 				ServiceName:         pointer.Ptr("svc"),
 				Env:                 pointer.Ptr("dev"),
+				ServiceVersion:      pointer.Ptr("0.0.0"),
 				Tracing:             pointer.Ptr(true),
 				LogInjection:        pointer.Ptr(true),
 				HealthMetrics:       pointer.Ptr(true),
@@ -90,6 +92,10 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 				{
 					Name:  "DD_ENV",
 					Value: "dev",
+				},
+				{
+					Name:  "DD_VERSION",
+					Value: "0.0.0",
 				},
 				{
 					Name:  "DD_TRACE_ENABLED",
@@ -189,6 +195,7 @@ func TestLibConfig_ToEnvs(t *testing.T) {
 			lc := LibConfig{
 				ServiceName:         tt.fields.ServiceName,
 				Env:                 tt.fields.Env,
+				ServiceVersion:      tt.fields.ServiceVersion,
 				Tracing:             tt.fields.Tracing,
 				LogInjection:        tt.fields.LogInjection,
 				HealthMetrics:       tt.fields.HealthMetrics,

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -255,7 +255,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			name: "all-lib.config",
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 			}.Create(),
 			libInfo: extractedPodLibInfo{
@@ -274,8 +274,8 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			name: "app-container.config",
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
-					"admission.datadoghq.com/python-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
-					"admission.datadoghq.com/java-lib.config.v1":   `{"version":1,"runtime_metrics_enabled":false,"tracing_rate_limit":60,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/python-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/java-lib.config.v1":   `{"version":"1","runtime_metrics_enabled":false,"tracing_rate_limit":60,"tracing_sampling_rate":0.3}`,
 				},
 			}.Create(),
 			libInfo: extractedPodLibInfo{
@@ -938,7 +938,7 @@ func TestInjectLibConfig(t *testing.T) {
 	}{
 		{
 			name:    "nominal case",
-			pod:     common.FakePodWithAnnotation("admission.datadoghq.com/java-lib.config.v1", `{"version":1,"service_language":"java","runtime_metrics_enabled":true,"tracing_rate_limit":50}`),
+			pod:     common.FakePodWithAnnotation("admission.datadoghq.com/java-lib.config.v1", `{"version":"1","service_language":"java","runtime_metrics_enabled":true,"tracing_rate_limit":50}`),
 			lang:    java,
 			wantErr: false,
 			expectedEnvs: []corev1.EnvVar{
@@ -954,7 +954,7 @@ func TestInjectLibConfig(t *testing.T) {
 		},
 		{
 			name:    "inject all case",
-			pod:     common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.config.v1", `{"version":1,"service_language":"all","runtime_metrics_enabled":true,"tracing_rate_limit":50}`),
+			pod:     common.FakePodWithAnnotation("admission.datadoghq.com/all-lib.config.v1", `{"version":"1","service_language":"all","runtime_metrics_enabled":true,"tracing_rate_limit":50}`),
 			lang:    "all",
 			wantErr: false,
 			expectedEnvs: []corev1.EnvVar{
@@ -1665,7 +1665,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
@@ -1674,6 +1674,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				ParentName: "deployment-1234",
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_lib_injection",
@@ -1745,7 +1749,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
@@ -1754,6 +1758,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				ParentKind: "deployment-1234",
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_lib_injection",
@@ -1825,15 +1833,19 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 					"admission.datadoghq.com/js-lib.version":    "v1.10",
-					"admission.datadoghq.com/js-lib.config.v1":  `{"version":1,"tracing_sampling_rate":0.4}`,
+					"admission.datadoghq.com/js-lib.config.v1":  `{"version":"1","tracing_sampling_rate":0.4}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_RUNTIME_METRICS_ENABLED",
 					Value: "true",
@@ -1873,14 +1885,18 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
-					"admission.datadoghq.com/js-lib.config.v1":  `{"version":1,"tracing_sampling_rate":0.4}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/js-lib.config.v1":  `{"version":"1","tracing_sampling_rate":0.4}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_lib_injection",
@@ -1953,7 +1969,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				Annotations: map[string]string{
 					// TODO: we might not want to be injecting the libraries if the config is malformed
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
@@ -2019,13 +2035,17 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/java-lib.version":   "latest",
-					"admission.datadoghq.com/java-lib.config.v1": `{"version":1,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/java-lib.config.v1": `{"version":"1","tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_lib_injection",
@@ -2057,13 +2077,17 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/python-lib.version":   "latest",
-					"admission.datadoghq.com/python-lib.config.v1": `{"version":1,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/python-lib.config.v1": `{"version":"1","tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_TRACE_SAMPLE_RATE",
 					Value: "0.30",
@@ -2095,13 +2119,17 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/js-lib.version":   "latest",
-					"admission.datadoghq.com/js-lib.config.v1": `{"version":1,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/js-lib.config.v1": `{"version":"1","tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_TRACE_SAMPLE_RATE",
 					Value: "0.30",
@@ -2133,7 +2161,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/java-lib.version":   "latest",
-					"admission.datadoghq.com/java-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,`,
+					"admission.datadoghq.com/java-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
@@ -2167,7 +2195,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/java-lib.version":   "latest",
-					"admission.datadoghq.com/java-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,`,
+					"admission.datadoghq.com/java-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "false",
@@ -2404,10 +2432,14 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/js-lib.version":   "v1.10",
-					"admission.datadoghq.com/js-lib.config.v1": `{"version":1,"tracing_sampling_rate":0.4}`,
+					"admission.datadoghq.com/js-lib.config.v1": `{"version":"1","tracing_sampling_rate":0.4}`,
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_RUNTIME_METRICS_ENABLED",
 					Value: "true",
@@ -2833,13 +2865,17 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_lib_injection",
@@ -2942,13 +2978,17 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_lib_injection",
@@ -3033,13 +3073,17 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
 				},
 			}.Create(),
 			expectedEnvs: []corev1.EnvVar{
+				{
+					Name:  "DD_VERSION",
+					Value: "1",
+				},
 				{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_lib_injection",
@@ -3114,7 +3158,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",
@@ -3131,7 +3175,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",
-					"admission.datadoghq.com/all-lib.config.v1": `{"version":1,"runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
+					"admission.datadoghq.com/all-lib.config.v1": `{"version":"1","runtime_metrics_enabled":true,"tracing_rate_limit":50,"tracing_sampling_rate":0.3}`,
 				},
 				Labels: map[string]string{
 					"admission.datadoghq.com/enabled": "true",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`admission.datadoghq.com/%s-lib.config.v1` supports `DD_VERSION`.

```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    admission.datadoghq.com/js-lib.config.v1: |
      {
        "library_language": "js",
        "library_version": "5.39.0",
        "service_name": "test-service",
        "env": "test-env",
        "version": "0.0.0" # -> DD_VERSION
      }
  labels:
    admission.datadoghq.com/enabled: "true"
```

### Motivation

We can `service` and `env` through `admission.datadoghq.com/%s-lib.config.v1`, but not `version`.

`version` is one of [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

```yaml
apiVersion: datadoghq.com/v2alpha1
kind: DatadogAgent
metadata:
  name: datadog
spec:
  features:
    apm:
      enabled: true
      instrumentation:
        enabled: true
        enabledNamespaces:
        - default
  override:
    clusterAgent:
      image:
        name: cluster-agent-dev
        tag: keisku-admission-dd-version
      replicas: 2
      - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PATCHER_ENABLED
        value: "true"
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->