### PR TITLE
fix(ssi): properly parse lib versions from env var

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -199,6 +199,103 @@ func TestNewInstrumentationConfig(t *testing.T) {
 	}
 }
 
+func TestLibVersionsEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected map[string]string
+	}{
+		{
+			name: "valid lib versions",
+			expected: map[string]string{
+				"python": "1",
+				"js":     "2",
+				"java":   "3",
+			},
+		},
+		{
+			name:     "empty",
+			expected: map[string]string{},
+		},
+		{
+			name:     "nil",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.expected)
+			require.NoError(t, err)
+			t.Setenv("DD_APM_INSTRUMENTATION_LIB_VERSIONS", string(data))
+			actual, err := NewInstrumentationConfig(configmock.New(t))
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual.LibVersions)
+		})
+	}
+}
+
+func TestEnabledNamespacesEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []string
+	}{
+		{
+			name:     "valid namespaces",
+			expected: []string{"foo", "bar"},
+		},
+		{
+			name:     "empty",
+			expected: []string{},
+		},
+		{
+			name:     "nil",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.expected)
+			require.NoError(t, err)
+			t.Setenv("DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES", string(data))
+			actual, err := NewInstrumentationConfig(configmock.New(t))
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual.EnabledNamespaces)
+		})
+	}
+}
+
+func TestDisabledNamespacesEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected []string
+	}{
+		{
+			name:     "valid namespaces",
+			expected: []string{"default", "kube-system"},
+		},
+		{
+			name:     "empty",
+			expected: []string{},
+		},
+		{
+			name:     "nil",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.expected)
+			require.NoError(t, err)
+			t.Setenv("DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES", string(data))
+			actual, err := NewInstrumentationConfig(configmock.New(t))
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual.DisabledNamespaces)
+		})
+	}
+}
+
 func TestTargetEnvVar(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -85,8 +85,29 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("apm_config.compute_stats_by_span_kind", true, "DD_APM_COMPUTE_STATS_BY_SPAN_KIND")                           //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled", false, "DD_APM_INSTRUMENTATION_ENABLED")
 	config.BindEnvAndSetDefault("apm_config.instrumentation.enabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_ENABLED_NAMESPACES")
+	config.ParseEnvAsStringSlice("apm_config.instrumentation.enabled_namespaces", func(in string) []string {
+		var mappings []string
+		if err := json.Unmarshal([]byte(in), &mappings); err != nil {
+			log.Errorf(`"apm_config.instrumentation.enabled_namespaces" can not be parsed: %v`, err)
+		}
+		return mappings
+	})
 	config.BindEnvAndSetDefault("apm_config.instrumentation.disabled_namespaces", []string{}, "DD_APM_INSTRUMENTATION_DISABLED_NAMESPACES")
+	config.ParseEnvAsStringSlice("apm_config.instrumentation.disabled_namespaces", func(in string) []string {
+		var mappings []string
+		if err := json.Unmarshal([]byte(in), &mappings); err != nil {
+			log.Errorf(`"apm_config.instrumentation.disabled_namespaces" can not be parsed: %v`, err)
+		}
+		return mappings
+	})
 	config.BindEnvAndSetDefault("apm_config.instrumentation.lib_versions", map[string]string{}, "DD_APM_INSTRUMENTATION_LIB_VERSIONS")
+	config.ParseEnvAsMapStringInterface("apm_config.instrumentation.lib_versions", func(in string) map[string]interface{} {
+		var mappings map[string]interface{}
+		if err := json.Unmarshal([]byte(in), &mappings); err != nil {
+			log.Errorf(`"apm_config.instrumentation.lib_versions" can not be parsed: %v`, err)
+		}
+		return mappings
+	})
 	// Note(stanistan): The flag "DD_APM_INSTRUMENTATION_VERSION"
 	//                  will remain undocumented for the duration of the beta.
 	//                  We intend to only switch back to v1 if beta customers have issues


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit ensures we can properly parse the lib versions config from an environment variable (`DD_APM_INSTRUMENTATION_LIB_VERSIONS`). Additionally, I've ensured that enabled/disabled namespaces will also parse as expected.

### Motivation
We switched to reading `apm_config.instrumentation` as a unit given we have added a lot more configuration options in [Kubernetes SSI | Workload Selection 🎯](https://docs.google.com/document/d/1Lol1ExLF1nGBe7njO6DBVkjuYAYxC1-sL2WP0rdqFRk/edit?usp=sharing) and it would be impossible to parse targets through the standard viper interface. As part of that work, we ensured that extraneous or bad keys would throw an error instead of being accepted. See this PR for more details: https://github.com/DataDog/datadog-agent/pull/34001

It seems like this config option was missed, and this PR has a lot more details: https://github.com/DataDog/datadog-agent/pull/34610. It does not work as it stands given we would not be able to ensure extraneous keys threw an exception.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The additional unit tests.

### Possible Drawbacks / Trade-offs
Our config is "standard" but it's admittedly a bit more complex then simpler configs in this repo. The plus side is that we're explicit about how these environment variables will parse.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->