### PR TITLE
[CWS-3988] Add more tests on FIM permission errors

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/rename.h
+++ b/pkg/security/ebpf/c/include/hooks/rename.h
@@ -143,9 +143,13 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
     if (syscall->state != DISCARDED && is_event_enabled(EVENT_RENAME)) {
         syscall->retval = retval;
 
-        // for centos7, use src dentry for target resolution as the pointers have been swapped
+        // target dentry is swapped with src in the case of a successful rename
+        if (retval >= 0) {
+            syscall->resolver.dentry = syscall->rename.src_dentry;
+        } else {
+            syscall->resolver.dentry = syscall->rename.target_dentry;
+        }
         syscall->resolver.key = syscall->rename.target_file.path_key;
-        syscall->resolver.dentry = syscall->rename.src_dentry;
         syscall->resolver.discarder_event_type = 0;
         syscall->resolver.callback = select_dr_key(dr_type, DR_RENAME_CALLBACK_KPROBE_KEY, DR_RENAME_CALLBACK_TRACEPOINT_KEY);
         syscall->resolver.iteration = 0;

--- a/pkg/security/tests/fim_test.go
+++ b/pkg/security/tests/fim_test.go
@@ -94,6 +94,10 @@ func TestFIMPermError(t *testing.T) {
 			ID:         "test_perm_chmod_rule",
 			Expression: `chmod.file.path == "{{.Root}}/test-file" && chmod.retval == -1`,
 		},
+		{
+			ID:         "test_perm_chown_rule",
+			Expression: `chown.file.path == "{{.Root}}/test-file" && chown.retval == -1`,
+		},
 	}
 
 	test, err := newTestModule(t, nil, ruleDefs)
@@ -180,6 +184,23 @@ func TestFIMPermError(t *testing.T) {
 		}, func(event *model.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_perm_chmod_rule")
 			assert.Equal(t, -int64(syscall.EPERM), event.Chmod.Retval)
+		})
+	})
+
+	test.Run(t, "chown", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		args := []string{
+			"process-credentials", "setuid", "4001", "4001", ";",
+			"chown", testFile, "0", "0",
+		}
+		envs := []string{}
+
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc(syscallTester, args, envs)
+			_, _ = cmd.CombinedOutput()
+			return nil
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_perm_chown_rule")
+			assert.Equal(t, -int64(syscall.EPERM), event.Chown.Retval)
 		})
 	})
 }

--- a/pkg/security/tests/fim_test.go
+++ b/pkg/security/tests/fim_test.go
@@ -146,8 +146,6 @@ func TestFIMPermError(t *testing.T) {
 	})
 
 	test.Run(t, "unlink", func(t *testing.T, _ wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		t.Skip("not stable")
-
 		args := []string{
 			"process-credentials", "setuid", "4001", "4001", ";",
 			"unlink", testFile,

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -1131,6 +1131,54 @@ int test_chmod(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+int test_chown(int argc, char **argv) {
+    if (argc != 4) {
+        fprintf(stderr, "Please specify a file name, a user ID, and a group ID\n");
+        return EXIT_FAILURE;
+    }
+
+    const char *filename = argv[1];
+
+    char *end;
+    unsigned long owner = strtoul(argv[2], &end, 10);
+    if (end == argv[2]) {
+        fprintf(stderr, "Invalid user ID: %s\n", argv[2]);
+        return EXIT_FAILURE;
+    } else if (*end != '\0') {
+        fprintf(stderr, "Invalid user ID: %s\n", argv[2]);
+        return EXIT_FAILURE;
+    } else if (errno == ERANGE && owner == ULONG_MAX) {
+        fprintf(stderr, "Invalid user ID: %s\n", argv[2]);
+        return EXIT_FAILURE;
+    } else if ((uid_t)owner != owner) {
+        fprintf(stderr, "Invalid user ID: %s\n", argv[2]);
+        return EXIT_FAILURE;
+    }
+
+
+    unsigned long group = strtoul(argv[3], &end, 10);
+    if (end == argv[3]) {
+        fprintf(stderr, "Invalid group ID: %s\n", argv[3]);
+        return EXIT_FAILURE;
+    } else if (*end != '\0') {
+        fprintf(stderr, "Invalid group ID: %s\n", argv[3]);
+        return EXIT_FAILURE;
+    } else if (errno == ERANGE && group == ULONG_MAX) {
+        fprintf(stderr, "Invalid group ID: %s\n", argv[3]);
+        return EXIT_FAILURE;
+    } else if ((gid_t)group != group) {
+        fprintf(stderr, "Invalid user ID: %s\n", argv[2]);
+        return EXIT_FAILURE;
+    }
+
+    if (chown(filename, (uid_t)owner, (gid_t)group) < 0) {
+        perror("chown");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     setbuf(stdout, NULL);
 
@@ -1216,6 +1264,8 @@ int main(int argc, char **argv) {
             exit_code = test_network_flow_send_udp4(sub_argc, sub_argv);
         } else if (strcmp(cmd, "chmod") == 0) {
             exit_code = test_chmod(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "chown") == 0) {
+            exit_code = test_chown(sub_argc, sub_argv);
         }
         else {
             fprintf(stderr, "Unknown command `%s`\n", cmd);

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -1179,6 +1179,23 @@ int test_chown(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+int test_rename(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "Please specify a source and a destination file name\n");
+        return EXIT_FAILURE;
+    }
+
+    const char *oldpath = argv[1];
+    const char *newpath = argv[2];
+
+    if (rename(oldpath, newpath) < 0) {
+        perror("rename");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     setbuf(stdout, NULL);
 
@@ -1266,6 +1283,8 @@ int main(int argc, char **argv) {
             exit_code = test_chmod(sub_argc, sub_argv);
         } else if (strcmp(cmd, "chown") == 0) {
             exit_code = test_chown(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "rename") == 0) {
+            return test_rename(sub_argc, sub_argv);
         }
         else {
             fprintf(stderr, "Unknown command `%s`\n", cmd);

--- a/pkg/security/tests/syscall_tester/c/syscall_tester.c
+++ b/pkg/security/tests/syscall_tester/c/syscall_tester.c
@@ -22,6 +22,7 @@
 #include <linux/un.h>
 #include <err.h>
 #include <limits.h>
+#include <sys/time.h>
 
 #define RPC_CMD 0xdeadc001
 #define REGISTER_SPAN_TLS_OP 6
@@ -1196,6 +1197,23 @@ int test_rename(int argc, char **argv) {
     return EXIT_SUCCESS;
 }
 
+int test_utimes(int argc, char **argv) {
+    if (argc != 2) {
+        fprintf(stderr, "Please specify a file name and a time\n");
+        return EXIT_FAILURE;
+    }
+
+    const char *filename = argv[1];
+
+    struct timeval times[2] = {0, 0};
+    if (utimes(filename, times) < 0) {
+        perror("utimes");
+        return EXIT_FAILURE;
+    }
+
+    return EXIT_SUCCESS;
+}
+
 int main(int argc, char **argv) {
     setbuf(stdout, NULL);
 
@@ -1285,6 +1303,8 @@ int main(int argc, char **argv) {
             exit_code = test_chown(sub_argc, sub_argv);
         } else if (strcmp(cmd, "rename") == 0) {
             return test_rename(sub_argc, sub_argv);
+        } else if (strcmp(cmd, "utimes") == 0) {
+            return test_utimes(sub_argc, sub_argv);
         }
         else {
             fprintf(stderr, "Unknown command `%s`\n", cmd);


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add tests for:
- `chmod` eperm error
- `chown` eperm error
- `utimes` eperm error
- `rename` eacces error + relevant fix
- remove `t.Skip` for the existing `unlink` eacces error test

A test for the `link` event type will be added in a followup PR.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->