### PR TITLE
[serverless] Use AWS FIPs endpoints when getting secrets

### DIFF
--- a/pkg/serverless/apikey/api_key.go
+++ b/pkg/serverless/apikey/api_key.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"net/http"
 	"os"
 	"regexp"
@@ -87,7 +88,7 @@ func decryptKMS(kmsClient kmsAPI, ciphertext string) (string, error) {
 
 // readAPIKeyFromKMS gets and decrypts an API key encrypted with KMS if the env var DD_KMS_API_KEY has been set.
 // If none has been set, it returns an empty string and a nil error.
-func readAPIKeyFromKMS(cipherText string) (string, error) {
+func readAPIKeyFromKMS(cipherText string, fipsEndpointState aws.FIPSEndpointState) (string, error) {
 	if cipherText == "" {
 		return "", nil
 	}
@@ -97,6 +98,7 @@ func readAPIKeyFromKMS(cipherText string) (string, error) {
 		awsconfig.WithHTTPClient(&http.Client{
 			Transport: datadogHttp.CreateHTTPTransport(pkgconfigsetup.Datadog()),
 		}),
+		awsconfig.WithUseFIPSEndpoint(fipsEndpointState),
 	)
 	if err != nil {
 		return "", err
@@ -112,13 +114,13 @@ func readAPIKeyFromKMS(cipherText string) (string, error) {
 
 // readAPIKeyFromSecretsManager reads an API Key from AWS Secrets Manager if the env var DD_API_KEY_SECRET_ARN has been set.
 // If none has been set, it returns an empty string and a nil error.
-func readAPIKeyFromSecretsManager(arn string) (string, error) {
+func readAPIKeyFromSecretsManager(arn string, fipsEndpointState aws.FIPSEndpointState) (string, error) {
 	if arn == "" {
 		return "", nil
 	}
 	log.Debugf("Found %s value, trying to use it.", arn)
 
-	region, err := extractRegionFromSecretsManagerArn(arn)
+	secretsManagerRegion, err := extractRegionFromSecretsManagerArn(arn)
 	if err != nil {
 		return "", err
 	}
@@ -127,7 +129,8 @@ func readAPIKeyFromSecretsManager(arn string) (string, error) {
 		awsconfig.WithHTTPClient(&http.Client{
 			Transport: datadogHttp.CreateHTTPTransport(pkgconfigsetup.Datadog()),
 		}),
-		awsconfig.WithRegion(region),
+		awsconfig.WithRegion(secretsManagerRegion),
+		awsconfig.WithUseFIPSEndpoint(fipsEndpointState),
 	)
 	if err != nil {
 		return "", err

--- a/pkg/serverless/apikey/api_key.go
+++ b/pkg/serverless/apikey/api_key.go
@@ -32,6 +32,9 @@ const encryptionContextKey = "LambdaFunctionName"
 // functionNameEnvVar is the environment variable that stores the function name.
 const functionNameEnvVar = "AWS_LAMBDA_FUNCTION_NAME"
 
+// lambdaRegionEnvVar is the environment variable that holds which region the Lambda is currently in.
+const lambdaRegionEnvVar = "AWS_REGION"
+
 // one of those env variable must be set
 const apiKeyEnvVar = "DD_API_KEY"
 const apiKeySecretManagerEnvVar = "DD_API_KEY_SECRET_ARN"

--- a/pkg/serverless/apikey/env.go
+++ b/pkg/serverless/apikey/env.go
@@ -21,12 +21,10 @@ type decryptFunc func(string, aws.FIPSEndpointState) (string, error)
 func getSecretEnvVars(envVars []string, kmsFunc decryptFunc, smFunc decryptFunc) map[string]string {
 	awsRegion := os.Getenv(lambdaRegionEnvVar)
 	isGovRegion := strings.HasPrefix(awsRegion, "us-gov-")
-	var fipsEndpointState aws.FIPSEndpointState
+	fipsEndpointState := aws.FIPSEndpointStateUnset
 	if isGovRegion {
 		fipsEndpointState = aws.FIPSEndpointStateEnabled
-		log.Info("Govcloud region detected. Using FIPs endpoints for secrets management.")
-	} else {
-		fipsEndpointState = aws.FIPSEndpointStateUnset
+		log.Debug("Govcloud region detected. Using FIPs endpoints for secrets management.")
 	}
 
 	decryptedEnvVars := make(map[string]string)

--- a/pkg/serverless/apikey/env_test.go
+++ b/pkg/serverless/apikey/env_test.go
@@ -60,11 +60,11 @@ func TestGetSecretEnvVarsWithFIPSEndpoint(t *testing.T) {
 
 			var kmsFIPS aws.FIPSEndpointState
 			var smFIPS aws.FIPSEndpointState
-			mockKMSFunc := func(val string, fips aws.FIPSEndpointState) (string, error) {
+			mockKMSFunc := func(_ string, fips aws.FIPSEndpointState) (string, error) {
 				kmsFIPS = fips
 				return "decrypted", nil
 			}
-			mockSMFunc := func(val string, fips aws.FIPSEndpointState) (string, error) {
+			mockSMFunc := func(_ string, fips aws.FIPSEndpointState) (string, error) {
 				smFIPS = fips
 				return "decrypted", nil
 			}

--- a/releasenotes/notes/serverless-use-fips-endpoints-in-govcloud-regions-644fee50c19e1ce4.yaml
+++ b/releasenotes/notes/serverless-use-fips-endpoints-in-govcloud-regions-644fee50c19e1ce4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added FIPS compliance support for Lambda Extension GovCloud customers. The Lambda Extension now
+    uses FIPS-enabled endpoints for AWS KMS and Secrets Manager when running in GovCloud regions.


### PR DESCRIPTION
### What does this PR do?

If we detect a user is in a Govcloud region, use FIPs endpoints.

### Motivation

Make our Lambda extension FIPs compliant

### Describe how you validated your changes

I tested manually on Govcloud and on commercial.

Added a unit test

### Possible Drawbacks / Trade-offs

### Additional Notes