### PR TITLE
usm: go tls: Silently fail for unsupported environments

### DIFF
--- a/pkg/network/usm/ebpf_gotls.go
+++ b/pkg/network/usm/ebpf_gotls.go
@@ -175,11 +175,13 @@ func newGoTLSProgramProtocolFactory(m *manager.Manager) protocols.ProtocolFactor
 		}
 
 		if !usmconfig.TLSSupported(c) {
-			return nil, errors.New("goTLS not supported by this platform")
+			log.Warn("goTLS not supported by this platform")
+			return nil, nil
 		}
 
 		if !c.EnableRuntimeCompiler && !c.EnableCORE {
-			return nil, errors.New("goTLS support requires runtime-compilation or CO-RE to be enabled")
+			log.Warn("goTLS support requires runtime-compilation or CO-RE to be enabled")
+			return nil, nil
 		}
 
 		return &goTLSProgram{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Aligns go-tls with other tls modules - if it is not supported, we silently fail.

### Motivation

As go-tls became enabled by default in 7.61, we failed to identify it is not always supported (for example, on arm with kernel older than 5.5).
That results with "usm fails to start".
We should patch that, and then address a proper mechanism for USM.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->