### PR TITLE
[process] Fix "address already in use" flake

### DIFF
--- a/comp/process/apiserver/apiserver_test.go
+++ b/comp/process/apiserver/apiserver_test.go
@@ -36,6 +36,7 @@ func TestLifecycle(t *testing.T) {
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
 
 	_ = fxutil.Test[Component](t, fx.Options(
 		Module(),
@@ -74,6 +75,7 @@ func TestPostAuthentication(t *testing.T) {
 	listener, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
+	listener.Close()
 
 	_ = fxutil.Test[Component](t, fx.Options(
 		Module(),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes this flake seen in `apiserver_test`:
```
    app.go:61: application didn't start cleanly: listen tcp 127.0.0.1:34003: bind: address already in use
```
To be honest, I'm not sure why this test sometimes succeeded before.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
```
go test -tags=linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/comp/process/apiserver
```

### Possible Drawbacks / Trade-offs
I'm not sure why this test actually sometimes passed without this PR, so maybe I'm missing something.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->