### PR TITLE
[CNM] clean up network ID / vpc ID logs

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -109,7 +109,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/network_id", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		id, err := nt.tracer.GetNetworkID(req.Context())
 		if err != nil {
-			log.Errorf("unable to retrieve network ID: %s", err)
+			log.Debugf("unable to retrieve network ID: %s", err)
 			w.WriteHeader(500)
 			return
 		}

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -517,10 +517,10 @@ func retryGetNetworkID(sysProbeClient *http.Client) (string, error) {
 // getNetworkID fetches network_id from the current netNS or from the system probe if necessary, where the root netNS is used
 func getNetworkID(sysProbeClient *http.Client) (string, error) {
 	networkID, err := network.GetNetworkID(context.Background())
-	if sysProbeClient == nil {
-		return "", fmt.Errorf("no network ID detected. system-probe client not available: %w", err)
-	}
 	if err != nil {
+		if sysProbeClient == nil {
+			return "", fmt.Errorf("no network ID detected and system-probe client not available: %w", err)
+		}
 		log.Debugf("no network ID detected. retrying via system-probe: %s", err)
 		networkID, err = net.GetNetworkID(sysProbeClient)
 		if err != nil {

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -524,8 +524,8 @@ func getNetworkID(sysProbeClient *http.Client) (string, error) {
 		log.Debugf("no network ID detected. retrying via system-probe: %s", err)
 		networkID, err = net.GetNetworkID(sysProbeClient)
 		if err != nil {
-			log.Infof("failed to get network ID from system-probe: %s", err)
-			return "", err
+			log.Debugf("failed to get network ID from system-probe: %s", err)
+			return "", fmt.Errorf("failed to get network ID from system-probe: %w", err)
 		}
 	}
 	return networkID, err

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -504,7 +504,7 @@ func retryGetNetworkID(sysProbeClient *http.Client) (string, error) {
 			return networkID, nil
 		}
 		log.Debugf(
-			"failed to get network ID from host or system-probe (attempt %d/%d): %s",
+			"failed to fetch network ID (attempt %d/%d): %s",
 			attempt,
 			maxRetries,
 			err,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

if the system-probe HTTP client is nil (this should never happen), we will never do any retries as it will immediately return an empty string and no error. This PR also cleans up the logging a bit to make it clearer what's happening.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->