### PR TITLE
[EBPF] kmt: do not install kmt dependencies for notify jobs

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -341,7 +341,7 @@ notify_ebpf_complexity_changes:
     # TODO: Remove this override once the standard build image supports building system probe
     - echo "libvirt-python; sys_platform == 'never'" >> /tmp/uv-overrides.txt
     - export UV_OVERRIDE=/tmp/uv-overrides.txt
-    - python3 -m dda self dep sync -f legacy-tasks -f legacy-kernel-matrix-testing
+    - python3 -m dda self dep sync -f legacy-tasks
     - !reference [.setup_agent_github_app]
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN
   script:

--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -334,13 +334,6 @@ notify_ebpf_complexity_changes:
               - fedora_38
             TEST_SET: no_usm
   before_script:
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    # TODO: Remove this override once the standard build image supports building system probe
-    - echo "libvirt-python; sys_platform == 'never'" >> /tmp/uv-overrides.txt
-    - export UV_OVERRIDE=/tmp/uv-overrides.txt
     - python3 -m dda self dep sync -f legacy-tasks
     - !reference [.setup_agent_github_app]
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN read_api) || exit $?; export GITLAB_TOKEN


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the `notify_ebpf_complexity_changes` job by removing the installation of all KMT requisites, which failed because `libvirt-python` could not be installed due to missing system requirements.

This is possible as the 0.5.2 version of `dda` moved the `tabulate` package to the `legacy-tasks` requirement set (https://github.com/DataDog/datadog-agent-dev/pull/40), so that we don't need extra requirements for this job.

### Motivation

Fix the failing job.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Job working on the pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/846954405

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->