### PR TITLE
quality_gate_idle: set memory bound to 266 MiB

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "283.0 MiB"
+      upper_bound: "266.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

To preserve recent memory efficiencies realized in the `quality_gate_idle` experiment's `memory_usage` Quality Gate, this commit decreases that gate's upper bound from 283 MiB to 266 MiB.

### Motivation

2025-03-06 nightly Quality Gates run showed maximum `memory_usage` at 262.22 MiB, so we'd like to preserve most of the decrease in memory usage while still providing enough slack to investigate improvements to other `memory_usage` Quality Gates.

### Describe how you validated your changes

n/a

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

This PR trades off increased probability of another incident occurring due to chance for locking in lower memory usage.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->