### PR TITLE
[Backport 7.64.x] [AGENTRUN-162] Disable X25519Kyber768Draft00 in the agent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,6 @@ go 1.23.5
 
 toolchain go1.23.6
 
-// Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
-// This was causing errors with AWS Network Firewall
-// See https://github.com/DataDog/datadog-agent/issues/34323 for details.
-// This will be revisited once we update to 1.24.x
-godebug tlskyber=0
-
 // v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
 // to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)
 // that retracts itself and the previous version.

--- a/go.work
+++ b/go.work
@@ -2,6 +2,12 @@ go 1.23.5
 
 toolchain go1.23.6
 
+// Disable experimental post-quantum key exchange mechanism X25519Kyber768Draft00
+// This was causing errors with AWS Network Firewall
+// See https://github.com/DataDog/datadog-agent/issues/34323 for details.
+// This will be revisited once we update to 1.24.x
+godebug tlskyber=0
+
 use (
 	.
 	comp/api/api/def

--- a/releasenotes/notes/fix-kyber-firewall-again-8252b095a52698e2.yaml
+++ b/releasenotes/notes/fix-kyber-firewall-again-8252b095a52698e2.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Disable the X25519Kyber768Draft00 key exchange mechanism to avoid issues with
+    firewalls not supporting it, in particular AWS Network Firewall.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Backport https://github.com/DataDog/datadog-agent/pull/34626 to 7.64.x.

Fix https://github.com/DataDog/datadog-agent/issues/34323.

https://github.com/DataDog/datadog-agent/pull/34481 added the `godebug` directive to disable tlskyber experiment by default, however it seems due to using a `go.work` the directive in the `go.mod` was ignored...
Some local testing indicates that setting the directive in the `go.work` works as expected.

### Motivation
Fix issues with AWS Network Firewall.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I don't have a setup with AWS Network Firewall at hand so I used a custom version of Go to check whether the GODEBUG directive was considered.

I also tried using delve, installing the agent, downloading debug symbols, setting up delve config to indicate the location of debug symbols, and finally attaching to the running agent to see the set of algorithms used.

```sh
dlv attach `pgrep -f '/opt/datadog-agent/bin/agent/agent run'`
```

Here are the delve instructions:
```
(dlv) break tlscommonend crypto/tls/common.go:114
(dlv) continue
(dlv) p curvePreferences
```

With 7.63.2:
```
(dlv) p curvePreferences
[]crypto/tls.CurveID len: 5, cap: 5, [x25519Kyber768Draft00 (25497),X25519 (29),CurveP256 (23),CurveP384 (24),CurveP521 (25)]
```

With 7.63.3~rc.1:
```
(dlv) p curvePreferences
[]crypto/tls.CurveID len: 4, cap: 4, [X25519 (29),CurveP256 (23),CurveP384 (24),CurveP521 (25)]
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->