### PR TITLE
SystemProbe config also uses nodetreemodel based upon env var

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -272,7 +272,15 @@ func init() {
 		datadog = viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 	}
 
-	systemProbe = viperconfig.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	if envvar == "enable" {
+		systemProbe = nodetreemodel.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	} else if envvar == "tee" {
+		viperConfig := viperconfig.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))      // nolint: forbidigo // legit use case
+		nodetreeConfig := nodetreemodel.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+		systemProbe = teeconfig.NewTeeConfig(viperConfig, nodetreeConfig)
+	} else {
+		systemProbe = viperconfig.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	}
 
 	// Configuration defaults
 	initConfig()


### PR DESCRIPTION
### What does this PR do?

Cause the DD_CONF_NODETREEMODEL env var to also be used for the system-probe configuration.

### Motivation

Remove dependency on viper.

### Describe how you validated your changes

Behavior stays the same as long as env var is not defined. Currently being tested with env var enable on staging.

### Possible Drawbacks / Trade-offs

### Additional Notes
