### PR TITLE
add option for exe install

### DIFF
--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -51,6 +51,7 @@ func install(ctx context.Context, env *env.Env, url string, experiment bool) err
 
 // downloadInstaller downloads the installer package from the registry and returns the path to the executable.
 func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir string) (*iexec.InstallerExec, error) {
+	var installPath string
 	downloader := oci.NewDownloader(env, env.HTTPClient())
 	downloadedPackage, err := downloader.Download(ctx, url)
 	if err != nil {
@@ -75,18 +76,22 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 		return nil, fmt.Errorf("failed to extract layers: %w", err)
 	}
 
+	installPath, err = getInstallerFromMSI(tmpDir)
+	if err != nil {
+		installPath, err = getInstallerFromOCI(tmpDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get installer: %w", err)
+		}
+	}
+	return iexec.NewInstallerExec(env, installPath), nil
+}
+
+func getInstallerFromMSI(tmpDir string) (string, error) {
 	msis, err := filepath.Glob(filepath.Join(tmpDir, "datadog-agent-*-x86_64.msi"))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	if len(msis) > 1 {
-		return nil, fmt.Errorf("too many MSIs in package")
-	} else if len(msis) == 0 {
-		return nil, fmt.Errorf("no MSIs in package")
-	}
-
 	adminInstallDir := path.Join(tmpDir, "datadog-installer")
-
 	cmd, err := msi.Cmd(
 		msi.AdministrativeInstall(),
 		msi.WithMsi(msis[0]),
@@ -98,9 +103,21 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("failed to install the Datadog Installer: %w\n%s", err, string(output))
+		return "", fmt.Errorf("failed to install the Datadog Installer: %w\n%s", err, string(output))
 	}
-	return iexec.NewInstallerExec(env, paths.GetAdminInstallerBinaryPath(adminInstallDir)), nil
+	return paths.GetAdminInstallerBinaryPath(adminInstallDir), nil
+
+}
+
+func getInstallerFromOCI(tmpDir string) (string, error) {
+	installers, err := filepath.Glob(filepath.Join(tmpDir, "datadog-installer.exe"))
+	if err != nil {
+		return "", err
+	}
+	if len(installers) == 0 {
+		return "", fmt.Errorf("no installer found in %s", tmpDir)
+	}
+	return installers[0], nil
 }
 
 func getInstallerOCI(_ context.Context, env *env.Env) string {

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
@@ -7,8 +7,37 @@
 
 package bootstrap
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestGetInstallPath(t *testing.T) {
+	// create temp directory
+	tmpDir := t.TempDir()
 
+	// add an exe to the temp directory
+	exePath := filepath.Join(tmpDir, "datadog-installer.exe")
+
+	// touch exe PATH
+	file, err := os.Create(exePath)
+	if err != nil {
+		t.Fatalf("Failed to create exe file: %v", err)
+	}
+	err = file.Close()
+	if err != nil {
+		t.Fatalf("Failed to close exe file: %v", err)
+	}
+
+	// get the install path
+	installPath, err := getInstallerPath(tmpDir)
+	if err != nil {
+		t.Fatalf("Failed to get install path: %v", err)
+	}
+
+	// check the install path
+	if installPath != exePath {
+		t.Fatalf("Expected install path to be %s, got %s", exePath, installPath)
+	}
 }

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows_test.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package bootstrap
+
+import "testing"
+
+func TestGetInstallPath(t *testing.T) {
+
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds an option to install from an EXE within the OCI package when the MSI is not present.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1321

This will allow us more flexibility to change how the fleet process works in the future without making breaking changes to the fleet processes. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Manual Steps:
- Install MSI
- Create test OCI package with an `datadog-installer.exe` and push to local registry
- Add local package to registry
- Run command like: `.\datadog-installer.exe daemon start-installer-experiment "datadog-agent" "7.67.0"`
(My example OCI created C:\test.txt so I looked for creation of this file)

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Validated by creating an OCI package with a `datadog-installer.exe` and verify that it correctly run and calls the setup of that exe

Steps:
- Run MSI to install full package
- Start local registry
- Upload fake OCI package that has `datadog-installer.exe` (mine just created C:\test.txt)
- Run command to set catalog: `.\installer.exe daemon set-catalog '{\"Packages\":[{\"Package\":\"datadog-agent\", \"Version\":\"7.69.0\", \"URL\":\"oci://192.168.61.1:5000/installer-package:7.69.0\"}]}'`
- Start experiment: `.\installer.exe daemon set-catalog  '{\"Packages\":[{\"Package\":\"datadog-agent\", \"Version\":\"7.69.0\", \"URL\":\"oci://192.168.61.1:5000/installer-package:7.69.0\"}]}'`
- Validate that `C:\test.txt` created for my example

Also validated by added unit tests.

MSI path tested by existing e2e tests that use MSI path to update.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->