### PR TITLE
[CWS] fix nil interface vs nil sub-type but not-nil interface confusion in scoper

### DIFF
--- a/pkg/security/secl/rules/scope.go
+++ b/pkg/security/secl/rules/scope.go
@@ -15,12 +15,18 @@ func getCommonStateScopes() map[Scope]VariableProviderFactory {
 	return map[Scope]VariableProviderFactory{
 		"process": func() VariableProvider {
 			return eval.NewScopedVariables(func(ctx *eval.Context) eval.VariableScope {
-				return ctx.Event.(*model.Event).ProcessCacheEntry
+				if pce := ctx.Event.(*model.Event).ProcessCacheEntry; pce != nil {
+					return pce
+				}
+				return nil
 			})
 		},
 		"container": func() VariableProvider {
 			return eval.NewScopedVariables(func(ctx *eval.Context) eval.VariableScope {
-				return ctx.Event.(*model.Event).ContainerContext
+				if cc := ctx.Event.(*model.Event).ContainerContext; cc != nil {
+					return cc
+				}
+				return nil
 			})
 		},
 	}

--- a/pkg/security/secl/rules/scope_linux.go
+++ b/pkg/security/secl/rules/scope_linux.go
@@ -15,7 +15,7 @@ func getStateScopes() map[Scope]VariableProviderFactory {
 	stateScopes := getCommonStateScopes()
 	stateScopes["cgroup"] = func() VariableProvider {
 		return eval.NewScopedVariables(func(ctx *eval.Context) eval.VariableScope {
-			if ctx.Event.(*model.Event).CGroupContext.CGroupFile.IsNull() {
+			if ctx.Event.(*model.Event).CGroupContext == nil || ctx.Event.(*model.Event).CGroupContext.CGroupFile.IsNull() {
 				return nil
 			}
 			return ctx.Event.(*model.Event).CGroupContext


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes a confusion in the returned value by the scoped variables scoper. When the process or container context is nil and returned directly, it's not a regular nil that is returned but a special value with actual type information and this value does not compare equal to regular nil causing some panic down the line, even with https://github.com/DataDog/datadog-agent/pull/34700 actually checking the nil value.

See this blog post for more info https://yourbasic.org/golang/gotcha-why-nil-error-not-equal-nil/

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1938da3]
goroutine 41584 [running]:
github.com/DataDog/datadog-agent/pkg/security/secl/model.(*ProcessCacheEntry).Hash(0x0)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/model/model_unix.go:389 +0x23
github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.(*ScopedVariables).NewSECLVariable.func1(0xc006ec4e70?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/variables.go:781 +0x46
github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.(*ScopedVariables).NewSECLVariable.func4(0xc006ec4ea0?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/variables.go:824 +0x17
github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.(*ScopedBoolVariable).GetEvaluator.func1(0x1ca44006ec4ec0?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/variables.go:146 +0x1b
github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval.And.func3(0xc004615680)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval/operators.go:177 +0x28
github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).Evaluate.func1()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/ruleset.go:629 +0x5b
github.com/DataDog/datadog-agent/pkg/security/secl/utils.PprofDoWithoutContext({{0x2f65c98?, 0xc001b9a7e0?}}, 0xc006ec5008)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/utils/pprof.go:35 +0x6f
github.com/DataDog/datadog-agent/pkg/security/secl/rules.(*RuleSet).Evaluate(0xc0044225a0, {0x2f72198, 0xc005af4a88})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/secl/rules/ruleset.go:628 +0x311
github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).HandleEvent(0xc00387e540?, 0xc005af4a88)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:609 +0xcf
github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).sendEventToHandlers(...)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:310
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).DispatchEvent(0xc0057e3888, 0xc005af4a88, 0x1)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:677 +0xce
github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).handleEvent(0xc0057e3888, 0x0, {0xc0054b3880, 0xa0, 0x1c0})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:1354 +0x52ec
github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer.(*RingBuffer).handleEvent(0xc0008e2390, 0xc005b12080, 0x0?, 0xc006ec5f38?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer/ringbuffer.go:60 +0x31
github.com/DataDog/ebpf-manager.(*RingBuffer).Start.func1()
	/pkg/mod/github.com/!data!dog/ebpf-manager@v0.7.7/ringbuffer.go:138 +0x187
created by github.com/DataDog/ebpf-manager.(*RingBuffer).Start in goroutine 1
	/pkg/mod/github.com/!data!dog/ebpf-manager@v0.7.7/ringbuffer.go:108 +0x125
```
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->