### PR TITLE
Failure when updating environment should account for skipDeleteOnFailure

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -572,7 +572,18 @@ func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 // [testify Suite]: https://pkg.go.dev/github.com/stretchr/testify/suite
 func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
 	if bs.T().Failed() {
+		if bs.firstFailTest == "" {
+			// As far as I know, there is no way to prevent other tests from being
+			// run when a test fail. Even calling panic doesn't work.
+			// Instead, this code stores the name of the first fail test and prevents
+			// the environment to be updated.
+			// Note: using os.Exit(1) prevents other tests from being run but at the
+			// price of having no test output at all.
+			bs.firstFailTest = fmt.Sprintf("%v.%v", suiteName, testName)
+		}
+
 		// create output directory for this failed test
+		// WARNING: the diagnose code can call require, if it fails everything that come after will ignored.
 		testPart := common.SanitizeDirectoryName(testName)
 		testOutputDir := filepath.Join(bs.SessionOutputDir(), testPart)
 		err := os.MkdirAll(testOutputDir, 0755)
@@ -589,16 +600,6 @@ func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
 					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
 				}
 			}
-		}
-
-		if bs.firstFailTest == "" {
-			// As far as I know, there is no way to prevent other tests from being
-			// run when a test fail. Even calling panic doesn't work.
-			// Instead, this code stores the name of the first fail test and prevents
-			// the environment to be updated.
-			// Note: using os.Exit(1) prevents other tests from being run but at the
-			// price of having no test output at all.
-			bs.firstFailTest = fmt.Sprintf("%v.%v", suiteName, testName)
 		}
 	}
 }

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -225,6 +225,7 @@ func (bs *BaseSuite[Env]) UpdateEnv(newProvisioners ...provisioners.Provisioner)
 		targetProvisioners[provisioner.ID()] = provisioner
 	}
 	if err := bs.reconcileEnv(targetProvisioners); err != nil {
+		bs.T().FailNow() // We need to call FailNow otherwise bs.T().Failed() will be false in AfterTest
 		panic(err)
 	}
 }
@@ -558,6 +559,7 @@ func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 	// In `Test` scope we can `panic`, it will be recovered and `AfterTest` will be called.
 	// Next tests will be called as well
 	if err := bs.reconcileEnv(bs.originalProvisioners); err != nil {
+		bs.T().FailNow() // We need to call FailNow otherwise bs.T().Failed() will be false in AfterTest
 		panic(err)
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Update suite to considered as failure the panics that are thrown when updating the environment. Otherwise `AfterTest` does not consider the test as failed and `bs.firstFailTest` is not updated, which breaks the `SkipDeleteOnFailure` feature.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->