### PR TITLE
[CWS] Add kernel compilation flags in sysctl snapshot event

### DIFF
--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -124,6 +124,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.period", "1h")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.ignored_base_names", []string{"netdev_rss_key", "stable_secret"})
+	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.kernel_compilation_flags", kernelCompilationFlags)
 
 	// CWS - UserSessions
 	cfg.BindEnvAndSetDefault("runtime_security_config.user_sessions.cache_size", 1024)
@@ -149,3 +150,106 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	cfg.BindEnvAndSetDefault("runtime_security_config.network_monitoring.enabled", false)
 }
+
+var (
+	// kernelCompilationFlags are the kernel compilation flags checked by CWS
+	kernelCompilationFlags = []string{
+		// memory management hardening
+		"CONFIG_DEBUG_KERNEL",
+		"CONFIG_DEBUG_RODATA",
+		"CONFIG_STRICT_KERNEL_RWX",
+		"CONFIG_ARCH_OPTIONAL_KERNEL_RWX",
+		"CONFIG_ARCH_HAS_STRICT_KERNEL_RWX",
+		"CONFIG_DEBUG_WX",
+		"CONFIG_CC_STACKPROTECTOR",
+		"CONFIG_CC_STACKPROTECTOR_STRONG",
+		"CONFIG_STACKPROTECTOR",
+		"CONFIG_STACKPROTECTOR_STRONG",
+		"CONFIG_DEVMEM",
+		"CONFIG_STRICT_DEVMEM",
+		"CONFIG_IO_STRICT_DEVMEM",
+		"CONFIG_SCHED_STACK_END_CHECK",
+		"CONFIG_HARDENED_USERCOPY",
+		"CONFIG_HARDENED_USERCOPY_FALLBACK",
+		"CONFIG_HARDENED_USERCOPY_PAGESPAN",
+		"CONFIG_VMAP_STACK",
+		"CONFIG_REFCOUNT_FULL",
+		"CONFIG_FORTIFY_SOURCE",
+		"CONFIG_ACPI_CUSTOM_METHOD",
+		"CONFIG_DEVKMEM",
+		"CONFIG_PROC_KCORE",
+		"CONFIG_COMPAT_VDSO",
+		"CONFIG_SECURITY_DMESG_RESTRICT",
+		"CONFIG_RETPOLINE",
+		"CONFIG_LEGACY_VSYSCALL_NONE",
+		"CONFIG_LEGACY_VSYSCALL_EMULATE",
+		"CONFIG_LEGACY_VSYSCALL_XONLY",
+		"CONFIG_X86_VSYSCALL_EMULATION",
+		// protect kernel data structures
+		"CONFIG_DEBUG_CREDENTIALS",
+		"CONFIG_DEBUG_NOTIFIERS",
+		"CONFIG_DEBUG_LIST",
+		"CONFIG_DEBUG_SG",
+		"CONFIG_BUG_ON_DATA_CORRUPTION",
+		"CONFIG_SLAB_FREELIST_RANDOM",
+		"CONFIG_SLUB",
+		"CONFIG_SLAB_FREELIST_HARDENED",
+		"CONFIG_SLAB_MERGE_DEFAULT",
+		"CONFIG_SLUB_DEBUG",
+		"CONFIG_PAGE_POISONING",
+		"CONFIG_PAGE_POISONING_NO_SANITY",
+		"CONFIG_PAGE_POISONING_ZERO",
+		"CONFIG_COMPAT_BRK",
+		// harden the management of kernel modules
+		"CONFIG_MODULES",
+		"CONFIG_STRICT_MODULE_RWX",
+		"CONFIG_MODULE_SIG",
+		"CONFIG_MODULE_SIG_FORCE",
+		"CONFIG_MODULE_SIG_ALL",
+		"CONFIG_MODULE_SIG_SHA512",
+		"CONFIG_MODULE_SIG_HASH",
+		"CONFIG_MODULE_SIG_KEY",
+		// handle abnormal situations
+		"CONFIG_BUG",
+		"CONFIG_PANIC_ON_OOPS",
+		"CONFIG_PANIC_TIMEOUT",
+		"CONFIG_SECCOMP",
+		"CONFIG_SECCOMP_FILTER",
+		"CONFIG_SECURITY",
+		"CONFIG_SECURITY_YAMA",
+		"CONFIG_SECURITY_WRITABLE_HOOKS",
+		"CONFIG_SECURITY_SELINUX_DISABLE",
+		// configure compiler plugins
+		"CONFIG_GCC_PLUGINS",
+		"CONFIG_GCC_PLUGIN_LATENT_ENTROPY",
+		"CONFIG_GCC_PLUGIN_STACKLEAK",
+		"CONFIG_GCC_PLUGIN_STRUCTLEAK",
+		"CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL",
+		"CONFIG_GCC_PLUGIN_RANDSTRUCT",
+		"CONFIG_GCC_PLUGIN_RANDSTRUCT_PERFORMANCE",
+		// configure the IP stack
+		"CONFIG_KEXEC",
+		"CONFIG_HIBERNATION",
+		"CONFIG_BINFMT_MISC",
+		"CONFIG_LEGACY_PTYS",
+		// options for x86_32 bit architectures
+		"CONFIG_HIGHMEM64G",
+		"CONFIG_X86_PAE",
+		"CONFIG_DEFAULT_MMAP_MIN_ADDR",
+		"CONFIG_RANDOMIZE_BASE",
+		// options for x86_64 bit architectures
+		"CONFIG_X86_64",
+		"CONFIG_RANDOMIZE_MEMORY",
+		"CONFIG_PAGE_TABLE_ISOLATION",
+		"CONFIG_IA32_EMULATION",
+		"CONFIG_MODIFY_LDT_SYSCALL",
+		// options for arm architectures
+		"CONFIG_VMSPLIT_3G",
+		"CONFIG_STRICT_MEMORY_RWX",
+		"CONFIG_CPU_SW_DOMAIN_PAN",
+		"CONFIG_OABI_COMPAT",
+		// options for arm64 architectures
+		"CONFIG_ARM64_SW_TTBR0_PAN",
+		"CONFIG_UNMAP_KERNEL_AT_EL0",
+	}
+)

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -124,7 +124,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.period", "1h")
 	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.ignored_base_names", []string{"netdev_rss_key", "stable_secret"})
-	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.kernel_compilation_flags", kernelCompilationFlags)
+	cfg.BindEnvAndSetDefault("runtime_security_config.sysctl.snapshot.kernel_compilation_flags", []string{})
 
 	// CWS - UserSessions
 	cfg.BindEnvAndSetDefault("runtime_security_config.user_sessions.cache_size", 1024)
@@ -150,106 +150,3 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	cfg.BindEnvAndSetDefault("runtime_security_config.network_monitoring.enabled", false)
 }
-
-var (
-	// kernelCompilationFlags are the kernel compilation flags checked by CWS
-	kernelCompilationFlags = []string{
-		// memory management hardening
-		"CONFIG_DEBUG_KERNEL",
-		"CONFIG_DEBUG_RODATA",
-		"CONFIG_STRICT_KERNEL_RWX",
-		"CONFIG_ARCH_OPTIONAL_KERNEL_RWX",
-		"CONFIG_ARCH_HAS_STRICT_KERNEL_RWX",
-		"CONFIG_DEBUG_WX",
-		"CONFIG_CC_STACKPROTECTOR",
-		"CONFIG_CC_STACKPROTECTOR_STRONG",
-		"CONFIG_STACKPROTECTOR",
-		"CONFIG_STACKPROTECTOR_STRONG",
-		"CONFIG_DEVMEM",
-		"CONFIG_STRICT_DEVMEM",
-		"CONFIG_IO_STRICT_DEVMEM",
-		"CONFIG_SCHED_STACK_END_CHECK",
-		"CONFIG_HARDENED_USERCOPY",
-		"CONFIG_HARDENED_USERCOPY_FALLBACK",
-		"CONFIG_HARDENED_USERCOPY_PAGESPAN",
-		"CONFIG_VMAP_STACK",
-		"CONFIG_REFCOUNT_FULL",
-		"CONFIG_FORTIFY_SOURCE",
-		"CONFIG_ACPI_CUSTOM_METHOD",
-		"CONFIG_DEVKMEM",
-		"CONFIG_PROC_KCORE",
-		"CONFIG_COMPAT_VDSO",
-		"CONFIG_SECURITY_DMESG_RESTRICT",
-		"CONFIG_RETPOLINE",
-		"CONFIG_LEGACY_VSYSCALL_NONE",
-		"CONFIG_LEGACY_VSYSCALL_EMULATE",
-		"CONFIG_LEGACY_VSYSCALL_XONLY",
-		"CONFIG_X86_VSYSCALL_EMULATION",
-		// protect kernel data structures
-		"CONFIG_DEBUG_CREDENTIALS",
-		"CONFIG_DEBUG_NOTIFIERS",
-		"CONFIG_DEBUG_LIST",
-		"CONFIG_DEBUG_SG",
-		"CONFIG_BUG_ON_DATA_CORRUPTION",
-		"CONFIG_SLAB_FREELIST_RANDOM",
-		"CONFIG_SLUB",
-		"CONFIG_SLAB_FREELIST_HARDENED",
-		"CONFIG_SLAB_MERGE_DEFAULT",
-		"CONFIG_SLUB_DEBUG",
-		"CONFIG_PAGE_POISONING",
-		"CONFIG_PAGE_POISONING_NO_SANITY",
-		"CONFIG_PAGE_POISONING_ZERO",
-		"CONFIG_COMPAT_BRK",
-		// harden the management of kernel modules
-		"CONFIG_MODULES",
-		"CONFIG_STRICT_MODULE_RWX",
-		"CONFIG_MODULE_SIG",
-		"CONFIG_MODULE_SIG_FORCE",
-		"CONFIG_MODULE_SIG_ALL",
-		"CONFIG_MODULE_SIG_SHA512",
-		"CONFIG_MODULE_SIG_HASH",
-		"CONFIG_MODULE_SIG_KEY",
-		// handle abnormal situations
-		"CONFIG_BUG",
-		"CONFIG_PANIC_ON_OOPS",
-		"CONFIG_PANIC_TIMEOUT",
-		"CONFIG_SECCOMP",
-		"CONFIG_SECCOMP_FILTER",
-		"CONFIG_SECURITY",
-		"CONFIG_SECURITY_YAMA",
-		"CONFIG_SECURITY_WRITABLE_HOOKS",
-		"CONFIG_SECURITY_SELINUX_DISABLE",
-		// configure compiler plugins
-		"CONFIG_GCC_PLUGINS",
-		"CONFIG_GCC_PLUGIN_LATENT_ENTROPY",
-		"CONFIG_GCC_PLUGIN_STACKLEAK",
-		"CONFIG_GCC_PLUGIN_STRUCTLEAK",
-		"CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL",
-		"CONFIG_GCC_PLUGIN_RANDSTRUCT",
-		"CONFIG_GCC_PLUGIN_RANDSTRUCT_PERFORMANCE",
-		// configure the IP stack
-		"CONFIG_KEXEC",
-		"CONFIG_HIBERNATION",
-		"CONFIG_BINFMT_MISC",
-		"CONFIG_LEGACY_PTYS",
-		// options for x86_32 bit architectures
-		"CONFIG_HIGHMEM64G",
-		"CONFIG_X86_PAE",
-		"CONFIG_DEFAULT_MMAP_MIN_ADDR",
-		"CONFIG_RANDOMIZE_BASE",
-		// options for x86_64 bit architectures
-		"CONFIG_X86_64",
-		"CONFIG_RANDOMIZE_MEMORY",
-		"CONFIG_PAGE_TABLE_ISOLATION",
-		"CONFIG_IA32_EMULATION",
-		"CONFIG_MODIFY_LDT_SYSCALL",
-		// options for arm architectures
-		"CONFIG_VMSPLIT_3G",
-		"CONFIG_STRICT_MEMORY_RWX",
-		"CONFIG_CPU_SW_DOMAIN_PAN",
-		"CONFIG_OABI_COMPAT",
-		// options for arm64 architectures
-		"CONFIG_ARM64_SW_TTBR0_PAN",
-		"CONFIG_UNMAP_KERNEL_AT_EL0",
-	}
-)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -236,6 +236,8 @@ type RuntimeSecurityConfig struct {
 	SysCtlSnapshotPeriod time.Duration
 	// SysCtlSnapshotIgnoredBaseNames defines the list of basenaes that should be ignored from the snapshot
 	SysCtlSnapshotIgnoredBaseNames []string
+	// SysCtlSnapshotKernelCompilationFlags defines the list of kernel compilation flags that should be collected by the agent
+	SysCtlSnapshotKernelCompilationFlags []string
 
 	// UserSessionsCacheSize defines the size of the User Sessions cache size
 	UserSessionsCacheSize int
@@ -426,10 +428,11 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		HashResolverReplace:        pkgconfigsetup.SystemProbe().GetStringMapString("runtime_security_config.hash_resolver.replace"),
 
 		// SysCtl config parameter
-		SysCtlEnabled:                  pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sysctl.enabled"),
-		SysCtlSnapshotEnabled:          pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sysctl.snapshot.enabled"),
-		SysCtlSnapshotPeriod:           pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sysctl.snapshot.period"),
-		SysCtlSnapshotIgnoredBaseNames: pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sysctl.snapshot.ignored_base_names"),
+		SysCtlEnabled:                        pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sysctl.enabled"),
+		SysCtlSnapshotEnabled:                pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sysctl.snapshot.enabled"),
+		SysCtlSnapshotPeriod:                 pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sysctl.snapshot.period"),
+		SysCtlSnapshotIgnoredBaseNames:       pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sysctl.snapshot.ignored_base_names"),
+		SysCtlSnapshotKernelCompilationFlags: pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sysctl.snapshot.kernel_compilation_flags"),
 
 		// security profiles
 		SecurityProfileEnabled:          pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.enabled"),

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -33,6 +33,115 @@ const (
 	ADMinMaxDumSize = 100
 )
 
+var (
+	// defaultKernelCompilationFlags are the kernel compilation flags checked by CWS
+	// This list was moved here, away from the config/ package, to reduce the size of the agent metadata payload in REDAPL.
+	defaultKernelCompilationFlags = []string{
+		// memory management hardening
+		"CONFIG_DEBUG_KERNEL",
+		"CONFIG_DEBUG_RODATA",
+		"CONFIG_STRICT_KERNEL_RWX",
+		"CONFIG_ARCH_OPTIONAL_KERNEL_RWX",
+		"CONFIG_ARCH_HAS_STRICT_KERNEL_RWX",
+		"CONFIG_DEBUG_WX",
+		"CONFIG_CC_STACKPROTECTOR",
+		"CONFIG_CC_STACKPROTECTOR_STRONG",
+		"CONFIG_STACKPROTECTOR",
+		"CONFIG_STACKPROTECTOR_STRONG",
+		"CONFIG_DEVMEM",
+		"CONFIG_STRICT_DEVMEM",
+		"CONFIG_IO_STRICT_DEVMEM",
+		"CONFIG_SCHED_STACK_END_CHECK",
+		"CONFIG_HARDENED_USERCOPY",
+		"CONFIG_HARDENED_USERCOPY_FALLBACK",
+		"CONFIG_HARDENED_USERCOPY_PAGESPAN",
+		"CONFIG_VMAP_STACK",
+		"CONFIG_REFCOUNT_FULL",
+		"CONFIG_FORTIFY_SOURCE",
+		"CONFIG_ACPI_CUSTOM_METHOD",
+		"CONFIG_DEVKMEM",
+		"CONFIG_PROC_KCORE",
+		"CONFIG_COMPAT_VDSO",
+		"CONFIG_SECURITY_DMESG_RESTRICT",
+		"CONFIG_RETPOLINE",
+		"CONFIG_LEGACY_VSYSCALL_NONE",
+		"CONFIG_LEGACY_VSYSCALL_EMULATE",
+		"CONFIG_LEGACY_VSYSCALL_XONLY",
+		"CONFIG_X86_VSYSCALL_EMULATION",
+		// protect kernel data structures
+		"CONFIG_DEBUG_CREDENTIALS",
+		"CONFIG_DEBUG_NOTIFIERS",
+		"CONFIG_DEBUG_LIST",
+		"CONFIG_DEBUG_SG",
+		"CONFIG_BUG_ON_DATA_CORRUPTION",
+		"CONFIG_SLAB_FREELIST_RANDOM",
+		"CONFIG_SLUB",
+		"CONFIG_SLAB_FREELIST_HARDENED",
+		"CONFIG_SLAB_MERGE_DEFAULT",
+		"CONFIG_SLUB_DEBUG",
+		"CONFIG_PAGE_POISONING",
+		"CONFIG_PAGE_POISONING_NO_SANITY",
+		"CONFIG_PAGE_POISONING_ZERO",
+		"CONFIG_COMPAT_BRK",
+		// harden the management of kernel modules
+		"CONFIG_MODULES",
+		"CONFIG_STRICT_MODULE_RWX",
+		"CONFIG_MODULE_SIG",
+		"CONFIG_MODULE_SIG_FORCE",
+		"CONFIG_MODULE_SIG_ALL",
+		"CONFIG_MODULE_SIG_SHA512",
+		"CONFIG_MODULE_SIG_HASH",
+		"CONFIG_MODULE_SIG_KEY",
+		// handle abnormal situations
+		"CONFIG_BUG",
+		"CONFIG_PANIC_ON_OOPS",
+		"CONFIG_PANIC_TIMEOUT",
+		// configure kernel security functions
+		"CONFIG_MULTIUSER",
+		"CONFIG_SECURITY",
+		"CONFIG_SECCOMP",
+		"CONFIG_SECCOMP_FILTER",
+		"CONFIG_SECURITY_YAMA",
+		"CONFIG_SECURITY_WRITABLE_HOOKS",
+		"CONFIG_SECURITY_SELINUX_DISABLE",
+		// configure compiler plugins
+		"CONFIG_GCC_PLUGINS",
+		"CONFIG_GCC_PLUGIN_LATENT_ENTROPY",
+		"CONFIG_GCC_PLUGIN_STACKLEAK",
+		"CONFIG_GCC_PLUGIN_STRUCTLEAK",
+		"CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL",
+		"CONFIG_GCC_PLUGIN_RANDSTRUCT",
+		"CONFIG_GCC_PLUGIN_RANDSTRUCT_PERFORMANCE",
+		// configure the IP stack
+		"CONFIG_IPV6",
+		"CONFIG_SYN_COOKIES",
+		// various kernel behavior
+		"CONFIG_KEXEC",
+		"CONFIG_HIBERNATION",
+		"CONFIG_BINFMT_MISC",
+		"CONFIG_LEGACY_PTYS",
+		// options for x86_32 bit architectures
+		"CONFIG_HIGHMEM64G",
+		"CONFIG_X86_PAE",
+		"CONFIG_DEFAULT_MMAP_MIN_ADDR",
+		"CONFIG_RANDOMIZE_BASE",
+		// options for x86_64 bit architectures
+		"CONFIG_X86_64",
+		"CONFIG_RANDOMIZE_MEMORY",
+		"CONFIG_PAGE_TABLE_ISOLATION",
+		"CONFIG_IA32_EMULATION",
+		"CONFIG_MODIFY_LDT_SYSCALL",
+		// options for arm architectures
+		"CONFIG_VMSPLIT_3G",
+		"CONFIG_STRICT_MEMORY_RWX",
+		"CONFIG_CPU_SW_DOMAIN_PAN",
+		"CONFIG_OABI_COMPAT",
+		// options for arm64 architectures
+		"CONFIG_ARM64_SW_TTBR0_PAN",
+		"CONFIG_UNMAP_KERNEL_AT_EL0",
+	}
+)
+
 // Policy represents a policy file in the configuration file
 type Policy struct {
 	Name  string   `mapstructure:"name"`
@@ -237,7 +346,7 @@ type RuntimeSecurityConfig struct {
 	// SysCtlSnapshotIgnoredBaseNames defines the list of basenaes that should be ignored from the snapshot
 	SysCtlSnapshotIgnoredBaseNames []string
 	// SysCtlSnapshotKernelCompilationFlags defines the list of kernel compilation flags that should be collected by the agent
-	SysCtlSnapshotKernelCompilationFlags []string
+	SysCtlSnapshotKernelCompilationFlags map[string]uint8
 
 	// UserSessionsCacheSize defines the size of the User Sessions cache size
 	UserSessionsCacheSize int
@@ -432,7 +541,7 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 		SysCtlSnapshotEnabled:                pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.sysctl.snapshot.enabled"),
 		SysCtlSnapshotPeriod:                 pkgconfigsetup.SystemProbe().GetDuration("runtime_security_config.sysctl.snapshot.period"),
 		SysCtlSnapshotIgnoredBaseNames:       pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sysctl.snapshot.ignored_base_names"),
-		SysCtlSnapshotKernelCompilationFlags: pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sysctl.snapshot.kernel_compilation_flags"),
+		SysCtlSnapshotKernelCompilationFlags: map[string]uint8{},
 
 		// security profiles
 		SecurityProfileEnabled:          pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.security_profile.enabled"),
@@ -485,6 +594,14 @@ func NewRuntimeSecurityConfig() (*RuntimeSecurityConfig, error) {
 
 		// direct sender
 		SendEventFromSystemProbe: pkgconfigsetup.SystemProbe().GetBool("runtime_security_config.direct_send_from_system_probe"),
+	}
+
+	compilationFlags := pkgconfigsetup.SystemProbe().GetStringSlice("runtime_security_config.sysctl.snapshot.kernel_compilation_flags")
+	if len(compilationFlags) == 0 {
+		compilationFlags = defaultKernelCompilationFlags
+	}
+	for _, configFlag := range compilationFlags {
+		rsConfig.SysCtlSnapshotKernelCompilationFlags[configFlag] = 1
 	}
 
 	activityDumpRateLimiter := pkgconfigsetup.SystemProbe().GetInt("runtime_security_config.activity_dump.rate_limiter")

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1815,7 +1815,7 @@ func (p *EBPFProbe) startSysCtlSnapshotLoop() {
 			return
 		case <-ticker.C:
 			// create the sysctl snapshot
-			event, err := sysctl.NewSnapshotEvent(p.config.RuntimeSecurity.SysCtlSnapshotIgnoredBaseNames)
+			event, err := sysctl.NewSnapshotEvent(p.config.RuntimeSecurity.SysCtlSnapshotIgnoredBaseNames, p.config.RuntimeSecurity.SysCtlSnapshotKernelCompilationFlags)
 			if err != nil {
 				seclog.Errorf("sysctl snapshot failed: %v", err)
 				continue

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -59,6 +59,19 @@ var SysFSRoot = funcs.MemoizeNoError(func() string {
 	return "/sys"
 })
 
+// BootRoot retrieves the current boot dir we should use
+var BootRoot = funcs.MemoizeNoError(func() string {
+	if v := os.Getenv("HOST_BOOT"); v != "" {
+		return v
+	}
+	if os.Getenv("DOCKER_DD_AGENT") != "" {
+		if _, err := os.Stat("/host"); err == nil {
+			return "/host/boot"
+		}
+	}
+	return "/boot"
+})
+
 // HostProc returns the location of a host's procfs. This can and will be
 // overridden when running inside a container.
 func HostProc(combineWith ...string) string {
@@ -69,6 +82,12 @@ func HostProc(combineWith ...string) string {
 // overridden when running inside a container.
 func HostSys(combineWith ...string) string {
 	return filepath.Join(SysFSRoot(), filepath.Join(combineWith...))
+}
+
+// HostBoot returns the location of a host's /boot folder. This can and will be
+// overridden when running inside a container.
+func HostBoot(combineWith ...string) string {
+	return filepath.Join(BootRoot(), filepath.Join(combineWith...))
 }
 
 // RootNSPID returns the current PID from the root namespace

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/moby/sys/mountinfo"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 )
 
@@ -64,7 +65,7 @@ var BootRoot = funcs.MemoizeNoError(func() string {
 	if v := os.Getenv("HOST_BOOT"); v != "" {
 		return v
 	}
-	if os.Getenv("DOCKER_DD_AGENT") != "" {
+	if env.IsContainerized() {
 		if _, err := os.Stat("/host"); err == nil {
 			return "/host/boot"
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the local kernel compilation flags to the `sysctl_snapshot` event.

### Motivation

Kernel compilation flags are part of the configuration parameters that should be checked in order to assess the hardening posture of a host.