### PR TITLE
[CWS] remove callbackContext allocation in most cases in paths reducer

### DIFF
--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -63,22 +63,37 @@ func NewPathsReducer() *PathsReducer {
 
 // ReducePath reduces a path according to the predefined heuristics
 func (r *PathsReducer) ReducePath(path string, fileEvent *model.FileEvent, node *ProcessNode) string {
-	ctx := &callbackContext{
-		path:        path,
-		fileEvent:   fileEvent,
-		processNode: node,
-	}
+	var ctx *callbackContext
 
 	for _, pattern := range r.patterns {
+
 		if pattern.PreCheck != nil && fileEvent != nil && !pattern.PreCheck(fileEvent) {
 			continue
 		}
 
-		if pattern.Hint != "" && !strings.Contains(ctx.path, pattern.Hint) {
+		currentPath := path
+		if ctx != nil {
+			currentPath = ctx.path
+		}
+
+		if pattern.Hint != "" && !strings.Contains(currentPath, pattern.Hint) {
 			continue
 		}
 
-		allMatches := pattern.Pattern.FindAllStringSubmatchIndex(ctx.path, -1)
+		allMatches := pattern.Pattern.FindAllStringSubmatchIndex(currentPath, -1)
+
+		if len(allMatches) == 0 {
+			continue
+		}
+
+		// if no regex matches, we fully skip the callbackContext allocation
+		if ctx == nil {
+			ctx = &callbackContext{
+				path:        path,
+				fileEvent:   fileEvent,
+				processNode: node,
+			}
+		}
 
 		for matchSet := len(allMatches) - 1; matchSet >= 0; matchSet-- {
 			if pattern.Callback != nil {
@@ -88,7 +103,11 @@ func (r *PathsReducer) ReducePath(path string, fileEvent *model.FileEvent, node 
 		}
 	}
 
-	return ctx.path
+	if ctx != nil {
+		return ctx.path
+	}
+
+	return path
 }
 
 // getPathsReducerPatterns returns the patterns used to reduce the paths in an activity tree


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Most paths that go through the path reducer are not going to match any regex. This PR takes advantage of this to allocate the `callbackContext` on demand when the first regex matches, skipping the allocation in most cases.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->