### PR TITLE
Add logs to show elem, tree in Autodiscovery

### DIFF
--- a/comp/core/autodiscovery/configresolver/configresolver.go
+++ b/comp/core/autodiscovery/configresolver/configresolver.go
@@ -216,6 +216,8 @@ func resolveDataWithTemplateVars(ctx context.Context, data integration.Data, svc
 		return data, err
 	}
 
+	log.Debugf("tree to parse is: %v", tree)
+
 	type treePointer struct {
 		get func() interface{}
 		set func(interface{})
@@ -293,7 +295,7 @@ func resolveDataWithTemplateVars(ctx context.Context, data integration.Data, svc
 		case nil, int, bool:
 
 		default:
-			log.Errorf("Unknown type: %T", elem)
+			log.Errorf("Unknown type: %T, value: %v", elem, elem)
 		}
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- show elem value
- show tree that will be processed 

### Motivation
To improve visibility
```
| CORE | ERROR | (comp/core/autodiscovery/configresolver/configresolver.go:xxx in resolveDataWithTemplateVars) | Unknown type: xxx
```
↑ Now we are not able to see the value of elem that caused the error. 
We can see just the type of it.
It doesn't provide enough information for troubleshooting.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->