### PR TITLE
[CWS] Allow setting a variable value to an expression

### DIFF
--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -19,8 +19,9 @@ import (
 
 // ParsingContext defines a parsing context
 type ParsingContext struct {
-	ruleParser  *participle.Parser
-	macroParser *participle.Parser
+	ruleParser       *participle.Parser
+	macroParser      *participle.Parser
+	expressionParser *participle.Parser
 
 	ruleCache map[string]*Rule
 }
@@ -54,9 +55,10 @@ any = "\u0000"…"\uffff" .
 	}
 
 	return &ParsingContext{
-		ruleParser:  buildParser(&Rule{}, seclLexer),
-		macroParser: buildParser(&Macro{}, seclLexer),
-		ruleCache:   ruleCache,
+		ruleParser:       buildParser(&Rule{}, seclLexer),
+		macroParser:      buildParser(&Macro{}, seclLexer),
+		expressionParser: buildParser(&Expression{}, seclLexer),
+		ruleCache:        ruleCache,
 	}
 }
 
@@ -138,6 +140,17 @@ func (pc *ParsingContext) ParseMacro(expr string) (*Macro, error) {
 	}
 
 	return macro, nil
+}
+
+// ParseExpression parses a SECL expression
+func (pc *ParsingContext) ParseExpression(expr string) (*Expression, error) {
+	expression := &Expression{}
+	err := pc.expressionParser.Parse(bytes.NewBufferString(expr), expression)
+	if err != nil {
+		return nil, err
+	}
+
+	return expression, nil
 }
 
 // Macro describes a SECL macro

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -347,8 +347,8 @@ func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, sta
 	return evaluator, nil
 }
 
-// StringValuesContainsWrapper makes use of operator overrides
-func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
+// stringValuesContainsWrapper makes use of operator overrides
+func stringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -364,8 +364,8 @@ func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, s
 	return evaluator, nil
 }
 
-// StringArrayMatchesWrapper makes use of operator overrides
-func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
+// stringArrayMatchesWrapper makes use of operator overrides
+func stringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, state *State) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -379,6 +379,11 @@ func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator
 	}
 
 	return evaluator, nil
+}
+
+// NodeToEvaluator converts an AST expression to an evaluator
+func NodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+	return nodeToEvaluator(obj, opts, state)
 }
 
 func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, lexer.Position, error) {
@@ -560,7 +565,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 						return nil, pos, err
 					}
 				case *StringValuesEvaluator:
-					boolEvaluator, err = StringValuesContainsWrapper(unary, nextString, state)
+					boolEvaluator, err = stringValuesContainsWrapper(unary, nextString, state)
 					if err != nil {
 						return nil, pos, err
 					}
@@ -574,7 +579,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			case *StringValuesEvaluator:
 				switch nextStringArray := next.(type) {
 				case *StringArrayEvaluator:
-					boolEvaluator, err = StringArrayMatchesWrapper(nextStringArray, unary, state)
+					boolEvaluator, err = stringArrayMatchesWrapper(nextStringArray, unary, state)
 					if err != nil {
 						return nil, pos, err
 					}
@@ -588,7 +593,7 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 			case *StringArrayEvaluator:
 				switch nextStringArray := next.(type) {
 				case *StringValuesEvaluator:
-					boolEvaluator, err = StringArrayMatchesWrapper(unary, nextStringArray, state)
+					boolEvaluator, err = stringArrayMatchesWrapper(unary, nextStringArray, state)
 					if err != nil {
 						return nil, pos, err
 					}

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -878,6 +878,30 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, le
 					}
 					return nil, pos, NewOpUnknownError(obj.Pos, *obj.ScalarComparison.Op)
 				}
+
+			case *CIDRArrayEvaluator:
+				cidrEvaluator, ok := next.(*CIDREvaluator)
+				if !ok {
+					return nil, pos, NewTypeError(pos, reflect.String)
+				}
+
+				switch *obj.ScalarComparison.Op {
+				case "!=":
+					boolEvaluator, err = CIDRArrayMatchesCIDREvaluator(unary, cidrEvaluator, state)
+					if err != nil {
+						return nil, obj.Pos, err
+					}
+					return Not(boolEvaluator, state), obj.Pos, nil
+				case "==":
+					boolEvaluator, err = CIDRArrayMatchesCIDREvaluator(unary, cidrEvaluator, state)
+					if err != nil {
+						return nil, pos, err
+					}
+					return boolEvaluator, obj.Pos, nil
+				}
+
+				return nil, pos, NewOpUnknownError(obj.Pos, *obj.ArrayComparison.Op)
+
 			case *StringArrayEvaluator:
 				nextString, ok := next.(*StringEvaluator)
 				if !ok {

--- a/pkg/security/secl/compiler/eval/evaluators.go
+++ b/pkg/security/secl/compiler/eval/evaluators.go
@@ -34,7 +34,10 @@ type BoolEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (b *BoolEvaluator) Eval(ctx *Context) interface{} {
-	return b.EvalFnc(ctx)
+	if b.EvalFnc != nil {
+		return b.EvalFnc(ctx)
+	}
+	return b.Value
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -68,7 +71,10 @@ type IntEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (i *IntEvaluator) Eval(ctx *Context) interface{} {
-	return i.EvalFnc(ctx)
+	if i.EvalFnc != nil {
+		return i.EvalFnc(ctx)
+	}
+	return i.Value
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -102,7 +108,10 @@ type StringEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (s *StringEvaluator) Eval(ctx *Context) interface{} {
-	return s.EvalFnc(ctx)
+	if s.EvalFnc != nil {
+		return s.EvalFnc(ctx)
+	}
+	return s.Value
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -156,7 +165,10 @@ type StringArrayEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (s *StringArrayEvaluator) Eval(ctx *Context) interface{} {
-	return s.EvalFnc(ctx)
+	if s.EvalFnc != nil {
+		return s.EvalFnc(ctx)
+	}
+	return s.Values
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -191,7 +203,10 @@ type StringValuesEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (s *StringValuesEvaluator) Eval(ctx *Context) interface{} {
-	return s.EvalFnc(ctx)
+	if s.EvalFnc != nil {
+		return s.EvalFnc(ctx)
+	}
+	return s.Values
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -257,7 +272,10 @@ type IntArrayEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (i *IntArrayEvaluator) Eval(ctx *Context) interface{} {
-	return i.EvalFnc(ctx)
+	if i.EvalFnc != nil {
+		return i.EvalFnc(ctx)
+	}
+	return i.Values
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -294,7 +312,10 @@ type BoolArrayEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (b *BoolArrayEvaluator) Eval(ctx *Context) interface{} {
-	return b.EvalFnc(ctx)
+	if b.EvalFnc != nil {
+		return b.EvalFnc(ctx)
+	}
+	return b.Values
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -363,7 +384,10 @@ type CIDRValuesEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (s *CIDRValuesEvaluator) Eval(ctx *Context) interface{} {
-	return s.EvalFnc(ctx)
+	if s.EvalFnc != nil {
+		s.EvalFnc(ctx)
+	}
+	return s.Value
 }
 
 // IsDeterministicFor returns whether the evaluator is partial
@@ -396,7 +420,10 @@ type CIDRArrayEvaluator struct {
 
 // Eval returns the result of the evaluation
 func (s *CIDRArrayEvaluator) Eval(ctx *Context) interface{} {
-	return s.EvalFnc(ctx)
+	if s.EvalFnc != nil {
+		return s.EvalFnc(ctx)
+	}
+	return s.Value
 }
 
 // IsDeterministicFor returns whether the evaluator is partial

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -341,19 +341,19 @@ func NewScopedIPArrayVariable(ipFnc func(ctx *Context) ([]net.IPNet, bool), setF
 
 // IntVariable describes a global integer variable
 type IntVariable struct {
-	set   bool
+	isSet bool
 	Value int
 }
 
 // GetValue returns the variable value
 func (m *IntVariable) GetValue() (interface{}, bool) {
-	return m.Value, m.set
+	return m.Value, m.isSet
 }
 
 // Set the variable with the specified value
 func (m *IntVariable) Set(_ *Context, value interface{}) error {
-	m.set = true
 	m.Value = value.(int)
+	m.isSet = true
 	return nil
 }
 
@@ -361,8 +361,8 @@ func (m *IntVariable) Set(_ *Context, value interface{}) error {
 func (m *IntVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
-		m.set = true
 		m.Value += value
+		m.isSet = true
 	default:
 		return errAppendNotSupported
 	}
@@ -380,7 +380,7 @@ func (m *IntVariable) GetEvaluator() interface{} {
 
 // BoolVariable describes a mutable boolean variable
 type BoolVariable struct {
-	set   bool
+	isSet bool
 	Value bool
 }
 
@@ -394,19 +394,19 @@ func (m *BoolVariable) GetEvaluator() interface{} {
 }
 
 // NewIntVariable returns a new mutable integer variable
-func NewIntVariable() *IntVariable {
-	return &IntVariable{}
+func NewIntVariable(value int) *IntVariable {
+	return &IntVariable{Value: value}
 }
 
 // GetValue returns the variable value
 func (m *BoolVariable) GetValue() (interface{}, bool) {
-	return m.Value, m.set
+	return m.Value, m.isSet
 }
 
 // Set the variable with the specified value
 func (m *BoolVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(bool)
-	m.set = true
+	m.isSet = true
 	return nil
 }
 
@@ -416,14 +416,14 @@ func (m *BoolVariable) Append(_ *Context, _ interface{}) error {
 }
 
 // NewBoolVariable returns a new mutable boolean variable
-func NewBoolVariable() *BoolVariable {
-	return &BoolVariable{}
+func NewBoolVariable(value bool) *BoolVariable {
+	return &BoolVariable{Value: value}
 }
 
 // StringVariable describes a mutable string variable
 type StringVariable struct {
 	Value string
-	set   bool
+	isSet bool
 }
 
 // GetEvaluator returns the variable SECL evaluator
@@ -438,7 +438,7 @@ func (m *StringVariable) GetEvaluator() interface{} {
 
 // GetValue returns the variable value
 func (m *StringVariable) GetValue() (interface{}, bool) {
-	return m.Value, m.set
+	return m.Value, m.isSet
 }
 
 // Append a value to the string
@@ -446,7 +446,7 @@ func (m *StringVariable) Append(_ *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
 		m.Value += value
-		m.set = true
+		m.isSet = true
 	default:
 		return errAppendNotSupported
 	}
@@ -456,30 +456,30 @@ func (m *StringVariable) Append(_ *Context, value interface{}) error {
 // Set the variable with the specified value
 func (m *StringVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(string)
-	m.set = true
+	m.isSet = true
 	return nil
 }
 
 // NewStringVariable returns a new mutable string variable
-func NewStringVariable() *StringVariable {
-	return &StringVariable{}
+func NewStringVariable(value string) *StringVariable {
+	return &StringVariable{Value: value}
 }
 
 // IPVariable describes a global IP variable
 type IPVariable struct {
 	Value net.IPNet
-	set   bool
+	isSet bool
 }
 
 // GetValue returns the variable value
 func (m *IPVariable) GetValue() (interface{}, bool) {
-	return m.Value, m.set
+	return m.Value, m.isSet
 }
 
 // Set the variable with the specified value
 func (m *IPVariable) Set(_ *Context, value interface{}) error {
 	m.Value = value.(net.IPNet)
-	m.set = true
+	m.isSet = true
 	return nil
 }
 
@@ -498,31 +498,38 @@ func (m *IPVariable) GetEvaluator() interface{} {
 }
 
 // NewIPVariable returns a new mutable IP variable
-func NewIPVariable() *IPVariable {
-	return &IPVariable{}
+func NewIPVariable(value net.IPNet) *IPVariable {
+	return &IPVariable{Value: value}
 }
 
 // StringArrayVariable describes a mutable string array variable
 type StringArrayVariable struct {
-	LRU *ttlcache.Cache[string, bool]
+	isSet bool
+	LRU   *ttlcache.Cache[string, bool]
 }
 
 // GetValue returns the variable value
 func (m *StringArrayVariable) GetValue() (interface{}, bool) {
 	keys := m.LRU.Keys()
-	return keys, len(keys) != 0
+	return keys, len(keys) != 0 && m.isSet
 }
 
-// Set the variable with the specified value
-func (m *StringArrayVariable) Set(_ *Context, values interface{}) error {
+func (m *StringArrayVariable) set(_ *Context, values interface{}) error {
 	if s, ok := values.(string); ok {
 		values = []string{s}
 	}
-
 	for _, v := range values.([]string) {
 		m.LRU.Set(v, true, ttlcache.DefaultTTL)
 	}
+	return nil
+}
 
+// Set the variable with the specified value
+func (m *StringArrayVariable) Set(ctx *Context, values interface{}) error {
+	if err := m.set(ctx, values); err != nil {
+		return err
+	}
+	m.isSet = true
 	return nil
 }
 
@@ -538,6 +545,7 @@ func (m *StringArrayVariable) Append(_ *Context, value interface{}) error {
 	default:
 		return errAppendNotSupported
 	}
+	m.isSet = true
 	return nil
 }
 
@@ -551,7 +559,7 @@ func (m *StringArrayVariable) GetEvaluator() interface{} {
 }
 
 // NewStringArrayVariable returns a new mutable string array variable
-func NewStringArrayVariable(size int, ttl time.Duration) *StringArrayVariable {
+func NewStringArrayVariable(value []string, size int, ttl time.Duration) *StringArrayVariable {
 	if size == 0 {
 		size = defaultMaxVariables
 	}
@@ -559,24 +567,26 @@ func NewStringArrayVariable(size int, ttl time.Duration) *StringArrayVariable {
 	lru := ttlcache.New(ttlcache.WithCapacity[string, bool](uint64(size)), ttlcache.WithTTL[string, bool](ttl))
 	go lru.Start()
 
-	return &StringArrayVariable{
+	v := &StringArrayVariable{
 		LRU: lru,
 	}
+	_ = v.set(nil, value)
+	return v
 }
 
 // IntArrayVariable describes a mutable integer array variable
 type IntArrayVariable struct {
-	LRU *ttlcache.Cache[int, bool]
+	isSet bool
+	LRU   *ttlcache.Cache[int, bool]
 }
 
 // GetValue returns the variable value
 func (m *IntArrayVariable) GetValue() (interface{}, bool) {
 	keys := m.LRU.Keys()
-	return keys, len(keys) != 0
+	return keys, len(keys) != 0 && m.isSet
 }
 
-// Set the variable with the specified value
-func (m *IntArrayVariable) Set(_ *Context, values interface{}) error {
+func (m *IntArrayVariable) set(_ *Context, values interface{}) error {
 	if i, ok := values.(int); ok {
 		values = []int{i}
 	}
@@ -585,6 +595,15 @@ func (m *IntArrayVariable) Set(_ *Context, values interface{}) error {
 		m.LRU.Set(v, true, ttlcache.DefaultTTL)
 	}
 
+	return nil
+}
+
+// Set the variable with the specified value
+func (m *IntArrayVariable) Set(ctx *Context, values interface{}) error {
+	if err := m.set(ctx, values); err != nil {
+		return err
+	}
+	m.isSet = true
 	return nil
 }
 
@@ -600,6 +619,7 @@ func (m *IntArrayVariable) Append(_ *Context, value interface{}) error {
 	default:
 		return errAppendNotSupported
 	}
+	m.isSet = true
 	return nil
 }
 
@@ -613,7 +633,7 @@ func (m *IntArrayVariable) GetEvaluator() interface{} {
 }
 
 // NewIntArrayVariable returns a new mutable integer array variable
-func NewIntArrayVariable(size int, ttl time.Duration) *IntArrayVariable {
+func NewIntArrayVariable(value []int, size int, ttl time.Duration) *IntArrayVariable {
 	if size == 0 {
 		size = defaultMaxVariables
 	}
@@ -621,14 +641,17 @@ func NewIntArrayVariable(size int, ttl time.Duration) *IntArrayVariable {
 	lru := ttlcache.New(ttlcache.WithCapacity[int, bool](uint64(size)), ttlcache.WithTTL[int, bool](ttl))
 	go lru.Start()
 
-	return &IntArrayVariable{
+	v := &IntArrayVariable{
 		LRU: lru,
 	}
+	_ = v.set(nil, value)
+	return v
 }
 
 // IPArrayVariable describes a global IP array variable
 type IPArrayVariable struct {
-	LRU *ttlcache.Cache[string, bool]
+	LRU   *ttlcache.Cache[string, bool]
+	isSet bool
 }
 
 // GetValue returns the variable value
@@ -640,11 +663,10 @@ func (m *IPArrayVariable) GetValue() (interface{}, bool) {
 			keys = append(keys, *ipNet)
 		}
 	}
-	return keys, len(keys) != 0
+	return keys, len(keys) != 0 && m.isSet
 }
 
-// Set the variable with the specified value
-func (m *IPArrayVariable) Set(_ *Context, values interface{}) error {
+func (m *IPArrayVariable) set(_ *Context, values interface{}) error {
 	if ip, ok := values.(net.IPNet); ok {
 		values = []net.IPNet{ip}
 	}
@@ -653,6 +675,15 @@ func (m *IPArrayVariable) Set(_ *Context, values interface{}) error {
 		m.LRU.Set(v.String(), true, ttlcache.DefaultTTL)
 	}
 
+	return nil
+}
+
+// Set the variable with the specified value
+func (m *IPArrayVariable) Set(ctx *Context, values interface{}) error {
+	if err := m.set(ctx, values); err != nil {
+		return err
+	}
+	m.isSet = true
 	return nil
 }
 
@@ -668,6 +699,8 @@ func (m *IPArrayVariable) Append(_ *Context, value interface{}) error {
 	default:
 		return errAppendNotSupported
 	}
+
+	m.isSet = true
 	return nil
 }
 
@@ -688,7 +721,7 @@ func (m *IPArrayVariable) GetEvaluator() interface{} {
 }
 
 // NewIPArrayVariable returns a new mutable IP array variable
-func NewIPArrayVariable(size int, ttl time.Duration) *IPArrayVariable {
+func NewIPArrayVariable(value []net.IPNet, size int, ttl time.Duration) *IPArrayVariable {
 	if size == 0 {
 		size = defaultMaxVariables
 	}
@@ -696,9 +729,11 @@ func NewIPArrayVariable(size int, ttl time.Duration) *IPArrayVariable {
 	lru := ttlcache.New(ttlcache.WithCapacity[string, bool](uint64(size)), ttlcache.WithTTL[string, bool](ttl))
 	go lru.Start()
 
-	return &IPArrayVariable{
+	v := &IPArrayVariable{
 		LRU: lru,
 	}
+	_ = v.set(nil, value)
+	return v
 }
 
 // VariableScope is the interface to be implemented by scoped variable in order to be released
@@ -727,19 +762,19 @@ func NewVariables() *Variables {
 func newSECLVariable(value interface{}, opts VariableOpts) (MutableSECLVariable, error) {
 	switch value := value.(type) {
 	case bool:
-		return NewBoolVariable(), nil
+		return NewBoolVariable(value), nil
 	case int:
-		return NewIntVariable(), nil
+		return NewIntVariable(value), nil
 	case string:
-		return NewStringVariable(), nil
+		return NewStringVariable(value), nil
 	case net.IPNet:
-		return NewIPVariable(), nil
+		return NewIPVariable(value), nil
 	case []string:
-		return NewStringArrayVariable(opts.Size, opts.TTL), nil
+		return NewStringArrayVariable(value, opts.Size, opts.TTL), nil
 	case []int:
-		return NewIntArrayVariable(opts.Size, opts.TTL), nil
+		return NewIntArrayVariable(value, opts.Size, opts.TTL), nil
 	case []net.IPNet:
-		return NewIPArrayVariable(opts.Size, opts.TTL), nil
+		return NewIPArrayVariable(value, opts.Size, opts.TTL), nil
 	default:
 		return nil, fmt.Errorf("unsupported value type: %s", reflect.TypeOf(value))
 	}
@@ -775,9 +810,6 @@ func (v *ScopedVariables) Len() int {
 func (v *ScopedVariables) NewSECLVariable(name string, value interface{}, opts VariableOpts) (SECLVariable, error) {
 	getVariable := func(ctx *Context) MutableSECLVariable {
 		scope := v.scoper(ctx)
-		if scope == nil {
-			return nil
-		}
 		key := scope.Hash()
 		v := v.vars[key]
 		return v[name]

--- a/pkg/security/secl/rules/actions.go
+++ b/pkg/security/secl/rules/actions.go
@@ -35,7 +35,7 @@ func (a *ActionDefinition) Check(opts PolicyLoaderOpts) error {
 		}
 
 		if a.Set.Name == "" {
-			return errors.New("action name is empty")
+			return errors.New("variable name is empty")
 		}
 
 		if (a.Set.Value == nil && a.Set.Field == "") || (a.Set.Value != nil && a.Set.Field != "") {

--- a/pkg/security/secl/rules/actions.go
+++ b/pkg/security/secl/rules/actions.go
@@ -9,6 +9,7 @@ package rules
 import (
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -38,8 +39,17 @@ func (a *ActionDefinition) Check(opts PolicyLoaderOpts) error {
 			return errors.New("variable name is empty")
 		}
 
-		if (a.Set.Value == nil && a.Set.Field == "") || (a.Set.Value != nil && a.Set.Field != "") {
-			return errors.New("either 'value' or 'field' must be specified")
+		if a.Set.DefaultValue != nil {
+			if defaultValueType, valueType := reflect.TypeOf(a.Set.DefaultValue), reflect.TypeOf(a.Set.Value); valueType != nil && defaultValueType != valueType {
+				return fmt.Errorf("'default_value' and 'value' must be of the same type (%s != %s)", defaultValueType, valueType)
+			}
+		}
+
+		if (a.Set.Value == nil && a.Set.Expression == "" && a.Set.Field == "") ||
+			(a.Set.Expression != "" && a.Set.Field != "") ||
+			(a.Set.Field != "" && a.Set.Value != nil) ||
+			(a.Set.Value != nil && a.Set.Expression != "") {
+			return errors.New("either 'value', 'field' or 'expression' must be specified")
 		}
 	} else if a.Kill != nil {
 		if opts.DisableEnforcement {

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -134,14 +134,15 @@ type Scope string
 
 // SetDefinition describes the 'set' section of a rule action
 type SetDefinition struct {
-	Name       string                 `yaml:"name" json:"name"`
-	Value      interface{}            `yaml:"value" json:"value,omitempty" jsonschema:"oneof_required=SetWithValue,oneof_type=string;integer;boolean;array"`
-	Field      string                 `yaml:"field" json:"field,omitempty" jsonschema:"oneof_required=SetWithField"`
-	Expression string                 `yaml:"expression" json:"expression,omitempty"`
-	Append     bool                   `yaml:"append" json:"append,omitempty"`
-	Scope      Scope                  `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=container,enum=cgroup"`
-	Size       int                    `yaml:"size" json:"size,omitempty"`
-	TTL        *HumanReadableDuration `yaml:"ttl" json:"ttl,omitempty"`
+	Name         string                 `yaml:"name" json:"name"`
+	Value        interface{}            `yaml:"value" json:"value,omitempty" jsonschema:"oneof_required=SetWithValue,oneof_type=string;integer;boolean;array"`
+	DefaultValue interface{}            `yaml:"default_value" json:"default_value,omitempty" jsonschema:"oneof_type=string;integer;boolean;array"`
+	Field        string                 `yaml:"field" json:"field,omitempty" jsonschema:"oneof_required=SetWithField"`
+	Expression   string                 `yaml:"expression" json:"expression,omitempty"`
+	Append       bool                   `yaml:"append" json:"append,omitempty"`
+	Scope        Scope                  `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=container,enum=cgroup"`
+	Size         int                    `yaml:"size" json:"size,omitempty"`
+	TTL          *HumanReadableDuration `yaml:"ttl" json:"ttl,omitempty"`
 }
 
 // KillDisarmerParamsDefinition describes the parameters of a kill action disarmer

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -134,13 +134,14 @@ type Scope string
 
 // SetDefinition describes the 'set' section of a rule action
 type SetDefinition struct {
-	Name   string                 `yaml:"name" json:"name"`
-	Value  interface{}            `yaml:"value" json:"value,omitempty" jsonschema:"oneof_required=SetWithValue,oneof_type=string;integer;boolean;array"`
-	Field  string                 `yaml:"field" json:"field,omitempty" jsonschema:"oneof_required=SetWithField"`
-	Append bool                   `yaml:"append" json:"append,omitempty"`
-	Scope  Scope                  `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=container,enum=cgroup"`
-	Size   int                    `yaml:"size" json:"size,omitempty"`
-	TTL    *HumanReadableDuration `yaml:"ttl" json:"ttl,omitempty"`
+	Name       string                 `yaml:"name" json:"name"`
+	Value      interface{}            `yaml:"value" json:"value,omitempty" jsonschema:"oneof_required=SetWithValue,oneof_type=string;integer;boolean;array"`
+	Field      string                 `yaml:"field" json:"field,omitempty" jsonschema:"oneof_required=SetWithField"`
+	Expression string                 `yaml:"expression" json:"expression,omitempty"`
+	Append     bool                   `yaml:"append" json:"append,omitempty"`
+	Scope      Scope                  `yaml:"scope" json:"scope,omitempty" jsonschema:"enum=process,enum=container,enum=cgroup"`
+	Size       int                    `yaml:"size" json:"size,omitempty"`
+	TTL        *HumanReadableDuration `yaml:"ttl" json:"ttl,omitempty"`
 }
 
 // KillDisarmerParamsDefinition describes the parameters of a kill action disarmer

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -10,6 +10,7 @@ package rules
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -656,32 +657,59 @@ func TestActionSetVariableConflict(t *testing.T) {
 
 func TestActionSetVariableExpression(t *testing.T) {
 	testPolicy := &PolicyDef{
-		Rules: []*RuleDefinition{{
-			ID:         "test_rule",
-			Expression: `open.file.path == "/tmp/test"`,
-			Actions: []*ActionDefinition{
-				{
-					Set: &SetDefinition{
-						Name:       "var1",
-						Value:      123,
-						Expression: "${var1} + ${var1} + 1",
+		Rules: []*RuleDefinition{
+			{
+				ID:         "test_rule",
+				Expression: `open.file.path == "/tmp/test"`,
+				Actions: []*ActionDefinition{
+					{
+						Set: &SetDefinition{
+							Name:       "var1",
+							Value:      123,
+							Expression: "${var1} + ${var1} + 1",
+						},
 					},
-				},
-				{
-					Set: &SetDefinition{
-						Name:  "var2",
-						Value: "foo",
+					{
+						Set: &SetDefinition{
+							Name:  "var2",
+							Value: "foo",
+						},
 					},
-				},
-				{
-					Set: &SetDefinition{
-						Name:       "var3",
-						Expression: `"${var2}:${var2}"`,
-						Value:      "",
+					{
+						Set: &SetDefinition{
+							Name:       "var3",
+							Expression: `"${var2}:${var2}"`,
+							Value:      "",
+						},
 					},
 				},
 			},
-		}},
+			{
+				ID:         "test_rule_connect",
+				Expression: `connect.addr.ip == 192.168.1.0/24`,
+				Actions: []*ActionDefinition{
+					{
+						Set: &SetDefinition{
+							Name:  "connected",
+							Value: true,
+						},
+					},
+					{
+						Set: &SetDefinition{
+							Name:  "connected_to",
+							Field: "connect.addr.ip",
+						},
+					},
+					{
+						Set: &SetDefinition{
+							Name:       "connected_to_check",
+							Expression: "${connected_to} == 192.168.1.1/32",
+							Value:      false,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	tmpDir := t.TempDir()
@@ -709,6 +737,12 @@ func TestActionSetVariableExpression(t *testing.T) {
 	existingVariable2 := opts.VariableStore.Get("var3")
 	assert.NotNil(t, existingVariable2)
 
+	existingVariable3 := opts.VariableStore.Get("connected")
+	assert.NotNil(t, existingVariable3)
+
+	existingVariable4 := opts.VariableStore.Get("connected_to")
+	assert.NotNil(t, existingVariable4)
+
 	intVar, ok := existingVariable.(eval.Variable)
 	assert.NotNil(t, intVar)
 	assert.True(t, ok)
@@ -720,6 +754,20 @@ func TestActionSetVariableExpression(t *testing.T) {
 	assert.NotNil(t, strVar)
 	assert.True(t, ok)
 	value, set = strVar.GetValue()
+	assert.NotNil(t, value)
+	assert.False(t, set)
+
+	connectedVar, ok := existingVariable3.(eval.Variable)
+	assert.NotNil(t, connectedVar)
+	assert.True(t, ok)
+	value, set = connectedVar.GetValue()
+	assert.NotNil(t, value)
+	assert.False(t, set)
+
+	connectedToVar, ok := existingVariable4.(eval.Variable)
+	assert.NotNil(t, connectedToVar)
+	assert.True(t, ok)
+	value, set = connectedToVar.GetValue()
 	assert.NotNil(t, value)
 	assert.False(t, set)
 
@@ -749,6 +797,36 @@ func TestActionSetVariableExpression(t *testing.T) {
 	value, set = intVar.GetValue()
 	assert.True(t, set)
 	assert.Equal(t, 3, value)
+
+	value, set = strVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, "foo:foo", value)
+
+	event2 := model.NewFakeEvent()
+	event2.Type = uint32(model.ConnectEventType)
+	processCacheEntry = &model.ProcessCacheEntry{}
+	processCacheEntry.Retain()
+	event2.ProcessCacheEntry = processCacheEntry
+	connectIP := net.IPNet{
+		IP:   net.IPv4(192, 168, 1, 1),
+		Mask: net.IPv4Mask(255, 255, 255, 0),
+	}
+	event2.SetFieldValue("connect.addr.ip", connectIP)
+
+	if !rs.Evaluate(event2) {
+		t.Errorf("Expected event to match rule")
+	}
+
+	value, set = connectedVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, true, value)
+
+	value, set = connectedToVar.GetValue()
+	assert.True(t, set)
+	assert.Equal(t, []net.IPNet{{
+		IP:   net.IPv4(192, 168, 1, 0).To4(),
+		Mask: connectIP.Mask,
+	}}, value)
 }
 
 func loadPolicy(t *testing.T, testPolicy *PolicyDef, policyOpts PolicyLoaderOpts) (*RuleSet, *multierror.Error) {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -248,13 +248,13 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					case reflect.Bool:
 						variableValue = false
 					case reflect.Struct:
-						if goType == "net.IP" {
-							variableValue = []net.IP{}
+						if goType == "net.IPNet" {
+							variableValue = []net.IPNet{}
 							break
 						}
 						fallthrough
 					default:
-						errs = multierror.Append(errs, fmt.Errorf("unsupported field type '%s' for variable '%s'", kind, actionDef.Set.Name))
+						errs = multierror.Append(errs, fmt.Errorf("unsupported field type '%s (%s)' for variable '%s'", kind, goType, actionDef.Set.Name))
 						continue
 					}
 				}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -195,14 +195,18 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 					continue
 				}
 
-				var variableValue interface{}
+				var variableValue interface{} = actionDef.Set.Value
 
 				if actionDef.Set.Value != nil {
 					switch value := actionDef.Set.Value.(type) {
 					case int:
-						actionDef.Set.Value = []int{value}
+						if actionDef.Set.Append {
+							variableValue = []int{value}
+						}
 					case string:
-						actionDef.Set.Value = []string{value}
+						if actionDef.Set.Append {
+							variableValue = []string{value}
+						}
 					case []interface{}:
 						if len(value) == 0 {
 							errs = multierror.Append(errs, fmt.Errorf("unable to infer item type for '%s'", actionDef.Set.Name))
@@ -211,16 +215,16 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 
 						switch arrayType := value[0].(type) {
 						case int:
-							actionDef.Set.Value = cast.ToIntSlice(value)
+							variableValue = cast.ToIntSlice(value)
 						case string:
-							actionDef.Set.Value = cast.ToStringSlice(value)
+							variableValue = cast.ToStringSlice(value)
 						default:
 							errs = multierror.Append(errs, fmt.Errorf("unsupported item type '%s' for array '%s'", reflect.TypeOf(arrayType), actionDef.Set.Name))
 							continue
 						}
-					}
 
-					variableValue = actionDef.Set.Value
+						actionDef.Set.Value = variableValue
+					}
 				} else if actionDef.Set.Field != "" {
 					_, kind, goType, err := rs.eventCtor().GetFieldMetadata(actionDef.Set.Field)
 					if err != nil {
@@ -230,9 +234,17 @@ func (rs *RuleSet) PopulateFieldsWithRuleActionsData(policyRules []*PolicyRule, 
 
 					switch kind {
 					case reflect.String:
-						variableValue = []string{}
+						if actionDef.Set.Append {
+							variableValue = []string{}
+						} else {
+							variableValue = ""
+						}
 					case reflect.Int:
-						variableValue = []int{}
+						if actionDef.Set.Append {
+							variableValue = []int{}
+						} else {
+							variableValue = 0
+						}
 					case reflect.Bool:
 						variableValue = false
 					case reflect.Struct:
@@ -403,13 +415,26 @@ func (rs *RuleSet) innerAddExpandedRule(parsingContext *ast.ParsingContext, pRul
 			}
 		}
 
-		if action.Def.Set != nil && action.Def.Set.Field != "" {
-			if _, found := rs.fieldEvaluators[action.Def.Set.Field]; !found {
-				evaluator, err := rs.model.GetEvaluator(action.Def.Set.Field, "")
-				if err != nil {
-					return "", err
+		if action.Def.Set != nil {
+			if field := action.Def.Set.Field; field != "" {
+				if _, found := rs.fieldEvaluators[field]; !found {
+					evaluator, err := rs.model.GetEvaluator(field, "")
+					if err != nil {
+						return "", err
+					}
+					rs.fieldEvaluators[field] = evaluator
 				}
-				rs.fieldEvaluators[action.Def.Set.Field] = evaluator
+			} else if expression := action.Def.Set.Expression; expression != "" {
+				astRule, err := parsingContext.ParseExpression(expression)
+				if err != nil {
+					return "", fmt.Errorf("failed to parse action expression: %w", err)
+				}
+
+				evaluator, _, err := eval.NodeToEvaluator(astRule, rs.evalOpts, eval.NewState(rs.model, "", rs.evalOpts.MacroStore))
+				if err != nil {
+					return "", fmt.Errorf("failed to compile action expression: %w", err)
+				}
+				rs.fieldEvaluators[expression] = evaluator.(eval.Evaluator)
 			}
 		}
 	}
@@ -584,6 +609,10 @@ func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) er
 				value := action.Def.Set.Value
 				if field := action.Def.Set.Field; field != "" {
 					if evaluator := rs.fieldEvaluators[field]; evaluator != nil {
+						value = evaluator.Eval(ctx)
+					}
+				} else if expression := action.Def.Set.Expression; expression != "" {
+					if evaluator := rs.fieldEvaluators[expression]; evaluator != nil {
 						value = evaluator.Eval(ctx)
 					}
 				}

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -410,6 +410,9 @@
         "field": {
           "type": "string"
         },
+        "expression": {
+          "type": "string"
+        },
         "append": {
           "type": "boolean"
         },

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -407,6 +407,22 @@
             }
           ]
         },
+        "default_value": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            },
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "array"
+            }
+          ]
+        },
         "field": {
           "type": "string"
         },


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add an `expression` field to the `set` action. 

### Motivation

Having an `expression` for a variable allows to do things such
as arithmetic or string concatenation.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Example rule:
```
id: XXX
actions:
  - set:
      name: foo2
      default_value: false
      expression: |-
        true || false
  - set:
      name: foo3
      default_value: 1
      expression: |-
        (${foo3} + ${foo3}) + 2
  - set:
      name: buffer
      expression: |-
        "${counter}:${process.pid}"
      default_value: ""
```
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->