### PR TITLE
[NDM][Cisco SD-WAN] Improve memory usage

### DIFF
--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics.go
@@ -46,7 +46,7 @@ func (ms *SDWanSender) SendDeviceMetrics(deviceStats []client.DeviceStatistics) 
 
 	for _, entry := range deviceStats {
 		tags := ms.getDeviceTags(entry.SystemIP)
-		key := ms.getMetricKey("device_metrics", tags)
+		key := ms.getMetricKey("device_metrics", entry.SystemIP)
 
 		if !ms.shouldSendEntry(key, entry.EntryTime) {
 			// If the timestamp is before the max timestamp already sent, do not re-send
@@ -100,7 +100,7 @@ func (ms *SDWanSender) SendInterfaceMetrics(interfaceStats []client.InterfaceSta
 			ms.sender.Gauge(ciscoSDWANMetricPrefix+"interface.speed", float64(itf.GetSpeedMbps()*1000), "", tags)
 		}
 
-		key := ms.getMetricKey("interface_metrics", tags)
+		key := ms.getMetricKey("interface_metrics", entry.VmanageSystemIP, entry.Interface)
 
 		if !ms.shouldSendEntry(key, entry.EntryTime) {
 			// If the timestamp is before the max timestamp already sent, do not re-send
@@ -143,7 +143,7 @@ func (ms *SDWanSender) SendAppRouteMetrics(appRouteStats []client.AppRouteStatis
 
 		tags := append(deviceTags, remoteTags...)
 		tags = append(tags, "local_color:"+entry.LocalColor, "remote_color:"+entry.RemoteColor, "state:"+entry.State)
-		key := ms.getMetricKey("tunnel_metrics", tags)
+		key := ms.getMetricKey("tunnel_metrics", entry.VmanageSystemIP, entry.RemoteSystemIP, entry.LocalColor, entry.RemoteColor)
 
 		if !ms.shouldSendEntry(key, entry.EntryTime) {
 			// If the timestamp is before the max timestamp already sent, do not re-send
@@ -266,7 +266,7 @@ func (ms *SDWanSender) SendCloudApplicationMetrics(cloudApplications []client.Cl
 
 		tags = append(tags, gatewayTags...)
 		tags = append(tags, "local_color:"+entry.LocalColor, "remote_color:"+entry.RemoteColor, "interface:"+entry.Interface, "exit_type:"+entry.ExitType, "application_group:"+entry.NbarAppGroupName, "application:"+entry.Application, "best_path:"+entry.BestPath, "vpn_id:"+fmt.Sprintf("%d", int(entry.VpnID)))
-		key := ms.getMetricKey("application_metrics", tags)
+		key := ms.getMetricKey("application_metrics", entry.VmanageSystemIP, entry.GatewaySystemIP, entry.LocalColor, entry.RemoteColor, entry.Application)
 
 		if !ms.shouldSendEntry(key, entry.EntryTime) {
 			// If the timestamp is before the max timestamp already sent, do not re-send
@@ -323,8 +323,8 @@ func (ms *SDWanSender) countWithTimestamp(name string, value float64, tags []str
 	}
 }
 
-func (ms *SDWanSender) getMetricKey(metric string, tags []string) string {
-	return metric + ":" + strings.Join(tags, ",")
+func (ms *SDWanSender) getMetricKey(metric string, keys ...string) string {
+	return metric + ":" + strings.Join(keys, ",")
 }
 
 func (ms *SDWanSender) shouldSendEntry(key string, ts float64) bool {

--- a/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
+++ b/pkg/collector/corechecks/network-devices/cisco-sdwan/report/metrics_test.go
@@ -70,7 +70,7 @@ func TestSendDeviceMetrics(t *testing.T) {
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"memory.usage", float64(0.56)*100, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"disk.usage", 30, "", expectedTags, 10)
 	require.Equal(t, map[string]float64{
-		"device_metrics:test:tag,test2:tag2": 11000,
+		"device_metrics:10.0.0.1": 11000,
 	}, sender.lastTimeSent)
 
 	devices = append(devices, client.DeviceStatistics{
@@ -95,7 +95,7 @@ func TestSendDeviceMetrics(t *testing.T) {
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"memory.usage", float64(0.75)*100, "", expectedTags, 15)
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"disk.usage", 35, "", expectedTags, 15)
 	require.Equal(t, map[string]float64{
-		"device_metrics:test:tag,test2:tag2": 15000,
+		"device_metrics:10.0.0.1": 15000,
 	}, sender.lastTimeSent)
 }
 
@@ -167,7 +167,7 @@ func TestSendInterfaceMetrics(t *testing.T) {
 	mockSender.AssertMetricWithTimestamp(t, "CountWithTimestamp", ciscoSDWANMetricPrefix+"interface.rx_drops", 65, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "CountWithTimestamp", ciscoSDWANMetricPrefix+"interface.tx_drops", 2, "", expectedTags, 10)
 	require.Equal(t, map[string]float64{
-		"interface_metrics:test:tag,test2:tag2,interface:interface-1,vpn_id:10,interface_index:10,dd.internal.resource:ndm_interface_user_tags:my-ns:10.0.0.1:10": 10000,
+		"interface_metrics:10.0.0.1,interface-1": 10000,
 	}, sender.lastTimeSent)
 
 	mockSender.ResetCalls()
@@ -178,7 +178,7 @@ func TestSendInterfaceMetrics(t *testing.T) {
 	mockSender.AssertNumberOfCalls(t, "GaugeWithTimestamp", 0)
 	mockSender.AssertNumberOfCalls(t, "CountWithTimestamp", 0)
 	require.Equal(t, map[string]float64{
-		"interface_metrics:test:tag,test2:tag2,interface:interface-1,vpn_id:10,interface_index:10,dd.internal.resource:ndm_interface_user_tags:my-ns:10.0.0.1:10": 10000,
+		"interface_metrics:10.0.0.1,interface-1": 10000,
 	}, sender.lastTimeSent)
 }
 
@@ -368,7 +368,7 @@ func TestSendApplicationAwareRoutingMetrics(t *testing.T) {
 	mockSender.AssertMetricWithTimestamp(t, "CountWithTimestamp", ciscoSDWANMetricPrefix+"tunnel.rx_packets", 512, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "CountWithTimestamp", ciscoSDWANMetricPrefix+"tunnel.tx_packets", 203, "", expectedTags, 10)
 	require.Equal(t, map[string]float64{
-		"tunnel_metrics:test:tag,test2:tag2,remote_test3:tag3,remote_test4:tag4,local_color:mpls,remote_color:public-internet,state:Up": 10000,
+		"tunnel_metrics:10.0.0.1,10.0.0.2,mpls,public-internet": 10000,
 	}, sender.lastTimeSent)
 
 	mockSender.ResetCalls()
@@ -379,7 +379,7 @@ func TestSendApplicationAwareRoutingMetrics(t *testing.T) {
 	mockSender.AssertNumberOfCalls(t, "GaugeWithTimestamp", 0)
 	mockSender.AssertNumberOfCalls(t, "CountWithTimestamp", 0)
 	require.Equal(t, map[string]float64{
-		"tunnel_metrics:test:tag,test2:tag2,remote_test3:tag3,remote_test4:tag4,local_color:mpls,remote_color:public-internet,state:Up": 10000,
+		"tunnel_metrics:10.0.0.1,10.0.0.2,mpls,public-internet": 10000,
 	}, sender.lastTimeSent)
 }
 
@@ -1241,7 +1241,7 @@ func TestSendCloudApplicationMetrics(t *testing.T) {
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"application.loss", 0.01, "", expectedTags, 10)
 	mockSender.AssertMetricWithTimestamp(t, "GaugeWithTimestamp", ciscoSDWANMetricPrefix+"application.qoe", 8, "", expectedTags, 10)
 	require.Equal(t, map[string]float64{
-		"application_metrics:test:tag,test2:tag2,gateway_test3:tag3,gateway_test4:tag4,local_color:mpls,remote_color:public-internet,interface:-,exit_type:Remote,application_group:app-group,application:test-app,best_path:TRUE,vpn_id:1": 10000,
+		"application_metrics:10.0.0.1,10.0.0.2,mpls,public-internet,test-app": 10000,
 	}, sender.lastTimeSent)
 
 	mockSender.ResetCalls()
@@ -1252,7 +1252,7 @@ func TestSendCloudApplicationMetrics(t *testing.T) {
 	mockSender.AssertNumberOfCalls(t, "GaugeWithTimestamp", 0)
 	mockSender.AssertNumberOfCalls(t, "CountWithTimestamp", 0)
 	require.Equal(t, map[string]float64{
-		"application_metrics:test:tag,test2:tag2,gateway_test3:tag3,gateway_test4:tag4,local_color:mpls,remote_color:public-internet,interface:-,exit_type:Remote,application_group:app-group,application:test-app,best_path:TRUE,vpn_id:1": 10000,
+		"application_metrics:10.0.0.1,10.0.0.2,mpls,public-internet,test-app": 10000,
 	}, sender.lastTimeSent)
 }
 

--- a/releasenotes/notes/improve-cisco-sdwan-memory-usage-a9f7e2dc4f34a060.yaml
+++ b/releasenotes/notes/improve-cisco-sdwan-memory-usage-a9f7e2dc4f34a060.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Cisco SD-WAN: improve memory usage.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
 Improve memory usage consumption by only using the necessary fields in the `expiredTimestamp` map, instead of the full list of tags. This is primarily to improve memory consumption in bigger environments.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->