### PR TITLE
[CSPM] fetch config only once in default rule filter

### DIFF
--- a/cmd/security-agent/subcommands/check/command.go
+++ b/cmd/security-agent/subcommands/check/command.go
@@ -161,7 +161,7 @@ func RunCheck(log log.Component, config config.Component, _ secrets.Component, s
 	} else if checkArgs.framework != "" {
 		benchDir, benchGlob = configDir, fmt.Sprintf("%s.yaml", checkArgs.framework)
 	} else {
-		ruleFilter = compliance.DefaultRuleFilter
+		ruleFilter = compliance.MakeDefaultRuleFilter()
 		benchDir, benchGlob = configDir, "*.yaml"
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[On some profiles](https://app.datadoghq.com/profiling/explorer?query=service%3Asecurity-agent%20language%3Ago%20env%3Asingle-machine-performance%20job_id%3A2ee13904-7e2f-4e56-8266-d5c14de86073&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&cols=timestamp%2Cservice%2C%40metrics.core_cpu_cores%2C%40metrics.core_alloc_bytes_per_sec%2Cversion%2Chost%2C%40metrics.go_lifetime_heap_bytes&event=AwAAAZWzSMmErDTwPQAAABhBWld6U01xakFBRDdtZlJ4T0RsWDhBQUEAAAAkMDE5NWIzNDgtZTA3NS00MGQ2LTk0ZTQtMTQ4YjQzMTI5MTU0AAAMRA&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&fromUser=true&my_code=disabled&overview_facet=log_prof_go_cpu_cores&profileId=AZWzSMqjAAD7mfRxODlX8AAA&refresh_mode=paused&stream_sort=%40metrics.core_cpu_cores%2Cdesc&viz=stream&from_ts=1742416990020&to_ts=1742503390020&live=false), `xccdfEnabled()` can represents nearly 10% of all the CPU used by the security agent. This is because the filter is evaluated for all rules and fetching from the config is pretty expensive.

This PR optimizes this by pre-computing the xccdf state once and returning a filter function re-using this given boolean.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->