### PR TITLE
[EBPF] gpu: fix k8s flaky test

### DIFF
--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/kubernetes_dump.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/kubernetes_dump.go
@@ -105,6 +105,7 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string, err err
 	ec2Client := awsec2.NewFromConfig(cfg)
 
 	user, _ := user.Current()
+	instanceName := name + "-aws-kind"
 	instancesDescription, err := ec2Client.DescribeInstances(ctx, &awsec2.DescribeInstancesInput{
 		Filters: []awsec2types.Filter{
 			{
@@ -117,7 +118,7 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string, err err
 			},
 			{
 				Name:   pointer.Ptr("tag:Name"),
-				Values: []string{name + "-aws-kind"},
+				Values: []string{instanceName},
 			},
 		},
 	})
@@ -126,11 +127,12 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string, err err
 	}
 
 	// instancesDescription.Reservations = []
-	if instancesDescription == nil || len(instancesDescription.Reservations) == 0 || (len(instancesDescription.Reservations) > 0 && len(instancesDescription.Reservations[0].Instances) != 1) {
-		if len(instancesDescription.Reservations) > 0 && len(instancesDescription.Reservations[0].Instances) != 0 {
-			return ret, fmt.Errorf("did not find exactly one instance for cluster %s: %+v", name, instancesDescription.Reservations[0].Instances)
-		}
-		return ret, fmt.Errorf("did not find exactly one instance for cluster %s", name)
+	if instancesDescription == nil {
+		return ret, fmt.Errorf("failed to describe instances, got nil result, err: %w", err)
+	} else if len(instancesDescription.Reservations) == 0 {
+		return ret, fmt.Errorf("did not find any reservations for cluster %s", instanceName)
+	} else if len(instancesDescription.Reservations[0].Instances) != 1 {
+		return ret, fmt.Errorf("did not find exactly one instance for cluster %s, found %d instead and %d reservations", instanceName, len(instancesDescription.Reservations[0].Instances), len(instancesDescription.Reservations))
 	}
 
 	instanceIP := instancesDescription.Reservations[0].Instances[0].PrivateIpAddress

--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/kubernetes_dump.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/kubernetes_dump.go
@@ -127,6 +127,9 @@ func dumpKindClusterState(ctx context.Context, name string) (ret string, err err
 
 	// instancesDescription.Reservations = []
 	if instancesDescription == nil || len(instancesDescription.Reservations) == 0 || (len(instancesDescription.Reservations) > 0 && len(instancesDescription.Reservations[0].Instances) != 1) {
+		if len(instancesDescription.Reservations) > 0 && len(instancesDescription.Reservations[0].Instances) != 0 {
+			return ret, fmt.Errorf("did not find exactly one instance for cluster %s: %+v", name, instancesDescription.Reservations[0].Instances)
+		}
 		return ret, fmt.Errorf("did not find exactly one instance for cluster %s", name)
 	}
 

--- a/test/new-e2e/pkg/utils/e2e/client/agent_client.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_client.go
@@ -93,7 +93,11 @@ func NewDockerAgentClient(context common.Context, dockerAgentOutput agent.Docker
 // such as AgentSelectorAnyPod that will select any pod that runs the agent.
 func NewK8sAgentClient(context common.Context, podSelector metav1.ListOptions, clusterClient *KubernetesClient, options ...agentclientparams.Option) (agentclient.Agent, error) {
 	params := agentclientparams.NewParams(osComp.LinuxFamily, options...)
-	ae := newAgentK8sExecutor(podSelector, clusterClient)
+	ae, err := newAgentK8sExecutor(podSelector, clusterClient)
+	if err != nil {
+		return nil, fmt.Errorf("could not create k8s agent executor: %w", err)
+	}
+
 	commandRunner := newAgentCommandRunner(context.T(), ae)
 
 	if params.ShouldWaitForReady {

--- a/test/new-e2e/pkg/utils/e2e/client/agent_k8s.go
+++ b/test/new-e2e/pkg/utils/e2e/client/agent_k8s.go
@@ -29,7 +29,7 @@ const agentNamespace = "datadog"
 // For example, you can pass Agent.LinuxNodeAgent to select any pod that runs the node agent.
 func AgentSelectorAnyPod(agentType kubernetes.KubernetesObjRefOutput) metav1.ListOptions {
 	return metav1.ListOptions{
-		FieldSelector: fields.OneTermEqualSelector("metadata.name", agentType.Name).String(),
+		LabelSelector: fields.OneTermEqualSelector("app", agentType.LabelSelectors["app"]).String(),
 		Limit:         1,
 	}
 }

--- a/test/new-e2e/tests/gpu/capabilities.go
+++ b/test/new-e2e/tests/gpu/capabilities.go
@@ -141,9 +141,7 @@ func (c *kubernetesCapabilities) FakeIntake() *components.FakeIntake {
 func (c *kubernetesCapabilities) Agent() agentclient.Agent {
 	linuxAgent := c.suite.Env().Agent.LinuxNodeAgent
 	client, err := client.NewK8sAgentClient(c.suite, client.AgentSelectorAnyPod(linuxAgent), c.suite.Env().KubernetesCluster.KubernetesClient)
-	if err != nil {
-		panic(err)
-	}
+	c.suite.Require().NoError(err)
 	return client
 }
 

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -160,24 +160,24 @@ func (v *gpuBaseSuite[Env]) SetupSuite() {
 	}
 }
 
-func (v *gpuK8sSuite) AfterTest(suiteName, testName string) {
-	v.BaseSuite.AfterTest(suiteName, testName)
+func (s *gpuK8sSuite) AfterTest(suiteName, testName string) {
+	s.BaseSuite.AfterTest(suiteName, testName)
 
-	if v.T().Failed() {
+	if s.T().Failed() {
 		return
 	}
 
-	k8sPulumiProvisioner, ok := v.provisioner.(*provisioners.PulumiProvisioner[environments.Kubernetes])
+	k8sPulumiProvisioner, ok := s.provisioner.(*provisioners.PulumiProvisioner[environments.Kubernetes])
 	if !ok {
 		return
 	}
 
-	diagnose, err := k8sPulumiProvisioner.Diagnose(context.Background(), v.Env().KubernetesCluster.ClusterName)
+	diagnose, err := k8sPulumiProvisioner.Diagnose(context.Background(), s.Env().KubernetesCluster.ClusterName)
 	if err != nil {
-		v.T().Logf("failed to diagnose provisioner: %v", err)
+		s.T().Logf("failed to diagnose provisioner: %v", err)
 	}
 
-	v.T().Logf("Diagnose result:\n\n%s", diagnose)
+	s.T().Logf("Diagnose result:\n\n%s", diagnose)
 }
 
 // runCudaDockerWorkload runs a CUDA workload in a Docker container and returns the container ID

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -163,7 +163,7 @@ func (v *gpuBaseSuite[Env]) SetupSuite() {
 func (s *gpuK8sSuite) AfterTest(suiteName, testName string) {
 	s.BaseSuite.AfterTest(suiteName, testName)
 
-	if s.T().Failed() {
+	if !s.T().Failed() {
 		return
 	}
 

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -7,6 +7,7 @@
 package gpu
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
 
@@ -35,6 +37,7 @@ type gpuBaseSuite[Env any] struct {
 	e2e.BaseSuite[Env]
 	caps                     suiteCapabilities
 	agentRestartsAtSuiteInit map[agentComponent]int
+	provisioner              provisioners.Provisioner
 }
 
 const vectorAddDockerImg = "ghcr.io/datadog/apps-cuda-basic"
@@ -114,7 +117,11 @@ func TestGPUK8sSuite(t *testing.T) {
 		suiteParams = append(suiteParams, e2e.WithDevMode())
 	}
 
-	suite := &gpuK8sSuite{}
+	suite := &gpuK8sSuite{
+		gpuBaseSuite: gpuBaseSuite[environments.Kubernetes]{
+			provisioner: provisioner,
+		},
+	}
 
 	e2e.Run(t, suite, suiteParams...)
 }
@@ -151,6 +158,26 @@ func (v *gpuBaseSuite[Env]) SetupSuite() {
 	for _, service := range services {
 		v.agentRestartsAtSuiteInit[service] = v.caps.GetRestartCount(service)
 	}
+}
+
+func (v *gpuK8sSuite) AfterTest(suiteName, testName string) {
+	v.BaseSuite.AfterTest(suiteName, testName)
+
+	if v.T().Failed() {
+		return
+	}
+
+	k8sPulumiProvisioner, ok := v.provisioner.(*provisioners.PulumiProvisioner[environments.Kubernetes])
+	if !ok {
+		return
+	}
+
+	diagnose, err := k8sPulumiProvisioner.Diagnose(context.Background(), v.Env().KubernetesCluster.ClusterName)
+	if err != nil {
+		v.T().Logf("failed to diagnose provisioner: %v", err)
+	}
+
+	v.T().Logf("Diagnose result:\n\n%s", diagnose)
 }
 
 // runCudaDockerWorkload runs a CUDA workload in a Docker container and returns the container ID

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -206,7 +206,7 @@ func gpuHostProvisioner(params *provisionerParams) provisioners.Provisioner {
 // gpuK8sProvisioner provisions a Kubernetes cluster with GPU support
 func gpuK8sProvisioner(params *provisionerParams) provisioners.Provisioner {
 	provisioner := provisioners.NewTypedPulumiProvisioner[environments.Kubernetes]("gpu-k8s", func(ctx *pulumi.Context, env *environments.Kubernetes) error {
-		name := "gpu-k8s"
+		name := "kind" // Match the name of the kind cluster in the aws-kind provisioner so that we can reuse the DiagnoseFunc, which assumes the VM name is kind
 		awsEnv, err := aws.NewEnvironment(ctx)
 		if err != nil {
 			return fmt.Errorf("aws.NewEnvironment: %w", err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the flaky GPU k8s e2e test. It does so by switching to a more reliable label selector, and by ensuring that we properly list all the returned values.

There are also some minor changes to the e2e infra code to improve error messages. For debugging, there's also an `AfterTest` function in the k8s suite that dumps the kind cluster state.

### Motivation

Fix flaky test.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

E2E test passing without it being a flaky pass (manually retried multiple times):
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/857442891
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/858913361
* https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/859168658

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->