### PR TITLE
[CWS] add kmt test run with just `TestEventMonitor`

### DIFF
--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -482,16 +482,21 @@ kmt_secagent_cleanup_arm64:
     ARCH: arm64
     INSTANCE_TYPE: "m6gd.metal"
 
-kmt_secagent_tests_join_x64:
+kmt_secagent_tests_join1_x64:
   extends:
     - .kmt_secagent_tests_join
   needs:
     - kmt_run_secagent_tests_x64
-    - kmt_run_secagent_tests_x64_peds
-    - kmt_run_secagent_tests_x64_required
     - kmt_run_secagent_tests_x64_ad
     - kmt_run_secagent_tests_x64_ebpfless
     - kmt_run_secagent_tests_x64_docker
+
+kmt_secagent_tests_join2_x64:
+  extends:
+    - .kmt_secagent_tests_join
+  needs:
+    - kmt_run_secagent_tests_x64_peds
+    - kmt_run_secagent_tests_x64_required
 
 kmt_secagent_cleanup_x64:
   when: always
@@ -499,7 +504,8 @@ kmt_secagent_cleanup_x64:
     - .kmt_secagent_cleanup
   needs:
     - kmt_setup_env_secagent_x64
-    - kmt_secagent_tests_join_x64
+    - kmt_secagent_tests_join1_x64
+    - kmt_secagent_tests_join2_x64
     - upload_dependencies_secagent_x64
     - upload_secagent_tests_x64
   variables:

--- a/.gitlab/kernel_matrix_testing/security_agent.yml
+++ b/.gitlab/kernel_matrix_testing/security_agent.yml
@@ -114,6 +114,10 @@ upload_secagent_tests_arm64:
   extends: .kmt_run_secagent_tests_base
   allow_failure: true
 
+.kmt_run_secagent_tests_required:
+  extends: .kmt_run_secagent_tests_base
+  allow_failure: false
+
 kmt_run_secagent_tests_x64:
   extends:
     - .kmt_run_secagent_tests
@@ -156,9 +160,51 @@ kmt_run_secagent_tests_x64:
     - !reference [.collect_outcomes_kmt]
     - !reference [.upload_junit_kmt]
 
+kmt_run_secagent_tests_x64_peds:
+  extends:
+    - .kmt_run_secagent_tests_required
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs:
+    - kmt_setup_env_secagent_x64
+    - upload_dependencies_secagent_x64
+    - upload_secagent_tests_x64
+  variables:
+    ARCH: "x86_64"
+  parallel:
+    matrix:
+      - TAG:
+          - "ubuntu_18.04"
+          - "ubuntu_20.04"
+          - "ubuntu_22.04"
+          - "ubuntu_24.04"
+          - "ubuntu_24.10"
+          - "amazon_4.14"
+          - "amazon_5.4"
+          - "amazon_5.10"
+          - "amazon_2023"
+          - "fedora_37"
+          - "fedora_38"
+          - "debian_10"
+          - "debian_11"
+          - "debian_12"
+          - "centos_7.9"
+          - "oracle_8.9"
+          - "oracle_9.3"
+          - "rocky_8.5"
+          - "rocky_9.3"
+          - "rocky_9.4"
+          - "opensuse_15.3"
+          - "opensuse_15.5"
+          - "suse_12.5"
+        TEST_SET: [cws_peds]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
 kmt_run_secagent_tests_x64_required:
   extends:
-    - .kmt_run_secagent_tests_base
+    - .kmt_run_secagent_tests_required
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/system-probe_x64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["arch:amd64"]
   needs:
@@ -290,6 +336,41 @@ kmt_run_secagent_tests_arm64:
     - !reference [.collect_outcomes_kmt]
     - !reference [.upload_junit_kmt]
 
+kmt_run_secagent_tests_arm64_peds:
+  extends:
+    - .kmt_run_secagent_tests_required
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/system-probe_arm64$DATADOG_AGENT_SYSPROBE_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: ["arch:arm64"]
+  needs:
+    - kmt_setup_env_secagent_arm64
+    - upload_dependencies_secagent_arm64
+    - upload_secagent_tests_arm64
+  variables:
+    ARCH: "arm64"
+  parallel:
+    matrix:
+      - TAG:
+          - "ubuntu_22.04"
+          - "ubuntu_24.04"
+          - "ubuntu_24.10"
+          - "amazon_5.4"
+          - "amazon_5.10"
+          - "amazon_2023"
+          - "fedora_37"
+          - "fedora_38"
+          - "debian_11"
+          - "debian_12"
+          - "oracle_8.9"
+          - "oracle_9.3"
+          - "rocky_8.5"
+          - "rocky_9.3"
+          - "rocky_9.4"
+          - "opensuse_15.5"
+        TEST_SET: [cws_peds]
+  after_script:
+    - !reference [.collect_outcomes_kmt]
+    - !reference [.upload_junit_kmt]
+
 kmt_run_secagent_tests_arm64_ad:
   extends:
     - .kmt_run_secagent_tests
@@ -384,6 +465,7 @@ kmt_secagent_tests_join_arm64:
     - .kmt_secagent_tests_join
   needs:
     - kmt_run_secagent_tests_arm64
+    - kmt_run_secagent_tests_arm64_peds
     - kmt_run_secagent_tests_arm64_ad
     - kmt_run_secagent_tests_arm64_ebpfless
     - kmt_run_secagent_tests_arm64_docker
@@ -405,6 +487,7 @@ kmt_secagent_tests_join_x64:
     - .kmt_secagent_tests_join
   needs:
     - kmt_run_secagent_tests_x64
+    - kmt_run_secagent_tests_x64_peds
     - kmt_run_secagent_tests_x64_required
     - kmt_run_secagent_tests_x64_ad
     - kmt_run_secagent_tests_x64_ebpfless

--- a/test/new-e2e/system-probe/test-runner/files/cws_peds.json
+++ b/test/new-e2e/system-probe/test-runner/files/cws_peds.json
@@ -1,0 +1,9 @@
+{
+	"filters": {
+		"pkg/security": {
+			"run-only": [
+				"TestEventMonitor"
+			]
+		}
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a new KMT test run, that runs only the `TestEventMonitor` tests. The goal with this is to guarantee that the process event data stream is working correctly.

The rest of the changes are related to the amount of jobs requirement that needed to split the join into 2.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->