### PR TITLE
[CONTP-704] Move DCA's cluster checks handler installation to start server

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -56,7 +56,7 @@ var (
 )
 
 // StartServer creates the router and starts the HTTP server
-func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component) error {
+func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component, clusterChecksEnabled bool) error {
 	// create the root HTTP router
 	router = mux.NewRouter()
 	apiRouter = router.PathPrefix("/api/v1").Subrouter()
@@ -69,6 +69,13 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 
 	// API V1 Language Detection APIs
 	languagedetection.InstallLanguageDetectionEndpoints(ctx, apiRouter, w, cfg)
+
+	// API V1 Cluster Check APIs
+	if clusterChecksEnabled {
+		v1.InstallChecksEndpoints(ctx, apiRouter, ac, taggerComp)
+	} else {
+		log.Debug("Cluster check Autodiscovery disabled")
+	}
 
 	// API V2 Series APIs
 	v2ApiRouter := router.PathPrefix("/api/v2").Subrouter()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Move clusterchecks handler initialziation to dca's api server start. This will make sure that the cluster agent http server starts with cluster checks handler. 

Code change:
```
var clusterCheckHandler *clusterchecks.Handler
clusterCheckHandler, err = setupClusterCheck
```
is moved to api/v1/install.go

### Motivation
In some rare case, there could be request hitting dca after startServer is called but clusterchecks handler is not installed yet. 
Error log:
Client
```
2025-03-11 13:54:25 UTC | CORE | ERROR | (comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:215 in collect) | Unable to collect configurations from provider endpoints-checks: "https://datadog-agent-cluster-agent.datadog-agent:5005/api/v1/endpointschecks/configs/eu1-prod-dog-latias-c-k8s-812095489ff39cb9-s85g" is unavailable: 404 Not Found
```

Server:
```
2025-03-11 13:54:25 UTC | CLUSTER | WARN | (/usr/local/go/src/log/log.go:268 in Printf) | Error from the agent http API server: http: panic serving 10.33.8.13:53428: runtime error: invalid memory address or nil pointer dereference
goroutine 522 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1947 +0xbe
panic({0x420eca0?, 0x78e3240?})
	/usr/local/go/src/runtime/panic.go:785 +0x132
github.com/DataDog/datadog-agent/cmd/cluster-agent/api.validateToken.func1({0x50d42e0, 0xc002468000}, 0xc00261a280)
	/go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/api/server.go:191 +0x8f
net/http.HandlerFunc.ServeHTTP(0xc00261a140?, {0x50d42e0?, 0xc002468000?}, 0xdf847512a?)
	/usr/local/go/src/net/http/server.go:2220 +0x29
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000dfb200, {0x50d42e0, 0xc002468000}, 0xc00261a000)
	/go/pkg/mod/github.com/gorilla/mux@v1.8.1/mux.go:212 +0x1e2
github.com/DataDog/datadog-agent/cmd/cluster-agent/api.StartServer.TimeoutHandlerFunc.func9({0x50d42e0, 0xc002468000}, 0xc00261a000)
	/go/src/github.com/DataDog/datadog-agent/pkg/util/grpc/server.go:58 +0x10d
net/http.HandlerFunc.ServeHTTP(0x497732?, {0x50d42e0?, 0xc002468000?}, 0xc002307b18?)
	/usr/local/go/src/net/http/server.go:2220 +0x29
github.com/DataDog/datadog-agent/pkg/util/grpc.NewMuxedGRPCServer.handlerWithFallback.func3({0x50d42e0?, 0xc002468000?}, 0xc002f8c2c0?)
	/go/src/github.com/DataDog/datadog-agent/pkg/util/grpc/server.go:72 +0xa5
net/http.HandlerFunc.ServeHTTP(0x48a6b9?, {0x50d42e0?, 0xc002468000?}, 0xc002307b70?)
	/usr/local/go/src/net/http/server.go:2220 +0x29
net/http.serverHandler.ServeHTTP({0xc0024f01e0?}, {0x50d42e0?, 0xc002468000?}, 0x6?)
	/usr/local/go/src/net/http/server.go:3210 +0x8e
net/http.(*conn).serve(0xc002292a20, {0x50f0730, 0xc002171440})
	/usr/local/go/src/net/http/server.go:2092 +0x5d0
created by net/http.(*Server).Serve in goroutine 510
	/usr/local/go/src/net/http/server.go:3360 +0x485
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->