### PR TITLE
upgrade(installer): Make agent experiment a simple unit

### DIFF
--- a/pkg/fleet/installer/packages/embedded/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-exp.service
@@ -1,22 +1,22 @@
 [Unit]
 Description=Datadog Agent Experiment
 After=network.target
-OnFailure=datadog-agent.service
-JobTimeoutSec=3000
-Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service
 Conflicts=datadog-agent.service
+Wants=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service
+OnFailure=datadog-agent.service
 Before=datadog-agent.service
 
 [Service]
-Type=oneshot
+Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/agent.pid
 User=dd-agent
+Restart=no
 EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
-ExecStart=/opt/datadog-packages/datadog-agent/experiment/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/experiment/run/agent.pid
-ExecStart=/bin/false
-ExecStop=/bin/false
+ExecStart=/usr/bin/timeout --kill-after=15s 3000s /opt/datadog-packages/datadog-agent/experiment/bin/agent/agent run -p /opt/datadog-packages/datadog-agent/experiment/run/agent.pid
+ExecStopPost=/bin/false
+# Since systemd 229, should be in [Unit] but in order to support systemd <229,
+# it is also supported to have it here.
+StartLimitInterval=10
+StartLimitBurst=5
 RuntimeDirectory=datadog
-
-[Install]
-WantedBy=multi-user.target

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-installer-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-installer-exp.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Datadog Installer Experiment
-After=network.target
+After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
+Conflicts=datadog-agent-installer.service
 ConditionPathExists=!/etc/systemd/system/datadog-installer.service
 ConditionPathExists=!/etc/systemd/system/datadog-installer-exp.service
 

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-installer.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-installer.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Datadog Installer
-After=network.target datadog-agent.service
+After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
+Conflicts=datadog-agent-installer-exp.service
 ConditionPathExists=!/etc/systemd/system/datadog-installer.service
 ConditionPathExists=!/etc/systemd/system/datadog-installer-exp.service
 

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-process-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-process-exp.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Datadog Process Agent Experiment
-After=network.target
+After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
+Conflicts=datadog-agent.service datadog-agent-process.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-process.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-process.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Datadog Process Agent
-After=network.target datadog-agent.service
+After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
+Conflicts=datadog-agent-exp.service datadog-agent-process-exp.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-security-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-security-exp.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Datadog Security Agent Experiment
-After=network.target
+After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
+Conflicts=datadog-agent-security.service
 ConditionPathExists=|/etc/datadog-agent/security-agent.yaml
 ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/security-agent.yaml
 

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-security.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-security.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Datadog Security Agent
-After=network.target datadog-agent.service
+After=network.target datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
+Conflicts=datadog-agent-security-exp.service
 ConditionPathExists=|/etc/datadog-agent/security-agent.yaml
 ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/security-agent.yaml
 

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe-exp.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=Datadog System Probe Experiment
 Requires=sys-kernel-debug.mount
+Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
+Conflicts=datadog-agent.service datadog-agent-sysprobe.service
 ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
 ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/system-probe.yaml
 

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Datadog System Probe
 Requires=sys-kernel-debug.mount
-Before=datadog-agent.service
+Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
+Conflicts=datadog-agent-exp.service datadog-agent-sysprobe-exp.service
 ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
 ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/system-probe.yaml
 

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-trace-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-trace-exp.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Datadog Trace Agent (APM) Experiment
+After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent-exp.service
+Conflicts=datadog-agent.service datadog-agent-trace.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-trace.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-trace.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Datadog Trace Agent (APM)
-After=datadog-agent.service
+After=datadog-agent.service datadog-agent-exp.service
 BindsTo=datadog-agent.service
+Conflicts=datadog-agent-exp.service datadog-agent-trace-exp.service
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/datadog-agent.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent.service
@@ -1,9 +1,8 @@
 [Unit]
 Description=Datadog Agent
 After=network.target
+Conflicts=datadog-agent-exp.service
 Wants=datadog-agent-installer.service datadog-agent-trace.service datadog-agent-process.service datadog-agent-sysprobe.service datadog-agent-security.service
-Conflicts=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service
-Before=datadog-agent-installer-exp.service datadog-agent-trace-exp.service datadog-agent-process-exp.service datadog-agent-sysprobe-exp.service datadog-agent-security-exp.service
 
 [Service]
 Type=simple

--- a/test/new-e2e/tests/installer/host/systemd.go
+++ b/test/new-e2e/tests/installer/host/systemd.go
@@ -39,7 +39,7 @@ func (h *Host) LastJournaldTimestamp() JournaldTimestamp {
 func (h *Host) AssertUnitProperty(unit, property, value string) {
 	res, err := h.remote.Execute(fmt.Sprintf("sudo systemctl show -p %s %s", property, unit))
 	require.NoError(h.t, err)
-	require.Equal(h.t, fmt.Sprintf("%s=%s\n", property, value), res)
+	require.Equal(h.t, fmt.Sprintf("%s=%s\n", property, value), res, "unit %s: %s != %s.\nUnit:\n%s", unit, fmt.Sprintf("%s=%s\n", property, value), res, h.remote.MustExecute(fmt.Sprintf("sudo systemctl cat %s", unit)))
 }
 
 func popIfMatches(searchedEvents []SystemdEvent, log journaldLog) []SystemdEvent {
@@ -58,7 +58,7 @@ func eventMatches(log journaldLog, event SystemdEvent) bool {
 	if log.Unit != event.Unit {
 		return false
 	}
-	match, _ := regexp.MatchString(event.Pattern, log.Message)
+	match, _ := regexp.MatchString("(?i)"+event.Pattern, log.Message)
 	return match
 }
 

--- a/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
+++ b/test/new-e2e/tests/installer/unix/upgrade_scenario_test.go
@@ -483,7 +483,7 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
 	timestamp = s.host.LastJournaldTimestamp()
 	s.mustStartConfigExperiment(datadogAgent, config)
 	// Assert the successful start of the experiment
-	s.host.WaitForUnitActivating(s.T(), agentUnitXP)
+	s.host.WaitForUnitActive(s.T(), agentUnitXP)
 	s.host.WaitForFileExists(false, "/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
 
 	// Assert experiment is running
@@ -493,7 +493,7 @@ func (s *upgradeScenarioSuite) TestConfigUpgradeNewAgents() {
 			Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents().
-			Starting(agentUnitXP).
+			Started(agentUnitXP).
 			Started(traceUnitXP).
 			Started(securityUnitXP).
 			Started(probeUnitXP),
@@ -590,7 +590,7 @@ func (s *upgradeScenarioSuite) TestUpgradeConfigFailure() {
 						Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents(). // Experiment starts
-						Starting(agentUnitXP).
+						Started(agentUnitXP).
 						Started(traceUnitXP),
 		).
 		Unordered(host.SystemdEvents(). // Experiment fails
@@ -768,7 +768,7 @@ func (s *upgradeScenarioSuite) setCatalog(newCatalog catalog) {
 }
 
 func (s *upgradeScenarioSuite) assertSuccessfulAgentStartExperiment(timestamp host.JournaldTimestamp, version string) {
-	s.host.WaitForUnitActivating(s.T(), agentUnitXP)
+	s.host.WaitForUnitActive(s.T(), agentUnitXP)
 	s.host.WaitForFileExists(false, "/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
 
 	// Assert experiment is running
@@ -778,7 +778,7 @@ func (s *upgradeScenarioSuite) assertSuccessfulAgentStartExperiment(timestamp ho
 			Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents().
-			Starting(agentUnitXP).
+			Started(agentUnitXP).
 			Started(traceUnitXP),
 		),
 	)
@@ -878,7 +878,7 @@ func (s *upgradeScenarioSuite) mustStopConfigExperiment(pkg packageName) string 
 }
 
 func (s *upgradeScenarioSuite) assertSuccessfulConfigStartExperiment(timestamp host.JournaldTimestamp, version string) {
-	s.host.WaitForUnitActivating(s.T(), agentUnitXP)
+	s.host.WaitForUnitActive(s.T(), agentUnitXP)
 	s.host.WaitForFileExists(false, "/opt/datadog-packages/datadog-agent/experiment/run/agent.pid")
 
 	// Assert experiment is running
@@ -888,7 +888,7 @@ func (s *upgradeScenarioSuite) assertSuccessfulConfigStartExperiment(timestamp h
 			Stopped(traceUnit),
 		).
 		Unordered(host.SystemdEvents().
-			Starting(agentUnitXP).
+			Started(agentUnitXP).
 			Started(traceUnitXP),
 		),
 	)


### PR DESCRIPTION
### What does this PR do?
Transform the datadog-agent-exp unit into a "simple" unit instead of a "oneshot" unit.

This PR makes sure that any given units except the core agent can only reference the following units:
- Itself (exp or stable)
- Core agent (exp or stable)

In turn, the core agent can only reference:
- Itself (stable or experiments)
- Other units in the same tree (stable references stables, experiment references experiments)

This will let us add or remove units more smoothly

### Motivation
Remove dependencies between units

### Describe how you validated your changes
E2E, manual tests on CentOS 7

### Possible Drawbacks / Trade-offs
We can't have a timeout baked in the unit, so we use /usr/bin/timeout. It's included in coreutils and should be available everywhere. If there's an OS where it's not present, we can add it to the agent package (<50kb).

### Additional Notes
