### PR TITLE
Add `admission.datadoghq.com/apm-inject.debug`

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -141,6 +141,43 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 			},
 		},
 		{
+			name: "java + debug enabled",
+			pod: common.FakePodSpec{
+				Annotations: map[string]string{
+					"admission.datadoghq.com/apm-inject.version": "v0",
+					"admission.datadoghq.com/apm-inject.debug":   "true",
+				},
+			}.Create(),
+			expectedInjectorImage:   commonRegistry + "/apm-inject:v0",
+			expectedSecurityContext: &corev1.SecurityContext{},
+			expectedLibConfigEnvs: map[string]string{
+				"DD_APM_INSTRUMENTATION_DEBUG": "true",
+				"DD_TRACE_STARTUP_LOGS":        "true",
+				"DD_TRACE_DEBUG":               "true",
+			},
+			libInfo: extractedPodLibInfo{
+				libs: []libInfo{
+					java.libInfo("", "gcr.io/datadoghq/dd-lib-java-init:v1"),
+				},
+			},
+		},
+		{
+			name: "java + debug disabled",
+			pod: common.FakePodSpec{
+				Annotations: map[string]string{
+					"admission.datadoghq.com/apm-inject.version": "v0",
+					"admission.datadoghq.com/apm-inject.debug":   "false",
+				},
+			}.Create(),
+			expectedInjectorImage:   commonRegistry + "/apm-inject:v0",
+			expectedSecurityContext: &corev1.SecurityContext{},
+			libInfo: extractedPodLibInfo{
+				libs: []libInfo{
+					java.libInfo("", "gcr.io/datadoghq/dd-lib-java-init:v1"),
+				},
+			},
+		},
+		{
 			name:                    "config injector-image-override",
 			pod:                     common.FakePod("java-pod"),
 			expectedInjectorImage:   "gcr.io/datadoghq/apm-inject:0.16-1",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars.go
@@ -96,6 +96,10 @@ func identityValFunc(s string) envValFunc {
 	return func(string) string { return s }
 }
 
+func trueValFunc() envValFunc {
+	return identityValFunc("true")
+}
+
 func joinValFunc(value string, separator string) envValFunc {
 	return func(predefinedVal string) string {
 		if predefinedVal == "" {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/injector.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -73,6 +74,7 @@ var volumeMountETCDPreloadAppContainer = etcVolume.mount(corev1.VolumeMount{
 type injector struct {
 	image      string
 	registry   string
+	debug      bool
 	injected   bool
 	injectTime time.Time
 	opts       libRequirementOptions
@@ -114,6 +116,36 @@ func (i *injector) initContainer() initContainer {
 }
 
 func (i *injector) requirements() libRequirement {
+	envVars := []envVar{
+		{
+			key:     "LD_PRELOAD",
+			valFunc: joinValFunc(asAbs(injectorFilePath("launcher.preload.so")), ":"),
+		},
+		{
+			key:     "DD_INJECT_SENDER_TYPE",
+			valFunc: identityValFunc("k8s"),
+		},
+		{
+			key:     "DD_INJECT_START_TIME",
+			valFunc: identityValFunc(strconv.FormatInt(i.injectTime.Unix(), 10)),
+		},
+	}
+	if i.debug {
+		envVars = append(envVars, []envVar{
+			{
+				key:     "DD_APM_INSTRUMENTATION_DEBUG",
+				valFunc: identityValFunc("true"),
+			},
+			{
+				key:     "DD_TRACE_STARTUP_LOGS",
+				valFunc: identityValFunc("true"),
+			},
+			{
+				key:     "DD_TRACE_DEBUG",
+				valFunc: identityValFunc("true"),
+			},
+		}...)
+	}
 	return libRequirement{
 		libRequirementOptions: i.opts,
 		initContainers:        []initContainer{i.initContainer()},
@@ -125,20 +157,7 @@ func (i *injector) requirements() libRequirement {
 			volumeMountETCDPreloadAppContainer.prepended(),
 			v2VolumeMountInjector.prepended(),
 		},
-		envVars: []envVar{
-			{
-				key:     "LD_PRELOAD",
-				valFunc: joinValFunc(asAbs(injectorFilePath("launcher.preload.so")), ":"),
-			},
-			{
-				key:     "DD_INJECT_SENDER_TYPE",
-				valFunc: identityValFunc("k8s"),
-			},
-			{
-				key:     "DD_INJECT_START_TIME",
-				valFunc: identityValFunc(strconv.FormatInt(i.injectTime.Unix(), 10)),
-			},
-		},
+		envVars: envVars,
 	}
 }
 
@@ -152,6 +171,11 @@ var injectorVersionAnnotationExtractor = annotationExtractor[injectorOption]{
 var injectorImageAnnotationExtractor = annotationExtractor[injectorOption]{
 	key: "admission.datadoghq.com/apm-inject.custom-image",
 	do:  infallibleFn(injectorWithImageName),
+}
+
+var injectorDebugAnnotationExtractor = annotationExtractor[injectorOption]{
+	key: "admission.datadoghq.com/apm-inject.debug",
+	do:  infallibleFn(injectorDebug),
 }
 
 func injectorWithLibRequirementOptions(opts libRequirementOptions) injectorOption {
@@ -169,6 +193,20 @@ func injectorWithImageName(name string) injectorOption {
 func injectorWithImageTag(tag string) injectorOption {
 	return func(i *injector) {
 		i.image = fmt.Sprintf("%s/apm-inject:%s", i.registry, tag)
+	}
+}
+
+func injectorDebug(boolean string) injectorOption {
+	var debug bool
+	var err error
+	if boolean != "" {
+		debug, err = strconv.ParseBool(boolean)
+		if err != nil {
+			log.Errorf("parse admission.datadoghq.com/apm-inject.debug: %s", err)
+		}
+	}
+	return func(i *injector) {
+		i.debug = debug
 	}
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -216,6 +216,7 @@ func (m *mutatorCore) newInjector(startTime time.Time, pod *corev1.Pod, opts ...
 	for _, e := range []annotationExtractor[injectorOption]{
 		injectorVersionAnnotationExtractor,
 		injectorImageAnnotationExtractor,
+		injectorDebugAnnotationExtractor,
 	} {
 		opt, err := e.extract(pod)
 		if err != nil {

--- a/releasenotes/notes/add-admission-controller-annotation-apm-inject-debug-dfdd9f8689c091b0.yaml
+++ b/releasenotes/notes/add-admission-controller-annotation-apm-inject-debug-dfdd9f8689c091b0.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add ``admission.datadoghq.com/apm-inject.debug: "true"`` annotation to inject
+    ``DD_APM_INSTRUMENTATION_DEBUG=true``, ``DD_TRACE_STARTUP_LOGS=true`` and
+    ``DD_TRACE_DEBUG=true`` to an application container.
+    This is useful for debuuging Single Step Instrumentation or tracer issues
+    in Kubernetes environments.

--- a/releasenotes/notes/add-admission-controller-annotation-apm-inject-debug-dfdd9f8689c091b0.yaml
+++ b/releasenotes/notes/add-admission-controller-annotation-apm-inject-debug-dfdd9f8689c091b0.yaml
@@ -11,5 +11,5 @@ enhancements:
     Add ``admission.datadoghq.com/apm-inject.debug: "true"`` annotation to inject
     ``DD_APM_INSTRUMENTATION_DEBUG=true``, ``DD_TRACE_STARTUP_LOGS=true`` and
     ``DD_TRACE_DEBUG=true`` to an application container.
-    This is useful for debuuging Single Step Instrumentation or tracer issues
+    This is useful for debugging Single Step Instrumentation or tracer issues
     in Kubernetes environments.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add new annotation, `admission.datadoghq.com/apm-inject.debug`.

### Motivation

To debug an injected container easier.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Ensured expected env vars were injected to a container in a Pod having `admission.datadoghq.com/apm-inject.debug: "true"`.

```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    admission.datadoghq.com/apm-inject.debug: "true"
    admission.datadoghq.com/apm-inject.version: v0
  labels:
    admission.datadoghq.com/enabled: "true"
spec:
  automountServiceAccountToken: false
  containers:
  - env:
    # ....skip.......
    - name: DD_INJECT_START_TIME
      value: "1741770582"
    - name: DD_APM_INSTRUMENTATION_DEBUG
      value: "true"
    - name: DD_TRACE_STARTUP_LOGS
      value: "true"
    - name: DD_TRACE_DEBUG
      value: "true"
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->