### PR TITLE
Fix wrong arguments type in update-current-milestone task

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1295,7 +1295,7 @@ def update_current_milestone(ctx, major_version: int = 7, upstream="origin"):
 
     gh = GithubAPI()
 
-    current = current_version(ctx, major_version)
+    current = current_version(ctx, str(major_version))
     next = current.next_version(bump_minor=True)
     next.devel = False
 
@@ -1305,7 +1305,7 @@ def update_current_milestone(ctx, major_version: int = 7, upstream="origin"):
     with agent_context(ctx, get_default_branch(major=major_version)):
         milestone_branch = f"release_milestone-{int(time.time())}"
         ctx.run(f"git switch -c {milestone_branch}")
-        set_current_milestone(next)
+        set_current_milestone(str(next))
         # Commit release.json
         ctx.run("git add release.json")
         ok = try_git_command(ctx, f"git commit -m 'Update release.json with current milestone to {next}'")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1295,7 +1295,7 @@ def update_current_milestone(ctx, major_version: int = 7, upstream="origin"):
 
     gh = GithubAPI()
 
-    current = current_version(ctx, str(major_version))
+    current = current_version(ctx, major_version)
     next = current.next_version(bump_minor=True)
     next.devel = False
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`current_version` and `set_current_milestone` expect string as parameter

### Motivation

Fix the `update-current-milestone` task

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->