### PR TITLE
smp: enable system-probe telemetry in quality gates idle all features

### DIFF
--- a/test/regression/cases/quality_gate_idle_all_features/datadog-agent/system-probe.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/datadog-agent/system-probe.yaml
@@ -5,6 +5,8 @@ runtime_security_config:
   enabled: true
 
 system_probe_config:
+  debug_port: 7654
+  telemetry_enabled: true
   enable_oom_kill: true
   enable_tcp_queue_length: true
   process_config:

--- a/test/regression/cases/quality_gate_idle_all_features/lading/lading.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/lading/lading.yaml
@@ -177,3 +177,8 @@ target_metrics:
       tags:
         sub_agent: "trace"
 
+
+  - prometheus: #system-probe telemetry
+      uri: "http://127.0.0.1:7654/telemetry"
+      tags:
+        sub_agent: "system-probe"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR enables system-probe telemetry and collects it from lading configuration in quality gates idle all features. This will allow to graph the system-probe go heap metrics in the bounds checks dashboard.

Port 7654 was chosen because this is the same port used in internal deployments.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->