### PR TITLE
Update tooling installation instructions regarding pip

### DIFF
--- a/docs/public/setup.md
+++ b/docs/public/setup.md
@@ -92,7 +92,8 @@ pip install dda
 ```
 
 !!! warning
-    This method modifies the Python environment in which you choose to install.
+    - This method modifies the Python environment in which you choose to install.
+    - Python 3.12.x is required.
 
 ## Windows
 


### PR DESCRIPTION
### Motivation

This should be documented because the runtime error when the Python version requirement is unmet has insufficient details:

```
$ pip install dda
ERROR: Could not find a version that satisfies the requirement dda (from versions: none)
ERROR: No matching distribution found for dda
```