### PR TITLE
[NDM][SNMP] Set hostname when sending interface status

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -292,7 +292,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 
 		deviceDiagnosis := d.diagnoses.Report()
 
-		d.sender.ReportNetworkDeviceMetadata(d.config, profile, values, deviceMetadataTags, collectionTime,
+		d.sender.ReportNetworkDeviceMetadata(d.config, profile, values, deviceMetadataTags, metricTags, collectionTime,
 			deviceStatus, pingStatus, deviceDiagnosis)
 	}
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -100,7 +100,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 		}
 		interfaceTags = append(interfaceTags, interfaceCfg.Tags...)
 
-		ms.sender.Gauge(interfaceStatusMetric, 1, "", interfaceTags)
+		ms.sender.Gauge(interfaceStatusMetric, 1, ms.hostname, interfaceTags)
 	}
 }
 

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata.go
@@ -52,9 +52,12 @@ var supportedDeviceTypes = map[string]bool{
 }
 
 // ReportNetworkDeviceMetadata reports device metadata
-func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, profile profiledefinition.ProfileDefinition, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus devicemetadata.DeviceStatus, pingStatus devicemetadata.DeviceStatus, diagnoses []devicemetadata.DiagnosisMetadata) {
+func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, profile profiledefinition.ProfileDefinition, store *valuestore.ResultValueStore, origTags []string, origMetricTags []string, collectTime time.Time, deviceStatus devicemetadata.DeviceStatus, pingStatus devicemetadata.DeviceStatus, diagnoses []devicemetadata.DiagnosisMetadata) {
 	tags := utils.CopyStrings(origTags)
 	tags = sortutil.UniqInPlace(tags)
+
+	metricTags := utils.CopyStrings(origMetricTags)
+	metricTags = sortutil.UniqInPlace(metricTags)
 
 	metadataStore := buildMetadataStore(profile.Metadata, store)
 
@@ -91,7 +94,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 		if interfaceStatus.Alias != "" {
 			interfaceTags = append(interfaceTags, "interface_alias:"+interfaceStatus.Alias)
 		}
-		interfaceTags = append(interfaceTags, tags...)
+		interfaceTags = append(interfaceTags, metricTags...)
 
 		// append user's custom interface tags
 		interfaceCfg, err := getInterfaceConfig(ms.interfaceConfigs, interfaceIndex, interfaceTags)

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -286,7 +286,8 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	ms := &MetricSender{
-		sender: sender,
+		hostname: "test",
+		sender:   sender,
 		interfaceConfigs: []snmpintegration.InterfaceConfig{
 			{
 				MatchField: "index",
@@ -370,8 +371,8 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1", "oper_status:up", "admin_status:down"}
 	ifTags2 := []string{"tag1", "tag2", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down", "muted", "someKey:someValue"}
 
-	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags1)
-	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "", ifTags2)
+	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "test", ifTags1)
+	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "test", ifTags2)
 	// language=json
 	event := []byte(`
 {

--- a/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/internal/report/report_device_metadata_test.go
@@ -136,7 +136,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 	profile, err := config.BuildProfile("")
 	require.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, profile, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusReachable, nil)
+	ms.ReportNetworkDeviceMetadata(config, profile, storeWithoutIfName, []string{"tag1", "tag2"}, nil, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusReachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -221,7 +221,7 @@ profiles:
 	profile, err := config.BuildProfile("")
 	require.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, profile, storeWithoutIfName, []string{"tag1", "tag2"}, collectTime,
+	ms.ReportNetworkDeviceMetadata(config, profile, storeWithoutIfName, []string{"tag1", "tag2"}, nil, collectTime,
 		metadata.DeviceStatusReachable, metadata.DeviceStatusReachable, nil)
 
 	// language=json
@@ -366,10 +366,10 @@ func Test_metricSender_reportNetworkDeviceMetadata_withDeviceInterfacesAndDiagno
 	str := "2014-11-12 11:45:26"
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
-	ms.ReportNetworkDeviceMetadata(config, profile, storeWithIfName, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, diagnosis)
+	ms.ReportNetworkDeviceMetadata(config, profile, storeWithIfName, []string{"tag1", "tag2"}, []string{"tag1", "tag2", "metric:tag"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, diagnosis)
 
-	ifTags1 := []string{"tag1", "tag2", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1", "oper_status:up", "admin_status:down"}
-	ifTags2 := []string{"tag1", "tag2", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down", "muted", "someKey:someValue"}
+	ifTags1 := []string{"tag1", "tag2", "metric:tag", "status:down", "interface:21", "interface_alias:ifAlias1", "interface_index:1", "oper_status:up", "admin_status:down"}
+	ifTags2 := []string{"tag1", "tag2", "metric:tag", "status:off", "interface:22", "interface_index:2", "oper_status:down", "admin_status:down", "muted", "someKey:someValue"}
 
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "test", ifTags1)
 	sender.AssertMetric(t, "Gauge", interfaceStatusMetric, 1., "test", ifTags2)
@@ -484,7 +484,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_fallbackOnFieldValue(t *testi
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
+	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, nil, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -559,7 +559,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_Nil(t *testing
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, 0, nil)
+	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, nil, collectTime, metadata.DeviceStatusReachable, 0, nil)
 
 	// language=json
 	event := []byte(`
@@ -633,7 +633,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_True(t *testin
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
+	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, nil, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
 
 	// language=json
 	event := []byte(`
@@ -708,7 +708,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_pingCanConnect_False(t *testi
 	collectTime, err := time.Parse(layout, str)
 	assert.NoError(t, err)
 
-	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
+	ms.ReportNetworkDeviceMetadata(config, profile, emptyMetadataStore, []string{"tag1", "tag2"}, nil, collectTime, metadata.DeviceStatusReachable, metadata.DeviceStatusUnreachable, nil)
 
 	// language=json
 	event := []byte(`


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Set hostname and ndm_device_user_tags metric tag when sending interface status metrics, so they are correctly enriched with user tags.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->