### PR TITLE
Add support to trigger ci-platform-machine-images workflow

### DIFF
--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -17,8 +17,8 @@ from tasks.libs.ciproviders.github_actions_tools import (
     follow_workflow_run,
     print_failed_jobs_logs,
     print_workflow_conclusion,
-    trigger_buildenv_workflow,
     trigger_macos_workflow,
+    trigger_windows_bump_workflow,
 )
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.constants import DEFAULT_INTEGRATIONS_CORE_BRANCH
@@ -113,17 +113,30 @@ def trigger_macos(
         raise Exit(message=f"Macos {workflow_type} workflow {conclusion}", code=1)
 
 
-def _update_windows_runner_version(new_version=None, buildenv_ref="master"):
+def _update_windows_runner_version(new_version=None, repo="buildenv"):
     if new_version is None:
-        raise Exit(message="Buildenv workflow need the 'new_version' field value to be not None")
+        raise Exit(message="workflow needs the 'new_version' field value to be not None")
+    args_per_repo = {
+        "buildenv": {
+            "workflow_name": "runner-bump.yml",
+            "github_action_ref": "master",
+        },
+        "ci-platform-machine-images": {
+            "workflow_name": "windows-runner-agent-bump.yml",
+            "github_action_ref": "main",
+        },
+    }
 
-    run = trigger_buildenv_workflow(
-        workflow_name="runner-bump.yml",
-        github_action_ref=buildenv_ref,
+    run = trigger_windows_bump_workflow(
+        repo=repo,
+        workflow_name=args_per_repo[repo]["workflow_name"],
+        github_action_ref=args_per_repo[repo]["github_action_ref"],
         new_version=new_version,
     )
-    # We are only waiting 0.5min between each status check because buildenv is much faster than macOS builds
-    workflow_conclusion, workflow_url = follow_workflow_run(run, "DataDog/buildenv", 0.5)
+    # We are only waiting 0.5min between each status check because buildenv
+    # or ci-platform-machine-images are much faster than macOS builds
+    full_repo = f"DataDog/{repo}"
+    workflow_conclusion, workflow_url = follow_workflow_run(run, full_repo, 0.5)
 
     if workflow_conclusion != "success":
         if workflow_conclusion == "failure":
@@ -132,7 +145,7 @@ def _update_windows_runner_version(new_version=None, buildenv_ref="master"):
 
     print_workflow_conclusion(workflow_conclusion, workflow_url)
 
-    download_with_retry(download_artifacts, run, ".", 3, 5, "DataDog/buildenv")
+    download_with_retry(download_artifacts, run, ".", 3, 5, full_repo)
 
     with open("PR_URL_ARTIFACT") as f:
         PR_URL = f.read().strip()
@@ -153,17 +166,17 @@ def _update_windows_runner_version(new_version=None, buildenv_ref="master"):
 def update_windows_runner_version(
     ctx,
     new_version=None,
-    buildenv_ref="master",
 ):
     """
-    Trigger a workflow on the buildenv repository to bump windows gitlab runner
+    Trigger a workflow on the buildenv and ci-platform-machine-images repositories to bump windows gitlab runner
     """
     if new_version is None:
         new_version = str(current_version(ctx, "7"))
 
-    conclusion = _update_windows_runner_version(new_version, buildenv_ref)
-    if conclusion != "success":
-        raise Exit(message=f"Buildenv workflow {conclusion}", code=1)
+    for repo in ["buildenv", "ci-platform-machine-images"]:
+        conclusion = _update_windows_runner_version(new_version, repo)
+        if conclusion != "success":
+            raise Exit(message=f"Windows runner bump workflow {conclusion} for {repo}", code=1)
 
 
 @task

--- a/tasks/libs/ciproviders/github_actions_tools.py
+++ b/tasks/libs/ciproviders/github_actions_tools.py
@@ -14,7 +14,9 @@ from tasks.libs.common.color import color_message
 from tasks.libs.common.git import get_default_branch
 
 
-def trigger_buildenv_workflow(workflow_name="runner-bump.yml", github_action_ref="master", new_version=None):
+def trigger_windows_bump_workflow(
+    repo="buildenv", workflow_name="runner-bump.yml", github_action_ref="master", new_version=None
+):
     """
     Trigger a workflow to bump windows gitlab runner
     """
@@ -23,15 +25,15 @@ def trigger_buildenv_workflow(workflow_name="runner-bump.yml", github_action_ref
         inputs["new-version"] = new_version
 
     print(
-        "Creating workflow on buildenv on commit {} with args:\n{}".format(  # noqa: FS002
-            github_action_ref, "\n".join([f"  - {k}: {inputs[k]}" for k in inputs])
+        "Creating workflow on {} on ref {} with args:\n{}".format(  # noqa: FS002
+            repo, github_action_ref, "\n".join([f"  - {k}: {inputs[k]}" for k in inputs])
         )
     )
 
     # Hack: get current time to only fetch workflows that started after now
     now = datetime.utcnow()
 
-    gh = GithubAPI('DataDog/buildenv')
+    gh = GithubAPI(f"DataDog/{repo}")
     result = gh.trigger_workflow(workflow_name, github_action_ref, inputs)
 
     if not result:


### PR DESCRIPTION
<details open><summary>

# Problem
</summary>

We are porting over the definition of our Windows runner AMIs to a different repo. In order to continue doing
dogfooding of release candidates, we need to update the version of the agent we install on our fleet of runners.
This is already done for the old repo so porting over to new one.

</details>

<details open><summary>

# Solution
</summary>

Refactor a bit the current functions that trigger the GH workflow on buildenv repository
so that we can support ci-platform-machine-images.

</details>

<details><summary>

# Testing Done
</summary>

I ran `dda inv -e github.update-windows-runner-version` locally and I was able to trigger both workflows
https://github.com/DataDog/buildenv/actions/runs/14093183746
https://github.com/DataDog/ci-platform-machine-images/actions/runs/14093141532
Things failed since I don't have the same permissions as the bot user which will trigger this on CI but the logic
to start the workflows works.

</details>
