### PR TITLE
fix(worktree):Remove filter option to prevent later issues at pull time

### DIFF
--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -31,13 +31,10 @@ def init_env(ctx, branch: str | None = None, commit: str | None = None):
         print(f'{color_message("Info", Color.BLUE)}: Cloning datadog agent into {WORKTREE_DIRECTORY}', file=sys.stderr)
         remote = ctx.run("git remote get-url origin", hide=True).stdout.strip()
         # Try to use this option to reduce cloning time
-        if all(
-            not ctx.run(
-                f"git clone '{remote}' '{WORKTREE_DIRECTORY}' -b {branch or 'main'} {filter_option}",
-                warn=True,
-                hide=True,
-            )
-            for filter_option in ["--filter=blob:none", ""]
+        if not ctx.run(
+            f"git clone '{remote}' '{WORKTREE_DIRECTORY}' -b {branch or 'main'}",
+            warn=True,
+            hide=True,
         ):
             raise Exit(
                 f'{color_message("Error", Color.RED)}: Cannot initialize worktree environment. You might want to reset the worktree directory with `dda inv worktree.remove`',


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove the `filter_option` used during the `git clone` of the "worktree"

### Motivation
Consecutive actions in the worktree led to `git pull` errors
```
fatal: pack has 23 unresolved deltas
fatal: fetch-pack: invalid index-pack output
```


### Describe how you validated your changes
This kind of error can relate to problems related to the clone (see [here](https://stackoverflow.com/a/22317479) or [here](https://superuser.com/a/867526)) I didn't manage to "fix" the clone (ie doing git operations then do a successful `git pull`. So I tried to remove this option, nuked the folder and do consecutive operations, which worked fine.
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->