### PR TITLE
fix race condition in handler test

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -77,9 +77,9 @@ func (e *fakeLeaderEngine) get() (string, error) {
 
 func (e *fakeLeaderEngine) set(ip string, err error) {
 	e.Lock()
-	defer e.Unlock()
 	e.ip = ip
 	e.err = err
+	e.Unlock()
 	if e.subscriber != nil {
 		e.notify()
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix race condition between get and set from fakeLeaderEngine in handler unit test

### Motivation
In race condition, a deadlock happens when calling [get](https://github.com/DataDog/datadog-agent/blob/dc261b78b199644468badb1a903f37e0aa341ef0/pkg/clusteragent/clusterchecks/handler_test.go#L58) in a callback function and [set](https://github.com/DataDog/datadog-agent/blob/dc261b78b199644468badb1a903f37e0aa341ef0/pkg/clusteragent/clusterchecks/handler_test.go#L201). 
1. when `set` is called, it tries to acquire the lock in fakeLeaderEngine
2. `set` calls `notify` which sends notification to handler
3. handler calls callback function which calls get in  fakeLeaderEngine
4. `get` also waits for lock

Fix is unlocking before `notify` so that `get` can acquire the lock

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->