### PR TITLE
[CONTP-683] feat[beta]: Support injecting APM and Dogstatsd sockets using CSI volumes instead of hostpath volume

### DIFF
--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -56,6 +56,24 @@ const (
 	webhookName = "agent_config"
 )
 
+// volumeType represents the type of the volume injected by this webhook
+// It can be either hostpath or csi volume
+type volumeType string
+
+const (
+	hostpathVolume volumeType = "hostpathvolume"
+	csiVolume                 = "csivolume"
+)
+
+// csiInjectionMode defines the mode of the injected csi volume
+// mode can be either 'socket' or 'local'
+type csiInjectionMode string
+
+const (
+	csiModeSocket csiInjectionMode = "socket"
+	csiModeLocal                   = "local"
+)
+
 // Webhook is the webhook that injects DD_AGENT_HOST and DD_ENTITY_ID into a pod
 type Webhook struct {
 	name            string

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -56,22 +56,13 @@ const (
 	webhookName = "agent_config"
 )
 
-// volumeType represents the type of the volume injected by this webhook
-// It can be either hostpath or csi volume
-type volumeType string
-
-const (
-	hostpathVolume volumeType = "hostpathvolume"
-	csiVolume                 = "csivolume"
-)
-
 // csiInjectionMode defines the mode of the injected csi volume
 // mode can be either 'socket' or 'local'
 type csiInjectionMode string
 
 const (
 	csiModeSocket csiInjectionMode = "socket"
-	csiModeLocal                   = "local"
+	csiModeLocal  csiInjectionMode = "local"
 )
 
 // Webhook is the webhook that injects DD_AGENT_HOST and DD_ENTITY_ID into a pod

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -351,7 +350,7 @@ func TestInjectSocket(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						CSI: &corev1.CSIVolumeSource{
 							Driver:   "k8s.csi.datadoghq.com",
-							ReadOnly: ptr.Bool(true),
+							ReadOnly: pointer.Ptr(true),
 							VolumeAttributes: map[string]string{
 								"path": "/var/run/datadog",
 								"mode": "local",
@@ -451,7 +450,7 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						CSI: &corev1.CSIVolumeSource{
 							Driver:   "k8s.csi.datadoghq.com",
-							ReadOnly: ptr.Bool(true),
+							ReadOnly: pointer.Ptr(true),
 							VolumeAttributes: map[string]string{
 								"path": "/var/run/datadog/dsd.socket",
 								"mode": "socket",
@@ -464,7 +463,7 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 					VolumeSource: corev1.VolumeSource{
 						CSI: &corev1.CSIVolumeSource{
 							Driver:   "k8s.csi.datadoghq.com",
-							ReadOnly: ptr.Bool(true),
+							ReadOnly: pointer.Ptr(true),
 							VolumeAttributes: map[string]string{
 								"path": "/var/run/datadog/apm.socket",
 								"mode": "socket",

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/aws/smithy-go/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -313,92 +314,217 @@ func TestInjectExternalDataEnvVar(t *testing.T) {
 }
 
 func TestInjectSocket(t *testing.T) {
-	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
-	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
-	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	filter, err := NewFilter(datadogConfig)
-	require.NoError(t, err)
-	mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-	webhook := NewWebhook(wmeta, datadogConfig, mutator)
-	injected, err := webhook.inject(pod, "", nil)
-	assert.Nil(t, err)
-	assert.True(t, injected)
+	tests := []struct {
+		name                 string
+		withCSIDriver        bool
+		expectedVolumeMounts []corev1.VolumeMount
+		expectedVolumes      []corev1.Volume
+	}{
+		{
+			name:          "no csi driver",
+			withCSIDriver: false,
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "datadog",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/run/datadog",
+							Type: pointer.Ptr(corev1.HostPathDirectoryOrCreate),
+						},
+					},
+				},
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "datadog",
+					MountPath: "/var/run/datadog",
+					ReadOnly:  true,
+				},
+			},
+		},
+		{
+			name:          "with csi driver",
+			withCSIDriver: true,
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "datadog",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:   "k8s.csi.datadoghq.com",
+							ReadOnly: ptr.Bool(true),
+							VolumeAttributes: map[string]string{
+								"path": "/var/run/datadog",
+								"mode": "local",
+							},
+						},
+					},
+				},
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "datadog",
+					MountPath: "/var/run/datadog",
+					ReadOnly:  true,
+				},
+			},
+		},
+	}
 
-	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
-	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"))
-	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].MountPath, "/var/run/datadog")
-	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].Name, "datadog")
-	assert.Equal(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly, true)
-	assert.Equal(t, pod.Spec.Volumes[0].Name, "datadog")
-	assert.Equal(t, pod.Spec.Volumes[0].VolumeSource.HostPath.Path, "/var/run/datadog")
-	assert.Equal(t, *pod.Spec.Volumes[0].VolumeSource.HostPath.Type, corev1.HostPathDirectoryOrCreate)
-	assert.Equal(t, "datadog", pod.Annotations[mutatecommon.K8sAutoscalerSafeToEvictVolumesAnnotation])
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
+			pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
+			wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
+			datadogConfig := fxutil.Test[config.Component](t, core.MockBundle(), fx.Replace(config.MockParams{
+				Overrides: map[string]interface{}{"csi.enabled": test.withCSIDriver},
+			}))
+			filter, err := NewFilter(datadogConfig)
+			require.NoError(t, err)
+			mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
+			webhook := NewWebhook(wmeta, datadogConfig, mutator)
+			injected, err := webhook.inject(pod, "", nil)
+			assert.Nil(t, err)
+			assert.True(t, injected)
+
+			assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
+			assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"))
+
+			assert.ElementsMatch(t, pod.Spec.Containers[0].VolumeMounts, test.expectedVolumeMounts)
+			assert.ElementsMatch(t, pod.Spec.Volumes, test.expectedVolumes)
+
+			assert.Equal(t, "datadog", pod.Annotations[mutatecommon.K8sAutoscalerSafeToEvictVolumesAnnotation])
+		})
+	}
 }
 
 func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
-	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
-	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
-	wmeta := fxutil.Test[workloadmeta.Component](
-		t,
-		core.MockBundle(),
-		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-		fx.Replace(config.MockParams{
-			Overrides: map[string]interface{}{"admission_controller.inject_config.type_socket_volumes": true},
-		}),
-	)
-	datadogConfig := fxutil.Test[config.Component](t, core.MockBundle())
-	filter, err := NewFilter(datadogConfig)
-	require.NoError(t, err)
-	mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-	webhook := NewWebhook(wmeta, datadogConfig, mutator)
-	injected, err := webhook.inject(pod, "", nil)
-	assert.Nil(t, err)
-	assert.True(t, injected)
 
-	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
-	assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"))
-
-	expectedVolumeMounts := []corev1.VolumeMount{
+	tests := []struct {
+		name                 string
+		withCSIDriver        bool
+		expectedVolumeMounts []corev1.VolumeMount
+		expectedVolumes      []corev1.Volume
+	}{
 		{
-			Name:      "datadog-dogstatsd",
-			MountPath: "/var/run/datadog/dsd.socket",
-			ReadOnly:  true,
-		},
-		{
-			Name:      "datadog-trace-agent",
-			MountPath: "/var/run/datadog/apm.socket",
-			ReadOnly:  true,
-		},
-	}
-	assert.ElementsMatch(t, pod.Spec.Containers[0].VolumeMounts, expectedVolumeMounts)
-
-	expectedVolumes := []corev1.Volume{
-		{
-			Name: "datadog-dogstatsd",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/run/datadog/dsd.socket",
-					Type: pointer.Ptr(corev1.HostPathSocket),
+			name:          "no csi driver",
+			withCSIDriver: false,
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "datadog-dogstatsd",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/run/datadog/dsd.socket",
+							Type: pointer.Ptr(corev1.HostPathSocket),
+						},
+					},
+				},
+				{
+					Name: "datadog-trace-agent",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/run/datadog/apm.socket",
+							Type: pointer.Ptr(corev1.HostPathSocket),
+						},
+					},
+				},
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "datadog-dogstatsd",
+					MountPath: "/var/run/datadog/dsd.socket",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "datadog-trace-agent",
+					MountPath: "/var/run/datadog/apm.socket",
+					ReadOnly:  true,
 				},
 			},
 		},
 		{
-			Name: "datadog-trace-agent",
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: "/var/run/datadog/apm.socket",
-					Type: pointer.Ptr(corev1.HostPathSocket),
+			name:          "with csi driver",
+			withCSIDriver: true,
+			expectedVolumes: []corev1.Volume{
+				{
+					Name: "datadog-dogstatsd",
+
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:   "k8s.csi.datadoghq.com",
+							ReadOnly: ptr.Bool(true),
+							VolumeAttributes: map[string]string{
+								"path": "/var/run/datadog/dsd.socket",
+								"mode": "socket",
+							},
+						},
+					},
+				},
+				{
+					Name: "datadog-trace-agent",
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:   "k8s.csi.datadoghq.com",
+							ReadOnly: ptr.Bool(true),
+							VolumeAttributes: map[string]string{
+								"path": "/var/run/datadog/apm.socket",
+								"mode": "socket",
+							},
+						},
+					},
+				},
+			},
+			expectedVolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "datadog-dogstatsd",
+					MountPath: "/var/run/datadog/dsd.socket",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "datadog-trace-agent",
+					MountPath: "/var/run/datadog/apm.socket",
+					ReadOnly:  true,
 				},
 			},
 		},
 	}
-	assert.ElementsMatch(t, pod.Spec.Volumes, expectedVolumes)
 
-	safeToEvictVolumes := strings.Split(pod.Annotations[mutatecommon.K8sAutoscalerSafeToEvictVolumesAnnotation], ",")
-	assert.Len(t, safeToEvictVolumes, 2)
-	assert.Contains(t, safeToEvictVolumes, "datadog-dogstatsd")
-	assert.Contains(t, safeToEvictVolumes, "datadog-trace-agent")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
+			pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "socket"})
+			wmeta := fxutil.Test[workloadmeta.Component](
+				t,
+				core.MockBundle(),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+				fx.Replace(config.MockParams{
+					Overrides: map[string]interface{}{"admission_controller.inject_config.type_socket_volumes": true},
+				}),
+			)
+			datadogConfig := fxutil.Test[config.Component](t, core.MockBundle(), fx.Replace(config.MockParams{
+				Overrides: map[string]interface{}{"csi.enabled": test.withCSIDriver},
+			}))
+			filter, err := NewFilter(datadogConfig)
+			require.NoError(t, err)
+			mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
+			webhook := NewWebhook(wmeta, datadogConfig, mutator)
+			injected, err := webhook.inject(pod, "", nil)
+			assert.Nil(t, err)
+			assert.True(t, injected)
+
+			assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_TRACE_AGENT_URL", "unix:///var/run/datadog/apm.socket"))
+			assert.Contains(t, pod.Spec.Containers[0].Env, mutatecommon.FakeEnvWithValue("DD_DOGSTATSD_URL", "unix:///var/run/datadog/dsd.socket"))
+
+			assert.ElementsMatch(t, pod.Spec.Containers[0].VolumeMounts, test.expectedVolumeMounts)
+			assert.ElementsMatch(t, pod.Spec.Volumes, test.expectedVolumes)
+
+			safeToEvictVolumes := strings.Split(pod.Annotations[mutatecommon.K8sAutoscalerSafeToEvictVolumesAnnotation], ",")
+			assert.Len(t, safeToEvictVolumes, 2)
+			assert.Contains(t, safeToEvictVolumes, "datadog-dogstatsd")
+			assert.Contains(t, safeToEvictVolumes, "datadog-trace-agent")
+
+		})
+	}
+
 }
 
 func TestInjectSocketWithConflictingVolumeAndInitContainer(t *testing.T) {

--- a/pkg/clusteragent/admission/mutate/config/mutator.go
+++ b/pkg/clusteragent/admission/mutate/config/mutator.go
@@ -15,6 +15,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/aws/smithy-go/ptr"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
@@ -269,7 +271,7 @@ func buildCSIVolume(volumeName, path string, injectionMode csiInjectionMode, rea
 		VolumeSource: corev1.VolumeSource{
 			CSI: &corev1.CSIVolumeSource{
 				Driver:   csiDriver,
-				ReadOnly: &readOnly,
+				ReadOnly: ptr.Bool(readOnly),
 				VolumeAttributes: map[string]string{
 					"mode": string(injectionMode),
 					"path": path,

--- a/pkg/clusteragent/admission/mutate/config/mutator.go
+++ b/pkg/clusteragent/admission/mutate/config/mutator.go
@@ -15,14 +15,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/aws/smithy-go/ptr"
-
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	apiCommon "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 // MutatorConfig contains the settings for the config injector.
@@ -271,7 +270,7 @@ func buildCSIVolume(volumeName, path string, injectionMode csiInjectionMode, rea
 		VolumeSource: corev1.VolumeSource{
 			CSI: &corev1.CSIVolumeSource{
 				Driver:   csiDriver,
-				ReadOnly: ptr.Bool(readOnly),
+				ReadOnly: pointer.Ptr(readOnly),
 				VolumeAttributes: map[string]string{
 					"mode": string(injectionMode),
 					"path": path,

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -749,6 +749,10 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Remote tagger
 	config.BindEnvAndSetDefault("remote_tagger.max_concurrent_sync", 3)
 
+	// CSI driver
+	config.BindEnvAndSetDefault("csi.enabled", false)
+	config.BindEnvAndSetDefault("csi.driver", "k8s.csi.datadoghq.com")
+
 	// Admission controller
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.validation.enabled", true)

--- a/releasenotes-dca/notes/support-csi-volume-in-dca-config-webhook-bb75ea7b0a81c3fe.yaml
+++ b/releasenotes-dca/notes/support-csi-volume-in-dca-config-webhook-bb75ea7b0a81c3fe.yaml
@@ -9,6 +9,6 @@
 features:
   - |
     [PREVIEW] Add support for mounting Datadog CSI volumes instead of hostpath 
-    volumes in the admission controller config webhook for sharing  DogStatsD 
+    volumes in the admission controller config webhook for sharing DogStatsD 
     and APM UDS sockets with user applications. This requires the Datadog 
     CSI driver to be installed and running on the cluster. 

--- a/releasenotes-dca/notes/support-csi-volume-in-dca-config-webhook-bb75ea7b0a81c3fe.yaml
+++ b/releasenotes-dca/notes/support-csi-volume-in-dca-config-webhook-bb75ea7b0a81c3fe.yaml
@@ -8,7 +8,7 @@
 ---
 features:
   - |
-    [BETA] Add support for mounting Datadog CSI Volumes instead of hostpath 
-    volumes in the admission controller config webhook. This applies
-    to mounting Dogstatsd and Tracing UDS sockets onto user applications.
-    This requires datadog CSI driver to be installed and running on the cluster. 
+    [PREVIEW] Add support for mounting Datadog CSI volumes instead of hostpath 
+    volumes in the admission controller config webhook for sharing  DogStatsD 
+    and APM UDS sockets with user applications. This requires the Datadog 
+    CSI driver to be installed and running on the cluster. 

--- a/releasenotes-dca/notes/support-csi-volume-in-dca-config-webhook-bb75ea7b0a81c3fe.yaml
+++ b/releasenotes-dca/notes/support-csi-volume-in-dca-config-webhook-bb75ea7b0a81c3fe.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    [BETA] Add support for mounting Datadog CSI Volumes instead of hostpath 
+    volumes in the admission controller config webhook. This applies
+    to mounting Dogstatsd and Tracing UDS sockets onto user applications.
+    This requires datadog CSI driver to be installed and running on the cluster. 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently, UDS sockets for DSD and APM are injected into user apps in the form of hostpath volumes thanks to the config webhook. 

We support two types of hostpath volumes:
- Socket
- DirectoryOrCreate

This PR allows configuring the admission controller to leverage the existence of a CSI driver to replace HostPath volumes by CSI volume.

This feature requires the datadog CSI driver to be deployed and running on the cluster.

The CSI volume will take into account the user's choice (Socket vs DirectoryOrCreate) when injecting the CSI driver and will provide the same behaviour in the CSI driver via the `mode` attribute set in the volumeAttributes. 

### Motivation

Allow users to use dogstatsd and APM tracing over UDS in namespaces having baseline or restrictive pod security standards. (CSI volumes are accepted in such contexts, hostpath volumes are not).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

#### Deploy the datadog csi driver

- Clone the [datadog csi driver repo](https://github.com/DataDog/datadog-csi-driver).
- From the root path, build the driver with `docker build`.
- Deploy the driver with `helm install --set image.repository=<image-name> --set image.tag=<tag> datadog-csi ./chart/datadog-csi-driver`

#### Deploy the agent with dca

```
datadog:
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  clusterName: adel-test-dca-csi
  clusterChecks:
    enabled: true
  kubelet:
    tlsVerify: false
  checksCardinality: none

clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
  envDict:
    DD_CSI_ENABLED: "true"
    DD_CSI_DRIVER: "k8s.csi.datadoghq.com"
    DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TYPE_SOCKET_VOLUMES: "true"
```

#### Deploy a test app

Once all agents (including the cluster agent) are up and running, create a test app in the dev namespace:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: datadogpy
  namespace: dev
spec:
  replicas: 1
  selector:
    matchLabels:
      app: datadogpy
  template:
    metadata:
      labels:
        app: datadogpy
    spec:
      containers:
        - name: datadogpy-local
          image: adelhajhassan918/datadogpy-uds-udp
          imagePullPolicy: Always
```

#### Verify CSI Volume Injection

Check the deployment pods and verify that they got CSI volumes injected and mounted:

```
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: false
      volumeAttributes:
        mode: socket
        path: /var/run/datadog/dsd.socket
    name: datadog-dogstatsd
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: false
      volumeAttributes:
        mode: socket
        path: /var/run/datadog/apm.socket
    name: datadog-trace-agent
```

Notice the mode of the volumes is `socket`, and the path is the socket file path.

They should be mounted like this:
```
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-dhctf
      readOnly: true
    - mountPath: /var/run/datadog/dsd.socket
      name: datadog-dogstatsd
    - mountPath: /var/run/datadog/apm.socket
      name: datadog-trace-agent
```

#### Verify custom metrics 

Check the UI and verify that the app is able to send custom metrics:
![image](https://github.com/user-attachments/assets/d742a887-2a6a-4630-8676-95a3700d0df7)

#### Verify that 

Uninstall the aget and delete the test app, then try again the same test while removing     `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TYPE_SOCKET_VOLUMES: "true"`.

The effect should be that the injected CSI volume should have mode `local` and have path `var/run/datadog`

```
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: false
      volumeAttributes:
        mode: local
        path: /var/run/datadog
    name: datadog
```

```
    volumeMounts:
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-bmpk8
      readOnly: true
    - mountPath: /var/run/datadog
      name: datadog
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
