### PR TITLE
(fleet) capture stdout and stderr for dotnet oci operation failures

### DIFF
--- a/pkg/fleet/installer/packages/exec/dotnet_library_exec.go
+++ b/pkg/fleet/installer/packages/exec/dotnet_library_exec.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -81,7 +82,9 @@ func (d *DotnetLibraryExec) RemoveIISInstrumentation(ctx context.Context) (exitC
 
 func (d *dotnetLibraryExecCmd) Run() (int, error) {
 	var errBuf bytes.Buffer
-	d.Stderr = &errBuf
+	mw := io.MultiWriter(&errBuf, os.Stderr)
+	d.Stderr = mw
+
 	err := d.Cmd.Run()
 	if err == nil {
 		return d.Cmd.ProcessState.ExitCode(), nil

--- a/pkg/fleet/installer/packages/exec/dotnet_library_exec.go
+++ b/pkg/fleet/installer/packages/exec/dotnet_library_exec.go
@@ -81,19 +81,21 @@ func (d *DotnetLibraryExec) RemoveIISInstrumentation(ctx context.Context) (exitC
 }
 
 func (d *dotnetLibraryExecCmd) Run() (int, error) {
-	var errBuf bytes.Buffer
-	mw := io.MultiWriter(&errBuf, os.Stderr)
-	d.Stderr = mw
+	var mergedBuffer bytes.Buffer
+	errWriter := io.MultiWriter(&mergedBuffer, os.Stderr)
+	outWriter := io.MultiWriter(&mergedBuffer, os.Stdout)
+	d.Stderr = errWriter
+	d.Stdout = outWriter
 
 	err := d.Cmd.Run()
 	if err == nil {
 		return d.Cmd.ProcessState.ExitCode(), nil
 	}
 
-	if len(errBuf.Bytes()) == 0 {
+	if len(mergedBuffer.Bytes()) == 0 {
 		return d.Cmd.ProcessState.ExitCode(), fmt.Errorf("run failed: %w", err)
 	}
 
-	installerError := installerErrors.FromJSON(strings.TrimSpace(errBuf.String()))
+	installerError := installerErrors.FromJSON(strings.TrimSpace(mergedBuffer.String()))
 	return d.Cmd.ProcessState.ExitCode(), fmt.Errorf("run failed: %w \n%s", installerError, err.Error())
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When running fleetinstaller for the dotnet OCI, ensures the entire program output (stderr and stdout) is both forwarded to stderr and stdout and captured in the error message in case of an error. 

### Motivation

Improve troubleshooting for local and remote installations.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manual testing

### Possible Drawbacks / Trade-offs

This might capture more verbose errors, but we can adjust the level of information in the program output if it is an issue.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->