### PR TITLE
[CWS] fix parsing of set value key ETW event

### DIFF
--- a/pkg/security/probe/probe_kernel_reg_windows.go
+++ b/pkg/security/probe/probe_kernel_reg_windows.go
@@ -104,7 +104,7 @@ type setValueKeyArgs struct {
 	capturedData             []byte
 	previousDataType         uint32
 	previousDataSize         uint32
-	capturedPreviousDataSize uint16 //nolint:golint,unused
+	capturedPreviousDataSize uint16
 	previousData             []byte
 	computedFullPath         string
 }
@@ -336,7 +336,10 @@ func (wp *WindowsProbe) parseSetValueKey(e *etw.DDEventRecord) (*setValueKeyArgs
 	sv.previousDataSize = data.GetUint32(nextOffset)
 	nextOffset += 4
 
-	sv.previousData = data.Bytes(nextOffset, int(sv.previousDataSize))
+	sv.capturedPreviousDataSize = data.GetUint16(nextOffset)
+	nextOffset += 2
+
+	sv.previousData = data.Bytes(nextOffset, int(sv.capturedPreviousDataSize))
 
 	if s, ok := wp.regPathResolver.Get(sv.keyObject); ok {
 		sv.computedFullPath = s


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the parsing of `setValueKeyArgs` from ETW events, by reading the actually captured size and using it to read the following data. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->