### PR TITLE
[CWS] add specific config entry for SBOM resolver analyzers

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -80,6 +80,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.workloads_cache_size", 10)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.analyzers", []string{"os"})
 
 	// CWS - Security Profiles
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.enabled", true)

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -34,12 +34,16 @@ func (c *Collector) CleanCache() error {
 
 // Init initialize the host collector
 func (c *Collector) Init(cfg config.Component, wmeta option.Option[workloadmeta.Component]) error {
+	return c.initWithOpts(cfg, wmeta, sbom.ScanOptionsFromConfigForHosts(cfg))
+}
+
+func (c *Collector) initWithOpts(cfg config.Component, wmeta option.Option[workloadmeta.Component], opts sbom.ScanOptions) error {
 	trivyCollector, err := trivy.GetGlobalCollector(cfg, wmeta)
 	if err != nil {
 		return err
 	}
 	c.trivyCollector = trivyCollector
-	c.opts = sbom.ScanOptionsFromConfigForHosts(cfg)
+	c.opts = opts
 	return nil
 }
 
@@ -48,9 +52,27 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 	path := request.ID() // for host request, ID == path
 	log.Infof("host scan request [%v]", path)
 
-	report, err := c.trivyCollector.ScanFilesystem(ctx, path, c.opts)
+	report, err := c.DirectScan(ctx, path)
 	return sbom.ScanResult{
 		Error:  err,
 		Report: report,
 	}
+}
+
+// DirectScan performs a scan on a specific path
+func (c *Collector) DirectScan(ctx context.Context, path string) (sbom.Report, error) {
+	return c.trivyCollector.ScanFilesystem(ctx, path, c.opts)
+}
+
+// NewCollectorForCWS creates a new host collector, specifically for CWS
+func NewCollectorForCWS(cfg config.Component, opts sbom.ScanOptions) (*Collector, error) {
+	c := &Collector{
+		resChan: make(chan sbom.ScanResult, channelSize),
+	}
+
+	if err := c.initWithOpts(cfg, option.None[workloadmeta.Component](), opts); err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -210,6 +210,8 @@ type RuntimeSecurityConfig struct {
 	SBOMResolverWorkloadsCacheSize int
 	// SBOMResolverHostEnabled defines if the SBOM resolver should compute the host's SBOM
 	SBOMResolverHostEnabled bool
+	// SBOMResolverAnalyzers defines the list of analyzers that should be used to compute the SBOM
+	SBOMResolverAnalyzers []string
 
 	// HashResolverEnabled defines if the hash resolver should be enabled
 	HashResolverEnabled bool
@@ -412,6 +414,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SBOMResolverEnabled:            pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.enabled"),
 		SBOMResolverWorkloadsCacheSize: pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.sbom.workloads_cache_size"),
 		SBOMResolverHostEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sbom.host.enabled"),
+		SBOMResolverAnalyzers:          pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sbom.analyzers"),
 
 		// Hash resolver
 		HashResolverEnabled:        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.hash_resolver.enabled"),


### PR DESCRIPTION
### What does this PR do?

Currently the CWS SBOM resolver reuses `sbom.host.analyzers` to configure it's analyzer list which is not really desired because you might want to have a different list of analyzers for Infra VM and for CWS (which only needs OS scans for now).

This PR reworks a bit the SBOM resolver so that it can use its own configuration flag, and also it's own host collector instead of re-using the global list of collectors.

### Motivation

### Describe how you validated your changes

This code is already tested in the CI.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->