### PR TITLE
[clusteragent/autoscaling] Ignore RC config expiry for autoscaling

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/config_retriever_test.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_test.go
@@ -24,7 +24,7 @@ type mockRCClient struct {
 	subscribers map[string][]rcCallbackFunc
 }
 
-func (m *mockRCClient) Subscribe(product string, callback func(map[string]state.RawConfig, func(string, state.ApplyStatus))) {
+func (m *mockRCClient) SubscribeIgnoreExpiration(product string, callback func(map[string]state.RawConfig, func(string, state.ApplyStatus))) {
 	if m.subscribers == nil {
 		m.subscribers = make(map[string][]rcCallbackFunc)
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This change uses the new function introduced here to allow us to subscribe to remote config updates while ignoring expiry: https://github.com/DataDog/datadog-agent/pull/34788.

### Motivation

When a config expires, its cache will be flushed and it will report that there is no longer any config. This behavior is not suitable for autoscaling as an empty config can cause us to delete the autoscaler/for the controller to take unintended actions. The change to use this new `SubscribeIgnoreExpiration` call allows us to make the distinction between a real empty config, and one that is empty because its signature has expired (and which we should ignore). 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Check that autoscaling still works as intended after change (the change should not have any noticeable effect on the product). 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->