### PR TITLE
GPU: hostgpu payload: filter out hosts with no GPUs

### DIFF
--- a/comp/metadata/hostgpu/impl/hostgpu.go
+++ b/comp/metadata/hostgpu/impl/hostgpu.go
@@ -152,7 +152,7 @@ func (gh *gpuHost) fillData() {
 func (gh *gpuHost) getPayload() marshaler.JSONMarshaler {
 	gh.fillData()
 
-	if gh.data.Devices == nil || len(gh.data.Devices) == 0 {
+	if gh.data == nil || len(gh.data.Devices) == 0 {
 		return nil
 	}
 

--- a/comp/metadata/hostgpu/impl/hostgpu.go
+++ b/comp/metadata/hostgpu/impl/hostgpu.go
@@ -152,6 +152,10 @@ func (gh *gpuHost) fillData() {
 func (gh *gpuHost) getPayload() marshaler.JSONMarshaler {
 	gh.fillData()
 
+	if gh.data.Devices == nil || len(gh.data.Devices) == 0 {
+		return nil
+	}
+
 	return &Payload{
 		Hostname:  gh.hostname,
 		Timestamp: time.Now().UnixNano(),

--- a/comp/metadata/hostgpu/impl/hostgpu.go
+++ b/comp/metadata/hostgpu/impl/hostgpu.go
@@ -152,7 +152,7 @@ func (gh *gpuHost) fillData() {
 func (gh *gpuHost) getPayload() marshaler.JSONMarshaler {
 	gh.fillData()
 
-	if gh.data == nil || len(gh.data.Devices) == 0 {
+	if len(gh.data.Devices) == 0 {
 		return nil
 	}
 

--- a/comp/metadata/hostgpu/impl/hostgpu_test.go
+++ b/comp/metadata/hostgpu/impl/hostgpu_test.go
@@ -123,16 +123,17 @@ func TestGetPayload(t *testing.T) {
 		},
 	}
 
-	p := gh.getPayload().(*Payload)
+	p, ok := gh.getPayload().(*Payload)
+	assert.True(t, ok)
 	assert.Equal(t, expectedMetadata, p.Metadata)
 }
 
-func TestGetPayloadError(t *testing.T) {
+func TestGetEmptyPayload(t *testing.T) {
 	gh := getTestInventoryHost(t)
 	gh.wmeta = &wmsErrorMock{}
 
-	p := gh.getPayload().(*Payload)
-	assert.Equal(t, &hostGPUMetadata{}, p.Metadata)
+	p := gh.getPayload()
+	assert.Nil(t, p)
 }
 
 func TestFlareProviderFilename(t *testing.T) {

--- a/comp/metadata/internal/util/inventory_payload.go
+++ b/comp/metadata/internal/util/inventory_payload.go
@@ -170,6 +170,11 @@ func (i *InventoryPayload) collect(_ context.Context) time.Duration {
 	i.LastCollect = time.Now()
 
 	p := i.getPayload()
+	// If the payload is nil, we don't want to send it to the backend.
+	if p == nil {
+		i.log.Debugf("inventory payload is nil, skipping submission")
+		return i.MinInterval
+	}
 	if err := i.serializer.SendMetadata(p); err != nil {
 		i.log.Errorf("unable to submit inventories payload, %s", err)
 	}


### PR DESCRIPTION
### What does this PR do?

- return nil hostgpu Payload when host doesn't have any GPU devices
- inventory_payload: don't send nil payloads to the backend 
- added UTs to cover the nil payload case

### Motivation

- avoid sending not useful payloads to the backend when hosts don't have any (supported) GPU devices

### Describe how you validated your changes

added UTs both for hostgpu and generic inventory_payload to test nil payload use case

### Possible Drawbacks / Trade-offs

### Additional Notes
