### PR TITLE
Revert "usm: tests: Skipping tests as it fails on main"

### DIFF
--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -2803,7 +2803,6 @@ func testPostgresSketches(t *testing.T, tr *tracer.Tracer) {
 
 func (s *USMSuite) TestVerifySketches() {
 	t := s.T()
-	t.Skip("skipping test, failing on main")
 	skipIfKernelIsNotSupported(t, usmconfig.MinimumKernelVersion)
 
 	cfg := utils.NewUSMEmptyConfig()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Reverts DataDog/datadog-agent#35013

### Motivation

In #35013 we skipped a test that found a bug merged into main, the bug is not related to the skipped test, but it was the only one to find it.

We reverted the original PR #35018 causing the bug
and fix another UT in #35019 to capture the original bug

Now we can use again the skipped test

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->