### PR TITLE
Get the milestone from the release.json file when opening a PR

### DIFF
--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -739,10 +739,9 @@ def create_release_pr(title, base_branch, target_branch, version, changelog_pr=F
     if milestone:
         milestone_name = milestone
     else:
-        # The milestone name is always using the .0 patch version (at least for now)
-        # Unless we pass explicitly the name, we use the version and force the patch version
-        milestone_name = str(version)
-        milestone_name = re.sub('.[0-9]+$', '.0', milestone_name)
+        from tasks.libs.releasing.json import get_current_milestone
+
+        milestone_name = get_current_milestone()
 
     labels = [
         "team/agent-delivery",

--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -343,6 +343,11 @@ def set_current_milestone(milestone):
     _save_release_json(rj)
 
 
+def get_current_milestone():
+    rj = load_release_json()
+    return rj["current_milestone"]
+
+
 def generate_repo_data(ctx, warning_mode, next_version, release_branch):
     if warning_mode:
         # Warning mode is used to warn integrations so that they prepare their release version in advance.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Get the milestone from the release.json file when opening a PR

### Motivation

We can now reliably use this field https://github.com/DataDog/datadog-agent/pull/34827

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->