### PR TITLE
[CWS] Forward signals from tracer to tracee

### DIFF
--- a/pkg/security/ptracer/ptracer.go
+++ b/pkg/security/ptracer/ptracer.go
@@ -578,13 +578,13 @@ func (ctx *CWSPtracerCtx) NewTracer() error {
 	}
 
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
+	signal.Notify(sigChan) // will catch all signals
 	go func() {
-		<-sigChan
-		os.Exit(0)
+		sig := <-sigChan
+		unixSig, _ := sig.(syscall.Signal)
+		// All signals will be forwarded to the tracee. This way, if a tracee have
+		// handlers for some of them it will continue to work as execpected.
+		syscall.Kill(pid, unixSig)
 	}()
 
 	// first process

--- a/pkg/security/ptracer/ptracer.go
+++ b/pkg/security/ptracer/ptracer.go
@@ -584,7 +584,9 @@ func (ctx *CWSPtracerCtx) NewTracer() error {
 		unixSig, _ := sig.(syscall.Signal)
 		// All signals will be forwarded to the tracee. This way, if a tracee have
 		// handlers for some of them it will continue to work as execpected.
-		syscall.Kill(pid, unixSig)
+		if err := syscall.Kill(pid, unixSig); err != nil {
+			logger.Errorf("Kill to forward sig %v to process %d failed: %v\n", sig, pid, err)
+		}
 	}()
 
 	// first process


### PR DESCRIPTION
### What does this PR do?

This will fix the issue when a workload have some special handlers (like to cleanup gracefully when receiving a SIGTERM) and did not receive them if such signals were sent to the tracer by a container runtime.

### Motivation

### Describe how you validated your changes

* build this C program:

```
#include <stdio.h>
#include <signal.h>
#include <unistd.h>

void handle_sig(int sig) {
    printf("SIGNAL: %d\n", sig);
}

int main(int ac, char** av) {
    signal(SIGTERM, handle_sig);
    while (run) {
        puts("running");
        sleep(10);
    }
    return (0);
}
```

* then trace it: sudo cws-instrumentation trace --disable-proc-scan --probe-addr= -- ./a.out
* and send a SIGTERM to cws-instrumentation: `$> sudo kill -TERM $(pidof cws-instrumentation)`
* you should see printed: `SIGNAL: 15`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->