### PR TITLE
Ignore bouncycastle-fips preview releases

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -218,3 +218,7 @@ updates:
       - changelog/no-changelog
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: org.bouncycaslte:*
+        # Ignore preview versions
+        versions: [ "[2.1,)" ]


### PR DESCRIPTION

### What does this PR do?

Limit bouncycastle updates to the current published stream.

https://www.bouncycastle.org/download/bouncy-castle-java-fips 

2.1 is a preview for an upcoming release:

https://www.bouncycastle.org/download/bouncy-castle-java-fips/roadmap/

### Motivation

We need to use a version with a published security certificate.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->