### PR TITLE
GPU: added host_gpu tag to host tags

### DIFF
--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	configUtils "github.com/DataDog/datadog-agent/pkg/config/utils"
+	gpu "github.com/DataDog/datadog-agent/pkg/gpu/tags"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/gce"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
@@ -121,6 +122,11 @@ func Get(ctx context.Context, cached bool, conf model.Reader) *Tags {
 	env := conf.GetString("env")
 	if env != "" {
 		hostTags = appendToHostTags(hostTags, []string{"env:" + env})
+	}
+
+	gpuTags := conf.GetBool("collect_gpu_tags")
+	if gpuTags {
+		hostTags = appendToHostTags(hostTags, gpu.GetTags())
 	}
 
 	hname, _ := hostname.Get(ctx)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -480,6 +480,12 @@ api_key:
 #
 # gce_metadata_timeout: 1000
 
+## @param collect_gpu_tags - boolean - optional - default: false
+## @env DD_COLLECT_GPU_TAGS - boolean - optional - default: false
+## Collect GPU related host tags
+#
+# collect_gpu_tags: false
+
 ## @param azure_hostname_style - string - optional - default: "os"
 ## @env DD_AZURE_HOSTNAME_STYLE - string - optional - default: "os"
 ## Changes how agent hostname is set on Azure virtual machines.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -623,6 +623,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("gce_send_project_id_tag", false)
 	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds
 
+	// GPU
+	config.BindEnvAndSetDefault("collect_gpu_tags", false)
 	// Cloud Foundry BBS
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.url", "https://bbs.service.cf.internal:8889")
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.poll_interval", 15)

--- a/pkg/gpu/tags/tags.go
+++ b/pkg/gpu/tags/tags.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package tags provides GPU-related host tags
+package tags
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+var nvmlLibrary nvml.Interface
+
+// GetTags returns gpu_host:true if any NVIDIA GPUs are present, nil otherwise
+func GetTags() []string {
+	if nvmlLibrary == nil {
+		nvmlLibrary = nvml.New()
+		if ret := nvmlLibrary.Init(); ret != nvml.SUCCESS && ret != nvml.ERROR_ALREADY_INITIALIZED {
+			log.Warnf("Failed to get gpu host tags, failed to initialize NVML: %v", nvml.ErrorString(ret))
+			return nil
+		}
+		// We don't call nvml.Shutdown() because the host tags will be queried multiple times
+		// during the agent's lifetime. We'll let the process cleanup handle the shutdown.
+	}
+
+	count, ret := nvmlLibrary.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		log.Warnf("Failed to get gpu host tags, couldn't assess number of devices: %v", nvml.ErrorString(ret))
+		return nil
+	}
+
+	if count > 0 {
+		return []string{"gpu_host:true"}
+	}
+
+	return nil
+}

--- a/pkg/gpu/tags/tags_nix.go
+++ b/pkg/gpu/tags/tags_nix.go
@@ -13,6 +13,7 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
+// used for tests to mock the NVML library
 var nvmlLibrary nvml.Interface
 
 // GetTags returns gpu_host:true if any NVIDIA GPUs are present, nil otherwise

--- a/pkg/gpu/tags/tags_nix.go
+++ b/pkg/gpu/tags/tags_nix.go
@@ -21,8 +21,6 @@ func GetTags() []string {
 			log.Warnf("Failed to get gpu host tags, failed to initialize NVML: %v", nvml.ErrorString(ret))
 			return nil
 		}
-		// We don't call nvml.Shutdown() because the host tags will be queried multiple times
-		// during the agent's lifetime. We'll let the process cleanup handle the shutdown.
 	}
 
 	count, ret := nvmlLibrary.DeviceGetCount()

--- a/pkg/gpu/tags/tags_nix.go
+++ b/pkg/gpu/tags/tags_nix.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux && !serverless
+//go:build linux && nvml
 
 // Package tags provides GPU-related host tags
 package tags

--- a/pkg/gpu/tags/tags_nix.go
+++ b/pkg/gpu/tags/tags_nix.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && !serverless
 
 // Package tags provides GPU-related host tags
 package tags

--- a/pkg/gpu/tags/tags_nix.go
+++ b/pkg/gpu/tags/tags_nix.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux
+
 // Package tags provides GPU-related host tags
 package tags
 

--- a/pkg/gpu/tags/tags_noop.go
+++ b/pkg/gpu/tags/tags_noop.go
@@ -1,0 +1,15 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+// Package tags provides GPU-related host tags
+package tags
+
+// GetTags returns empty list for non linux environments,
+// that's because the go-nvml supports only linux.
+func GetTags() []string {
+	return nil
+}

--- a/pkg/gpu/tags/tags_noop.go
+++ b/pkg/gpu/tags/tags_noop.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux
+//go:build !linux || serverless
 
 // Package tags provides GPU-related host tags
 package tags

--- a/pkg/gpu/tags/tags_noop.go
+++ b/pkg/gpu/tags/tags_noop.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !linux || serverless
+//go:build !linux || !nvml
 
 // Package tags provides GPU-related host tags
 package tags

--- a/pkg/gpu/tags/tags_test.go
+++ b/pkg/gpu/tags/tags_test.go
@@ -77,10 +77,7 @@ func BenchmarkGetTags(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		nvmlLibrary = nil
-		tags := GetTags()
-		if len(tags) > 0 {
-			b.Logf("GPU detected: %v", tags)
-		}
+		_ = GetTags()
 	}
 
 	// Verify the function completes within 500ms
@@ -91,5 +88,7 @@ func BenchmarkGetTags(b *testing.B) {
 	duration := time.Since(start)
 	if duration > 500*time.Millisecond {
 		b.Errorf("GetTags took %v, expected less than 500ms", duration)
+	} else {
+		b.Logf("GetTags took %v", duration)
 	}
 }

--- a/pkg/gpu/tags/tags_test.go
+++ b/pkg/gpu/tags/tags_test.go
@@ -17,16 +17,11 @@ import (
 type mockNVML struct {
 	nvml.Interface
 	deviceCount int
-	initError   nvml.Return
 	countError  nvml.Return
 }
 
 func (m *mockNVML) DeviceGetCount() (int, nvml.Return) {
 	return m.deviceCount, m.countError
-}
-
-func (m *mockNVML) Init() nvml.Return {
-	return m.initError
 }
 
 func TestGetTags(t *testing.T) {
@@ -39,7 +34,6 @@ func TestGetTags(t *testing.T) {
 			name: "no GPUs",
 			nvml: mockNVML{
 				deviceCount: 0,
-				initError:   nvml.SUCCESS,
 				countError:  nvml.SUCCESS,
 			},
 			wantTags: nil,
@@ -48,22 +42,13 @@ func TestGetTags(t *testing.T) {
 			name: "has GPUs",
 			nvml: mockNVML{
 				deviceCount: 2,
-				initError:   nvml.SUCCESS,
 				countError:  nvml.SUCCESS,
 			},
 			wantTags: []string{"gpu_host:true"},
 		},
 		{
-			name: "NVML init error",
-			nvml: mockNVML{
-				initError: nvml.ERROR_UNKNOWN,
-			},
-			wantTags: nil,
-		},
-		{
 			name: "device count error",
 			nvml: mockNVML{
-				initError:  nvml.SUCCESS,
 				countError: nvml.ERROR_UNKNOWN,
 			},
 			wantTags: nil,

--- a/pkg/gpu/tags/tags_test.go
+++ b/pkg/gpu/tags/tags_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && nvml
 
 package tags
 


### PR DESCRIPTION
### What does this PR do?

[Jira Ticket](https://datadoghq.atlassian.net/browse/EBPF-685)

Adds a new host_gpu:true tag to hosts that have at least one gpu device.
This extra tag is collected only when `collect_gpu_tags` config value is `true`, currently the default is `false`

### Motivation

allow effective filtering of gpu hosts in GPU Monitoring product

### Describe how you validated your changes

- added UTs
- manually tested one host with gpu devices and another host without

### Possible Drawbacks / Trade-offs

It is critical to return the host payload very fast, hence we need to make sure the GPU tags retrieval isn't a costly operation.
Added manual benchmark test to measure the gpu.GetTags function (main bottleneck is loading the native library)

### Additional Notes

The implementation is using go-nvml library to match the behavior of the GPU core-check.
**Currently only linux hosts are supported and only Nvidia as GPU vendor.** 
