### PR TITLE
(fleet) adding fleet as co-owners of the agent package script and systemd units

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -283,6 +283,10 @@
 /Makefile.trace                         @DataDog/agent-apm
 
 /omnibus/                               @DataDog/agent-delivery
+/omnibus/package-scripts/agent-rpm/     @DataDog/agent-delivery @DataDog/fleet
+/omnibus/package-scripts/agent-deb/     @DataDog/agent-delivery @DataDog/fleet
+/omnibus/package-scripts/installer-deb/ @DataDog/agent-delivery @DataDog/fleet
+/omnibus/package-scripts/installer-rpm/ @DataDog/agent-delivery @DataDog/fleet
 /omnibus/python-scripts/                @DataDog/agent-runtimes @DataDog/windows-agent
 /omnibus/config/patches/openscap/                         @DataDog/agent-cspm
 /omnibus/config/software/datadog-agent-integrations-*.rb  @DataDog/agent-integrations
@@ -290,6 +294,7 @@
 /omnibus/config/software/openscap.rb                      @DataDog/agent-cspm
 /omnibus/config/software/sds.rb                           @DataDog/agent-log-pipelines
 /omnibus/config/software/snmp-traps.rb                    @DataDog/ndm-core
+/omnibus/config/templates/init-scripts-agent/             @DataDog/agent-delivery @DataDog/fleet
 /omnibus/resources/*/msi/                                 @DataDog/windows-agent
 
 # The following is managed by `dda inv lint-components` -- DO NOT EDIT


### PR DESCRIPTION
This PR adds fleet as co-owners of the following parts of the agent packaging:
- systemd units of the agent
- package scripts of the agent and installer

### Motivation

- We need to review each changes made on those files today since they will almost always require installer changes to align
- We want to eventually unify those scripts and the scripts ran in the installer in one logic for deb/rpm/oci