### PR TITLE
[clusteragent/api/v1/types] Optimize DeepCopy()

### DIFF
--- a/pkg/clusteragent/api/v1/types.go
+++ b/pkg/clusteragent/api/v1/types.go
@@ -61,7 +61,9 @@ func (m NamespacesPodsStringsSet) DeepCopy(old *NamespacesPodsStringsSet) Namesp
 			if _, ok := m[nsKey][pod]; !ok {
 				m[nsKey][pod] = sets.New[string]()
 			}
-			m[nsKey][pod] = m[nsKey][pod].Union(svcs)
+			for svc := range svcs {
+				m[nsKey][pod].Insert(svc)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR optimizes the `NamespacesPodsStringsSet.DeepCopy()` function in `pkg/clusteragent/api/v1/types.go`.

Previously, the function used `Union` to copy elements, which first clones the set before inserting item, introducing unnecessary overhead. This change replaces `Union` with a direct iteration over the items, calling `Insert` for each one.

This optimization reduces CPU usage in the Cluster Agent. In the profile of a large cluster that I've checked, this code previously accounted for ~2% of total CPU time. After the change, it drops to <1%.


### Describe how you validated your changes

This is covered by automated tests.
