### PR TITLE
[CWS] fix `pidToMounts` cleanup in mount resolver

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -183,24 +183,27 @@ func (mr *Resolver) delete(mount *model.Mount) {
 		curr, rest := openQueue[len(openQueue)-1], openQueue[:len(openQueue)-1]
 		openQueue = rest
 
-		delete(mr.mounts, curr.MountID)
-		for _, mounts := range mr.pidToMounts {
-			delete(mounts, curr.MountID)
-		}
-
-		entry := redemptionEntry{
-			mount:      curr,
-			insertedAt: now,
-		}
-		mr.redemption.Add(curr.MountID, &entry)
+		mr.deleteOne(curr, now)
 
 		for _, child := range mr.mounts {
 			if child.ParentPathKey.MountID == curr.MountID {
 				openQueue = append(openQueue, child)
 			}
 		}
-
 	}
+}
+
+func (mr *Resolver) deleteOne(curr *model.Mount, now time.Time) {
+	delete(mr.mounts, curr.MountID)
+	for _, mounts := range mr.pidToMounts {
+		delete(mounts, curr.MountID)
+	}
+
+	entry := redemptionEntry{
+		mount:      curr,
+		insertedAt: now,
+	}
+	mr.redemption.Add(curr.MountID, &entry)
 }
 
 func (mr *Resolver) finalize(mount *model.Mount) {

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -184,6 +184,9 @@ func (mr *Resolver) delete(mount *model.Mount) {
 		openQueue = rest
 
 		delete(mr.mounts, curr.MountID)
+		for _, mounts := range mr.pidToMounts {
+			delete(mounts, curr.MountID)
+		}
 
 		entry := redemptionEntry{
 			mount:      curr,
@@ -197,9 +200,6 @@ func (mr *Resolver) delete(mount *model.Mount) {
 			}
 		}
 
-		for _, mounts := range mr.pidToMounts {
-			delete(mounts, mount.MountID)
-		}
 	}
 }
 

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -176,6 +176,8 @@ func (mr *Resolver) syncCache(mountID uint32, pids []uint32) error {
 func (mr *Resolver) delete(mount *model.Mount) {
 	now := time.Now()
 
+	mr.deleteOne(mount, now)
+
 	openQueue := make([]*model.Mount, 0, len(mr.mounts))
 	openQueue = append(openQueue, mount)
 
@@ -183,11 +185,10 @@ func (mr *Resolver) delete(mount *model.Mount) {
 		curr, rest := openQueue[len(openQueue)-1], openQueue[:len(openQueue)-1]
 		openQueue = rest
 
-		mr.deleteOne(curr, now)
-
 		for _, child := range mr.mounts {
 			if child.ParentPathKey.MountID == curr.MountID {
 				openQueue = append(openQueue, child)
+				mr.deleteOne(child, now)
 			}
 		}
 	}

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -178,16 +178,16 @@ func (mr *Resolver) delete(mount *model.Mount) {
 
 	mr.deleteOne(mount, now)
 
-	openQueue := make([]*model.Mount, 0, len(mr.mounts))
-	openQueue = append(openQueue, mount)
+	openQueue := make([]uint32, 0, len(mr.mounts))
+	openQueue = append(openQueue, mount.MountID)
 
 	for len(openQueue) != 0 {
 		curr, rest := openQueue[len(openQueue)-1], openQueue[:len(openQueue)-1]
 		openQueue = rest
 
 		for _, child := range mr.mounts {
-			if child.ParentPathKey.MountID == curr.MountID {
-				openQueue = append(openQueue, child)
+			if child.ParentPathKey.MountID == curr {
+				openQueue = append(openQueue, child.MountID)
 				mr.deleteOne(child, now)
 			}
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently  when a mount is deleted, only the original mount is removed from the `pidToMounts` mapping. This PR fixes this by ensuring all child mounts are deleted as well, extracts this removal code into a separate function (this ensure that there is no confusion between `curr`, `mount` etc), and simplifying a bit the logic to remove the amount of mounts iterations.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->