### PR TITLE
[OTAGENT-343] Set default for api site in otel-agent

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -260,13 +260,16 @@ func getDDExporterConfig(cfg *confmap.Conf) (*datadogconfig.Config, error) {
 // setSiteIfEmpty sets datadog::api::site to datadoghq.com if it is an empty string (default in helm)
 // Returns an error if the input datadog exporter config is invalid
 func setSiteIfEmpty(ddcfg any) (map[string]any, error) {
+	if ddcfg == nil {
+		return nil, nil // OK if datadog::api is not set, in that case we use the default from datadogexporter.CreateDefaultConfig()
+	}
 	ddcfgMap, ok := ddcfg.(map[string]any)
 	if !ok {
 		return nil, errors.New("invalid datadog exporter config")
 	}
 	apicfg, ok := ddcfgMap["api"]
-	if !ok {
-		return nil, errors.New("invalid datadog exporter config")
+	if !ok || apicfg == nil {
+		return nil, nil // OK if datadog::api is not set, in that case we use the default from datadogexporter.CreateDefaultConfig()
 	}
 	apicfgMap, ok := apicfg.(map[string]any)
 	if !ok {

--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -214,21 +214,20 @@ func getServiceConfig(cfg *confmap.Conf) (*service.Config, error) {
 
 func getDDExporterConfig(cfg *confmap.Conf) (*datadogconfig.Config, error) {
 	var configs []*datadogconfig.Config
-	var err error
 	for k, v := range cfg.ToStringMap() {
 		if k != "exporters" {
 			continue
 		}
 		exporters, ok := v.(map[string]any)
 		if !ok {
-			return nil, fmt.Errorf("invalid exporters config")
+			return nil, errors.New("invalid exporters config")
 		}
 		for k, v := range exporters {
 			if strings.HasPrefix(k, "datadog") {
 				ddcfg := datadogexporter.CreateDefaultConfig().(*datadogconfig.Config)
-				m, ok := v.(map[string]any)
-				if !ok {
-					return nil, fmt.Errorf("invalid datadog exporter config")
+				m, err := setSiteIfEmpty(v)
+				if err != nil {
+					return nil, err
 				}
 				err = confmap.NewFromStringMap(m).Unmarshal(&ddcfg)
 				if err != nil {
@@ -256,4 +255,26 @@ func getDDExporterConfig(cfg *confmap.Conf) (*datadogconfig.Config, error) {
 
 	datadogConfig := configs[0]
 	return datadogConfig, nil
+}
+
+// setSiteIfEmpty sets datadog::api::site to datadoghq.com if it is an empty string (default in helm)
+// Returns an error if the input datadog exporter config is invalid
+func setSiteIfEmpty(ddcfg any) (map[string]any, error) {
+	ddcfgMap, ok := ddcfg.(map[string]any)
+	if !ok {
+		return nil, errors.New("invalid datadog exporter config")
+	}
+	apicfg, ok := ddcfgMap["api"]
+	if !ok {
+		return nil, errors.New("invalid datadog exporter config")
+	}
+	apicfgMap, ok := apicfg.(map[string]any)
+	if !ok {
+		return nil, errors.New("invalid datadog exporter config")
+	}
+	apiSite, ok := apicfgMap["site"]
+	if !ok || apiSite == "" {
+		apicfgMap["site"] = "datadoghq.com"
+	}
+	return ddcfgMap, nil
 }

--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -261,7 +261,7 @@ func getDDExporterConfig(cfg *confmap.Conf) (*datadogconfig.Config, error) {
 // Returns an error if the input datadog exporter config is invalid
 func setSiteIfEmpty(ddcfg any) (map[string]any, error) {
 	if ddcfg == nil {
-		return nil, nil // OK if datadog::api is not set, in that case we use the default from datadogexporter.CreateDefaultConfig()
+		return nil, nil // OK if datadog section is not set, in that case we use the default from datadogexporter.CreateDefaultConfig()
 	}
 	ddcfgMap, ok := ddcfg.(map[string]any)
 	if !ok {
@@ -269,7 +269,7 @@ func setSiteIfEmpty(ddcfg any) (map[string]any, error) {
 	}
 	apicfg, ok := ddcfgMap["api"]
 	if !ok || apicfg == nil {
-		return nil, nil // OK if datadog::api is not set, in that case we use the default from datadogexporter.CreateDefaultConfig()
+		return ddcfgMap, nil // OK if datadog::api is not set, in that case we use the default from datadogexporter.CreateDefaultConfig()
 	}
 	apicfgMap, ok := apicfg.(map[string]any)
 	if !ok {

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -8,10 +8,11 @@ package config
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/collector/featuregate"
 	"io/fs"
 	"os"
 	"testing"
+
+	"go.opentelemetry.io/collector/featuregate"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -308,6 +309,53 @@ func (suite *ConfigTestSuite) TestMultipleDDExporters() {
 	fileName := "testdata/config_multiple_dd_exporters.yaml"
 	_, err := NewConfigComponent(context.Background(), "", []string{fileName})
 	assert.EqualError(t, err, "multiple datadog exporters found")
+}
+
+func (suite *ConfigTestSuite) TestNoDDAPISection() {
+	t := suite.T()
+	fileName := "testdata/config_no_api.yaml"
+	_, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	assert.EqualError(t, err, "invalid datadog exporter config")
+}
+
+func (suite *ConfigTestSuite) TestMalformedDDAPISection() {
+	t := suite.T()
+	fileName := "testdata/config_malformed_api.yaml"
+	_, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	assert.EqualError(t, err, "invalid datadog exporter config")
+}
+
+func (suite *ConfigTestSuite) TestDDAPISiteEmpty() {
+	t := suite.T()
+	fileName := "testdata/config_site_empty.yaml"
+	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	assert.NoError(t, err)
+	assert.Equal(t, "datadoghq.com", c.Get("site"))
+	assert.Equal(t, "https://api.datadoghq.com", c.Get("dd_url"))
+	assert.Equal(t, "https://agent-http-intake.logs.datadoghq.com", c.Get("logs_config.logs_dd_url"))
+	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
+}
+
+func (suite *ConfigTestSuite) TestDDAPISiteNotSet() {
+	t := suite.T()
+	fileName := "testdata/config_site_not_set.yaml"
+	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	assert.NoError(t, err)
+	assert.Equal(t, "datadoghq.com", c.Get("site"))
+	assert.Equal(t, "https://api.datadoghq.com", c.Get("dd_url"))
+	assert.Equal(t, "https://agent-http-intake.logs.datadoghq.com", c.Get("logs_config.logs_dd_url"))
+	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
+}
+
+func (suite *ConfigTestSuite) TestDDAPISiteSet() {
+	t := suite.T()
+	fileName := "testdata/config_site_set.yaml"
+	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	assert.NoError(t, err)
+	assert.Equal(t, "us3.datadoghq.com", c.Get("site"))
+	assert.Equal(t, "https://api.us3.datadoghq.com", c.Get("dd_url"))
+	assert.Equal(t, "https://agent-http-intake.logs.us3.datadoghq.com", c.Get("logs_config.logs_dd_url"))
+	assert.Equal(t, "https://trace.agent.us3.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 }
 
 // TestSuite runs the CalculatorTestSuite

--- a/cmd/otel-agent/config/agent_config_test.go
+++ b/cmd/otel-agent/config/agent_config_test.go
@@ -18,6 +18,7 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -314,8 +315,23 @@ func (suite *ConfigTestSuite) TestMultipleDDExporters() {
 func (suite *ConfigTestSuite) TestNoDDAPISection() {
 	t := suite.T()
 	fileName := "testdata/config_no_api.yaml"
-	_, err := NewConfigComponent(context.Background(), "", []string{fileName})
-	assert.EqualError(t, err, "invalid datadog exporter config")
+	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	require.NoError(t, err)
+	assert.Equal(t, "datadoghq.com", c.Get("site"))
+	assert.Equal(t, "https://api.datadoghq.com", c.Get("dd_url"))
+	assert.Equal(t, "https://agent-http-intake.logs.datadoghq.com", c.Get("logs_config.logs_dd_url"))
+	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
+}
+
+func (suite *ConfigTestSuite) TestNilDDAPISection() {
+	t := suite.T()
+	fileName := "testdata/config_nil_api.yaml"
+	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
+	require.NoError(t, err)
+	assert.Equal(t, "datadoghq.com", c.Get("site"))
+	assert.Equal(t, "https://api.datadoghq.com", c.Get("dd_url"))
+	assert.Equal(t, "https://agent-http-intake.logs.datadoghq.com", c.Get("logs_config.logs_dd_url"))
+	assert.Equal(t, "https://trace.agent.datadoghq.com", c.Get("apm_config.apm_dd_url"))
 }
 
 func (suite *ConfigTestSuite) TestMalformedDDAPISection() {
@@ -329,7 +345,7 @@ func (suite *ConfigTestSuite) TestDDAPISiteEmpty() {
 	t := suite.T()
 	fileName := "testdata/config_site_empty.yaml"
 	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "datadoghq.com", c.Get("site"))
 	assert.Equal(t, "https://api.datadoghq.com", c.Get("dd_url"))
 	assert.Equal(t, "https://agent-http-intake.logs.datadoghq.com", c.Get("logs_config.logs_dd_url"))
@@ -340,7 +356,7 @@ func (suite *ConfigTestSuite) TestDDAPISiteNotSet() {
 	t := suite.T()
 	fileName := "testdata/config_site_not_set.yaml"
 	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "datadoghq.com", c.Get("site"))
 	assert.Equal(t, "https://api.datadoghq.com", c.Get("dd_url"))
 	assert.Equal(t, "https://agent-http-intake.logs.datadoghq.com", c.Get("logs_config.logs_dd_url"))
@@ -351,7 +367,7 @@ func (suite *ConfigTestSuite) TestDDAPISiteSet() {
 	t := suite.T()
 	fileName := "testdata/config_site_set.yaml"
 	c, err := NewConfigComponent(context.Background(), "", []string{fileName})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "us3.datadoghq.com", c.Get("site"))
 	assert.Equal(t, "https://api.us3.datadoghq.com", c.Get("dd_url"))
 	assert.Equal(t, "https://agent-http-intake.logs.us3.datadoghq.com", c.Get("logs_config.logs_dd_url"))

--- a/cmd/otel-agent/config/testdata/config_malformed_api.yaml
+++ b/cmd/otel-agent/config/testdata/config_malformed_api.yaml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  datadog:
+    api: [] # should be a map rather than a list
+processors:
+  batch:
+    timeout: 10s
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/cmd/otel-agent/config/testdata/config_nil_api.yaml
+++ b/cmd/otel-agent/config/testdata/config_nil_api.yaml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  datadog:
+    api:
+processors:
+  batch:
+    timeout: 10s
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/cmd/otel-agent/config/testdata/config_no_api.yaml
+++ b/cmd/otel-agent/config/testdata/config_no_api.yaml
@@ -1,0 +1,16 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  datadog:
+processors:
+  batch:
+    timeout: 10s
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/cmd/otel-agent/config/testdata/config_site_empty.yaml
+++ b/cmd/otel-agent/config/testdata/config_site_empty.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  datadog:
+    api:
+      key: KEY
+      site: ""
+processors:
+  batch:
+    timeout: 10s
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/cmd/otel-agent/config/testdata/config_site_not_set.yaml
+++ b/cmd/otel-agent/config/testdata/config_site_not_set.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  datadog:
+    api:
+      key: KEY
+processors:
+  batch:
+    timeout: 10s
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]

--- a/cmd/otel-agent/config/testdata/config_site_set.yaml
+++ b/cmd/otel-agent/config/testdata/config_site_set.yaml
@@ -1,0 +1,19 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+exporters:
+  datadog:
+    api:
+      key: KEY
+      site: "us3.datadoghq.com"
+processors:
+  batch:
+    timeout: 10s
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog]


### PR DESCRIPTION
### What does this PR do?
Set datadog::api::site to datadoghq.com if it is an empty string (default in helm) in otel-agent

### Motivation
In helm datadog::api::site is set to an empty string by default and it used to crash the otel-agent

### Describe how you validated your changes
unit + e2e tests

For manual QA, start the embedded collector with no otel collector config in helm and do not set site in values.yaml:
`helm upgrade -i agent-qa datadog/datadog -f values.yaml`
Then verify otel-agent starts properly with the correct site and URLs.