### PR TITLE
Reduce amount of error messages related to DNS events

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -760,7 +760,7 @@ func (p *EBPFProbe) unmarshalDNSResponse(data []byte) {
 	for _, answer := range dnsLayer.Answers {
 		if answer.Type == layers.DNSTypeCNAME {
 			p.Resolvers.DNSResolver.AddNewCname(string(answer.CNAME), string(answer.Name))
-		} else {
+		} else if answer.Type == layers.DNSTypeA || answer.Type == layers.DNSTypeAAAA {
 			ip, ok := netip.AddrFromSlice(answer.IP)
 			if ok {
 				p.Resolvers.DNSResolver.AddNew(string(answer.Name), ip)


### PR DESCRIPTION
### What does this PR do?
Only try to parse DNS A and AAAA records, and show an error message in cases their IP addresses could not be parsed.

### Motivation
The previous code was "greedy", tried to get IP addresses from all record types it could and raised an error if it failed during conversion. Since we only care about A and AAAA records, the code will only try to parse these and raise an error if it fails.

### Describe how you validated your changes
* Functional tests and KMT

### Possible Drawbacks / Trade-offs
* We could be potentially ignoring IPs from records such as MX. If it turns out to be interesting for an usecase in the future, we can enable on a case-by-case basis.