### PR TITLE
cleanup(pkg/network/ebpf): remove some unused macro

### DIFF
--- a/pkg/network/driver/ddnpmapi.h
+++ b/pkg/network/driver/ddnpmapi.h
@@ -377,11 +377,6 @@ typedef struct filterPacketHeader
 // This determines the size of the payload fragment that is captured for each HTTP request
 #define HTTP_BUFFER_SIZE 25
 
-// This controls the number of HTTP transactions read from userspace at a time
-#define HTTP_BATCH_SIZE 15
-
-#define HTTPS_PORT 443
-
 typedef enum _HttpPacketType {
     HTTP_PACKET_UNKNOWN = 0,
     HTTP_REQUEST,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR should remove 2 unused macro
- HTTP_BATCH_SIZE seems redefined in HTTP protocol files https://github.com/DataDog/datadog-agent/blob/17702bb3ffa1595d2763e1eb341902dd8fa8bc95/pkg/network/ebpf/c/protocols/http/usm-events.h#L8
- HTTPS_PORT seems not to be used at all

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->