### PR TITLE
[CWS] Keep cookie set when adding profiles to the pending cache

### DIFF
--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -135,7 +135,7 @@ func New(opts ...Opts) *Profile {
 		LoadedInKernel:  atomic.NewBool(false),
 		LoadedNano:      atomic.NewUint64(0),
 		versionContexts: make(map[string]*VersionContext),
-		profileCookie:   utils.NewCookie(),
+		profileCookie:   utils.RandNonZeroUint64(),
 	}
 
 	for _, opt := range opts {
@@ -624,8 +624,8 @@ func (p *Profile) LoadFromNewProfile(newProfile *Profile) {
 func (p *Profile) Reset() {
 	p.LoadedInKernel.Store(false)
 	p.LoadedNano.Store(0)
-	p.profileCookie = 0
 	p.Instances = nil
+	// keep the profileCookie in case we end up reloading the profile from the cache
 }
 
 // ComputeSyscallsList computes the top level list of syscalls


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

Profiles added to the `pendingCache` have their cookie reset to 0.
This causes all profiles loaded from this cache to share the same cookie (0) when these profiles need to be reused.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->