### PR TITLE
[netpath] enable traceroute when network_path.connections_monitoring.enabled is enabled

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -155,6 +155,7 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(pngNS("enabled")) {
 		c.EnabledModules[PingModule] = struct{}{}
 	}
+	// TODO: add test
 	if cfg.GetBool(tracerouteNS("enabled")) || cfg.GetBool("network_path.connections_monitoring.enabled") {
 		c.EnabledModules[TracerouteModule] = struct{}{}
 	}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -155,7 +155,7 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(pngNS("enabled")) {
 		c.EnabledModules[PingModule] = struct{}{}
 	}
-	if cfg.GetBool(tracerouteNS("enabled")) {
+	if cfg.GetBool(tracerouteNS("enabled")) || cfg.GetBool("network_path.connections_monitoring.enabled") {
 		c.EnabledModules[TracerouteModule] = struct{}{}
 	}
 	if cfg.GetBool(discoveryNS("enabled")) {

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -155,8 +155,7 @@ func load() (*types.Config, error) {
 	if cfg.GetBool(pngNS("enabled")) {
 		c.EnabledModules[PingModule] = struct{}{}
 	}
-	// TODO: add test
-	if cfg.GetBool(tracerouteNS("enabled")) || cfg.GetBool("network_path.connections_monitoring.enabled") {
+	if cfg.GetBool(tracerouteNS("enabled")) || cfg.GetBool(npNS("connections_monitoring.enabled")) {
 		c.EnabledModules[TracerouteModule] = struct{}{}
 	}
 	if cfg.GetBool(discoveryNS("enabled")) {

--- a/cmd/system-probe/config/ns.go
+++ b/cmd/system-probe/config/ns.go
@@ -67,6 +67,11 @@ func tracerouteNS(k ...string) string {
 	return NSkey("traceroute", k...)
 }
 
+// npNS adds `network_path` namespace to config key
+func npNS(k ...string) string {
+	return NSkey("network_path", k...)
+}
+
 // discoveryNS adds `discovery` namespace to config key
 func discoveryNS(k ...string) string {
 	return NSkey("discovery", k...)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -30,6 +30,7 @@ const (
 	wcdNS                        = "windows_crash_detection"
 	pngNS                        = "ping"
 	tracerouteNS                 = "traceroute"
+	npNS                         = "network_path"
 	discoveryNS                  = "discovery"
 	gpuNS                        = "gpu_monitoring"
 	defaultConnsMessageBatchSize = 600
@@ -412,8 +413,9 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	// Ping
 	cfg.BindEnvAndSetDefault(join(pngNS, "enabled"), false)
 
-	// Traceroute
+	// Traceroute / Network Path
 	cfg.BindEnvAndSetDefault(join(tracerouteNS, "enabled"), false)
+	cfg.BindEnvAndSetDefault(join(npNS, "connections_monitoring.enabled"), false)
 
 	// CCM config
 	cfg.BindEnvAndSetDefault(join(ccmNS, "enabled"), false)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[netpath] enable traceroute when network_path.connections_monitoring.enabled is enabled

### Motivation


`network_path.connections_monitoring.enabled` feature  requires traceroute module

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->