### PR TITLE
(fleet) repair package when it is reinstalled while a previous installation cannot safely be deleted

### DIFF
--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -7,12 +7,16 @@
 package repository
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -359,6 +363,16 @@ func movePackageFromSource(packageName string, rootPath string, sourcePath strin
 	if err == nil {
 		// TODO: Do we want to differentiate between packages that cannot be deleted
 		// due to the pre-remove hook and other reasons?
+		// On Windows, if directory exists, check contents and copy missing files
+		if runtime.GOOS == "windows" {
+			if err := repairDirectory(sourcePath, targetPath); err != nil {
+				return "", fmt.Errorf("target package directory exists and could not be repaired: %w", err)
+			}
+			if err := paths.SetRepositoryPermissions(targetPath); err != nil {
+				return "", fmt.Errorf("could not set permissions on package: %w", err)
+			}
+			return targetPath, nil
+		}
 		return "", fmt.Errorf("target package already exists")
 	}
 	if !errors.Is(err, os.ErrNotExist) {
@@ -480,4 +494,140 @@ func (l *link) Delete() error {
 	}
 	l.packagePath = nil
 	return nil
+}
+
+func buildFileMap(rootPath string) (map[string]struct{}, error) {
+	files := make(map[string]struct{})
+	err := filepath.Walk(rootPath, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			relPath, err := filepath.Rel(rootPath, path)
+			if err != nil {
+				return fmt.Errorf("failed to get relative path: %w", err)
+			}
+			files[relPath] = struct{}{}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk directory: %w", err)
+	}
+	return files, nil
+}
+
+// repairDirectory compares files between source and target directories,
+// copying any missing files or files with mismatched content from source to target.
+// It preserves the directory structure and file permissions.
+func repairDirectory(sourcePath, targetPath string) error {
+	// Build maps of source and target files
+	sourceFiles, err := buildFileMap(sourcePath)
+	if err != nil {
+		return fmt.Errorf("failed to build source file map: %w", err)
+	}
+
+	targetFiles, err := buildFileMap(targetPath)
+	if err != nil {
+		return fmt.Errorf("failed to build target file map: %w", err)
+	}
+
+	// Check for extra files in target
+	for relPath := range targetFiles {
+		if _, exists := sourceFiles[relPath]; !exists {
+			return fmt.Errorf("extra file found in target directory: %s", relPath)
+		}
+	}
+
+	// Walk through source directory and compare/copy files
+	return filepath.Walk(sourcePath, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Get relative path from source root
+		relPath, err := filepath.Rel(sourcePath, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path: %w", err)
+		}
+
+		// Construct target path
+		targetFilePath := filepath.Join(targetPath, relPath)
+
+		if info.IsDir() {
+			// Create directory if it doesn't exist
+			return os.MkdirAll(targetFilePath, info.Mode())
+		}
+
+		// Check if file exists in target
+		_, exists := targetFiles[relPath]
+		if !exists {
+			// File doesn't exist in target, copy it
+			return copyFile(path, targetFilePath)
+		}
+
+		// File exists, compare content
+		match, err := compareFiles(path, targetFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to compare files: %w", err)
+		}
+
+		if !match {
+			// Content doesn't match, return error
+			return fmt.Errorf("file content mismatch: %s", relPath)
+		}
+
+		return nil
+	})
+}
+
+// compareFiles checks if two files have identical content by comparing their hashes
+func compareFiles(file1, file2 string) (bool, error) {
+	f1, err := os.Open(file1)
+	if err != nil {
+		return false, err
+	}
+	defer f1.Close()
+
+	f2, err := os.Open(file2)
+	if err != nil {
+		return false, err
+	}
+	defer f2.Close()
+
+	h1 := sha256.New()
+	h2 := sha256.New()
+
+	if _, err := io.Copy(h1, f1); err != nil {
+		return false, err
+	}
+
+	if _, err := io.Copy(h2, f2); err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(h1.Sum(nil), h2.Sum(nil)), nil
+}
+
+// copyFile copies a file from src to dst, preserving file mode
+func copyFile(src, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+
+	// Ensure the destination directory exists
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	destination, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+
+	_, err = io.Copy(destination, source)
+	return err
 }

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -530,6 +530,9 @@ func buildFileMap(rootPath string) (map[string]struct{}, error) {
 // repairDirectory compares files between source and target directories,
 // copying any missing files or files with mismatched content from source to target.
 // It preserves the directory structure and file permissions.
+// For simplicity, on Windows it is case sensitive although the file system is
+// case insensitive but it's not an issue since the filesystem preserves casing
+// and the OCI casing will not change.
 func repairDirectory(sourcePath, targetPath string) error {
 	// Build maps of source and target files
 	sourceFiles, err := buildFileMap(sourcePath)

--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -224,6 +224,16 @@ func (r *Repository) SetExperiment(ctx context.Context, name string, sourcePath 
 	if !repository.experiment.Exists() {
 		return fmt.Errorf("experiment link does not exist, invalid state")
 	}
+	// Because we repair directories on windows, repository.setExperiment will
+	// not fail if called for a version that is already set to experiment or
+	// stable while it does on unix.  These check ensure that we have the same
+	// behavior on both platforms.
+	if filepath.Base(*repository.experiment.packagePath) == name {
+		return fmt.Errorf("cannot set new experiment to the same version as the current experiment")
+	}
+	if filepath.Base(*repository.stable.packagePath) == name {
+		return fmt.Errorf("cannot set new experiment to the same version as stable")
+	}
 	err = repository.setExperiment(name, sourcePath)
 	if err != nil {
 		return fmt.Errorf("could not set experiment: %w", err)

--- a/pkg/fleet/installer/repository/repository_test.go
+++ b/pkg/fleet/installer/repository/repository_test.go
@@ -330,18 +330,14 @@ func TestRepairDirectoryEmptyTarget(t *testing.T) {
 
 func TestRepairDirectoryMissingFiles(t *testing.T) {
 	sourceFiles := map[string]string{
-		"file1.txt":         "content1",
-		"file2.txt":         "content2",
-		"subdir/file3.txt":  "content3",
-		"subdir/file4.txt":  "content4",
-		"subdir2/file5.txt": "content5",
-		"subdir2/file6.txt": "content6",
+		"file1.txt":        "content1",
+		"file2.txt":        "content2",
+		"subdir/file3.txt": "content3",
+		"subdir/file4.txt": "content4",
 	}
 	targetFiles := map[string]string{
-		"file2.txt":         "content2",
-		"subdir/file4.txt":  "content4",
-		"subdir2/file5.txt": "content5",
-		"subdir2/file6.txt": "content6",
+		"file2.txt":        "content2",
+		"subdir/file4.txt": "content4",
 	}
 
 	sourceDir := createTestDirectory(t, sourceFiles)
@@ -355,20 +351,16 @@ func TestRepairDirectoryMissingFiles(t *testing.T) {
 
 func TestRepairDirectoryDifferentContent(t *testing.T) {
 	sourceFiles := map[string]string{
-		"file1.txt":         "content1",
-		"file2.txt":         "content2",
-		"subdir/file3.txt":  "content3",
-		"subdir/file4.txt":  "content4",
-		"subdir2/file5.txt": "content5",
-		"subdir2/file6.txt": "content6",
+		"file1.txt":        "content1",
+		"file2.txt":        "content2",
+		"subdir/file3.txt": "content3",
+		"subdir/file4.txt": "content4",
 	}
 	targetFiles := map[string]string{
-		"file1.txt":         "wrong_content",
-		"file2.txt":         "content2",
-		"subdir/file3.txt":  "wrong_content",
-		"subdir/file4.txt":  "content4",
-		"subdir2/file5.txt": "content5",
-		"subdir2/file6.txt": "content6",
+		"file1.txt":        "wrong_content",
+		"file2.txt":        "content2",
+		"subdir/file3.txt": "wrong_content",
+		"subdir/file4.txt": "content4",
 	}
 
 	sourceDir := createTestDirectory(t, sourceFiles)
@@ -380,21 +372,30 @@ func TestRepairDirectoryDifferentContent(t *testing.T) {
 
 func TestRepairDirectoryExtraFiles(t *testing.T) {
 	sourceFiles := map[string]string{
-		"file1.txt":         "content1",
-		"file2.txt":         "content2",
-		"subdir/file3.txt":  "content3",
-		"subdir/file4.txt":  "content4",
-		"subdir2/file5.txt": "content5",
-		"subdir2/file6.txt": "content6",
+		"file1.txt":        "content1",
+		"file2.txt":        "content2",
+		"subdir/file3.txt": "content3",
 	}
 	targetFiles := map[string]string{
-		"file1.txt":         "content1",
-		"file2.txt":         "content2",
-		"subdir/file3.txt":  "content3",
-		"subdir/file4.txt":  "content4",
-		"subdir2/file5.txt": "content5",
-		"subdir2/file6.txt": "content6",
-		"extra.txt":         "extra content",
+		"file1.txt":        "content1",
+		"file2.txt":        "content2",
+		"subdir/file3.txt": "content3",
+		"extra.txt":        "extra content",
+	}
+
+	sourceDir := createTestDirectory(t, sourceFiles)
+	targetDir := createTestDirectory(t, targetFiles)
+
+	err := repairDirectory(sourceDir, targetDir)
+	assert.Error(t, err)
+}
+
+func TestRepairDirectoryDifferentCasing(t *testing.T) {
+	sourceFiles := map[string]string{
+		"file1.txt": "content1",
+	}
+	targetFiles := map[string]string{
+		"FILE1.txt": "content1",
 	}
 
 	sourceDir := createTestDirectory(t, sourceFiles)

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -153,7 +153,7 @@ func (s *testAgentUpgradeSuite) TestExperimentCurrentVersionFails() {
 
 	// Act
 	_, err := s.StartExperimentCurrentVersion()
-	s.Require().ErrorContains(err, "target package already exists")
+	s.Require().ErrorContains(err, "cannot set new experiment to the same version as the current experiment")
 	s.Installer().StopExperiment(consts.AgentPackage)
 	s.assertSuccessfulAgentStopExperiment(s.CurrentAgentVersion().GetNumberAndPre())
 

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_test.go
@@ -140,7 +140,7 @@ func (s *testDotnetLibraryInstallSuite) TestUpgradeAndDowngradePackage() {
 
 	// Start app using the library
 	defer s.stopIISApp()
-	s.startIISApp()
+	s.startIISApp(webConfigFile, aspxFile)
 	initialLibraryPath := s.getLibraryPathFromInstrumentedIIS()
 	s.Require().Contains(initialLibraryPath, initialVersion[:len(initialVersion)-2], "library path should contain initial version")
 
@@ -161,7 +161,7 @@ func (s *testDotnetLibraryInstallSuite) TestUpgradeAndDowngradePackage() {
 
 	// Restart app and verify downgrade
 	s.stopIISApp()
-	s.startIISApp()
+	s.startIISApp(webConfigFile, aspxFile)
 
 	downgradedLibraryPath := s.getLibraryPathFromInstrumentedIIS()
 	s.Require().Contains(downgradedLibraryPath, initialVersion[:len(initialVersion)-2], "library path should contain initial version after downgrade")

--- a/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/apm-library-dotnet-package/install_test.go
@@ -66,13 +66,13 @@ func (s *testDotnetLibraryInstallSuite) TestReinstall() {
 
 func (s *testDotnetLibraryInstallSuite) TestUpdate() {
 	const (
-		oldVersion = "3.13.0-pipeline.58926677.beta.sha-af5a1fab-1"
-		newVersion = "3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"
+		initialVersion = "3.13.0-pipeline.58926677.beta.sha-af5a1fab-1"
+		upgradeVersion = "3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"
 	)
 	flake.Mark(s.T())
 
 	// Install first version
-	s.installDotnetAPMLibraryWithVersion(oldVersion)
+	s.installDotnetAPMLibraryWithVersion(initialVersion)
 
 	// Start the IIS app to load the library
 	defer s.stopIISApp()
@@ -80,14 +80,14 @@ func (s *testDotnetLibraryInstallSuite) TestUpdate() {
 
 	// Check that the expected version of the library is loadedi
 	oldLibraryPath := s.getLibraryPathFromInstrumentedIIS()
-	s.Require().Contains(oldLibraryPath, oldVersion[:len(oldVersion)-2])
+	s.Require().Contains(oldLibraryPath, initialVersion[:len(initialVersion)-2])
 
 	// Install the new version of the library
-	s.installDotnetAPMLibraryWithVersion(newVersion)
+	s.installDotnetAPMLibraryWithVersion(upgradeVersion)
 
 	// Check that the old version of the library is still loaded since we have not restarted yet
 	output := s.getLibraryPathFromInstrumentedIIS()
-	s.Require().Contains(output, oldVersion[:len(oldVersion)-2])
+	s.Require().Contains(output, initialVersion[:len(initialVersion)-2])
 
 	// Check that a garbage collection does not remove the old version of the library
 	output, err := s.Installer().GarbageCollect()
@@ -99,7 +99,7 @@ func (s *testDotnetLibraryInstallSuite) TestUpdate() {
 
 	// Check that the new version of the library is loaded
 	output = s.getLibraryPathFromInstrumentedIIS()
-	s.Require().Contains(output, newVersion[:len(newVersion)-2], "the new library path should contain the new version")
+	s.Require().Contains(output, upgradeVersion[:len(upgradeVersion)-2], "the new library path should contain the new version")
 
 	// Check that garbage collection removes the old version of the library
 	output, err = s.Installer().GarbageCollect()
@@ -128,6 +128,43 @@ func (s *testDotnetLibraryInstallSuite) TestRemovePackageFailsIfInUse() {
 	s.removeDotnetAPMLibrary()
 
 	s.Require().Host(s.Env().RemoteHost).NoDirExists(pathDir(libraryPath), "the package directory should no longer exist")
+}
+
+func (s *testDotnetLibraryInstallSuite) TestUpgradeAndDowngradePackage() {
+	const (
+		initialVersion = "3.13.0-pipeline.58926677.beta.sha-af5a1fab-1"
+		upgradeVersion = "3.13.0-pipeline.58951229.beta.sha-af5a1fab-1"
+	)
+	// Install initial version
+	s.installDotnetAPMLibraryWithVersion(initialVersion)
+
+	// Start app using the library
+	defer s.stopIISApp()
+	s.startIISApp()
+	initialLibraryPath := s.getLibraryPathFromInstrumentedIIS()
+	s.Require().Contains(initialLibraryPath, initialVersion[:len(initialVersion)-2], "library path should contain initial version")
+
+	// Upgrade to newer version
+	s.installDotnetAPMLibraryWithVersion(upgradeVersion)
+
+	// Check that an arbitrary file from the package still exists to make sure
+	// that the files were not deleted when attempting to remove the package
+	output, err := s.Installer().GarbageCollect()
+	s.Require().NoErrorf(err, "failed to garbage collect: %s", output)
+	libraryPath := s.getLibraryPathFromInstrumentedIIS()
+	s.Require().Contains(libraryPath, initialVersion[:len(initialVersion)-2], "library path should contain initial version")
+	versionPath := pathJoin(pathDir(libraryPath), "version")
+	s.Require().Host(s.Env().RemoteHost).FileExists(versionPath, "the package files should still exist, %s is missing", versionPath)
+
+	// Downgrade back to initial version
+	s.installDotnetAPMLibraryWithVersion(initialVersion)
+
+	// Restart app and verify downgrade
+	s.stopIISApp()
+	s.startIISApp()
+
+	downgradedLibraryPath := s.getLibraryPathFromInstrumentedIIS()
+	s.Require().Contains(downgradedLibraryPath, initialVersion[:len(initialVersion)-2], "library path should contain initial version after downgrade")
 }
 
 func (s *testDotnetLibraryInstallSuite) TestRemoveCorruptedPackageFails() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes it possible to reinstall packages even if the files from a previous installation of the same version of the package is stil in use. In that case it checks that the directory contains all the expected files and copies any missing file.

The change is scoped to windows for now, to minimise the likelihood of introducing a regression and because that need hasn't surfaced on linux yet.

### Motivation

Make package installation more resilient on windows.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

The new code is unit tested and the behavior of the datadog-installer is checked by numerous E2E tests.

### Possible Drawbacks / Trade-offs


### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->