### PR TITLE
feat(renovate): Auto bump of omnibus repositories

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,29 @@
         "depNameTemplate": "protoc",
         "versioningTemplate": "loose",
         "datasourceTemplate": "custom.protoc"
-      }
+      },
+      {
+        "customType": "regex",
+        "fileMatch": ["release.json"],
+        "matchStrings": [
+          "[ ]+\"OMNIBUS_RUBY_VERSION\": \"(?<currentDigest>[a-z0-9]+)\""
+        ],
+        "currentValueTemplate": "datadog-5.5.0",
+        "depNameTemplate": "omnibus-ruby",
+        "packageNameTemplate": "https://github.com/DataDog/omnibus-ruby",
+        "datasourceTemplate": "git-refs"
+     },
+     {
+        "customType": "regex",
+        "fileMatch": ["release.json"],
+        "matchStrings": [
+          "[ ]+\"OMNIBUS_SOFTWARE_VERSION\": \"(?<currentDigest>[a-z0-9]+)\""
+        ],
+        "currentValueTemplate": "master",
+        "depNameTemplate": "omnibus-software",
+        "packageNameTemplate": "https://github.com/DataDog/omnibus-software",
+        "datasourceTemplate": "git-refs"
+   }
     ],
     "customDatasources": {
       "buildimages": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabledManagers": ["custom.regex"],
+    "labels": ["dependencies"],
     "customManagers" : [
       {
         "customType": "regex",
@@ -20,9 +21,8 @@
         "matchStrings": [
           "(?<currentValue>[0-9]+.[0-9]+)"
         ],
-        "depNameTemplate": "protoc",
-        "versioningTemplate": "loose",
-        "datasourceTemplate": "custom.protoc"
+        "depNameTemplate": "protocolbuffers/protobuf",
+        "datasourceTemplate": "github-releases"
       },
       {
         "customType": "regex",
@@ -52,12 +52,6 @@
         "defaultRegistryUrlTemplate": "https://hub.docker.com/v2/namespaces/datadog/repositories/agent-buildimages-deb_x64/tags",
         "transformTemplates": [
           "{\"releases\": $map(results, function($v) { {\"version\": $v.name, \"releaseTimestamp\": $v.last_updated } }) }"
-        ]
-      },
-      "protoc": {
-        "defaultRegistryUrlTemplate": "https://api.github.com/repos/protocolbuffers/protobuf/releases",
-        "transformTemplates": [
-          "{\"releases\": $map($.[tag_name,published_at], function($v) { {\"version\": $v[0], \"releaseTimestamp\": $v[1] } }) }"
         ]
       }
     }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Setup automatic bump from `omnibus-ruby` and `omnibus-software` repositories
- Improve the `protoc` automatic update using a preset datasource.

### Motivation
Get rid of [homemade solutions](https://github.com/DataDog/omnibus-ruby/blob/datadog-5.5.0/.github/workflows/open-datadog-agent-pr.yml) for automatic bump of our internal dependencies

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
Replaces #34905 
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->