### PR TITLE
Avoid calling diagnose on nil environment

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -510,11 +510,13 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 		// run environment diagnose
 		if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok {
 			// at least one test failed, diagnose the environment
-			diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
-			if diagnoseErr != nil {
-				bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
-			} else {
-				bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+			if diagnosableEnv != nil {
+				diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
+				if diagnoseErr != nil {
+					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+				} else {
+					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+				}
 			}
 		}
 
@@ -593,11 +595,14 @@ func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
 			// run environment diagnose if the test failed
 			if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok {
 				// at least one test failed, diagnose the environment
-				diagnose, diagnoseErr := diagnosableEnv.Diagnose(testOutputDir)
-				if diagnoseErr != nil {
-					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
-				} else {
-					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+				if diagnosableEnv != nil {
+					diagnose, diagnoseErr := diagnosableEnv.Diagnose(testOutputDir)
+					if diagnoseErr != nil {
+						bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+					} else {
+						bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+
+					}
 				}
 			}
 		}

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -508,15 +508,13 @@ func (bs *BaseSuite[Env]) SetupSuite() {
 		bs.firstFailTest = "Initial provisioning SetupSuite" // This is required to handle skipDeleteOnFailure
 
 		// run environment diagnose
-		if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok {
+		if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok && diagnosableEnv != nil {
 			// at least one test failed, diagnose the environment
-			if diagnosableEnv != nil {
-				diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
-				if diagnoseErr != nil {
-					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
-				} else {
-					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
-				}
+			diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
+			if diagnoseErr != nil {
+				bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+			} else {
+				bs.T().Logf("Diagnose result:\n\n%s", diagnose)
 			}
 		}
 
@@ -593,16 +591,13 @@ func (bs *BaseSuite[Env]) AfterTest(suiteName, testName string) {
 			bs.T().Logf("unable to create test output directory: %v", err)
 		} else {
 			// run environment diagnose if the test failed
-			if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok {
+			if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok && diagnosableEnv != nil {
 				// at least one test failed, diagnose the environment
-				if diagnosableEnv != nil {
-					diagnose, diagnoseErr := diagnosableEnv.Diagnose(testOutputDir)
-					if diagnoseErr != nil {
-						bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
-					} else {
-						bs.T().Logf("Diagnose result:\n\n%s", diagnose)
-
-					}
+				diagnose, diagnoseErr := diagnosableEnv.Diagnose(testOutputDir)
+				if diagnoseErr != nil {
+					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+				} else {
+					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
 				}
 			}
 		}

--- a/test/new-e2e/pkg/environments/host.go
+++ b/test/new-e2e/pkg/environments/host.go
@@ -35,6 +35,10 @@ var _ common.Diagnosable = (*Host)(nil)
 
 // Diagnose returns a string containing the diagnosis of the environment
 func (e *Host) Diagnose(outputDir string) (string, error) {
+	if e == nil {
+		return "", fmt.Errorf("Host component is not initialized")
+	}
+
 	diagnoses := []string{}
 	if e.RemoteHost == nil {
 		return "", fmt.Errorf("RemoteHost component is not initialized")

--- a/test/new-e2e/pkg/environments/host.go
+++ b/test/new-e2e/pkg/environments/host.go
@@ -35,10 +35,6 @@ var _ common.Diagnosable = (*Host)(nil)
 
 // Diagnose returns a string containing the diagnosis of the environment
 func (e *Host) Diagnose(outputDir string) (string, error) {
-	if e == nil {
-		return "", fmt.Errorf("Host component is not initialized")
-	}
-
 	diagnoses := []string{}
 	if e.RemoteHost == nil {
 		return "", fmt.Errorf("RemoteHost component is not initialized")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The Host diagnose method panics and break normal workflow if the environment is `nil`. Which can happen if the environment failed to initialize properly

### Motivation

Avoid unexpected panics that prevent resource cleaning

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->