### PR TITLE
(fleet) use the config repository to generate the config tmp dir on experiments

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -368,7 +368,7 @@ func (i *installerImpl) InstallConfigExperiment(ctx context.Context, pkg string,
 	i.m.Lock()
 	defer i.m.Unlock()
 
-	tmpDir, err := i.config.MkdirTemp()
+	tmpDir, err := i.configs.MkdirTemp()
 	if err != nil {
 		return installerErrors.Wrap(
 			installerErrors.ErrFilesystemIssue,

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -368,7 +368,7 @@ func (i *installerImpl) InstallConfigExperiment(ctx context.Context, pkg string,
 	i.m.Lock()
 	defer i.m.Unlock()
 
-	tmpDir, err := i.packages.MkdirTemp()
+	tmpDir, err := i.config.MkdirTemp()
 	if err != nil {
 		return installerErrors.Wrap(
 			installerErrors.ErrFilesystemIssue,


### PR DESCRIPTION
This PR fixes issues moving the experiment config from the packages partition to the config partition.

Example:
```
Error while upgrading host (code 4): Filesystem issue while installing updates, please check the permissions - Description: could not start config experiment: run failed: could not set experiment: could not set experiment: could not move experiment source: could not move source: rename /opt/datadog-packages/tmp-i-2076359623 /etc/datadog-agent/managed/datadog-agent/ysin-1i4e-b6cz: invalid cross-device link 
exit status 255
```