### PR TITLE
Build cryptography against embedded OpenSSL for FIPS Windows Agent

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -40,6 +40,7 @@
       -e AGENT_FLAVOR=${AGENT_FLAVOR}
       -e OMNIBUS_SOFTWARE_VERSION="${OMNIBUS_SOFTWARE_VERSION}"
       -e OMNIBUS_RUBY_VERSION="${OMNIBUS_RUBY_VERSION}"
+      -e PYTHONUTF8=1
       ${WINBUILDIMAGE}
       powershell -C "c:\mnt\tasks\winbuildscripts\Build-AgentPackages.ps1 -BuildOutOfSource 1 -InstallDeps 1 -CheckGoVersion 1 -BuildUpgrade 1"
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -285,14 +285,18 @@ build do
         FileUtils.rm([libssl_match, libcrypto_match])
       end
       if windows_target?
-        # We delete the libraries shipped with the wheel and replace them with links to the embedded OpenSSL libraries.
+        # We delete the libraries shipped with the wheel and replace them with copies of the embedded OpenSSL libraries.
         # This is the most straightforward solution on Windows because manipulating the binary would be a bit too involved
-        cryptography_libs_folder = windows_safe_path(install_dir, "embedded3", "lib", "site-packages", "cryptography.libs")
-        libssl_match = Dir.glob(windows_safe_path(cryptography_libs_folder, "libssl-*.so.3"))[0]
-        libcrypto_match = Dir.glob(windows_safe_path(cryptography_libs_folder, "libcrypto-*.so.3"))[0]
-        dll_folder = windows_safe_path(install_dir, "embedded3", "DLLS")
-        FileUtils.ln_s(windows_safe_path(dll_folder, "libssl-3-x64.dll"), libssl_match, force=true)
-        FileUtils.ln_s(windows_safe_path(dll_folder, "libcrypto-3-x64.dll"), libcrypto_match, force=true)
+        cryptography_libs_folder = File.join(install_dir, "embedded3", "lib", "site-packages", "cryptography.libs")
+        libssl_match = Dir.glob(File.join(cryptography_libs_folder, "libssl-3-*.dll"))[0]
+        libcrypto_match = Dir.glob(File.join(cryptography_libs_folder, "libcrypto-3-*.dll"))[0]
+        dll_folder = File.join(install_dir, "embedded3", "DLLS")
+        puts `dir "#{cryptography_libs_folder}"`
+        FileUtils.rm([libssl_match, libcrypto_match])
+        puts `dir "#{cryptography_libs_folder}"`
+        FileUtils.cp(File.join(dll_folder, "libssl-3-x64.dll"), libssl_match)
+        FileUtils.cp(File.join(dll_folder, "libcrypto-3-x64.dll"), libcrypto_match)
+        puts `dir "#{cryptography_libs_folder}"`
       end
     end
   end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -284,6 +284,16 @@ build do
         shellout! "patchelf --add-rpath #{install_dir}/embedded/lib #{so_to_patch}"
         FileUtils.rm([libssl_match, libcrypto_match])
       end
+      if windows_target?
+        # We delete the libraries shipped with the wheel and replace them with links to the embedded OpenSSL libraries.
+        # This is the most straightforward solution on Windows because manipulating the binary would be a bit too involved
+        cryptography_libs_folder = windows_safe_path(install_dir, "embedded3", "lib", "site-packages", "cryptography.libs")
+        libssl_match = Dir.glob(windows_safe_path(cryptography_libs_folder, "libssl-*.so.3"))[0]
+        libcrypto_match = Dir.glob(windows_safe_path(cryptography_libs_folder, "libcrypto-*.so.3"))[0]
+        dll_folder = windows_safe_path(install_dir, "embedded3", "DLLS")
+        FileUtils.ln_s(windows_safe_path(dll_folder, "libssl-3-x64.dll"), libssl_match, force=true)
+        FileUtils.ln_s(windows_safe_path(dll_folder, "libcrypto-3-x64.dll"), libcrypto_match, force=true)
+      end
     end
   end
 


### PR DESCRIPTION
### What does this PR do?

Builds the Python `cryptography` library inside Omnibus for the FIPS Agent, solving openssl init-related errors coming from conflicting OpenSSL configurations.

It also injects a `.pth` file into the `site-packages` such that Python extensions can find DLL's in the Agent's DLL folder, as needed for the rust OpenSSL bindings to find the OpenSSL DLL's shipped with the Agent.

### Motivation

[BARX-668](https://datadoghq.atlassian.net/browse/BARX-668)

### Describe how you validated your changes

Manually tested on a VM by running the following script using the Agent's embedded Python:

```python
import paramiko
from cryptography.hazmat.backends.openssl import backend; backend._enable_fips()
```

And checking that no exception is raised.

### Possible Drawbacks / Trade-offs

Note that this is not intended as a permanent solution. There are a couple of significant drawbacks currently:
- The version of `cryptography` is hardcoded and could run out of sync with whatever is specified by `integrations-core`.
- It bypasses our existing separation between the build of the Agent and that of Python deps for integrations; thus, this gives up the advantages of having such a separation, including a higher risk of regular Agent pipelines failing, and a (relatively small) time penalty.

There will be follow-up work to find a more permanent solution to the problem at hand.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[BARX-668]: https://datadoghq.atlassian.net/browse/BARX-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ