### PR TITLE
Install the expected version of cryptography instead of pinning it

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -285,20 +285,27 @@ build do
         FileUtils.rm([libssl_match, libcrypto_match])
       end
     elsif windows_target?
-      dll_folder = File.join(install_dir, "embedded3", "DLLS")
       # Build the cryptography library in this case so that it gets linked to Agent's OpenSSL
-      # We first need to copy some files around (we need the .lib files for building)
-      copy File.join(install_dir, "embedded3", "lib", "libssl.dll.a"),
+      lib_folder = File.join(install_dir, "embedded3", "lib")
+      dll_folder = File.join(install_dir, "embedded3", "DLLS")
+      include_folder = File.join(install_dir, "embedded3", "include")
+
+      # We first need create links to some files around such that cryptography finds .lib files
+      link File.join(lib_folder, "libssl.dll.a"),
            File.join(dll_folder, "libssl-3-x64.lib")
-      copy File.join(install_dir, "embedded3", "lib", "libcrypto.dll.a"),
+      link File.join(lib_folder, "libcrypto.dll.a"),
            File.join(dll_folder, "libcrypto-3-x64.lib")
 
-      command "#{python} -m pip install --force-reinstall --no-deps --no-binary cryptography cryptography==43.0.1",
-              env: {
-                "OPENSSL_LIB_DIR" => dll_folder,
-                "OPENSSL_INCLUDE_DIR" => File.join(install_dir, "embedded3", "include"),
-                "OPENSSL_LIBS" => "libssl-3-x64:libcrypto-3-x64",
-              }
+      block "Build cryptopgraphy library against Agent's OpenSSL" do
+        cryptography_requirement = (shellout! "#{python} -m pip list --format=freeze").stdout[/cryptography==.*?$/]
+
+        shellout! "#{python} -m pip install --force-reinstall --no-deps --no-binary cryptography #{cryptography_requirement}",
+                env: {
+                  "OPENSSL_LIB_DIR" => dll_folder,
+                  "OPENSSL_INCLUDE_DIR" => include_folder,
+                  "OPENSSL_LIBS" => "libssl-3-x64:libcrypto-3-x64",
+                }
+      end
       # Python extensions on windows require this to find their DLL dependencies,
       # we abuse the `.pth` loading system to inject it
       block "Inject dll path for Python extensions" do


### PR DESCRIPTION
### What does this PR do?

This cleans up some of what was done in #34619 to build `cryptography` against the Agent's OpenSSL on FIPS builds. The main change is dynamically setting the version of `cryptography` we build to match what the integrations expect.

### Motivation

[BARX-668](https://datadoghq.atlassian.net/browse/BARX-668)

#34619 left `cryptography` pinned to the version matching integrations requirements at that time; that's obviously problematic because it could produce mismatches as integrations bump this dependency and we don't want to keep them in sync manually.

### Describe how you validated your changes

The build passes and loading cryptography's openssl backend from the Agent's embedded Python works.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[BARX-668]: https://datadoghq.atlassian.net/browse/BARX-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ