### PR TITLE
Allow custom choco releases

### DIFF
--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -63,7 +63,7 @@ if (![string]::IsNullOrEmpty($VersionOverride)) {
 $copyright = "Datadog {0}" -f (Get-Date).Year
 
 $releasePattern = "(\d+\.\d+\.\d+)"
-$releaseCandidatePattern = "^(\d+\.\d+\.\d+)-rc\.(\d+)$"
+$releaseCandidatePattern = "(\d+\.\d+\.\d+)-rc\.(\d+)"
 $develPattern = "^(\d+\.\d+\.\d+)-devel\.git\.\d+\.(.+)"
 
 # Build the package in a temporary directory

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -62,7 +62,7 @@ if (![string]::IsNullOrEmpty($VersionOverride)) {
 }
 $copyright = "Datadog {0}" -f (Get-Date).Year
 
-$releasePattern = "^(\d+\.\d+\.\d+)$"
+$releasePattern = "(\d+\.\d+\.\d+)"
 $releaseCandidatePattern = "^(\d+\.\d+\.\d+)-rc\.(\d+)$"
 $develPattern = "^(\d+\.\d+\.\d+)-devel\.git\.\d+\.(.+)"
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes an issue with choco jobs failing for custom builds http://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/856594274.

I think the issue was introduced in https://github.com/DataDog/datadog-agent/pull/32310/files#diff-2bb2ce257e8d6f43475d0663271e9aa730428491a54fadde5075ae5ab50126e0, adding ^$ to the regex would enforce strict matching.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->