### PR TITLE
[EBPF] kmt: fix detection of runtime failures

### DIFF
--- a/test/new-e2e/system-probe/test-json-review/main_test.go
+++ b/test/new-e2e/system-probe/test-json-review/main_test.go
@@ -28,19 +28,23 @@ const flakeTestData = `{"Time":"2024-06-14T22:24:53.156240262Z","Action":"run","
 {"Time":"2024-06-14T22:24:53.156263319Z","Action":"output","Package":"a/b/c","Test":"testname","Output":"=== RUN   testname\n"}
 {"Time":"2024-06-14T22:24:53.156271614Z","Action":"output","Package":"a/b/c","Test":"testname","Output":"    file_test.go:10: flakytest: this is a known flaky test\n"}
 {"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Test":"testname","Elapsed":26.25}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Elapsed":26.25}
 `
 
 const failedTestData = `{"Time":"2024-06-14T22:24:53.156240262Z","Action":"run","Package":"a/b/c","Test":"testname"}
 {"Time":"2024-06-14T22:24:53.156263319Z","Action":"output","Package":"a/b/c","Test":"testname","Output":"=== RUN   testname\n"}
 {"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Test":"testname","Elapsed":26.25}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Elapsed":26.25}
 `
 
 const rerunTestData = `{"Time":"2024-06-14T22:24:53.156240262Z","Action":"run","Package":"a/b/c","Test":"testname"}
 {"Time":"2024-06-14T22:24:53.156263319Z","Action":"output","Package":"a/b/c","Test":"testname","Output":"=== RUN   testname\n"}
 {"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Test":"testname","Elapsed":26.25}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Elapsed":26.25}
 {"Time":"2024-06-14T22:27:53.156240262Z","Action":"run","Package":"a/b/c","Test":"testname"}
 {"Time":"2024-06-14T22:27:53.156263319Z","Action":"output","Package":"a/b/c","Test":"testname","Output":"=== RUN   testname\n"}
 {"Time":"2024-06-14T22:28:02.039003529Z","Action":"pass","Package":"a/b/c","Test":"testname","Elapsed":26.25}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"pass","Package":"a/b/c","Elapsed":26.25}
 `
 
 const onlyParentOfFlakeFailed = `{"Time":"2024-06-14T22:24:52.156240262Z","Action":"run","Package":"a/b/c","Test":"testparent"}
@@ -49,6 +53,7 @@ const onlyParentOfFlakeFailed = `{"Time":"2024-06-14T22:24:52.156240262Z","Actio
 {"Time":"2024-06-14T22:24:53.156271614Z","Action":"output","Package":"a/b/c","Test":"testparent/testname","Output":"    file_test.go:10: flakytest: this is a known flaky test\n"}
 {"Time":"2024-06-14T22:26:02.039003529Z","Action":"pass","Package":"a/b/c","Test":"testparent/testname","Elapsed":26.25}
 {"Time":"2024-06-14T22:26:03.039003529Z","Action":"fail","Package":"a/b/c","Test":"testparent","Elapsed":28.25}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Elapsed":26.25}
 `
 
 const flakyFailWithParentFail = `{"Time":"2024-06-14T22:24:52.156240262Z","Action":"run","Package":"a/b/c","Test":"testparent"}
@@ -57,6 +62,7 @@ const flakyFailWithParentFail = `{"Time":"2024-06-14T22:24:52.156240262Z","Actio
 {"Time":"2024-06-14T22:24:53.156271614Z","Action":"output","Package":"a/b/c","Test":"testparent/testname","Output":"    file_test.go:10: flakytest: this is a known flaky test\n"}
 {"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Test":"testparent/testname","Elapsed":26.25}
 {"Time":"2024-06-14T22:26:03.039003529Z","Action":"fail","Package":"a/b/c","Test":"testparent","Elapsed":28.25}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Elapsed":26.25}
 `
 const parentWithFlakyAndNormalFail = `{"Time":"2024-06-14T22:24:52.156240262Z","Action":"run","Package":"a/b/c","Test":"testparent"}
 {"Time":"2024-06-14T22:24:53.156240262Z","Action":"run","Package":"a/b/c","Test":"testparent/testname"}
@@ -67,6 +73,15 @@ const parentWithFlakyAndNormalFail = `{"Time":"2024-06-14T22:24:52.156240262Z","
 {"Time":"2024-06-14T22:24:55.156263319Z","Action":"output","Package":"a/b/c","Test":"testparent/testname2","Output":"=== RUN   testparent/testname2\n"}
 {"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Test":"testparent/testname2","Elapsed":26.25}
 {"Time":"2024-06-14T22:26:03.039003529Z","Action":"fail","Package":"a/b/c","Test":"testparent","Elapsed":28.25}
+{"Time":"2024-06-14T22:26:02.039003529Z","Action":"fail","Package":"a/b/c","Elapsed":26.25}
+`
+
+const packageFailGlibcError = `{"Time":"2025-03-04T11:09:29.073111111Z","Action":"start","Package":"pkg/security"}
+{"Time":"2025-03-04T11:09:29.073856561Z","Action":"output","Package":"pkg/security","Output":"/opt/kmt-ramfs/security-agent-tests/pkg/security/testsuite: /lib64/libc.so.6: version GLIBC_2.28 not found (required by /opt/kmt-ramfs/security-agent-tests/pkg/security/testsuite)\n"}
+{"Time":"2025-03-04T11:09:29.073915303Z","Action":"fail","Package":"pkg/security","Elapsed":0.001}
+{"Time":"2025-03-04T11:09:29.123090011Z","Action":"start","Package":"pkg/security"}
+{"Time":"2025-03-04T11:09:29.123688408Z","Action":"output","Package":"pkg/security","Output":"/opt/kmt-ramfs/security-agent-tests/pkg/security/testsuite: /lib64/libc.so.6: version GLIBC_2.28 not found (required by /opt/kmt-ramfs/security-agent-tests/pkg/security/testsuite)\n"}
+{"Time":"2025-03-04T11:09:29.123790519Z","Action":"fail","Package":"pkg/security","Elapsed":0.001}
 `
 
 func TestFlakeInOutput(t *testing.T) {
@@ -124,5 +139,16 @@ func TestParentOfFlakeAndFailIsFailed(t *testing.T) {
 
 	assert.Equal(t, failStr, out.Failed)
 	assert.Equal(t, flakyChild, out.Flaky)
+	assert.Empty(t, out.ReRuns)
+}
+
+func TestPackageRunFail(t *testing.T) {
+	out, err := reviewTestsReaders(bytes.NewBuffer([]byte(packageFailGlibcError)), nil, nil)
+	require.NoError(t, err)
+
+	failStr := fmt.Sprintf(failFormatTest, "pkg/security", "")
+
+	assert.Equal(t, failStr, out.Failed)
+	assert.Empty(t, out.Flaky)
 	assert.Empty(t, out.ReRuns)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes an issue with the test-json-review program that runs in KMT, where runtime failures of the test program (not of the tests themselves) would be ignored and it would be reported as a successful run. 

The fix consists of tracking packages marked as failed and the number of tests they ran. A package that failed with no ran tests is marked as failed directly.

### Motivation

Accurate reporting of failed tests.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests included

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

An alternative implementation building the complete tree of tests was considered, but it was more complex. However, it would be interesting to keep it in mind in case there's more failing cases in the code.