### PR TITLE
Fix flake finder pipeline + add a check that the generated pipeline is valid

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -797,8 +797,9 @@ generate-flakes-finder-pipeline:
     - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:
+    - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
     - dda inv -e testwasher.generate-flake-finder-pipeline
-    - inv -e linter.gitlab-ci --input-file $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
+    - dda inv -e linter.gitlab-ci --input-file $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
   artifacts:
     paths:
       - $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
@@ -846,7 +847,9 @@ generate-fips-e2e-pipeline:
     - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:
-    - inv -e fips.generate-fips-e2e-pipeline
+    - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
+    - dda inv -e fips.generate-fips-e2e-pipeline
+    - dda inv -e linter.gitlab-ci --input-file $CI_PROJECT_DIR/fips-e2e-gitlab-ci.yml
   artifacts:
     paths:
       - $CI_PROJECT_DIR/fips-e2e-gitlab-ci.yml

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -798,6 +798,7 @@ generate-flakes-finder-pipeline:
   tags: ["arch:amd64"]
   script:
     - dda inv -e testwasher.generate-flake-finder-pipeline
+    - inv -e linter.gitlab-ci --input-file $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml
   artifacts:
     paths:
       - $CI_PROJECT_DIR/flake-finder-gitlab-ci.yml

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -413,7 +413,7 @@ def list_get_parameter_calls(file):
 
 
 @task
-def gitlab_ci(ctx, test="all", custom_context=None):
+def gitlab_ci(ctx, test="all", custom_context=None, input_file=".gitlab-ci.yml"):
     """Lints Gitlab CI files in the datadog-agent repository.
 
     This will lint the main gitlab ci file with different
@@ -424,7 +424,7 @@ def gitlab_ci(ctx, test="all", custom_context=None):
         custom_context: A custom context to test the gitlab ci file with.
     """
     print(f'{color_message("info", Color.BLUE)}: Fetching Gitlab CI configurations...')
-    configs = get_all_gitlab_ci_configurations(ctx, with_lint=False)
+    configs = get_all_gitlab_ci_configurations(ctx, input_file=input_file, with_lint=False)
 
     for entry_point, input_config in configs.items():
         with gitlab_section(f"Testing {entry_point}", echo=True):

--- a/tasks/testwasher.py
+++ b/tasks/testwasher.py
@@ -286,7 +286,8 @@ def generate_flake_finder_pipeline(ctx, n=3, generate_config=False):
     # Create n jobs with the same configuration
     for job in kept_job:
         for i in range(n):
-            new_jobs[f"{job}-{i}"] = updated_jobs[job]
+            new_jobs[f"{job}-{i}"] = copy.deepcopy(updated_jobs[job])
+            new_jobs[f"{job}-{i}"]["stage"] = f"flake-finder-{i}"
 
             if 'E2E_PRE_INITIALIZED' in new_jobs[f"{job}-{i}"]['variables']:
                 del new_jobs[f"{job}-{i}"]['variables']['E2E_PRE_INITIALIZED']


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix the flake finder pipeline that was broken since the refactoring done to support creating nightly FIPS pipelines
Also add a check in the job generating the pipeline, to make sure it fails if the pipeline is invalid

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->