### PR TITLE
[USMON-1427] usm: Change map keys from u32 to void*

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/go-tls-maps.h
@@ -21,6 +21,6 @@ BPF_HASH_MAP(go_tls_write_args, go_tls_function_args_key_t, go_tls_write_args_da
    It is used to implement a simplified version of tup_from_ssl_ctx from usm.c
    Map size is set to 1 as goTLS is optional, this will be overwritten to MaxTrackedConnections
    if goTLS is enabled. */
-BPF_HASH_MAP(conn_tup_by_go_tls_conn, __u32, conn_tuple_t, 1)
+BPF_HASH_MAP(conn_tup_by_go_tls_conn, void*, conn_tuple_t, 1)
 
 #endif //__GO_TLS_MAPS_H

--- a/pkg/network/ebpf/c/protocols/tls/native-tls-maps.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls-maps.h
@@ -15,7 +15,7 @@ BPF_HASH_MAP(ssl_write_ex_args, u64, ssl_write_ex_args_t, 1024)
 
 BPF_HASH_MAP(bio_new_socket_args, __u64, __u32, 1024)
 
-BPF_HASH_MAP(fd_by_ssl_bio, __u32, void *, 1024)
+BPF_HASH_MAP(fd_by_ssl_bio, void*, void *, 1024)
 
 BPF_HASH_MAP(ssl_ctx_by_pid_tgid, __u64, void *, 1)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Change map keys from u32 to void*

### Motivation

The given maps are using pointers as keys, on 64bit systems (the vast majority) a pointer is 8bytes, so using u32 (4bytes) can cause collision and ambigious behavior

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->