### PR TITLE
[Backport 7.64.x] CAP-2329 Unblocking Configure() by moving Initialize() in the first Run(). (#34773)

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -11,6 +11,7 @@ package orchestrator
 import (
 	"expvar"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -50,6 +51,7 @@ type CollectorBundle struct {
 	manifestBuffer      *ManifestBuffer
 	collectorDiscovery  *discovery.DiscoveryCollector
 	activatedCollectors map[string]struct{}
+	initializeOnce      sync.Once
 }
 
 // NewCollectorBundle creates a new bundle from the check configuration.
@@ -266,7 +268,11 @@ func (cb *CollectorBundle) prepareExtraSyncTimeout() {
 // Initialize is used to initialize collectors part of the bundle.
 // During initialization informers are created, started and their cache is
 // synced.
-func (cb *CollectorBundle) Initialize() error {
+func (cb *CollectorBundle) Initialize() {
+	cb.initializeOnce.Do(cb.initialize)
+}
+
+func (cb *CollectorBundle) initialize() {
 	informersToSync := make(map[apiserver.InformerName]cache.SharedInformer)
 	// informerSynced is a helper map which makes sure that we don't initialize the same informer twice.
 	// i.e. the cluster and nodes resources share the same informer and using both can lead to a race condition activating both concurrently.
@@ -300,8 +306,6 @@ func (cb *CollectorBundle) Initialize() error {
 			cb.skipCollector(informerName, err)
 		}
 	}
-
-	return nil
 }
 
 func (cb *CollectorBundle) skipCollector(informerName apiserver.InformerName, err error) {

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -171,12 +171,14 @@ func (o *OrchestratorCheck) Configure(senderManager sender.SenderManager, integr
 	// Create a new bundle for the check.
 	o.collectorBundle = NewCollectorBundle(o)
 
-	// Initialize collectors.
-	return o.collectorBundle.Initialize()
+	return nil
 }
 
 // Run runs the orchestrator check
 func (o *OrchestratorCheck) Run() error {
+	// Initialize collectors
+	o.collectorBundle.Initialize()
+
 	// access serializer
 	sender, err := o.GetSender()
 	if err != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_test.go
@@ -89,8 +89,7 @@ func TestOrchestratorCheckSafeReSchedule(t *testing.T) {
 
 	orchCheck.orchestratorInformerFactory = getOrchestratorInformerFactory(cl)
 	bundle := newCollectorBundle(t, orchCheck)
-	err := bundle.Initialize()
-	assert.NoError(t, err)
+	bundle.Initialize()
 
 	wg.Add(2)
 
@@ -99,10 +98,10 @@ func TestOrchestratorCheckSafeReSchedule(t *testing.T) {
 
 	bundle.runCfg.OrchestratorInformerFactory = getOrchestratorInformerFactory(cl)
 	bundle.stopCh = make(chan struct{})
-	err = bundle.Initialize()
-	assert.NoError(t, err)
+	bundle.initializeOnce = sync.Once{}
+	bundle.Initialize()
 
-	_, err = bundle.runCfg.OrchestratorInformerFactory.InformerFactory.Core().V1().Nodes().Informer().AddEventHandler(&cache.ResourceEventHandlerFuncs{
+	_, err := bundle.runCfg.OrchestratorInformerFactory.InformerFactory.Core().V1().Nodes().Informer().AddEventHandler(&cache.ResourceEventHandlerFuncs{
 		AddFunc: func(_ interface{}) {
 			wg.Done()
 		},

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -68,6 +68,10 @@ type syncInformerResult struct {
 
 // SyncInformersReturnErrors does the same thing as SyncInformers except it returns a map of InformerName and error
 func SyncInformersReturnErrors(informers map[InformerName]cache.SharedInformer, extraWait time.Duration) map[InformerName]error {
+	if len(informers) == 0 {
+		return nil
+	}
+
 	resultChan := make(chan syncInformerResult)
 	errors := make(map[InformerName]error, len(informers))
 	timeoutConfig := pkgconfigsetup.Datadog().GetDuration("kube_cache_sync_timeout_seconds") * time.Second


### PR DESCRIPTION

(cherry picked from commit 9842a72472bb92952238105045706a39ead590d8)

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->