### PR TITLE
[NDINT-225] Start scaffolding for versa integration

### DIFF
--- a/pkg/collector/corechecks/network-devices/versa/report/metadata.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/metadata.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package report
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
+	devicemetadata "github.com/DataDog/datadog-agent/pkg/networkdevice/metadata"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// TimeNow useful for mocking
+var TimeNow = time.Now
+
+// SendMetadata send Versa device, interface and IP Address metadata
+func (s *Sender) SendMetadata(devices []devicemetadata.DeviceMetadata, interfaces []devicemetadata.InterfaceMetadata, ipAddresses []devicemetadata.IPAddressMetadata) {
+	collectionTime := TimeNow()
+	metadataPayloads := devicemetadata.BatchPayloads(s.namespace, "", collectionTime, devicemetadata.PayloadMetadataBatchSize, devices, interfaces, ipAddresses, nil, nil, nil)
+	for _, payload := range metadataPayloads {
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			log.Errorf("Error marshalling Versa metadata : %s", err)
+			continue
+		}
+		s.sender.EventPlatformEvent(payloadBytes, eventplatform.EventTypeNetworkDevicesMetadata)
+	}
+}

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 )
 
-// VersaSender implements methods for sending Versa metrics and metadata
+// Sender implements methods for sending Versa metrics and metadata
 type Sender struct {
 	sender       sender.Sender
 	namespace    string
@@ -24,5 +24,6 @@ func NewSender(sender sender.Sender, namespace string) *Sender {
 		sender:       sender,
 		namespace:    namespace,
 		lastTimeSent: make(map[string]float64),
+		deviceTags:   make(map[string][]string),
 	}
 }

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package report
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+)
+
+// VersaSender implements methods for sending Versa metrics and metadata
+type Sender struct {
+	sender       sender.Sender
+	namespace    string
+	lastTimeSent map[string]float64
+	deviceTags   map[string][]string
+}
+
+// NewSender returns a new VersaSender
+func NewSender(sender sender.Sender, namespace string) *Sender {
+	return &Sender{
+		sender:       sender,
+		namespace:    namespace,
+		lastTimeSent: make(map[string]float64),
+	}
+}

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+// Package report implements Versa metadata and metrics reporting
 package report
 
 import (

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -1,0 +1,145 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+// Package ciscosdwan implements NDM Cisco SD-WAN corecheck
+package ciscosdwan
+
+import (
+	"time"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/cisco-sdwan/report"
+	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+const (
+	// CheckName is the name of the check
+	CheckName            = "versa"
+	defaultCheckInterval = 1 * time.Minute
+)
+
+// Configuration for the Cisco SD-WAN check
+type checkCfg struct {
+	// add versa specific fields
+	Namespace                       string `yaml:"namespace"`
+	SendNDMMetadata                 *bool  `yaml:"send_ndm_metadata"`
+	MinCollectionInterval           int    `yaml:"min_collection_interval"`
+	CollectHardwareMetrics          *bool  `yaml:"collect_hardware_metrics"`
+	CollectInterfaceMetrics         *bool  `yaml:"collect_interface_metrics"`
+	CollectTunnelMetrics            *bool  `yaml:"collect_tunnel_metrics"`
+	CollectControlConnectionMetrics *bool  `yaml:"collect_control_connection_metrics"`
+	CollectOMPPeerMetrics           *bool  `yaml:"collect_omp_peer_metrics"`
+	CollectDeviceCountersMetrics    *bool  `yaml:"collect_device_counters_metrics"`
+	CollectBFDSessionStatus         *bool  `yaml:"collect_bfd_session_status"`
+	CollectHardwareStatus           *bool  `yaml:"collect_hardware_status"`
+	CollectCloudApplicationsMetrics *bool  `yaml:"collect_cloud_applications_metrics"`
+	CollectBGPNeighborStates        *bool  `yaml:"collect_bgp_neighbor_states"`
+}
+
+// VersaCheck contains the fields for the Versa check
+type VersaCheck struct {
+	core.CheckBase
+	interval      time.Duration
+	config        checkCfg
+	metricsSender *report.SDWanSender
+}
+
+// Run executes the check
+func (v *VersaCheck) Run() error {
+
+	// Commit
+	v.metricsSender.Commit()
+
+	return nil
+}
+
+// Configure the Versa check
+func (v *VersaCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+	// Must be called before v.CommonConfigure
+	v.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
+
+	err := v.CommonConfigure(senderManager, rawInitConfig, rawInstance, source)
+	if err != nil {
+		return err
+	}
+
+	sender, err := v.GetSender()
+	if err != nil {
+		return err
+	}
+
+	var instanceConfig checkCfg
+
+	// Set defaults before unmarshalling
+	instanceConfig.CollectHardwareMetrics = boolPointer(true)
+	instanceConfig.CollectInterfaceMetrics = boolPointer(true)
+	instanceConfig.CollectTunnelMetrics = boolPointer(true)
+	instanceConfig.CollectControlConnectionMetrics = boolPointer(true)
+	instanceConfig.CollectOMPPeerMetrics = boolPointer(true)
+	instanceConfig.CollectDeviceCountersMetrics = boolPointer(true)
+	instanceConfig.SendNDMMetadata = boolPointer(true)
+
+	instanceConfig.CollectBFDSessionStatus = boolPointer(false)
+	instanceConfig.CollectHardwareStatus = boolPointer(false)
+	instanceConfig.CollectCloudApplicationsMetrics = boolPointer(false)
+	instanceConfig.CollectBGPNeighborStates = boolPointer(false)
+
+	err = yaml.Unmarshal(rawInstance, &instanceConfig)
+	if err != nil {
+		return err
+	}
+	v.config = instanceConfig
+
+	if v.config.Namespace == "" {
+		v.config.Namespace = "default"
+	} else {
+		namespace, err := utils.NormalizeNamespace(v.config.Namespace)
+		if err != nil {
+			return err
+		}
+		v.config.Namespace = namespace
+	}
+
+	if v.config.MinCollectionInterval != 0 {
+		v.interval = time.Second * time.Duration(v.config.MinCollectionInterval)
+	}
+
+	v.metricsSender = report.NewSDWanSender(sender, v.config.Namespace)
+
+	return nil
+}
+
+// Interval returns the scheduling time for the check
+func (v *VersaCheck) Interval() time.Duration {
+	return v.interval
+}
+
+// IsHASupported returns true if the check supports HA
+func (v *VersaCheck) IsHASupported() bool {
+	// TODO: Is this true? I would think probably?
+	return true
+}
+
+func boolPointer(b bool) *bool {
+	return &b
+}
+
+// Factory creates a new check factory
+func Factory() option.Option[func() check.Check] {
+	return option.New(newCheck)
+}
+
+func newCheck() check.Check {
+	return &VersaCheck{
+		CheckBase: core.NewCheckBase(CheckName),
+		interval:  defaultCheckInterval,
+	}
+}

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
-// Package ciscosdwan implements NDM Cisco SD-WAN corecheck
-package ciscosdwan
+// Package versa implements NDM Versa corecheck
+package versa
 
 import (
 	"time"
@@ -15,8 +15,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/cisco-sdwan/report"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/versa/report"
 	"github.com/DataDog/datadog-agent/pkg/snmp/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
@@ -26,9 +27,10 @@ const (
 	defaultCheckInterval = 1 * time.Minute
 )
 
-// Configuration for the Cisco SD-WAN check
+// Configuration for the Versa check
 type checkCfg struct {
 	// add versa specific fields
+	Name                            string `yaml:"name"` // TODO: remove this field, only added it for testing
 	Namespace                       string `yaml:"namespace"`
 	SendNDMMetadata                 *bool  `yaml:"send_ndm_metadata"`
 	MinCollectionInterval           int    `yaml:"min_collection_interval"`
@@ -49,20 +51,23 @@ type VersaCheck struct {
 	core.CheckBase
 	interval      time.Duration
 	config        checkCfg
-	metricsSender *report.SDWanSender
+	metricsSender *report.Sender
 }
 
 // Run executes the check
 func (v *VersaCheck) Run() error {
 
+	log.Infof("Running Versa check for instance: %s", v.config.Name)
+
 	// Commit
-	v.metricsSender.Commit()
+	//v.metricsSender.Commit()
 
 	return nil
 }
 
 // Configure the Versa check
 func (v *VersaCheck) Configure(senderManager sender.SenderManager, integrationConfigDigest uint64, rawInstance integration.Data, rawInitConfig integration.Data, source string) error {
+
 	// Must be called before v.CommonConfigure
 	v.BuildID(integrationConfigDigest, rawInstance, rawInitConfig)
 
@@ -112,7 +117,7 @@ func (v *VersaCheck) Configure(senderManager sender.SenderManager, integrationCo
 		v.interval = time.Second * time.Duration(v.config.MinCollectionInterval)
 	}
 
-	v.metricsSender = report.NewSDWanSender(sender, v.config.Namespace)
+	v.metricsSender = report.NewSender(sender, v.config.Namespace)
 
 	return nil
 }

--- a/pkg/commonchecks/corechecks.go
+++ b/pkg/commonchecks/corechecks.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/net/network"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/net/ntp"
 	ciscosdwan "github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/cisco-sdwan"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/network-devices/versa"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/networkpath"
 	nvidia "github.com/DataDog/datadog-agent/pkg/collector/corechecks/nvidia/jetson"
 	oracle "github.com/DataDog/datadog-agent/pkg/collector/corechecks/oracle"
@@ -102,4 +103,5 @@ func RegisterChecks(store workloadmeta.Component, tagger tagger.Component, cfg c
 	corecheckLoader.RegisterCheck(cri.CheckName, cri.Factory(store, tagger))
 	corecheckLoader.RegisterCheck(ciscosdwan.CheckName, ciscosdwan.Factory())
 	corecheckLoader.RegisterCheck(servicediscovery.CheckName, servicediscovery.Factory())
+	corecheckLoader.RegisterCheck(versa.CheckName, versa.Factory())
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Creates a more or less no-op implementation of the Versa integration. I say more or less because it logs the name of each instance of the check configured.

### Motivation
Starting Versa integration work to send data to NDM

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->