### PR TITLE
[CWS] size based hint for container id path reducer

### DIFF
--- a/pkg/security/secl/containerutils/helpers.go
+++ b/pkg/security/secl/containerutils/helpers.go
@@ -21,6 +21,9 @@ var containerIDPattern *regexp.Regexp
 var containerIDCoreChars = "0123456789abcdefABCDEF"
 
 func init() {
+	// when changing this pattern, make sure to also update the pre-check
+	// in pkg/security/security_profile/activity_tree/paths_reducer.go
+
 	ContainerIDPatternStr = "([0-9a-fA-F]{64})|([0-9a-fA-F]{32}-\\d+)|([0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){4})"
 	containerIDPattern = regexp.MustCompile(ContainerIDPatternStr)
 }

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -162,6 +162,20 @@ func getPathsReducerPatterns() []PatternReducer {
 		},
 		{
 			Pattern: regexp.MustCompile(containerutils.ContainerIDPatternStr), // container ID
+			PreCheck: func(path string, _ *model.FileEvent) bool {
+				var count int
+				for _, c := range []byte(path) {
+					if isHexChar(c) {
+						count++
+						if count >= 28 { // 28 is the minimal length of a container ID
+							return true
+						}
+					} else {
+						count = 0
+					}
+				}
+				return false
+			},
 			Callback: func(ctx *callbackContext) {
 				start, end := ctx.getGroup(0)
 				ctx.replaceBy(start, end, "*")
@@ -187,4 +201,11 @@ func getPathsReducerPatterns() []PatternReducer {
 			},
 		},
 	}
+}
+
+func isHexChar(c byte) bool {
+	return ('0' <= c && c <= '9') ||
+		('a' <= c && c <= 'f') ||
+		('A' <= c && c <= 'F') ||
+		c == '-'
 }

--- a/pkg/security/security_profile/activity_tree/paths_reducer.go
+++ b/pkg/security/security_profile/activity_tree/paths_reducer.go
@@ -165,7 +165,7 @@ func getPathsReducerPatterns() []PatternReducer {
 			PreCheck: func(path string, _ *model.FileEvent) bool {
 				var count int
 				for _, c := range []byte(path) {
-					if isHexChar(c) {
+					if isHexChar(c) || c == '-' {
 						count++
 						if count >= 28 { // 28 is the minimal length of a container ID
 							return true
@@ -206,6 +206,5 @@ func getPathsReducerPatterns() []PatternReducer {
 func isHexChar(c byte) bool {
 	return ('0' <= c && c <= '9') ||
 		('a' <= c && c <= 'f') ||
-		('A' <= c && c <= 'F') ||
-		c == '-'
+		('A' <= c && c <= 'F')
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The container ID pattern is currently the only pattern with no hint and no precheck in the path reducers. Meaning that every path going through it will evaluate the regex.

This PR adds a simple pre-check, that looks for strings of hex characters that could be interpreted as container IDs.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->