### PR TITLE
CAP-2329 Unblocking Configure() by moving Initialize() in the first Run().

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -172,12 +172,14 @@ func (o *OrchestratorCheck) Configure(senderManager sender.SenderManager, integr
 	// Create a new bundle for the check.
 	o.collectorBundle = NewCollectorBundle(o)
 
-	// Initialize collectors.
-	return o.collectorBundle.Initialize()
+	return nil
 }
 
 // Run runs the orchestrator check
 func (o *OrchestratorCheck) Run() error {
+	// Initialize collectors
+	o.collectorBundle.Initialize()
+
 	// access serializer
 	sender, err := o.GetSender()
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
@@ -89,8 +89,7 @@ func TestOrchestratorCheckSafeReSchedule(t *testing.T) {
 
 	orchCheck.orchestratorInformerFactory = getOrchestratorInformerFactory(cl)
 	bundle := newCollectorBundle(t, orchCheck)
-	err := bundle.Initialize()
-	assert.NoError(t, err)
+	bundle.Initialize()
 
 	wg.Add(2)
 
@@ -99,10 +98,10 @@ func TestOrchestratorCheckSafeReSchedule(t *testing.T) {
 
 	bundle.runCfg.OrchestratorInformerFactory = getOrchestratorInformerFactory(cl)
 	bundle.stopCh = make(chan struct{})
-	err = bundle.Initialize()
-	assert.NoError(t, err)
+	bundle.initializeOnce = sync.Once{}
+	bundle.Initialize()
 
-	_, err = bundle.runCfg.OrchestratorInformerFactory.InformerFactory.Core().V1().Nodes().Informer().AddEventHandler(&cache.ResourceEventHandlerFuncs{
+	_, err := bundle.runCfg.OrchestratorInformerFactory.InformerFactory.Core().V1().Nodes().Informer().AddEventHandler(&cache.ResourceEventHandlerFuncs{
 		AddFunc: func(_ interface{}) {
 			wg.Done()
 		},

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -68,13 +68,12 @@ type syncInformerResult struct {
 
 // SyncInformersReturnErrors does the same thing as SyncInformers except it returns a map of InformerName and error
 func SyncInformersReturnErrors(informers map[InformerName]cache.SharedInformer, extraWait time.Duration) map[InformerName]error {
-	resultChan := make(chan syncInformerResult)
-	errors := make(map[InformerName]error, len(informers))
-
 	if len(informers) == 0 {
-		return errors
+		return nil
 	}
 
+	resultChan := make(chan syncInformerResult)
+	errors := make(map[InformerName]error, len(informers))
 	timeoutConfig := pkgconfigsetup.Datadog().GetDuration("kube_cache_sync_timeout_seconds") * time.Second
 	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
 	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -70,6 +70,11 @@ type syncInformerResult struct {
 func SyncInformersReturnErrors(informers map[InformerName]cache.SharedInformer, extraWait time.Duration) map[InformerName]error {
 	resultChan := make(chan syncInformerResult)
 	errors := make(map[InformerName]error, len(informers))
+
+	if len(informers) == 0 {
+		return errors
+	}
+
 	timeoutConfig := pkgconfigsetup.Datadog().GetDuration("kube_cache_sync_timeout_seconds") * time.Second
 	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
 	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Fixed `SyncInformersReturnErrors` to prevent the function from waiting indefinitely when the informer is empty.  
- Moved `Initialize()` outside of `Configure()` so that `Configure()` becomes a non-blocking function, preventing it from impacting other checks' schedules if the orchestrator check has an issue.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->