### PR TITLE
usm: protocols: Don't exclude probes, maps and TCs if those are used by a supported protocol

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -438,9 +438,30 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		}
 	}
 
+	// We might have shared maps, probes and TCs between supported and not supported protocols. We need to make sure
+	// that we're not excluding a shared resource if it is used by at least one supported protocol.
+	supportedMaps := make(map[string]struct{})
+	supportedProbes := make(map[string]struct{})
+	supportedTCs := make(map[string]struct{})
+	for _, p := range supported {
+		for _, m := range p.Maps {
+			supportedMaps[m.Name] = struct{}{}
+		}
+		for _, probe := range p.Probes {
+			supportedProbes[probe.ProbeIdentificationPair.EBPFFuncName] = struct{}{}
+		}
+		for _, tc := range p.TailCalls {
+			supportedTCs[tc.ProbeIdentificationPair.EBPFFuncName] = struct{}{}
+		}
+	}
+
 	// Add excluded functions from disabled protocols
 	for _, p := range notSupported {
 		for _, m := range p.Maps {
+			if _, ok := supportedMaps[m.Name]; ok {
+				log.Debugf("map %s is shared between enabled and disabled protocols", m.Name)
+				continue
+			}
 			// Unused maps still need to have a non-zero size
 			options.MapSpecEditors[m.Name] = manager.MapSpecEditor{
 				MaxEntries: uint32(1),
@@ -451,11 +472,21 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 		}
 
 		for _, probe := range p.Probes {
+			if _, ok := supportedProbes[probe.ProbeIdentificationPair.EBPFFuncName]; ok {
+				log.Debugf("probe %s is shared between enabled and disabled protocols", probe.ProbeIdentificationPair.EBPFFuncName)
+				continue
+			}
 			options.ExcludedFunctions = append(options.ExcludedFunctions, probe.ProbeIdentificationPair.EBPFFuncName)
+			log.Debugf("disabled probe: %v", probe.ProbeIdentificationPair.EBPFFuncName)
 		}
 
 		for _, tc := range p.TailCalls {
+			if _, ok := supportedTCs[tc.ProbeIdentificationPair.EBPFFuncName]; ok {
+				log.Debugf("tail call %s is shared between enabled and disabled protocols", tc.ProbeIdentificationPair.EBPFFuncName)
+				continue
+			}
 			options.ExcludedFunctions = append(options.ExcludedFunctions, tc.ProbeIdentificationPair.EBPFFuncName)
+			log.Debugf("disabled tail call: %v", tc.ProbeIdentificationPair.EBPFFuncName)
 		}
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Allowing sharing maps, probes and TC between protocols.

### Motivation

We can have shared maps, probes and TCs between supported and unsupported modules. Today, we would just disable those resources, preventing from sharing resources. After the fix, we are sensitive to this scenario and allowing it.

It will be crucial for the separation of istio and nodejs protocols from the native tls implementations, as we share probes and maps between them.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->