### PR TITLE
ci(rules): Fix automatic trigger of new-e2e-orchestrator

### DIFF
--- a/.gitlab/dev_container_deploy/e2e.yml
+++ b/.gitlab/dev_container_deploy/e2e.yml
@@ -129,6 +129,7 @@ qa_dogstatsd:
   stage: dev_container_deploy
   rules:
     - !reference [.on_container_or_e2e_changes]
+    - !reference [.on_orchestrator_or_e2e_changes]
     - !reference [.manual]
   needs:
     - docker_build_dogstatsd_amd64

--- a/test/new-e2e/tests/orchestrator/k8s_test.go
+++ b/test/new-e2e/tests/orchestrator/k8s_test.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// fake update
 package orchestrator
 
 import (

--- a/test/new-e2e/tests/orchestrator/k8s_test.go
+++ b/test/new-e2e/tests/orchestrator/k8s_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// fake update
 package orchestrator
 
 import (


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Update the trigger rule of `qa_dogstatsd`

### Motivation
This job is a dependency of `new-e2e-orchestrator`:
```
new-e2e-orchestrator:
  extends:
    - .new_e2e_template_needs_container_deploy
  rules:
    - !reference [.on_orchestrator_or_e2e_changes]
    - !reference [.manual]
```
and 
```
.new_e2e_template_needs_container_deploy:
  extends: .new_e2e_template
  needs:
    - !reference [.needs_new_e2e_template]
    - qa_agent
    - qa_agent_jmx
    - qa_dca
    - qa_dogstatsd
```
However, `qa_dogstatsd` has a different `rules` than other `qa_*` jobs:
```
qa_agent:
  extends: .docker_publish_job_definition
  stage: dev_container_deploy
  rules:
    - !reference [.except_mergequeue]
    - !reference [.except_disable_e2e_tests]
    - when: on_success
```
but
```
qa_dogstatsd:
  extends: .docker_publish_job_definition
  stage: dev_container_deploy
  rules:
    - !reference [.on_container_or_e2e_changes]
    - !reference [.manual]
```

As a consequence in this PR #25182, despite modifications on `test/new-e2e/tests/orchestrator` the `new-e2e-orchestrator` was [skipped](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3A%22DataDog%2Fdatadog-agent%22%20%40ci.job.name%3A%22new-e2e-orchestrator%22%20%40git.branch%3Akangyi%2Fe2e-ecs&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&start=1741075876795&end=1741680676795&paused=false), because the `qa_dogstatsd` was waiting a manual trigger.
I aligned the rules to have an automatic trigger, as in this [example pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/58376767) (thanks to this [fake commit](https://github.com/DataDog/datadog-agent/pull/34984/commits/3fefff7851885c1403782e53fb80188e1131827f))


### Describe how you validated your changes
Triggered a [pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/58376767) with a fake update to trigger `new-e2e-orchestrator` [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/841560173)

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->