### PR TITLE
[Backport 7.64.x] [cluster-agent/languagedetection] Use strings.Builder to reduce allocations (#34743)

### DIFF
--- a/cmd/cluster-agent/api/v1/languagedetection/handler.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/handler.go
@@ -112,9 +112,14 @@ func (handler *languageDetectionHandler) leaderHandler(w http.ResponseWriter, r 
 
 	ownersLanguagesFromRequest := getOwnersLanguages(requestData, time.Now().Add(handler.cfg.languageTTL))
 
-	log.Tracef("Owner Languages state pre merge-and-flush:\n %s", handler.ownersLanguages.String())
+	if log.ShouldLog(log.TraceLvl) { // Avoid call to String() if not needed
+		log.Tracef("Owner Languages state pre merge-and-flush: %s", handler.ownersLanguages.String())
+	}
 	err = handler.ownersLanguages.mergeAndFlush(ownersLanguagesFromRequest, handler.wlm)
-	log.Tracef("Owner Languages state post merge-and-flush:\n %s", handler.ownersLanguages.String())
+	if log.ShouldLog(log.TraceLvl) { // Avoid call to String() if not needed
+		log.Tracef("Owner Languages state post merge-and-flush: %s", handler.ownersLanguages.String())
+	}
+
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to store some (or all) languages in workloadmeta store: %s", err), http.StatusInternalServerError)
 		ProcessedRequests.Inc(statusError)

--- a/cmd/cluster-agent/api/v1/languagedetection/util.go
+++ b/cmd/cluster-agent/api/v1/languagedetection/util.go
@@ -77,24 +77,41 @@ func (ownersLanguages *OwnersLanguages) String() string {
 	ownersLanguages.mutex.Lock()
 	defer ownersLanguages.mutex.Unlock()
 
-	state := ""
+	var sb strings.Builder
+	sb.WriteString("[")
+
+	firstOwner := true
 	for owner, langs := range ownersLanguages.containersLanguages {
-		state += fmt.Sprintf("===== %s/%s/%s ====\n", owner.Namespace, owner.Kind, owner.Name)
-		if langs.dirty {
-			state += "dirty\n"
-		} else {
-			state += "clean\n"
+		if !firstOwner {
+			sb.WriteString(",")
 		}
 
+		sb.WriteString(fmt.Sprintf("(%s/%s/%s, %v,[", owner.Namespace, owner.Kind, owner.Name, langs.dirty))
+
+		firstContainer := true
 		for container, languageSet := range langs.languages {
-			state += container.Name + ": "
-			for languagename := range languageSet {
-				state += fmt.Sprintf("%s,", languagename)
+			if !firstContainer {
+				sb.WriteString(",")
 			}
-			state += "\n"
+			sb.WriteString(container.Name + ": (")
+
+			languages := make([]string, 0, len(languageSet))
+			for languagename := range languageSet {
+				languages = append(languages, string(languagename))
+			}
+			sb.WriteString(strings.Join(languages, ","))
+
+			sb.WriteString(")")
+			firstContainer = false
 		}
+
+		sb.WriteString("])")
+		firstOwner = false
 	}
-	return state
+
+	sb.WriteString("]")
+
+	return sb.String()
 }
 
 // getOrInitialize returns the containers languages for a specific namespaced owner, initialising it if it doesn't already


### PR DESCRIPTION
(cherry picked from commit 0ad715c59d14da78787af7283fdf39c5c6c735a5)

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->