### PR TITLE
[USMON-1401] reintroduce `tracepoint__net__netif_receive_skb` split

### DIFF
--- a/pkg/network/ebpf/c/protocols/flush.h
+++ b/pkg/network/ebpf/c/protocols/flush.h
@@ -9,9 +9,14 @@
 #include "protocols/postgres/decoding.h"
 #include "protocols/redis/decoding.h"
 
-
 SEC("tracepoint/net/netif_receive_skb")
 int tracepoint__net__netif_receive_skb_http(void *ctx) {
+    http_batch_flush_with_telemetry(ctx);
+    return 0;
+}
+
+SEC("kprobe/__netif_receive_skb_core")
+int netif_receive_skb_core_http_4_14(void *ctx) {
     http_batch_flush_with_telemetry(ctx);
     return 0;
 }
@@ -29,14 +34,32 @@ int tracepoint__net__netif_receive_skb_kafka(void *ctx) {
     return 0;
 }
 
+SEC("kprobe/__netif_receive_skb_core")
+int netif_receive_skb_core_kafka_4_14(void *ctx) {
+    kafka_batch_flush_with_telemetry(ctx);
+    return 0;
+}
+
 SEC("tracepoint/net/netif_receive_skb")
 int tracepoint__net__netif_receive_skb_postgres(void *ctx) {
     postgres_batch_flush_with_telemetry(ctx);
     return 0;
 }
 
+SEC("kprobe/__netif_receive_skb_core")
+int netif_receive_skb_core_postgres_4_14(void *ctx) {
+    postgres_batch_flush_with_telemetry(ctx);
+    return 0;
+}
+
 SEC("tracepoint/net/netif_receive_skb")
 int tracepoint__net__netif_receive_skb_redis(void *ctx) {
+    redis_batch_flush_with_telemetry(ctx);
+    return 0;
+}
+
+SEC("kprobe/__netif_receive_skb_core")
+int netif_receive_skb_core_redis_4_14(void *ctx) {
     redis_batch_flush_with_telemetry(ctx);
     return 0;
 }

--- a/pkg/network/ebpf/c/protocols/flush.h
+++ b/pkg/network/ebpf/c/protocols/flush.h
@@ -9,6 +9,22 @@
 #include "protocols/postgres/decoding.h"
 #include "protocols/redis/decoding.h"
 
+/**
+Note - We used to have a single tracepoint to flush all the protocols, but we had to split it
+to enable telemetry for all protocols.
+
+However, kernel 4.14 does not support multiple programs to hook the same tracepoint, hence
+we move into kprobes to workaround that.
+
+The kprobe we use is '__netif_receive_skb_core', which is hook-able in several kernels
+including 4.14, but it is not supported for kprobe hooking in kernels 6+.
+
+To simplify the scenario, we have a support for 4.14 based on kprobes, and 4.15+ will be using
+the tracepoints.
+
+http2 is supported only from kernel 5.2, therefore it does not have the kprobe version
+*/
+
 SEC("tracepoint/net/netif_receive_skb")
 int tracepoint__net__netif_receive_skb_http(void *ctx) {
     http_batch_flush_with_telemetry(ctx);

--- a/pkg/network/protocols/events/README.md
+++ b/pkg/network/protocols/events/README.md
@@ -36,8 +36,8 @@ filter programs. Because of that we recommend to call it from
 
 ```c
 SEC("tracepoint/net/netif_receive_skb")
-int tracepoint__net__netif_receive_skb(struct pt_regs* ctx) {
-    <protocol>_batch_flush(ctx);
+int tracepoint__net__netif_receive_skb_<protocol>(struct pt_regs* ctx) {
+    <protocol>_batch_flush_with_telemetry(ctx);
     return 0;
 }
 ```

--- a/pkg/network/protocols/events/README.md
+++ b/pkg/network/protocols/events/README.md
@@ -32,11 +32,20 @@ This will instantiate the necessary eBPF maps along with two functions:
 Please note that `<protocol>_batch_flush` requires access to the
 `bpf_perf_event_output` helper, which is typically not available to socket
 filter programs. Because of that we recommend to call it from
-`__netif_receive_skb_core` which is associated to the execution of socket filter programs:
+`__netif_receive_skb_core` or `netif_receive_skb` which is associated to the execution of socket filter programs.
+
+For kernels 4.14 we need the kprobe, as we cannot have multiple probes attached to the same tracepoint,
+and for kernels 4.15 and above we can use the tracepoint as the kprobe is not available from kernels 6 and above
 
 ```c
 SEC("kprobe/__netif_receive_skb_core")
-int BPF_KPROBE(netif_receive_skb_core_<protocol>) {
+int netif_receive_skb_core_<protocol>_4_14(void *ctx) {
+    <protocol>_batch_flush_with_telemetry(ctx);
+    return 0;
+}
+
+SEC("tracepoint/net/netif_receive_skb")
+int tracepoint__net__netif_receive_skb_<protocol>(void *ctx) {
     <protocol>_batch_flush_with_telemetry(ctx);
     return 0;
 }

--- a/pkg/network/protocols/events/README.md
+++ b/pkg/network/protocols/events/README.md
@@ -32,11 +32,11 @@ This will instantiate the necessary eBPF maps along with two functions:
 Please note that `<protocol>_batch_flush` requires access to the
 `bpf_perf_event_output` helper, which is typically not available to socket
 filter programs. Because of that we recommend to call it from
-`netif_receive_skb` which is associated to the execution of socket filter programs:
+`__netif_receive_skb_core` which is associated to the execution of socket filter programs:
 
 ```c
-SEC("tracepoint/net/netif_receive_skb")
-int tracepoint__net__netif_receive_skb_<protocol>(struct pt_regs* ctx) {
+SEC("kprobe/__netif_receive_skb_core")
+int BPF_KPROBE(netif_receive_skb_core_<protocol>) {
     <protocol>_batch_flush_with_telemetry(ctx);
     return 0;
 }

--- a/pkg/network/protocols/http/protocol.go
+++ b/pkg/network/protocols/http/protocol.go
@@ -44,6 +44,7 @@ const (
 	tlsProcessTailCall     = "uprobe__http_process"
 	tlsTerminationTailCall = "uprobe__http_termination"
 	eventStream            = "http"
+	netifProbes            = "tracepoint__net__netif_receive_skb_http"
 )
 
 // Spec is the protocol spec for the HTTP protocol.
@@ -64,6 +65,13 @@ var Spec = &protocols.ProtocolSpec{
 		},
 		{
 			Name: "http_batches",
+		},
+	},
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: netifProbes,
+			},
 		},
 	},
 	TailCalls: []manager.TailCallRoute{
@@ -130,6 +138,7 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
+	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: netifProbes}})
 	utils.EnableOption(opts, "http_monitoring_enabled")
 	// Configure event stream
 	events.Configure(p.cfg, eventStream, p.mgr, opts)

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -128,6 +128,7 @@ var Spec = &protocols.ProtocolSpec{
 		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFFuncName: netifProbe,
+				UID:          eventStream,
 			},
 		},
 	},
@@ -274,7 +275,12 @@ func (p *Protocol) ConfigureOptions(opts *manager.Options) {
 		EditorFlag: manager.EditMaxEntries,
 	}
 
-	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: netifProbe}})
+	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          eventStream,
+			EBPFFuncName: netifProbe,
+		},
+	})
 	utils.EnableOption(opts, "http2_monitoring_enabled")
 	utils.EnableOption(opts, "terminated_http2_monitoring_enabled")
 	// Configure event stream

--- a/pkg/network/protocols/http2/protocol.go
+++ b/pkg/network/protocols/http2/protocol.go
@@ -58,6 +58,7 @@ const (
 	dynamicTableCleaner       = "socket__http2_dynamic_table_cleaner"
 	eosParserTailCall         = "socket__http2_eos_parser"
 	eventStream               = "http2"
+	netifProbe                = "tracepoint__net__netif_receive_skb_http2"
 
 	// TelemetryMap is the name of the map that collects telemetry for plaintext and TLS encrypted HTTP/2 traffic.
 	TelemetryMap = "http2_telemetry"
@@ -121,6 +122,13 @@ var Spec = &protocols.ProtocolSpec{
 		},
 		{
 			Name: "terminated_http2_batches",
+		},
+	},
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: netifProbe,
+			},
 		},
 	},
 	TailCalls: []manager.TailCallRoute{
@@ -266,6 +274,7 @@ func (p *Protocol) ConfigureOptions(opts *manager.Options) {
 		EditorFlag: manager.EditMaxEntries,
 	}
 
+	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: netifProbe}})
 	utils.EnableOption(opts, "http2_monitoring_enabled")
 	utils.EnableOption(opts, "terminated_http2_monitoring_enabled")
 	// Configure event stream

--- a/pkg/network/protocols/kafka/protocol.go
+++ b/pkg/network/protocols/kafka/protocol.go
@@ -67,6 +67,7 @@ const (
 	tlsDispatcherTailCall  = "uprobe__tls_protocol_dispatcher_kafka"
 	// eBPFTelemetryMap is the name of the eBPF map used to retrieve metrics from the kernel
 	eBPFTelemetryMap = "kafka_telemetry"
+	netifProbe       = "tracepoint__net__netif_receive_skb_kafka"
 )
 
 // Spec is the protocol spec for the kafka protocol.
@@ -99,6 +100,13 @@ var Spec = &protocols.ProtocolSpec{
 		},
 		{
 			Name: "kafka_batches",
+		},
+	},
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: netifProbe,
+			},
 		},
 	},
 	TailCalls: []manager.TailCallRoute{
@@ -255,6 +263,7 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
+	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: netifProbe}})
 	events.Configure(p.cfg, eventStreamName, p.mgr, opts)
 	utils.EnableOption(opts, "kafka_monitoring_enabled")
 }

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/events"
 	postgresebpf "github.com/DataDog/datadog-agent/pkg/network/protocols/postgres/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/buildmode"
+	usmconfig "github.com/DataDog/datadog-agent/pkg/network/usm/config"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -44,6 +45,7 @@ const (
 	tlsHandleResponseTailCall = "uprobe__postgres_tls_handle_response"
 	eventStream               = "postgres"
 	netifProbe                = "tracepoint__net__netif_receive_skb_postgres"
+	netifProbe414             = "netif_receive_skb_core_postgres_4_14"
 )
 
 // protocol holds the state of the postgres protocol monitoring.
@@ -83,8 +85,16 @@ var Spec = &protocols.ProtocolSpec{
 	},
 	Probes: []*manager.Probe{
 		{
+			KprobeAttachMethod: manager.AttachKprobeWithPerfEventOpen,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: netifProbe414,
+				UID:          eventStream,
+			},
+		},
+		{
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				EBPFFuncName: netifProbe,
+				UID:          eventStream,
 			},
 		},
 	},
@@ -167,7 +177,14 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
-	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: netifProbe}})
+	netifProbeID := manager.ProbeIdentificationPair{
+		EBPFFuncName: netifProbe,
+		UID:          eventStream,
+	}
+	if usmconfig.ShouldUseNetifReceiveSKBCoreKprobe() {
+		netifProbeID.EBPFFuncName = netifProbe414
+	}
+	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: netifProbeID})
 	utils.EnableOption(opts, "postgres_monitoring_enabled")
 	// Configure event stream
 	events.Configure(p.cfg, eventStream, p.mgr, opts)

--- a/pkg/network/protocols/postgres/protocol.go
+++ b/pkg/network/protocols/postgres/protocol.go
@@ -43,6 +43,7 @@ const (
 	tlsTerminationTailCall    = "uprobe__postgres_tls_termination"
 	tlsHandleResponseTailCall = "uprobe__postgres_tls_handle_response"
 	eventStream               = "postgres"
+	netifProbe                = "tracepoint__net__netif_receive_skb_postgres"
 )
 
 // protocol holds the state of the postgres protocol monitoring.
@@ -78,6 +79,13 @@ var Spec = &protocols.ProtocolSpec{
 		},
 		{
 			Name: "postgres_batches",
+		},
+	},
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: netifProbe,
+			},
 		},
 	},
 	TailCalls: []manager.TailCallRoute{
@@ -159,6 +167,7 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
+	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: netifProbe}})
 	utils.EnableOption(opts, "postgres_monitoring_enabled")
 	// Configure event stream
 	events.Configure(p.cfg, eventStream, p.mgr, opts)

--- a/pkg/network/protocols/redis/protocol.go
+++ b/pkg/network/protocols/redis/protocol.go
@@ -32,6 +32,7 @@ const (
 	tlsProcessTailCall     = "uprobe__redis_tls_process"
 	tlsTerminationTailCall = "uprobe__redis_tls_termination"
 	eventStream            = "redis"
+	netifProbe             = "tracepoint__net__netif_receive_skb_redis"
 )
 
 type protocol struct {
@@ -47,6 +48,13 @@ var Spec = &protocols.ProtocolSpec{
 	Factory: newRedisProtocol,
 	Maps: []*manager.Map{
 		{Name: inFlightMap},
+	},
+	Probes: []*manager.Probe{
+		{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFFuncName: netifProbe,
+			},
+		},
 	},
 	TailCalls: []manager.TailCallRoute{
 		{
@@ -98,6 +106,7 @@ func (p *protocol) ConfigureOptions(opts *manager.Options) {
 		MaxEntries: p.cfg.MaxUSMConcurrentRequests,
 		EditorFlag: manager.EditMaxEntries,
 	}
+	opts.ActivatedProbes = append(opts.ActivatedProbes, &manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: netifProbe}})
 	utils.EnableOption(opts, "redis_monitoring_enabled")
 	events.Configure(p.cfg, eventStream, p.mgr, opts)
 }

--- a/pkg/network/usm/config/config.go
+++ b/pkg/network/usm/config/config.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
@@ -22,11 +23,15 @@ import (
 // MinimumKernelVersion indicates the minimum kernel version required for HTTP monitoring
 var MinimumKernelVersion kernel.Version
 
+// NetifReceiveSKBCoreKprobeMaximumKernelVersion indicates the maximum kernel version to use with the __netif_receive_skb_core kprobe
+var NetifReceiveSKBCoreKprobeMaximumKernelVersion kernel.Version
+
 // ErrNotSupported is the error returned if USM is not supported on this platform
 var ErrNotSupported = errors.New("Universal Service Monitoring (USM) is not supported")
 
 func init() {
 	MinimumKernelVersion = kernel.VersionCode(4, 14, 0)
+	NetifReceiveSKBCoreKprobeMaximumKernelVersion = kernel.VersionCode(4, 15, 0)
 }
 
 func runningOnARM() bool {
@@ -49,6 +54,27 @@ func TLSSupported(c *config.Config) bool {
 	return kversion >= MinimumKernelVersion
 }
 
+var (
+	mu                    sync.Mutex
+	isKernelVersionCached bool
+	cachedKernelVersion   kernel.Version
+)
+
+// GetCachedKernelVersion returns the cached kernel version
+func GetCachedKernelVersion() kernel.Version {
+	mu.Lock()
+	defer mu.Unlock()
+	return cachedKernelVersion
+}
+
+// SetCachedKernelVersion sets the cached kernel version
+func SetCachedKernelVersion(version kernel.Version) {
+	mu.Lock()
+	defer mu.Unlock()
+	isKernelVersionCached = true
+	cachedKernelVersion = version
+}
+
 // CheckUSMSupported returns an error if USM is not supported
 // on this platform. Callers can check `errors.Is(err, ErrNotSupported)`
 // to verify if USM is supported
@@ -67,6 +93,7 @@ func CheckUSMSupported(cfg *config.Config) error {
 		return fmt.Errorf("%w: a Linux kernel version of %s or higher is required; we detected %s", ErrNotSupported, MinimumKernelVersion, kversion)
 	}
 
+	SetCachedKernelVersion(kversion)
 	return nil
 }
 
@@ -79,4 +106,20 @@ func IsUSMSupportedAndEnabled(config *config.Config) bool {
 // NeedProcessMonitor returns true if the process monitor is needed for the given configuration
 func NeedProcessMonitor(config *config.Config) bool {
 	return config.EnableNativeTLSMonitoring || config.EnableGoTLSSupport || config.EnableIstioMonitoring || config.EnableNodeJSMonitoring
+}
+
+// ShouldUseNetifReceiveSKBCoreKprobe returns true if the __netif_receive_skb_core kprobe should be used.
+func ShouldUseNetifReceiveSKBCoreKprobe() bool {
+	mu.Lock()
+	isCached := isKernelVersionCached
+	mu.Unlock()
+	if !isCached {
+		kversion, err := kernel.HostVersion()
+		if err != nil {
+			log.Warnf("could not determine the current kernel version: %s", err)
+			return false
+		}
+		SetCachedKernelVersion(kversion)
+	}
+	return GetCachedKernelVersion() < NetifReceiveSKBCoreKprobeMaximumKernelVersion
 }

--- a/pkg/network/usm/ebpf_main.go
+++ b/pkg/network/usm/ebpf_main.go
@@ -112,12 +112,6 @@ func newEBPFProgram(c *config.Config, connectionProtocolMap *ebpf.Map) (*ebpfPro
 			},
 			{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					EBPFFuncName: "tracepoint__net__netif_receive_skb",
-					UID:          probeUID,
-				},
-			},
-			{
-				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFFuncName: protocolDispatcherSocketFilterFunction,
 					UID:          probeUID,
 				},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The PR splits `tracepoint__net__netif_receive_skb` into multiple probes, each per protocol
That allows us to enable telemetry in `<protocol>_batch_flush` for every protocol

The PR introduce a kprobe version, only for 4.14 kernels, as only 4.15 kernel [introduced](https://github.com/torvalds/linux/commit/e87c6bc3852b981e71c757be20771546ce9f76f3) the option to have multiple probes on the same tracepoint

The PR uses a kprobe on `__netif_receive_skb_core` in 4.14, and tracepoint on `net/netif_receive_skb` for any other kernel
as `__netif_receive_skb_core` is not hook-able in kernels 6+.

### Motivation

The original change was introduced in #34962, and got reverted in #35018 due to incident-36060.
The reason for the revert was - USM couldn't run on kernel 4.14 due to the limitation describe in the section above.
The CI passed as we didn't have a test that verifies USM is loaded with all features on 4.14 kernel.
The gap was accidentally discovered when #34959 PR was merged, as it added a test that loads USM with all features and verifies USM is actually running.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

A test to verify USM is loaded with all features was fixed - #34959

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

An alternative could be - have a single TP for all protocol besides HTTP2 (as it is not supported before kernel 5.2), but such a solution is only temporary, as any new protocol being added can push us over the instruction limit and then we will need to split it.

First commit is revert of #35018 and actually equal to #34962
The second commit is the changed applied on top of it.