### PR TITLE
[cluster-agent/api/v1/languagedetection] Use strings.Builder to generate trace log

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -113,7 +113,8 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 	ownersLanguagesFromRequest := getOwnersLanguages(requestData, time.Now().Add(handler.cfg.languageTTL))
 
 	if log.ShouldLog(log.TraceLvl) {
-	log.Tracef("Owner Languages state pre merge-and-flush: %s", handler.ownersLanguages.String())
+		log.Tracef("Owner Languages state pre merge-and-flush: %s", handler.ownersLanguages.String())
+	}
 	err = handler.ownersLanguages.mergeAndFlush(ownersLanguagesFromRequest, handler.wlm)
 	if log.ShouldLog(log.TraceLvl) {
 		log.Tracef("Owner Languages state post merge-and-flush: %s", handler.ownersLanguages.String())

--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -112,9 +112,13 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 
 	ownersLanguagesFromRequest := getOwnersLanguages(requestData, time.Now().Add(handler.cfg.languageTTL))
 
+	if log.ShouldLog(log.TraceLvl) {
 	log.Tracef("Owner Languages state pre merge-and-flush: %s", handler.ownersLanguages.String())
 	err = handler.ownersLanguages.mergeAndFlush(ownersLanguagesFromRequest, handler.wlm)
-	log.Tracef("Owner Languages state post merge-and-flush: %s", handler.ownersLanguages.String())
+	if log.ShouldLog(log.TraceLvl) {
+		log.Tracef("Owner Languages state post merge-and-flush: %s", handler.ownersLanguages.String())
+	}
+
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to store some (or all) languages in workloadmeta store: %s", err), http.StatusInternalServerError)
 		ProcessedRequests.Inc(statusError)

--- a/cmd/cluster-agent/api/v1/languagedetection/util.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/util.go
@@ -77,20 +77,23 @@ func (ownersLanguages *OwnersLanguages) String() string {
 	ownersLanguages.mutex.Lock()
 	defer ownersLanguages.mutex.Unlock()
 
-	state := "["
+	var state strings.Builder
+	state.WriteString("[")
+
 	for owner, langs := range ownersLanguages.containersLanguages {
-		state += fmt.Sprintf("(%s/%s/%s, %v,[", owner.Namespace, owner.Kind, owner.Name, langs.dirty)
+		state.WriteString(fmt.Sprintf("(%s/%s/%s, %v,[", owner.Namespace, owner.Kind, owner.Name, langs.dirty))
 		for container, languageSet := range langs.languages {
-			state += container.Name + ": ("
+			state.WriteString(container.Name + ": (")
 			for languagename := range languageSet {
-				state += fmt.Sprintf("%s,", languagename)
+				state.WriteString(fmt.Sprintf("%s,", languagename))
 			}
-			state += "),"
+			state.WriteString("),")
 		}
-		state += "]),"
+		state.WriteString("]),")
 	}
-	state += "]"
-	return state
+
+	state.WriteString("]")
+	return state.String()
 }
 
 // getOrInitialize returns the containers languages for a specific namespaced owner, initialising it if it doesn't already


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use `strings.Builder` to generate trace log for outputting current state of owners languages.

Also added a check to only call `.String()` if we are planning to log it (though without this change, using `strings.Builder` already yields significant gain so not sure if it's necessary). 

### Motivation
According to profiles, this was causing increased CPU/memory consumption.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Deployed changes and checked that CPU/memory consumption in the cluster agent decreased.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->