### PR TITLE
Use agent commands client when adding process agent files to flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -224,7 +224,8 @@ func getProcessAgentFullConfig() ([]byte, error) {
 
 	procStatusURL := fmt.Sprintf("https://%s/config/all", addressPort)
 
-	bytes, err := getHTTPCallContent(procStatusURL)
+	c := apiutil.GetClient(false) // FIX: get certificates right then make this true
+	bytes, err := apiutil.DoGet(c, procStatusURL, apiutil.LeaveConnectionOpen)
 	if err != nil {
 		return []byte("error: process-agent is not running or is unreachable\n"), nil
 	}
@@ -247,11 +248,12 @@ func getChecksFromProcessAgent(fb flaretypes.FlareBuilder, getAddressPort func()
 			return
 		}
 
-		err := fb.AddFileFromFunc(filename, func() ([]byte, error) { return getHTTPCallContent(checkURL + checkName) })
+		c := apiutil.GetClient(false) // FIX: get certificates right then make this true
+		err := fb.AddFileFromFunc(filename, func() ([]byte, error) { return apiutil.DoGet(c, checkURL+checkName, apiutil.LeaveConnectionOpen) })
 		if err != nil {
 			fb.AddFile( //nolint:errcheck
-				"process_check_output.json",
-				[]byte(fmt.Sprintf("error: process-agent is not running or is unreachable: %s", err.Error())),
+				filename,
+				[]byte(err.Error()),
 			)
 		}
 	}

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -234,8 +234,7 @@ func TestProcessAgentChecks(t *testing.T) {
 	t.Run("without process-agent running", func(t *testing.T) {
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
 		getChecksFromProcessAgent(mock, func() (string, error) { return "fake:1337", nil })
-
-		mock.AssertFileContentMatch("error: process-agent is not running or is unreachable: error collecting data for 'process_discovery_check_output.json': .*", "process_check_output.json")
+		mock.AssertFileContentMatch("error collecting data for 'process_discovery_check_output.json': .*", "process_discovery_check_output.json")
 	})
 	t.Run("with process-agent running", func(t *testing.T) {
 		cfg := configmock.New(t)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
-	"github.com/DataDog/datadog-agent/comp/process/apiserver"
 	processapiserver "github.com/DataDog/datadog-agent/comp/process/apiserver"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	model "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -87,7 +86,7 @@ func setupIPCAddress(t *testing.T, confMock model.Config, URL string) {
 
 func setupProcessAPIServer(t *testing.T, port int) {
 	_ = fxutil.Test[processapiserver.Component](t, fx.Options(
-		apiserver.Module(),
+		processapiserver.Module(),
 		core.MockBundle(),
 		fx.Replace(config.MockParams{Overrides: map[string]interface{}{
 			"process_config.cmd_port": port,
@@ -324,6 +323,7 @@ func TestProcessAgentChecks(t *testing.T) {
 		listener, err := net.Listen("tcp", ":0")
 		require.NoError(t, err)
 		port := listener.Addr().(*net.TCPAddr).Port
+		defer listener.Close()
 
 		setupProcessAPIServer(t, port)
 

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -320,16 +320,13 @@ func TestProcessAgentChecks(t *testing.T) {
 		mock.AssertFileContent(string(expectedProcessDiscoveryJSON), "process_discovery_check_output.json")
 	})
 	t.Run("verify auth", func(t *testing.T) {
-		listener, err := net.Listen("tcp", ":0")
-		require.NoError(t, err)
-		port := listener.Addr().(*net.TCPAddr).Port
-		defer listener.Close()
-
+		// Setting an unused port to avoid problem when test run next to running Process Agent
+		port := 56789
 		setupProcessAPIServer(t, port)
 
 		cfg := configmock.New(t)
 		cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-		cfg.SetWithoutSource("process_config.cmd_port", port)
+		cfg.SetWithoutSource("process_config.cmd_port", 56789)
 
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
 		getChecksFromProcessAgent(mock, getProcessAPIAddressPort)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -231,6 +231,11 @@ process_config:
 	})
 
 	t.Run("verify auth", func(t *testing.T) {
+		listener, err := net.Listen("tcp", ":0")
+		require.NoError(t, err)
+		port := listener.Addr().(*net.TCPAddr).Port
+		listener.Close()
+
 		setupProcessAPIServer(t, port)
 
 		cfg := configmock.New(t)
@@ -320,13 +325,16 @@ func TestProcessAgentChecks(t *testing.T) {
 		mock.AssertFileContent(string(expectedProcessDiscoveryJSON), "process_discovery_check_output.json")
 	})
 	t.Run("verify auth", func(t *testing.T) {
-		// Setting an unused port to avoid problem when test run next to running Process Agent
-		port := 56789
+		listener, err := net.Listen("tcp", ":0")
+		require.NoError(t, err)
+		port := listener.Addr().(*net.TCPAddr).Port
+		listener.Close()
+
 		setupProcessAPIServer(t, port)
 
 		cfg := configmock.New(t)
 		cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-		cfg.SetWithoutSource("process_config.cmd_port", 56789)
+		cfg.SetWithoutSource("process_config.cmd_port", port)
 
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
 		getChecksFromProcessAgent(mock, getProcessAPIAddressPort)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/pull/31940 introduced a bug where the prcess agent files in the generated flares only had `no session token provided` as the content. This was due the client in use not providing the auth token in requests. This PR fixes the issue by using the `apiutil.DoGet` method instead as it does add the auth token.

### Motivation

Flares from support escalations had this issue.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Validated manually by building a flare and verifying process agent files had actual content.

```
$ cat process_check_output.json
[
  {
    "hostName": "agent-dev-ubuntu-24",
    "processes": [
      {
        "pid": 1,
        "nsPid": 1,
        "command": {
          "args": [
            "/sbin/init",
            "autoinstall"
          ],
          "comm": "systemd"
...
```

Added unit tests which fail on main but pass on feature branch
```
    archive_test.go:244:
        	Error Trace:	/git/datadog-agent/pkg/flare/archive_test.go:244
        	Error:      	Not equal:
        	            	expected: ""
        	            	actual  : "no session token provided\n"

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1,2 @@
        	            	+no session token provided

        	Test:       	TestProcessAgentFullConfig/verify_auth

=== FAIL: pkg/flare TestProcessAgentFullConfig (0.03s)
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->