### PR TITLE
[cluster-agent/languagedetection] Use strings.Builder to reduce allocations

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -112,9 +112,13 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 
 	ownersLanguagesFromRequest := getOwnersLanguages(requestData, time.Now().Add(handler.cfg.languageTTL))
 
-	log.Tracef("Owner Languages state pre merge-and-flush: %s", handler.ownersLanguages.String())
+	if log.ShouldLog(log.TraceLvl) { // Avoid call to String() if not needed
+		log.Tracef("Owner Languages state pre merge-and-flush: %s", handler.ownersLanguages.String())
+	}
 	err = handler.ownersLanguages.mergeAndFlush(ownersLanguagesFromRequest, handler.wlm)
-	log.Tracef("Owner Languages state post merge-and-flush: %s", handler.ownersLanguages.String())
+	if log.ShouldLog(log.TraceLvl) { // Avoid call to String() if not needed
+		log.Tracef("Owner Languages state post merge-and-flush: %s", handler.ownersLanguages.String())
+	}
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to store some (or all) languages in workloadmeta store: %s", err), http.StatusInternalServerError)
 		ProcessedRequests.Inc(statusError)

--- a/cmd/cluster-agent/api/v1/languagedetection/util.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/util.go
@@ -77,20 +77,41 @@ func (ownersLanguages *OwnersLanguages) String() string {
 	ownersLanguages.mutex.Lock()
 	defer ownersLanguages.mutex.Unlock()
 
-	state := "["
+	var sb strings.Builder
+	sb.WriteString("[")
+
+	firstOwner := true
 	for owner, langs := range ownersLanguages.containersLanguages {
-		state += fmt.Sprintf("(%s/%s/%s, %v,[", owner.Namespace, owner.Kind, owner.Name, langs.dirty)
-		for container, languageSet := range langs.languages {
-			state += container.Name + ": ("
-			for languagename := range languageSet {
-				state += fmt.Sprintf("%s,", languagename)
-			}
-			state += "),"
+		if !firstOwner {
+			sb.WriteString(",")
 		}
-		state += "]),"
+
+		sb.WriteString(fmt.Sprintf("(%s/%s/%s, %v,[", owner.Namespace, owner.Kind, owner.Name, langs.dirty))
+
+		firstContainer := true
+		for container, languageSet := range langs.languages {
+			if !firstContainer {
+				sb.WriteString(",")
+			}
+			sb.WriteString(container.Name + ": (")
+
+			languages := make([]string, 0, len(languageSet))
+			for languagename := range languageSet {
+				languages = append(languages, string(languagename))
+			}
+			sb.WriteString(strings.Join(languages, ","))
+
+			sb.WriteString(")")
+			firstContainer = false
+		}
+
+		sb.WriteString("])")
+		firstOwner = false
 	}
-	state += "]"
-	return state
+
+	sb.WriteString("]")
+
+	return sb.String()
 }
 
 // getOrInitialize returns the containers languages for a specific namespaced owner, initialising it if it doesn't already


### PR DESCRIPTION
### What does this PR do?

This PR replaces string concatenations with a `strings.Builder` in the `String` function of `cmd/cluster-agent/api/v1/languagedetection/util.go`.

The goal is to reduce memory allocations and improve performance, as this function frequently appears in profiles with high CPU and memory usage.

### Describe how you validated your changes

I checked that the log is printed with the expected format. We'll check improvement in CPU/memory when deploying on large clusters.