### PR TITLE
[EBPF] gpu: disable fatbin parsing by default

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -437,6 +437,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "process_scan_interval_seconds"), 5)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "initial_process_sync"), true)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "configure_cgroup_perms"), false)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "enable_fatbin_parsing"), false)
 
 	initCWSSystemProbeConfig(cfg)
 }

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -34,6 +34,8 @@ type Config struct {
 	NVMLLibraryPath string
 	// ConfigureCgroupPerms indicates whether the probe should configure cgroup permissions for GPU monitoring
 	ConfigureCgroupPerms bool
+	// EnableFatbinParsing indicates whether the probe should enable fatbin parsing.
+	EnableFatbinParsing bool
 }
 
 // New generates a new configuration for the GPU monitoring probe.
@@ -46,5 +48,6 @@ func New() *Config {
 		NVMLLibraryPath:       spCfg.GetString(sysconfig.FullKeyPath(GPUNS, "nvml_lib_path")),
 		Enabled:               spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enabled")),
 		ConfigureCgroupPerms:  spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "configure_cgroup_perms")),
+		EnableFatbinParsing:   spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enable_fatbin_parsing")),
 	}
 }

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -76,6 +76,10 @@ type systemContext struct {
 
 	// fatbinTelemetry holds telemetry counters and histograms for the fatbin parsing process
 	fatbinTelemetry *fatbinTelemetry
+
+	// fatbinParsingEnabled is a flag to enable/disable fatbin parsing.
+	// TODO: this flag will be unnecessary once we have a separate structure for the fatbin parser
+	fatbinParsingEnabled bool
 }
 
 // symbolFileIdentifier holds the inode and file size of a symbol file, which we use to avoid

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -148,6 +148,8 @@ func NewProbe(cfg *config.Config, deps ProbeDependencies) (*Probe, error) {
 		return nil, fmt.Errorf("error getting system context: %w", err)
 	}
 
+	sysCtx.fatbinParsingEnabled = cfg.EnableFatbinParsing
+
 	p := &Probe{
 		cfg:       cfg,
 		deps:      deps,

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -46,6 +46,9 @@ func (s *probeTestSuite) getProbe() *Probe {
 	// Avoid waiting for the initial sync to finish in tests, we don't need it
 	cfg.InitialProcessSync = false
 
+	// Enable fatbin parsing in tests so we can validate it runs
+	cfg.EnableFatbinParsing = true
+
 	deps := ProbeDependencies{
 		NvmlLib:        testutil.GetBasicNvmlMock(),
 		ProcessMonitor: consumerstestutil.NewTestProcessConsumer(t),

--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -155,7 +155,7 @@ func findEntryInMaps(procMaps []*procfs.ProcMap, addr uintptr) *procfs.ProcMap {
 }
 
 func (sh *StreamHandler) tryAttachKernelData(event *enrichedKernelLaunch) error {
-	if sh.sysCtx == nil || sh.sysCtx.fatbinParsingEnabled == false || sh.smVersion == noSmVersion {
+	if sh.sysCtx == nil || !sh.sysCtx.fatbinParsingEnabled || sh.smVersion == noSmVersion {
 		// Fatbin parsing is disabled or we don't have SM version, so we can't attach kernel data
 		return nil
 	}

--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -155,9 +155,8 @@ func findEntryInMaps(procMaps []*procfs.ProcMap, addr uintptr) *procfs.ProcMap {
 }
 
 func (sh *StreamHandler) tryAttachKernelData(event *enrichedKernelLaunch) error {
-	if sh.sysCtx == nil || sh.smVersion == noSmVersion {
-		// No system context or we don't have a SM version to use,
-		// kernel data attaching is disabled
+	if sh.sysCtx == nil || sh.sysCtx.fatbinParsingEnabled == false || sh.smVersion == noSmVersion {
+		// Fatbin parsing is disabled or we don't have SM version, so we can't attach kernel data
 		return nil
 	}
 

--- a/pkg/gpu/stream_test.go
+++ b/pkg/gpu/stream_test.go
@@ -325,6 +325,8 @@ func TestKernelLaunchesIncludeEnrichedKernelData(t *testing.T) {
 	sysCtx, err := getSystemContext(testutil.GetBasicNvmlMock(), proc, testutil.GetWorkloadMetaMock(t), testutil.GetTelemetryMock(t))
 	require.NoError(t, err)
 
+	sysCtx.fatbinParsingEnabled = true
+
 	// Set up the caches in system context so no actual queries are done
 	pid, tid := uint64(1), uint64(1)
 	kernAddress := uint64(42)

--- a/pkg/gpu/stream_test.go
+++ b/pkg/gpu/stream_test.go
@@ -320,106 +320,128 @@ func TestMemoryAllocationsMultipleAllocsHandled(t *testing.T) {
 	require.Empty(t, stream.memAllocEvents)
 }
 
-func TestKernelLaunchesIncludeEnrichedKernelData(t *testing.T) {
-	proc := kernel.ProcFSRoot()
-	sysCtx, err := getSystemContext(testutil.GetBasicNvmlMock(), proc, testutil.GetWorkloadMetaMock(t), testutil.GetTelemetryMock(t))
-	require.NoError(t, err)
+func TestKernelLaunchEnrichment(t *testing.T) {
+	for _, fatbinParsingEnabled := range []bool{true, false} {
+		name := "fatbinParsingEnabled"
+		if !fatbinParsingEnabled {
+			name = "fatbinParsingDisabled"
+		}
 
-	sysCtx.fatbinParsingEnabled = true
+		t.Run(name, func(t *testing.T) {
+			proc := kernel.ProcFSRoot()
+			sysCtx, err := getSystemContext(testutil.GetBasicNvmlMock(), proc, testutil.GetWorkloadMetaMock(t), testutil.GetTelemetryMock(t))
+			require.NoError(t, err)
+			sysCtx.fatbinParsingEnabled = fatbinParsingEnabled
 
-	// Set up the caches in system context so no actual queries are done
-	pid, tid := uint64(1), uint64(1)
-	kernAddress := uint64(42)
-	binPath := "/path/to/binary"
-	smVersion := uint32(75)
-	kernName := "kernel"
-	kernSize := uint64(1000)
-	sharedMem := uint64(100)
-	constantMem := uint64(200)
+			// Set up the caches in system context so no actual queries are done
+			pid, tid := uint64(1), uint64(1)
+			kernAddress := uint64(42)
+			binPath := "/path/to/binary"
+			smVersion := uint32(75)
+			kernName := "kernel"
+			kernSize := uint64(1000)
+			sharedMem := uint64(100)
+			constantMem := uint64(200)
 
-	sysCtx.pidMaps[int(pid)] = []*procfs.ProcMap{
-		{StartAddr: 0, EndAddr: 1000, Offset: 0, Pathname: binPath},
+			sysCtx.pidMaps[int(pid)] = []*procfs.ProcMap{
+				{StartAddr: 0, EndAddr: 1000, Offset: 0, Pathname: binPath},
+			}
+
+			procBinPath := path.Join(proc, fmt.Sprintf("%d/root/%s", pid, binPath))
+			kernKey := cuda.CubinKernelKey{Name: kernName, SmVersion: smVersion}
+
+			fatbin := cuda.NewFatbin()
+			fatbin.AddKernel(kernKey, &cuda.CubinKernel{
+				Name:        kernName,
+				KernelSize:  kernSize,
+				SharedMem:   sharedMem,
+				ConstantMem: constantMem,
+			})
+
+			procBinIdent, err := buildSymbolFileIdentifier(procBinPath)
+			require.NoError(t, err)
+
+			sysCtx.cudaSymbols[procBinIdent] = &symbolsEntry{
+				Symbols: &cuda.Symbols{
+					SymbolTable: map[uint64]string{kernAddress: kernName},
+					Fatbin:      fatbin,
+				},
+			}
+
+			stream := newStreamHandler(uint32(pid), "", smVersion, sysCtx)
+
+			kernStartTime := uint64(1)
+			launch := &gpuebpf.CudaKernelLaunch{
+				Header: gpuebpf.CudaEventHeader{
+					Type:      uint32(gpuebpf.CudaEventTypeKernelLaunch),
+					Pid_tgid:  uint64(pid<<32 + tid),
+					Ktime_ns:  kernStartTime,
+					Stream_id: 1,
+				},
+				Kernel_addr:     kernAddress,
+				Grid_size:       gpuebpf.Dim3{X: 10, Y: 10, Z: 10},
+				Block_size:      gpuebpf.Dim3{X: 2, Y: 2, Z: 1},
+				Shared_mem_size: 0,
+			}
+			threadCount := 10 * 10 * 10 * 2 * 2
+
+			numLaunches := 3
+			for i := 0; i < numLaunches; i++ {
+				stream.handleKernelLaunch(launch)
+			}
+
+			// No sync, so we should have data
+			require.Nil(t, stream.getPastData(false))
+
+			// We should have a current kernel span running
+			currTime := uint64(100)
+			currData := stream.getCurrentData(currTime)
+			require.NotNil(t, currData)
+			require.Len(t, currData.spans, 1)
+
+			span := currData.spans[0]
+			require.Equal(t, kernStartTime, span.startKtime)
+			require.Equal(t, currTime, span.endKtime)
+			require.Equal(t, uint64(numLaunches), span.numKernels)
+			require.Equal(t, uint64(threadCount), span.avgThreadCount)
+
+			if fatbinParsingEnabled {
+				require.Equal(t, sharedMem, span.avgMemoryUsage[sharedMemAlloc])
+				require.Equal(t, constantMem, span.avgMemoryUsage[constantMemAlloc])
+				require.Equal(t, kernSize, span.avgMemoryUsage[kernelMemAlloc])
+			} else {
+				require.Equal(t, uint64(0), span.avgMemoryUsage[sharedMemAlloc])
+				require.Equal(t, uint64(0), span.avgMemoryUsage[constantMemAlloc])
+				require.Equal(t, uint64(0), span.avgMemoryUsage[kernelMemAlloc])
+			}
+
+			// Now we mark a sync event
+			syncTime := uint64(200)
+			stream.markSynchronization(syncTime)
+
+			// We should have a past kernel span
+			pastData := stream.getPastData(true)
+			require.NotNil(t, pastData)
+
+			require.Len(t, pastData.spans, 1)
+			span = pastData.spans[0]
+			require.Equal(t, kernStartTime, span.startKtime)
+			require.Equal(t, syncTime, span.endKtime)
+			require.Equal(t, uint64(numLaunches), span.numKernels)
+			require.Equal(t, uint64(threadCount), span.avgThreadCount)
+
+			if fatbinParsingEnabled {
+				require.Equal(t, sharedMem, span.avgMemoryUsage[sharedMemAlloc])
+				require.Equal(t, constantMem, span.avgMemoryUsage[constantMemAlloc])
+				require.Equal(t, kernSize, span.avgMemoryUsage[kernelMemAlloc])
+			} else {
+				require.Equal(t, uint64(0), span.avgMemoryUsage[sharedMemAlloc])
+				require.Equal(t, uint64(0), span.avgMemoryUsage[constantMemAlloc])
+				require.Equal(t, uint64(0), span.avgMemoryUsage[kernelMemAlloc])
+			}
+
+			// We should have no current data
+			require.Nil(t, stream.getCurrentData(currTime))
+		})
 	}
-
-	procBinPath := path.Join(proc, fmt.Sprintf("%d/root/%s", pid, binPath))
-	kernKey := cuda.CubinKernelKey{Name: kernName, SmVersion: smVersion}
-
-	fatbin := cuda.NewFatbin()
-	fatbin.AddKernel(kernKey, &cuda.CubinKernel{
-		Name:        kernName,
-		KernelSize:  kernSize,
-		SharedMem:   sharedMem,
-		ConstantMem: constantMem,
-	})
-
-	procBinIdent, err := buildSymbolFileIdentifier(procBinPath)
-	require.NoError(t, err)
-
-	sysCtx.cudaSymbols[procBinIdent] = &symbolsEntry{
-		Symbols: &cuda.Symbols{
-			SymbolTable: map[uint64]string{kernAddress: kernName},
-			Fatbin:      fatbin,
-		},
-	}
-
-	stream := newStreamHandler(uint32(pid), "", smVersion, sysCtx)
-
-	kernStartTime := uint64(1)
-	launch := &gpuebpf.CudaKernelLaunch{
-		Header: gpuebpf.CudaEventHeader{
-			Type:      uint32(gpuebpf.CudaEventTypeKernelLaunch),
-			Pid_tgid:  uint64(pid<<32 + tid),
-			Ktime_ns:  kernStartTime,
-			Stream_id: 1,
-		},
-		Kernel_addr:     kernAddress,
-		Grid_size:       gpuebpf.Dim3{X: 10, Y: 10, Z: 10},
-		Block_size:      gpuebpf.Dim3{X: 2, Y: 2, Z: 1},
-		Shared_mem_size: 0,
-	}
-	threadCount := 10 * 10 * 10 * 2 * 2
-
-	numLaunches := 3
-	for i := 0; i < numLaunches; i++ {
-		stream.handleKernelLaunch(launch)
-	}
-
-	// No sync, so we should have data
-	require.Nil(t, stream.getPastData(false))
-
-	// We should have a current kernel span running
-	currTime := uint64(100)
-	currData := stream.getCurrentData(currTime)
-	require.NotNil(t, currData)
-	require.Len(t, currData.spans, 1)
-
-	span := currData.spans[0]
-	require.Equal(t, kernStartTime, span.startKtime)
-	require.Equal(t, currTime, span.endKtime)
-	require.Equal(t, uint64(numLaunches), span.numKernels)
-	require.Equal(t, uint64(threadCount), span.avgThreadCount)
-	require.Equal(t, sharedMem, span.avgMemoryUsage[sharedMemAlloc])
-	require.Equal(t, constantMem, span.avgMemoryUsage[constantMemAlloc])
-	require.Equal(t, kernSize, span.avgMemoryUsage[kernelMemAlloc])
-
-	// Now we mark a sync event
-	syncTime := uint64(200)
-	stream.markSynchronization(syncTime)
-
-	// We should have a past kernel span
-	pastData := stream.getPastData(true)
-	require.NotNil(t, pastData)
-
-	require.Len(t, pastData.spans, 1)
-	span = pastData.spans[0]
-	require.Equal(t, kernStartTime, span.startKtime)
-	require.Equal(t, syncTime, span.endKtime)
-	require.Equal(t, uint64(numLaunches), span.numKernels)
-	require.Equal(t, uint64(threadCount), span.avgThreadCount)
-	require.Equal(t, sharedMem, span.avgMemoryUsage[sharedMemAlloc])
-	require.Equal(t, constantMem, span.avgMemoryUsage[constantMemAlloc])
-	require.Equal(t, kernSize, span.avgMemoryUsage[kernelMemAlloc])
-
-	// We should have no current data
-	require.Nil(t, stream.getCurrentData(currTime))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR disables fatbin parsing by default, adding a config flag.

### Motivation

As we want to split shared memory usage from the memory metrics and fatbin parsing is computationally expensive, we're disabling it by default until we add more features that require that feature.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passing.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->