### PR TITLE
Fix automatic milestone workflow on release branch

### DIFF
--- a/.github/workflows/add_milestone.yml
+++ b/.github/workflows/add_milestone.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Get repo current milestone
         id: current-milestone
         run: |
-          if [[ ${GITHUB_REF##*/} =~ ^7\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ${GITHUB_BASE_REF##*/} =~ ^7\.[0-9]+\.x$ ]]; then
             # If we're on a release branch, set the milestone to the latest release milestone found.
-            MILESTONE=$(gh release list | grep -o $(echo ${GITHUB_REF##*/} | sed 's/x/[0-9]*/g') | sort -uV | tail -1)
+            MILESTONE=$(gh release list | grep -o $(echo ${GITHUB_BASE_REF##*/} | sed 's/x/[0-9]*/g') | sort -uV | tail -1)
             if [ -z "$MILESTONE" ]; then
               echo "Error: Couldn't get the latest release milestone from Github."
               exit 1


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the automatic milestone workflow on release branches.

### Motivation
Have the correct workflow on PRs merged on release branches.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Not very sure how I can test...

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
`GITHUB_REF` has format `refs/pull/42/merge` on pull requests (with 42 being the PR number), so it's really not what we want to use here.
`GITHUB_BASE_REF` is the name of the target branch of the PR. 