### PR TITLE
Propagate agent host tags for oracle

### DIFF
--- a/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/oracle.d/conf.yaml.example
@@ -6,6 +6,12 @@ init_config:
   ## Active session sampling interval in seconds
   # min_collection_interval: <interval_in_seconds>
 
+  ## @param propagate_agent_tags - boolean - optional - default: false
+  ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+  ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.
+  #
+  # propagate_agent_tags: false
+
   ## @param global_custom_queries - list of mappings - optional
   ## See `custom_queries` defined below.
   ##
@@ -113,6 +119,13 @@ instances:
     ## Set to `true` to enable Database Monitoring.
     #
     # dbm: false
+
+    ## @param propagate_agent_tags - boolean - optional - default: false
+    ## Set to `true` to propagate the tags from `datadog.yaml` and the agent host tags to the check.
+    ## When set to `true`, the tags from the agent host are added to the check's tags for all instances.
+    ## This option takes precedence over the `propagate_agent_tags` option in `init_config`.
+    #
+    # propagate_agent_tags: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/releasenotes/notes/add-propagate-agent-host-tags-flag-bc1fcd6ba35cbf12.yaml
+++ b/releasenotes/notes/add-propagate-agent-host-tags-flag-bc1fcd6ba35cbf12.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add the propagate_agent_tags setting. When set to `true`, the tags from the agent host are added to the check's tag for all instances.
+    Add the `propagate_agent_tags setting`. When set to `true`, the tags from the Agent host are added to the check's tag for all instances.

--- a/releasenotes/notes/add-propagate-agent-host-tags-flag-bc1fcd6ba35cbf12.yaml
+++ b/releasenotes/notes/add-propagate-agent-host-tags-flag-bc1fcd6ba35cbf12.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    List new features here, or remove this section.
+enhancements:
+  - |
+    List enhancements (new behavior that is too small to be
+    considered a new feature), or remove this section.
+    Add the propagate_agent_tags setting. When set to `true`, the tags from the agent host are added to the check's tag for all instances.

--- a/releasenotes/notes/add-propagate-agent-host-tags-flag-bc1fcd6ba35cbf12.yaml
+++ b/releasenotes/notes/add-propagate-agent-host-tags-flag-bc1fcd6ba35cbf12.yaml
@@ -6,11 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-features:
-  - |
-    List new features here, or remove this section.
 enhancements:
   - |
-    List enhancements (new behavior that is too small to be
-    considered a new feature), or remove this section.
     Add the propagate_agent_tags setting. When set to `true`, the tags from the agent host are added to the check's tag for all instances.


### PR DESCRIPTION
### What does this PR do?
This PR updates the agent host tags that we use in the oracle integration. This change only affects DBM customers with the `propagate_agent_tags` flag set to true. By getting host tags, we not only use the tags in the conf.yaml file but also other tags on the agent host. We already have this for our other integrations, so adding it for oracle too.

### Motivation
Metrics emitted by DBM integrations are tagged with the tags from the database instance host. We would like to update the `propagate_agent_tags` option (default false) that allows us to also consider the tags of the agent host. If this setting is enabled, we will propagate all agent host tags. This allows user to opt-in to having their postgres metrics tagged with the agent host tags.

