### PR TITLE
Bump the current_milestone to the next patch version on release branches

### DIFF
--- a/.github/workflows/add_milestone.yml
+++ b/.github/workflows/add_milestone.yml
@@ -29,21 +29,13 @@ jobs:
       - name: Get repo current milestone
         id: current-milestone
         run: |
-          if [[ ${GITHUB_BASE_REF##*/} =~ ^7\.[0-9]+\.x$ ]]; then
-            # If we're on a release branch, set the milestone to the latest release milestone found.
-            MILESTONE=$(gh release list | grep -o $(echo ${GITHUB_BASE_REF##*/} | sed 's/x/[0-9]*/g') | sort -uV | tail -1)
-            if [ -z "$MILESTONE" ]; then
-              echo "Error: Couldn't get the latest release milestone from Github."
-              exit 1
-            fi
-          else
-            # Else use the current_milestone field in the release.json file.
-            MILESTONE=$(cat release.json | jq -r .current_milestone)
-            if [ -z "$MILESTONE" ]; then
-              echo "Error: Couldn't find the current_milestone field in the release.json file."
-              exit 1
-            fi
+          # Use the current_milestone field in the release.json file.
+          MILESTONE=$(cat release.json | jq -r .current_milestone)
+          if [ -z "$MILESTONE" ]; then
+            echo "Error: Couldn't find the current_milestone field in the release.json file."
+            exit 1
           fi
+
           if [[ ! $MILESTONE =~ ^7\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Malformed milestone $MILESTONE. It should be of the form '7.x.y'."
             exit 1

--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -337,6 +337,12 @@ def set_new_release_branch(branch):
     _save_release_json(rj)
 
 
+def set_current_milestone(milestone):
+    rj = load_release_json()
+    rj["current_milestone"] = milestone
+    _save_release_json(rj)
+
+
 def generate_repo_data(ctx, warning_mode, next_version, release_branch):
     if warning_mode:
         # Warning mode is used to warn integrations so that they prepare their release version in advance.

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -63,6 +63,7 @@ from tasks.libs.releasing.json import (
     _save_release_json,
     generate_repo_data,
     load_release_json,
+    set_current_milestone,
     set_new_release_branch,
     update_release_json,
 )
@@ -303,6 +304,14 @@ def finish(ctx, release_branch, upstream="origin"):
         ):
             raise Exit(color_message("Aborting.", "red"), code=1)
         update_release_json(new_version, new_version)
+
+        next_milestone = next_final_version(ctx, release_branch, True)
+        next_milestone = next_milestone.next_version(bump_patch=True)
+        print(f"Creating the {next_milestone} milestone...")
+
+        gh = GithubAPI()
+        gh.create_milestone(str(next_milestone), exist_ok=True)
+        set_current_milestone(str(next_milestone))
 
         # Step 2: Update internal module dependencies
 
@@ -1308,9 +1317,7 @@ def update_current_milestone(ctx, major_version: int = 7, upstream="origin"):
     with agent_context(ctx, get_default_branch(major=major_version)):
         milestone_branch = f"release_milestone-{int(time.time())}"
         ctx.run(f"git switch -c {milestone_branch}")
-        rj = load_release_json()
-        rj["current_milestone"] = f"{next}"
-        _save_release_json(rj)
+        set_current_milestone(next)
         # Commit release.json
         ctx.run("git add release.json")
         ok = try_git_command(ctx, f"git commit -m 'Update release.json with current milestone to {next}'")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Bump the current_milestone to the next patch version on release branches

### Motivation

We currently never bump the milestone on release branches and keep using `7.XX.0`, which is wrong. We can automatically bump it as part of the `finish` command.

Always read this file from now to set the milestone

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

https://datadoghq.atlassian.net/browse/BARX-886