### PR TITLE
[CWS] Use distinct probe UIDs for kprobes hooking on the same symbol

### DIFF
--- a/pkg/security/ebpf/probes/builder.go
+++ b/pkg/security/ebpf/probes/builder.go
@@ -53,3 +53,9 @@ func kretprobeOrFexit(funcName string, options ...psbOption) *manager.ProbeSelec
 		},
 	}
 }
+
+func withUID(uid string) psbOption {
+	return func(psb *probeSelectorBuilder) {
+		psb.uid = uid
+	}
+}

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -117,7 +117,7 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("security_bprm_check"),
 				}},
 				kprobeOrFentry("setup_new_exec_interp"),
-				kprobeOrFentry("setup_new_exec_args_envs"),
+				kprobeOrFentry("setup_new_exec_args_envs", withUID(SecurityAgentUID+"_a")),
 				kprobeOrFentry("setup_arg_pages"),
 				kprobeOrFentry("mprotect_fixup"),
 				kprobeOrFentry("exit_itimers"),

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -117,6 +117,8 @@ func GetSelectorsPerEventType(fentry bool) map[eval.EventType][]manager.ProbesSe
 					kprobeOrFentry("security_bprm_check"),
 				}},
 				kprobeOrFentry("setup_new_exec_interp"),
+				// kernels < 4.17 will rely on the tracefs events interface to attach kprobes, which requires event names to be unique
+				// because the setup_new_exec_interp and setup_new_exec_args_envs probes are attached to the same function, we rely on using a secondary uid for that purpose
 				kprobeOrFentry("setup_new_exec_args_envs", withUID(SecurityAgentUID+"_a")),
 				kprobeOrFentry("setup_arg_pages"),
 				kprobeOrFentry("mprotect_fixup"),

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -94,6 +94,8 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				// kernels < 4.17 will rely on the tracefs events interface to attach kprobes, which requires event names to be unique
+				// because the setup_new_exec_interp and setup_new_exec_args_envs probes are attached to the same function, we rely on using a secondary uid for that purpose
 				UID:          SecurityAgentUID + "_a",
 				EBPFFuncName: "hook_setup_new_exec_args_envs",
 			},

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -94,7 +94,7 @@ func getExecProbes(fentry bool) []*manager.Probe {
 		},
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				UID:          SecurityAgentUID,
+				UID:          SecurityAgentUID + "_a",
 				EBPFFuncName: "hook_setup_new_exec_args_envs",
 			},
 		},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use distinct probe UIDs for kprobes hooking on the same symbol

### Motivation

The `perf_event_open` interface to attach kprobes isn't available before kernel version 4.17.
This means pior kernel versions rely exclusively on the tracefs events interface to attach kprobes, which requires event names to be unique. The kprobe event names are currently constructed based on the kernel symbol (and UID) rather than the eBPF program name, thus we must rely on using a secondary UID when attaching two kprobes to the same symbol.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->