### PR TITLE
Revert "Mark k8s executor flake as a global flake"

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -25,6 +25,3 @@ test/new-e2e/tests/containers:
   - test: TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
   - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
-
-on-log:
-  - "panic: Expected to find a single pod" # K8s Agent Executor can be flaky with the current implementation


### PR DESCRIPTION
Reverts DataDog/datadog-agent#35276 because it is breaking KMT tests