### PR TITLE
Adjust Quality Gate limits downward

### DIFF
--- a/test/regression/cases/quality_gate_idle/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle/experiment.yaml
@@ -36,7 +36,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "255.0 MiB"
+      upper_bound: "240.00 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
+++ b/test/regression/cases/quality_gate_idle_all_features/experiment.yaml
@@ -56,7 +56,7 @@ checks:
     description: "Memory usage quality gate. This puts a bound on the total agent memory usage."
     bounds:
       series: total_pss_bytes
-      upper_bound: "640.0 MiB"
+      upper_bound: "620.00 MiB"
 
   - name: intake_connections
     description: "Connections established to intake APIs. This puts a bound on total connections per Agent instance."

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -28,7 +28,7 @@ checks:
     description: "Memory usage"
     bounds:
       series: total_pss_bytes
-      upper_bound: "275.0 MiB"
+      upper_bound: "260.00 MiB"
 
   - name: lost_bytes
     description: "Allowable bytes not polled by log Agent"


### PR DESCRIPTION
### What does this PR do?

This commit moves all quality gate experiments limits' down, between 15 MiB and 20 MiB, depending on the experiment.

