### PR TITLE
Improve resiliency of autoscaling settings config retriever to always converge to desired in all edge cases

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/config_retriever.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever.go
@@ -8,6 +8,7 @@
 package workload
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/utils/clock"
@@ -18,7 +19,8 @@ import (
 )
 
 const (
-	configRetrieverStoreID string = "cr"
+	configRetrieverStoreID    string        = "cr"
+	settingsReconcileInterval time.Duration = 5 * time.Minute
 )
 
 // RcClient is a subinterface of rcclient.Component to allow mocking
@@ -28,46 +30,82 @@ type RcClient interface {
 
 // ConfigRetriever is responsible for retrieving remote objects (Autoscaling .Spec and values)
 type ConfigRetriever struct {
-	store    *store
 	isLeader func() bool
-	clock    clock.Clock
+	clock    clock.WithTicker
+
+	settingsProcessor autoscalingSettingsProcessor
+	valuesProcessor   autoscalingValuesProcessor
 }
 
 // NewConfigRetriever creates a new ConfigRetriever
-func NewConfigRetriever(store *store, isLeader func() bool, rcClient RcClient) (*ConfigRetriever, error) {
+func NewConfigRetriever(ctx context.Context, clock clock.WithTicker, store *store, isLeader func() bool, rcClient RcClient) (*ConfigRetriever, error) {
 	cr := &ConfigRetriever{
-		store:    store,
 		isLeader: isLeader,
-		clock:    clock.RealClock{},
+		clock:    clock,
+
+		settingsProcessor: newAutoscalingSettingsProcessor(store),
+		valuesProcessor:   newAutoscalingValuesProcessor(store),
 	}
 
-	rcClient.SubscribeIgnoreExpiration(data.ProductContainerAutoscalingSettings, func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
-		// For autoscaling settings, we need to be able to clean up the store to handle deleted configs.
-		// Remote config guarantees that we receive all configs at once, so we can safely clean up the store after processing all configs.
-		autoscalingSettingsProcessor := newAutoscalingSettingsProcessor(cr.store)
-		cr.autoscalerUpdateCallback(cr.clock.Now(), update, applyStateCallback, autoscalingSettingsProcessor.process, autoscalingSettingsProcessor.postProcess)
-	})
+	// Subscribe to remote config updates
+	rcClient.SubscribeIgnoreExpiration(data.ProductContainerAutoscalingSettings, cr.autoscalingSettingsCallback)
+	rcClient.SubscribeIgnoreExpiration(data.ProductContainerAutoscalingValues, cr.autoscalingValuesCallback)
 
-	rcClient.SubscribeIgnoreExpiration(data.ProductContainerAutoscalingValues, func(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
-		autoscalingValuesProcessor := newAutoscalingValuesProcessor(cr.store)
-		cr.autoscalerUpdateCallback(cr.clock.Now(), update, applyStateCallback, autoscalingValuesProcessor.process, autoscalingValuesProcessor.postProcess)
-	})
+	// Add a regular reconcile for settings. Several edge cases can happen that would prevent creation or deletion of a PodAutoscaler
+	// For instance, if a leader change happens before the old persisted the update in Kubernetes.
+	go func() {
+		ticker := cr.clock.NewTicker(settingsReconcileInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C():
+				cr.settingsProcessor.reconcile(cr.isLeader())
+			}
+		}
+	}()
 
 	log.Debugf("Created new workload scaling config retriever")
 	return cr, nil
 }
 
-func (cr *ConfigRetriever) autoscalerUpdateCallback(
-	timestamp time.Time,
-	update map[string]state.RawConfig,
-	applyStateCallback func(string, state.ApplyStatus),
-	process func(time.Time, string, state.RawConfig) error,
-	postProcess func(errors []error),
-) {
-	log.Tracef("Received update from RC")
+func (cr *ConfigRetriever) autoscalingSettingsCallback(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	timestamp := cr.clock.Now()
 
+	cr.settingsProcessor.preProcess()
+	for configKey, rawConfig := range update {
+		log.Debugf("Processing config key: %s, product: %s, id: %s, name: %s, version: %d, leader: %v", configKey, rawConfig.Metadata.Product, rawConfig.Metadata.ID, rawConfig.Metadata.Name, rawConfig.Metadata.Version, cr.isLeader())
+
+		err := cr.settingsProcessor.processItem(timestamp, configKey, rawConfig)
+		if err != nil {
+			log.Warnf("Error processing autoscaling settings for %s: %v", configKey, err)
+			applyStateCallback(configKey, state.ApplyStatus{
+				State: state.ApplyStateError,
+				Error: err.Error(),
+			})
+		} else {
+			applyStateCallback(configKey, state.ApplyStatus{
+				State: state.ApplyStateAcknowledged,
+				Error: "",
+			})
+		}
+	}
+	cr.settingsProcessor.postProcess()
+
+	// Reconcile the remote config state and the local store
+	cr.settingsProcessor.reconcile(cr.isLeader())
+}
+
+func (cr *ConfigRetriever) autoscalingValuesCallback(update map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
+	// For autoscaling values, we don't reconcile internal state, store directly in the store.
+	// That's because we expect to receive more data and a lot more frequently.
+	// The internal state would be using more memory for only a small benefit (reconcile before next update).
+	timestamp := cr.clock.Now()
 	isLeader := cr.isLeader()
-	var errors []error
+
+	cr.valuesProcessor.preProcess()
 	for configKey, rawConfig := range update {
 		log.Debugf("Processing config key: %s, product: %s, id: %s, name: %s, version: %d, leader: %v", configKey, rawConfig.Metadata.Product, rawConfig.Metadata.ID, rawConfig.Metadata.Name, rawConfig.Metadata.Version, isLeader)
 
@@ -79,9 +117,9 @@ func (cr *ConfigRetriever) autoscalerUpdateCallback(
 			continue
 		}
 
-		err := process(timestamp, configKey, rawConfig)
+		err := cr.valuesProcessor.process(timestamp, configKey, rawConfig)
 		if err != nil {
-			errors = append(errors, err)
+			log.Warnf("Error processing autoscaling values for %s: %v", configKey, err)
 			applyStateCallback(configKey, state.ApplyStatus{
 				State: state.ApplyStateError,
 				Error: err.Error(),
@@ -95,7 +133,7 @@ func (cr *ConfigRetriever) autoscalerUpdateCallback(
 	}
 
 	// If `process` was not called, we're not calling postProcess
-	if isLeader && postProcess != nil {
-		postProcess(errors)
+	if isLeader {
+		cr.valuesProcessor.postProcess()
 	}
 }

--- a/pkg/clusteragent/autoscaling/workload/config_retriever_test.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_test.go
@@ -8,13 +8,12 @@
 package workload
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/clock"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
 
@@ -39,14 +38,12 @@ func (m *mockRCClient) triggerUpdate(product string, update map[string]state.Raw
 	}
 }
 
-func newMockConfigRetriever(t *testing.T, isLeader bool, clock clock.Clock) (*ConfigRetriever, *mockRCClient) {
+func newMockConfigRetriever(t *testing.T, isLeader func() bool, store *store, clock clock.WithTicker) (*ConfigRetriever, *mockRCClient) {
 	t.Helper()
 
-	store := autoscaling.NewStore[model.PodAutoscalerInternal]()
 	mockRCClient := &mockRCClient{}
 
-	cr, err := NewConfigRetriever(store, func() bool { return isLeader }, mockRCClient)
-	cr.clock = clock
+	cr, err := NewConfigRetriever(context.Background(), clock, store, isLeader, mockRCClient)
 	assert.NoError(t, err)
 
 	return cr, mockRCClient

--- a/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
@@ -28,21 +28,28 @@ import (
 )
 
 type autoscalingValuesProcessor struct {
-	store     *store
-	processed map[string]struct{}
+	store *store
+
+	processed           map[string]struct{}
+	lastProcessingError bool
 }
 
 func newAutoscalingValuesProcessor(store *store) autoscalingValuesProcessor {
 	return autoscalingValuesProcessor{
-		store:     store,
-		processed: make(map[string]struct{}),
+		store: store,
 	}
 }
 
-func (p autoscalingValuesProcessor) process(receivedTimestamp time.Time, configKey string, rawConfig state.RawConfig) error {
+func (p *autoscalingValuesProcessor) preProcess() {
+	p.processed = make(map[string]struct{}, len(p.processed))
+	p.lastProcessingError = false
+}
+
+func (p *autoscalingValuesProcessor) process(receivedTimestamp time.Time, configKey string, rawConfig state.RawConfig) error {
 	valuesList := &kubeAutoscaling.WorkloadValuesList{}
 	err := json.Unmarshal(rawConfig.Config, &valuesList)
 	if err != nil {
+		p.lastProcessingError = true
 		return fmt.Errorf("failed to unmarshal config id:%s, version: %d, config key: %s, err: %v", rawConfig.Metadata.ID, rawConfig.Metadata.Version, configKey, err)
 	}
 
@@ -53,10 +60,11 @@ func (p autoscalingValuesProcessor) process(receivedTimestamp time.Time, configK
 		}
 	}
 
+	p.lastProcessingError = err != nil
 	return err
 }
 
-func (p autoscalingValuesProcessor) processValues(values *kubeAutoscaling.WorkloadValues, timestamp time.Time) error {
+func (p *autoscalingValuesProcessor) processValues(values *kubeAutoscaling.WorkloadValues, timestamp time.Time) error {
 	if values == nil || values.Namespace == "" || values.Name == "" {
 		// Should never happen, but protecting the code from invalid inputs
 		return nil
@@ -142,10 +150,10 @@ func (p autoscalingValuesProcessor) processValues(values *kubeAutoscaling.Worklo
 	return nil
 }
 
-func (p autoscalingValuesProcessor) postProcess(errors []error) {
+func (p *autoscalingValuesProcessor) postProcess() {
 	// We don't want to delete configs if we received incorrect data
-	if len(errors) > 0 {
-		log.Debugf("Skipping autoscaling values clean up due to errors while processing new data: %v", errors)
+	if p.lastProcessingError {
+		log.Debugf("Skipping autoscaling values clean up due to errors while processing new data")
 		return
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -78,6 +78,7 @@ type Controller struct {
 
 // NewController returns a new workload autoscaling controller
 func NewController(
+	clock clock.Clock,
 	clusterID string,
 	eventRecorder record.EventRecorder,
 	restMapper apimeta.RESTMapper,
@@ -92,7 +93,7 @@ func NewController(
 ) (*Controller, error) {
 	c := &Controller{
 		clusterID:         clusterID,
-		clock:             clock.RealClock{},
+		clock:             clock,
 		eventRecorder:     eventRecorder,
 		localSender:       localSender,
 		isFallbackEnabled: false, // keep fallback disabled by default

--- a/pkg/clusteragent/autoscaling/workload/controller_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_test.go
@@ -52,7 +52,7 @@ func newFixture(t *testing.T, testTime time.Time) *fixture {
 		ControllerFixture: autoscaling.NewFixture(
 			t, podAutoscalerGVR,
 			func(fakeClient *fake.FakeDynamicClient, informer dynamicinformer.DynamicSharedInformerFactory, isLeader func() bool) (*autoscaling.Controller, error) {
-				c, err := NewController("cluster-id1", recorder, nil, nil, fakeClient, informer, isLeader, store, nil, nil, hashHeap)
+				c, err := NewController(clock, "cluster-id1", recorder, nil, nil, fakeClient, informer, isLeader, store, nil, nil, hashHeap)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/clusteragent/autoscaling/workload/local/recommender.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/utils/clock"
+
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/loadstore"
@@ -30,8 +32,8 @@ type Recommender struct {
 }
 
 // NewRecommender creates a new Recommender to start generating local recommendations
-func NewRecommender(podWatcher workload.PodWatcher, store *autoscaling.Store[model.PodAutoscalerInternal]) *Recommender {
-	replicaCalculator := newReplicaCalculator(podWatcher)
+func NewRecommender(clock clock.Clock, podWatcher workload.PodWatcher, store *autoscaling.Store[model.PodAutoscalerInternal]) *Recommender {
+	replicaCalculator := newReplicaCalculator(clock, podWatcher)
 
 	return &Recommender{
 		replicaCalculator: replicaCalculator,

--- a/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/recommender_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/clock"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 
@@ -54,7 +55,7 @@ func TestProcessScaleUp(t *testing.T) {
 	assert.Len(t, queryResult.Results, 1)
 
 	// test
-	recommender := NewRecommender(pw, store)
+	recommender := NewRecommender(clock.RealClock{}, pw, store)
 	recommender.process(ctx)
 	pai, found := store.Get("default/autoscaler1")
 	assert.True(t, found)
@@ -118,7 +119,7 @@ func TestProcessScaleDown(t *testing.T) {
 	assert.Len(t, queryResult.Results, 3)
 
 	// test
-	recommender := NewRecommender(pw, store)
+	recommender := NewRecommender(clock.RealClock{}, pw, store)
 	recommender.process(ctx)
 	pai, found := store.Get("default/autoscaler1")
 	assert.True(t, found)

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator.go
@@ -42,10 +42,10 @@ type utilizationResult struct {
 	recommendationTimestamp time.Time
 }
 
-func newReplicaCalculator(podWatcher workload.PodWatcher) replicaCalculator {
+func newReplicaCalculator(clock clock.Clock, podWatcher workload.PodWatcher) replicaCalculator {
 	return replicaCalculator{
 		podWatcher: podWatcher,
-		clock:      clock.RealClock{},
+		clock:      clock,
 	}
 }
 

--- a/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/local/replica_calculator_test.go
@@ -17,6 +17,7 @@ import (
 
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
@@ -1606,7 +1607,7 @@ func TestCalculateHorizontalRecommendationsScaleUp(t *testing.T) {
 	}
 	dpai := model.NewPodAutoscalerInternal(dpa)
 
-	r := newReplicaCalculator(pw)
+	r := newReplicaCalculator(clock.RealClock{}, pw)
 	res, err := r.calculateHorizontalRecommendations(dpai, lStore)
 	assert.NoError(t, err)
 	assert.Equal(t, int32(2), res.Replicas)

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/clock"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
@@ -52,7 +53,8 @@ func StartWorkloadAutoscaling(
 	podPatcher := workload.NewPodPatcher(store, isLeaderFunc, apiCl.DynamicCl, eventRecorder)
 	podWatcher := workload.NewPodWatcher(wlm, podPatcher)
 
-	_, err := workload.NewConfigRetriever(store, isLeaderFunc, rcClient)
+	clock := clock.RealClock{}
+	_, err := workload.NewConfigRetriever(ctx, clock, store, isLeaderFunc, rcClient)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start workload autoscaling config retriever: %w", err)
 	}
@@ -66,7 +68,7 @@ func StartWorkloadAutoscaling(
 
 	limitHeap := autoscaling.NewHashHeap(maxDatadogPodAutoscalerObjects, store)
 
-	controller, err := workload.NewController(clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap)
+	controller, err := workload.NewController(clock, clusterID, eventRecorder, apiCl.RESTMapper, apiCl.ScaleCl, apiCl.DynamicInformerCl, apiCl.DynamicInformerFactory, isLeaderFunc, store, podWatcher, sender, limitHeap)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to start workload autoscaling controller: %w", err)
 	}
@@ -81,7 +83,7 @@ func StartWorkloadAutoscaling(
 
 	// Only start the local recommender if failover metrics collection is enabled
 	if pkgconfigsetup.Datadog().GetBool("autoscaling.failover.enabled") {
-		localRecommender := local.NewRecommender(podWatcher, store)
+		localRecommender := local.NewRecommender(clock, podWatcher, store)
 		go localRecommender.Run(ctx)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Modify the Autoscaling config retriever to store desired state and reconcile it every 5m against what's in the store. That allows non-leader to store the desired state and make sure no update is forgotten (until a Cluster Agent restart).

### Motivation

Improve reliability.

### Describe how you validated your changes

Non-regression testing internally.
Testing the edge case live is hard as it requires to time both a Remote Config update and a leader change.

### Possible Drawbacks / Trade-offs

It will trigger reconcile of all remote DPA every 5m, but should be mostly no-op (and we have a re-queue of 5m anyway)

### Additional Notes