### PR TITLE
[sysprobe] Pass factory deps directly, add hostname.Component

### DIFF
--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -12,6 +12,7 @@ import (
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -38,4 +39,5 @@ type FactoryDependencies struct {
 	Telemetry   telemetry.Component
 	Compression logscompression.Component
 	Statsd      ddgostatsd.ClientInterface
+	Hostname    hostname.Component
 }

--- a/cmd/system-probe/api/restart.go
+++ b/cmd/system-probe/api/restart.go
@@ -14,12 +14,9 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
-	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 )
 
-func restartModuleHandler(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component, tagger tagger.Component, telemetry telemetry.Component) {
+func restartModuleHandler(w http.ResponseWriter, r *http.Request, deps module.FactoryDependencies) {
 	vars := mux.Vars(r)
 	moduleName := sysconfigtypes.ModuleName(vars["module-name"])
 
@@ -40,7 +37,7 @@ func restartModuleHandler(w http.ResponseWriter, r *http.Request, wmeta workload
 		return
 	}
 
-	err := module.RestartModule(target, wmeta, tagger, telemetry)
+	err := module.RestartModule(target, deps)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR changes the system-probe startup process to pass `FactoryDependencies` directly out of fx. It also adds `hostname.Component` to the dependencies which will be used here: [[netpath] Use remote hostname from core agent](https://github.com/DataDog/datadog-agent/pull/34911)
### Motivation
Less code + more consistency with `FactoryDependencies`, for example `RestartModule` was missing statsd and compression but now they should all flow through from fx.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI should pass including e2e tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->