### PR TITLE
APM - Enable container based second primary tags

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -505,10 +505,7 @@ func (a *Agent) discardSpans(p *api.Payload) {
 }
 
 func (a *Agent) processStats(in *pb.ClientStatsPayload, lang, tracerVersion, containerID, obfuscationVersion string) *pb.ClientStatsPayload {
-	enableContainers := a.conf.HasFeature("enable_cid_stats") || (a.conf.FargateOrchestrator != config.OrchestratorUnknown)
-	if !enableContainers || a.conf.HasFeature("disable_cid_stats") {
-		// only allow the ContainerID stats dimension if we're in a Fargate instance or it's
-		// been explicitly enabled and it's not prohibited by the disable_cid_stats feature flag.
+	if a.conf.HasFeature("disable_cid_stats") {
 		in.ContainerID = ""
 		in.Tags = nil
 	} else {

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -316,7 +316,7 @@ func (a *Agent) Process(p *api.Payload) {
 	defer a.Timing.Since("datadog.trace_agent.internal.process_payload_ms", now)
 	ts := p.Source
 	sampledChunks := new(writer.SampledChunks)
-	statsInput := stats.NewStatsInput(len(p.TracerPayload.Chunks), p.TracerPayload.ContainerID, p.ClientComputedStats, a.conf)
+	statsInput := stats.NewStatsInput(len(p.TracerPayload.Chunks), p.TracerPayload.ContainerID, p.ClientComputedStats)
 
 	p.TracerPayload.Env = traceutil.NormalizeTagValue(p.TracerPayload.Env)
 

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -2549,7 +2549,7 @@ func TestConvertStats(t *testing.T) {
 				Version:       "code_version",
 				Lang:          "java",
 				TracerVersion: "v1",
-				ContainerID:   "",
+				ContainerID:   "abc123",
 				Stats: []*pb.ClientStatsBucket{
 					{
 						Start:    1,

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -646,42 +646,6 @@ func TestConcentratorInput(t *testing.T) {
 			},
 		},
 		{
-			name: "containerID no orchestrator",
-			in: &api.Payload{
-				TracerPayload: &pb.TracerPayload{
-					Chunks:      []*pb.TraceChunk{spansToChunk(rootSpan)},
-					ContainerID: "no-orch",
-				},
-			},
-			expected: stats.Input{
-				Traces: []traceutil.ProcessedTrace{
-					{
-						Root:       rootSpan,
-						TraceChunk: spansToChunk(rootSpan),
-					},
-				},
-			},
-		},
-		{
-			name: "containerID feature disabled",
-			in: &api.Payload{
-				TracerPayload: &pb.TracerPayload{
-					Chunks:      []*pb.TraceChunk{spansToChunk(rootSpan)},
-					ContainerID: "feature_disabled",
-				},
-			},
-			withFargate: true,
-			features:    "disable_cid_stats",
-			expected: stats.Input{
-				Traces: []traceutil.ProcessedTrace{
-					{
-						Root:       rootSpan,
-						TraceChunk: spansToChunk(rootSpan),
-					},
-				},
-			},
-		},
-		{
 			name: "client computed stats",
 			in: &api.Payload{
 				TracerPayload: &pb.TracerPayload{

--- a/pkg/trace/stats/otel_benckmark_test.go
+++ b/pkg/trace/stats/otel_benckmark_test.go
@@ -148,7 +148,6 @@ func BenchmarkOTelContainerTags(b *testing.B) {
 	conf := config.New()
 	conf.Hostname = "agent_host"
 	conf.DefaultEnv = "agent_env"
-	conf.Features["enable_cid_stats"] = struct{}{}
 	conf.OTLPReceiver.AttributesTranslator = attributesTranslator
 
 	concentrator := NewTestConcentratorWithCfg(time.Now(), conf)

--- a/pkg/trace/stats/otel_util_test.go
+++ b/pkg/trace/stats/otel_util_test.go
@@ -235,7 +235,6 @@ func TestProcessOTLPTraces(t *testing.T) {
 			conf := config.New()
 			conf.Hostname = agentHost
 			conf.DefaultEnv = agentEnv
-			conf.Features["enable_cid_stats"] = struct{}{}
 			if !tt.enableReceiveResourceSpansV2 {
 				conf.Features["disable_receive_resource_spans_v2"] = struct{}{}
 			}

--- a/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
+++ b/pkg/trace/stats/oteltest/otel_apm_stats_comparison_test.go
@@ -124,7 +124,6 @@ func getTraceAgentCfg(attributesTranslator *attributes.Translator) *traceconfig.
 	acfg.OTLPReceiver.AttributesTranslator = attributesTranslator
 	acfg.ComputeStatsBySpanKind = true
 	acfg.PeerTagsAggregation = true
-	acfg.Features["enable_cid_stats"] = struct{}{}
 	acfg.Features["enable_otlp_compute_top_level_by_span_kind"] = struct{}{}
 	return acfg
 }

--- a/releasenotes/notes/enable-apm-stats-cid-collection-9a3371f51218c238.yaml
+++ b/releasenotes/notes/enable-apm-stats-cid-collection-9a3371f51218c238.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    APM: Container-based second primary tags are now available by default.
+    APM: Container-based primary tags are now available by default.

--- a/releasenotes/notes/enable-apm-stats-cid-collection-9a3371f51218c238.yaml
+++ b/releasenotes/notes/enable-apm-stats-cid-collection-9a3371f51218c238.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    APM: Container-based second primary tags are now available by default.


### PR DESCRIPTION
### What does this PR do?
Enable [extraction of container tags for APM stats by default](https://docs.datadoghq.com/tracing/guide/setting_primary_tags_to_scope/?tab=helm#container-based-second-primary-tags), this allows choosing container tags as secondary primary tags.
To disable the extraction set in the agent configuration the following env
```
datadog:
  #...
  env:
    - name: DD_APM_FEATURES
      value: 'disable_cid_stats'
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->