### PR TITLE
traceroute: parse query URL only once in handler

### DIFF
--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -112,19 +113,22 @@ func logTracerouteRequests(cfg tracerouteutil.Config, client string, runCount ui
 func parseParams(req *http.Request) (tracerouteutil.Config, error) {
 	vars := mux.Vars(req)
 	host := vars["host"]
-	port, err := parseUint(req, "port", 16)
+
+	query := req.URL.Query()
+
+	port, err := parseUint(query, "port", 16)
 	if err != nil {
 		return tracerouteutil.Config{}, fmt.Errorf("invalid port: %s", err)
 	}
-	maxTTL, err := parseUint(req, "max_ttl", 8)
+	maxTTL, err := parseUint(query, "max_ttl", 8)
 	if err != nil {
 		return tracerouteutil.Config{}, fmt.Errorf("invalid max_ttl: %s", err)
 	}
-	timeout, err := parseUint(req, "timeout", 64)
+	timeout, err := parseUint(query, "timeout", 64)
 	if err != nil {
 		return tracerouteutil.Config{}, fmt.Errorf("invalid timeout: %s", err)
 	}
-	protocol := req.URL.Query().Get("protocol")
+	protocol := query.Get("protocol")
 
 	return tracerouteutil.Config{
 		DestHostname: host,
@@ -135,9 +139,9 @@ func parseParams(req *http.Request) (tracerouteutil.Config, error) {
 	}, nil
 }
 
-func parseUint(req *http.Request, field string, bitSize int) (uint64, error) {
-	if req.URL.Query().Has(field) {
-		return strconv.ParseUint(req.URL.Query().Get(field), 10, bitSize)
+func parseUint(query url.Values, field string, bitSize int) (uint64, error) {
+	if query.Has(field) {
+		return strconv.ParseUint(query.Get(field), 10, bitSize)
 	}
 
 	return 0, nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Calling `req.URL.Query` actually parses the query from scratch (this is not cached), this means that before this PR the query is parsed between 4 and 7 times which is a bit wasteful. This PR fixes this by parsing the query only once.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->