### PR TITLE
usm: gotls: Remove special constructor

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -133,6 +133,7 @@ type goTLSProgram struct {
 var _ utils.Attacher = &goTLSProgram{}
 
 var goTLSSpec = &protocols.ProtocolSpec{
+	Factory: newGoTLS,
 	Maps: []*manager.Map{
 		{Name: offsetsDataMap},
 		{Name: goTLSReadArgsMap},
@@ -168,32 +169,29 @@ var goTLSSpec = &protocols.ProtocolSpec{
 	},
 }
 
-func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactory {
-	return func(c *config.Config) (protocols.Protocol, error) {
-		if !c.EnableGoTLSSupport {
-			return nil, nil
-		}
-
-		if !usmconfig.TLSSupported(c) {
-			log.Warn("goTLS not supported by this platform")
-			return nil, nil
-		}
-
-		if !c.EnableRuntimeCompiler && !c.EnableCORE {
-			log.Warn("goTLS support requires runtime-compilation or CO-RE to be enabled")
-			return nil, nil
-		}
-
-		return &goTLSProgram{
-			done:               make(chan struct{}),
-			cfg:                c,
-			manager:            m,
-			procRoot:           c.ProcRoot,
-			binAnalysisMetric:  libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
-			binNoSymbolsMetric: libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
-			registry:           utils.NewFileRegistry(consts.USMModuleName, "go-tls"),
-		}, nil
+func newGoTLS(c *config.Config) (protocols.Protocol, error) {
+	if !c.EnableGoTLSSupport {
+		return nil, nil
 	}
+
+	if !usmconfig.TLSSupported(c) {
+		log.Warn("goTLS not supported by this platform")
+		return nil, nil
+	}
+
+	if !c.EnableRuntimeCompiler && !c.EnableCORE {
+		log.Warn("goTLS support requires runtime-compilation or CO-RE to be enabled")
+		return nil, nil
+	}
+
+	return &goTLSProgram{
+		done:               make(chan struct{}),
+		cfg:                c,
+		procRoot:           c.ProcRoot,
+		binAnalysisMetric:  libtelemetry.NewCounter("usm.go_tls.analysis_time", libtelemetry.OptPrometheus),
+		binNoSymbolsMetric: libtelemetry.NewCounter("usm.go_tls.missing_symbols", libtelemetry.OptPrometheus),
+		registry:           utils.NewFileRegistry(consts.USMModuleName, "go-tls"),
+	}, nil
 }
 
 // Name return the program's name.
@@ -216,6 +214,7 @@ func (p *goTLSProgram) ConfigureOptions(_ *manager.Manager, options *manager.Opt
 
 // PreStart launches the goTLS main goroutine to handle events.
 func (p *goTLSProgram) PreStart(m *manager.Manager) error {
+	p.manager = m
 	var err error
 
 	p.offsetsDataMap, _, err = m.GetMap(offsetsDataMap)

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -156,7 +156,6 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map) (*ebpfPro
 	}
 
 	opensslSpec.Factory = newSSLProgramProtocolFactory(mgr)
-	goTLSSpec.Factory = newGoTLSProgramProtocolFactory(mgr)
 
 	if err := program.initProtocols(c); err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes special constructor from go-tls

### Motivation

We needed in the past access to the ebpf manager at the constructor, but that's no longer the case so we can simplify the setup and stick with the regular protocol setup

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->