### PR TITLE
[Closed] Support multiple authentications in network devices autodiscovery

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -405,6 +405,17 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		return nil, fmt.Errorf("min collection interval must be > 0, but got: %v", c.MinCollectionInterval.Seconds())
 	}
 
+	fmt.Println("READING AUTHENTICATIONS OF LEN ", len(instance.Authentications))
+	fmt.Println("CommunityString: ", instance.CommunityString)
+	fmt.Println("SnmpVersion: ", instance.SnmpVersion)
+	fmt.Println("Timeout: ", instance.Timeout)
+	fmt.Println("Retries: ", instance.Retries)
+	fmt.Println("User: ", instance.User)
+	fmt.Println("AuthProtocol: ", instance.AuthProtocol)
+	fmt.Println("AuthKey: ", instance.AuthKey)
+	fmt.Println("PrivProtocol: ", instance.PrivProtocol)
+	fmt.Println("PrivKey: ", instance.PrivKey)
+	fmt.Println("ContextName: ", instance.ContextName)
 	if instance.CommunityString != "" || instance.User != "" {
 		ica := InstanceConfigAuthentication{
 			CommunityString: instance.CommunityString,

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -405,21 +405,36 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		return nil, fmt.Errorf("min collection interval must be > 0, but got: %v", c.MinCollectionInterval.Seconds())
 	}
 
-	ica := InstanceConfigAuthentication{
-		CommunityString: instance.CommunityString,
-		SnmpVersion:     instance.SnmpVersion,
-		Timeout:         instance.Timeout,
-		Retries:         instance.Retries,
-		User:            instance.User,
-		AuthProtocol:    instance.AuthProtocol,
-		AuthKey:         instance.AuthKey,
-		PrivProtocol:    instance.PrivProtocol,
-		PrivKey:         instance.PrivKey,
-		ContextName:     instance.ContextName,
-	}
-	c.Authentications = append(c.Authentications, ica.toAuthentication())
-	for _, ica = range instance.Authentications {
+	if instance.CommunityString != "" || instance.User != "" {
+		ica := InstanceConfigAuthentication{
+			CommunityString: instance.CommunityString,
+			SnmpVersion:     instance.SnmpVersion,
+			Timeout:         instance.Timeout,
+			Retries:         instance.Retries,
+			User:            instance.User,
+			AuthProtocol:    instance.AuthProtocol,
+			AuthKey:         instance.AuthKey,
+			PrivProtocol:    instance.PrivProtocol,
+			PrivKey:         instance.PrivKey,
+			ContextName:     instance.ContextName,
+		}
 		c.Authentications = append(c.Authentications, ica.toAuthentication())
+	}
+	for _, ica := range instance.Authentications {
+		c.Authentications = append(c.Authentications, ica.toAuthentication())
+	}
+
+	if len(c.Authentications) != 0 {
+		c.CommunityString = c.Authentications[0].CommunityString
+		c.SnmpVersion = c.Authentications[0].SnmpVersion
+		c.Timeout = c.Authentications[0].Timeout
+		c.Retries = c.Authentications[0].Retries
+		c.User = c.Authentications[0].User
+		c.AuthProtocol = c.Authentications[0].AuthProtocol
+		c.AuthKey = c.Authentications[0].AuthKey
+		c.PrivProtocol = c.Authentications[0].PrivProtocol
+		c.PrivKey = c.Authentications[0].PrivKey
+		c.ContextName = c.Authentications[0].ContextName
 	}
 
 	if instance.OidBatchSize != 0 {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -424,19 +424,6 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.Authentications = append(c.Authentications, ica.toAuthentication())
 	}
 
-	if len(c.Authentications) != 0 {
-		c.CommunityString = c.Authentications[0].CommunityString
-		c.SnmpVersion = c.Authentications[0].SnmpVersion
-		c.Timeout = c.Authentications[0].Timeout
-		c.Retries = c.Authentications[0].Retries
-		c.User = c.Authentications[0].User
-		c.AuthProtocol = c.Authentications[0].AuthProtocol
-		c.AuthKey = c.Authentications[0].AuthKey
-		c.PrivProtocol = c.Authentications[0].PrivProtocol
-		c.PrivKey = c.Authentications[0].PrivKey
-		c.ContextName = c.Authentications[0].ContextName
-	}
-
 	if instance.OidBatchSize != 0 {
 		c.OidBatchSize = int(instance.OidBatchSize)
 	} else if initConfig.OidBatchSize != 0 {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -45,6 +45,17 @@ authKey: my-authKey
 privProtocol: aes
 privKey: my-privKey
 context_name: my-contextName
+authentications:
+  - community_string: my-community-string-2
+  - timeout: 6
+    retries: 4
+    snmp_version: 3
+    user: my-user-2
+    authProtocol: sha
+    authKey: my-authKey-2
+    privProtocol: aes
+    privKey: my-privKey-2
+    context_name: my-contextName-2
 metrics:
 - symbol:
     OID: 1.3.6.1.2.1.2.1
@@ -159,6 +170,16 @@ bulk_max_repetitions: 20
 	assert.Equal(t, "aes", config.PrivProtocol)
 	assert.Equal(t, "my-privKey", config.PrivKey)
 	assert.Equal(t, "my-contextName", config.ContextName)
+	assert.Equal(t, "my-community-string-2", config.Authentications[1].CommunityString)
+	assert.Equal(t, 6, config.Authentications[2].Timeout)
+	assert.Equal(t, 4, config.Authentications[2].Retries)
+	assert.Equal(t, "3", config.Authentications[2].SnmpVersion)
+	assert.Equal(t, "my-user-2", config.Authentications[2].User)
+	assert.Equal(t, "sha", config.Authentications[2].AuthProtocol)
+	assert.Equal(t, "my-authKey-2", config.Authentications[2].AuthKey)
+	assert.Equal(t, "aes", config.Authentications[2].PrivProtocol)
+	assert.Equal(t, "my-privKey-2", config.Authentications[2].PrivKey)
+	assert.Equal(t, "my-contextName-2", config.Authentications[2].ContextName)
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
 	assert.True(t, config.ProfileProvider.HasProfile("f5-big-ip"))
 	assert.Equal(t, "default:1.2.3.4", config.DeviceID)
@@ -347,6 +368,8 @@ ip_address: 1.2.3.4
 snmp_version: 2c
 profile: inline-profile
 community_string: '123'
+authentications:
+  - community_string: '456'
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
@@ -374,6 +397,7 @@ profiles:
 
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
 	assert.Equal(t, "123", config.CommunityString)
+	assert.Equal(t, "456", config.Authentications[1].CommunityString)
 	assert.True(t, config.ProfileProvider.HasProfile("f5-big-ip"))
 	assert.True(t, config.ProfileProvider.HasProfile("inline-profile"))
 	assert.Equal(t, "default:1.2.3.4", config.DeviceID)
@@ -404,6 +428,8 @@ func TestDefaultConfigurations(t *testing.T) {
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
 community_string: abc
+authentications:
+  - community_string: dce
 `)
 	// language=yaml
 	rawInitConfig := []byte(``)
@@ -415,6 +441,8 @@ community_string: abc
 	assert.Equal(t, uint16(161), config.Port)
 	assert.Equal(t, 2, config.Timeout)
 	assert.Equal(t, 3, config.Retries)
+	assert.Equal(t, 2, config.Authentications[1].Timeout)
+	assert.Equal(t, 3, config.Authentications[1].Retries)
 
 	assert.True(t, config.ProfileProvider.HasProfile("f5-big-ip"))
 	assert.True(t, config.ProfileProvider.HasProfile("another_profile"))
@@ -767,13 +795,17 @@ community_string: abc
 port: "123"
 timeout: "15"
 retries: "5"
+authentications:
+  - timeout: "10"
+  - retries: "3"
 `)
 	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint16(123), config.Port)
 	assert.Equal(t, 15, config.Timeout)
 	assert.Equal(t, 5, config.Retries)
-
+	assert.Equal(t, 10, config.Authentications[1].Timeout)
+	assert.Equal(t, 3, config.Authentications[1].Retries)
 }
 
 func TestExtraTags(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -161,15 +161,15 @@ bulk_max_repetitions: 20
 	assert.Equal(t, uint32(20), config.BulkMaxRepetitions)
 	assert.Equal(t, "1.2.3.4", config.IPAddress)
 	assert.Equal(t, uint16(1161), config.Port)
-	assert.Equal(t, 7, config.Timeout)
-	assert.Equal(t, 5, config.Retries)
-	assert.Equal(t, "2c", config.SnmpVersion)
-	assert.Equal(t, "my-user", config.User)
-	assert.Equal(t, "sha", config.AuthProtocol)
-	assert.Equal(t, "my-authKey", config.AuthKey)
-	assert.Equal(t, "aes", config.PrivProtocol)
-	assert.Equal(t, "my-privKey", config.PrivKey)
-	assert.Equal(t, "my-contextName", config.ContextName)
+	assert.Equal(t, 7, config.Authentications[0].Timeout)
+	assert.Equal(t, 5, config.Authentications[0].Retries)
+	assert.Equal(t, "2c", config.Authentications[0].SnmpVersion)
+	assert.Equal(t, "my-user", config.Authentications[0].User)
+	assert.Equal(t, "sha", config.Authentications[0].AuthProtocol)
+	assert.Equal(t, "my-authKey", config.Authentications[0].AuthKey)
+	assert.Equal(t, "aes", config.Authentications[0].PrivProtocol)
+	assert.Equal(t, "my-privKey", config.Authentications[0].PrivKey)
+	assert.Equal(t, "my-contextName", config.Authentications[0].ContextName)
 	assert.Equal(t, "my-community-string-2", config.Authentications[1].CommunityString)
 	assert.Equal(t, 6, config.Authentications[2].Timeout)
 	assert.Equal(t, 4, config.Authentications[2].Retries)
@@ -289,6 +289,49 @@ bulk_max_repetitions: 20
 	})
 }
 
+func TestAuthenticationsConfiguration(t *testing.T) {
+	// language=yaml
+	rawInstanceConfig := []byte(`
+network_address: 127.0.0.0/24
+authentications:
+  - community_string: my-community-string
+    snmp_version: 2c
+    timeout: 12
+    retries: 2
+  - user: my-user
+    authProtocol: sha
+    authKey: my-authKey
+    privProtocol: aes
+    privKey: my-privKey
+    context_name: my-contextName
+    timeout: 9
+    retries: 4
+  - community_string: my-community-string-2
+    timeout: 11
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+`)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "127.0.0.0/24", config.Network)
+	assert.Equal(t, "my-community-string", config.Authentications[0].CommunityString)
+	assert.Equal(t, "2c", config.Authentications[0].SnmpVersion)
+	assert.Equal(t, 12, config.Authentications[0].Timeout)
+	assert.Equal(t, 2, config.Authentications[0].Retries)
+	assert.Equal(t, "my-user", config.Authentications[1].User)
+	assert.Equal(t, "sha", config.Authentications[1].AuthProtocol)
+	assert.Equal(t, "my-authKey", config.Authentications[1].AuthKey)
+	assert.Equal(t, "aes", config.Authentications[1].PrivProtocol)
+	assert.Equal(t, "my-privKey", config.Authentications[1].PrivKey)
+	assert.Equal(t, "my-contextName", config.Authentications[1].ContextName)
+	assert.Equal(t, 9, config.Authentications[1].Timeout)
+	assert.Equal(t, 4, config.Authentications[1].Retries)
+	assert.Equal(t, "my-community-string-2", config.Authentications[2].CommunityString)
+	assert.Equal(t, 11, config.Authentications[2].Timeout)
+}
+
 func TestDiscoveryConfigurations(t *testing.T) {
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -396,7 +439,7 @@ profiles:
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}, config.GetStaticTags())
-	assert.Equal(t, "123", config.CommunityString)
+	assert.Equal(t, "123", config.Authentications[0].CommunityString)
 	assert.Equal(t, "456", config.Authentications[1].CommunityString)
 	assert.True(t, config.ProfileProvider.HasProfile("f5-big-ip"))
 	assert.True(t, config.ProfileProvider.HasProfile("inline-profile"))
@@ -439,8 +482,8 @@ authentications:
 	assert.Equal(t, "default", config.Namespace)
 	assert.Equal(t, "1.2.3.4", config.IPAddress)
 	assert.Equal(t, uint16(161), config.Port)
-	assert.Equal(t, 2, config.Timeout)
-	assert.Equal(t, 3, config.Retries)
+	assert.Equal(t, 2, config.Authentications[0].Timeout)
+	assert.Equal(t, 3, config.Authentications[0].Retries)
 	assert.Equal(t, 2, config.Authentications[1].Timeout)
 	assert.Equal(t, 3, config.Authentications[1].Retries)
 
@@ -802,8 +845,8 @@ authentications:
 	config, err := NewCheckConfig(rawInstanceConfig, []byte(``), nil)
 	assert.Nil(t, err)
 	assert.Equal(t, uint16(123), config.Port)
-	assert.Equal(t, 15, config.Timeout)
-	assert.Equal(t, 5, config.Retries)
+	assert.Equal(t, 15, config.Authentications[0].Timeout)
+	assert.Equal(t, 5, config.Authentications[0].Retries)
 	assert.Equal(t, 10, config.Authentications[1].Timeout)
 	assert.Equal(t, 3, config.Authentications[1].Retries)
 }

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
@@ -193,6 +193,10 @@ func (d *Discovery) checkDevice(job checkDeviceJob) error {
 	config := *job.subnet.config // shallow copy
 	config.IPAddress = job.currentIP.String()
 
+	fmt.Println("=====================================")
+	fmt.Println("AUTHENTICATIONS LENGTH: " + fmt.Sprint(len(config.Authentications)))
+	fmt.Println("=====================================")
+
 	deviceFound := false
 	for _, authentication := range config.Authentications {
 		config.CommunityString = authentication.CommunityString

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery.go
@@ -231,6 +231,20 @@ func (d *Discovery) checkDevice(job checkDeviceJob) error {
 }
 
 func (d *Discovery) checkDeviceForConfig(config *checkconfig.CheckConfig) (bool, error) {
+	fmt.Println("=====================================")
+	fmt.Println("CommunityString: " + config.CommunityString)
+	fmt.Println("SnmpVersion: " + config.SnmpVersion)
+	fmt.Println("Timeout: " + fmt.Sprint(config.Timeout))
+	fmt.Println("Retries: " + fmt.Sprint(config.Retries))
+	fmt.Println("User: " + config.User)
+	fmt.Println("AuthProtocol: " + config.AuthProtocol)
+	fmt.Println("AuthKey: " + config.AuthKey)
+	fmt.Println("PrivProtocol: " + config.PrivProtocol)
+	fmt.Println("PrivKey: " + config.PrivKey)
+	fmt.Println("ContextName: " + config.ContextName)
+	fmt.Println("IPAddress: " + config.IPAddress)
+	fmt.Println("=====================================")
+
 	sess, err := d.sessionFactory(config)
 	if err != nil {
 		return false, fmt.Errorf("error configure session for ip %s: %v", config.IPAddress, err)

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -88,6 +88,68 @@ func TestDiscovery(t *testing.T) {
 	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIps)
 }
 
+//func TestDiscoveryMultipleAuthentications(t *testing.T) {
+//	config := agentconfig.NewMock(t)
+//	config.SetWithoutSource("run_path", t.TempDir())
+//
+//	sess := session.CreateMockSession()
+//	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+//		return sess, nil
+//	}
+//
+//	packet := gosnmp.SnmpPacket{
+//		Variables: []gosnmp.SnmpPDU{
+//			{
+//				Name:  "1.3.6.1.2.1.1.2.0",
+//				Type:  gosnmp.ObjectIdentifier,
+//				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+//			},
+//		},
+//	}
+//	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
+//
+//	checkConfig := &checkconfig.CheckConfig{
+//		Network: "192.168.0.0/29",
+//		Authentications: []checkconfig.Authentication{
+//			{
+//				CommunityString: "invalid-1",
+//			},
+//			{
+//				CommunityString: "invalid-2",
+//			},
+//			{
+//				CommunityString: "public",
+//			},
+//		},
+//		DiscoveryInterval:  3600,
+//		DiscoveryWorkers:   1,
+//		IgnoredIPAddresses: map[string]bool{"192.168.0.5": true},
+//		ProfileProvider:    profile.StaticProvider(nil),
+//	}
+//	discovery := NewDiscovery(checkConfig, sessionFactory, config)
+//	discovery.Start()
+//	assert.NoError(t, waitForDiscoveredDevices(discovery, 7, 2*time.Second))
+//	discovery.Stop()
+//
+//	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()
+//
+//	var actualDiscoveredIps []string
+//	for _, deviceCk := range deviceConfigs {
+//		actualDiscoveredIps = append(actualDiscoveredIps, deviceCk.GetIPAddress())
+//	}
+//	expectedDiscoveredIps := []string{
+//		"192.168.0.0",
+//		"192.168.0.1",
+//		"192.168.0.2",
+//		"192.168.0.3",
+//		"192.168.0.4",
+//		// 192.168.0.5 is ignored
+//		"192.168.0.6",
+//		"192.168.0.7",
+//	}
+//	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIps)
+//}
+
 func TestDiscoveryCache(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetWithoutSource("run_path", t.TempDir())

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -53,8 +53,7 @@ func TestDiscovery(t *testing.T) {
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
 
 	checkConfig := &checkconfig.CheckConfig{
-		Network:         "192.168.0.0/29",
-		CommunityString: "public",
+		Network: "192.168.0.0/29",
 		Authentications: []checkconfig.Authentication{
 			{
 				CommunityString: "public",
@@ -344,8 +343,12 @@ func TestDiscovery_createDevice(t *testing.T) {
 	config.SetWithoutSource("run_path", t.TempDir())
 
 	checkConfig := &checkconfig.CheckConfig{
-		Network:                  "192.168.0.0/32",
-		CommunityString:          "public",
+		Network: "192.168.0.0/32",
+		Authentications: []checkconfig.Authentication{
+			{
+				CommunityString: "public",
+			},
+		},
 		DiscoveryInterval:        1,
 		DiscoveryWorkers:         1,
 		DiscoveryAllowedFailures: 3,

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -88,10 +88,6 @@ func TestDiscovery(t *testing.T) {
 	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIps)
 }
 
-func TestDiscoveryMultipleAuthentications(t *testing.T) {
-
-}
-
 func TestDiscoveryCache(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetWithoutSource("run_path", t.TempDir())

--- a/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/internal/discovery/discovery_test.go
@@ -53,8 +53,13 @@ func TestDiscovery(t *testing.T) {
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
 
 	checkConfig := &checkconfig.CheckConfig{
-		Network:            "192.168.0.0/29",
-		CommunityString:    "public",
+		Network:         "192.168.0.0/29",
+		CommunityString: "public",
+		Authentications: []checkconfig.Authentication{
+			{
+				CommunityString: "public",
+			},
+		},
 		DiscoveryInterval:  3600,
 		DiscoveryWorkers:   1,
 		IgnoredIPAddresses: map[string]bool{"192.168.0.5": true},
@@ -84,6 +89,10 @@ func TestDiscovery(t *testing.T) {
 	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIps)
 }
 
+func TestDiscoveryMultipleAuthentications(t *testing.T) {
+
+}
+
 func TestDiscoveryCache(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetWithoutSource("run_path", t.TempDir())
@@ -105,8 +114,12 @@ func TestDiscoveryCache(t *testing.T) {
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
 
 	checkConfig := &checkconfig.CheckConfig{
-		Network:           "192.168.0.0/30",
-		CommunityString:   "public",
+		Network: "192.168.0.0/30",
+		Authentications: []checkconfig.Authentication{
+			{
+				CommunityString: "public",
+			},
+		},
 		DiscoveryInterval: 3600,
 		DiscoveryWorkers:  1,
 		ProfileProvider:   profile.StaticProvider(nil),
@@ -138,8 +151,12 @@ func TestDiscoveryCache(t *testing.T) {
 	}
 
 	checkConfig = &checkconfig.CheckConfig{
-		Network:           "192.168.0.0/30",
-		CommunityString:   "public",
+		Network: "192.168.0.0/30",
+		Authentications: []checkconfig.Authentication{
+			{
+				CommunityString: "public",
+			},
+		},
 		DiscoveryInterval: 3600,
 		DiscoveryWorkers:  0, // no workers, the devices will be loaded from cache
 		ProfileProvider:   profile.StaticProvider(nil),
@@ -181,8 +198,12 @@ func TestDiscoveryTicker(t *testing.T) {
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
 
 	checkConfig := &checkconfig.CheckConfig{
-		Network:           "192.168.0.0/32",
-		CommunityString:   "public",
+		Network: "192.168.0.0/32",
+		Authentications: []checkconfig.Authentication{
+			{
+				CommunityString: "public",
+			},
+		},
 		DiscoveryInterval: 1,
 		DiscoveryWorkers:  1,
 		ProfileProvider:   profile.StaticProvider(nil),
@@ -201,8 +222,12 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	config := agentconfig.NewMock(t)
 	config.SetWithoutSource("run_path", t.TempDir())
 	checkConfig := &checkconfig.CheckConfig{
-		Network:           "192.168.0.0/32",
-		CommunityString:   "public",
+		Network: "192.168.0.0/32",
+		Authentications: []checkconfig.Authentication{
+			{
+				CommunityString: "public",
+			},
+		},
 		DiscoveryInterval: 1,
 		DiscoveryWorkers:  1,
 		ProfileProvider:   profile.StaticProvider(nil),

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3977,6 +3977,74 @@ api_key:
       #
       #   context_name: <CONTEXT_NAME>
 
+      ## @param authentications - list of custom objects - optional
+      ## A list of authentication configurations to try when connecting to your SNMP devices.
+      ## The Agent tries each configuration until it successfully connects.
+      #
+      #   authentications:
+          ## @param snmp_version - integer - optional - default: <BEST_GUESS>
+          ## Set the version of the SNMP protocol. Available options are: `1`, `2` or `3`.
+          ## If unset, the Agent tries to guess the correct version based on other configuration
+          ## parameters, for example: if `user` is set, the Agent uses SNMP v3.
+          #
+          # - snmp_version: <VERSION>
+
+          ## @param timeout - integer - optional - default: 5
+          ## The number of seconds before timing out.
+          #
+          #   timeout: 5
+
+          ## @param retries - integer - optional - default: 3
+          ## The number of retries before failure.
+          #
+          #   retries: 3
+
+          ## @param community_string - string - optional
+          ## Required for SNMP v1 & v2.
+          ## Enclose the community string with single quote like below (to avoid special characters being interpreted).
+          ## Ex: 'public'
+          #
+          #   community_string: '<COMMUNITY>'
+
+          ## @param user - string - optional
+          ## The username to connect to your SNMP devices.
+          ## SNMPv3 only.
+          #
+          #   user: <USERNAME>
+
+          ## @param authKey - string - optional
+          ## The passphrase to use with your Authentication type.
+          ## SNMPv3 only.
+          #
+          #   authKey: <AUTHENTICATION_KEY>
+
+          ## @param authProtocol - string - optional
+          ## The authentication protocol to use when connecting to your SNMP devices.
+          ## Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512
+          ## Defaults to MD5 when `authentication_key` is specified.
+          ## SNMPv3 only.
+          #
+          #   authProtocol: <AUTHENTICATION_PROTOCOL>
+
+          ## @param privKey - string - optional
+          ## The passphrase to use with your privacy protocol.
+          ## SNMPv3 only.
+          #
+          #   privKey: <PRIVACY_KEY>
+
+          ## @param privProtocol - string - optional
+          ## The privacy protocol to use when connecting to your SNMP devices.
+          ## Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
+          ## Defaults to DES when `privacy_key` is specified.
+          ## SNMPv3 only.
+          #
+          #   privProtocol: <PRIVACY_PROTOCOL>
+
+          ## @param context_name - string - optional
+          ## The name of your context (optional SNMP v3-only parameter).
+          #
+          #   context_name: <CONTEXT_NAME>
+
       ## @param tags - list of strings - optional
       ## A list of tags to attach to every metric and service check of all devices discovered in the subnet.
       ##

--- a/releasenotes/notes/ndm-support-multiple-authentications-in-autodiscovery-a186429db52f6c5d.yaml
+++ b/releasenotes/notes/ndm-support-multiple-authentications-in-autodiscovery-a186429db52f6c5d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Support multiple authentications in network devices autodiscovery.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds support for multiple authentication configuration in network devices autodiscovery. For each SNMP device, we try each configuration until one works.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

- Unit tests for reading the new `authentications` config and for device autodiscovery with multiple authentications.
- TODO: Install agent on mimic3 to test.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->