### PR TITLE
[CONTP-681] Add 'fips' to cluster-agent version tag if it is built with fips flag

### DIFF
--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -102,7 +103,11 @@ func getVersion(w http.ResponseWriter, _ *http.Request) {
 		httputils.SetJSONError(w, err, 500)
 		return
 	}
-	j, err := json.Marshal(av)
+	versionString := av.String()
+	if strings.Contains(av.Pre, "fips") {
+		versionString = av.GetNumberAndPre()
+	}
+	j, err := json.Marshal(versionString)
 	if err != nil {
 		httputils.SetJSONError(w, err, 500)
 		return


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
If agent version has prefix containing fips, the version string will become numberVersion + prefix (with "fips")

### Motivation
When dca fips image is used, the agent version doesn't include prefix "fips" because it only includes number in current setup. 
<img width="485" alt="Screenshot 2025-03-18 at 12 31 04 PM" src="https://github.com/user-attachments/assets/d2b37ddd-37c9-4d85-a90b-326e85b60a97" />

With this change, the new version will be like  "7.64.0-rc.13-fips"
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Validate by checking fed.staging with the version tag of 7.65.9-rc.1-fips

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->