### PR TITLE
[gitlab] Align Windows and Linux build jobs dependencies

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -2,7 +2,7 @@
 .windows_msi_base:
   stage: package_build
   extends: .windows_docker_default
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   script:
     - $ErrorActionPreference = 'Stop'
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the `go_mod_tidy_check` job as a dependency of the Windows package builds.

### Motivation

Aligns behavior with the Linux jobs. The current situation is:
![image](https://github.com/user-attachments/assets/685417df-7004-4261-8b77-adfac4df9064)
![image](https://github.com/user-attachments/assets/97140801-132f-48c5-8373-63b69388b095)

The main consequence of this change is that Windows builds will now start ~6.5 minutes earlier. Since they are part of the critical path of the pipeline, this will also reduce the total duration of the pipeline. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Run CI, and Windows packaging jobs should not fail.

### Possible Drawbacks / Trade-offs

n/a

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

n/a