### PR TITLE
[CWS] optimize disabled use case in k8s user session resolver

### DIFF
--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -83,12 +83,12 @@ func (r *Resolver) Start(manager *manager.Manager) error {
 
 // ResolveUserSession returns the user session associated to the provided ID
 func (r *Resolver) ResolveUserSession(id uint64) *model.UserSessionContext {
-	r.Lock()
-	defer r.Unlock()
-
 	if id == 0 {
 		return nil
 	}
+
+	r.Lock()
+	defer r.Unlock()
 
 	// is this session already in cache ?
 	if session, ok := r.userSessions.Get(id); ok {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This `id` check doesn't depend on the resolver, and as such doesn't need to be in the critical section. This will allow most events (because they are not attached to a session, or because this feature is disabled) to fully skip the lock/unlock step.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->