### PR TITLE
ci(source_test): Add a serverless-init test

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -20,6 +20,7 @@ fetch_openjdk                        @DataDog/agent-metric-pipelines
 # Notifications are handled separately for more fine-grained control on go tests
 tests_*                                 @DataDog/multiple
 tests_ebpf*                             @DataDog/ebpf-platform
+tests_serverless                        @DataDog/serverless
 tests_windows_sysprobe*                 @DataDog/windows-kernel-integrations
 security_go_generate_check              @DataDog/agent-security
 prepare_sysprobe_ebpf_functional_tests* @DataDog/ebpf-platform

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -131,6 +131,19 @@ tests_rpm-arm64-py3:
   variables:
     CONDA_ENV: ddpy3
 
+tests_serverless-init:
+  extends: .linux_x64
+  stage: source_test
+  needs: ["go_deps"]
+  rules:
+    - !reference [.except_disable_unit_tests]
+    - !reference [.except_mergequeue]
+    - when: on_success
+  script:
+    - !reference [.retrieve_linux_go_deps]
+    - go test -tags "serverless otlp test" ./cmd/serverless-init/.
+
+
 # Check consistency of go.mod file with project imports
 go_mod_tidy_check:
   stage: source_test


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add a `serverless-init` test in the gitlab pipeline of `datadog-agent`

### Motivation
We need to confirm that serverless-init can build properly before new PRs are merged into the agent. We have dealt with multiple incidents in the last year due to an engineer outside our team making an update to a dependency or unrelated file that broke the deployment for serverless-init. We want to make it clearer that serverless-init depends on the Datadog agent by having this go test command run
https://datadoghq.atlassian.net/browse/ACIX-585

### Describe how you validated your changes
The tests passed on the executed [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/856458116)
```
$ go test -tags "serverless otlp test" ./cmd/serverless-init/.
ok  	github.com/DataDog/datadog-agent/cmd/serverless-init	0.168s
```
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->