### PR TITLE
Clone strings to free DWARF objects in dynamic instrumentation

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -17,19 +17,11 @@ import (
 	"slices"
 	"strings"
 
-	"net/http"
-	_ "net/http/pprof"
+	"github.com/go-delve/delve/pkg/dwarf/godwarf"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/go-delve/delve/pkg/dwarf/godwarf"
 )
-
-func init() {
-	go func() {
-		fmt.Println(http.ListenAndServe("localhost:6069", nil))
-	}()
-}
 
 func getTypeMap(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditypes.TypeMap, error) {
 	return loadFunctionDefinitions(dwarfData, targetFunctions)

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -83,19 +83,14 @@ entryLoop:
 			}
 			var files []*dwarf.LineFile
 			if cuLineReader != nil {
-				files = cuLineReader.Files()
-			}
-
-			filesCopy := make([]*dwarf.LineFile, len(files))
-
-			for i := range files {
-				if files[i] == nil {
-					continue
-				}
-				filesCopy[i] = &dwarf.LineFile{
-					Name:   strings.Clone(files[i].Name),
-					Mtime:  files[i].Mtime,
-					Length: files[i].Length,
+				for _, file := range cuLineReader.Files() {
+					if file != nil {
+						files = append(files, &dwarf.LineFile{
+							Name:   strings.Clone(file.Name),
+							Mtime:  file.Mtime,
+							Length: file.Length,
+						})
+					}
 				}
 			}
 

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -84,13 +84,15 @@ entryLoop:
 			var files []*dwarf.LineFile
 			if cuLineReader != nil {
 				for _, file := range cuLineReader.Files() {
-					if file != nil {
-						files = append(files, &dwarf.LineFile{
-							Name:   strings.Clone(file.Name),
-							Mtime:  file.Mtime,
-							Length: file.Length,
-						})
+					if file == nil {
+						continue
 					}
+
+					files = append(files, &dwarf.LineFile{
+						Name:   strings.Clone(file.Name),
+						Mtime:  file.Mtime,
+						Length: file.Length,
+					})
 				}
 			}
 


### PR DESCRIPTION
### What does this PR do?

Fixes freeing of DWARF line entries.

### Motivation

We've observed a memory leak where dwarf.LineFile objects were not being freed by GC and through manual testing concluded that this was occuring because the string was being copied (meaning the pointer to the underlying character array was being used), causing GC to not free the object that the string was a part of.

### Describe how you validated your changes

Heap analysis with pprof+[goref](https://github.com/cloudwego/goref)

### Possible Drawbacks / Trade-offs

We still need to clean up the type map generation logic to not use recursion which can lead to a large spike in memory usage (that at least get's fully freed now)

### Additional Notes
