### PR TITLE
fix(heroku): Properly embed the installer in the agent

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -95,7 +95,6 @@ AGENT_TAGS = {
 # AGENT_HEROKU_TAGS lists the tags for Heroku agent build
 AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
     {
-        "bundle_installer",
         "containerd",
         "no_dynamic_plugins",
         "cri",


### PR DESCRIPTION
### What does this PR do?
This PR is a follow-up of https://github.com/DataDog/datadog-agent/pull/34601. The installer wasn't added in the Heroku flavor. The Heroku flavor uses the same post install scripts as the main flavor; and these scripts will soon call the installer so the installer needs to be embedded.

### Motivation

### Describe how you validated your changes
Manual QA

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->