### PR TITLE
refactor the remote-tagger to have initialization and loop fetch in two step

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -589,11 +589,11 @@ func (t *remoteTagger) startTaggerStream(maxElapsed time.Duration) error {
 			Prefixes:    prefixes,
 		})
 		if err != nil {
-			t.log.Infof("unable to establish stream, will possibly retry: %s", err)
+			t.log.Debug("unable to establish stream, will possibly retry: %s", err)
 			return err
 		}
 
-		t.log.Info("tagger stream established successfully")
+		t.log.Debug("tagger stream successfully initialized")
 
 		return nil
 	}, expBackoff)

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -494,6 +494,8 @@ func (t *remoteTagger) run() {
 			continue
 		}
 
+		t.log.Info("tagger stream successfully initialized")
+
 		t.telemetryStore.Receives.Inc()
 
 		err = t.processResponse(response)
@@ -592,8 +594,6 @@ func (t *remoteTagger) startTaggerStream(maxElapsed time.Duration) error {
 			t.log.Debug("unable to establish stream, will possibly retry: %s", err)
 			return err
 		}
-
-		t.log.Debug("tagger stream successfully initialized")
 
 		return nil
 	}, expBackoff)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
To manually test this changes:
- stop the traceAgent
- change the authtoken value loaded by the traceAgent by setting `auth_token_file_path` to a secondary auth_token file
- assert that there is no the upper-mentionned logs and that an error is raised to mention that the  remote-tagger was unable to start.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->