### PR TITLE
trivy: do not drop layers information when scanning container with overlayfs scan method

### DIFF
--- a/cmd/sbomgen/scanners.go
+++ b/cmd/sbomgen/scanners.go
@@ -28,7 +28,7 @@ func runScanFS(path string, analyzers []string, fast bool) error {
 	report, err := collector.ScanFilesystem(ctx, path, sbom.ScanOptions{
 		Analyzers: analyzers,
 		Fast:      fast,
-	})
+	}, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/sbom/collectors/host/host.go
+++ b/pkg/sbom/collectors/host/host.go
@@ -61,7 +61,7 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 
 // DirectScan performs a scan on a specific path
 func (c *Collector) DirectScan(ctx context.Context, path string) (sbom.Report, error) {
-	return c.trivyCollector.ScanFilesystem(ctx, path, c.opts)
+	return c.trivyCollector.ScanFilesystem(ctx, path, c.opts, true)
 }
 
 // NewCollectorForCWS creates a new host collector, specifically for CWS

--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -312,7 +312,7 @@ func (c *Collector) ScanContainerdImageFromFilesystem(ctx context.Context, imgMe
 		}
 	}()
 
-	report, err := c.ScanFilesystem(ctx, imagePath, scanOptions)
+	report, err := c.ScanFilesystem(ctx, imagePath, scanOptions, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to scan image %s, err: %w", imgMeta.ID, err)
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

In order to not trigger [this condition in trivy code](https://github.com/DataDog/trivy/blob/161e65c035868acb7bd368e3b84e6a7ceca9127b/pkg/scanner/scan.go#L63) that drops layer code when scanning a filesystem, this PR adds a wrapper on top of artifacts that returns the correct artifact type for the scanner.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->