### PR TITLE
quality_gate_logs: set upper bound to 297 MiB

### DIFF
--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_rss_bytes
-      upper_bound: "314.0 MiB"
+      upper_bound: "297.0 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

To preserve recent memory efficiencies realized in the `quality_gate_logs` experiment's `memory_usage` Quality Gate, this commit decreases that gate's upper bound from 314 MiB to 297 MiB.

### Motivation

Preserve decreased `memory_usage` on logs-related loads; 2025-03-06 nightly results observed maximum memory usage of 292.95 MiB. Simultaneously, the decrease provides enough slack to reduce the risk of this gate failing while `quality_gate_idle_all_features` work is ongoing.

### Describe how you validated your changes

n/a

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

Trades off locking in decreased memory usage for an increased risk of `quality_gate_logs`'s `memory_usage` check to fail due to chance alone.

### Additional Notes

n/a
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->