### PR TITLE
[AGENTRUN-168] remove hardcoded logs-agent component from API component

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -50,7 +50,6 @@ import (
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
-	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
@@ -150,7 +149,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Supply(option.None[rcservice.Component]()),
 			fx.Supply(option.None[rcservicemrf.Component]()),
 			fx.Supply(option.None[collector.Component]()),
-			fx.Supply(option.None[logsAgent.Component]()),
 			fx.Supply(option.None[integrations.Component]()),
 			fx.Provide(func() dogstatsdServer.Component { return nil }),
 			fx.Provide(func() pidmap.Component { return nil }),

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
 	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -50,7 +49,6 @@ type apiServer struct {
 	authToken           authtoken.Component
 	taggerComp          tagger.Component
 	autoConfig          autodiscovery.Component
-	logsAgentComp       option.Option[logsAgent.Component]
 	wmeta               workloadmeta.Component
 	collector           option.Option[collector.Component]
 	senderManager       diagnosesendermanager.Component
@@ -75,7 +73,6 @@ type dependencies struct {
 	Tagger                tagger.Component
 	Cfg                   config.Component
 	AutoConfig            autodiscovery.Component
-	LogsAgentComp         option.Option[logsAgent.Component]
 	WorkloadMeta          workloadmeta.Component
 	Collector             option.Option[collector.Component]
 	DiagnoseSenderManager diagnosesendermanager.Component
@@ -99,7 +96,6 @@ func newAPIServer(deps dependencies) api.Component {
 		taggerComp:          deps.Tagger,
 		cfg:                 deps.Cfg,
 		autoConfig:          deps.AutoConfig,
-		logsAgentComp:       deps.LogsAgentComp,
 		wmeta:               deps.WorkloadMeta,
 		collector:           deps.Collector,
 		senderManager:       deps.DiagnoseSenderManager,

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap/pidmapimpl"
 	replaymock "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/fx-mock"
 	dogstatsdServer "github.com/DataDog/datadog-agent/comp/dogstatsd/server"
-	logsAgent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservice"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcservicemrf"
 
@@ -85,7 +84,6 @@ func getTestAPIServer(t *testing.T, params config.MockParams) testdeps {
 		fx.Provide(func(mock autodiscovery.Mock) autodiscovery.Component {
 			return mock
 		}),
-		fx.Supply(option.None[logsAgent.Component]()),
 		fx.Supply(option.None[collector.Component]()),
 		pidmapimpl.Module(),
 		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints

--- a/comp/api/api/apiimpl/internal/agent/agent_test.go
+++ b/comp/api/api/apiimpl/internal/agent/agent_test.go
@@ -100,7 +100,6 @@ func setupRoutes(t *testing.T) *mux.Router {
 	SetupHandlers(
 		router,
 		deps.Wmeta,
-		deps.LogsAgent,
 		sender,
 		deps.SecretResolver,
 		deps.Collector,

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -109,7 +109,6 @@ func (server *apiServer) startCMDServer(
 			agent.SetupHandlers(
 				agentMux,
 				server.wmeta,
-				server.logsAgentComp,
 				server.senderManager,
 				server.secretResolver,
 				server.collector,

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -62,7 +62,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
-	logagent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
@@ -206,7 +205,6 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				// in others commands such as run.
 				fx.Supply(option.None[rcservice.Component]()),
 				fx.Supply(option.None[rcservicemrf.Component]()),
-				fx.Supply(option.None[logagent.Component]()),
 				fx.Supply(option.None[integrations.Component]()),
 				fx.Provide(func() server.Component { return nil }),
 				fx.Provide(func() replay.Component { return nil }),

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -62,6 +62,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/eventplatformreceiverimpl"
 	orchestratorForwarderImpl "github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
+	logagent "github.com/DataDog/datadog-agent/comp/logs/agent"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
@@ -205,6 +206,7 @@ func MakeCommand(globalParamsGetter func() GlobalParams) *cobra.Command {
 				// in others commands such as run.
 				fx.Supply(option.None[rcservice.Component]()),
 				fx.Supply(option.None[rcservicemrf.Component]()),
+				fx.Supply(option.None[logagent.Component]()),
 				fx.Supply(option.None[integrations.Component]()),
 				fx.Provide(func() server.Component { return nil }),
 				fx.Provide(func() replay.Component { return nil }),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove the hardcoded dependency of Logs Agent in the main API component

### Motivation

Reduce the number of hardcoded components are required to run the API component 😄 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit Tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->