### PR TITLE
[DJM] Fix jobid runid parsing logic

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -156,7 +156,7 @@ func getJobAndRunIDs() (jobID, runID string, ok bool) {
 		return "", "", false
 	}
 	parts := strings.Split(clusterName, "-")
-	if len(parts) != 4 {
+	if len(parts) < 4 {
 		return "", "", false
 	}
 	if parts[0] != "job" || parts[2] != "run" {

--- a/pkg/fleet/installer/setup/djm/databricks_test.go
+++ b/pkg/fleet/installer/setup/djm/databricks_test.go
@@ -85,3 +85,47 @@ func TestSetupCommonHostTags(t *testing.T) {
 		})
 	}
 }
+
+func TestGetJobAndRunIDs(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           map[string]string
+		expectedJobID string
+		expectedRunID string
+		expectedOk    bool
+	}{
+		{
+			name: "Valid job and run ID",
+			env: map[string]string{
+				"DB_CLUSTER_NAME": "job-605777310657626-run-1020337925419295-databricks_cost_job_cluster",
+			},
+			expectedJobID: "605777310657626",
+			expectedRunID: "1020337925419295",
+			expectedOk:    true,
+		},
+		{
+			name: "Invalid cluster name",
+			env: map[string]string{
+				"DB_CLUSTER_NAME": "invalid-cluster-name",
+			},
+			expectedJobID: "",
+			expectedRunID: "",
+			expectedOk:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			for k, v := range tt.env {
+				require.NoError(t, os.Setenv(k, v))
+			}
+
+			jobID, runID, ok := getJobAndRunIDs()
+
+			assert.Equal(t, tt.expectedJobID, jobID)
+			assert.Equal(t, tt.expectedRunID, runID)
+			assert.Equal(t, tt.expectedOk, ok)
+		})
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
New logic accepts DB_CLUSTER_NAME with more than 4 hyphens and simply dumps the part after the 4 hyphens, focusing on the 2nd and 4th parts.
### Motivation
Current logic breaks for name with more than 4 hyphens like `DB_CLUSTER_NAME=job-605777310657626-run-1020337925419295-databricks_cost_job_cluster`, which is common. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->