### PR TITLE
[CWS] split raw packet unmarshaller in build gated file

### DIFF
--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -19,8 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/gopacket"
-	"github.com/google/gopacket/layers"
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -1351,61 +1349,6 @@ func (e *OnDemandEvent) UnmarshalBinary(data []byte) (int, error) {
 	e.ID = binary.NativeEndian.Uint32(data[0:4])
 	SliceToArray(data[4:260], e.Data[:])
 	return 260, nil
-}
-
-// UnmarshalBinary unmarshals a binary representation of itself
-func (e *RawPacketEvent) UnmarshalBinary(data []byte) (int, error) {
-	read, err := e.NetworkContext.Device.UnmarshalBinary(data)
-	if err != nil {
-		return 0, ErrNotEnoughData
-	}
-	data = data[read:]
-
-	e.Size = binary.NativeEndian.Uint32(data)
-	data = data[4:]
-	e.Data = data
-	e.CaptureInfo.InterfaceIndex = int(e.NetworkContext.Device.IfIndex)
-	e.CaptureInfo.Length = int(e.NetworkContext.Size)
-	e.CaptureInfo.CaptureLength = len(data)
-
-	packet := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.DecodeOptions{NoCopy: true, Lazy: true, DecodeStreamsAsDatagrams: true})
-	if layer := packet.Layer(layers.LayerTypeIPv4); layer != nil {
-		if rl, ok := layer.(*layers.IPv4); ok {
-			e.L3Protocol = unix.ETH_P_IP
-			e.Source.IPNet = *eval.IPNetFromIP(rl.SrcIP)
-			e.Destination.IPNet = *eval.IPNetFromIP(rl.DstIP)
-		}
-	} else if layer := packet.Layer(layers.LayerTypeIPv6); layer != nil {
-		if rl, ok := layer.(*layers.IPv4); ok {
-			e.L3Protocol = unix.ETH_P_IPV6
-			e.Source.IPNet = *eval.IPNetFromIP(rl.SrcIP)
-			e.Destination.IPNet = *eval.IPNetFromIP(rl.DstIP)
-		}
-	}
-
-	if layer := packet.Layer(layers.LayerTypeUDP); layer != nil {
-		if rl, ok := layer.(*layers.UDP); ok {
-			e.L4Protocol = unix.IPPROTO_UDP
-			e.Source.Port = uint16(rl.SrcPort)
-			e.Destination.Port = uint16(rl.DstPort)
-		}
-	} else if layer := packet.Layer(layers.LayerTypeTCP); layer != nil {
-		if rl, ok := layer.(*layers.TCP); ok {
-			e.L4Protocol = unix.IPPROTO_TCP
-			e.Source.Port = uint16(rl.SrcPort)
-			e.Destination.Port = uint16(rl.DstPort)
-		}
-	}
-
-	if layer := packet.Layer(layers.LayerTypeTLS); layer != nil {
-		if rl, ok := layer.(*layers.TLS); ok {
-			if len(rl.AppData) > 0 {
-				e.TLSContext.Version = uint16(rl.AppData[0].Version)
-			}
-		}
-	}
-
-	return len(data), nil
 }
 
 // UnmarshalBinary unmarshals a binary representation of itself

--- a/pkg/security/secl/model/unmarshallers_pcap_linux.go
+++ b/pkg/security/secl/model/unmarshallers_pcap_linux.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && pcap
+
+// Package model holds model related files
+package model
+
+import (
+	"encoding/binary"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"golang.org/x/sys/unix"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+// UnmarshalBinary unmarshals a binary representation of itself
+func (e *RawPacketEvent) UnmarshalBinary(data []byte) (int, error) {
+	read, err := e.NetworkContext.Device.UnmarshalBinary(data)
+	if err != nil {
+		return 0, ErrNotEnoughData
+	}
+	data = data[read:]
+
+	e.Size = binary.NativeEndian.Uint32(data)
+	data = data[4:]
+	e.Data = data
+	e.CaptureInfo.InterfaceIndex = int(e.NetworkContext.Device.IfIndex)
+	e.CaptureInfo.Length = int(e.NetworkContext.Size)
+	e.CaptureInfo.CaptureLength = len(data)
+
+	packet := gopacket.NewPacket(data, layers.LayerTypeEthernet, gopacket.DecodeOptions{NoCopy: true, Lazy: true, DecodeStreamsAsDatagrams: true})
+	if layer := packet.Layer(layers.LayerTypeIPv4); layer != nil {
+		if rl, ok := layer.(*layers.IPv4); ok {
+			e.L3Protocol = unix.ETH_P_IP
+			e.Source.IPNet = *eval.IPNetFromIP(rl.SrcIP)
+			e.Destination.IPNet = *eval.IPNetFromIP(rl.DstIP)
+		}
+	} else if layer := packet.Layer(layers.LayerTypeIPv6); layer != nil {
+		if rl, ok := layer.(*layers.IPv4); ok {
+			e.L3Protocol = unix.ETH_P_IPV6
+			e.Source.IPNet = *eval.IPNetFromIP(rl.SrcIP)
+			e.Destination.IPNet = *eval.IPNetFromIP(rl.DstIP)
+		}
+	}
+
+	if layer := packet.Layer(layers.LayerTypeUDP); layer != nil {
+		if rl, ok := layer.(*layers.UDP); ok {
+			e.L4Protocol = unix.IPPROTO_UDP
+			e.Source.Port = uint16(rl.SrcPort)
+			e.Destination.Port = uint16(rl.DstPort)
+		}
+	} else if layer := packet.Layer(layers.LayerTypeTCP); layer != nil {
+		if rl, ok := layer.(*layers.TCP); ok {
+			e.L4Protocol = unix.IPPROTO_TCP
+			e.Source.Port = uint16(rl.SrcPort)
+			e.Destination.Port = uint16(rl.DstPort)
+		}
+	}
+
+	if layer := packet.Layer(layers.LayerTypeTLS); layer != nil {
+		if rl, ok := layer.(*layers.TLS); ok {
+			if len(rl.AppData) > 0 {
+				e.TLSContext.Version = uint16(rl.AppData[0].Version)
+			}
+		}
+	}
+
+	return len(data), nil
+}


### PR DESCRIPTION

### What does this PR do?

This PR splits the unmarshaller of `RawPacketEvent` to be in a file build gated with `pcap`. This allows the security-agent to not import google/gopacket.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->