### PR TITLE
[EBPF] gpu: move ProbeDependencies constructor to the gpu package

### DIFF
--- a/cmd/system-probe/modules/gpu.go
+++ b/cmd/system-probe/modules/gpu.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
@@ -66,18 +65,9 @@ var GPUMonitoring = module.Factory{
 			configureCgroupPermissions()
 		}
 
-		probeDeps := gpu.ProbeDependencies{
-			Telemetry: deps.Telemetry,
-			//if the config parameter doesn't exist or is empty string, the default value is used as defined in go-nvml library
-			//(https://github.com/NVIDIA/go-nvml/blob/main/pkg/nvml/lib.go#L30)
-			NvmlLib:        nvml.New(nvml.WithLibraryPath(c.NVMLLibraryPath)),
-			ProcessMonitor: processEventConsumer,
-			WorkloadMeta:   deps.WMeta,
-		}
-
-		ret := probeDeps.NvmlLib.Init()
-		if ret != nvml.SUCCESS && ret != nvml.ERROR_ALREADY_INITIALIZED {
-			return nil, fmt.Errorf("unable to initialize NVML library: %v", ret)
+		probeDeps, err := gpu.NewProbeDependencies(c, deps.Telemetry, processEventConsumer, deps.WMeta)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create probe dependencies: %w", err)
 		}
 
 		p, err := gpu.NewProbe(c, probeDeps)

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -103,6 +103,7 @@ type ProbeDependencies struct {
 	WorkloadMeta workloadmeta.Component
 }
 
+// NewProbeDependencies creates a new ProbeDependencies instance
 func NewProbeDependencies(cfg *config.Config, telemetry telemetry.Component, processMonitor uprobes.ProcessMonitor, workloadMeta workloadmeta.Component) (ProbeDependencies, error) {
 	nvmlLib := nvml.New(nvml.WithLibraryPath(cfg.NVMLLibraryPath))
 	ret := nvmlLib.Init()

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -103,6 +103,21 @@ type ProbeDependencies struct {
 	WorkloadMeta workloadmeta.Component
 }
 
+func NewProbeDependencies(cfg *config.Config, telemetry telemetry.Component, processMonitor uprobes.ProcessMonitor, workloadMeta workloadmeta.Component) (ProbeDependencies, error) {
+	nvmlLib := nvml.New(nvml.WithLibraryPath(cfg.NVMLLibraryPath))
+	ret := nvmlLib.Init()
+	if ret != nvml.SUCCESS && ret != nvml.ERROR_ALREADY_INITIALIZED {
+		return ProbeDependencies{}, fmt.Errorf("unable to initialize NVML library: %w", ret)
+	}
+
+	return ProbeDependencies{
+		Telemetry:      telemetry,
+		NvmlLib:        nvmlLib,
+		ProcessMonitor: processMonitor,
+		WorkloadMeta:   workloadMeta,
+	}, nil
+}
+
 // Probe represents the GPU monitoring probe
 type Probe struct {
 	m                *ddebpf.Manager

--- a/pkg/gpu/probe_stub.go
+++ b/pkg/gpu/probe_stub.go
@@ -25,6 +25,7 @@ type ProbeDependencies struct {
 	WorkloadMeta   workloadmeta.Component
 }
 
+// NewProbeDependencies is not implemented on non-linux systems
 func NewProbeDependencies(_ *config.Config, _ telemetry.Component, _ any, _ workloadmeta.Component) (ProbeDependencies, error) {
 	return ProbeDependencies{}, nil
 }

--- a/pkg/gpu/probe_stub.go
+++ b/pkg/gpu/probe_stub.go
@@ -10,8 +10,6 @@ package gpu
 import (
 	"context"
 
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
-
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
@@ -22,9 +20,13 @@ import (
 // ProbeDependencies holds the dependencies for the probe
 type ProbeDependencies struct {
 	Telemetry      telemetry.Component
-	NvmlLib        nvml.Interface
 	ProcessMonitor any // uprobes.ProcessMonitor is only compiled with the linux_bpf build tag, so we need to use type any here
+	NvmlLib        any // nvml.Interface is only compiled with the nvml build tag, so we need to use type any here
 	WorkloadMeta   workloadmeta.Component
+}
+
+func NewProbeDependencies(_ *config.Config, _ telemetry.Component, _ any, _ workloadmeta.Component) (ProbeDependencies, error) {
+	return ProbeDependencies{}, nil
 }
 
 // Probe is not implemented on non-linux systems


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Moves the code initializing NVML to the `pkg/gpu` package

### Motivation

Enable moving NVML-dependent code under the `nvml` build tag

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passing and build correct.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->