### PR TITLE
[CWS] move `StartRuntimeSecurity` into agent package

### DIFF
--- a/cmd/security-agent/main_windows.go
+++ b/cmd/security-agent/main_windows.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	saconfig "github.com/DataDog/datadog-agent/cmd/security-agent/config"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/runtime"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/start"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit/autoexitimpl"
@@ -46,13 +45,11 @@ import (
 	"github.com/DataDog/datadog-agent/comp/metadata/host/hostimpl"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
-	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
-
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
+	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/utils/hostnameutils"
-
 	"github.com/DataDog/datadog-agent/pkg/util/defaultpaths"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
@@ -139,7 +136,7 @@ func (s *service) Run(svcctx context.Context) error {
 				return status.NewInformationProvider(nil), nil, err
 			}
 
-			runtimeAgent, err := runtime.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, wmeta, compression)
+			runtimeAgent, err := agent.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, wmeta, compression)
 			if err != nil {
 				return status.NewInformationProvider(nil), nil, err
 			}

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -25,23 +25,17 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
-	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
-
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
-	"github.com/DataDog/datadog-agent/pkg/security/common"
 	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
 	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
-	"github.com/DataDog/datadog-agent/pkg/security/reporter"
 	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -51,7 +45,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/startstop"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -712,43 +705,6 @@ func reloadRuntimePolicies(_ log.Component, _ config.Component, _ secrets.Compon
 	}
 
 	return nil
-}
-
-// StartRuntimeSecurity starts runtime security
-func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, wmeta workloadmeta.Component, compression compression.Component) (*secagent.RuntimeSecurityAgent, error) {
-	enabled := config.GetBool("runtime_security_config.enabled")
-	if !enabled {
-		log.Info("Datadog runtime security agent disabled by config")
-		return nil, nil
-	}
-
-	// start/stop order is important, agent need to be stopped first and started after all the others
-	// components
-	agent, err := secagent.NewRuntimeSecurityAgent(statsdClient, hostname, secagent.RSAOptions{
-		LogProfiledWorkloads: config.GetBool("runtime_security_config.log_profiled_workloads"),
-	}, wmeta)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create a runtime security agent instance: %w", err)
-	}
-	stopper.Add(agent)
-
-	useSecRuntimeTrack := config.GetBool("runtime_security_config.use_secruntime_track")
-	endpoints, ctx, err := common.NewLogContextRuntime(useSecRuntimeTrack)
-	if err != nil {
-		_ = log.Error(err)
-	}
-	stopper.Add(ctx)
-
-	reporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, ctx, compression)
-	if err != nil {
-		return nil, err
-	}
-
-	agent.Start(reporter, endpoints)
-
-	log.Info("Datadog runtime security agent is now running")
-
-	return agent, nil
 }
 
 func downloadPolicy(log log.Component, config config.Component, _ secrets.Component, downloadPolicyArgs *downloadPolicyCliParams) error {

--- a/cmd/security-agent/subcommands/runtime/command_unsupported.go
+++ b/cmd/security-agent/subcommands/runtime/command_unsupported.go
@@ -9,32 +9,12 @@
 package runtime
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
-	"github.com/DataDog/datadog-agent/comp/core/config"
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
-	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
-	"github.com/DataDog/datadog-agent/pkg/util/startstop"
-	"github.com/DataDog/datadog-go/v5/statsd"
 )
 
 // Commands returns the runtime security commands
 func Commands(*command.GlobalParams) []*cobra.Command {
 	return nil
-}
-
-// StartRuntimeSecurity starts runtime security
-func StartRuntimeSecurity(log log.Component, config config.Component, _ string, _ startstop.Stopper, _ statsd.ClientInterface, _ workloadmeta.Component, _ compression.Component) (*secagent.RuntimeSecurityAgent, error) {
-	enabled := config.GetBool("runtime_security_config.enabled")
-	if !enabled {
-		log.Info("Datadog runtime security agent disabled by config")
-		return nil, nil
-	}
-
-	return nil, errors.New("Datadog runtime security agent is only supported on Linux and Windows")
 }

--- a/cmd/security-agent/subcommands/start/command.go
+++ b/cmd/security-agent/subcommands/start/command.go
@@ -26,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/command"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/compliance"
-	"github.com/DataDog/datadog-agent/cmd/security-agent/subcommands/runtime"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit"
 	"github.com/DataDog/datadog-agent/comp/agent/autoexit/autoexitimpl"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
@@ -130,7 +129,7 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 						return status.NewInformationProvider(nil), nil, err
 					}
 
-					runtimeAgent, err := runtime.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, wmeta, compression)
+					runtimeAgent, err := agent.StartRuntimeSecurity(log, config, hostnameDetected, stopper, statsdClient, wmeta, compression)
 					if err != nil {
 						return status.NewInformationProvider(nil), nil, err
 					}

--- a/pkg/security/agent/start.go
+++ b/pkg/security/agent/start.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux || windows
+
+// Package agent holds agent related files
+package agent
+
+import (
+	"fmt"
+
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
+	"github.com/DataDog/datadog-agent/pkg/security/common"
+	"github.com/DataDog/datadog-agent/pkg/security/reporter"
+	"github.com/DataDog/datadog-agent/pkg/util/startstop"
+)
+
+// StartRuntimeSecurity starts runtime security
+func StartRuntimeSecurity(log log.Component, config config.Component, hostname string, stopper startstop.Stopper, statsdClient ddgostatsd.ClientInterface, wmeta workloadmeta.Component, compression compression.Component) (*RuntimeSecurityAgent, error) {
+	enabled := config.GetBool("runtime_security_config.enabled")
+	if !enabled {
+		log.Info("Datadog runtime security agent disabled by config")
+		return nil, nil
+	}
+
+	// start/stop order is important, agent need to be stopped first and started after all the others
+	// components
+	agent, err := NewRuntimeSecurityAgent(statsdClient, hostname, RSAOptions{
+		LogProfiledWorkloads: config.GetBool("runtime_security_config.log_profiled_workloads"),
+	}, wmeta)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a runtime security agent instance: %w", err)
+	}
+	stopper.Add(agent)
+
+	useSecRuntimeTrack := config.GetBool("runtime_security_config.use_secruntime_track")
+	endpoints, ctx, err := common.NewLogContextRuntime(useSecRuntimeTrack)
+	if err != nil {
+		_ = log.Error(err)
+	}
+	stopper.Add(ctx)
+
+	reporter, err := reporter.NewCWSReporter(hostname, stopper, endpoints, ctx, compression)
+	if err != nil {
+		return nil, err
+	}
+
+	agent.Start(reporter, endpoints)
+
+	log.Info("Datadog runtime security agent is now running")
+
+	return agent, nil
+}

--- a/pkg/security/agent/start_unsupported.go
+++ b/pkg/security/agent/start_unsupported.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !(linux || windows)
+
+// Package agent holds agent related files
+package agent
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	compression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
+	"github.com/DataDog/datadog-agent/pkg/util/startstop"
+	"github.com/DataDog/datadog-go/v5/statsd"
+)
+
+// StartRuntimeSecurity starts runtime security
+func StartRuntimeSecurity(log log.Component, config config.Component, _ string, _ startstop.Stopper, _ statsd.ClientInterface, _ workloadmeta.Component, _ compression.Component) (*RuntimeSecurityAgent, error) {
+	enabled := config.GetBool("runtime_security_config.enabled")
+	if !enabled {
+		log.Info("Datadog runtime security agent disabled by config")
+		return nil, nil
+	}
+
+	return nil, errors.New("Datadog runtime security agent is only supported on Linux and Windows")
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR moves the `StartRuntimeSecurity` into the pkg/security/agent package where it really belongs since this function is the entrypoint of the security agent.

The underlying goal of this PR is to make progress towards reducing the amount of dependencies from the security-agent to the CWS code that should live only in the system-probe with the goal of reducing the size of the security-agent.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->