### PR TITLE
[AGENT-13319] Fix NVIDIA Jetson check frequency parsing with multiple GPCs

### DIFF
--- a/pkg/collector/corechecks/nvidia/jetson/cpuMetricsSender.go
+++ b/pkg/collector/corechecks/nvidia/jetson/cpuMetricsSender.go
@@ -24,7 +24,7 @@ type cpuMetricSender struct {
 
 func (cpuMetricSender *cpuMetricSender) Init() error {
 	// List of CPUs and their usage/frequency, e.g. 2%@102,1%@102,0%@102,0%@102,off,off,off,off
-	regex, err := regexp.Compile(`CPU\s*\[((?:.,?)+)]`)
+	regex, err := regexp.Compile(`CPU\s*\[((?:\S,?)+)]`)
 	if err != nil {
 		return err
 	}

--- a/releasenotes/notes/check-nvidia-jetson-fix-r36-e76f6a19c53ad70d.yaml
+++ b/releasenotes/notes/check-nvidia-jetson-fix-r36-e76f6a19c53ad70d.yaml
@@ -10,4 +10,4 @@ fixes:
   - |
     Fix the NVIDIA Jetson check to support parsing the ``tegrastats`` output 
     when there are multiple Graphics Processing Clusters (GPCs). In that case, the metric 
-    ``nvidia.jetson.gpu.freq`` is emitted for each GPC and tagged with ``gpc:0``, ``gpc:1``, etc.
+    ``nvidia.jetson.gpu.freq`` is emitted for each GPC and tagged with ``gpc:0``, ``gpc:1``, and so on.

--- a/releasenotes/notes/check-nvidia-jetson-fix-r36-e76f6a19c53ad70d.yaml
+++ b/releasenotes/notes/check-nvidia-jetson-fix-r36-e76f6a19c53ad70d.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the NVIDIA Jetson check to support parsing the ``tegrastats`` output 
+    when there are multiple Graphics Processing Clusters (GPCs). In that case, the metric 
+    ``nvidia.jetson.gpu.freq`` is emitted for each GPC and tagged with ``gpc:0``, ``gpc:1``, etc.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix parsing the output of `tegrastats` when there are multiple Graphics Processing Clusters.

As mentioned in https://forums.developer.nvidia.com/t/gpu-utilization-from-tegrastats-in-jetpack-6/286782, the format used to be `GR3D X%@F1` but with multiple GPCs it's now `GR3D X%@[F1,F2]`.

In that case, the metric `nvidia.jetson.gpu.freq` is emitted multiple times, and tagged with `gpc:0`, `gpc:1`, etc.

### Motivation
The format was changed, which breaks the check.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Added a comprehensive unit test, using output provided by a user.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I didn't add the tag on the metric when there is a single GPC to avoid any change for users, but that can be changed.