### PR TITLE
apm: fix data race in stats writer

### DIFF
--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -175,6 +175,8 @@ func (w *DatadogStatsWriter) SendPayload(p *pb.StatsPayload) {
 }
 
 func (w *DatadogStatsWriter) sendPayloads() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	for _, p := range w.payloads {
 		w.SendPayload(p)
 	}

--- a/releasenotes/notes/statsrace-c56bd838484d6f5a.yaml
+++ b/releasenotes/notes/statsrace-c56bd838484d6f5a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix a rare panic that can occur when using client side stats in the tracers.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Resolves a data race in how we write stats. Adds a lock around sending the payloads. When using client stats this was causing a panic under heavy load.

### Motivation
Panics are bad

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I added a new test that replicates the exact panic + race to ensure this issue is resolved and doesn't reoccur. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->