### PR TITLE
[BARX-518] Use dd-pkg upload for datadog-installer linux packages

### DIFF
--- a/.gitlab/common/shared.yml
+++ b/.gitlab/common/shared.yml
@@ -47,13 +47,16 @@
   - GITHUB_INSTALLATION_ID=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $AGENT_GITHUB_APP installation_id) || exit $?; export GITHUB_INSTALLATION_ID
   - echo "Using agent GitHub App"
 
-# Shared `dd-pkg` steps:
+## Shared `dd-pkg` steps:
 # - Install `dd-pkg`, logging the version in use for the job
+.setup_dd_pkg:
+  - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
+  - dd-pkg version
+
 # - Lint packages produced by Omnibus (supports only deb and rpm packages)
 # - Create detached signatures for packages produced by Omnibus, to be used by agent-release-management in downstream pipelines
 .create_signature_and_lint_linux_packages:
-  - curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${DD_PKG_ARCH}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
-  - dd-pkg version
+  - !reference [.setup_dd_pkg]
   - find $OMNIBUS_PACKAGE_DIR -iregex '.*\.\(deb\|rpm\)' | xargs dd-pkg lint
   - |
     if [ -n "$PACKAGE_REQUIRED_FILES_LIST" ]; then

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -74,11 +74,6 @@
     MAJOR_VERSION: 7
 
 # Datadog Installer
-
-# The installer is a special case because it's built by the datadog-agent pipeline, but
-# is expected to be deployed in a dedicated folder, so we need to define a special base which
-# fetches packages from a custom value of S3_RELEASE_ARTIFACTS_URI as the default value
-# include datadog-agent as a product
 .deploy_installer_deb:
   rules:
     !reference [.on_deploy_installer]
@@ -89,7 +84,9 @@
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*_7.*${PACKAGE_ARCH}.deb" "$OMNIBUS_PACKAGE_DIR" "${S3_RELEASE_INSTALLER_ARTIFACTS_URI}/deb/${PACKAGE_ARCH}/"
+    - !reference [.setup_dd_pkg]
+    # --signed is used here since Omnibus is still signing the packages when building, this should be dropped when we stop signing in Omnibus
+    - dd-pkg upload "${OMNIBUS_PACKAGE_DIR}" --project-name "datadog-installer" --signed
 
 .deploy_installer_rpm:
   rules:
@@ -103,12 +100,14 @@
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD --recursive --exclude "*" --include "*-7.*${PACKAGE_ARCH}.rpm" "$OMNIBUS_PACKAGE_DIR" "${S3_RELEASE_INSTALLER_ARTIFACTS_URI}/${ARTIFACTS_PREFIX}rpm/${PACKAGE_ARCH}/"
+    - !reference [.setup_dd_pkg]
+    # --signed is used here since Omnibus is still signing the packages when building, this should be dropped when we stop signing in Omnibus
+    - dd-pkg upload "${OMNIBUS_PACKAGE_DIR}" --project-name "datadog-installer" --signed "${DD_PKG_EXTRA_ARGS}"
 
 .deploy_installer_suse_rpm:
   extends: .deploy_installer_rpm
   variables:
-    ARTIFACTS_PREFIX: suse_
+    DD_PKG_EXTRA_ARTS: --suse
     OMNIBUS_PACKAGE_DIR: $OMNIBUS_PACKAGE_DIR_SUSE
 
 deploy_installer_install_scripts:

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -109,7 +109,7 @@
 .deploy_installer_suse_rpm:
   extends: .deploy_installer_rpm
   variables:
-    DD_PKG_EXTRA_ARTS: --suse
+    DD_PKG_EXTRA_ARGS: --suse
     OMNIBUS_PACKAGE_DIR: $OMNIBUS_PACKAGE_DIR_SUSE
 
 deploy_installer_install_scripts:

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -95,8 +95,6 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: deploy_packages
   tags: ["arch:amd64"]
-  variables:
-    ARTIFACTS_PREFIX: ""
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:

--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -81,6 +81,8 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: deploy_packages
   tags: ["arch:amd64"]
+  variables:
+    DD_PKG_ARCH: x86_64
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
@@ -95,6 +97,8 @@
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: deploy_packages
   tags: ["arch:amd64"]
+  variables:
+    DD_PKG_ARCH: x86_64
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This replaces the existing direct usage of `aws s3` to upload packages with the equivalent `dd-pkg` command. This hasn't moved where we are signing the installer packages today.

### Motivation

BARX-518

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passes, a custom build was created and uploaded to trial repos successfully.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->