### PR TITLE
[CONTP-496] Improve cluster-agent CPU and memory usage in api handler

### DIFF
--- a/cmd/cluster-agent/api/v2/series/series.go
+++ b/cmd/cluster-agent/api/v2/series/series.go
@@ -36,12 +36,6 @@ var bufferPool = sync.Pool{
 	},
 }
 
-var metricPayloadPool = sync.Pool{
-	New: func() interface{} {
-		return &gogen.MetricPayload{}
-	},
-}
-
 type buffer struct {
 	buf *[]byte
 }
@@ -111,11 +105,7 @@ func (h *seriesHandler) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metricPayload := metricPayloadPool.Get().(*gogen.MetricPayload)
-	defer metricPayloadPool.Put(metricPayload)
-
-	// Reset the metricPayload before using it
-	*metricPayload = gogen.MetricPayload{}
+	metricPayload := &gogen.MetricPayload{}
 	if err := metricPayload.Unmarshal(payload); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/pkg/clusteragent/api/leader_forwarder.go
+++ b/pkg/clusteragent/api/leader_forwarder.go
@@ -43,7 +43,6 @@ type LeaderForwarder struct {
 func NewLeaderForwarder(apiPort, maxConnections int) *LeaderForwarder {
 	// Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
 	logWriter, _ := pkglogsetup.NewLogWriter(4, log.DebugLvl)
-	maxConnections = 10
 	return &LeaderForwarder{
 		apiPort: strconv.Itoa(apiPort),
 		transport: &http.Transport{

--- a/pkg/clusteragent/api/leader_handler.go
+++ b/pkg/clusteragent/api/leader_handler.go
@@ -37,6 +37,7 @@ type leaderEngine interface {
 
 type leaderForwarder interface {
 	SetLeaderIP(ip string)
+	GetLeaderIP() string
 	Forward(w http.ResponseWriter, r *http.Request)
 }
 
@@ -118,8 +119,10 @@ func (lph *LeaderProxyHandler) rejectOrForwardLeaderQuery(rw http.ResponseWriter
 		http.Error(rw, "leader forwarder is not available", http.StatusServiceUnavailable)
 		return true
 	}
-
-	lph.leaderForwarder.SetLeaderIP(ip)
+	if lph.leaderForwarder.GetLeaderIP() != ip {
+		log.Infof("leader ip changed to %s", ip)
+		lph.leaderForwarder.SetLeaderIP(ip)
+	}
 	forwardedRequest.Inc(lph.handlerName)
 	lph.leaderForwarder.Forward(rw, req)
 	return true

--- a/pkg/clusteragent/api/leader_handler_test.go
+++ b/pkg/clusteragent/api/leader_handler_test.go
@@ -35,6 +35,11 @@ type fakeLeaderForwarder struct{}
 // SetLeaderIP does nothing
 func (f *fakeLeaderForwarder) SetLeaderIP(_ string) {}
 
+// GetLeaderIP does nothing
+func (f *fakeLeaderForwarder) GetLeaderIP() string {
+	return ""
+}
+
 // Forward returns ok
 func (f *fakeLeaderForwarder) Forward(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
1. Create leader election before cluster agent server starts 
2. Reuse existing http proxy and connection pool instead of creating new connection for each forward request
3. Create a memory buffer pool to avoid memory allocation for each metric payload decompression. 

### Motivation
For point 2, the current logic calls SetLeaderIP on every forward. However, SetLeaderIP resets and recreates the connection, which is inefficient. To optimize this, we update only the IP address instead of recreating the entire proxy client, allowing connection pool reuse. Additionally, we fixed a bug in NewLeaderForwarder related to the maxConnections parameter. It should be sourced from cluster_agent.max_leader_connections instead of cluster_agent.max_connections, with a default value of 100.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
It should cover by e2e test since it affect all api handlers.  And local stress test shows 50% cpu reduction from high http connections. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->