### PR TITLE
Introduce safe Eventually suite method

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -215,26 +215,26 @@ func (bs *BaseSuite[Env]) Env() *Env {
 }
 
 // EventuallyWithT is a wrapper around testify.Suite.EventuallyWithT that catches panics to fail test without skipping TeardownSuite
-func (bs *BaseSuite[Env]) EventuallyWithT(f func(*assert.CollectT), timeout time.Duration, interval time.Duration, msgAndArgs ...interface{}) {
-	bs.Suite.EventuallyWithT(func(c *assert.CollectT) {
+func (bs *BaseSuite[Env]) EventuallyWithT(condition func(*assert.CollectT), timeout time.Duration, interval time.Duration, msgAndArgs ...interface{}) bool {
+	return bs.Suite.EventuallyWithT(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
 				require.Nil(bs.T(), r, "Panic in EventuallyWithT: %v", r)
 			}
 		}()
-		f(c)
+		condition(c)
 	}, timeout, interval, msgAndArgs...)
 }
 
 // EventuallyWithTf is a wrapper around testify.Suite.EventuallyWithTf that catches panics to fail test without skipping TeardownSuite
-func (bs *BaseSuite[Env]) EventuallyWithTf(f func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) {
-	bs.Suite.EventuallyWithTf(func(c *assert.CollectT) {
+func (bs *BaseSuite[Env]) EventuallyWithTf(condition func(*assert.CollectT), waitFor time.Duration, tick time.Duration, msg string, args ...interface{}) bool {
+	return bs.Suite.EventuallyWithTf(func(c *assert.CollectT) {
 		defer func() {
 			if r := recover(); r != nil {
 				require.Nil(bs.T(), r, "Panic in EventuallyWithTf: %v", r)
 			}
 		}()
-		f(c)
+		condition(c)
 	}, waitFor, tick, msg, args)
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make `EventuallyWithT` and `EventuallyWithTf` safer for the base e2e test suite.
Without that any panic happening in Eventually will completely stop the execution of the test without triggering the TearDown, we want to avoid that to not leak resources

### Motivation

Avoid leaking resources

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->