### PR TITLE
[CWS] tests: fix `SetVersionState` data race

### DIFF
--- a/pkg/security/security_profile/profile/grpc.go
+++ b/pkg/security/security_profile/profile/grpc.go
@@ -141,8 +141,8 @@ func NewProfileFromActivityDumpMessage(msg *api.ActivityDumpMessage) (*Profile, 
 
 // ToSecurityProfileMessage returns a SecurityProfileMessage filled with the content of the current Security Profile
 func (p *Profile) ToSecurityProfileMessage(timeResolver *ktime.Resolver) *api.SecurityProfileMessage {
-	p.versionContextsLock.Lock()
-	defer p.versionContextsLock.Unlock()
+	p.m.Lock()
+	defer p.m.Unlock()
 
 	// construct the list of image tags for this profile
 	imageTags := ""

--- a/pkg/security/security_profile/profile/profile.go
+++ b/pkg/security/security_profile/profile/profile.go
@@ -73,8 +73,7 @@ type Profile struct {
 	selector cgroupModel.WorkloadSelector
 	tags     []string
 
-	versionContextsLock sync.Mutex
-	versionContexts     map[string]*VersionContext
+	versionContexts map[string]*VersionContext
 
 	eventTypes []model.EventType
 
@@ -415,8 +414,8 @@ func (p *Profile) GetProfileCookie() uint64 {
 
 // GenerateSyscallsFilters generates the syscall filters for the profile
 func (p *Profile) GenerateSyscallsFilters() [64]byte {
-	p.versionContextsLock.Lock()
-	defer p.versionContextsLock.Unlock()
+	p.m.Lock()
+	defer p.m.Unlock()
 
 	var output [64]byte
 	for _, pCtxt := range p.versionContexts {
@@ -468,8 +467,8 @@ func (p *Profile) getGlobalState() model.EventFilteringProfileState {
 
 // GetVersionContext returns the context of the givent version if any
 func (p *Profile) GetVersionContext(imageTag string) (*VersionContext, bool) {
-	p.versionContextsLock.Lock()
-	defer p.versionContextsLock.Unlock()
+	p.m.Lock()
+	defer p.m.Unlock()
 
 	ctx, ok := p.versionContexts[imageTag]
 	return ctx, ok
@@ -477,8 +476,8 @@ func (p *Profile) GetVersionContext(imageTag string) (*VersionContext, bool) {
 
 // GetVersions returns the number of versions stored in the profile (debug purpose only)
 func (p *Profile) GetVersions() []string {
-	p.versionContextsLock.Lock()
-	defer p.versionContextsLock.Unlock()
+	p.m.Lock()
+	defer p.m.Unlock()
 	versions := []string{}
 	for version := range p.versionContexts {
 		versions = append(versions, version)
@@ -488,8 +487,8 @@ func (p *Profile) GetVersions() []string {
 
 // SetVersionState force a state for a given version (debug purpose only)
 func (p *Profile) SetVersionState(imageTag string, state model.EventFilteringProfileState, lastAnomalyNano uint64) error {
-	p.versionContextsLock.Lock()
-	defer p.versionContextsLock.Unlock()
+	p.m.Lock()
+	defer p.m.Unlock()
 
 	ctx, found := p.versionContexts[imageTag]
 	if !found {
@@ -515,6 +514,9 @@ func (p *Profile) IsEventTypeValid(evtType model.EventType) bool {
 
 // GetGlobalEventTypeState returns the global state of a profile for a given event type: AutoLearning, StableEventType or UnstableEventType
 func (p *Profile) GetGlobalEventTypeState(et model.EventType) model.EventFilteringProfileState {
+	p.m.Lock()
+	defer p.m.Unlock()
+
 	globalState := model.AutoLearning
 	for _, ctx := range p.versionContexts {
 		s, ok := ctx.EventTypeState[et]
@@ -532,6 +534,9 @@ func (p *Profile) GetGlobalEventTypeState(et model.EventType) model.EventFilteri
 
 // PrepareNewVersion prepares a new version of the profile
 func (p *Profile) PrepareNewVersion(newImageTag string, tags []string, maxImageTags int, nowTimestamp uint64) []string {
+	p.m.Lock()
+	defer p.m.Unlock()
+
 	// prepare new profile context to be inserted
 	newProfileCtx := &VersionContext{
 		EventTypeState: make(map[model.EventType]*EventTypeState),
@@ -541,7 +546,6 @@ func (p *Profile) PrepareNewVersion(newImageTag string, tags []string, maxImageT
 	}
 
 	// add the new profile context to the list
-	// (versionContextsLock already locked here)
 	evictedVersions := p.makeRoomForNewVersion(maxImageTags)
 	p.versionContexts[newImageTag] = newProfileCtx
 	return evictedVersions
@@ -549,8 +553,8 @@ func (p *Profile) PrepareNewVersion(newImageTag string, tags []string, maxImageT
 
 // AddVersionContext adds a new version context to the profile
 func (p *Profile) AddVersionContext(version string, ctx *VersionContext) {
-	p.versionContextsLock.Lock()
-	defer p.versionContextsLock.Unlock()
+	p.m.Lock()
+	defer p.m.Unlock()
 
 	p.versionContexts[version] = ctx
 }
@@ -676,9 +680,9 @@ func (p *Profile) getTimeOrderedVersionContexts() []*VersionContext {
 
 // GetVersionContextIndex returns the context of the givent version if any
 func (p *Profile) GetVersionContextIndex(index int) *VersionContext {
-	p.versionContextsLock.Lock()
+	p.m.Lock()
 	orderedVersions := p.getTimeOrderedVersionContexts()
-	p.versionContextsLock.Unlock()
+	p.m.Unlock()
 
 	if index >= len(orderedVersions) {
 		return nil
@@ -688,8 +692,8 @@ func (p *Profile) GetVersionContextIndex(index int) *VersionContext {
 
 // ListAllVersionStates prints the state of all versions of the profile
 func (p *Profile) ListAllVersionStates() {
-	p.versionContextsLock.Lock()
-	defer p.versionContextsLock.Unlock()
+	p.m.Lock()
+	defer p.m.Unlock()
 
 	if len(p.versionContexts) > 0 {
 		fmt.Printf("### Profile: %+v\n", p.GetSelectorStr())


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- remove the `versionContextsLock` mutex which was redundant with the existing profile mutex.
- re-use the existing profile mutex where `versionContextsLock` was previously used.
- add missing profile locking in `GetGlobalEventTypeState` and `PrepareNewVersion` methods

### Motivation

This fixes a race between `EncodeSecurityProfileProtobuf` and `SetVersionState` as the latter was only taking the `versionContextsLock` mutex. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->