### PR TITLE
[Dynamic Instrumentation] Make `param_stack` a per-CPU map to prevent data corruption

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/c/event.h
+++ b/pkg/dynamicinstrumentation/codegen/c/event.h
@@ -14,12 +14,13 @@ typedef struct event {
 // expression_context contains state that is meant to be shared across location expressions
 // during execution of the full bpf program.
 typedef struct expression_context {
-    __u64 output_offset; // current offset within the output buffer to write to
-    __u8 stack_counter;  // current size of the bpf parameter stack, used for emptying stack
+    __u64 output_offset;    // current offset within the output buffer to write to
+    __u8 stack_counter;     // current size of the bpf parameter stack, used for emptying stack
     struct pt_regs *ctx;
-    event_t *event;  // output event allocated on ringbuffer
-    __u64 *temp_storage;  // temporary storage array on heap used by some location expressions
-    char *zero_string;    // array of zero's used to zero out buffers
+    event_t *event;         // output event allocated on ringbuffer
+    __u64 *temp_storage;    // temporary storage array on heap used by some location expressions
+    char *zero_string;      // array of zero's used to zero out buffers
+    void *param_stack;      // a pointer to the `param_stack` map of the cpu currently executing the bpf program
 } expression_context_t;
 
 #endif

--- a/pkg/dynamicinstrumentation/codegen/c/expressions.h
+++ b/pkg/dynamicinstrumentation/codegen/c/expressions.h
@@ -11,7 +11,7 @@ static __always_inline int read_register(expression_context_t *context, __u64 re
     if (err != 0) {
         log_debug("error when reading data from register: %ld", err);
     }
-    bpf_map_push_elem(&param_stack, &valueHolder, 0);
+    bpf_map_push_elem(&context->param_stack, &valueHolder, 0);
     context->stack_counter += 1;
     return err;
 }
@@ -26,7 +26,7 @@ static __always_inline int read_stack(expression_context_t *context, size_t stac
     if (err != 0) {
         log_debug("error when reading data from stack: %ld", err);
     }
-    bpf_map_push_elem(&param_stack, &valueHolder, 0);
+    bpf_map_push_elem(&context->param_stack, &valueHolder, 0);
     context->stack_counter += 1;
     return err;
 }
@@ -66,7 +66,7 @@ static __always_inline int pop(expression_context_t *context, __u64 num_elements
     int i;
     __u8 num_elements_byte = (__u8)num_elements;
     for(i = 0; i < num_elements_byte; i++) {
-        bpf_map_pop_elem(&param_stack, &valueHolder);
+        bpf_map_pop_elem(&context->param_stack, &valueHolder);
         context->stack_counter -= 1;
         log_debug("Popping to output: %llu", valueHolder);
         err = bpf_probe_read_kernel(&context->event->output[(context->output_offset)+i], element_size, &valueHolder);
@@ -87,7 +87,7 @@ static __always_inline int dereference(expression_context_t *context, __u32 elem
 {
     long err;
     __u64 addressHolder = 0;
-    err = bpf_map_pop_elem(&param_stack, &addressHolder);
+    err = bpf_map_pop_elem(&context->param_stack, &addressHolder);
     if (err != 0) {
         log_debug("Error popping: %ld", err);
     } else {
@@ -104,7 +104,7 @@ static __always_inline int dereference(expression_context_t *context, __u32 elem
     __u64 mask = (element_size == 8) ? ~0ULL : (1ULL << (8 * element_size)) - 1;
     __u64 encodedValueHolder = valueHolder & mask;
 
-    bpf_map_push_elem(&param_stack, &encodedValueHolder, 0);
+    bpf_map_push_elem(&context->param_stack, &encodedValueHolder, 0);
     context->stack_counter += 1;
     return err;
 }
@@ -118,7 +118,7 @@ static __always_inline int dereference_to_output(expression_context_t *context, 
     long return_err;
     long err;
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&param_stack, &addressHolder);
+    bpf_map_pop_elem(&context->param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     __u64 valueHolder = 0;
@@ -152,7 +152,7 @@ static __always_inline int dereference_large(expression_context_t *context, __u3
     long return_err;
     long err;
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&param_stack, &addressHolder);
+    bpf_map_pop_elem(&context->param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     int i;
@@ -173,7 +173,7 @@ static __always_inline int dereference_large(expression_context_t *context, __u3
     }
 
     for (int i = 0; i < num_chunks; i++) {
-        bpf_map_push_elem(&param_stack, &context->temp_storage[i], 0);
+        bpf_map_push_elem(&context->param_stack, &context->temp_storage[i], 0);
         context->stack_counter += 1;
     }
 
@@ -193,7 +193,7 @@ static __always_inline int dereference_large_to_output(expression_context_t *con
 {
     long err;
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&param_stack, &addressHolder);
+    bpf_map_pop_elem(&context->param_stack, &addressHolder);
     context->stack_counter -= 1;
     err = bpf_probe_read_user(&context->event->output[(context->output_offset)], element_size, (void*)(addressHolder));
     if (err != 0) {
@@ -207,11 +207,11 @@ static __always_inline int dereference_large_to_output(expression_context_t *con
 static __always_inline int apply_offset(expression_context_t *context, size_t offset)
 {
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&param_stack, &addressHolder);
+    bpf_map_pop_elem(&context->param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     addressHolder += offset;
-    bpf_map_push_elem(&param_stack, &addressHolder, 0);
+    bpf_map_push_elem(&context->param_stack, &addressHolder, 0);
     context->stack_counter += 1;
     return 0;
 }
@@ -223,11 +223,11 @@ static __always_inline int dereference_dynamic_to_output(expression_context_t *c
 {
     long err = 0;
     __u64 lengthToRead = 0;
-    bpf_map_pop_elem(&param_stack, &lengthToRead);
+    bpf_map_pop_elem(&context->param_stack, &lengthToRead);
     context->stack_counter -= 1;
 
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&param_stack, &addressHolder);
+    bpf_map_pop_elem(&context->param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     __u32 collection_size;
@@ -255,7 +255,7 @@ static __always_inline int set_limit_entry(expression_context_t *context, __u16 
 {
     // Read the 2 byte length from top of the stack, then set collectionLimit to the minimum of the two
     __u64 length;
-    bpf_map_pop_elem(&param_stack, &length);
+    bpf_map_pop_elem(&context->param_stack, &length);
     context->stack_counter -= 1;
 
     __u16 lengthShort = (__u16)length;
@@ -277,21 +277,21 @@ static __always_inline int set_limit_entry(expression_context_t *context, __u16 
 static __always_inline int copy(expression_context_t *context)
 {
     __u64 holder;
-    bpf_map_peek_elem(&param_stack, &holder);
-    bpf_map_push_elem(&param_stack, &holder, 0);
+    bpf_map_peek_elem(&context->param_stack, &holder);
+    bpf_map_push_elem(&context->param_stack, &holder, 0);
     context->stack_counter += 1;
     return 0;
 }
 
 // read_str_to_output reads a Go string to the output buffer, limited in length by `limit`.
-// In Go, strings are internally implemented as structs with two fields. The fields are length, 
+// In Go, strings are internally implemented as structs with two fields. The fields are length,
 // and a pointer to a character array. This expression expects the address of the string struct
 // itself to be on the top of the stack.
 static __always_inline int read_str_to_output(expression_context_t *context, __u16 limit)
 {
     long err;
     __u64 stringStructAddressHolder = 0;
-    err = bpf_map_pop_elem(&param_stack, &stringStructAddressHolder);
+    err = bpf_map_pop_elem(&context->param_stack, &stringStructAddressHolder);
     if (err != 0) {
         log_debug("error popping string struct addr: %ld", err);
         return err;

--- a/pkg/dynamicinstrumentation/codegen/c/maps.h
+++ b/pkg/dynamicinstrumentation/codegen/c/maps.h
@@ -25,7 +25,10 @@ BPF_PERCPU_ARRAY_MAP(temp_storage_array, __u64[4000], 1);
 // when reading the values in the collection.
 BPF_HASH_MAP(collection_limits, char[6], __u16, 1024);
 
-// The param_stack map is used as a stack for the location expressions
-// to operate on values and addresses.
-BPF_STACK_MAP(param_stack, __u64, 2048);
+// The param_stack_cpu_<i> map is used as a stack for the location expressions
+// to operate on values and addresses. We use templating to create per-cpu map
+{{- range $i, $val := until .InstrumentationInfo.InstrumentationOptions.NumCPUs }}
+BPF_STACK_MAP(param_stack_cpu_{{$i}}, __u64, 2048);
+{{- end }}
+
 #endif

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -12,6 +12,7 @@ package diconfig
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/google/uuid"
@@ -225,6 +226,7 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 			StringMaxSize:     ditypes.StringMaxSize,
 			MaxReferenceDepth: conf.Capture.MaxReferenceDepth,
 			MaxFieldCount:     conf.Capture.MaxFieldCount,
+			NumCPUs:           runtime.NumCPU(),
 		}
 
 		probe, probeExists := procInfo.ProbesByID[configPath.ProbeUUID.String()]
@@ -300,6 +302,7 @@ func newConfigProbe() *ditypes.Probe {
 				MaxFieldCount:     int(ditypes.MaxFieldCount),
 				MaxReferenceDepth: 8,
 				CaptureParameters: true,
+				NumCPUs:           runtime.NumCPU(),
 			},
 		},
 		RateLimiter: ratelimiter.NewSingleEventRateLimiter(0),

--- a/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"runtime"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
@@ -226,6 +227,7 @@ func (rc *rcConfig) toProbe(service string) *ditypes.Probe {
 				SliceMaxLength:    ditypes.SliceMaxLength,
 				MaxReferenceDepth: rc.Capture.MaxReferenceDepth,
 				MaxFieldCount:     rc.Capture.MaxFieldCount,
+				NumCPUs:           runtime.NumCPU(),
 			},
 		},
 	}

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -270,6 +270,7 @@ type InstrumentationOptions struct {
 	MaxReferenceDepth int
 	MaxFieldCount     int
 	SliceMaxLength    int
+	NumCPUs           int
 }
 
 // Probe represents a location in a GoProgram that can be instrumented

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -125,6 +125,15 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 	return nil
 }
 
+// until generates a slice of integers from 0 to n-1
+func until(n int) []int {
+	arr := make([]int, n)
+	for i := 0; i < n; i++ {
+		arr[i] = i
+	}
+	return arr
+}
+
 // CompileBPFProgram compiles the code for a single probe
 func CompileBPFProgram(probe *ditypes.Probe) error {
 	f := func(in io.Reader, out io.Writer) error {
@@ -132,7 +141,10 @@ func CompileBPFProgram(probe *ditypes.Probe) error {
 		if err != nil {
 			return err
 		}
-		programTemplate, err := template.New("program_template").Parse(string(fileContents))
+		programTemplate := template.New("program_template").Funcs(template.FuncMap{
+			"until": until,
+		})
+		programTemplate, err = programTemplate.Parse(string(fileContents))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?
This PR modifies the `param_stack` map (of type `BPF_MAP_TYPE_STACK`) to be per-CPU rather than shared across all CPUs.

Previously, `param_stack` was a single instance shared across all CPUs for a single BPF program, potentially leading to corruption when multiple CPUs executed the same BPF program concurrently.
Now, each CPU gets its own instance of `param_stack`, ensuring execution remains isolated and correct per CPU.

### Motivation
Avoid multiple CPUs race. Now there is `param_stack_cpu_<i>` map per-cpu, generated dynamically with templating.

### Describe how you validated your changes
Dynamic Instrumentation's e2e tests are sufficient for now. They all pass.

### Additional Notes
Fixes DEBUG-3259.