### PR TITLE
USM: make the nodejs monitor to a real protocol

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -53,6 +53,7 @@ var (
 		opensslSpec,
 		goTLSSpec,
 		istioSpec,
+		nodejsSpec,
 	}
 )
 

--- a/pkg/network/usm/ebpf_ssl.go
+++ b/pkg/network/usm/ebpf_ssl.go
@@ -428,13 +428,12 @@ var opensslSpec = &protocols.ProtocolSpec{
 }
 
 type sslProgram struct {
-	cfg           *config.Config
-	watcher       *sharedlibraries.Watcher
-	nodeJSMonitor *nodeJSMonitor
+	cfg     *config.Config
+	watcher *sharedlibraries.Watcher
 }
 
 func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protocols.Protocol, error) {
-	if (!c.EnableNativeTLSMonitoring || !usmconfig.TLSSupported(c)) && !c.EnableNodeJSMonitoring {
+	if !c.EnableNativeTLSMonitoring || !usmconfig.TLSSupported(c) {
 		return nil, nil
 	}
 
@@ -468,15 +467,9 @@ func newSSLProgramProtocolFactory(m *manager.Manager, c *config.Config) (protoco
 		}
 	}
 
-	nodejs, err := newNodeJSMonitor(c, m)
-	if err != nil {
-		return nil, fmt.Errorf("error initializing nodejs monitor: %w", err)
-	}
-
 	return &sslProgram{
-		cfg:           c,
-		watcher:       watcher,
-		nodeJSMonitor: nodejs,
+		cfg:     c,
+		watcher: watcher,
 	}, nil
 }
 
@@ -507,7 +500,6 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 // PreStart is called before the start of the provided eBPF manager.
 func (o *sslProgram) PreStart() error {
 	o.watcher.Start()
-	o.nodeJSMonitor.Start()
 	return nil
 }
 
@@ -519,7 +511,6 @@ func (o *sslProgram) PostStart() error {
 // Stop stops the program.
 func (o *sslProgram) Stop() {
 	o.watcher.Stop()
-	o.nodeJSMonitor.Stop()
 }
 
 // DumpMaps dumps the content of the map represented by mapName & currentMap, if it used by the eBPF program, to output.

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -9,16 +9,20 @@ package usm
 
 import (
 	"fmt"
+	"io"
 	"strings"
+
+	"github.com/cilium/ebpf"
 
 	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/protocols"
+	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/consts"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -106,14 +110,94 @@ var (
 	}
 )
 
+var nodejsSpec = &protocols.ProtocolSpec{
+	Factory: newNodeJSMonitor,
+	Maps:    sharedLibrariesMaps,
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: "kprobe__tcp_sendmsg",
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslDoHandshakeProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslDoHandshakeRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslSetBioProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslSetFDProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: bioNewSocketProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: bioNewSocketRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslReadProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: nodejsSslReadRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: nodejsSslReadExRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslWriteProbe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: nodejsSslWriteRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: nodejsSslWriteExRetprobe,
+			},
+		},
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: sslShutdownProbe,
+			},
+		},
+	},
+}
+
 // nodeJSMonitor essentially scans for Node processes and attaches SSL uprobes
 // to them.
 type nodeJSMonitor struct {
+	cfg            *config.Config
 	attacher       *uprobes.UprobeAttacher
 	processMonitor *monitor.ProcessMonitor
 }
 
-func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) (*nodeJSMonitor, error) {
+var _ protocols.Protocol = (*nodeJSMonitor)(nil)
+
+func newNodeJSMonitor(mgr *manager.Manager, c *config.Config) (protocols.Protocol, error) {
 	if !c.EnableNodeJSMonitoring {
 		return nil, nil
 	}
@@ -137,22 +221,28 @@ func newNodeJSMonitor(c *config.Config, mgr *manager.Manager) (*nodeJSMonitor, e
 	}
 
 	return &nodeJSMonitor{
+		cfg:            c,
 		attacher:       attacher,
 		processMonitor: procMon,
 	}, nil
 }
 
-// Start the nodeJSMonitor
-func (m *nodeJSMonitor) Start() {
-	if m == nil {
-		return
-	}
+// ConfigureOptions changes map attributes to the given options.
+func (m *nodeJSMonitor) ConfigureOptions(options *manager.Options) {
+	sharedLibrariesConfigureOptions(options, m.cfg)
+}
 
+// PreStart is called before the start of the provided eBPF manager.
+func (m *nodeJSMonitor) PreStart() error {
 	if err := m.attacher.Start(); err != nil {
-		log.Errorf("cannot start nodeJS attacher: %s", err)
-	} else {
-		log.Info("Node JS TLS monitoring enabled")
+		return fmt.Errorf("cannot start nodeJS attacher: %w", err)
 	}
+	return nil
+}
+
+// PostStart is called after the start of the provided eBPF manager.
+func (*nodeJSMonitor) PostStart() error {
+	return nil
 }
 
 // Stop the nodeJSMonitor.
@@ -172,4 +262,22 @@ func isNodeJSBinary(_ string, procInfo *uprobes.ProcInfo) bool {
 		return false
 	}
 	return strings.Contains(exe, nodeJSPath)
+}
+
+// DumpMaps is a no-op.
+func (*nodeJSMonitor) DumpMaps(io.Writer, string, *ebpf.Map) {}
+
+// Name return the program's name.
+func (*nodeJSMonitor) Name() string {
+	return nodeJsAttacherName
+}
+
+// GetStats is a no-op.
+func (*nodeJSMonitor) GetStats() (*protocols.ProtocolStats, func()) {
+	return nil, nil
+}
+
+// IsBuildModeSupported returns always true, as tls module is supported by all modes.
+func (*nodeJSMonitor) IsBuildModeSupported(buildmode.Type) bool {
+	return true
 }

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -196,6 +196,7 @@ type nodeJSMonitor struct {
 	processMonitor *monitor.ProcessMonitor
 }
 
+// Ensuring nodeJSMonitor implements the protocols.Protocol interface.
 var _ protocols.Protocol = (*nodeJSMonitor)(nil)
 
 func newNodeJSMonitor(mgr *manager.Manager, c *config.Config) (protocols.Protocol, error) {

--- a/pkg/network/usm/nodejs.go
+++ b/pkg/network/usm/nodejs.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
+	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/consts"
 	"github.com/DataDog/datadog-agent/pkg/process/monitor"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -198,7 +199,7 @@ type nodeJSMonitor struct {
 var _ protocols.Protocol = (*nodeJSMonitor)(nil)
 
 func newNodeJSMonitor(mgr *manager.Manager, c *config.Config) (protocols.Protocol, error) {
-	if !c.EnableNodeJSMonitoring {
+	if !c.EnableNodeJSMonitoring || !usmconfig.TLSSupported(c) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Introduces a standalone nodejs protocol, which is not encapsulated inside openssl monitor.

### Motivation

clean code and remove complexity from openssl monitor.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://dddev.datadoghq.com/dashboard/gqu-2wz-asy/usm-performance-evaluation-20?fromUser=true&refresh_mode=paused&tpl_var_base_agent-env%5B0%5D=usmon-907-base&tpl_var_client-service%5B0%5D=node-k6-client-http-tls&tpl_var_compare_agent-env%5B0%5D=usmon-907-new&tpl_var_http.version%5B0%5D=http%2F1.1&tpl_var_kube_cluster_name%5B0%5D=usm2&tpl_var_server-service%5B0%5D=node-httpbin-tls&tpl_var_tls.library%5B0%5D=nodejs&from_ts=1741179302208&to_ts=1741182573478&live=false

Performance left untouched
![image](https://github.com/user-attachments/assets/d1cf1267-8f49-4cd1-b5ef-0ee138a70f8f)

Memory
![image](https://github.com/user-attachments/assets/fadd2db9-5617-4abc-9980-8ddc5a2237c3)

cpu 
![image](https://github.com/user-attachments/assets/7cb2d130-bec5-4814-b8e7-5d28ba114f76)

