### PR TITLE
Keep SQL alias when normalizing with SQL lexer

### DIFF
--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -485,7 +485,7 @@ func (o *Obfuscator) ObfuscateWithSQLLexer(in string, opts *SQLConfig) (*Obfusca
 		sqllexer.WithCollectCommands(opts.CollectCommands),
 		sqllexer.WithCollectTables(opts.TableNames),
 		sqllexer.WithCollectProcedures(opts.CollectProcedures),
-		sqllexer.WithKeepSQLAlias(opts.KeepSQLAlias),
+		sqllexer.WithKeepSQLAlias(true),
 		sqllexer.WithRemoveSpaceBetweenParentheses(opts.RemoveSpaceBetweenParentheses),
 		sqllexer.WithKeepTrailingSemicolon(opts.KeepTrailingSemicolon),
 		sqllexer.WithKeepIdentifierQuotation(opts.KeepIdentifierQuotation),

--- a/releasenotes/notes/sql-alias-64dd941949cbdc83.yaml
+++ b/releasenotes/notes/sql-alias-64dd941949cbdc83.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Keep SQL alias when ``sql_obfuscation_mode`` is set to ``obfuscate_and_normalize`` to improve APM/DBM correlation.


### PR DESCRIPTION
### What does this PR do?

Keep alias when normalizing SQL statements with SQL lexer.

### Motivation

Improving APM/DBM match rates.

### Describe how you validated your changes

1. Verify that the aliases are kept, when the SQL lexer normalization is configured:

![image](https://github.com/user-attachments/assets/c179bc38-2878-48b7-b08e-ae4a342b3422)

2. The execution plan is shown:

![image](https://github.com/user-attachments/assets/2f4b585d-101a-4a42-bc81-7c374bf11511)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->