### PR TITLE
Index parameter captures in output buffer of dynamic instrumentation snapshots

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/c/base_event.h
+++ b/pkg/dynamicinstrumentation/codegen/c/base_event.h
@@ -2,14 +2,15 @@
 #define DI_BASE_EVENT_H
 
 #include "ktypes.h"
+#include "macros.h"
 
 // standard fields which all events created in bpf will contain, regardless of the function that the
 // probe is instrumenting
 struct base_event {
     __u32 pid; // process ID
     __u32 uid; // user ID
-    __u64 program_counters[10]; // program counters representing the stack trace of the instrumented function invocation
-    __u64 param_indicies[20]; // indicies of where each parameter starts in argument buffer
+    __u64 program_counters[STACK_DEPTH_LIMIT]; // program counters representing the stack trace of the instrumented function invocation
+    __u64 param_indicies[MAX_FIELD_AND_PARAM_COUNT]; // indicies of where each parameter starts in argument buffer
     char probe_id[36]; // identifier for each user-configured instrumentation point, it's a standard 36 character UUID
 };
 

--- a/pkg/dynamicinstrumentation/codegen/c/base_event.h
+++ b/pkg/dynamicinstrumentation/codegen/c/base_event.h
@@ -10,7 +10,7 @@ struct base_event {
     __u32 uid; // user ID
     __u64 program_counters[10]; // program counters representing the stack trace of the instrumented function invocation
     char probe_id[36]; // identifier for each user-configured instrumentation point, it's a standard 36 character UUID
-    __u16 param_indicies[20];
+    __u64 param_indicies[20];
 };
 
 #endif

--- a/pkg/dynamicinstrumentation/codegen/c/base_event.h
+++ b/pkg/dynamicinstrumentation/codegen/c/base_event.h
@@ -10,6 +10,7 @@ struct base_event {
     __u32 uid; // user ID
     __u64 program_counters[10]; // program counters representing the stack trace of the instrumented function invocation
     char probe_id[36]; // identifier for each user-configured instrumentation point, it's a standard 36 character UUID
+    __u16 param_indicies[20];
 };
 
 #endif

--- a/pkg/dynamicinstrumentation/codegen/c/base_event.h
+++ b/pkg/dynamicinstrumentation/codegen/c/base_event.h
@@ -9,8 +9,8 @@ struct base_event {
     __u32 pid; // process ID
     __u32 uid; // user ID
     __u64 program_counters[10]; // program counters representing the stack trace of the instrumented function invocation
+    __u64 param_indicies[20]; // indicies of where each parameter starts in argument buffer
     char probe_id[36]; // identifier for each user-configured instrumentation point, it's a standard 36 character UUID
-    __u64 param_indicies[20];
 };
 
 #endif

--- a/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
+++ b/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
@@ -2,8 +2,8 @@
 #include "bpf_tracing.h"
 #include "kconfig.h"
 #include <asm/ptrace.h>
-#include "base_event.h"
 #include "macros.h"
+#include "base_event.h"
 #include "event.h"
 #include "maps.h"
 #include "expressions.h"

--- a/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
+++ b/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
@@ -46,6 +46,10 @@ int {{.GetBPFFuncName}}(struct pt_regs *ctx)
     if (err != 0) {
         log_debug("could not write probe id to output");
     }
+    err = bpf_probe_read_kernel(&event->base.param_indicies, sizeof(event->base.param_indicies), zero_string);
+    if (err != 0) {
+        log_debug("could not zero out param indicies");
+    }
 
     // Get tid and tgid
     u64 pidtgid = bpf_get_current_pid_tgid();

--- a/pkg/dynamicinstrumentation/codegen/c/macros.h
+++ b/pkg/dynamicinstrumentation/codegen/c/macros.h
@@ -5,5 +5,5 @@
 #define PARAM_BUFFER_SIZE {{ .InstrumentationInfo.InstrumentationOptions.ArgumentsMaxSize }}
 #define STACK_DEPTH_LIMIT 10
 #define MAX_SLICE_LENGTH {{ .InstrumentationInfo.InstrumentationOptions.SliceMaxLength }}
-
+#define MAX_FIELD_AND_PARAM_COUNT 20
 #endif

--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -32,8 +32,13 @@ func GenerateBPFParamsCode(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) 
 
 		params = applyCaptureDepth(params, depth)
 		for i := range params {
+			err := generateParameterIndexText(i, out)
+			if err != nil {
+				return err
+			}
+
 			flattenedParams := flattenParameters([]*ditypes.Parameter{params[i]})
-			err := generateHeadersText(flattenedParams, out)
+			err = generateHeadersText(flattenedParams, out)
 			if err != nil {
 				return err
 			}
@@ -72,6 +77,15 @@ func generateHeadersText(params []*ditypes.Parameter, out io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func generateParameterIndexText(index int, out io.Writer) error {
+	expr := ditypes.SetParameterIndexLocationExpression(uint16(index))
+	t, err := resolveLocationExpressionTemplate(expr)
+	if err != nil {
+		return err
+	}
+	return t.Execute(out, expr)
 }
 
 func generateHeaderText(param *ditypes.Parameter, out io.Writer) error {
@@ -199,6 +213,8 @@ func resolveLocationExpressionTemplate(locationExpression ditypes.LocationExpres
 		return template.New("print_statement").Parse(printStatementText)
 	case ditypes.OpComment:
 		return template.New("comment").Parse(commentText)
+	case ditypes.OpSetParameterIndex:
+		return template.New("set_parameter_index").Parse(setParameterIndexText)
 	default:
 		return nil, errors.New("invalid location expression opcode")
 	}

--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -32,6 +32,11 @@ func GenerateBPFParamsCode(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) 
 
 		params = applyCaptureDepth(params, depth)
 		for i := range params {
+			if params[i].DoNotCapture {
+				log.Tracef("Not capturing parameter %d %s: %s", i, params[i].Name, params[i].NotCaptureReason.String())
+				continue
+			}
+
 			err := generateParameterIndexText(i, out)
 			if err != nil {
 				return err

--- a/pkg/dynamicinstrumentation/codegen/expression_templates.go
+++ b/pkg/dynamicinstrumentation/codegen/expression_templates.go
@@ -112,3 +112,8 @@ var commentText = `
 var printStatementText = `
 log_debug("{{.Label}}", "{{.CollectionIdentifier}}");
 `
+
+var setParameterIndexText = `
+bpf_printk("Setting param index %d to %d", {{.Arg1}}, context.output_offset);
+event->base.param_indicies[{{.Arg1}}] = context.output_offset;
+`

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -60,6 +60,16 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 
 	procInfo.TypeMap = typeMap
 
+	// Enforce limit on number of parameters
+	for funcName := range procInfo.TypeMap.Functions {
+		for i, param := range procInfo.TypeMap.Functions[funcName] {
+			if i >= 20 {
+				param.DoNotCapture = true
+				param.NotCaptureReason = ditypes.FieldLimitReached
+			}
+		}
+	}
+
 	fieldIDs := make([]bininspect.FieldIdentifier, 0)
 	for _, funcParams := range typeMap.Functions {
 		for _, param := range funcParams {

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -63,7 +63,7 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 	// Enforce limit on number of parameters
 	for funcName := range procInfo.TypeMap.Functions {
 		for i, param := range procInfo.TypeMap.Functions[funcName] {
-			if i >= 20 {
+			if i >= ditypes.MaxFieldCount {
 				param.DoNotCapture = true
 				param.NotCaptureReason = ditypes.FieldLimitReached
 			}

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -53,7 +53,6 @@ func loadFunctionDefinitions(dwarfData *dwarf.Data, targetFunctions map[string]b
 
 entryLoop:
 	for {
-
 		entry, err = entryReader.Next()
 		if err == io.EOF || entry == nil {
 			break

--- a/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
@@ -225,6 +225,7 @@ func (rc *rcConfig) toProbe(service string) *ditypes.Probe {
 				StringMaxSize:     ditypes.StringMaxSize,
 				SliceMaxLength:    ditypes.SliceMaxLength,
 				MaxReferenceDepth: rc.Capture.MaxReferenceDepth,
+				MaxFieldCount:     rc.Capture.MaxFieldCount,
 			},
 		},
 	}

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -56,6 +56,21 @@ const (
 	CaptureDepthReached                             // CaptureDepthReached means the parameter wasn't captures because the data type has too many levels
 )
 
+func (r NotCaptureReason) String() string {
+	switch r {
+	case Unsupported:
+		return "unsupported"
+	case NoFieldLocation:
+		return "no field location"
+	case FieldLimitReached:
+		return "field limit reached"
+	case CaptureDepthReached:
+		return "capture depth reached"
+	default:
+		return fmt.Sprintf("unknown reason (%d)", r)
+	}
+}
+
 // SpecialKind is used for clarity in generated events that certain fields weren't read
 type SpecialKind uint8
 
@@ -71,6 +86,8 @@ func (s SpecialKind) String() string {
 		return "Unsupported"
 	case KindCutFieldLimit:
 		return "CutFieldLimit"
+	case KindCaptureDepthReached:
+		return "CaptureDepthReached"
 	default:
 		return fmt.Sprintf("%d", s)
 	}

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -133,6 +133,8 @@ const (
 	// OpPopPointerAddress is a special opcode for a compound operation (combination of location expressions)
 	// that are used for popping the address when reading pointers
 	OpPopPointerAddress
+	// OpSetParameterIndex sets the parameter index in the base event's param_indicies array field
+	OpSetParameterIndex
 )
 
 func (op LocationExpressionOpcode) String() string {
@@ -177,6 +179,8 @@ func (op LocationExpressionOpcode) String() string {
 		return "SetGlobalLimit"
 	case OpJumpIfGreaterThanLimit:
 		return "JumpIfGreaterThanLimit"
+	case OpSetParameterIndex:
+		return "SetParamIndex"
 	default:
 		return fmt.Sprintf("LocationExpressionOpcode(%d)", int(op))
 	}
@@ -379,6 +383,17 @@ func InsertComment(comment string) LocationExpression {
 // Example usage: PrintStatement("%d", "variableName")
 func PrintStatement(format, arguments string) LocationExpression {
 	return LocationExpression{Opcode: OpPrintStatement, Label: format, CollectionIdentifier: arguments}
+}
+
+// SetParameterIndexLocationExpression creates an expression which
+// sets the parameter index in the base event's param_indicies array field.
+// This allows tracking which parameters were successfully collected.
+// Arg1 = index of the parameter
+func SetParameterIndexLocationExpression(index uint16) LocationExpression {
+	return LocationExpression{
+		Opcode: OpSetParameterIndex,
+		Arg1:   uint(index),
+	}
 }
 
 // LocationExpression is an operation which will be executed in bpf with the purpose

--- a/pkg/dynamicinstrumentation/ditypes/ebpf_linux.go
+++ b/pkg/dynamicinstrumentation/ditypes/ebpf_linux.go
@@ -7,8 +7,9 @@ type BaseEvent struct {
 	Pid              uint32
 	Uid              uint32
 	Program_counters [10]uint64
-	Probe_id         [36]byte
 	Param_indicies   [20]uint64
+	Probe_id         [36]byte
+	Pad_cgo_0        [4]byte
 }
 
 const SizeofBaseEvent = 0x120

--- a/pkg/dynamicinstrumentation/ditypes/ebpf_linux.go
+++ b/pkg/dynamicinstrumentation/ditypes/ebpf_linux.go
@@ -8,8 +8,7 @@ type BaseEvent struct {
 	Uid              uint32
 	Program_counters [10]uint64
 	Probe_id         [36]byte
-	Param_indicies   [20]uint16
-	Pad_cgo_0        [4]byte
+	Param_indicies   [20]uint64
 }
 
-const SizeofBaseEvent = 0xa8
+const SizeofBaseEvent = 0x120

--- a/pkg/dynamicinstrumentation/ditypes/ebpf_linux.go
+++ b/pkg/dynamicinstrumentation/ditypes/ebpf_linux.go
@@ -8,7 +8,8 @@ type BaseEvent struct {
 	Uid              uint32
 	Program_counters [10]uint64
 	Probe_id         [36]byte
+	Param_indicies   [20]uint16
 	Pad_cgo_0        [4]byte
 }
 
-const SizeofBaseEvent = 0x80
+const SizeofBaseEvent = 0xa8

--- a/pkg/dynamicinstrumentation/ditypes/ringbuffer.go
+++ b/pkg/dynamicinstrumentation/ditypes/ringbuffer.go
@@ -15,11 +15,12 @@ var EventsRingbuffer *ebpf.Map
 
 // DIEvent represents a single invocation of a function and it's captured information
 type DIEvent struct {
-	ProbeID  string
-	PID      uint32
-	UID      uint32
-	Argdata  []*Param
-	StackPCs []uint64
+	ProbeID       string
+	PID           uint32
+	UID           uint32
+	Argdata       []*Param
+	StackPCs      []uint64
+	ParamIndicies []uint64
 }
 
 // Param is the representation of a single function parameter after being parsed from

--- a/pkg/dynamicinstrumentation/eventparser/event_parser_test.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser_test.go
@@ -149,6 +149,7 @@ func TestReadParams(t *testing.T) {
 	tests := []struct {
 		name           string
 		inputBuffer    []byte
+		indicies       []uint64
 		expectedResult []*ditypes.Param
 	}{
 		{
@@ -166,6 +167,7 @@ func TestReadParams(t *testing.T) {
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 				0, 0, 0, 0,
 			},
+			indicies: []uint64{0},
 			expectedResult: []*ditypes.Param{{
 				Type: "[]struct", Size: 0x2, Kind: 0x17,
 				Fields: []*ditypes.Param{
@@ -186,7 +188,7 @@ func TestReadParams(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := readParams(tt.inputBuffer)
+			output := readParams(tt.indicies, tt.inputBuffer)
 			assert.Equal(t, output, tt.expectedResult)
 		})
 	}
@@ -329,13 +331,15 @@ func TestParseParams(t *testing.T) {
 	type testCase struct {
 		Name           string
 		Buffer         []byte
+		Indicies       []uint64
 		ExpectedOutput []*ditypes.Param
 	}
 
 	testCases := []testCase{
 		{
-			Name:   "uint slice ok",
-			Buffer: []byte{23, 3, 0, 7, 8, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Name:     "uint slice ok",
+			Buffer:   []byte{23, 3, 0, 7, 8, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Indicies: []uint64{0},
 			ExpectedOutput: []*ditypes.Param{
 				{
 					Type: "[]uint",
@@ -365,8 +369,9 @@ func TestParseParams(t *testing.T) {
 			},
 		},
 		{
-			Name:   "uint pointer ok",
-			Buffer: []byte{22, 8, 0, 7, 8, 0, 248, 60, 128, 0, 64, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Name:     "uint pointer ok",
+			Buffer:   []byte{22, 8, 0, 7, 8, 0, 248, 60, 128, 0, 64, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Indicies: []uint64{0},
 			ExpectedOutput: []*ditypes.Param{
 				{
 					Type: "*uint",
@@ -384,8 +389,9 @@ func TestParseParams(t *testing.T) {
 			},
 		},
 		{
-			Name:   "struct pointer ok",
-			Buffer: []byte{22, 8, 0, 25, 2, 0, 7, 8, 0, 1, 1, 0, 248, 60, 128, 0, 64, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Name:     "struct pointer ok",
+			Buffer:   []byte{22, 8, 0, 25, 2, 0, 7, 8, 0, 1, 1, 0, 248, 60, 128, 0, 64, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Indicies: []uint64{0},
 			ExpectedOutput: []*ditypes.Param{
 				{
 					Type: "*struct",
@@ -416,8 +422,9 @@ func TestParseParams(t *testing.T) {
 			},
 		},
 		{
-			Name:   "struct pointer nil",
-			Buffer: []byte{22, 8, 0, 25, 3, 0, 1, 1, 0, 2, 8, 0, 4, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Name:     "struct pointer nil",
+			Buffer:   []byte{22, 8, 0, 25, 3, 0, 1, 1, 0, 2, 8, 0, 4, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Indicies: []uint64{0},
 			ExpectedOutput: []*ditypes.Param{
 				{
 					Type:     "*struct",
@@ -432,7 +439,7 @@ func TestParseParams(t *testing.T) {
 
 	for i := range testCases {
 		t.Run(testCases[i].Name, func(t *testing.T) {
-			result := readParams(testCases[i].Buffer)
+			result := readParams(testCases[i].Indicies, testCases[i].Buffer)
 			for i := range result {
 				if strings.HasPrefix(result[i].Type, "*") && result[i].ValueStr != "0x0" {
 					result[i].ValueStr = ""

--- a/pkg/dynamicinstrumentation/testutil/sample/arrays.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/arrays.go
@@ -83,6 +83,13 @@ func test_array_of_structs(a [2]nestedStruct) {
 }
 
 //nolint:all
+//go:noinline
+func test_over_limit_array_parameters(a, b, c, d, e, f, g,
+	h, i, j, k, l, m, n,
+	o, p, q, r, s, t, u [3]uint32) {
+}
+
+//nolint:all
 func ExecuteArrayFuncs() {
 	test_byte_array([2]byte{1, 1})
 	test_rune_array([2]rune{1, 2})
@@ -103,4 +110,8 @@ func ExecuteArrayFuncs() {
 	test_array_of_strings([2]string{"first", "second"})
 	test_array_of_structs([2]nestedStruct{{42, "foo"}, {24, "bar"}})
 	test_array_of_arrays_of_arrays([2][2][2]int{{[2]int{1, 2}, [2]int{3, 4}}, {[2]int{5, 6}, [2]int{7, 8}}})
+
+	test_over_limit_array_parameters([3]uint32{1, 2, 1}, [3]uint32{1, 2, 2}, [3]uint32{1, 2, 3}, [3]uint32{1, 2, 4}, [3]uint32{1, 2, 5}, [3]uint32{1, 2, 6}, [3]uint32{1, 2, 7},
+		[3]uint32{1, 2, 8}, [3]uint32{1, 2, 9}, [3]uint32{1, 2, 10}, [3]uint32{1, 2, 11}, [3]uint32{1, 2, 12}, [3]uint32{1, 2, 13}, [3]uint32{1, 2, 14},
+		[3]uint32{1, 2, 15}, [3]uint32{1, 2, 16}, [3]uint32{1, 2, 17}, [3]uint32{1, 2, 18}, [3]uint32{1, 2, 19}, [3]uint32{1, 2, 20}, [3]uint32{1, 2, 21})
 }

--- a/pkg/dynamicinstrumentation/testutil/sample/multi_params.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/multi_params.go
@@ -11,6 +11,14 @@ package sample
 
 //nolint:all
 //go:noinline
+func test_over_limit_parameters(
+	a, b, c, d, e, f, g,
+	h, i, j, k, l, m, n,
+	o, p, q, r, s, t, u byte) {
+}
+
+//nolint:all
+//go:noinline
 func test_combined_byte(w byte, x byte, y float32) {}
 
 //nolint:all
@@ -103,4 +111,8 @@ func ExecuteMultiParamFuncs() {
 	test_combined_uint16(2, 1216, 3.0)
 	test_combined_uint32(2, 1232, 3.0)
 	test_combined_uint64(2, 1264, 3.0)
+	test_over_limit_parameters(1, 2, 3, 4, 5, 6, 7,
+		8, 9, 10, 11, 12, 13, 14,
+		15, 16, 17, 18, 19, 20, 21)
+
 }


### PR DESCRIPTION
### What does this PR do?

Adds logic where each parameter that's captured in BPF records at what index in the buffer it's content starts at. This allows for individual parsing of the parameters which benefits reliability of partial snapshot captures. In other words, if there's an issue parsing one parameter, the others can still be captured.

It also adds logic to properly enforce a parameter limit of 20.

### Motivation

Better reliability of partial snapshot captures

### Describe how you validated your changes

Updated tests.

### Possible Drawbacks / Trade-offs

### Additional Notes

This also enables us to add logic where we can fallback from verifier/compilation errors by disabling one/more parameters but not others.