### PR TITLE
[CONTP-496] cluster-agent leader election: use channel for leader watch in cluster-checks handler

### DIFF
--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -45,17 +45,17 @@ type pluggableAutoConfig interface {
 
 // Handler is the glue holding all components for cluster-checks management
 type Handler struct {
-	autoconfig           pluggableAutoConfig
-	dispatcher           *dispatcher
-	leaderStatusFreq     time.Duration
-	warmupDuration       time.Duration
-	leaderStatusCallback types.LeaderIPCallback
-	leadershipChan       chan state
-	leaderForwarder      *api.LeaderForwarder
-	m                    sync.RWMutex // Below fields protected by the mutex
-	state                state
-	leaderIP             string
-	errCount             int
+	autoconfig               pluggableAutoConfig
+	dispatcher               *dispatcher
+	warmupDuration           time.Duration
+	leaderStatusCallback     types.LeaderIPCallback
+	leadershipStateNotifChan <-chan struct{} //from subscribing leader election engine (external)
+	leadershipChan           chan state      // for internal notification in handler class
+	leaderForwarder          *api.LeaderForwarder
+	m                        sync.RWMutex // Below fields protected by the mutex
+	state                    state
+	leaderIP                 string
+	errCount                 int
 }
 
 // NewHandler returns a populated Handler
@@ -65,11 +65,10 @@ func NewHandler(ac pluggableAutoConfig, tagger tagger.Component) (*Handler, erro
 		return nil, errors.New("empty autoconfig object")
 	}
 	h := &Handler{
-		autoconfig:       ac,
-		leaderStatusFreq: 5 * time.Second,
-		warmupDuration:   pkgconfigsetup.Datadog().GetDuration("cluster_checks.warmup_duration") * time.Second,
-		leadershipChan:   make(chan state, 1),
-		dispatcher:       newDispatcher(tagger),
+		autoconfig:     ac,
+		warmupDuration: pkgconfigsetup.Datadog().GetDuration("cluster_checks.warmup_duration") * time.Second,
+		leadershipChan: make(chan state, 1),
+		dispatcher:     newDispatcher(tagger),
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("leader_election") {
@@ -79,6 +78,10 @@ func NewHandler(ac pluggableAutoConfig, tagger tagger.Component) (*Handler, erro
 			return nil, err
 		}
 		h.leaderStatusCallback = callback
+		h.leadershipStateNotifChan, err = getLeadershipStateNotifiChan()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Cache a pointer to the handler for the agent status command
@@ -174,14 +177,11 @@ func (h *Handler) leaderWatch(ctx context.Context) {
 	healthProbe := health.RegisterLiveness("clusterchecks-leadership")
 	defer health.Deregister(healthProbe) //nolint:errcheck
 
-	watchTicker := time.NewTicker(h.leaderStatusFreq)
-	defer watchTicker.Stop()
-
 	for {
 		select {
 		case <-healthProbe.C:
 			// This goroutine might hang if the leader election engine blocks
-		case <-watchTicker.C:
+		case <-h.leadershipStateNotifChan: // notification from leader election engine
 			err := h.updateLeaderIP()
 			h.m.Lock()
 			if err != nil {
@@ -195,6 +195,8 @@ func (h *Handler) leaderWatch(ctx context.Context) {
 				if h.errCount > 0 {
 					log.Infof("Found leadership status after %d tries", h.errCount)
 					h.errCount = 0
+				} else {
+					log.Infof("Found leadership status change from leader election engine without errors")
 				}
 			}
 			h.m.Unlock()

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -105,6 +105,8 @@ func TestUpdateLeaderIP(t *testing.T) {
 	h = &Handler{
 		leadershipChan:       make(chan state, 1),
 		leaderStatusCallback: le.get,
+
+		leadershipStateNotifChan: le.subscribe(),
 	}
 	le.set("1.2.3.4", nil)
 	err = h.updateLeaderIP()
@@ -117,6 +119,8 @@ func TestUpdateLeaderIP(t *testing.T) {
 	h = &Handler{
 		leadershipChan:       make(chan state, 1),
 		leaderStatusCallback: le.get,
+
+		leadershipStateNotifChan: le.subscribe(),
 	}
 	le.set("", errors.New("failing"))
 	for i := 0; i < 4; i++ {
@@ -141,9 +145,7 @@ func TestHandlerRun(t *testing.T) {
 	ac := &mockedPluggableAutoConfig{}
 	fakeTagger := taggerMock.SetupFakeTagger(t)
 	ac.Test(t)
-	le := &fakeLeaderEngine{
-		err: errors.New("failing"),
-	}
+	le := newFakeLeaderEngine()
 
 	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "I'm a teapot", 418)
@@ -153,12 +155,13 @@ func TestHandlerRun(t *testing.T) {
 
 	h := &Handler{
 		autoconfig:           ac,
-		leaderStatusFreq:     100 * time.Millisecond,
 		warmupDuration:       250 * time.Millisecond,
 		leadershipChan:       make(chan state, 1),
 		dispatcher:           newDispatcher(fakeTagger),
 		leaderStatusCallback: le.get,
 		leaderForwarder:      api.NewLeaderForwarder(testPort, 10),
+
+		leadershipStateNotifChan: le.subscribe(),
 	}
 
 	//

--- a/pkg/clusteragent/clusterchecks/leadership_kube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_kube.go
@@ -22,3 +22,15 @@ func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 
 	return engine.GetLeaderIP, nil
 }
+
+func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
+	engine, err := leaderelection.GetLeaderEngine()
+	if err != nil {
+		return nil, err
+	}
+
+	engine.StartLeaderElectionRun()
+
+	leadershipChangeNotif, _ := engine.Subscribe()
+	return leadershipChangeNotif, nil
+}

--- a/pkg/clusteragent/clusterchecks/leadership_nokube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_nokube.go
@@ -16,3 +16,7 @@ import (
 func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 	return nil, errors.New("No leader election engine compiled in")
 }
+
+func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
+	return nil, errors.New("No leader election engine compiled in")
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
When cluster agents (leader and followers) start re-election, the new leader notification will be sent via channel to cluster checks instead of let cluster check handler refresh every 5s. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Refreshing every 5s will create a inconsistent state between two dca instances. For example, if an old follower instance is elected to be new instance and old leader instance becomes follower, the 5s gap inconsistence could cause infinite loop in forwarding requests between two instances until both of them refresh.  (see the 10M requests in a short period of time below)
<img width="1386" alt="Screenshot 2025-03-06 at 11 16 08 AM" src="https://github.com/user-attachments/assets/be8fa8a6-87f9-483e-af98-721f8ddbbd7b" />

To fix this, we can use channel/subscribe function provided in leaderelection engine. This is already used in admission controller.   

**Before change** 
Notice the gap between admission controller notification and clustercheck handler refreshing time. 
```
0 19:36:02 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:152 in func1) | New leader "datadog-agent-linux-cluster-agent-6b7ff75ffb-qttzx"
2025-03-10 19:36:02 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:158 in func2) | Started leading as "datadog-agent-linux-cluster-agent-6b7ff75ffb-qttzx"...
2025-03-10 19:36:02 UTC | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:106 in enqueueOnLeaderNotif) | Got a leader notification, enqueuing a reconciliation for datadog-agent-helm/webhook-certificate
2025-03-10 19:36:06 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:117 in Run) | Becoming leader, waiting 30s for node-agents to report
2025-03-10 19:36:36 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:130 in Run) | Warmup phase finished, starting to serve configurations
```
**After change**
Leader is updated instantly
```
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:120 in Run) | Becoming leader, waiting 30s for node-agents to report
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go:236 in runLeaderElection) | Starting leader election process for "datadog-agent-linux-cluster-agent-c5cd8bc9b-vqjg8"...
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (client-go@v0.31.2/tools/leaderelection/leaderelection.go:212 in Run) | attempting to acquire leader lease datadog-agent-helm/datadog-agent-linux-leader-election...
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (apimachinery@v0.31.2/pkg/util/wait/backoff.go:226 in func1) | successfully acquired lease datadog-agent-helm/datadog-agent-linux-leader-election
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:152 in func1) | New leader "datadog-agent-linux-cluster-agent-c5cd8bc9b-vqjg8"
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:158 in func2) | Started leading as "datadog-agent-linux-cluster-agent-c5cd8bc9b-vqjg8"...
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:199 in leaderWatch) | Found leadership status change from leader election engine without errors
2025-03-10 20:23:13 UTC | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:106 in enqueueOnLeaderNotif) | Got a leader notification, enqueuing a reconciliation for datadog-agent-helm/webhook-certificate
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->