### PR TITLE
usm: sharedlibraries: Move tcpsendmsg kprobe from general usm to native tls

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/usm.c
+++ b/pkg/network/ebpf/c/prebuilt/usm.c
@@ -40,13 +40,4 @@ int uprobe__tls_protocol_dispatcher_kafka(struct pt_regs *ctx) {
     return 0;
 };
 
-SEC("kprobe/tcp_sendmsg")
-int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendmsg, struct sock *sk) {
-    log_debug("kprobe/tcp_sendmsg: sk=%p", sk);
-    // map connection tuple during SSL_do_handshake(ctx)
-    map_ssl_ctx_to_sock(sk);
-
-    return 0;
-}
-
 char _license[] SEC("license") = "GPL";

--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -549,4 +549,13 @@ int BPF_BYPASSABLE_UPROBE(uprobe__gnutls_deinit, void *ssl_session) {
     return 0;
 }
 
+SEC("kprobe/tcp_sendmsg")
+int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendmsg, struct sock *sk) {
+    log_debug("kprobe/tcp_sendmsg: sk=%p", sk);
+    // map connection tuple during SSL_do_handshake(ctx)
+    map_ssl_ctx_to_sock(sk);
+
+    return 0;
+}
+
 #endif

--- a/pkg/network/ebpf/c/runtime/usm.c
+++ b/pkg/network/ebpf/c/runtime/usm.c
@@ -56,15 +56,6 @@ int uprobe__tls_protocol_dispatcher_kafka(struct pt_regs *ctx) {
     return 0;
 };
 
-SEC("kprobe/tcp_sendmsg")
-int BPF_BYPASSABLE_KPROBE(kprobe__tcp_sendmsg, struct sock *sk) {
-    log_debug("kprobe/tcp_sendmsg: sk=%p", sk);
-    // map connection tuple during SSL_do_handshake(ctx)
-    map_ssl_ctx_to_sock(sk);
-
-    return 0;
-}
-
 // GO TLS PROBES
 
 // func (c *Conn) Write(b []byte) (int, error)

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -104,12 +104,6 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map) (*ebpfPro
 		Probes: []*manager.Probe{
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: "kprobe__tcp_sendmsg",
-					UID:          probeUID,
-				},
-			},
-			{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFFuncName: tcpCloseProbe,
 					UID:          probeUID,
 				},

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -280,7 +280,6 @@ var opensslSpec = &protocols.ProtocolSpec{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFFuncName: "kprobe__tcp_sendmsg",
-				UID:          probeUID,
 			},
 		},
 		{
@@ -501,6 +500,9 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 		MaxEntries: o.cfg.MaxTrackedConnections,
 		EditorFlag: manager.EditMaxEntries,
 	}
+	options.ActivatedProbes = append(options.ActivatedProbes, &manager.ProbeSelector{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_sendmsg"},
+	})
 }
 
 // PreStart is called before the start of the provided eBPF manager.

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -279,6 +279,12 @@ var opensslSpec = &protocols.ProtocolSpec{
 	Probes: []*manager.Probe{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "kprobe__tcp_sendmsg",
+				UID:          probeUID,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFFuncName: sslReadExProbe,
 			},
 		},


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Moves the activation of tcp_sendmsg kprobe from general usm (always enabled) to sharedlibraries module, to be enabled only if we have native tls, istio or nodejs monitoring enabled.

### Motivation

The probe belongs with the native tls modules, and not with general usm

Better organization of the code

Enable only relevant probes, and reduce redundant footprint when not needed

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->