### PR TITLE
[AI-5037] Fix embedded `gstatus` binary using wrong python env

### DIFF
--- a/omnibus/config/software/gstatus.rb
+++ b/omnibus/config/software/gstatus.rb
@@ -26,6 +26,9 @@ source :url => "https://github.com/gluster/gstatus/releases/download/v#{version}
 build do
   license "GPL-3.0"
 
+  # fix the shebang of the gstatus artifact to use the embedded agent python environment
+  # #!/usr/bin/env python3 -> #!/opt/datadog-agent/embedded/bin/python
+  command "sed -i '1s|.*|#!#{install_dir}/embedded/bin/python|' gstatus"
   copy "gstatus", "#{install_dir}/embedded/sbin/gstatus"
   command "chmod +x #{install_dir}/embedded/sbin/gstatus"
 end

--- a/releasenotes/notes/fix-embedded-gstatus-missing-package-error-5bcf18520799459f.yaml
+++ b/releasenotes/notes/fix-embedded-gstatus-missing-package-error-5bcf18520799459f.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Fix the shebang of the `gstatus` binary to use the embededd python environment.

--- a/releasenotes/notes/fix-embedded-gstatus-missing-package-error-5bcf18520799459f.yaml
+++ b/releasenotes/notes/fix-embedded-gstatus-missing-package-error-5bcf18520799459f.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fix the shebang of the `gstatus` binary to use the embededd python environment.
+    Fix the shebang of the `gstatus` binary to use the embedded Python environment.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes the embedded `gstatus` binary shebang `#!/usr/bin/env python3` to point to the agent embedded python environment.

### Motivation

Fixes an error in the latest gstatus broken release, that is installed with a missing `packaging` dependency. 
This is a short time fix that will be resolved in a separate PR for a better work around.

https://datadoghq.atlassian.net/browse/AI-5037

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manual testing in EC2.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->