### PR TITLE
[Fleet] add admin check

### DIFF
--- a/cmd/installer/subcommands/subcommands.go
+++ b/cmd/installer/subcommands/subcommands.go
@@ -7,8 +7,6 @@
 package subcommands
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/cmd/installer/command"
 	"github.com/DataDog/datadog-agent/cmd/installer/subcommands/daemon"
 	"github.com/DataDog/datadog-agent/cmd/installer/user"
@@ -42,7 +40,7 @@ func withRoot(factory command.SubcommandFactory) command.SubcommandFactory {
 			return nil
 		}
 		if !user.IsRoot() {
-			return fmt.Errorf("this command requires root privileges")
+			return user.ErrRootRequired
 		}
 		return user.DatadogAgentToRoot()
 	})
@@ -54,7 +52,7 @@ func withDatadogAgent(factory command.SubcommandFactory) command.SubcommandFacto
 			return nil
 		}
 		if !user.IsRoot() {
-			return fmt.Errorf("this command requires root privileges")
+			return user.ErrRootRequired
 		}
 		return user.RootToDatadogAgent()
 	})

--- a/cmd/installer/user/user_darwin.go
+++ b/cmd/installer/user/user_darwin.go
@@ -8,7 +8,13 @@
 // Package user provides helpers to change the user of the process.
 package user
 
-import "syscall"
+import (
+	"fmt"
+	"syscall"
+)
+
+// ErrRootRequired is the error returned when an operation requires root privileges.
+var ErrRootRequired = fmt.Errorf("operation requires root privileges")
 
 // IsRoot always returns true on darwin.
 func IsRoot() bool {

--- a/cmd/installer/user/user_nix.go
+++ b/cmd/installer/user/user_nix.go
@@ -15,6 +15,9 @@ import (
 	"syscall"
 )
 
+// ErrRootRequired is the error returned when an operation requires root privileges.
+var ErrRootRequired = fmt.Errorf("operation requires root privileges")
+
 // IsRoot returns true if the process is running as root.
 func IsRoot() bool {
 	return syscall.Getuid() == 0

--- a/cmd/installer/user/user_windows.go
+++ b/cmd/installer/user/user_windows.go
@@ -8,9 +8,22 @@
 // Package user provides helpers to change the user of the process.
 package user
 
-// IsRoot always returns true on windows.
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+)
+
+// ErrRootRequired is the error returned when an operation requires Administrator privileges.
+var ErrRootRequired = fmt.Errorf("operation requires Administrator privileges")
+
+// IsRoot returns true if token has Administrators group enabled
 func IsRoot() bool {
-	return true
+	isAdmin, err := winutil.IsUserAnAdmin()
+	if err != nil {
+		fmt.Printf("error checking if user is admin: %v\n", err)
+	}
+	return isAdmin
 }
 
 // RootToDatadogAgent is a noop on windows.

--- a/pkg/util/winutil/users.go
+++ b/pkg/util/winutil/users.go
@@ -56,7 +56,7 @@ func IsUserAnAdmin() (bool, error) {
 		0, 0, 0, 0, 0, 0,
 		&administratorsGroup)
 	if err != nil {
-		return false, fmt.Errorf("could not get local system SID: %w", err)
+		return false, fmt.Errorf("could not get Administrators group SID: %w", err)
 	}
 	defer windows.FreeSid(administratorsGroup)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds "is admin" check to fleet installer / bootstrapper. Fills out the pre-existing `IsRoot` function, which allows `version` to be run without root but other commands will throw an error.

Creates a per-platform `ErrRootRequired` error message since Linux uses `root` and Windows uses `Administrator`

Not removing the admin check from the install script, it's not hurting anything.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1310
Moving logic from install script to exe to support powershell restricted envs

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
as non-elevated/non-admin
```
> .\installer.exe version
7.64.0-devel+git.968.22bdd27
> .\installer.exe status
{"error":"operation requires Administrator privileges","code":0}
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->