### PR TITLE
Revert "Update last_stable to 7.64.0"

### DIFF
--- a/release.json
+++ b/release.json
@@ -3,7 +3,7 @@
     "current_milestone": "7.65.0",
     "last_stable": {
         "6": "6.53.1",
-        "7": "7.64.0"
+        "7": "7.63.3"
     },
     "nightly": {
         "OMNIBUS_RUBY_VERSION": "95630818722a63cb9e6f3163984f363d799633a1",


### PR DESCRIPTION
Reverts DataDog/datadog-agent#35279

we unpromoted 7.64.0 for incident-36348