### PR TITLE
move network related files from `pkg/util/cloudproviders` to separate package

### DIFF
--- a/comp/metadata/host/hostimpl/utils/host.go
+++ b/comp/metadata/host/hostimpl/utils/host.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 	containerMetadata "github.com/DataDog/datadog-agent/pkg/util/containers/metadata"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
@@ -100,7 +101,7 @@ type Payload struct {
 }
 
 func getNetworkMeta(ctx context.Context) *NetworkMeta {
-	nid, err := cloudproviders.GetNetworkID(ctx)
+	nid, err := network.GetNetworkID(ctx)
 	if err != nil {
 		log.Infof("could not get network metadata: %s", err)
 		return nil

--- a/comp/metadata/host/hostimpl/utils/host_test.go
+++ b/comp/metadata/host/hostimpl/utils/host_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
-	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
@@ -44,7 +44,7 @@ func TestOTLPEnabled(t *testing.T) {
 
 func TestGetNetworkMeta(t *testing.T) {
 	ctx := context.Background()
-	cloudproviders.MockNetworkID(t, "test networkID")
+	network.MockNetworkID(t, "test networkID")
 
 	m := getNetworkMeta(ctx)
 	assert.Equal(t, "test networkID", m.ID)

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -28,7 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
-	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 )
 
 const (
@@ -208,7 +208,7 @@ func (s *npCollectorImpl) getVPCSubnets() ([]*net.IPNet, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	vpcSubnets, err := cloudproviders.GetVPCSubnetsForHost(ctx)
+	vpcSubnets, err := network.GetVPCSubnetsForHost(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("disable_intra_vpc_collection is enforced, but failed to get VPC subnets: %w", err)
 	}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -33,7 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/flare/priviledged"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	systemprobeStatus "github.com/DataDog/datadog-agent/pkg/status/systemprobe"
-	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs"
 	"github.com/DataDog/datadog-agent/pkg/util/installinfo"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -138,7 +138,7 @@ func getVPCSubnetsForHost() ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	subnets, err := cloudproviders.GetVPCSubnetsForHost(ctx)
+	subnets, err := network.GetVPCSubnetsForHost(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -27,7 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/tcp"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	cloudprovidersnetwork "github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -71,7 +71,7 @@ func New(telemetryComp telemetryComponent.Component, hostnameService hostname.Co
 	var err error
 	var networkID string
 	if ec2.IsRunningOn(context.TODO()) {
-		networkID, err = cloudproviders.GetNetworkID(context.Background())
+		networkID, err = cloudprovidersnetwork.GetNetworkID(context.Background())
 		if err != nil {
 			log.Errorf("failed to get network ID: %s", err.Error())
 		}

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -29,7 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/net/resolver"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -516,7 +516,7 @@ func retryGetNetworkID(sysProbeClient *http.Client) (string, error) {
 
 // getNetworkID fetches network_id from the current netNS or from the system probe if necessary, where the root netNS is used
 func getNetworkID(sysProbeClient *http.Client) (string, error) {
-	networkID, err := cloudproviders.GetNetworkID(context.TODO())
+	networkID, err := network.GetNetworkID(context.TODO())
 	if err != nil && sysProbeClient != nil {
 		log.Debugf("no network ID detected. retrying via system-probe: %s", err)
 		networkID, err = net.GetNetworkID(sysProbeClient)

--- a/pkg/util/cloudproviders/network/network.go
+++ b/pkg/util/cloudproviders/network/network.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package cloudproviders
+// Package network provides utilities around cloud provider networking.
+package network
 
 import (
 	"context"

--- a/pkg/util/cloudproviders/network/network_mock.go
+++ b/pkg/util/cloudproviders/network/network_mock.go
@@ -5,7 +5,7 @@
 
 //go:build test
 
-package cloudproviders
+package network
 
 import (
 	"testing"

--- a/pkg/util/cloudproviders/network/network_test.go
+++ b/pkg/util/cloudproviders/network/network_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-package cloudproviders
+package network
 
 import (
 	"context"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR moves (no code change otherwise) some network related function from `pkg/util/cloudproviders` to a separate package. This allows system-probe to reduce its dependency on the rest of the cloudproviders package, and while the space saving is not huge, this removes multiple 3rd party dependencies from system-probe which is win.

### Motivation

### Describe how you validated your changes

No actual code change, current tests + build test should be enough.
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->