### PR TITLE
fix(auto_assign_issue): Install `dda` from pypi

### DIFF
--- a/.github/workflows/assign_issue.yml
+++ b/.github/workflows/assign_issue.yml
@@ -23,7 +23,7 @@ jobs:
       # Dependencies are installed at runtime. Otherwise it would create a huge image see https://hub.docker.com/r/pytorch/pytorch/tags
       run: |
         pip install --upgrade pip
-        pip install --no-compile --no-cache-dir torch transformers "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
+        pip install --no-compile --no-cache-dir torch transformers "dda==$(cat .dda/version)"
         dda self dep sync -f legacy-tasks
     - name: Assign issue
       env:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Replace the installation from repository by installation from pypi

### Motivation
This is [currently failing](https://github.com/DataDog/datadog-agent/actions/runs/13718125294/job/38367282003) for a weird reason (`ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version`)
As `dda` is also available from `pip` we can use a more straightforward installation 

### Describe how you validated your changes
[Update](https://github.com/DataDog/datadog-agent/pull/34934/commits/a621b9dc831a263ef108a41b15c1da2d0fc1f084) tested with a [temporary job](https://github.com/DataDog/datadog-agent/actions/runs/13761375577/job/38478040502?pr=34934)
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->