### PR TITLE
Auto Multiline V2 - Correctly handle custom samples as JSON from the config or an env var

### DIFF
--- a/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/timestamp_detector.go
@@ -80,7 +80,7 @@ var staticTokenGraph = makeStaticTokenGraph()
 // minimumTokenLength is the minimum number of tokens needed to evaluate a timestamp probability.
 // This is not configurable because it has a large impact of the relative accuracy of the heuristic.
 // For example, a string 12:30:2017 is tokenized to 5 tokens DD:DD:DDDD which can easily be confused
-// with other non timestamp string. Enforcing more tokens to determine a likely timetamp decreases
+// with other non timestamp string. Enforcing more tokens to determine a likely timestamp decreases
 // the likelihood of a false positive. 8 was chosen by iterative testing using the tests in timestamp_detector_test.go.
 var minimumTokenLength = 8
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
@@ -7,6 +7,7 @@
 package automultilinedetection
 
 import (
+	"encoding/json"
 	"regexp"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -20,16 +21,16 @@ const defaultMatchThreshold = 0.75
 // UserSample represents a user-defined sample for auto multi-line detection.
 type UserSample struct {
 	// Sample is a raw log message sample used to aggregate logs.
-	Sample string `mapstructure:"sample"`
+	Sample string `mapstructure:"sample" json:"sample"`
 	// MatchThreshold is the ratio of tokens that must match between the sample and the log message to consider it a match.
 	// From a user perspective, this is how similar the log has to be to the sample to be considered a match.
 	// Optional - Default value is 0.75.
-	MatchThreshold *float64 `mapstructure:"match_threshold,omitempty"`
+	MatchThreshold *float64 `mapstructure:"match_threshold,omitempty" json:"match_threshold,omitempty"`
 	// Regex is a pattern used to aggregate logs. NOTE that you can use either a sample or a regex, but not both.
-	Regex string `mapstructure:"regex,omitempty"`
+	Regex string `mapstructure:"regex,omitempty" json:"regex,omitempty"`
 	// Label is the label to apply to the log message if it matches the sample.
 	// Optional - Default value is "start_group".
-	Label *string `mapstructure:"label,omitempty"`
+	Label *string `mapstructure:"label,omitempty" json:"label,omitempty"`
 
 	// Parse fields
 	tokens         []tokens.Token
@@ -47,7 +48,18 @@ type UserSamples struct {
 func NewUserSamples(config model.Reader) *UserSamples {
 	tokenizer := NewTokenizer(0)
 	s := make([]*UserSample, 0)
-	err := structure.UnmarshalKey(config, "logs_config.auto_multi_line_detection_custom_samples", &s)
+	var err error
+	raw := config.Get("logs_config.auto_multi_line_detection_custom_samples")
+	if raw == nil {
+		return &UserSamples{
+			samples: []*UserSample{},
+		}
+	}
+	if str, ok := raw.(string); ok && str != "" {
+		err = json.Unmarshal([]byte(str), &s)
+	} else {
+		err = structure.UnmarshalKey(config, "logs_config.auto_multi_line_detection_custom_samples", &s)
+	}
 
 	if err != nil {
 		log.Error("Failed to unmarshal custom samples: ", err)

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
@@ -59,10 +59,7 @@ func NewUserSamples(config model.Reader) *UserSamples {
 
 		if err != nil {
 			log.Error("Failed to unmarshal custom samples: ", err)
-			return &UserSamples{
-				samples: []*UserSample{},
-			}
-
+			s = make([]*UserSample, 0)
 		}
 	}
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples.go
@@ -50,21 +50,19 @@ func NewUserSamples(config model.Reader) *UserSamples {
 	s := make([]*UserSample, 0)
 	var err error
 	raw := config.Get("logs_config.auto_multi_line_detection_custom_samples")
-	if raw == nil {
-		return &UserSamples{
-			samples: []*UserSample{},
+	if raw != nil {
+		if str, ok := raw.(string); ok && str != "" {
+			err = json.Unmarshal([]byte(str), &s)
+		} else {
+			err = structure.UnmarshalKey(config, "logs_config.auto_multi_line_detection_custom_samples", &s)
 		}
-	}
-	if str, ok := raw.(string); ok && str != "" {
-		err = json.Unmarshal([]byte(str), &s)
-	} else {
-		err = structure.UnmarshalKey(config, "logs_config.auto_multi_line_detection_custom_samples", &s)
-	}
 
-	if err != nil {
-		log.Error("Failed to unmarshal custom samples: ", err)
-		return &UserSamples{
-			samples: []*UserSample{},
+		if err != nil {
+			log.Error("Failed to unmarshal custom samples: ", err)
+			return &UserSamples{
+				samples: []*UserSample{},
+			}
+
 		}
 	}
 

--- a/pkg/logs/internal/decoder/auto_multiline_detection/user_samples_test.go
+++ b/pkg/logs/internal/decoder/auto_multiline_detection/user_samples_test.go
@@ -80,6 +80,36 @@ logs_config:
 	assert.Equal(t, aggregate, samples.samples[2].label)
 }
 
+func TestUserPatternsJSON(t *testing.T) {
+
+	mockConfig := mock.New(t)
+	mockConfig.SetWithoutSource("logs_config.auto_multi_line_detection_custom_samples", `[{"sample": "1", "label": "start_group"}, {"regex": "\\d\\w", "label": "no_aggregate"}, {"sample": "3", "match_threshold": 0.1}]`)
+
+	samples := NewUserSamples(mockConfig)
+	assert.Equal(t, 3, len(samples.samples))
+	assert.Equal(t, startGroup, samples.samples[0].label)
+	assert.Equal(t, "1", samples.samples[0].Sample)
+	assert.Equal(t, noAggregate, samples.samples[1].label)
+	assert.Equal(t, "\\d\\w", samples.samples[1].Regex)
+	assert.Equal(t, "3", samples.samples[2].Sample)
+	assert.Equal(t, 0.1, samples.samples[2].matchThreshold)
+}
+
+func TestUserPatternsJSONEnv(t *testing.T) {
+
+	mockConfig := mock.New(t)
+	t.Setenv("DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION_CUSTOM_SAMPLES", `[{"sample": "1", "label": "start_group"}, {"regex": "\\d\\w", "label": "no_aggregate"}, {"sample": "3", "match_threshold": 0.1}]`)
+
+	samples := NewUserSamples(mockConfig)
+	assert.Equal(t, 3, len(samples.samples))
+	assert.Equal(t, startGroup, samples.samples[0].label)
+	assert.Equal(t, "1", samples.samples[0].Sample)
+	assert.Equal(t, noAggregate, samples.samples[1].label)
+	assert.Equal(t, "\\d\\w", samples.samples[1].Regex)
+	assert.Equal(t, "3", samples.samples[2].Sample)
+	assert.Equal(t, 0.1, samples.samples[2].matchThreshold)
+}
+
 func TestUserPatternsMatchThreshold(t *testing.T) {
 
 	datadogYaml := `


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

It turns out our config parser can't automatically handle JSON strings when unmarshalling, and this needs to be explicitly handled. This PR makes the parsing behavior consistent for `DD_LOGS_CONFIG_AUTO_MULTI_LINE_DETECTION_CUSTOM_SAMPLES` with other complex config keys that support JSON in env vars. 

### Motivation

### Describe how you validated your changes

Unit test coverage, Local sanity test. 
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->