### PR TITLE
Wmeta: use lower case for gpu device's uuid and name tags

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -10,6 +10,7 @@ package nvml
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"go.uber.org/fx"
@@ -46,7 +47,8 @@ func (c *collector) getDeviceInfo(device nvml.Device) (string, string, error) {
 	if ret != nvml.SUCCESS {
 		return "", "", fmt.Errorf("failed to get device name: %v", nvml.ErrorString(ret))
 	}
-	return uuid, name, nil
+	// we always want to return the lower case version as tags are being hashed when stored in cache in the Tagger component
+	return strings.ToLower(uuid), strings.ToLower(name), nil
 }
 
 // getMigProfileName() returns the canonical name of the MIG device

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -9,6 +9,7 @@ package nvml
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
@@ -43,8 +44,8 @@ func TestPull(t *testing.T) {
 		foundIDs[gpu.ID] = true
 		require.Equal(t, testutil.DefaultNvidiaDriverVersion, gpu.DriverVersion)
 		require.Equal(t, nvidiaVendor, gpu.Vendor)
-		require.Equal(t, testutil.DefaultGPUName, gpu.Name)
-		require.Equal(t, testutil.DefaultGPUName, gpu.Device)
+		require.Equal(t, strings.ToLower(testutil.DefaultGPUName), gpu.Name)
+		require.Equal(t, strings.ToLower(testutil.DefaultGPUName), gpu.Device)
 		require.Equal(t, "hopper", gpu.Architecture)
 		require.Equal(t, testutil.DefaultGPUComputeCapMajor, gpu.ComputeCapability.Major)
 		require.Equal(t, testutil.DefaultGPUComputeCapMinor, gpu.ComputeCapability.Minor)
@@ -55,7 +56,7 @@ func TestPull(t *testing.T) {
 	}
 
 	for _, uuid := range testutil.GPUUUIDs {
-		require.True(t, foundIDs[uuid], "GPU with UUID %s not found", uuid)
+		require.True(t, foundIDs[strings.ToLower(uuid)], "GPU with UUID %s not found", uuid)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Stores the uuid and device name tags for GPUEntity in lower case

### Motivation

The tags are hashed when stored in the local cache, cache function is case sensitive

### Describe how you validated your changes

modified existing UTs to validate string case

### Possible Drawbacks / Trade-offs

### Additional Notes