### PR TITLE
Update warning about unkown key to use the caller location

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -658,6 +658,7 @@ linters-settings:
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnc
       - github.com/DataDog/datadog-agent/pkg/util/log.Warnf
       - github.com/DataDog/datadog-agent/pkg/util/log.WarnStackDepth
+      - github.com/DataDog/datadog-agent/pkg/util/log.WarnfStackDepth
       - golang.org/x/sys/windows.CloseHandle
       - golang.org/x/sys/windows.FreeLibrary
       - golang.org/x/sys/windows.FreeSid

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -201,8 +201,8 @@ func (c *safeConfig) checkKnownKey(key string) {
 	c.unknownKeys[key] = struct{}{}
 	c.Unlock()
 
-	// log without holding the lock
-	log.Warnf("config key %v is unknown", key)
+	// log without holding the lock. We use stack depth +3 to use the caller function location instead of checkKnownKey
+	log.WarnfStackDepth(3, "config key %q is unknown", key)
 }
 
 // GetKnownKeysLowercased returns all the keys that meet at least one of these criteria:


### PR DESCRIPTION
### What does this PR do?

Update warning about unkown key to use the caller location.

Instead of logging:
```
(pkg/config/viperconfig/viper.go:205 in checkKnownKey) | config key XXX is unknown
```

We will log, for example:
```
(cmd/agent/subcommands/run/command.go:535 in startAgent) | config key 'XXX' is unknown
```

### Describe how you validated your changes

Running the CI is enought.