### PR TITLE
Add proxy endpoint for OpenLineage intake

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -637,6 +637,18 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "evp_proxy_config.receiver_timeout"; core.IsSet(k) {
 		c.EVPProxy.ReceiverTimeout = core.GetInt(k)
 	}
+	if k := "ol_proxy_config.enabled"; core.IsSet(k) {
+		c.OpenLineageProxy.Enabled = core.GetBool(k)
+	}
+	if k := "ol_proxy_config.dd_url"; core.IsSet(k) {
+		c.OpenLineageProxy.DDURL = core.GetString(k)
+	}
+	if k := "ol_proxy_config.api_key"; core.IsSet(k) {
+		c.OpenLineageProxy.APIKey = core.GetString(k)
+	}
+	if k := "ol_proxy_config.additional_endpoints"; core.IsSet(k) {
+		c.OpenLineageProxy.AdditionalEndpoints = core.GetStringMapStringSlice(k)
+	}
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	return nil
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -972,6 +972,12 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnv("evp_proxy_config.max_payload_size")
 	config.BindEnv("evp_proxy_config.receiver_timeout")
 
+	// trace-agent's ol_proxy
+	config.BindEnvAndSetDefault("ol_proxy_config.enabled", true)
+	config.BindEnv("ol_proxy_config.dd_url")
+	config.BindEnv("ol_proxy_config.api_key")
+	config.BindEnv("ol_proxy_config.additional_endpoints")
+
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")
 

--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -114,6 +114,10 @@ var endpoints = []Endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return r.pipelineStatsProxyHandler() },
 	},
 	{
+		Pattern: "/openlineage/api/v1/lineage",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.openLineageProxyHandler() },
+	},
+	{
 		Pattern:         "/evp_proxy/v1/",
 		Handler:         func(r *HTTPReceiver) http.Handler { return r.evpProxyHandler(1) },
 		TimeoutOverride: getConfiguredEVPRequestTimeoutDuration,

--- a/pkg/trace/api/openlineage.go
+++ b/pkg/trace/api/openlineage.go
@@ -41,7 +41,11 @@ func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []s
 		} else {
 			host = fmt.Sprintf(openlineageURLTemplate, site)
 		}
+	} else if cfg.Site != "" {
+		// Fallback to the main agent site
+		host = fmt.Sprintf(openlineageURLTemplate, cfg.Site)
 	}
+	log.Debug("[openlineage] OpenLineage Host: %s", host)
 	u, err := url.Parse(host)
 	if err != nil {
 		// if the main intake URL is invalid we don't use additional endpoints

--- a/pkg/trace/api/openlineage.go
+++ b/pkg/trace/api/openlineage.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	stdlog "log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-go/v5/statsd"
+)
+
+const (
+	openlineageURLTemplate = "https://data-obs-intake.%s/api/v1/lineage"
+	openlineageURLDefault  = "https://data-obs-intake.datadoghq.com/api/v1/lineage"
+)
+
+// openLineageEndpoint returns the openlineage intake url and the corresponding API key.
+func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []string, err error) {
+	host := openlineageURLDefault
+	apiKey := cfg.OpenLineageProxy.APIKey
+	if apiKey == "" {
+		apiKey = cfg.APIKey()
+	}
+	site := cfg.OpenLineageProxy.DDURL
+	if site != "" {
+		// Directly passed URL
+		if strings.HasPrefix(site, "http://") || strings.HasPrefix(site, "https://") {
+			host = site
+		} else {
+			host = fmt.Sprintf(openlineageURLTemplate, site)
+		}
+	}
+	u, err := url.Parse(host)
+	if err != nil {
+		// if the main intake URL is invalid we don't use additional endpoints
+		return nil, nil, fmt.Errorf("[openlineage] error parsing intake URL %s: %v", host, err)
+	}
+	urls = append(urls, u)
+	apiKeys = append(apiKeys, apiKey)
+
+	for host, keys := range cfg.OpenLineageProxy.AdditionalEndpoints {
+		for _, key := range keys {
+			urlStr := fmt.Sprintf(openlineageURLTemplate, host)
+			u, err := url.Parse(urlStr)
+			if err != nil {
+				log.Errorf("[openlineage] error parsing additional intake URL %s: %v", urlStr, err)
+				continue
+			}
+			urls = append(urls, u)
+			apiKeys = append(apiKeys, key)
+		}
+	}
+	return urls, apiKeys, nil
+}
+
+func openLineageErrorHandler(message string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		msg := fmt.Sprintf("OpenLineage forwarder is OFF: %s", message)
+		http.Error(w, msg, http.StatusInternalServerError)
+	})
+}
+
+// openLineageProxyHandler returns a new HTTP handler which will proxy requests to the openlineage intake.
+func (r *HTTPReceiver) openLineageProxyHandler() http.Handler {
+	if !r.conf.OpenLineageProxy.Enabled {
+		log.Debug("[openlineage] Proxy is disabled in config")
+		return openLineageErrorHandler("Has been disabled in config")
+	}
+	log.Debug("[openlineage] Creating proxy handler")
+	urls, apiKeys, err := openLineageEndpoints(r.conf)
+	if err != nil {
+		return openLineageErrorHandler(err.Error())
+	}
+	tags := fmt.Sprintf("host:%s,default_env:%s,agent_version:%s", r.conf.Hostname, r.conf.DefaultEnv, r.conf.AgentVersion)
+	return newOpenLineageProxy(r.conf, urls, apiKeys, tags, r.statsd)
+}
+
+// newOpenLineageProxy creates an http.ReverseProxy which forwards requests to the openlineage intake.
+// The tags will be added as a header to all proxied requests.
+func newOpenLineageProxy(conf *config.AgentConfig, urls []*url.URL, keys []string, tags string, statsd statsd.ClientInterface) *httputil.ReverseProxy {
+	log.Debug("[openlineage] Creating reverse proxy")
+	cidProvider := NewIDProvider(conf.ContainerProcRoot, conf.ContainerIDFromOriginInfo)
+	director := func(req *http.Request) {
+		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", conf.AgentVersion))
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to the default value
+			// that net/http gives it: Go-http-client/1.1
+			// See https://codereview.appspot.com/7532043
+			req.Header.Set("User-Agent", "")
+		}
+		containerID := cidProvider.GetContainerID(req.Context(), req.Header)
+		if ctags := getContainerTags(conf.ContainerTags, containerID); ctags != "" {
+			ctagsHeader := normalizeHTTPHeader(ctags)
+			req.Header.Set("X-Datadog-Container-Tags", ctagsHeader)
+			log.Debugf("Setting header X-Datadog-Container-Tags=%s for openlineage proxy", ctagsHeader)
+		}
+		req.Header.Set("X-Datadog-Additional-Tags", tags)
+		log.Debugf("Setting header X-Datadog-Additional-Tags=%s for openlineage proxy", tags)
+		_ = statsd.Count("datadog.trace_agent.openlineage", 1, nil, 1)
+
+	}
+	logger := log.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
+	return &httputil.ReverseProxy{
+		Director:  director,
+		ErrorLog:  stdlog.New(logger, "openlineage.Proxy: ", 0),
+		Transport: &openLineageTransport{rt: conf.NewHTTPTransport(), urls: urls, keys: keys},
+	}
+}
+
+// openLineageTransport sends HTTP requests to multiple targets using an
+// underlying http.RoundTripper. API keys are set separately for each target.
+// When multiple endpoints are in use the response from the main endpoint
+// is proxied back to the client, while for all additional endpoints the
+// response is discarded. There is no de-duplication done between endpoint
+// hosts or api keys.
+type openLineageTransport struct {
+	rt   http.RoundTripper
+	urls []*url.URL
+	keys []string
+}
+
+func (m *openLineageTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
+	setTarget := func(r *http.Request, u *url.URL, apiKey string) {
+		r.Host = u.Host
+		r.URL = u
+		// OL endpoint follows where OL OSS client puts API key
+		r.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	if len(m.urls) == 1 {
+		setTarget(req, m.urls[0], m.keys[0])
+		rresp, rerr = m.rt.RoundTrip(req)
+		if rerr != nil {
+			log.Errorf("[openlineage] RoundTrip failed: %v", rerr)
+		} else {
+			log.Debugf("[openlineage] Returned status: %s, from host: %s, path: %s", rresp.Status, m.urls[0].Host, m.urls[0].Path)
+		}
+
+		return rresp, rerr
+	}
+	slurp, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	for i, u := range m.urls {
+		newreq := req.Clone(req.Context())
+		newreq.Body = io.NopCloser(bytes.NewReader(slurp))
+		setTarget(newreq, u, m.keys[i])
+		if i == 0 {
+			// given the way we construct the list of targets the main endpoint
+			// will be the first one called, we return its response and error
+			rresp, rerr = m.rt.RoundTrip(newreq)
+			if rerr != nil {
+				log.Errorf("[openlineage] RoundTrip failed: %v", rerr)
+			} else {
+				log.Debugf("[openlineage] Returned status: %s, from host: %s, path: %s", rresp.Status, m.urls[0].Host, m.urls[0].Path)
+			}
+			continue
+		}
+
+		if resp, err := m.rt.RoundTrip(newreq); err == nil {
+			// we discard responses for all subsequent requests
+			io.Copy(io.Discard, resp.Body) //nolint:errcheck
+			resp.Body.Close()
+		} else {
+			log.Error(err)
+		}
+	}
+	return rresp, rerr
+}

--- a/pkg/trace/api/openlineage_test.go
+++ b/pkg/trace/api/openlineage_test.go
@@ -28,7 +28,7 @@ func TestOpenLineageProxy(t *testing.T) {
 		if body := string(slurp); body != "body" {
 			t.Fatalf("invalid request body: %q", body)
 		}
-		if v := req.Header.Get("Authorization"); v != "123" {
+		if v := req.Header.Get("Authorization"); v != "Bearer 123" {
 			t.Fatalf("got invalid API key: %q", v)
 		}
 		if v := req.Header.Get("X-Datadog-Additional-Tags"); v != "key:val" {
@@ -49,7 +49,7 @@ func TestOpenLineageProxy(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 	c := &config.AgentConfig{ContainerIDFromOriginInfo: config.NoopContainerIDFromOriginInfoFunc}
-	newPipelineStatsProxy(c, []*url.URL{u}, []string{"123"}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
+	newOpenLineageProxy(c, []*url.URL{u}, []string{"123"}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
 	result := rec.Result()
 	slurp, err := io.ReadAll(result.Body)
 	result.Body.Close()

--- a/pkg/trace/api/openlineage_test.go
+++ b/pkg/trace/api/openlineage_test.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestOpenLineageProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		slurp, err := io.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if body := string(slurp); body != "body" {
+			t.Fatalf("invalid request body: %q", body)
+		}
+		if v := req.Header.Get("Authorization"); v != "123" {
+			t.Fatalf("got invalid API key: %q", v)
+		}
+		if v := req.Header.Get("X-Datadog-Additional-Tags"); v != "key:val" {
+			t.Fatalf("got invalid X-Datadog-Additional-Tags: %q", v)
+		}
+		_, err = w.Write([]byte("OK"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", "dummy.com/path", strings.NewReader("body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	c := &config.AgentConfig{ContainerIDFromOriginInfo: config.NoopContainerIDFromOriginInfoFunc}
+	newPipelineStatsProxy(c, []*url.URL{u}, []string{"123"}, "key:val", &statsd.NoOpClient{}).ServeHTTP(rec, req)
+	result := rec.Result()
+	slurp, err := io.ReadAll(result.Body)
+	result.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(slurp) != "OK" {
+		t.Fatal("did not proxy")
+	}
+}
+
+func TestOpenLineageEndpoint(t *testing.T) {
+	var cfg config.AgentConfig
+	cfg.OpenLineageProxy.DDURL = "us3.datadoghq.com"
+	cfg.OpenLineageProxy.APIKey = "test_api_key"
+	cfg.OpenLineageProxy.AdditionalEndpoints = map[string][]string{
+		"us5.datadoghq.com":       {"test_api_key_2"},
+		"datadoghq.eu":            {"test_api_key_3"},
+		"datad0g.com":             {"test_api_key_4"},
+		"ddstaging.datadoghq.com": {"test_api_key_5"},
+	}
+
+	urls, keys, err := openLineageEndpoints(&cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, urls[0].String(), "https://data-obs-intake.us3.datadoghq.com/api/v1/lineage")
+	assert.Equal(t, urls[1].String(), "https://data-obs-intake.us5.datadoghq.com/api/v1/lineage")
+	assert.Equal(t, urls[2].String(), "https://data-obs-intake.datadoghq.eu/api/v1/lineage")
+	assert.Equal(t, urls[3].String(), "https://data-obs-intake.datad0g.com/api/v1/lineage")
+	assert.Equal(t, urls[4].String(), "https://data-obs-intake.ddstaging.datadoghq.com/api/v1/lineage")
+	assert.Equal(t, keys, []string{"test_api_key", "test_api_key_2", "test_api_key_3", "test_api_key_4", "test_api_key_5"})
+
+	cfg.OpenLineageProxy.DDURL = "datadoghq.com"
+	cfg.OpenLineageProxy.APIKey = "test_api_key"
+	cfg.OpenLineageProxy.AdditionalEndpoints = map[string][]string{}
+
+	urls, keys, err = openLineageEndpoints(&cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.com/api/v1/lineage")
+
+	cfg.OpenLineageProxy.DDURL = ""
+	cfg.Site = "datadoghq.com"
+	cfg.OpenLineageProxy.APIKey = "test_api_key"
+
+	urls, keys, err = openLineageEndpoints(&cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.com/api/v1/lineage")
+
+	cfg.OpenLineageProxy.DDURL = "https://intake.testing.com/different-api"
+	cfg.Site = "datadoghq.com"
+	cfg.OpenLineageProxy.APIKey = "test_api_key"
+	urls, keys, err = openLineageEndpoints(&cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, urls[0].String(), "https://intake.testing.com/different-api")
+
+}
+
+func TestOpenLineageProxyHandler(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+			v := req.Header.Get("X-Datadog-Additional-Tags")
+			tags := strings.Split(v, ",")
+			m := make(map[string]string)
+			for _, tag := range tags {
+				kv := strings.Split(tag, ":")
+				if strings.Contains(kv[0], "orchestrator") {
+					t.Fatalf("non-fargate environment shouldn't contain '%s' tag : %q", kv[0], v)
+				}
+				m[kv[0]] = kv[1]
+			}
+			for _, tag := range []string{"host", "default_env", "agent_version"} {
+				if _, ok := m[tag]; !ok {
+					t.Fatalf("invalid X-Datadog-Additional-Tags header, should contain '%s': %q", tag, v)
+				}
+			}
+			called = true
+		}))
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := newTestReceiverConfig()
+		conf.OpenLineageProxy.DDURL = srv.URL
+		fmt.Println("srv url", srv.URL)
+		receiver := newTestReceiverFromConfig(conf)
+		receiver.openLineageProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
+		if !called {
+			t.Fatal("request not proxied")
+		}
+	})
+
+	t.Run("proxy_code", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		conf := config.New()
+		conf.OpenLineageProxy.DDURL = srv.URL
+		conf.Endpoints[0].APIKey = "test_api_key"
+		conf.OpenLineageProxy.Enabled = true
+
+		req, _ := http.NewRequest("POST", "/some/path", nil)
+		receiver := newTestReceiverFromConfig(conf)
+		rec := httptest.NewRecorder()
+		receiver.openLineageProxyHandler().ServeHTTP(rec, req)
+		resp := rec.Result()
+		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+		resp.Body.Close()
+	})
+
+	t.Run("error", func(t *testing.T) {
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		conf := newTestReceiverConfig()
+		conf.OpenLineageProxy.DDURL = "asd:\r\n"
+		r := newTestReceiverFromConfig(conf)
+		r.openLineageProxyHandler().ServeHTTP(rec, req)
+		res := rec.Result()
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("invalid response: %s", res.Status)
+		}
+		res.Body.Close()
+		slurp, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(slurp), "OpenLineage forwarder is OFF") {
+			t.Fatalf("invalid message: %q", slurp)
+		}
+	})
+}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -262,6 +262,18 @@ type EVPProxy struct {
 	ReceiverTimeout int
 }
 
+// OpenLineageProxy contains the settings for the OpenLineageProxy proxy.
+type OpenLineageProxy struct {
+	// Enabled reports whether OpenLineageProxy is enabled (true by default).
+	Enabled bool
+	// DDURL is the Datadog site to forward payloads to (defaults to the Site setting if not set).
+	DDURL string
+	// APIKey is the main API Key (defaults to the main API key).
+	APIKey string `json:"-"` // Never marshal this field
+	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
+	AdditionalEndpoints map[string][]string
+}
+
 // InstallSignatureConfig contains the information on how the agent was installed
 // and a unique identifier that distinguishes this agent from others.
 type InstallSignatureConfig struct {
@@ -450,6 +462,9 @@ type AgentConfig struct {
 	// EVPProxy contains the settings for the EVPProxy proxy.
 	EVPProxy EVPProxy
 
+	// OpenLineageProxy contains the settings for the OpenLineageProxy proxy;
+	OpenLineageProxy OpenLineageProxy
+
 	// DebuggerProxy contains the settings for the Live Debugger proxy.
 	DebuggerProxy DebuggerProxyConfig
 
@@ -588,6 +603,9 @@ func New() *AgentConfig {
 		EVPProxy: EVPProxy{
 			Enabled:        true,
 			MaxPayloadSize: 5 * 1024 * 1024,
+		},
+		OpenLineageProxy: OpenLineageProxy{
+			Enabled: true,
 		},
 
 		Features:               make(map[string]struct{}),

--- a/releasenotes/notes/apm-openlineage-proxy-9c64ae84094d8d6c.yaml
+++ b/releasenotes/notes/apm-openlineage-proxy-9c64ae84094d8d6c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Added new OpenLineage event proxy endpoint.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds proxy for OpenLineage events to Data Observability Intake. Heavily inspired by existing proxies.

### Motivation

We want to send OpenLineage events to our backend - right now, mostly from Spark instrumentation in Java tracer. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Via added tests + ran this manually on laptop with real events end to end. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->