### PR TITLE
fix(conductor): Adapt schedule time when jet lag varies

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -690,4 +690,4 @@ def is_installed(binary) -> bool:
 
 def is_conductor_scheduled_pipeline() -> bool:
     pipeline_start = datetime.fromisoformat(os.environ['CI_PIPELINE_CREATED_AT'])
-    return pipeline_start.hour == 6 and pipeline_start.minute < 30
+    return pipeline_start.hour in [5, 6] and pipeline_start.minute < 30

--- a/tasks/unit_tests/notify_tests.py
+++ b/tasks/unit_tests/notify_tests.py
@@ -442,3 +442,10 @@ class TestFailureSummarySendNotifications(unittest.TestCase):
     def test_sheduled_conductor(self, print_mock):
         notify.failure_summary_send_notifications(MockContext(), daily_summary=True)
         print_mock.assert_not_called()
+
+    @patch.dict('os.environ', {'CI_PIPELINE_CREATED_AT': '2025-02-07T05:22:22.222Z'})
+    @patch('tasks.notify.failure_summary', new=MagicMock())
+    @patch('builtins.print')
+    def test_sheduled_conductor_dst(self, print_mock):
+        notify.failure_summary_send_notifications(MockContext(), daily_summary=True)
+        print_mock.assert_not_called()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Identify as valid "conductor scheduled" pipelines starting at 5am

### Motivation
The daylight saving time start date has 1 week delay between US and EU. As a consequence, the start time of the conductor pipeline varies. This (ugly) fix prevent mismatch of condition during this special week (it occurs twice a year)

### Describe how you validated your changes
Added a UT
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->