### PR TITLE
feat(ci): Set a variable to identify triggered pipelines

### DIFF
--- a/tasks/libs/notify/pipeline_status.py
+++ b/tasks/libs/notify/pipeline_status.py
@@ -40,7 +40,7 @@ def send_message(pipeline_id, dry_run):
     # For deploy pipelines not on the main branch, send notifications in a
     # dedicated channel.
     slack_channel = PIPELINES_CHANNEL
-    pipeline_type = get_pipeline_type(pipeline)
+    pipeline_type = get_pipeline_type()
     if pipeline_type == "deploy" and pipeline.ref != get_default_branch():
         slack_channel = DEPLOY_PIPELINES_CHANNEL
 

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -58,13 +58,13 @@ def should_notify(pipeline_id):
     return pipeline.source != 'pipeline' or pipeline.source == 'pipeline' and 'DDR_WORKFLOW_ID' in os.environ
 
 
-def get_pipeline_type(pipeline):
+def get_pipeline_type():
     """
     Return the type of notification to send (related to the type of pipeline, amongst 'deploy', 'trigger' and 'merge')
     """
     if os.environ.get('DEPLOY_AGENT', '') == 'true':
         return 'deploy'
-    elif pipeline.source != 'push':
+    elif os.environ.get('TRIGGERED_PIPELINE', 'false') == 'true':
         return 'trigger'
     else:
         return 'merge'

--- a/tasks/libs/notify/utils.py
+++ b/tasks/libs/notify/utils.py
@@ -64,7 +64,7 @@ def get_pipeline_type():
     """
     if os.environ.get('DEPLOY_AGENT', '') == 'true':
         return 'deploy'
-    elif os.environ.get('TRIGGERED_PIPELINE', 'false') == 'true':
+    elif os.environ.get('TRIGGERED_PIPELINE', 'false') == 'true' or 'DDR_WORKFLOW_ID' in os.environ:
         return 'trigger'
     else:
         return 'merge'

--- a/tasks/libs/pipeline/tools.py
+++ b/tasks/libs/pipeline/tools.py
@@ -136,7 +136,7 @@ def trigger_agent_pipeline(
     """
 
     ref = ref or get_default_branch()
-    args = {}
+    args = {"TRIGGERED_PIPELINE": "true"}
 
     if deploy:
         args["DEPLOY_AGENT"] = "true"

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -57,6 +57,28 @@ class TestSendMessage(unittest.TestCase):
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
     @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
+    @patch('builtins.print')
+    @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
+    def test_merge_ddci(self, api_mock, print_mock):
+        repo_mock = api_mock.return_value.projects.get.return_value
+        repo_mock.jobs.get.return_value.artifact.return_value = b"{}"
+        repo_mock.jobs.get.return_value.trace.return_value = b"Log trace"
+        repo_mock.pipelines.get.return_value.ref = "test"
+        repo_mock.pipelines.get.return_value.source = "api"
+        repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
+        repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:59:48.396Z"
+        list_mock = repo_mock.pipelines.get.return_value.jobs.list
+        list_mock.side_effect = [get_fake_jobs(), []]
+        with patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'coin'}, clear=True):
+            notify.send_message(MockContext(), "42", dry_run=True)
+        list_mock.assert_called()
+        repo_mock.pipelines.get.assert_called_with("42")
+        self.assertTrue("merge" in print_mock.mock_calls[0].args[0])
+        repo_mock.jobs.get.assert_called()
+
+    @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
+    @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
+    @patch('slack_sdk.WebClient', new=MagicMock())
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('tasks.libs.notify.pipeline_status.get_failed_jobs')
     @patch('builtins.print')
@@ -264,6 +286,7 @@ class TestSendMessage(unittest.TestCase):
     @patch('tasks.libs.pipeline.notifications.get_pr_from_commit', new=MagicMock(return_value=""))
     @patch('tasks.libs.notify.pipeline_status.get_jobs_skipped_on_pr', new=MagicMock(return_value=([], "")))
     @patch('slack_sdk.WebClient', new=MagicMock())
+    @patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'miaou', 'TRIGGERED_PIPELINE': 'true'}, clear=True)
     @patch('tasks.libs.ciproviders.gitlab_api.get_gitlab_api')
     @patch('builtins.print')
     def test_trigger_with_get_failed_call(self, print_mock, api_mock):
@@ -279,8 +302,7 @@ class TestSendMessage(unittest.TestCase):
         repo_mock.pipelines.get.return_value.started_at = "2025-02-07T05:59:48.396Z"
         repo_mock.pipelines.get.return_value.finished_at = "2025-02-07T06:59:48.396Z"
 
-        with patch.dict('os.environ', {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'miaou'}, clear=True):
-            notify.send_message(MockContext(), "42", dry_run=True)
+        notify.send_message(MockContext(), "42", dry_run=True)
         self.assertTrue("arrow_forward" in print_mock.mock_calls[0].args[0])
         self.assertTrue("[:hourglass: 60 min]" in print_mock.mock_calls[0].args[0])
         trace_mock.assert_called()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set a new `TRIGGERED_PIPELINE` environment variable when we call the trigger_pipeline api.

### Motivation
After ddci migration, there will be no more `push` event pipelines. As a consequence we need another way to idenfify the pipeline type for the notification report.
https://datadoghq.atlassian.net/browse/ACIX-534


### Describe how you validated your changes
Triggered a manual pipeline: the param is well set
```
inv pipeline.run -he                
Creating pipeline for datadog-agent on branch/tag nschweitzer/pipeline_type with args:
  - TRIGGERED_PIPELINE: true
```
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->