### PR TITLE
(fleet) store the tasks state persistently

### DIFF
--- a/pkg/fleet/daemon/daemon_test.go
+++ b/pkg/fleet/daemon/daemon_test.go
@@ -8,6 +8,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"testing"
@@ -215,10 +216,13 @@ func newTestInstaller(t *testing.T) *testInstaller {
 	pm.On("ConfigStates").Return(map[string]repository.State{}, nil)
 	rcc := newTestRemoteConfigClient(t)
 	rc := &remoteConfig{client: rcc}
+	taskDB, err := newTaskDB(filepath.Join(t.TempDir(), "tasks.db"))
+	require.NoError(t, err)
 	daemon := newDaemon(
 		rc,
 		func(_ *env.Env) installer.Installer { return pm },
 		&env.Env{RemoteUpdates: true},
+		taskDB,
 	)
 	i := &testInstaller{
 		daemonImpl: daemon,

--- a/pkg/fleet/daemon/task_db.go
+++ b/pkg/fleet/daemon/task_db.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"go.etcd.io/bbolt"
+)
+
+var (
+	bucketTasks = []byte("tasks")
+)
+
+// taskDB is a database that stores information about tasks.
+// It is opened by the installer daemon.
+type taskDB struct {
+	db *bbolt.DB
+}
+
+// newTaskDB creates a new TasksDB
+func newTaskDB(dbPath string) (*taskDB, error) {
+	db, err := bbolt.Open(dbPath, 0644, &bbolt.Options{
+		FreelistType: bbolt.FreelistArrayType,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not open database: %w", err)
+	}
+	err = db.Update(func(tx *bbolt.Tx) error {
+		_, err := tx.CreateBucketIfNotExists(bucketTasks)
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not create tasks bucket: %w", err)
+	}
+	return &taskDB{
+		db: db,
+	}, nil
+}
+
+// Close closes the database
+func (p *taskDB) Close() error {
+	return p.db.Close()
+}
+
+// SetLastTask sets the last task
+func (p *taskDB) SetTaskState(task requestState) error {
+	err := p.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketTasks)
+		if b == nil {
+			return fmt.Errorf("bucket not found")
+		}
+		rawTask, err := json.Marshal(&task)
+		if err != nil {
+			return fmt.Errorf("could not marshal task: %w", err)
+		}
+		return b.Put([]byte(task.Package), rawTask)
+	})
+	if err != nil {
+		return fmt.Errorf("could not set task: %w", err)
+	}
+	return nil
+}
+
+// GetTasksState returns the last task
+func (p *taskDB) GetTasksState() (map[string]requestState, error) {
+	var tasks = map[string]requestState{}
+	err := p.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketTasks)
+		if b == nil {
+			return fmt.Errorf("bucket not found")
+		}
+		err := b.ForEach(func(k, v []byte) error {
+			var task requestState
+			err := json.Unmarshal(v, &task)
+			if err != nil {
+				return fmt.Errorf("could not unmarshal task: %w", err)
+			}
+			tasks[string(k)] = task
+			return nil
+		})
+		return err
+	})
+	if err != nil {
+		return nil, fmt.Errorf("could not get task: %w", err)
+	}
+	return tasks, nil
+}

--- a/pkg/fleet/daemon/task_db_test.go
+++ b/pkg/fleet/daemon/task_db_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package daemon
 
 import (

--- a/pkg/fleet/daemon/task_db_test.go
+++ b/pkg/fleet/daemon/task_db_test.go
@@ -1,0 +1,39 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetTaskState(t *testing.T) {
+	db, err := newTaskDB(filepath.Join(t.TempDir(), "test.db"))
+	assert.NoError(t, err)
+	defer db.Close()
+
+	task1 := requestState{
+		Package:   "test-package1",
+		ID:        "test-id1",
+		State:     core.TaskState_ERROR,
+		Err:       "test-error",
+		ErrorCode: 1,
+	}
+	err = db.SetTaskState(task1)
+	assert.NoError(t, err)
+
+	task2 := requestState{
+		Package: "test-package2",
+		ID:      "test-id2",
+		State:   core.TaskState_DONE,
+	}
+	err = db.SetTaskState(task2)
+	assert.NoError(t, err)
+
+	tasks, err := db.GetTasksState()
+	assert.NoError(t, err)
+	assert.Len(t, tasks, 2)
+	assert.Equal(t, task1, tasks["test-package1"])
+	assert.Equal(t, task2, tasks["test-package2"])
+}


### PR DESCRIPTION
This PR stores the task state in a persistent way to avoid having it lost when the daemon restart during an upgrade/configure.

