### PR TITLE
[GPU]: core-check: small fix in fields collector

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields.go
@@ -72,9 +72,7 @@ func (c *fieldsCollector) getFieldValues() ([]nvml.FieldValue, error) {
 	}
 
 	ret := c.device.GetFieldValues(fields)
-	if ret == nvml.ERROR_NOT_SUPPORTED {
-		return nil, errUnsupportedDevice
-	} else if ret != nvml.SUCCESS {
+	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("failed to get field values: %s", nvml.ErrorString(ret))
 	}
 


### PR DESCRIPTION
### What does this PR do?

removed redundant check for return value from nvml API call

### Motivation

DeviceGetFields doesn't return NotSupported error according to its API ([ref](https://docs.nvidia.com/deploy/nvml-api/group__nvmlFieldValueQueries.html#group__nvmlFieldValueQueries_1g0b02941a262ee4327eb82831f91a1bc0))

### Describe how you validated your changes
existing UTs should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->