### PR TITLE
Fix the ot-beta and fips images pushed to our internal ECR

### DIFF
--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -235,7 +235,7 @@ deploy_containers-a7-fips_internal:
     JMX: "-jmx"
 
 deploy_containers-a7-fips_internal-rc:
-  extends: .deploy_containers-a7-base-ot
+  extends: .deploy_containers-a7-base-fips
   rules:
     !reference [.on_internal_rc]
   variables:
@@ -308,7 +308,14 @@ deploy_containers_latest-a7_internal:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
         IMG_SOURCES: "%BASE%-full-amd64,%BASE%-full-arm64,%BASE%-jmx-win1809-amd64,%BASE%-jmx-winltsc2022-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-full
-
+      # ot-beta image: linux only for now
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64"
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-ot-beta-jmx
+      # fips image: linux only for now
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${PARENT_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64"
+        IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-fips-jmx
 
 deploy_containers_latest-dogstatsd:
   extends: .docker_publish_job_definition


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix the ot-beta and fips images pushed to our internal ECR

### Motivation

- 7-fips-rc and 7-fips-rc-jmx are pushed using the `ot-beta` tags
- We do not push the final `fips` and `ot-beta` images internally

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/BARX-887