### PR TITLE
regression_detector.yml: bump smp 0.20.2 -> 0.21.0

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -22,7 +22,7 @@ single-machine-performance-regression_detector:
       - outputs/decision_record.md # for posterity, this is appended to final PR comment
     when: always
   variables:
-    SMP_VERSION: 0.20.2
+    SMP_VERSION: 0.21.0
   # See 'decision_record.md' for the determination of whether this job passes or fails.
   allow_failure: false
   script:


### PR DESCRIPTION
### What does this PR do?

This pull request updates the `smp` CLI version used in Agent CI from 0.20.2 to 0.21.0.

### Motivation

Keep `agent` up to date with the latest stable `smp` CLI version.

Edit: The first regression detector run failed because it started before I deployed the update to Agent. A new attempt is in progress now.
