### PR TITLE
[SMP] Adjust `quality_gate_*` limits

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "266.0 MiB"
+      upper_bound: "255.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_rss_bytes
-      upper_bound: "675.0 MiB"
+      upper_bound: "665.0 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_rss_bytes
-      upper_bound: "297.0 MiB"
+      upper_bound: "275.0 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?
lowers:
`quality_gate_logs` rss limit from `297 MiB` to `275 MiB`
`quality_gate_idle` rss limit from `266 MiB` to `255 MiB`
`quality_gate_idle_all_features` rss limit from `675 MiB` to `665 MiB`

### Motivation

Max observed rss for `quality_gate_logs` is `~270 MiB` (excluding the exception we believe to be a bug) on todays (march 10) nightly `job_id:f04f9709-fc13-4294-a98d-43e560187b89` , nightly version:`nightly-main-819b1103-py3` [dashboard](https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=false&refresh_mode=paused&tpl_var_experiment%5B0%5D=quality_gate_logs&tpl_var_job_id%5B0%5D=f04f9709-fc13-4294-a98d-43e560187b89&tpl_var_run-id%5B0%5D=f04f9709-fc13-4294-a98d-43e560187b89&view=spans&from_ts=1741591346000&to_ts=1741591946000&live=false)

`quality_gate_idle` and `quality_gate_idle_all_features` also show some minor improvements which we will lock in as part of this PR