### PR TITLE
[GPU] Added nvml build tag

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -42,6 +42,7 @@ ALL_TAGS = {
     "netcgo",  # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
     "netgo",
     "npm",
+    "nvml",  # used for the nvidia go-nvml library
     "oracle",
     "orchestrator",
     "osusergo",
@@ -80,6 +81,7 @@ AGENT_TAGS = {
     "kubeapiserver",
     "kubelet",
     "netcgo",
+    "nvml",
     "oracle",
     "orchestrator",
     "otlp",
@@ -104,6 +106,7 @@ AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
         "jetson",
         "kubeapiserver",
         "kubelet",
+        "nvml",
         "oracle",
         "orchestrator",
         "podman",
@@ -185,6 +188,7 @@ SYSTEM_PROBE_TAGS = {
     "linux_bpf",
     "netcgo",
     "npm",
+    "nvml",
     "pcap",
     "trivy",
     "zlib",
@@ -225,13 +229,13 @@ AGENT_TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
 ### Tag exclusion lists
 
 # List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "pcap", "podman", "trivy"}
+LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "podman", "trivy"}
 
 # List of tags to always remove when building on Windows
-WINDOWS_EXCLUDE_TAGS = {"linux_bpf", "requirefips"}
+WINDOWS_EXCLUDE_TAGS = {"linux_bpf", "nvml", "requirefips"}
 
 # List of tags to always remove when building on Darwin/macOS
-DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "no_dynamic_plugins", "cri", "crio"}
+DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "no_dynamic_plugins", "nvml",  "cri", "crio"}
 
 # Unit test build tags
 UNIT_TEST_TAGS = {"test"}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -235,7 +235,7 @@ LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "nvml", "pcap", "
 WINDOWS_EXCLUDE_TAGS = {"linux_bpf", "nvml", "requirefips"}
 
 # List of tags to always remove when building on Darwin/macOS
-DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "no_dynamic_plugins", "nvml",  "cri", "crio"}
+DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "no_dynamic_plugins", "nvml", "cri", "crio"}
 
 # Unit test build tags
 UNIT_TEST_TAGS = {"test"}


### PR DESCRIPTION
### What does this PR do?

Adds a new `nvml` build tag 
Included in Agent_tags, linux_tags, system_probe_tags
Explicitly excluded in Darwin and Windows tags subsets

### Motivation

Avoid increasing package size that don't require nvml library (~1mb). (e.g: dogstatsd)

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
application of the tag on ALL related GPU monitoring .go files will be done in a separate PR