### PR TITLE
Provide a way for agent RC integrations to ignore "signature expired" config updates

### DIFF
--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -351,6 +351,7 @@ func (c *Client) Subscribe(product string, cb func(update map[string]state.RawCo
 	c.SubscribeAll(product, NewUpdateListener(cb))
 }
 
+// SubscribeIgnoreExpiration subscribes to config updates of a product, but ignores the case when signatures have expired.
 func (c *Client) SubscribeIgnoreExpiration(product string, cb func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
 	c.SubscribeAll(product, NewUpdateListenerIgnoreExpiration(cb))
 }

--- a/pkg/config/remote/client/client.go
+++ b/pkg/config/remote/client/client.go
@@ -50,6 +50,7 @@ type ConfigFetcher interface {
 type Listener interface {
 	OnUpdate(map[string]state.RawConfig, func(cfgPath string, status state.ApplyStatus))
 	OnStateChange(bool)
+	ShouldIgnoreSignatureExpiration() bool
 }
 
 // fetchConfigs defines the function that an agent client uses to get config updates
@@ -350,6 +351,10 @@ func (c *Client) Subscribe(product string, cb func(update map[string]state.RawCo
 	c.SubscribeAll(product, NewUpdateListener(cb))
 }
 
+func (c *Client) SubscribeIgnoreExpiration(product string, cb func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) {
+	c.SubscribeAll(product, NewUpdateListenerIgnoreExpiration(cb))
+}
+
 // GetConfigs returns the current configs applied of a product.
 func (c *Client) GetConfigs(product string) map[string]state.RawConfig {
 	c.m.Lock()
@@ -494,7 +499,10 @@ func (c *Client) update() error {
 	for product, productListeners := range c.listeners {
 		if containsProduct(changedProducts, product) {
 			for _, listener := range productListeners {
-				listener.OnUpdate(c.state.GetConfigs(product), c.state.UpdateApplyStatus)
+				if response.ConfigStatus == pbgo.ConfigStatus_CONFIG_STATUS_OK ||
+					!listener.ShouldIgnoreSignatureExpiration() {
+					listener.OnUpdate(c.state.GetConfigs(product), c.state.UpdateApplyStatus)
+				}
 			}
 		}
 	}
@@ -616,8 +624,9 @@ func (c *Client) newUpdateRequest() (*pbgo.ClientGetConfigsRequest, error) {
 }
 
 type listener struct {
-	onUpdate      func(map[string]state.RawConfig, func(cfgPath string, status state.ApplyStatus))
-	onStateChange func(bool)
+	onUpdate               func(map[string]state.RawConfig, func(cfgPath string, status state.ApplyStatus))
+	onStateChange          func(bool)
+	shouldIgnoreExpiration bool
 }
 
 func (l *listener) OnUpdate(configs map[string]state.RawConfig, cb func(cfgPath string, status state.ApplyStatus)) {
@@ -632,9 +641,18 @@ func (l *listener) OnStateChange(state bool) {
 	}
 }
 
+func (l *listener) ShouldIgnoreSignatureExpiration() bool {
+	return l.shouldIgnoreExpiration
+}
+
 // NewUpdateListener creates a remote config listener from a update callback
 func NewUpdateListener(onUpdate func(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) Listener {
 	return &listener{onUpdate: onUpdate}
+}
+
+// NewUpdateListenerIgnoreExpiration creates a remote config listener that ignores signature expiration
+func NewUpdateListenerIgnoreExpiration(onUpdate func(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus))) Listener {
+	return &listener{onUpdate: onUpdate, shouldIgnoreExpiration: true}
 }
 
 // NewListener creates a remote config listener from a couple of update and state change callbacks


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This provides a way for Remote Config integrations to ignore config updates due to signature expiration. The general behavior when a signature has expired is to empty the local repository, but this isn't ideal for all integrations.

### Motivation

The autoscaling group relies on RC to provide autoscaling configuration. If the configuration is suddenly dumped, the autoscaling behavior will revert to the default, which causes significant churn. Therefore we provide an additional entry point to subscribing to config updates, that specifically ignores signature expiration.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->