### PR TITLE
usm: exclude unused maps

### DIFF
--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -490,10 +490,7 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 				continue
 			}
 			// Unused maps still need to have a non-zero size
-			options.MapSpecEditors[m.Name] = manager.MapSpecEditor{
-				MaxEntries: uint32(1),
-				EditorFlag: manager.EditMaxEntries,
-			}
+			options.ExcludedMaps = append(options.ExcludedMaps, m.Name)
 
 			log.Debugf("disabled map: %v", m.Name)
 		}

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -489,7 +489,6 @@ func (e *ebpfProgram) init(buf bytecode.AssetReader, options manager.Options) er
 				log.Debugf("map %s is shared between enabled and disabled protocols", m.Name)
 				continue
 			}
-			// Unused maps still need to have a non-zero size
 			options.ExcludedMaps = append(options.ExcludedMaps, m.Name)
 
 			log.Debugf("disabled map: %v", m.Name)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Excluding unused maps instead of resizing them to have only 1 entry

### Motivation

* Small RSS gain, as each unused map costs at least 4K
* Ensuring we're not excluding a used-map (USM will fail to start)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI covers this scenario, as we only enable relevant features for every test, hence, a bug would have been caught in the CI

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->