### PR TITLE
Add SBOM on fargate using procfs

### DIFF
--- a/pkg/collector/corechecks/sbom/check.go
+++ b/pkg/collector/corechecks/sbom/check.go
@@ -9,6 +9,7 @@ package sbom
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"time"
 

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -284,9 +284,10 @@ func (p *processor) triggerProcfsScan(ctr *workloadmeta.Container) {
 func (p *processor) processProcfsScanResult(result sbom.ScanResult) {
 	log.Debugf("processing procfs scanresult: %v", result)
 	sbom := &model.SBOMEntity{
-		Status:             model.SBOMStatus_SUCCESS,
-		Id:                 result.RequestID,
-		Type:               model.SBOMSourceType_CONTAINER_FILE_SYSTEM,
+		Status: model.SBOMStatus_SUCCESS,
+		Id:     result.RequestID,
+		//Type:               model.SBOMSourceType_CONTAINER_FILE_SYSTEM,
+		Type:               model.SBOMSourceType_HOST_IMAGE,
 		InUse:              true,
 		GeneratedAt:        timestamppb.New(result.CreatedAt),
 		GenerationDuration: convertDuration(result.Duration),

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -280,10 +280,9 @@ func (p *processor) triggerProcfsScan(ctr *workloadmeta.Container) {
 func (p *processor) processProcfsScanResult(result sbom.ScanResult) {
 	log.Debugf("processing procfs scanresult: %v", result)
 	sbom := &model.SBOMEntity{
-		Status: model.SBOMStatus_SUCCESS,
-		Id:     result.RequestID,
-		//Type:               model.SBOMSourceType_CONTAINER_FILE_SYSTEM,
-		Type:               model.SBOMSourceType_HOST_IMAGE,
+		Status:             model.SBOMStatus_SUCCESS,
+		Id:                 result.RequestID,
+		Type:               model.SBOMSourceType_HOST_IMAGE, //Change this to SBOMSourceType_CONTAINER_FILE_SYSTEM once BE is ready
 		InUse:              true,
 		GeneratedAt:        timestamppb.New(result.CreatedAt),
 		GenerationDuration: convertDuration(result.Duration),

--- a/pkg/collector/corechecks/sbom/processor.go
+++ b/pkg/collector/corechecks/sbom/processor.go
@@ -88,6 +88,7 @@ func newProcessor(workloadmetaStore workloadmeta.Component, sender sender.Sender
 		imageUsers:            make(map[string]map[string]struct{}),
 		sbomScanner:           sbomScanner,
 		hostSBOM:              hostSBOM,
+		procfsSBOM:            procfsSBOM,
 		hostname:              hname,
 		hostHeartbeatValidity: hostHeartbeatValidity,
 	}, nil

--- a/pkg/collector/corechecks/sbom/processor_test.go
+++ b/pkg/collector/corechecks/sbom/processor_test.go
@@ -632,7 +632,7 @@ func TestProcessEvents(t *testing.T) {
 
 			// Define a max size of 1 for the queue. With a size > 1, it's difficult to
 			// control the number of events sent on each call.
-			p, err := newProcessor(workloadmetaStore, sender, fakeTagger, 1, 50*time.Millisecond, false, time.Second)
+			p, err := newProcessor(workloadmetaStore, sender, fakeTagger, 1, 50*time.Millisecond, false, false, time.Second)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -886,7 +886,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.scan_queue.base_backoff", "5m")
 	config.BindEnvAndSetDefault("sbom.scan_queue.max_backoff", "1h")
 
-	// Container SBOM configuration
+	// Container image SBOM configuration
 	config.BindEnvAndSetDefault("sbom.container_image.enabled", false)
 	config.BindEnvAndSetDefault("sbom.container_image.use_mount", false)
 	config.BindEnvAndSetDefault("sbom.container_image.scan_interval", 0)    // Integer seconds
@@ -895,6 +895,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("sbom.container_image.check_disk_usage", true)
 	config.BindEnvAndSetDefault("sbom.container_image.min_available_disk", "1Gb")
 	config.BindEnvAndSetDefault("sbom.container_image.overlayfs_direct_scan", false)
+
+	// Container file system SBOM configuration
+	config.BindEnvAndSetDefault("sbom.container.enabled", false)
 
 	// Host SBOM configuration
 	config.BindEnvAndSetDefault("sbom.host.enabled", false)

--- a/pkg/sbom/collectors/collectors.go
+++ b/pkg/sbom/collectors/collectors.go
@@ -33,6 +33,8 @@ const (
 	DockerCollector = "docker"
 	// HostCollector is the name of the host collector
 	HostCollector = "host"
+	// ProcfsCollector is the name of the procfs collector
+	ProcfsCollector = "procfs"
 )
 
 // Collector interface
@@ -83,6 +85,11 @@ func GetCrioScanner() Collector {
 // GetHostScanner returns the host scanner
 func GetHostScanner() Collector {
 	return Collectors[HostCollector]
+}
+
+// GetProcfsScanner returns the fargate scanner
+func GetProcfsScanner() Collector {
+	return Collectors[ProcfsCollector]
 }
 
 // NewSBOMContainerFilter returns a new include/exclude filter for containers

--- a/pkg/sbom/collectors/procfs/collector.go
+++ b/pkg/sbom/collectors/procfs/collector.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+
+package procfs
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/sbom"
+	"github.com/DataDog/datadog-agent/pkg/sbom/collectors"
+)
+
+// resultChanSize defines the result channel size
+const resultChanSize = 1000
+
+// Type returns the container image scan type
+func (c *Collector) Type() collectors.ScanType {
+	return collectors.ProcfsCollector
+}
+
+// Channel returns the channel to send scan results
+func (c *Collector) Channel() chan sbom.ScanResult {
+	return c.resChan
+}
+
+// Options returns the collector options
+func (c *Collector) Options() sbom.ScanOptions {
+	return c.opts
+}
+
+// Shutdown shuts down the collector
+func (c *Collector) Shutdown() {
+	if c.resChan != nil && !c.closed {
+		close(c.resChan)
+	}
+	c.closed = true
+}
+
+func init() {
+	collectors.RegisterCollector(collectors.ProcfsCollector, &Collector{
+		resChan: make(chan sbom.ScanResult, resultChanSize),
+	})
+}

--- a/pkg/sbom/collectors/procfs/doc.go
+++ b/pkg/sbom/collectors/procfs/doc.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package procfs holds procfs related files
+package procfs

--- a/pkg/sbom/collectors/procfs/errors.go
+++ b/pkg/sbom/collectors/procfs/errors.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package procfs
+
+import "errors"
+
+// ErrNotFound is returns when the resource is not found
+var ErrNotFound = errors.New("not found")

--- a/pkg/sbom/collectors/procfs/procfs.go
+++ b/pkg/sbom/collectors/procfs/procfs.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+
+package procfs
+
+import (
+	"context"
+	"errors"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/sbom"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+	"github.com/DataDog/datadog-agent/pkg/util/trivy"
+)
+
+var ErrNotFound = errors.New("not found")
+
+// Collector defines a procfs collector
+type Collector struct {
+	trivyCollector *trivy.Collector
+	resChan        chan sbom.ScanResult
+	opts           sbom.ScanOptions
+
+	closed bool
+}
+
+// CleanCache cleans the cache
+func (c *Collector) CleanCache() error {
+	return nil
+}
+
+// Init initialize the host collector
+func (c *Collector) Init(cfg config.Component, wmeta option.Option[workloadmeta.Component]) error {
+	trivyCollector, err := trivy.GetGlobalCollector(cfg, wmeta)
+	if err != nil {
+		return err
+	}
+	c.trivyCollector = trivyCollector
+	c.opts = sbom.ScanOptionsFromConfigForHosts(cfg)
+	return nil
+}
+
+// Scan performs a scan
+func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.ScanResult {
+	log.Infof("fargate scan request [%v]", request.ID())
+
+	scanPath, err := c.getPath(request)
+	if err != nil {
+		return sbom.ScanResult{
+			Error: err,
+		}
+	}
+
+	report, err := c.trivyCollector.ScanFilesystem(ctx, scanPath, c.opts)
+	return sbom.ScanResult{
+		RequestID: request.ID(),
+		Error:     err,
+		Report:    report,
+	}
+}

--- a/pkg/sbom/collectors/procfs/procfs.go
+++ b/pkg/sbom/collectors/procfs/procfs.go
@@ -47,7 +47,7 @@ func (c *Collector) Init(cfg config.Component, wmeta option.Option[workloadmeta.
 func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.ScanResult {
 	log.Infof("fargate scan request [%v]", request.ID())
 
-	scanPath, err := c.getPath(request)
+	scanPath, err := getPath(request)
 	if err != nil {
 		return sbom.ScanResult{
 			Error: err,

--- a/pkg/sbom/collectors/procfs/procfs.go
+++ b/pkg/sbom/collectors/procfs/procfs.go
@@ -57,7 +57,7 @@ func (c *Collector) Scan(ctx context.Context, request sbom.ScanRequest) sbom.Sca
 		}
 	}
 
-	report, err := c.trivyCollector.ScanFilesystem(ctx, scanPath, c.opts)
+	report, err := c.trivyCollector.ScanFilesystem(ctx, scanPath, c.opts, true)
 	return sbom.ScanResult{
 		RequestID: request.ID(),
 		Error:     err,

--- a/pkg/sbom/collectors/procfs/procfs.go
+++ b/pkg/sbom/collectors/procfs/procfs.go
@@ -9,7 +9,6 @@ package procfs
 
 import (
 	"context"
-	"errors"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -18,8 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/trivy"
 )
-
-var ErrNotFound = errors.New("not found")
 
 // Collector defines a procfs collector
 type Collector struct {

--- a/pkg/sbom/collectors/procfs/procfs_linux.go
+++ b/pkg/sbom/collectors/procfs/procfs_linux.go
@@ -8,8 +8,6 @@
 package procfs
 
 import (
-	"bytes"
-	"os"
 	"strconv"
 
 	"github.com/shirou/gopsutil/v4/process"
@@ -18,28 +16,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
-func cgroupContains(pid uint32, str string) (bool, error) {
-	cgroupPath := kernel.HostProc(strconv.FormatUint(uint64(pid), 10), "cgroup")
-
-	data, err := os.ReadFile(cgroupPath)
-	if err != nil {
-		return false, err
-	}
-
-	return bytes.Contains(data, []byte(str)), nil
-}
-
 func procRootPath(pid uint32) string {
 	return kernel.HostProc(strconv.FormatUint(uint64(pid), 10), "root")
 }
 
-// IsAgentContainer returns whether the container ID is the agent one
-func IsAgentContainer(ctrID string) (bool, error) {
-	pid := os.Getpid()
-	return cgroupContains(uint32(pid), ctrID)
-}
-
-func (c *Collector) getPath(request sbom.ScanRequest) (string, error) {
+func getPath(request sbom.ScanRequest) (string, error) {
 	pids, err := process.Pids()
 	if err != nil {
 		return "", err

--- a/pkg/sbom/collectors/procfs/procfs_linux.go
+++ b/pkg/sbom/collectors/procfs/procfs_linux.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy
+
+package procfs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/shirou/gopsutil/v4/process"
+
+	"github.com/DataDog/datadog-agent/pkg/sbom"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+func (c *Collector) getPath(request sbom.ScanRequest) (string, error) {
+	pids, err := process.Pids()
+	if err != nil {
+		return "", err
+	}
+
+	selfPid := uint32(os.Getpid())
+	selfCid, err := utils.GetProcContainerID(selfPid, selfPid)
+	if err != nil {
+		return "", err
+	}
+
+	for _, pid := range pids {
+		cid, err := utils.GetProcContainerID(uint32(pid), uint32(pid))
+		if err != nil || cid == "" {
+			continue
+		}
+
+		if cid == containerutils.ContainerID(request.ID()) && cid != selfCid {
+			fmt.Printf("%d CID: %s => %v\n", pid, cid, err)
+
+			return utils.ProcRootPath(uint32(pid)), nil
+		}
+	}
+
+	return "", ErrNotFound
+}

--- a/pkg/sbom/collectors/procfs/procfs_other.go
+++ b/pkg/sbom/collectors/procfs/procfs_other.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build trivy && !linux
+
+package procfs
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/sbom"
+)
+
+func (c *Collector) getPath(_ sbom.ScanRequest) (string, error) {
+	return "", errors.New("not supported")
+}

--- a/pkg/sbom/collectors/procfs/procfs_other.go
+++ b/pkg/sbom/collectors/procfs/procfs_other.go
@@ -16,3 +16,8 @@ import (
 func (c *Collector) getPath(_ sbom.ScanRequest) (string, error) {
 	return "", errors.New("not supported")
 }
+
+// IsAgentContainer returns whether the container ID is the agent one
+func IsAgentContainer(ctrID string) (bool, error) {
+	return false, errors.New("not supported")
+}

--- a/pkg/sbom/collectors/procfs/request.go
+++ b/pkg/sbom/collectors/procfs/request.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package procfs
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/sbom/types"
+)
+
+// scanRequest defines a scan request. This struct should be
+// hashable to be pushed in the work queue for processing.
+type scanRequest struct {
+	ContainerID string
+}
+
+// NewScanRequest creates a new scan request
+func NewScanRequest(containerID string) types.ScanRequest {
+	return scanRequest{ContainerID: containerID}
+}
+
+// Collector returns the collector name
+func (r scanRequest) Collector() string {
+	return "procfs"
+}
+
+// Type returns the scan request type
+func (r scanRequest) Type(types.ScanOptions) string {
+	return types.ScanFilesystemType
+}
+
+// ID returns the scan request ID
+func (r scanRequest) ID() string {
+	return r.ContainerID
+}

--- a/pkg/sbom/collectors/procfs/utils_linux.go
+++ b/pkg/sbom/collectors/procfs/utils_linux.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package procfs
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+func cgroupContains(pid uint32, str string) (bool, error) {
+	cgroupPath := kernel.HostProc(strconv.FormatUint(uint64(pid), 10), "cgroup")
+
+	data, err := os.ReadFile(cgroupPath)
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Contains(data, []byte(str)), nil
+}
+
+// IsAgentContainer returns whether the container ID is the agent one
+func IsAgentContainer(ctrID string) (bool, error) {
+	pid := os.Getpid()
+	return cgroupContains(uint32(pid), ctrID)
+}

--- a/pkg/sbom/collectors/procfs/utils_other.go
+++ b/pkg/sbom/collectors/procfs/utils_other.go
@@ -3,16 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build trivy && !linux
+//go:build !linux
 
 package procfs
 
-import (
-	"errors"
+import "errors"
 
-	"github.com/DataDog/datadog-agent/pkg/sbom"
-)
-
-func getPath(_ sbom.ScanRequest) (string, error) {
-	return "", errors.New("not supported")
+// IsAgentContainer returns whether the container ID is the agent one
+func IsAgentContainer(_ string) (bool, error) {
+	return false, errors.New("not supported")
 }

--- a/pkg/sbom/sbom.go
+++ b/pkg/sbom/sbom.go
@@ -60,4 +60,5 @@ type ScanResult struct {
 	CreatedAt time.Time
 	Duration  time.Duration
 	ImgMeta   *workloadmeta.ContainerImageMetadata
+	RequestID string
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use procfs to scan container file system. For each container, except the core agent one (self pid), we use the /proc/pid/root path to trigger a scan.

This feature is limited to Fargate instance as this is the main target for now. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->