### PR TITLE
fix return type of connection_protocol map lookup

### DIFF
--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -78,10 +78,11 @@ __maybe_unused static __always_inline void delete_protocol_stack(conn_tuple_t* n
     }
 
     if (!stack) {
-        stack = bpf_map_lookup_elem(&connection_protocol, normalized_tuple);
-        if (!stack) {
+        protocol_stack_wrapper_t *wrapper = bpf_map_lookup_elem(&connection_protocol, normalized_tuple);
+        if (!wrapper) {
             return;
         }
+        stack = &wrapper->stack;
     }
 
     if (!(stack->flags&FLAG_USM_ENABLED) || !(stack->flags&FLAG_NPM_ENABLED)) {

--- a/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
+++ b/pkg/network/ebpf/c/protocols/classification/shared-tracer-maps.h
@@ -82,6 +82,7 @@ __maybe_unused static __always_inline void delete_protocol_stack(conn_tuple_t* n
         if (!wrapper) {
             return;
         }
+        barrier_var(wrapper); // prevent compiler from putting access before NULL check
         stack = &wrapper->stack;
     }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes the expected type from reading from the `connection_protocol` map from `protocol_stack_t` to `protocol_stack_wrapper_t`. This was not a problem before #32979 because `stack` was the first field in the wrapper struct.

### Motivation

Elevated entry count and deletion rate for the `connection_protocol` map.

### Describe how you validated your changes

Automated tests and load testing environment.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

Will be backported to 7.64

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->