### PR TITLE
[kubernetes] Move WPA dependency so it's only imported in DCA

### DIFF
--- a/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/autoscaling/externalmetrics/autoscaler_watcher.go
@@ -27,7 +27,7 @@ import (
 	"github.com/DataDog/watermarkpodautoscaler/apis/datadoghq/v1alpha1"
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/externalmetrics/model"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/controllers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -277,7 +277,7 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 
 		for _, wpaObj := range wpaList {
 			wpa := &v1alpha1.WatermarkPodAutoscaler{}
-			err := apiserver.UnstructuredIntoWPA(wpaObj, wpa)
+			err := controllers.UnstructuredIntoWPA(wpaObj, wpa)
 			if err != nil {
 				log.Errorf("Error converting wpa from the cache %v", err)
 				continue

--- a/pkg/util/kubernetes/apiserver/controllers/controller_util.go
+++ b/pkg/util/kubernetes/apiserver/controllers/controller_util.go
@@ -23,7 +23,6 @@ import (
 	datadogclient "github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/custommetrics"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -113,7 +112,7 @@ func (h *autoscalersController) gc() {
 		log.Debugf("Garbage collection over %d WPAs", len(wpaListObj))
 		for _, obj := range wpaListObj {
 			tmp := &v1alpha1.WatermarkPodAutoscaler{}
-			if err := apiserver.UnstructuredIntoWPA(obj, tmp); err != nil {
+			if err := UnstructuredIntoWPA(obj, tmp); err != nil {
 				log.Errorf("Unable to cast object from local cache into a WPA: %v", err)
 				continue
 			}

--- a/pkg/util/kubernetes/apiserver/controllers/wpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/wpa_controller.go
@@ -9,6 +9,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	dynamic_client "k8s.io/client-go/dynamic"
 	dynamic_informer "k8s.io/client-go/dynamic/dynamicinformer"
@@ -25,7 +28,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/custommetrics"
 	"github.com/DataDog/datadog-agent/pkg/errors"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -197,7 +199,7 @@ func (h *autoscalersController) syncWPA(key interface{}) error {
 		return err
 	}
 	wpaCached := &apis_v1alpha1.WatermarkPodAutoscaler{}
-	err = apiserver.UnstructuredIntoWPA(wpaCachedObj, wpaCached)
+	err = UnstructuredIntoWPA(wpaCachedObj, wpaCached)
 	if err != nil {
 		log.Errorf("Could not cast wpa %s retrieved from cache to wpa structure: %v", key, err)
 		return err
@@ -232,7 +234,7 @@ func (h *autoscalersController) syncWPA(key interface{}) error {
 
 func (h *autoscalersController) addWPAutoscaler(obj interface{}) {
 	newAutoscaler := &apis_v1alpha1.WatermarkPodAutoscaler{}
-	if err := apiserver.UnstructuredIntoWPA(obj, newAutoscaler); err != nil {
+	if err := UnstructuredIntoWPA(obj, newAutoscaler); err != nil {
 		log.Errorf("Unable to cast obj %s to a WPA: %v", obj, err)
 		return
 	}
@@ -244,12 +246,12 @@ func (h *autoscalersController) addWPAutoscaler(obj interface{}) {
 //nolint:revive // TODO(CAPP) Fix revive linter
 func (h *autoscalersController) updateWPAutoscaler(old, obj interface{}) {
 	newAutoscaler := &apis_v1alpha1.WatermarkPodAutoscaler{}
-	if err := apiserver.UnstructuredIntoWPA(obj, newAutoscaler); err != nil {
+	if err := UnstructuredIntoWPA(obj, newAutoscaler); err != nil {
 		log.Errorf("Unable to cast obj %s to a WPA: %v", obj, err)
 		return
 	}
 	oldAutoscaler := &apis_v1alpha1.WatermarkPodAutoscaler{}
-	if err := apiserver.UnstructuredIntoWPA(obj, oldAutoscaler); err != nil {
+	if err := UnstructuredIntoWPA(obj, oldAutoscaler); err != nil {
 		log.Errorf("Unable to cast obj %s to a WPA: %v", obj, err)
 		h.enqueueWPA(newAutoscaler) // We still want to enqueue the newAutoscaler to get the new change
 		return
@@ -275,7 +277,7 @@ func (h *autoscalersController) deleteWPAutoscaler(obj interface{}) {
 	defer h.mu.Unlock()
 	toDelete := &custommetrics.MetricsBundle{}
 	deletedWPA := &apis_v1alpha1.WatermarkPodAutoscaler{}
-	if err := apiserver.UnstructuredIntoWPA(obj, deletedWPA); err == nil {
+	if err := UnstructuredIntoWPA(obj, deletedWPA); err == nil {
 		toDelete.External = autoscalers.InspectWPA(deletedWPA)
 		h.deleteFromLocalStore(toDelete.External)
 		log.Debugf("Deleting %s/%s from the local cache", deletedWPA.Namespace, deletedWPA.Name)
@@ -294,7 +296,7 @@ func (h *autoscalersController) deleteWPAutoscaler(obj interface{}) {
 		log.Errorf("Could not get object from tombstone %#v", obj)
 		return
 	}
-	if err := apiserver.UnstructuredIntoWPA(tombstone, deletedWPA); err != nil {
+	if err := UnstructuredIntoWPA(tombstone, deletedWPA); err != nil {
 		log.Errorf("Tombstone contained object that is not an Autoscaler: %#v", obj)
 		return
 	}
@@ -306,4 +308,13 @@ func (h *autoscalersController) deleteWPAutoscaler(obj interface{}) {
 		h.enqueueWPA(deletedWPA)
 		return
 	}
+}
+
+// UnstructuredIntoWPA converts an unstructured into a WPA
+func UnstructuredIntoWPA(obj interface{}, structDest *apis_v1alpha1.WatermarkPodAutoscaler) error {
+	unstrObj, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return fmt.Errorf("could not cast Unstructured object: %v", obj)
+	}
+	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.UnstructuredContent(), structDest)
 }

--- a/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/wpa_controller_test.go
@@ -289,7 +289,7 @@ func TestWPAController(t *testing.T) {
 	require.NoError(t, err)
 
 	wpaDecoded := &v1alpha1.WatermarkPodAutoscaler{}
-	err = apiserver.UnstructuredIntoWPA(res, wpaDecoded)
+	err = UnstructuredIntoWPA(res, wpaDecoded)
 	require.NoError(t, err)
 	require.Equal(t, wpaName, wpaDecoded.Name)
 
@@ -306,7 +306,7 @@ func TestWPAController(t *testing.T) {
 	require.NoError(t, err)
 
 	storedWPA := &v1alpha1.WatermarkPodAutoscaler{}
-	err = apiserver.UnstructuredIntoWPA(storedWPAObject, storedWPA)
+	err = UnstructuredIntoWPA(storedWPAObject, storedWPA)
 	require.NoError(t, err)
 
 	require.Equal(t, storedWPA, wpaDecoded)
@@ -363,7 +363,7 @@ func TestWPAController(t *testing.T) {
 		require.NoError(t, err)
 
 		res, updateErr := wpaClient.Resource(gvrWPA).Namespace(namespace).Update(context.TODO(), resWPA, metav1.UpdateOptions{})
-		err = apiserver.UnstructuredIntoWPA(res, wpaDecoded)
+		err = UnstructuredIntoWPA(res, wpaDecoded)
 		require.NoError(t, err)
 
 		return updateErr
@@ -391,7 +391,7 @@ func TestWPAController(t *testing.T) {
 
 	storedWPAObject, err = hctrl.wpaLister.ByNamespace(namespace).Get(wpaName)
 	require.NoError(t, err)
-	err = apiserver.UnstructuredIntoWPA(storedWPAObject, storedWPA)
+	err = UnstructuredIntoWPA(storedWPAObject, storedWPA)
 	require.NoError(t, err)
 	require.Equal(t, storedWPA, wpaDecoded)
 	// Checking the local cache holds the correct Data.
@@ -607,7 +607,7 @@ func TestUnstructuredIntoWPA(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("#%d %s", i, testCase.caseName), func(t *testing.T) {
 			testWPA := &v1alpha1.WatermarkPodAutoscaler{}
-			err := apiserver.UnstructuredIntoWPA(testCase.obj, testWPA)
+			err := UnstructuredIntoWPA(testCase.obj, testWPA)
 			require.Equal(t, testCase.error, err)
 			if err == nil {
 				// because we use the fake client, the GVK is missing from the WPA object.

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -17,8 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/DataDog/watermarkpodautoscaler/apis/datadoghq/v1alpha1"
-
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -110,15 +108,6 @@ func SyncInformersReturnErrors(informers map[InformerName]cache.SharedInformer, 
 	}
 
 	return errors
-}
-
-// UnstructuredIntoWPA converts an unstructured into a WPA
-func UnstructuredIntoWPA(obj interface{}, structDest *v1alpha1.WatermarkPodAutoscaler) error {
-	unstrObj, ok := obj.(*unstructured.Unstructured)
-	if !ok {
-		return fmt.Errorf("could not cast Unstructured object: %v", obj)
-	}
-	return runtime.DefaultUnstructuredConverter.FromUnstructured(unstrObj.UnstructuredContent(), structDest)
 }
 
 // UnstructuredFromAutoscaler converts a WPA object into an Unstructured


### PR DESCRIPTION
### What does this PR do?

This PR refactors the code to ensure that the core-agent no longer depends on the WPA package, as it should only be used by the cluster-agent. The dependency existed due to a small helper function, `UnstructuredIntoWPA`, being declared in a file used by the core-agent.

To fix this, this PR moves the function to a file that's only imported by the cluster-agent (`pkg/util/kubernetes/apiserver/controllers/wpa_controller.go`).

This change mainly improves code clarity. It doesn’t do much to reduce the binary size on its own, but it helps untangle dependencies, making future cleanups easier (separating everything that’s only used by the cluster-agent could help with binary size, though it’s not a simple task).


### Describe how you validated your changes

Unit and integration tests should be enough.
