### PR TITLE
[CNM] Fix panic when gwLookup has closed

### DIFF
--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -393,9 +393,6 @@ func (t *Tracer) Resume() error {
 
 // Stop stops the tracer
 func (t *Tracer) Stop() {
-	if t.gwLookup != nil {
-		t.gwLookup.Close()
-	}
 	if t.reverseDNS != nil {
 		t.reverseDNS.Close()
 	}
@@ -405,6 +402,9 @@ func (t *Tracer) Stop() {
 	}
 	if t.usmMonitor != nil {
 		t.usmMonitor.Stop()
+	}
+	if t.gwLookup != nil {
+		t.gwLookup.Close()
 	}
 	if t.conntracker != nil {
 		t.conntracker.Close()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes a panic seen infrequently: 
```
2025-03-05 16:44:38 UTC | SYS-PROBE | INFO | (comp/core/workloadmeta/collectors/internal/remote/generic.go:175 in func1) | workloadmeta stream established successfully
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1787026]
goroutine 611 [running]:
github.com/hashicorp/golang-lru/v2/internal.(*LruList[...]).MoveToFront(...)
	/pkg/mod/github.com/hashicorp/golang-lru/v2@v2.0.7/internal/list.go:137
github.com/hashicorp/golang-lru/v2/simplelru.(*LRU[...]).Get(0x3825d20, 0x273e79a)
	/pkg/mod/github.com/hashicorp/golang-lru/v2@v2.0.7/simplelru/lru.go:73 +0x46
github.com/DataDog/datadog-agent/pkg/network.(*gatewayLookup).LookupWithIPs(0xc004a9c700, {{{0xc000094fe8?, 0x273e860?}, {0xc0003c2078?}}}, {{{0x37cc6a0?, 0xc006be2840?}, {0xc0003c2078?}}}, 0x0?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/network/gateway_lookup_linux.go:139 +0xff
github.com/DataDog/datadog-agent/pkg/network.(*gatewayLookup).Lookup(0xc00486dec0?, 0xc0040adc68?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/network/gateway_lookup_linux.go:121 +0x51
github.com/DataDog/datadog-agent/pkg/network/tracer.(*Tracer).connVia(...)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer.go:788
github.com/DataDog/datadog-agent/pkg/network/tracer.(*Tracer).storeClosedConnection(0xc000a1c1c0, 0xc0040adc20)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/network/tracer/tracer.go:332 +0xdf
github.com/DataDog/datadog-agent/pkg/network/tracer/connection.(*tcpCloseConsumer).Callback(0xc0047b98c0, 0xc0040adc20)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/network/tracer/connection/tcp_close_consumer.go:98 +0x7c
github.com/DataDog/datadog-agent/pkg/network/tracer/connection.(*ebpfTracer).closedPerfCallback(...)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/network/tracer/connection/ebpf_tracer.go:349
github.com/DataDog/datadog-agent/pkg/network/tracer/connection.initClosedConnEventHandler.func1(0xc0040adc20?, {0x0?, 0x0?})
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/network/tracer/connection/ebpf_tracer.go:292 +0xfc
github.com/DataDog/datadog-agent/pkg/network/tracer/connection.initClosedConnEventHandler.BinaryUnmarshalCallback[...].func3()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/util/encoding/binary.go:34 +0xa6
github.com/DataDog/datadog-agent/pkg/ebpf/perf.(*EventHandler).ringLoopHandler(0xc0007800a0?, 0xc0066295a0?)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/ebpf/perf/event.go:423 +0x6d
github.com/DataDog/datadog-agent/pkg/ebpf/perf.(*EventHandler).ringLoop(...)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/ebpf/perf/event.go:409
created by github.com/DataDog/datadog-agent/pkg/ebpf/perf.(*EventHandler).PreStart in goroutine 1
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/ebpf/perf/event.go:301 +0x1a
```

This looks like a race where a call to `Tracer.Close()` has closed the gateway lookup object (and the cache that goes with it), while another in the closed connection callback is also using the cache. The gateway lookup close is now moved to after the the ebpf tracer is closed so the closed connection callbacks stop first.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->