### PR TITLE
[CWS] Fix DNS packet unmarshalling

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/dns.h
+++ b/pkg/security/ebpf/c/include/hooks/network/dns.h
@@ -134,8 +134,8 @@ int classifier_dns_response(struct __sk_buff *skb) {
 
     int len = pkt->payload_len;
 
-    if (len > DNS_MAX_LENGTH) {
-        len = DNS_MAX_LENGTH;
+    if (len > DNS_RECEIVE_MAX_LENGTH) {
+        len = DNS_RECEIVE_MAX_LENGTH;
     }
 
     struct dns_response_event_t evt = {0};


### PR DESCRIPTION
### What does this PR do?

Partially fixes the DNS packet unmarshalling (Full fix in Part2) by using the correct variable and not truncating the packet by 256 bytes.

### Motivation

We were getting many error / traces informing that the packet parser failed to decode the DNS packet.

This was because the packet was being truncated at only 256 bytes by the eBPF probe. The code was updated to use the current maximum size of 468. Some bigger packets are still failing to parse, and we will be able to capture the entire packet with Part 2.

### Describe how you validated your changes

Deployed on a cluster, verified there was a significant reduction of traces (110k down to 9k).

### Possible Drawbacks / Trade-offs

N/A

