### PR TITLE
Revert "Fix map deletes which may be affected by race conditions (#34826)

### DIFF
--- a/pkg/network/ebpf/c/protocols/tls/https.h
+++ b/pkg/network/ebpf/c/protocols/tls/https.h
@@ -277,10 +277,6 @@ static __always_inline void map_ssl_ctx_to_sock(struct sock *skp) {
     if (ssl_ctx_map_val == NULL) {
         return;
     }
-
-    // copy map value to stack. required for older kernels
-    void *ssl_ctx = *ssl_ctx_map_val;
-
     bpf_map_delete_elem(&ssl_ctx_by_pid_tgid, &pid_tgid);
 
     ssl_sock_t ssl_sock = {};
@@ -288,6 +284,8 @@ static __always_inline void map_ssl_ctx_to_sock(struct sock *skp) {
         return;
     }
 
+    // copy map value to stack. required for older kernels
+    void *ssl_ctx = *ssl_ctx_map_val;
     bpf_map_update_with_telemetry(ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 

--- a/pkg/network/ebpf/c/protocols/tls/native-tls.h
+++ b/pkg/network/ebpf/c/protocols/tls/native-tls.h
@@ -122,6 +122,7 @@ static __always_inline int SSL_read_ret(struct pt_regs *ctx, __u64 tags) {
     }
 
     char *buffer_ptr = args->buf;
+    bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     // The read tuple should be flipped (compared to the write tuple).
     // tls_process and the appropriate parsers will flip it back if needed.
     conn_tuple_t copy = {0};
@@ -130,7 +131,7 @@ static __always_inline int SSL_read_ret(struct pt_regs *ctx, __u64 tags) {
     // the inverse direction, thus we're normalizing the tuples into a client <-> server direction.
     normalize_tuple(&copy);
     tls_process(ctx, &copy, buffer_ptr, len, tags);
-
+    return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -181,7 +182,7 @@ static __always_inline int SSL_write_ret(struct pt_regs* ctx, __u64 flags) {
     }
 
     char *buffer_ptr = args->buf;
-
+    bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     conn_tuple_t copy = {0};
     bpf_memcpy(&copy, t, sizeof(conn_tuple_t));
     // We want to guarantee write-TLS hooks generates the same connection tuple, while read-TLS hooks generate
@@ -190,7 +191,7 @@ static __always_inline int SSL_write_ret(struct pt_regs* ctx, __u64 flags) {
     normalize_tuple(&copy);
     flip_tuple(&copy);
     tls_process(ctx, &copy, buffer_ptr, write_len, flags);
-
+    return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;
@@ -260,6 +261,7 @@ static __always_inline int SSL_read_ex_ret(struct pt_regs* ctx, __u64 tags) {
     }
 
     char *buffer_ptr = args->buf;
+    bpf_map_delete_elem(&ssl_read_ex_args, &pid_tgid);
     // The read tuple should be flipped (compared to the write tuple).
     // tls_process and the appropriate parsers will flip it back if needed.
     conn_tuple_t copy = {0};
@@ -268,7 +270,7 @@ static __always_inline int SSL_read_ex_ret(struct pt_regs* ctx, __u64 tags) {
     // the inverse direction, thus we're normalizing the tuples into a client <-> server direction.
     normalize_tuple(&copy);
     tls_process(ctx, &copy, buffer_ptr, bytes_count, tags);
-
+    return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_read_ex_args, &pid_tgid);
     return 0;
@@ -329,6 +331,7 @@ static __always_inline int SSL_write_ex_ret(struct pt_regs* ctx, __u64 tags) {
     }
 
     char *buffer_ptr = args->buf;
+    bpf_map_delete_elem(&ssl_write_ex_args, &pid_tgid);
     conn_tuple_t copy = {0};
     bpf_memcpy(&copy, conn_tuple, sizeof(conn_tuple_t));
     // We want to guarantee write-TLS hooks generates the same connection tuple, while read-TLS hooks generate
@@ -337,7 +340,7 @@ static __always_inline int SSL_write_ex_ret(struct pt_regs* ctx, __u64 tags) {
     normalize_tuple(&copy);
     flip_tuple(&copy);
     tls_process(ctx, &copy, buffer_ptr, bytes_count, tags);
-
+    return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_write_ex_args, &pid_tgid);
     return 0;
@@ -458,6 +461,7 @@ int BPF_BYPASSABLE_URETPROBE(uretprobe__gnutls_record_recv, ssize_t read_len) {
     }
 
     char *buffer_ptr = args->buf;
+    bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     // The read tuple should be flipped (compared to the write tuple).
     // tls_process and the appropriate parsers will flip it back if needed.
     conn_tuple_t copy = {0};
@@ -466,7 +470,7 @@ int BPF_BYPASSABLE_URETPROBE(uretprobe__gnutls_record_recv, ssize_t read_len) {
     // the inverse direction, thus we're normalizing the tuples into a client <-> server direction.
     normalize_tuple(&copy);
     tls_process(ctx, &copy, buffer_ptr, read_len, LIBGNUTLS);
-
+    return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -503,6 +507,7 @@ int BPF_BYPASSABLE_URETPROBE(uretprobe__gnutls_record_send, ssize_t write_len) {
     }
 
     char *buffer_ptr = args->buf;
+    bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     conn_tuple_t copy = {0};
     bpf_memcpy(&copy, t, sizeof(conn_tuple_t));
     // We want to guarantee write-TLS hooks generates the same connection tuple, while read-TLS hooks generate
@@ -511,7 +516,7 @@ int BPF_BYPASSABLE_URETPROBE(uretprobe__gnutls_record_send, ssize_t write_len) {
     normalize_tuple(&copy);
     flip_tuple(&copy);
     tls_process(ctx, &copy, buffer_ptr, write_len, LIBGNUTLS);
-
+    return 0;
 cleanup:
     bpf_map_delete_elem(&ssl_write_args, &pid_tgid);
     return 0;


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This reverts commit a2091d7a5b3b7505866cbc614b1f3f39f5b8b208.

### Motivation

Original PR #34826  caused a reduced accuracy, and it wasn't been tested properly, hence discovered after merged into main

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Deployed to load test with `grpc-openssl` scenario

On [main](https://dddev.datadoghq.com/s/2CEYN2/4fe-md3-k87) we didn't capture traffic at all, but with the revert we do [capture](https://dddev.datadoghq.com/s/2CEYN2/a8p-t5s-c4p) traffic

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->