### PR TITLE
GPU: refactor gpu-check collectors 

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/clocks.go
+++ b/pkg/collector/corechecks/gpu/nvidia/clocks.go
@@ -20,11 +20,10 @@ const clocksMetricsPrefix = "clock.throttle_reasons"
 // clocksCollector collects clock metrics from an NVML device.
 type clocksCollector struct {
 	device nvml.Device
-	tags   []string
 }
 
 // newClocksCollector creates a new clocksMetricsCollector for the given NVML device.
-func newClocksCollector(device nvml.Device, tags []string) (Collector, error) {
+func newClocksCollector(device nvml.Device) (Collector, error) {
 	// Check first if the device supports clock throttle reasons
 	_, ret := device.GetCurrentClocksThrottleReasons()
 	if ret == nvml.ERROR_NOT_SUPPORTED {
@@ -35,7 +34,6 @@ func newClocksCollector(device nvml.Device, tags []string) (Collector, error) {
 
 	return &clocksCollector{
 		device: device,
-		tags:   tags,
 	}, nil
 }
 
@@ -57,7 +55,6 @@ func (c *clocksCollector) Collect() ([]Metric, error) {
 		metric := Metric{
 			Name:  fmt.Sprintf("%s.%s", clocksMetricsPrefix, name),
 			Value: value,
-			Tags:  c.tags,
 			Type:  metrics.GaugeType,
 		}
 		metricValues = append(metricValues, metric)

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -113,7 +113,7 @@ func buildCollectors(deps *CollectorDependencies, builders map[CollectorName]sub
 	return collectors, nil
 }
 
-// GetDeviceTagsMapping returns the tags associated with the given NVML device identified by its UUID.
+// GetDeviceTagsMapping returns the mapping of tags per GPU device.
 func GetDeviceTagsMapping(lib nvml.Interface, tagger tagger.Component) map[string][]string {
 	devCount, ret := lib.DeviceGetCount()
 	if ret != nvml.SUCCESS {

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -40,9 +40,8 @@ const (
 
 // Metric represents a single metric collected from the NVML library.
 type Metric struct {
-	Name  string   // Name holds the name of the metric.
-	Value float64  // Value holds the value of the metric.
-	Tags  []string // Tags holds the tags associated with the metric.
+	Name  string  // Name holds the name of the metric.
+	Value float64 // Value holds the value of the metric.
 	Type  metrics.MetricType
 }
 
@@ -61,7 +60,7 @@ type Collector interface {
 
 // subsystemBuilder is a function that creates a new subsystem Collector. device the device it should collect metrics from. It also receives
 // the tags associated with the device, the collector should use them when generating metrics.
-type subsystemBuilder func(device nvml.Device, tags []string) (Collector, error)
+type subsystemBuilder func(device nvml.Device) (Collector, error)
 
 // factory is a map of all the subsystems that can be used to collect metrics from NVML.
 var factory = map[CollectorName]subsystemBuilder{
@@ -74,9 +73,6 @@ var factory = map[CollectorName]subsystemBuilder{
 
 // CollectorDependencies holds the dependencies needed to create a set of collectors.
 type CollectorDependencies struct {
-	// Tagger is the tagger component used to tag the metrics.
-	Tagger tagger.Component
-
 	// NVML is the NVML library interface used to interact with the NVIDIA devices.
 	NVML nvml.Interface
 }
@@ -100,14 +96,8 @@ func buildCollectors(deps *CollectorDependencies, builders map[CollectorName]sub
 			return nil, fmt.Errorf("failed to get device handle for index %d: %s", i, nvml.ErrorString(ret))
 		}
 
-		tags, err := getTagsFromDevice(dev, deps.Tagger)
-		if err != nil {
-			log.Warnf("failed to get tags for device %s: %s", dev, err)
-			continue
-		}
-
 		for name, builder := range builders {
-			c, err := builder(dev, tags)
+			c, err := builder(dev)
 			if errors.Is(err, errUnsupportedDevice) {
 				log.Warnf("device %s does not support collector %s", dev, name)
 				continue
@@ -123,24 +113,43 @@ func buildCollectors(deps *CollectorDependencies, builders map[CollectorName]sub
 	return collectors, nil
 }
 
-// getTagsFromDevice returns the tags associated with the given NVML device.
-func getTagsFromDevice(dev nvml.Device, tagger tagger.Component) ([]string, error) {
-	uuid, ret := dev.GetUUID()
+// GetDeviceTagsMapping returns the tags associated with the given NVML device identified by its UUID.
+func GetDeviceTagsMapping(lib nvml.Interface, tagger tagger.Component) map[string][]string {
+	devCount, ret := lib.DeviceGetCount()
 	if ret != nvml.SUCCESS {
-		return nil, fmt.Errorf("failed to get device UUID: %s", nvml.ErrorString(ret))
+		log.Errorf("failed to get devices tags mapping, couldn't get available GPU devices: %s", nvml.ErrorString(ret))
+		return nil
 	}
 
-	entityID := taggertypes.NewEntityID(taggertypes.GPU, uuid)
-	tags, err := tagger.Tag(entityID, tagger.ChecksCardinality())
-	if err != nil {
-		log.Warnf("Error collecting GPU tags for GPU UUID %s: %s", uuid, err)
+	tagsMapping := make(map[string][]string, devCount)
+
+	for i := 0; i < devCount; i++ {
+		dev, ret := lib.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			// skip retrieving tags for this device if we failed to get its handle
+			continue
+		}
+
+		uuid, ret := dev.GetUUID()
+		if ret != nvml.SUCCESS {
+			// skip retrieving tags for this device if we failed to get its UUID
+			continue
+		}
+
+		entityID := taggertypes.NewEntityID(taggertypes.GPU, uuid)
+		tags, err := tagger.Tag(entityID, tagger.ChecksCardinality())
+		if err != nil {
+			log.Warnf("Error collecting GPU tags for GPU UUID %s: %s", uuid, err)
+		}
+
+		if len(tags) == 0 {
+			// If we get no tags (either WMS hasn't collected GPUs yet, or we are running the check standalone with 'agent check')
+			// add at least the UUID as a tag to distinguish the values.
+			tags = []string{fmt.Sprintf("gpu_uuid:%s", uuid)}
+		}
+
+		tagsMapping[uuid] = tags
 	}
 
-	if len(tags) == 0 {
-		// If we get no tags (either WMS hasn't collected GPUs yet, or we are running the check standalone with 'agent check')
-		// add at least the UUID as a tag to distinguish the values.
-		tags = []string{fmt.Sprintf("gpu_uuid:%s", uuid)}
-	}
-
-	return tags, nil
+	return tagsMapping
 }

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -11,19 +11,35 @@ import (
 	"errors"
 	"testing"
 
-	taggerMock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
+	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/require"
 )
 
-func getBasicNvmlDeviceMock() nvml.Device {
+// this mock returns proper values only for devices with index 0 and 1, otherwise it will return an error
+func getBasicNvmlDeviceMock(index int) nvml.Device {
 	return &nvmlmock.Device{
 		GetUUIDFunc: func() (string, nvml.Return) {
-			return "GPU-123", nvml.SUCCESS
+			switch index {
+			case 0:
+				return "GPU-123", nvml.SUCCESS
+			case 1:
+				return "GPU-456", nvml.SUCCESS
+			default:
+				return "", nvml.ERROR_UNKNOWN
+			}
 		},
 		GetNameFunc: func() (string, nvml.Return) {
-			return "Tesla UltraMegaPower", nvml.SUCCESS
+			switch index {
+			case 0:
+				return "Tesla UltraMegaPower", nvml.SUCCESS
+			case 1:
+				return "H100", nvml.SUCCESS
+			default:
+				return "", nvml.ERROR_UNKNOWN
+			}
 		},
 	}
 }
@@ -35,8 +51,8 @@ func getBasicNvmlMock() *nvmlmock.Interface {
 		DeviceGetCountFunc: func() (int, nvml.Return) {
 			return 1, nvml.SUCCESS
 		},
-		DeviceGetHandleByIndexFunc: func(int) (nvml.Device, nvml.Return) {
-			return getBasicNvmlDeviceMock(), nvml.SUCCESS
+		DeviceGetHandleByIndexFunc: func(index int) (nvml.Device, nvml.Return) {
+			return getBasicNvmlDeviceMock(index), nvml.SUCCESS
 		},
 	}
 }
@@ -47,7 +63,7 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 
 	// On the first call, this function returns correctly. On the second it fails.
 	// We need this as we cannot rely on the order of the subsystems in the map.
-	factory := func(_ nvml.Device, _ []string) (Collector, error) {
+	factory := func(_ nvml.Device) (Collector, error) {
 		if !factorySucceeded {
 			factorySucceeded = true
 			return succeedCollector, nil
@@ -56,10 +72,93 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 	}
 
 	nvmlMock := getBasicNvmlMock()
-	fakeTagger := taggerMock.SetupFakeTagger(t)
-	deps := &CollectorDependencies{NVML: nvmlMock, Tagger: fakeTagger}
+	deps := &CollectorDependencies{NVML: nvmlMock}
 	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
 	require.NotNil(t, collectors)
 	require.NoError(t, err)
 
+}
+
+func TestGetDeviceTagsMapping(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockSetup func() (*nvmlmock.Interface, taggermock.Mock)
+		expected  func(t *testing.T, tagsMapping map[string][]string)
+	}{
+		{
+			name: "Happy flow with 2 devices",
+			mockSetup: func() (*nvmlmock.Interface, taggermock.Mock) {
+				nvmlMock := &nvmlmock.Interface{
+					DeviceGetCountFunc: func() (int, nvml.Return) {
+						return 2, nvml.SUCCESS
+					},
+					DeviceGetHandleByIndexFunc: func(index int) (nvml.Device, nvml.Return) {
+						return getBasicNvmlDeviceMock(index), nvml.SUCCESS
+					},
+				}
+				fakeTagger := taggermock.SetupFakeTagger(t)
+				fakeTagger.SetTags(types.NewEntityID(types.GPU, "GPU-123"), "foo", []string{"gpu_uuid=GPU-123", "gpu_vendor=nvidia", "gpu_arch=pascal"}, nil, nil, nil)
+				fakeTagger.SetTags(types.NewEntityID(types.GPU, "GPU-456"), "foo", []string{"gpu_uuid=GPU-456", "gpu_vendor=nvidia", "gpu_arch=turing"}, nil, nil, nil)
+				return nvmlMock, fakeTagger
+			},
+			expected: func(t *testing.T, tagsMapping map[string][]string) {
+				require.Len(t, tagsMapping, 2)
+				tags, ok := tagsMapping["GPU-123"]
+				require.True(t, ok)
+				require.ElementsMatch(t, tags, []string{"gpu_vendor=nvidia", "gpu_arch=pascal", "gpu_uuid=GPU-123"})
+
+				tags, ok = tagsMapping["GPU-456"]
+				require.True(t, ok)
+				require.ElementsMatch(t, tags, []string{"gpu_vendor=nvidia", "gpu_arch=turing", "gpu_uuid=GPU-456"})
+			},
+		},
+		{
+			name: "No available devices",
+			mockSetup: func() (*nvmlmock.Interface, taggermock.Mock) {
+				nvmlMock := &nvmlmock.Interface{
+					DeviceGetCountFunc: func() (int, nvml.Return) {
+						return 0, nvml.ERROR_UNKNOWN
+					},
+				}
+				fakeTagger := taggermock.SetupFakeTagger(t)
+				return nvmlMock, fakeTagger
+			},
+			expected: func(t *testing.T, tagsMapping map[string][]string) {
+				require.Nil(t, tagsMapping)
+			},
+		},
+		{
+			name: "Only one device successfully retrieved",
+			mockSetup: func() (*nvmlmock.Interface, taggermock.Mock) {
+				nvmlMock := &nvmlmock.Interface{
+					DeviceGetCountFunc: func() (int, nvml.Return) {
+						return 2, nvml.SUCCESS
+					},
+					DeviceGetHandleByIndexFunc: func(index int) (nvml.Device, nvml.Return) {
+						// off by 1 on index will return error for device with index==1 and succeed for the device with index==0
+						return getBasicNvmlDeviceMock(index + 1), nvml.SUCCESS
+					},
+				}
+				fakeTagger := taggermock.SetupFakeTagger(t)
+				fakeTagger.SetTags(types.NewEntityID(types.GPU, "GPU-456"), "foo", []string{"gpu_vendor=nvidia", "gpu_arch=pascal", "gpu_uuid=GPU-456"}, nil, nil, nil)
+				return nvmlMock, fakeTagger
+			},
+			expected: func(t *testing.T, tagsMapping map[string][]string) {
+				require.Len(t, tagsMapping, 1)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			nvmlMock, fakeTagger := tc.mockSetup()
+
+			// Execute
+			tagsMapping := GetDeviceTagsMapping(nvmlMock, fakeTagger)
+
+			// Assert
+			tc.expected(t, tagsMapping)
+		})
+	}
 }

--- a/pkg/collector/corechecks/gpu/nvidia/device.go
+++ b/pkg/collector/corechecks/gpu/nvidia/device.go
@@ -43,14 +43,12 @@ var allDeviceMetrics = []deviceMetric{
 
 type deviceCollector struct {
 	device        nvml.Device
-	tags          []string
 	metricGetters []deviceMetric
 }
 
-func newDeviceCollector(device nvml.Device, tags []string) (Collector, error) {
+func newDeviceCollector(device nvml.Device) (Collector, error) {
 	c := &deviceCollector{
 		device: device,
-		tags:   tags,
 	}
 	c.metricGetters = append(c.metricGetters, allDeviceMetrics...) // copy all metrics to avoid modifying the original slice
 
@@ -109,7 +107,6 @@ func (c *deviceCollector) Collect() ([]Metric, error) {
 		values = append(values, Metric{
 			Name:  metric.name,
 			Value: value,
-			Tags:  c.tags,
 			Type:  metric.metricType,
 		})
 

--- a/pkg/collector/corechecks/gpu/nvidia/fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields.go
@@ -20,14 +20,12 @@ import (
 
 type fieldsCollector struct {
 	device       nvml.Device
-	tags         []string
 	fieldMetrics []fieldValueMetric
 }
 
-func newFieldsCollector(device nvml.Device, tags []string) (Collector, error) {
+func newFieldsCollector(device nvml.Device) (Collector, error) {
 	c := &fieldsCollector{
 		device: device,
-		tags:   tags,
 	}
 	c.fieldMetrics = append(c.fieldMetrics, metricNameToFieldID...) // copy all metrics to avoid modifying the original slice
 
@@ -103,7 +101,11 @@ func (c *fieldsCollector) Collect() ([]Metric, error) {
 			err = multierror.Append(err, fmt.Errorf("failed to convert field value %s: %w", name, convErr))
 		}
 
-		metrics = append(metrics, Metric{Name: name, Value: value, Tags: c.tags, Type: metricNameToFieldID[i].metricType})
+		metrics = append(metrics, Metric{
+			Name:  name,
+			Value: value,
+			Type:  metricNameToFieldID[i].metricType},
+		)
 	}
 
 	return metrics, err

--- a/pkg/collector/corechecks/gpu/nvidia/remappedrows.go
+++ b/pkg/collector/corechecks/gpu/nvidia/remappedrows.go
@@ -19,11 +19,10 @@ const remappedRowsMetricPrefix = "remapped_rows"
 
 type remappedRowsCollector struct {
 	device nvml.Device
-	tags   []string
 }
 
 // newRemappedRowsCollector creates a new remappedRowsMetricsCollector for the given NVML device.
-func newRemappedRowsCollector(device nvml.Device, tags []string) (Collector, error) {
+func newRemappedRowsCollector(device nvml.Device) (Collector, error) {
 	// Do a first check to see if the device supports remapped rows metrics
 	_, _, _, _, ret := device.GetRemappedRows()
 	if ret == nvml.ERROR_NOT_SUPPORTED {
@@ -34,7 +33,6 @@ func newRemappedRowsCollector(device nvml.Device, tags []string) (Collector, err
 
 	return &remappedRowsCollector{
 		device: device,
-		tags:   tags,
 	}, nil
 }
 
@@ -52,10 +50,10 @@ func (c *remappedRowsCollector) Collect() ([]Metric, error) {
 	}
 
 	return []Metric{
-		{Name: fmt.Sprintf("%s.correctable", remappedRowsMetricPrefix), Value: float64(correctable), Tags: c.tags, Type: metrics.CountType},
-		{Name: fmt.Sprintf("%s.uncorrectable", remappedRowsMetricPrefix), Value: float64(uncorrectable), Tags: c.tags, Type: metrics.CountType},
-		{Name: fmt.Sprintf("%s.pending", remappedRowsMetricPrefix), Value: boolToFloat(pending), Tags: c.tags, Type: metrics.CountType},
-		{Name: fmt.Sprintf("%s.failed", remappedRowsMetricPrefix), Value: boolToFloat(failed), Tags: c.tags, Type: metrics.CountType},
+		{Name: fmt.Sprintf("%s.correctable", remappedRowsMetricPrefix), Value: float64(correctable), Type: metrics.CountType},
+		{Name: fmt.Sprintf("%s.uncorrectable", remappedRowsMetricPrefix), Value: float64(uncorrectable), Type: metrics.CountType},
+		{Name: fmt.Sprintf("%s.pending", remappedRowsMetricPrefix), Value: boolToFloat(pending), Type: metrics.CountType},
+		{Name: fmt.Sprintf("%s.failed", remappedRowsMetricPrefix), Value: boolToFloat(failed), Type: metrics.CountType},
 	}, nil
 }
 

--- a/pkg/collector/corechecks/gpu/nvidia/samples.go
+++ b/pkg/collector/corechecks/gpu/nvidia/samples.go
@@ -33,14 +33,12 @@ type sampleMetric struct {
 
 type samplesCollector struct {
 	device           nvml.Device
-	tags             []string
 	samplesToCollect []sampleMetric
 }
 
-func newSamplesCollector(device nvml.Device, tags []string) (Collector, error) {
+func newSamplesCollector(device nvml.Device) (Collector, error) {
 	c := &samplesCollector{
 		device: device,
-		tags:   tags,
 	}
 	c.samplesToCollect = append(c.samplesToCollect, allSamples...) // copy all metrics to avoid modifying the original slice
 
@@ -148,7 +146,6 @@ func (c *samplesCollector) Collect() ([]Metric, error) {
 		values = append(values, Metric{
 			Name:  metric.name,
 			Value: total,
-			Tags:  c.tags,
 			Type:  metrics.GaugeType,
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

This PR removes the tags field from all the collectors and stores them once in the core check (mapped per GPU device)

### Motivation

Simplify the gpu core-check.

### Describe how you validated your changes

Added UTs to check the tags map creation functionality

### Possible Drawbacks / Trade-offs

### Additional Notes
This is a first PR in a series
[Jira ticket](https://datadoghq.atlassian.net/browse/EBPF-678)