### PR TITLE
Add GPU metrics origin

### DIFF
--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -62,6 +62,7 @@ const (
 	MetricSourceSnmp
 	MetricSourceCloudFoundry
 	MetricSourceJenkins
+	MetricSourceGPU
 
 	// Python Checks
 	MetricSourceZenohRouter
@@ -547,6 +548,8 @@ func (ms MetricSource) String() string {
 		return "glusterfs"
 	case MetricSourceGoExpvar:
 		return "go_expvar"
+	case MetricSourceGPU:
+		return "gpu"
 	case MetricSourceGunicorn:
 		return "gunicorn"
 	case MetricSourceHaproxy:
@@ -1171,6 +1174,8 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceGlusterfs
 	case "go_expvar":
 		return MetricSourceGoExpvar
+	case "gpu":
+		return MetricSourceGPU
 	case "gunicorn":
 		return MetricSourceGunicorn
 	case "haproxy":

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -12,14 +12,18 @@ import (
 func metricSourceToOriginProduct(ms metrics.MetricSource) int32 {
 	const serieMetadataOriginOriginProductAgentType = 10
 	const serieMetadataOriginOriginProductDatadogExporterType = 19
+	const serieMetadataOriginOriginProductGPU = 38 // ref: https://github.com/DataDog/dd-source/blob/main/domains/metrics/shared/libs/proto/origin/origin.proto#L277
 	if ms >= metrics.MetricSourceOpenTelemetryCollectorUnknown && ms <= metrics.MetricSourceOpenTelemetryCollectorCouchdbReceiver {
 		return serieMetadataOriginOriginProductDatadogExporterType
+	}
+	if ms == metrics.MetricSourceGPU {
+		return serieMetadataOriginOriginProductGPU
 	}
 	return serieMetadataOriginOriginProductAgentType
 }
 
 func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
-	// These constants map to specific fields in the 'OriginCategory' enum in origin.proto
+	// These constants map to specific fields in the 'OriginSubproduct' enum in origin.proto
 	switch ms {
 	case metrics.MetricSourceUnknown:
 		return 0
@@ -320,6 +324,8 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceQuarkus,
 		metrics.MetricSourceMilvus:
 		return 11 // integrationMetrics
+	case metrics.MetricSourceGPU:
+		return 72 // ref: https://github.com/DataDog/dd-source/blob/main/domains/metrics/shared/libs/proto/origin/origin.proto#L424
 	default:
 		return 0
 	}
@@ -440,6 +446,8 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 65
 	case metrics.MetricSourceGoExpvar:
 		return 66
+	case metrics.MetricSourceGPU:
+		return 466
 	case metrics.MetricSourceGunicorn:
 		return 67
 	case metrics.MetricSourceHaproxy:

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -325,7 +325,7 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceMilvus:
 		return 11 // integrationMetrics
 	case metrics.MetricSourceGPU:
-		return 72 // ref: https://github.com/DataDog/dd-source/blob/main/domains/metrics/shared/libs/proto/origin/origin.proto#L424
+		return 72 // ref: https://github.com/DataDog/dd-source/blob/276882b71d84785ec89c31973046ab66d5a01807/domains/metrics/shared/libs/proto/origin/origin.proto#L427
 	default:
 		return 0
 	}

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -12,7 +12,7 @@ import (
 func metricSourceToOriginProduct(ms metrics.MetricSource) int32 {
 	const serieMetadataOriginOriginProductAgentType = 10
 	const serieMetadataOriginOriginProductDatadogExporterType = 19
-	const serieMetadataOriginOriginProductGPU = 38 // ref: https://github.com/DataDog/dd-source/blob/main/domains/metrics/shared/libs/proto/origin/origin.proto#L277
+	const serieMetadataOriginOriginProductGPU = 38 // ref: https://github.com/DataDog/dd-source/blob/276882b71d84785ec89c31973046ab66d5a01807/domains/metrics/shared/libs/proto/origin/origin.proto#L277
 	if ms >= metrics.MetricSourceOpenTelemetryCollectorUnknown && ms <= metrics.MetricSourceOpenTelemetryCollectorCouchdbReceiver {
 		return serieMetadataOriginOriginProductDatadogExporterType
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds support for the new GPU metrics origin in the metricsource mappings.


### Motivation

Correct metric origin attribution.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Will test in staging clusters that the metric origin is correctly recognized.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Related dd-source PR: https://github.com/DataDog/dd-source/pull/194667