### PR TITLE
[serverless] Implement periodic flushing strategy

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -233,6 +233,10 @@ func configureAdaptiveFlush(serverlessDaemon *daemon.Daemon) {
 		} else {
 			serverlessDaemon.UseAdaptiveFlush(false) // we're forcing the flush strategy, we won't be using the adaptive flush
 			serverlessDaemon.SetFlushStrategy(flushStrategy)
+
+			if fs, ok := flushStrategy.(*flush.Periodically); ok {
+				serverlessDaemon.StartPeriodicFlusher(fs.Interval)
+			}
 		}
 	} else {
 		serverlessDaemon.UseAdaptiveFlush(true) // already initialized to true, but let's be explicit just in case

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -60,6 +60,9 @@ type Daemon struct {
 	// through configuration.
 	useAdaptiveFlush bool
 
+	// periodicFlushStop is used to stop the background flusher loop when the daemon stops
+	periodicFlushStop chan struct{}
+
 	// Stopped represents whether the Daemon has been Stopped
 	Stopped bool
 
@@ -338,6 +341,11 @@ func (d *Daemon) Stop() {
 
 	if d.logCollector != nil {
 		d.logCollector.Shutdown()
+	}
+
+	// Close periodic flushing channel
+	if d.periodicFlushStop != nil {
+		close(d.periodicFlushStop)
 	}
 
 	// Once the HTTP server is shut down, it is safe to shut down the agents

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -120,6 +120,11 @@ func (s *Periodically) String() string {
 
 // ShouldFlush returns true if this strategy want to flush at the given moment.
 func (s *Periodically) ShouldFlush(moment Moment, t time.Time) bool {
+	if moment == Stopping {
+		// Always flush at the end of the invocation so that any logs arriving near shutdown are sent.
+		return true
+	}
+
 	if moment == Starting && !globalRetryState.shouldWaitBackoff(t) {
 		if s.lastFlush.Add(s.Interval).Before(t) {
 			s.lastFlush = t

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -105,24 +105,23 @@ func (s *AtTheEnd) Success() {
 // Periodically is the strategy flushing at least every N [nano/micro/milli]seconds
 // at the start of the function.
 type Periodically struct {
-	interval  time.Duration
+	Interval  time.Duration
 	lastFlush time.Time
 }
 
 // NewPeriodically returns an initialized Periodically flush strategy.
 func NewPeriodically(interval time.Duration) *Periodically {
-	return &Periodically{interval: interval}
+	return &Periodically{Interval: interval}
 }
 
 func (s *Periodically) String() string {
-	return fmt.Sprintf("periodically,%d", s.interval/time.Millisecond)
+	return fmt.Sprintf("periodically,%d", s.Interval/time.Millisecond)
 }
 
 // ShouldFlush returns true if this strategy want to flush at the given moment.
 func (s *Periodically) ShouldFlush(moment Moment, t time.Time) bool {
 	if moment == Starting && !globalRetryState.shouldWaitBackoff(t) {
-		// Periodically strategy will not flush anyway if the s.interval didn't pass
-		if s.lastFlush.Add(s.interval).Before(t) {
+		if s.lastFlush.Add(s.Interval).Before(t) {
 			s.lastFlush = t
 			return true
 		}

--- a/pkg/serverless/flush/strategy.go
+++ b/pkg/serverless/flush/strategy.go
@@ -120,12 +120,8 @@ func (s *Periodically) String() string {
 
 // ShouldFlush returns true if this strategy want to flush at the given moment.
 func (s *Periodically) ShouldFlush(moment Moment, t time.Time) bool {
-	if moment == Stopping {
-		// Always flush at the end of the invocation so that any logs arriving near shutdown are sent.
-		return true
-	}
-
 	if moment == Starting && !globalRetryState.shouldWaitBackoff(t) {
+		// Periodically strategy will not flush anyway if the s.interval didn't pass
 		if s.lastFlush.Add(s.Interval).Before(t) {
 			s.lastFlush = t
 			return true

--- a/pkg/serverless/flush/strategy_test.go
+++ b/pkg/serverless/flush/strategy_test.go
@@ -27,7 +27,7 @@ func TestPeriodically(t *testing.T) {
 	assert := assert.New(t)
 
 	// flush should happen at least every 2 second
-	s := &Periodically{interval: 2 * time.Second}
+	s := &Periodically{Interval: 2 * time.Second}
 	s.lastFlush = time.Now().Add(-time.Second * 10)
 
 	assert.True(s.ShouldFlush(Starting, time.Now()), "it should flush because last flush was 10 seconds ago")
@@ -48,22 +48,22 @@ func TestStrategyFromString(t *testing.T) {
 
 	s, err = StrategyFromString("periodically")
 	assert.Equal("periodically,10000", s.String())
-	assert.Equal(s.(*Periodically).interval, 10*time.Second, "default value should be 10s")
+	assert.Equal(s.(*Periodically).Interval, 10*time.Second, "default value should be 10s")
 	assert.NoError(err, "parsing this string shouldn't fail")
 
 	s, err = StrategyFromString("periodically,10000")
 	assert.Equal("periodically,10000", s.String())
-	assert.Equal(s.(*Periodically).interval, 10*time.Second, "default value should be 10s")
+	assert.Equal(s.(*Periodically).Interval, 10*time.Second, "default value should be 10s")
 	assert.NoError(err, "parsing this string shouldn't fail")
 
 	s, err = StrategyFromString("periodically,2000")
 	assert.Equal("periodically,2000", s.String())
-	assert.Equal(s.(*Periodically).interval, 2*time.Second, "should be 2s")
+	assert.Equal(s.(*Periodically).Interval, 2*time.Second, "should be 2s")
 	assert.NoError(err, "parsing this string shouldn't fail")
 
 	s, err = StrategyFromString("periodically,4789")
 	assert.Equal("periodically,4789", s.String())
-	assert.Equal(s.(*Periodically).interval, 4789*time.Millisecond, "should be 4.789s")
+	assert.Equal(s.(*Periodically).Interval, 4789*time.Millisecond, "should be 4.789s")
 	assert.NoError(err, "parsing this string shouldn't fail")
 
 	s, err = StrategyFromString("ddog")

--- a/pkg/serverless/flush/strategy_test.go
+++ b/pkg/serverless/flush/strategy_test.go
@@ -119,3 +119,13 @@ func TestMaxBackoff(t *testing.T) {
 		sEnd.Success() // reset global var
 	})
 }
+
+func TestPeriodicallyStategyFlushesAtStopping(t *testing.T) {
+	assert := assert.New(t)
+
+	s := &Periodically{Interval: 2 * time.Second}
+	s.lastFlush = time.Now().Add(-1 * time.Second)
+
+	assert.False(s.ShouldFlush(Starting, time.Now()), "At Starting, flush should not occur if the interval hasn't passed")
+	assert.True(s.ShouldFlush(Stopping, time.Now()), "At Stopping, flush should always occur regardless of the interval")
+}

--- a/releasenotes/notes/serverless-implement-periodic-flushing-strategy-9d98ccf97d3b777a.yaml
+++ b/releasenotes/notes/serverless-implement-periodic-flushing-strategy-9d98ccf97d3b777a.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Implement periodic flushing strategy in the compatibility-version Lambda extension.
+    This can be enabled with the `DD_SERVERLESS_FLUSH_STRATEGY: periodically,<period in ms>` environment variable.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Implements periodic flushing strategy for when user has the environment variable `DD_SERVERLESS_FLUSH_STRATEGY = periodically,<time in ms>`

Somehow this was never implemented here.

If we detect a periodic flushing strategy, we start a Go channel and flush every `<interval>` milliseconds.

### Motivation

This feature is implemented in [Bottlecap](https://github.com/DataDog/datadog-lambda-extension/tree/main/bottlecap); this backports it to the compatibility-version lambda extension.

Some customers want to use this feature, but are falling back to the Go Lambda extension because of features that are missing in Bottlecap, such as appsec.

Prior to this change, the Lambda extension only flushes at the start and end of the Lambda invocation, since most Lambda invocations are very short. However, for long-running Lambdas, customers must set this `DD_SERVERLESS_FLUSH_STRATEGY = periodically,<time>` environment variable if they want to see their logs in Datadog in live tail during the invocation.

Since this was never implemented, the `DD_SERVERLESS_FLUSH_STRATEGY` did nothing before this.

### Describe how you validated your changes
Manual testing:
- Before, logs were only flushed at the start and end of the lambda invocation
- Now, logs are flushed periodically as expected and logs are visible in the live tail even before the Lambda has finished executing.

added a unit test

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->