### PR TITLE
upgrade(installer): Create postinst

### DIFF
--- a/pkg/fleet/installer/installinfo/installinfo.go
+++ b/pkg/fleet/installer/installinfo/installinfo.go
@@ -7,9 +7,11 @@
 package installinfo
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -25,6 +27,7 @@ const (
 	installSigFile  = "/etc/datadog-agent/install.json"
 
 	toolInstaller = "installer"
+	execTimeout   = 30 * time.Second
 )
 
 // WriteInstallInfo writes install info and signature files.
@@ -38,11 +41,13 @@ func writeInstallInfo(installInfoFile string, installSigFile string, installType
 		return nil
 	}
 
+	tool, toolVersion, installerVersion := getToolVersion(installType)
+
 	info := map[string]map[string]string{
 		"install_method": {
-			"tool":              toolInstaller,
-			"tool_version":      version.AgentVersion,
-			"installer_version": installType,
+			"tool":              tool,
+			"tool_version":      toolVersion,
+			"installer_version": installerVersion,
 		},
 	}
 	yamlData, err := yaml.Marshal(info)
@@ -55,7 +60,7 @@ func writeInstallInfo(installInfoFile string, installSigFile string, installType
 
 	sig := map[string]string{
 		"install_id":   strings.ToLower(uuid),
-		"install_type": installType,
+		"install_type": installerVersion,
 		"install_time": strconv.FormatInt(time.Unix(), 10),
 	}
 	jsonData, err := json.Marshal(sig)
@@ -75,4 +80,48 @@ func RemoveInstallInfo() {
 			log.Warnf("Failed to remove %s: %v", file, err)
 		}
 	}
+}
+
+func getToolVersion(installType string) (tool string, toolVersion string, installerVersion string) {
+	tool = toolInstaller
+	toolVersion = version.AgentVersion
+	installerVersion = fmt.Sprintf("%s_package", installType)
+	if _, err := exec.LookPath("dpkg-query"); err == nil {
+		tool = "dpkg"
+		toolVersion, err = getDpkgVersion()
+		if err != nil {
+			toolVersion = "dpkg-unknown"
+		}
+	}
+	if _, err := exec.LookPath("rpm"); err == nil {
+		tool = "rpm"
+		toolVersion, err = getRPMVersion()
+		if err != nil {
+			toolVersion = "rpm-unknown"
+		}
+	}
+	return
+}
+
+func getRPMVersion() (string, error) {
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeout)
+	defer cancelfunc()
+	output, err := exec.CommandContext(cancelctx, "rpm", "-q", "-f", "/bin/rpm", "--queryformat", "%%{VERSION}").Output()
+	return string(output), err
+}
+
+func getDpkgVersion() (string, error) {
+	cancelctx, cancelfunc := context.WithTimeout(context.Background(), execTimeout)
+	defer cancelfunc()
+	cmd := exec.CommandContext(cancelctx, "dpkg-query", "--showformat=${Version}", "--show", "dpkg")
+	output, err := cmd.Output()
+	if err != nil {
+		log.Warnf("Failed to get dpkg version: %s", err)
+		return "", err
+	}
+	splitVersion := strings.Split(strings.TrimSpace(string(output)), ".")
+	if len(splitVersion) < 3 {
+		return "", fmt.Errorf("failed to parse dpkg version: %s", string(output))
+	}
+	return strings.Join(splitVersion[:3], "."), nil
 }

--- a/pkg/fleet/installer/installinfo/installinfo_test.go
+++ b/pkg/fleet/installer/installinfo/installinfo_test.go
@@ -21,10 +21,15 @@ import (
 )
 
 func TestWriteInstallInfo(t *testing.T) {
+	// To avoid flakiness, remove dpkg & rpm from path, if any
+	oldPath := os.Getenv("PATH")
+	defer func() { os.Setenv("PATH", oldPath) }()
+	os.Setenv("PATH", "")
+
 	tmpDir := t.TempDir()
 	infoPath := filepath.Join(tmpDir, "install_info")
 	sigPath := filepath.Join(tmpDir, "install.json")
-	testInstallType := "manual_update_via_apt"
+	testInstallType := "deb"
 
 	// Call the internal writeInstallInfo function.
 	time := time.Now()
@@ -43,7 +48,7 @@ func TestWriteInstallInfo(t *testing.T) {
 		"install_method": {
 			"tool":              "installer",
 			"tool_version":      version.AgentVersion,
-			"installer_version": testInstallType,
+			"installer_version": testInstallType + "_package",
 		},
 	}
 	assert.Equal(t, expectedYAML, info)
@@ -57,7 +62,7 @@ func TestWriteInstallInfo(t *testing.T) {
 
 	expectedSig := map[string]string{
 		"install_id":   uuid,
-		"install_type": testInstallType,
+		"install_type": testInstallType + "_package",
 		"install_time": strconv.FormatInt(time.Unix(), 10),
 	}
 	assert.Equal(t, expectedSig, sig)

--- a/pkg/fleet/installer/packages/datadog_installer.go
+++ b/pkg/fleet/installer/packages/datadog_installer.go
@@ -56,7 +56,7 @@ func SetupInstaller(ctx context.Context) (err error) {
 	}()
 
 	// 1. Ensure the dd-agent user and group exist
-	err = user.EnsureAgentUserAndGroup(ctx)
+	err = user.EnsureAgentUserAndGroup(ctx, "/opt/datadog-packages")
 	if err != nil {
 		return fmt.Errorf("error ensuring dd-agent user and group: %w", err)
 	}

--- a/pkg/fleet/installer/packages/selinux/selinux.go
+++ b/pkg/fleet/installer/packages/selinux/selinux.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package selinux offers an interface to set agent's SELinux permissions.
+package selinux
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	gopsutilhost "github.com/shirou/gopsutil/v4/host"
+)
+
+const manualInstallTemplate = `To be able to run system-probe on your host, please install or update the selinux-policy-targeted and
+policycoreutils-python (or policycoreutils-python-utils depending on your distribution) packages.
+Then run the following commands, or reinstall datadog-agent:
+	semodule -i %[1]s/selinux/system_probe_policy.pp
+	semanage fcontext -a -t system_probe_t %[2]s/embedded/bin/system-probe
+	semanage fcontext -a -t system_probe_t %[2]s/bin/agent/agent
+	restorecon -v %[2]s/embedded/bin/system-probe %[2]s/bin/agent/agent
+`
+
+// SetAgentPermissions sets the SELinux permissions for the agent if the OS requires it.
+func SetAgentPermissions(configPath, installPath string) error {
+	shouldSet, err := isSELinuxSupported()
+	if err != nil {
+		return fmt.Errorf("error checking if SELinux is supported: %w", err)
+	}
+	if !shouldSet {
+		return nil
+	}
+
+	// Load the SELinux policy module for the agent
+	fmt.Println("Loading SELinux policy module for datadog-agent.")
+	cmd := exec.Command("semodule", "-v", "-i", filepath.Join(configPath, "selinux/system_probe_policy.pp"))
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Couldn't load system-probe policy (%v).\n", err)
+		printManualInstructions(configPath, installPath)
+		return fmt.Errorf("couldn't load system-probe policy: %v", err)
+	}
+
+	// Check if semanage / restorecon are available
+	if !isInstalled("semanage") || !isInstalled("restorecon") {
+		fmt.Println("Couldn't load system-probe policy (missing selinux utilities).")
+		printManualInstructions(configPath, installPath)
+		return errors.New("missing selinux utilities")
+	}
+
+	// Label the system-probe binary
+	fmt.Println("Labeling SELinux type for the system-probe binary.")
+	cmd = exec.Command("semanage", "fcontext", "-a", "-t", "system_probe_t", filepath.Join(installPath, "embedded/bin/system-probe"))
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Couldn't install system-probe policy (%v).\n", err)
+		printManualInstructions(configPath, installPath)
+		return fmt.Errorf("couldn't install system-probe policy: %v", err)
+	}
+	cmd = exec.Command("semanage", "fcontext", "-a", "-t", "system_probe_t", filepath.Join(installPath, "bin/agent/agent"))
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Couldn't install system-probe policy (%v).\n", err)
+		printManualInstructions(configPath, installPath)
+		return fmt.Errorf("couldn't install system-probe policy: %v", err)
+	}
+	cmd = exec.Command("restorecon", "-v", filepath.Join(installPath, "embedded/bin/system-probe"))
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Couldn't install system-probe policy (%v).\n", err)
+		printManualInstructions(configPath, installPath)
+		return fmt.Errorf("couldn't install system-probe policy: %v", err)
+	}
+	cmd = exec.Command("restorecon", "-v", filepath.Join(installPath, "bin/agent/agent"))
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("Couldn't install system-probe policy (%v).\n", err)
+		printManualInstructions(configPath, installPath)
+		return fmt.Errorf("couldn't install system-probe policy: %v", err)
+	}
+
+	return nil
+}
+
+func printManualInstructions(configPath, installPath string) {
+	fmt.Printf(manualInstallTemplate, configPath, installPath)
+}
+
+// isSelinuxSupported checks if SELinux is supported on the host,
+// ie if the host is on RHEL 7
+func isSELinuxSupported() (bool, error) {
+	_, family, version, err := gopsutilhost.PlatformInformation()
+	if err != nil {
+		return false, fmt.Errorf("error getting platform information: %w", err)
+	}
+	return (family == "rhel" && version[0:1] == "7") && isInstalled("semodule"), nil
+}
+
+func isInstalled(program string) bool {
+	_, err := exec.LookPath(program)
+	return err == nil
+}

--- a/pkg/fleet/installer/packages/user/user.go
+++ b/pkg/fleet/installer/packages/user/user.go
@@ -16,7 +16,7 @@ import (
 )
 
 // EnsureAgentUserAndGroup ensures that the user and group required by the agent are present on the system.
-func EnsureAgentUserAndGroup(ctx context.Context) error {
+func EnsureAgentUserAndGroup(ctx context.Context, installPath string) error {
 	if _, err := user.LookupGroup("dd-agent"); err == nil {
 		return nil
 	}
@@ -27,7 +27,7 @@ func EnsureAgentUserAndGroup(ctx context.Context) error {
 	if _, err := user.Lookup("dd-agent"); err == nil {
 		return nil
 	}
-	err = exec.CommandContext(ctx, "useradd", "--system", "--shell", "/usr/sbin/nologin", "--home", "/opt/datadog-packages", "--no-create-home", "--no-user-group", "-g", "dd-agent", "dd-agent").Run()
+	err = exec.CommandContext(ctx, "useradd", "--system", "--shell", "/usr/sbin/nologin", "--home", installPath, "--no-create-home", "--no-user-group", "-g", "dd-agent", "dd-agent").Run()
 	if err != nil {
 		return fmt.Errorf("error creating dd-agent user: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?
- Create a path-dependent `PostInstallAgent` method
  - Except for ownership of files in `/etc/datadog-agent` & `/var/run/datadog`, it doesn't act outside of the agent install dir
  - It doesn't handle the systemd units
- Call it in Setup (stable path), StartExperiment (experiment path), StopExperiment (stable path), PromoteExperiment (stable path)
  - This will ensure the experiment is always properly set up   
- Add back deb/rpm install method write
- Adds integration's post.py to match the deb postinst / rpm posttrans
- Adds FIPS script to match the deb postinst / rpm posttrans
- Adds SELinux policy setup to match the deb postinst / rpm posttrans

### Motivation
Re-writing the deb postinst / rpm posttrans in Go. Next step is to make these scripts call the installer.

### Describe how you validated your changes
Manual QA on a VM, E2E tests

### Possible Drawbacks / Trade-offs

### Additional Notes
deb postinst / rpm posttrans will be updated in another PR