### PR TITLE
Surface NotCaptureReason, Fix param/field names

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/capture_depth.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth.go
@@ -19,8 +19,7 @@ type captureDepthItem struct {
 	parameter *ditypes.Parameter
 }
 
-func applyCaptureDepth(params []*ditypes.Parameter, targetDepth int) []*ditypes.Parameter {
-	setDoNotCapture(params, targetDepth)
+func applyCaptureDepth(params []*ditypes.Parameter) []*ditypes.Parameter {
 	params = pruneDoNotCaptureParams(params)
 	correctStructSizes(params)
 	return params
@@ -49,8 +48,8 @@ func pruneDoNotCaptureParams(params []*ditypes.Parameter) []*ditypes.Parameter {
 	return result
 }
 
-// setDoNotCapture sets the DoNotCapture flag on all parameters that are at or beyond the target depth
-func setDoNotCapture(params []*ditypes.Parameter, targetDepth int) {
+// setDoNotCaptureBeyondDepth sets the DoNotCapture flag on all parameters that are at or beyond the target depth
+func setDoNotCaptureBeyondDepth(params []*ditypes.Parameter, targetDepth int) {
 	queue := []*captureDepthItem{}
 	for i := range params {
 		if params[i] == nil {

--- a/pkg/dynamicinstrumentation/codegen/capture_depth.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth.go
@@ -19,7 +19,7 @@ type captureDepthItem struct {
 	parameter *ditypes.Parameter
 }
 
-func applyCaptureDepth(params []*ditypes.Parameter) []*ditypes.Parameter {
+func applyExclusions(params []*ditypes.Parameter) []*ditypes.Parameter {
 	params = pruneDoNotCaptureParams(params)
 	correctStructSizes(params)
 	return params
@@ -98,8 +98,8 @@ func markExcessiveFieldsDoNotCapture(structParam *ditypes.Parameter, fieldCountL
 	}
 }
 
-// setDoNotCaptureBeyondDepth sets the DoNotCapture flag on all parameters that are at or beyond the target depth
-func setDoNotCaptureBeyondDepth(params []*ditypes.Parameter, targetDepth int) {
+// setDepthLimit sets the DoNotCapture flag on all parameters that are at or beyond the target depth
+func setDepthLimit(params []*ditypes.Parameter, targetDepth int) {
 	queue := []*captureDepthItem{}
 	for i := range params {
 		if params[i] == nil {

--- a/pkg/dynamicinstrumentation/codegen/capture_depth_test.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth_test.go
@@ -1448,7 +1448,7 @@ func TestApplyCaptureDepth(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			setDoNotCapture(test.parameters, test.targetDepth)
+			setDoNotCaptureBeyondDepth(test.parameters, test.targetDepth)
 			assert.Equal(t, test.expectedResult, test.parameters)
 		})
 	}

--- a/pkg/dynamicinstrumentation/codegen/capture_depth_test.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth_test.go
@@ -1448,7 +1448,7 @@ func TestApplyCaptureDepth(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			setDoNotCaptureBeyondDepth(test.parameters, test.targetDepth)
+			setDepthLimit(test.parameters, test.targetDepth)
 			assert.Equal(t, test.expectedResult, test.parameters)
 		})
 	}

--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -27,10 +27,14 @@ func GenerateBPFParamsCode(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) 
 	out := bytes.NewBuffer(parameterBytes)
 
 	if probe.InstrumentationInfo.InstrumentationOptions.CaptureParameters {
-		params := procInfo.TypeMap.Functions[probe.FuncName]
+		preChange := procInfo.TypeMap.Functions[probe.FuncName]
 		depth := probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth
+		setDoNotCaptureBeyondDepth(preChange, depth)
 
-		params = applyCaptureDepth(params, depth)
+		params := make([]*ditypes.Parameter, len(preChange))
+		copyTree(&params, &preChange)
+
+		params = applyCaptureDepth(params)
 		for i := range params {
 			if params[i].DoNotCapture {
 				log.Tracef("Not capturing parameter %d %s: %s", i, params[i].Name, params[i].NotCaptureReason.String())
@@ -321,4 +325,60 @@ func excludePopPointerAddressExpressions(expressions *[]ditypes.LocationExpressi
 type sliceHeaderWrapper struct {
 	Parameter           *ditypes.Parameter
 	SliceTypeHeaderText string
+}
+
+func copyTree(dst, src *[]*ditypes.Parameter) {
+	if dst == nil || src == nil || len(*src) == 0 {
+		return
+	}
+	*dst = make([]*ditypes.Parameter, len(*src))
+	for i := range *src {
+		if (*src)[i] == nil {
+			continue
+		}
+
+		// Create a new Parameter object for each element
+		srcParam := (*src)[i]
+		(*dst)[i] = &ditypes.Parameter{
+			Name:             srcParam.Name,
+			ID:               srcParam.ID,
+			Type:             srcParam.Type,
+			TotalSize:        srcParam.TotalSize,
+			Kind:             srcParam.Kind,
+			FieldOffset:      srcParam.FieldOffset,
+			DoNotCapture:     srcParam.DoNotCapture,
+			NotCaptureReason: srcParam.NotCaptureReason,
+		}
+
+		// Deep copy the Location if present
+		if srcParam.Location != nil {
+			(*dst)[i].Location = &ditypes.Location{
+				InReg:            srcParam.Location.InReg,
+				StackOffset:      srcParam.Location.StackOffset,
+				Register:         srcParam.Location.Register,
+				NeedsDereference: srcParam.Location.NeedsDereference,
+				PointerOffset:    srcParam.Location.PointerOffset,
+			}
+		}
+
+		// Deep copy the LocationExpressions slice
+		if len(srcParam.LocationExpressions) > 0 {
+			(*dst)[i].LocationExpressions = make([]ditypes.LocationExpression, len(srcParam.LocationExpressions))
+			for j, expr := range srcParam.LocationExpressions {
+				// Copy the LocationExpression struct
+				(*dst)[i].LocationExpressions[j] = expr
+
+				// Deep copy any IncludedExpressions
+				if len(expr.IncludedExpressions) > 0 {
+					(*dst)[i].LocationExpressions[j].IncludedExpressions = make([]ditypes.LocationExpression, len(expr.IncludedExpressions))
+					copy((*dst)[i].LocationExpressions[j].IncludedExpressions, expr.IncludedExpressions)
+				}
+			}
+		}
+
+		// Recursively copy ParameterPieces
+		if len(srcParam.ParameterPieces) > 0 {
+			copyTree(&((*dst)[i].ParameterPieces), &(srcParam.ParameterPieces))
+		}
+	}
 }

--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -29,8 +29,9 @@ func GenerateBPFParamsCode(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) 
 	if probe.InstrumentationInfo.InstrumentationOptions.CaptureParameters {
 		preChange := procInfo.TypeMap.Functions[probe.FuncName]
 		depth := probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth
+		fieldCountLimit := probe.InstrumentationInfo.InstrumentationOptions.MaxFieldCount
 		setDoNotCaptureBeyondDepth(preChange, depth)
-
+		setFieldLimit(preChange, fieldCountLimit)
 		params := make([]*ditypes.Parameter, len(preChange))
 		copyTree(&params, &preChange)
 

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -287,6 +287,7 @@ generateCompileAttach:
 		}
 		return
 	}
+
 }
 
 func newConfigProbe() *ditypes.Probe {

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -173,13 +173,11 @@ entryLoop:
 
 			// Collect information about the type of this ditypes.Parameter
 			if entry.Field[i].Attr == dwarf.AttrType {
-
 				typeReader.Seek(entry.Field[i].Val.(dwarf.Offset))
 				typeEntry, err := typeReader.Next()
 				if err != nil {
 					return nil, err
 				}
-
 				typeFields, err = expandTypeData(typeEntry.Offset, dwarfData, seenTypes)
 				if err != nil {
 					return nil, fmt.Errorf("error while parsing debug information: %w", err)
@@ -467,6 +465,7 @@ func getTypeEntryBasicInfo(typeEntry *dwarf.Entry) (typeName string, typeSize in
 	for i := range typeEntry.Field {
 		if typeEntry.Field[i].Attr == dwarf.AttrName {
 			typeName = strings.Clone(typeEntry.Field[i].Val.(string))
+			fmt.Println("TYPE NAME", typeName)
 		}
 		if typeEntry.Field[i].Attr == dwarf.AttrByteSize {
 			typeSize = typeEntry.Field[i].Val.(int64)
@@ -545,7 +544,10 @@ func copyTree(dst, src *[]*ditypes.Parameter) {
 func kindIsSupported(k reflect.Kind) bool {
 	if k == reflect.Map ||
 		k == reflect.UnsafePointer ||
-		k == reflect.Chan {
+		k == reflect.Chan ||
+		k == reflect.Float32 ||
+		k == reflect.Float64 ||
+		k == reflect.Interface {
 		return false
 	}
 	return true
@@ -592,8 +594,9 @@ func resolveUnsupportedEntry(e *dwarf.Entry) *ditypes.Parameter {
 		kind = uint(reflect.UnsafePointer)
 	}
 	return &ditypes.Parameter{
-		Type:             fmt.Sprintf("unsupported-%s", reflect.Kind(kind).String()),
+		Type:             fmt.Sprintf("%s", reflect.Kind(kind).String()),
 		Kind:             kind,
 		NotCaptureReason: ditypes.Unsupported,
+		DoNotCapture:     true,
 	}
 }

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -594,7 +594,7 @@ func resolveUnsupportedEntry(e *dwarf.Entry) *ditypes.Parameter {
 		kind = uint(reflect.UnsafePointer)
 	}
 	return &ditypes.Parameter{
-		Type:             fmt.Sprintf("%s", reflect.Kind(kind).String()),
+		Type:             reflect.Kind(kind).String(),
 		Kind:             kind,
 		NotCaptureReason: ditypes.Unsupported,
 		DoNotCapture:     true,

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -465,7 +465,6 @@ func getTypeEntryBasicInfo(typeEntry *dwarf.Entry) (typeName string, typeSize in
 	for i := range typeEntry.Field {
 		if typeEntry.Field[i].Attr == dwarf.AttrName {
 			typeName = strings.Clone(typeEntry.Field[i].Val.(string))
-			fmt.Println("TYPE NAME", typeName)
 		}
 		if typeEntry.Field[i].Attr == dwarf.AttrByteSize {
 			typeSize = typeEntry.Field[i].Val.(int64)

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -50,10 +50,11 @@ func (p Parameter) String() string {
 type NotCaptureReason uint8
 
 const (
-	Unsupported         NotCaptureReason = iota + 1 // Unsupported means the data type of the parameter is unsupported
-	NoFieldLocation                                 // NoFieldLocation means the parameter wasn't captured because location information is missing from analysis
-	FieldLimitReached                               // FieldLimitReached means the parameter wasn't captured because the data type has too many fields
-	CaptureDepthReached                             // CaptureDepthReached means the parameter wasn't captures because the data type has too many levels
+	Unsupported            NotCaptureReason = iota + 1 // Unsupported means the data type of the parameter is unsupported
+	NoFieldLocation                                    // NoFieldLocation means the parameter wasn't captured because location information is missing from analysis
+	FieldLimitReached                                  // FieldLimitReached means the parameter wasn't captured because the data type has too many fields
+	CaptureDepthReached                                // CaptureDepthReached means the parameter wasn't captures because the data type has too many levels
+	CollectionLimitReached                             // CollectionLimitReached means the parameter wasn't captured because the data type has too many elements
 )
 
 func (r NotCaptureReason) String() string {
@@ -63,9 +64,11 @@ func (r NotCaptureReason) String() string {
 	case NoFieldLocation:
 		return "no field location"
 	case FieldLimitReached:
-		return "field limit reached"
+		return "fieldCount"
 	case CaptureDepthReached:
-		return "capture depth reached"
+		return "depth"
+	case CollectionLimitReached:
+		return "collectionSize"
 	default:
 		return fmt.Sprintf("unknown reason (%d)", r)
 	}

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -161,17 +161,14 @@ func convertArgs(defs []*ditypes.Parameter, captures []*ditypes.Param) map[strin
 			cv := &ditypes.CapturedValue{
 				Type: capture.Type,
 			}
-
 			if capture.ValueStr != "" || capture.Type == "string" {
 				valueCopy := capture.ValueStr
 				cv.Value = &valueCopy
 			}
-
 			// Don't recursively process fields for captures not in defs
 			args[argName] = cv
 		}
 	}
-
 	return args
 }
 

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -106,41 +106,72 @@ func reportCaptureError(defs []*ditypes.Parameter) ditypes.Captures {
 
 func convertArgs(defs []*ditypes.Parameter, captures []*ditypes.Param) map[string]*ditypes.CapturedValue {
 	args := make(map[string]*ditypes.CapturedValue)
-	for idx, capture := range captures {
-		if capture == nil {
-			continue
-		}
-		var (
-			argName   string
-			defPieces []*ditypes.Parameter
-		)
-		if idx < len(defs) {
-			argName = defs[idx].Name
-		}
+
+	for idx, def := range defs {
+		argName := def.Name
 		if argName == "" {
 			argName = fmt.Sprintf("arg_%d", idx)
 		}
-		if reflect.Kind(capture.Kind) == reflect.Slice {
-			args[argName] = convertSlice(capture)
-			continue
+
+		var capture *ditypes.Param
+		if idx < len(captures) {
+			capture = captures[idx]
 		}
+
 		if capture == nil {
+			// No capture for this def, check for not capture reason
+			args[argName] = &ditypes.CapturedValue{
+				Type: def.Type,
+			}
+			if def.DoNotCapture && def.NotCaptureReason != 0 {
+				args[argName].NotCapturedReason = def.NotCaptureReason.String()
+			}
 			continue
 		}
-		cv := &ditypes.CapturedValue{Type: capture.Type}
+
+		cv := &ditypes.CapturedValue{
+			Type: capture.Type,
+		}
+
 		if capture.ValueStr != "" || capture.Type == "string" {
-			// we make a copy of the string so the pointer isn't overwritten in the loop
 			valueCopy := capture.ValueStr
 			cv.Value = &valueCopy
 		}
-		if idx < len(defs) {
-			defPieces = defs[idx].ParameterPieces
+
+		// Handle nested fields if both def and capture have them
+		if capture.Fields != nil && def.ParameterPieces != nil {
+			// For slice types, use convertSlice helper which already exists
+			if uint(capture.Kind) == uint(reflect.Slice) {
+				args[argName] = convertSlice(capture)
+			} else {
+				// For struct types, recursively process fields
+				cv.Fields = convertArgs(def.ParameterPieces, capture.Fields)
+				args[argName] = cv
+			}
+		} else {
+			// No nested fields or already handled above
+			args[argName] = cv
 		}
-		if capture.Fields != nil {
-			cv.Fields = convertArgs(defPieces, capture.Fields)
-		}
-		args[argName] = cv
 	}
+
+	// Handle extra captures not in defs
+	for idx, capture := range captures {
+		if idx >= len(defs) && capture != nil {
+			argName := fmt.Sprintf("arg_%d", idx)
+			cv := &ditypes.CapturedValue{
+				Type: capture.Type,
+			}
+
+			if capture.ValueStr != "" || capture.Type == "string" {
+				valueCopy := capture.ValueStr
+				cv.Value = &valueCopy
+			}
+
+			// Don't recursively process fields for captures not in defs
+			args[argName] = cv
+		}
+	}
+
 	return args
 }
 

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -130,7 +130,7 @@ func convertArgs(defs []*ditypes.Parameter, captures []*ditypes.Param) map[strin
 		}
 
 		cv := &ditypes.CapturedValue{
-			Type: capture.Type,
+			Type: def.Type,
 		}
 
 		if capture.ValueStr != "" || capture.Type == "string" {


### PR DESCRIPTION
### What does this PR do?

- Fixes an issue where the `NotCaptureReason` was not being displayed in the UI when fields were cut due to being unsupported/capture-depth/field-limit/...
- Fixes an issue where the type names of parameters/fields were not being properly populated in snapshots.
- Applies field count limits

### Motivation

Improvements to UX 

### Describe how you validated your changes

e2e testing and manually in UI

### Possible Drawbacks / Trade-offs

### Additional Notes
