### PR TITLE
USM: make the istio monitor to a real protocol

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -52,6 +52,7 @@ var (
 		// factory.
 		opensslSpec,
 		goTLSSpec,
+		istioSpec,
 	}
 )
 

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -485,19 +485,23 @@ func (o *sslProgram) Name() string {
 	return "openssl"
 }
 
-// ConfigureOptions changes map attributes to the given options.
-func (o *sslProgram) ConfigureOptions(options *manager.Options) {
+func sharedLibrariesConfigureOptions(options *manager.Options, cfg *config.Config) {
 	options.MapSpecEditors[sslSockByCtxMap] = manager.MapSpecEditor{
-		MaxEntries: o.cfg.MaxTrackedConnections,
+		MaxEntries: cfg.MaxTrackedConnections,
 		EditorFlag: manager.EditMaxEntries,
 	}
 	options.MapSpecEditors[sslCtxByPIDTGIDMap] = manager.MapSpecEditor{
-		MaxEntries: o.cfg.MaxTrackedConnections,
+		MaxEntries: cfg.MaxTrackedConnections,
 		EditorFlag: manager.EditMaxEntries,
 	}
 	options.ActivatedProbes = append(options.ActivatedProbes, &manager.ProbeSelector{
 		ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_sendmsg"},
 	})
+}
+
+// ConfigureOptions changes map attributes to the given options.
+func (o *sslProgram) ConfigureOptions(options *manager.Options) {
+	sharedLibrariesConfigureOptions(options, o.cfg)
 }
 
 // PreStart is called before the start of the provided eBPF manager.

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -428,12 +428,11 @@ var opensslSpec = &protocols.ProtocolSpec{
 type sslProgram struct {
 	cfg           *config.Config
 	watcher       *sharedlibraries.Watcher
-	istioMonitor  *istioMonitor
 	nodeJSMonitor *nodeJSMonitor
 }
 
 func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protocols.Protocol, error) {
-	if (!c.EnableNativeTLSMonitoring || !usmconfig.TLSSupported(c)) && !c.EnableIstioMonitoring && !c.EnableNodeJSMonitoring {
+	if (!c.EnableNativeTLSMonitoring || !usmconfig.TLSSupported(c)) && !c.EnableNodeJSMonitoring {
 		return nil, nil
 	}
 
@@ -472,15 +471,9 @@ func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protoco
 		return nil, fmt.Errorf("error initializing nodejs monitor: %w", err)
 	}
 
-	istio, err := newIstioMonitor(c, m)
-	if err != nil {
-		return nil, fmt.Errorf("error initializing istio monitor: %w", err)
-	}
-
 	return &sslProgram{
 		cfg:           c,
 		watcher:       watcher,
-		istioMonitor:  istio,
 		nodeJSMonitor: nodejs,
 	}, nil
 }
@@ -508,7 +501,6 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 // PreStart is called before the start of the provided eBPF manager.
 func (o *sslProgram) PreStart() error {
 	o.watcher.Start()
-	o.istioMonitor.Start()
 	o.nodeJSMonitor.Start()
 	return nil
 }
@@ -521,7 +513,6 @@ func (o *sslProgram) PostStart() error {
 // Stop stops the program.
 func (o *sslProgram) Stop() {
 	o.watcher.Stop()
-	o.istioMonitor.Stop()
 	o.nodeJSMonitor.Stop()
 }
 

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -243,14 +243,8 @@ const (
 
 var (
 	buildKitProcessName = []byte("buildkitd")
-)
 
-// Template, will be modified during runtime.
-// The constructor of SSLProgram requires more parameters than we provide in the general way, thus we need to have
-// a dynamic initialization.
-var opensslSpec = &protocols.ProtocolSpec{
-	Factory: newSSLProgramProtocolFactory,
-	Maps: []*manager.Map{
+	sharedLibrariesMaps = []*manager.Map{
 		{
 			Name: sslSockByCtxMap,
 		},
@@ -275,7 +269,15 @@ var opensslSpec = &protocols.ProtocolSpec{
 		{
 			Name: sslCtxByPIDTGIDMap,
 		},
-	},
+	}
+)
+
+// Template, will be modified during runtime.
+// The constructor of SSLProgram requires more parameters than we provide in the general way, thus we need to have
+// a dynamic initialization.
+var opensslSpec = &protocols.ProtocolSpec{
+	Factory: newSSLProgramProtocolFactory,
+	Maps:    sharedLibrariesMaps,
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -146,6 +146,9 @@ type istioMonitor struct {
 	processMonitor *monitor.ProcessMonitor
 }
 
+// Ensure istioMonitor implements the Protocol interface.
+var _ protocols.Protocol = (*istioMonitor)(nil)
+
 func newIstioMonitor(mgr *manager.Manager, c *config.Config) (protocols.Protocol, error) {
 	if !c.EnableIstioMonitoring || !usmconfig.TLSSupported(c) {
 		return nil, nil

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/consts"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -87,7 +88,7 @@ type istioMonitor struct {
 }
 
 func newIstioMonitor(c *config.Config, mgr *manager.Manager) (*istioMonitor, error) {
-	if !c.EnableIstioMonitoring {
+	if !c.EnableIstioMonitoring || !usmconfig.TLSSupported(c) {
 		return nil, nil
 	}
 

--- a/pkg/network/usm/istio.go
+++ b/pkg/network/usm/istio.go
@@ -8,13 +8,19 @@
 package usm
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"strings"
+
+	"github.com/cilium/ebpf"
 
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/consts"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
@@ -75,6 +81,58 @@ var istioProbes = []manager.ProbesSelector{
 	},
 }
 
+var istioSpec = &protocols.ProtocolSpec{
+	Factory: newIstioMonitor,
+	Maps:    sharedLibrariesMaps,
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "kprobe__tcp_sendmsg",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslDoHandshakeProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslDoHandshakeRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslSetBioProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslReadProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: istioSslReadRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslWriteProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: istioSslWriteRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslShutdownProbe,
+			},
+		},
+	},
+}
+
 // istioMonitor essentially scans for Envoy processes and attaches SSL uprobes
 // to them.
 //
@@ -82,17 +140,19 @@ var istioProbes = []manager.ProbesSelector{
 // because the Envoy binary embedded in the Istio containers have debug symbols
 // whereas the "vanilla" Envoy images are distributed without them.
 type istioMonitor struct {
+	cfg            *config.Config
 	attacher       *uprobes.UprobeAttacher
 	envoyCmd       string
 	processMonitor *monitor.ProcessMonitor
 }
 
-func newIstioMonitor(c *config.Config, mgr *manager.Manager) (*istioMonitor, error) {
+func newIstioMonitor(mgr *manager.Manager, c *config.Config) (protocols.Protocol, error) {
 	if !c.EnableIstioMonitoring || !usmconfig.TLSSupported(c) {
 		return nil, nil
 	}
 
 	m := &istioMonitor{
+		cfg:            c,
 		envoyCmd:       c.EnvoyPath,
 		attacher:       nil,
 		processMonitor: monitor.GetProcessMonitor(),
@@ -119,30 +179,31 @@ func newIstioMonitor(c *config.Config, mgr *manager.Manager) (*istioMonitor, err
 	return m, nil
 }
 
-// Start the istioMonitor
-func (m *istioMonitor) Start() {
-	if m == nil {
-		return
-	}
+// ConfigureOptions changes map attributes to the given options.
+func (m *istioMonitor) ConfigureOptions(options *manager.Options) {
+	sharedLibrariesConfigureOptions(options, m.cfg)
+}
 
+// PreStart is called before the start of the provided eBPF manager.
+func (m *istioMonitor) PreStart() error {
 	if m.attacher == nil {
-		log.Error("istio monitoring is enabled but the attacher is nil")
-		return
+		return errors.New("istio monitoring is enabled but the attacher is nil")
 	}
 
 	if err := m.attacher.Start(); err != nil {
-		log.Errorf("Cannot start istio attacher: %s", err)
+		return fmt.Errorf("cannot start istio attacher: %w", err)
 	}
 
-	log.Info("istio monitoring enabled")
+	return nil
+}
+
+// PostStart is called after the start of the provided eBPF manager.
+func (*istioMonitor) PostStart() error {
+	return nil
 }
 
 // Stop the istioMonitor.
 func (m *istioMonitor) Stop() {
-	if m == nil {
-		return
-	}
-
 	if m.attacher == nil {
 		log.Error("istio monitoring is enabled but the attacher is nil")
 		return
@@ -155,4 +216,22 @@ func (m *istioMonitor) Stop() {
 // command substring (as defined by m.envoyCmd).
 func (m *istioMonitor) isIstioBinary(path string, _ *uprobes.ProcInfo) bool {
 	return strings.Contains(path, m.envoyCmd)
+}
+
+// DumpMaps is a no-op.
+func (*istioMonitor) DumpMaps(io.Writer, string, *ebpf.Map) {}
+
+// Name return the program's name.
+func (*istioMonitor) Name() string {
+	return istioAttacherName
+}
+
+// GetStats is a no-op.
+func (*istioMonitor) GetStats() (*protocols.ProtocolStats, func()) {
+	return nil, nil
+}
+
+// IsBuildModeSupported returns always true, as tls module is supported by all modes.
+func (*istioMonitor) IsBuildModeSupported(buildmode.Type) bool {
+	return true
 }

--- a/pkg/network/usm/istio_test.go
+++ b/pkg/network/usm/istio_test.go
@@ -130,9 +130,9 @@ func newIstioTestMonitor(t *testing.T, procRoot string) *istioMonitor {
 }
 
 func newIstioTestMonitorWithCFG(t *testing.T, cfg *config.Config) *istioMonitor {
-	monitor, err := newIstioMonitor(cfg, nil)
+	monitor, err := newIstioMonitor(nil, cfg)
 	require.NoError(t, err)
 	require.NotNil(t, monitor)
 
-	return monitor
+	return monitor.(*istioMonitor)
 }

--- a/pkg/network/usm/istio_test.go
+++ b/pkg/network/usm/istio_test.go
@@ -8,7 +8,6 @@
 package usm
 
 import (
-	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 )
 

--- a/pkg/network/usm/istio_test.go
+++ b/pkg/network/usm/istio_test.go
@@ -8,6 +8,7 @@
 package usm
 
 import (
+	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,6 +27,9 @@ const (
 )
 
 func TestIsIstioBinary(t *testing.T) {
+	if !usmconfig.TLSSupported(utils.NewUSMEmptyConfig()) {
+		t.Skip("TLS not supported")
+	}
 	procRoot := uprobes.CreateFakeProcFS(t, []uprobes.FakeProcFSEntry{})
 	m := newIstioTestMonitor(t, procRoot)
 
@@ -38,6 +42,9 @@ func TestIsIstioBinary(t *testing.T) {
 }
 
 func TestGetEnvoyPathWithConfig(t *testing.T) {
+	if !usmconfig.TLSSupported(utils.NewUSMEmptyConfig()) {
+		t.Skip("TLS not supported")
+	}
 	cfg := utils.NewUSMEmptyConfig()
 	cfg.EnableIstioMonitoring = true
 	cfg.EnvoyPath = "/test/envoy"
@@ -48,6 +55,9 @@ func TestGetEnvoyPathWithConfig(t *testing.T) {
 }
 
 func TestIstioSync(t *testing.T) {
+	if !usmconfig.TLSSupported(utils.NewUSMEmptyConfig()) {
+		t.Skip("TLS not supported")
+	}
 	t.Run("calling sync for the first time", func(tt *testing.T) {
 		procRoot := uprobes.CreateFakeProcFS(tt, []uprobes.FakeProcFSEntry{
 			{Pid: 1, Exe: defaultEnvoyName},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Introduces a standalone istio protocol, which is not encapsulated inside openssl monitor.

### Motivation

clean code and remove complexity from openssl monitor.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Load test results shows 100% accuracy without any side effect

![image](https://github.com/user-attachments/assets/ce2eca6e-d585-42f0-8f73-4ec2dc98d735)

cpu
![image](https://github.com/user-attachments/assets/9230bdc2-b878-4b3f-be3b-6098097d3629)

memory
![image](https://github.com/user-attachments/assets/e5ca0fb4-466c-4d42-8407-b9d7d52ae908)
