### PR TITLE
AGNTLOG-4 - implement RTT fairness in the log pipeline destination senders

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -418,12 +418,12 @@ func newHTTPPassthroughPipeline(
 	reliable := []client.Destination{}
 	for i, endpoint := range endpoints.GetReliableEndpoints() {
 		destMeta := client.NewDestinationMetadata(desc.eventType, pipelineMonitor.ID(), "reliable", strconv.Itoa(i))
-		reliable = append(reliable, logshttp.NewDestination(endpoint, desc.contentType, destinationsContext, endpoints.BatchMaxConcurrentSend, true, destMeta, pkgconfigsetup.Datadog(), pipelineMonitor))
+		reliable = append(reliable, logshttp.NewDestination(endpoint, desc.contentType, destinationsContext, true, destMeta, pkgconfigsetup.Datadog(), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
 	}
 	additionals := []client.Destination{}
 	for i, endpoint := range endpoints.GetUnReliableEndpoints() {
 		destMeta := client.NewDestinationMetadata(desc.eventType, pipelineMonitor.ID(), "unreliable", strconv.Itoa(i))
-		additionals = append(additionals, logshttp.NewDestination(endpoint, desc.contentType, destinationsContext, endpoints.BatchMaxConcurrentSend, false, destMeta, pkgconfigsetup.Datadog(), pipelineMonitor))
+		additionals = append(additionals, logshttp.NewDestination(endpoint, desc.contentType, destinationsContext, false, destMeta, pkgconfigsetup.Datadog(), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
 	}
 	destinations := client.NewDestinations(reliable, additionals)
 	inputChan := make(chan *message.Message, endpoints.InputChanSize)

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -56,6 +56,11 @@ var (
 //nolint:revive // TODO(AML) Fix revive linter
 var emptyJsonPayload = message.Payload{MessageMetas: []*message.MessageMetadata{}, Encoded: []byte("{}")}
 
+type destinationResult struct {
+	latency time.Duration
+	err     error
+}
+
 // Destination sends a payload over HTTP.
 type Destination struct {
 	// Config
@@ -70,8 +75,8 @@ type Destination struct {
 	isMRF               bool
 
 	// Concurrency
-	climit chan struct{} // semaphore for limiting concurrent background sends
-	wg     sync.WaitGroup
+	workerPool *workerPool
+	wg         sync.WaitGroup
 
 	// Retry
 	backoff        backoff.Policy
@@ -88,26 +93,28 @@ type Destination struct {
 }
 
 // NewDestination returns a new Destination.
-// If `maxConcurrentBackgroundSends` > 0, then at most that many background payloads will be sent concurrently, else
-// there is no concurrency and the background sending pipeline will block while sending each payload.
+// minConcurrency denotes the minimum number of concurrent http requests the pipeline will allow at once.
+// maxConcurrency represents the maximum number of concurrent http requests, reachable when the client is experiencing a large latency in sends.
 // TODO: add support for SOCKS5
 func NewDestination(endpoint config.Endpoint,
 	contentType string,
 	destinationsContext *client.DestinationsContext,
-	maxConcurrentBackgroundSends int,
 	shouldRetry bool,
 	destMeta *client.DestinationMetadata,
 	cfg pkgconfigmodel.Reader,
+	minConcurrency int,
+	maxConcurrency int,
 	pipelineMonitor metrics.PipelineMonitor) *Destination {
 
 	return newDestination(endpoint,
 		contentType,
 		destinationsContext,
 		time.Second*10,
-		maxConcurrentBackgroundSends,
 		shouldRetry,
 		destMeta,
 		cfg,
+		minConcurrency,
+		maxConcurrency,
 		pipelineMonitor)
 }
 
@@ -115,15 +122,13 @@ func newDestination(endpoint config.Endpoint,
 	contentType string,
 	destinationsContext *client.DestinationsContext,
 	timeout time.Duration,
-	maxConcurrentBackgroundSends int,
 	shouldRetry bool,
 	destMeta *client.DestinationMetadata,
 	cfg pkgconfigmodel.Reader,
+	minConcurrency int,
+	maxConcurrency int,
 	pipelineMonitor metrics.PipelineMonitor) *Destination {
 
-	if maxConcurrentBackgroundSends <= 0 {
-		maxConcurrentBackgroundSends = 1
-	}
 	policy := backoff.NewExpBackoffPolicy(
 		endpoint.BackoffFactor,
 		endpoint.BackoffBase,
@@ -140,6 +145,8 @@ func newDestination(endpoint config.Endpoint,
 		metrics.DestinationExpVars.Set(destMeta.TelemetryName(), expVars)
 	}
 
+	workerPool := newDefaultWorkerPool(minConcurrency, maxConcurrency, destMeta)
+
 	return &Destination{
 		host:                endpoint.Host,
 		url:                 buildURL(endpoint),
@@ -147,7 +154,7 @@ func newDestination(endpoint config.Endpoint,
 		contentType:         contentType,
 		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(timeout, cfg)),
 		destinationsContext: destinationsContext,
-		climit:              make(chan struct{}, maxConcurrentBackgroundSends),
+		workerPool:          workerPool,
 		wg:                  sync.WaitGroup{},
 		backoff:             policy,
 		protocol:            endpoint.Protocol,
@@ -222,20 +229,16 @@ func (d *Destination) run(input chan *message.Payload, output chan *message.Payl
 
 func (d *Destination) sendConcurrent(payload *message.Payload, output chan *message.Payload, isRetrying chan bool) {
 	d.wg.Add(1)
-	d.climit <- struct{}{}
-	go func() {
-		defer func() {
-			<-d.climit
-			d.wg.Done()
-		}()
-		d.sendAndRetry(payload, output, isRetrying)
-	}()
+	d.workerPool.run(func() destinationResult {
+		result := d.sendAndRetry(payload, output, isRetrying)
+		d.wg.Done()
+		return result
+	})
 }
 
 // Send sends a payload over HTTP,
-func (d *Destination) sendAndRetry(payload *message.Payload, output chan *message.Payload, isRetrying chan bool) {
+func (d *Destination) sendAndRetry(payload *message.Payload, output chan *message.Payload, isRetrying chan bool) destinationResult {
 	for {
-
 		d.retryLock.Lock()
 		nbErrors := d.nbErrors
 		d.retryLock.Unlock()
@@ -249,7 +252,13 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 			metrics.TlmRetryCount.Add(1)
 		}
 
+		start := time.Now()
 		err := d.unconditionalSend(payload)
+		latency := time.Since(start)
+		result := destinationResult{
+			latency: latency,
+			err:     err,
+		}
 
 		if err != nil {
 			metrics.DestinationErrors.Add(1)
@@ -265,7 +274,7 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 
 		if err == context.Canceled {
 			d.updateRetryState(nil, isRetrying)
-			return
+			return result
 		}
 
 		if d.shouldRetry {
@@ -277,7 +286,7 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 		metrics.LogsSent.Add(payload.Count())
 		metrics.TlmLogsSent.Add(float64(payload.Count()))
 		output <- payload
-		return
+		return result
 	}
 }
 
@@ -322,7 +331,6 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 
 	req = req.WithContext(ctx)
 	resp, err := d.client.Do(req)
-
 	latency := time.Since(then).Milliseconds()
 	metrics.TlmSenderLatency.Observe(float64(latency))
 	metrics.SenderLatency.Set(latency)
@@ -460,7 +468,8 @@ func getMessageTimestamp(messages []*message.MessageMetadata) int64 {
 func prepareCheckConnectivity(endpoint config.Endpoint, cfg pkgconfigmodel.Reader) (*client.DestinationsContext, *Destination) {
 	ctx := client.NewDestinationsContext()
 	// Lower the timeout to 5s because HTTP connectivity test is done synchronously during the agent bootstrap sequence
-	destination := newDestination(endpoint, JSONContentType, ctx, time.Second*5, 0, false, client.NewNoopDestinationMetadata(), cfg, metrics.NewNoopPipelineMonitor(""))
+	destination := newDestination(endpoint, JSONContentType, ctx, time.Second*5, false, client.NewNoopDestinationMetadata(), cfg, 1, 1, metrics.NewNoopPipelineMonitor(""))
+
 	return ctx, destination
 }
 

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -95,7 +95,7 @@ func testNoRetry(t *testing.T, statusCode int) {
 func retryTest(t *testing.T, statusCode int) {
 	cfg := configmock.New(t)
 	respondChan := make(chan int)
-	server := NewTestServerWithOptions(statusCode, 0, true, respondChan, cfg)
+	server := NewTestServerWithOptions(statusCode, 1, true, respondChan, cfg)
 	input := make(chan *message.Payload)
 	output := make(chan *message.Payload)
 	isRetrying := make(chan bool, 1)
@@ -125,7 +125,7 @@ func retryTest(t *testing.T, statusCode int) {
 func TestDestinationContextCancel(t *testing.T) {
 	cfg := configmock.New(t)
 	respondChan := make(chan int)
-	server := NewTestServerWithOptions(429, 0, true, respondChan, cfg)
+	server := NewTestServerWithOptions(429, 1, true, respondChan, cfg)
 	input := make(chan *message.Payload)
 	output := make(chan *message.Payload)
 	isRetrying := make(chan bool, 1)
@@ -329,7 +329,7 @@ func TestDestinationConcurrentSendsShutdownIsHandled(t *testing.T) {
 func TestBackoffDelayEnabled(t *testing.T) {
 	cfg := configmock.New(t)
 	respondChan := make(chan int)
-	server := NewTestServerWithOptions(500, 0, true, respondChan, cfg)
+	server := NewTestServerWithOptions(500, 1, true, respondChan, cfg)
 	input := make(chan *message.Payload)
 	output := make(chan *message.Payload)
 	isRetrying := make(chan bool, 1)
@@ -346,7 +346,7 @@ func TestBackoffDelayEnabled(t *testing.T) {
 func TestBackoffDelayDisabled(t *testing.T) {
 	cfg := configmock.New(t)
 	respondChan := make(chan int)
-	server := NewTestServerWithOptions(500, 0, false, respondChan, cfg)
+	server := NewTestServerWithOptions(500, 1, false, respondChan, cfg)
 	input := make(chan *message.Payload)
 	output := make(chan *message.Payload)
 	isRetrying := make(chan bool, 1)
@@ -367,7 +367,7 @@ func TestDestinationHA(t *testing.T) {
 		}
 		isEndpointMRF := endpoint.IsMRF
 
-		dest := NewDestination(endpoint, JSONContentType, client.NewDestinationsContext(), 1, false, client.NewNoopDestinationMetadata(), configmock.New(t), metrics.NewNoopPipelineMonitor(""))
+		dest := NewDestination(endpoint, JSONContentType, client.NewDestinationsContext(), false, client.NewNoopDestinationMetadata(), configmock.New(t), 1, 1, metrics.NewNoopPipelineMonitor(""))
 		isDestMRF := dest.IsMRF()
 
 		assert.Equal(t, isEndpointMRF, isDestMRF)

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -26,15 +26,19 @@ type SyncDestination struct {
 }
 
 // NewSyncDestination returns a new synchronous Destination.
-func NewSyncDestination(endpoint config.Endpoint,
+func NewSyncDestination(
+	endpoint config.Endpoint,
 	contentType string,
 	destinationsContext *client.DestinationsContext,
 	senderDoneChan chan *sync.WaitGroup,
 	destMeta *client.DestinationMetadata,
-	cfg pkgconfigmodel.Reader) *SyncDestination {
+	cfg pkgconfigmodel.Reader,
+) *SyncDestination {
+	minConcurrency := 1
+	maxConcurrency := minConcurrency
 
 	return &SyncDestination{
-		destination:    newDestination(endpoint, contentType, destinationsContext, time.Second*10, 1, false, destMeta, cfg, metrics.NewNoopPipelineMonitor("0")),
+		destination:    newDestination(endpoint, contentType, destinationsContext, time.Second*10, false, destMeta, cfg, minConcurrency, maxConcurrency, metrics.NewNoopPipelineMonitor("0")),
 		senderDoneChan: senderDoneChan,
 	}
 }

--- a/pkg/logs/client/http/test_utils.go
+++ b/pkg/logs/client/http/test_utils.go
@@ -39,11 +39,11 @@ type TestServer struct {
 
 // NewTestServer creates a new test server
 func NewTestServer(statusCode int, cfg pkgconfigmodel.Reader) *TestServer {
-	return NewTestServerWithOptions(statusCode, 0, true, nil, cfg)
+	return NewTestServerWithOptions(statusCode, 1, true, nil, cfg)
 }
 
 // NewTestServerWithOptions creates a new test server with concurrency and response control
-func NewTestServerWithOptions(statusCode int, senders int, retryDestination bool, respondChan chan int, cfg pkgconfigmodel.Reader) *TestServer {
+func NewTestServerWithOptions(statusCode int, concurrentSends int, retryDestination bool, respondChan chan int, cfg pkgconfigmodel.Reader) *TestServer {
 	statusCodeContainer := &StatusCodeContainer{statusCode: statusCode}
 	var request http.Request
 	var mu = sync.Mutex{}
@@ -82,7 +82,7 @@ func NewTestServerWithOptions(statusCode int, senders int, retryDestination bool
 	endpoint.BackoffMax = 10
 	endpoint.RecoveryInterval = 1
 
-	dest := NewDestination(endpoint, JSONContentType, destCtx, senders, retryDestination, client.NewNoopDestinationMetadata(), cfg, metrics.NewNoopPipelineMonitor(""))
+	dest := NewDestination(endpoint, JSONContentType, destCtx, retryDestination, client.NewNoopDestinationMetadata(), cfg, concurrentSends, concurrentSends, metrics.NewNoopPipelineMonitor(""))
 	return &TestServer{
 		httpServer:          ts,
 		DestCtx:             destCtx,

--- a/pkg/logs/client/http/worker_pool.go
+++ b/pkg/logs/client/http/worker_pool.go
@@ -1,0 +1,197 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package http provides an HTTP destination for logs.
+package http
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	ewmaAlpha                           = 0.064
+	concurrentSendersEwmaSampleInterval = 1 * time.Second
+	targetLatency                       = 150 * time.Millisecond
+)
+
+// workerPool is an struct for managing the concurrency of destinations.
+type workerPool struct {
+	pool chan struct{}
+
+	// virtualLatency is an ewma (exponentially weighted moving average) of the calculated latency seen by the pool
+	virtualLatency time.Duration
+	// ewmaSampleInterval is the interval over which the virtual latency is calculated.
+	ewmaSampleInterval time.Duration
+	// alpha is the alpha value for the ewma calculation.
+	alpha float64
+
+	// targetLatencyPerWorker is a runtime constant used to generate a target number of workers for a given virtual latency.
+	targetLatencyPerWorker time.Duration
+
+	inUseWorkers int
+
+	// If minWorkers == maxWorkers, there are no latency calculations and no dynamic scaling.
+	minWorkers int
+	maxWorkers int
+
+	destMeta *client.DestinationMetadata
+
+	// windowSum is the sum of the latencies seen by the pool over the current ewmaSampleInterval.
+	windowSum float64
+	// samples is the number of samples taken over the current ewmaSampleInterval.
+	samples int
+	// shouldBackoff, if true, will reset the virtual latency to 0 and drop workers to the minWorkers count.
+	shouldBackoff bool
+	// virtualLatencyLastSample is the time of the last sample taken for the virtual latency calculation.
+	virtualLatencyLastSample time.Time
+
+	sync.Mutex
+}
+
+// newDefaultWorkerPool returns a new workerPool implementation that limits the number of concurrent destination jobs.
+// It will supply production appropriate default values for fields such as targetLatency.
+func newDefaultWorkerPool(minWorkers int, maxWorkers int, destMeta *client.DestinationMetadata) *workerPool {
+	return newWorkerPool(
+		concurrentSendersEwmaSampleInterval,
+		ewmaAlpha,
+		minWorkers,
+		maxWorkers,
+		targetLatency,
+		destMeta,
+	)
+}
+
+// newWorkerPool returns a new workerPool implementation that limits the number of concurrent destination jobs.
+// targetLatency is divided by the minWorker count to generate the targetLatencyPerWorker value.
+// Example: if the targetLatency is 150ms and the minWorkers is 4, the targetLatencyPerWorker will be 37.5ms
+// If the virtualLatency is 300ms, the inUseWorkers will converge on 8.
+// If the virtualLatency is 75ms, the inUseWorkers will converge on 4 (the value of minWorkers).
+func newWorkerPool(
+	ewmaSampleInterval time.Duration,
+	alpha float64,
+	minWorkers int,
+	maxWorkers int,
+	targetLatency time.Duration,
+	destMeta *client.DestinationMetadata,
+) *workerPool {
+	if minWorkers <= 0 {
+		minWorkers = 1
+	}
+	if maxWorkers < minWorkers {
+		maxWorkers = minWorkers
+	}
+	targetLatencyPerWorker := targetLatency / time.Duration(minWorkers)
+
+	sp := &workerPool{
+		pool:                     make(chan struct{}, maxWorkers),
+		minWorkers:               minWorkers,
+		maxWorkers:               maxWorkers,
+		targetLatencyPerWorker:   targetLatencyPerWorker,
+		virtualLatencyLastSample: time.Now(),
+		inUseWorkers:             minWorkers,
+		destMeta:                 destMeta,
+		samples:                  0,
+		ewmaSampleInterval:       ewmaSampleInterval,
+		alpha:                    alpha,
+	}
+	// Start with minWorker senders
+	for range minWorkers {
+		sp.pool <- struct{}{}
+	}
+	return sp
+}
+
+// run starts the doWork task in the pool. Will block if there are no
+// workers available to pick up the task.
+//
+// This function is not concurrency safe and should not be called in a separate goroutine.
+func (l *workerPool) run(doWork func() destinationResult) {
+	l.resizeUnsafe()
+	<-l.pool
+	go func() {
+		result := doWork()
+		l.pool <- struct{}{}
+
+		if l.maxWorkers == l.minWorkers {
+			// If we can't change the worker count there's no point in adjusting latency calcs.
+			return
+		}
+		l.Lock()
+		defer l.Unlock()
+		if result.err != nil {
+			// We only want to trigger a backoff for retryable errors. Issues such as
+			// server 400s should effectively freeze the pipeline pending a resolution.
+			_, ok := result.err.(*client.RetryableError)
+			l.shouldBackoff = l.shouldBackoff || ok
+			return
+		}
+
+		l.windowSum += float64(result.latency)
+		l.samples++
+	}()
+}
+
+// Concurrency is scaled by attempting to converge on a target virtual latency.
+// Virtual latency is the amount of time it takes to submit a payload to the worker pool.
+// If Latency is above the target, more workers are added to the pool until the virtual latency is reached.
+// This ensures the payload egress rate remains fair no matter how long the HTTP transaction takes
+// (up to maxWorkers)
+//
+// This function is not concurrency safe and should not be called outside of the run function.
+func (l *workerPool) resizeUnsafe() {
+	if l.maxWorkers == l.minWorkers {
+		// We can't resize, no variability in worker count allowed.
+		return
+	}
+
+	if time.Since(l.virtualLatencyLastSample) >= l.ewmaSampleInterval {
+		l.Lock()
+		windowSum := l.windowSum
+		samples := l.samples
+		l.windowSum = 0
+		l.samples = 0
+		shouldBackoff := l.shouldBackoff
+		l.shouldBackoff = false
+		l.Unlock()
+
+		if samples > 0 {
+			avgLatency := windowSum / float64(samples)
+			l.virtualLatency = time.Duration(float64(l.virtualLatency)*(1.0-ewmaAlpha) + (avgLatency * ewmaAlpha))
+			l.virtualLatencyLastSample = time.Now()
+		}
+
+		targetWorkers := int(math.Ceil(float64(l.virtualLatency) / float64(l.targetLatencyPerWorker)))
+
+		if shouldBackoff {
+			metrics.TlmDestWorkerResets.Add(1, l.destMeta.TelemetryName())
+			log.Debugf("Backing off sender pool workers in response to transient connection issues with destination.")
+			// Backoff quickly on sender error
+			l.virtualLatency = 0
+			workersToDrop := l.inUseWorkers - l.minWorkers
+			for i := 0; i < workersToDrop; i++ {
+				<-l.pool
+				l.inUseWorkers--
+			}
+		} else if targetWorkers > l.inUseWorkers && l.inUseWorkers < l.maxWorkers {
+			// If the virtual latency is above the target, add a worker to the pool.
+			l.pool <- struct{}{}
+			l.inUseWorkers++
+		} else if targetWorkers < l.inUseWorkers && l.inUseWorkers > l.minWorkers {
+			// else if the virtual latency is below the target, remove a worker from the pool if there is more than minWorkers.
+			<-l.pool
+			l.inUseWorkers--
+		}
+
+		metrics.TlmDestNumWorkers.Set(float64(l.inUseWorkers), l.destMeta.TelemetryName())
+		metrics.TlmDestVirtualLatency.Set(float64(l.virtualLatency/time.Millisecond), l.destMeta.TelemetryName())
+		log.Debugf("Pool worker count at {%d} after resize, with virtual latency %s", l.inUseWorkers, l.virtualLatency)
+	}
+}

--- a/pkg/logs/client/http/worker_pool_test.go
+++ b/pkg/logs/client/http/worker_pool_test.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package http
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+)
+
+var defaultMinWorkers = 4
+var defaultMaxWorkers = defaultMinWorkers * 10
+
+func defaultPool() *workerPool {
+	return newWorkerPool(0, ewmaAlpha, defaultMinWorkers, defaultMaxWorkers, targetLatency, client.NewNoopDestinationMetadata())
+}
+
+func TestRetryableError(t *testing.T) {
+	pool := defaultPool()
+	for i := 0; i < 100; i++ {
+		pool.run(func() destinationResult {
+			return destinationResult{latency: targetLatency * 2}
+		})
+	}
+
+	require.Equal(t, defaultMinWorkers*2, pool.inUseWorkers)
+
+	pool.run(func() destinationResult {
+		return destinationResult{latency: targetLatency * 2, err: client.NewRetryableError(errors.New(""))}
+	})
+
+	start := time.Now()
+
+	pool.Lock()
+	backoff := pool.shouldBackoff
+	pool.Unlock()
+	for !backoff && time.Since(start) < 500*time.Millisecond {
+		time.Sleep(time.Millisecond)
+		pool.Lock()
+		backoff = pool.shouldBackoff
+		pool.Unlock()
+	}
+
+	assert.Equal(t, true, pool.shouldBackoff)
+
+	// The next pool run will detect the backoff flag to
+	// 1. Reduce the worker load to the minimum
+	// 2. Reset the tracked latency to force a gradual increase.
+	pool.run(func() destinationResult {
+		return destinationResult{latency: targetLatency * 2}
+	})
+
+	assert.Equal(t, defaultMinWorkers, pool.inUseWorkers)
+	assert.Equal(t, time.Duration(0), pool.virtualLatency)
+
+	// Confirm that we do in fact recover over time
+	for i := 0; i < 100; i++ {
+		pool.run(func() destinationResult {
+			return destinationResult{latency: targetLatency * 2}
+		})
+	}
+
+	require.Equal(t, defaultMinWorkers*2, pool.inUseWorkers)
+}
+
+func TestNonRetryableError(t *testing.T) {
+	pool := defaultPool()
+	for i := 0; i < 100; i++ {
+		pool.run(func() destinationResult {
+			return destinationResult{latency: targetLatency * 2}
+		})
+	}
+
+	require.Equal(t, defaultMinWorkers*2, pool.inUseWorkers)
+	pool.run(func() destinationResult {
+		return destinationResult{latency: targetLatency * 2, err: errors.New("")}
+	})
+	pool.resizeUnsafe()
+	pool.resizeUnsafe()
+	assert.Equal(t, defaultMinWorkers*2, pool.inUseWorkers)
+}
+
+func TestWorkerCounts(t *testing.T) {
+	scenarios := []struct {
+		name                string
+		latency             time.Duration
+		expectedWorkerCount int
+	}{
+		{
+			name:                "Mininum Workers chosen if latency below target",
+			latency:             0,
+			expectedWorkerCount: defaultMinWorkers,
+		},
+		{
+			name:                "Reasonable number of workers added at higher than target latency",
+			latency:             targetLatency * 2,
+			expectedWorkerCount: defaultMinWorkers * 2,
+		},
+		{
+			name:                "Maximum number of workers not exceeded",
+			latency:             targetLatency * 20,
+			expectedWorkerCount: defaultMaxWorkers,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			pool := defaultPool()
+
+			for i := 0; i < 500; i++ {
+				pool.run(func() destinationResult {
+					return destinationResult{latency: s.latency}
+				})
+			}
+			time.Sleep(10 * time.Millisecond)
+
+			assert.Equal(t, s.expectedWorkerCount, pool.inUseWorkers)
+			assert.Equal(t, s.expectedWorkerCount, len(pool.pool))
+			assert.InDelta(t, s.latency, pool.virtualLatency, float64(time.Millisecond))
+		})
+	}
+}

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -88,9 +88,15 @@ var (
 	TlmUtilizationRatio = telemetry.NewGauge("logs_component_utilization", "ratio", []string{"name", "instance"}, "Gauge of the utilization ratio of a component")
 	// TlmUtilizationItems is the capacity of a component by number of elements
 	// Both the number of items and the number of bytes are aggregated and exposed as a ewma.
-	TlmUtilizationItems = telemetry.NewGauge("logs_component_utilization", "items", []string{"name", "instance"}, "Gauge of the number of items currently held in a component and it's bufferes")
+	TlmUtilizationItems = telemetry.NewGauge("logs_component_utilization", "items", []string{"name", "instance"}, "Gauge of the number of items currently held in a component and its buffers")
 	// TlmUtilizationBytes is the capacity of a component by number of bytes
-	TlmUtilizationBytes = telemetry.NewGauge("logs_component_utilization", "bytes", []string{"name", "instance"}, "Gauge of the number of bytes currently held in a component and it's bufferes")
+	TlmUtilizationBytes = telemetry.NewGauge("logs_component_utilization", "bytes", []string{"name", "instance"}, "Gauge of the number of bytes currently held in a component and its buffers")
+	// TlmDestNumWorkers is the number of destination workers in use.
+	TlmDestNumWorkers = telemetry.NewGauge("logs_destination", "destination_workers", []string{"instance"}, "Gauge of the number of destination workers in use")
+	// TlmDestVirtualLatency is a moving average of the destination's latency.
+	TlmDestVirtualLatency = telemetry.NewGauge("logs_destination", "virtual_latency", []string{"instance"}, "Gauge of the destination's average latency")
+	// TlmDestWorkerResets tracks the count of times the destination worker pool resets the worker count after encountering a retryable error.
+	TlmDestWorkerResets = telemetry.NewCounter("logs_destination", "destination_worker_resets", []string{"instance"}, "Count of times the destination worker pool resets the worker count")
 )
 
 func init() {

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -136,7 +136,7 @@ func getDestinations(endpoints *config.Endpoints, destinationsContext *client.De
 			if serverless {
 				reliable = append(reliable, http.NewSyncDestination(endpoint, http.JSONContentType, destinationsContext, senderDoneChan, destMeta, cfg))
 			} else {
-				reliable = append(reliable, http.NewDestination(endpoint, http.JSONContentType, destinationsContext, endpoints.BatchMaxConcurrentSend, true, destMeta, cfg, pipelineMonitor))
+				reliable = append(reliable, http.NewDestination(endpoint, http.JSONContentType, destinationsContext, true, destMeta, cfg, endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
 			}
 		}
 		for i, endpoint := range endpoints.GetUnReliableEndpoints() {
@@ -144,7 +144,7 @@ func getDestinations(endpoints *config.Endpoints, destinationsContext *client.De
 			if serverless {
 				additionals = append(additionals, http.NewSyncDestination(endpoint, http.JSONContentType, destinationsContext, senderDoneChan, destMeta, cfg))
 			} else {
-				additionals = append(additionals, http.NewDestination(endpoint, http.JSONContentType, destinationsContext, endpoints.BatchMaxConcurrentSend, false, destMeta, cfg, pipelineMonitor))
+				additionals = append(additionals, http.NewDestination(endpoint, http.JSONContentType, destinationsContext, false, destMeta, cfg, endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
 			}
 		}
 		return client.NewDestinations(reliable, additionals)

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -17,14 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
-const (
-	// DefaultWorkerCount - By default most pipelines will only require a single sender worker, as the single worker itself can
-	// concurrently transmit multiple http requests at once. This value is not intended to be configurable, but legacy
-	// usages of the sender will override this value where necessary. If there is a desire to edit the concurrency of the senders
-	// via config, see the BatchMaxConcurrentSend endpoint setting.
-	DefaultWorkerCount = 1
-)
-
 var (
 	tlmPayloadsDropped = telemetry.NewCounterWithOpts("logs_sender", "payloads_dropped", []string{"reliable", "destination"}, "Payloads dropped", telemetry.Options{DefaultMetric: true})
 	tlmMessagesDropped = telemetry.NewCounterWithOpts("logs_sender", "messages_dropped", []string{"reliable", "destination"}, "Messages dropped", telemetry.Options{DefaultMetric: true})

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -17,6 +17,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 )
 
+const (
+	// DefaultWorkerCount - By default most pipelines will only require a single sender worker, as the single worker itself can
+	// concurrently transmit multiple http requests at once. This value is not intended to be configurable, but legacy
+	// usages of the sender will override this value where necessary. If there is a desire to edit the concurrency of the senders
+	// via config, see the BatchMaxConcurrentSend endpoint setting.
+	DefaultWorkerCount = 1
+)
+
 var (
 	tlmPayloadsDropped = telemetry.NewCounterWithOpts("logs_sender", "payloads_dropped", []string{"reliable", "destination"}, "Payloads dropped", telemetry.Options{DefaultMetric: true})
 	tlmMessagesDropped = telemetry.NewCounterWithOpts("logs_sender", "messages_dropped", []string{"reliable", "destination"}, "Messages dropped", telemetry.Options{DefaultMetric: true})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR makes the underlying architecture change required to support RTT fairness: an algorithm that will allow more concurrency for consumers experiencing higher than average latency when sending logs. The changes in this PR should be nonfunctional, providing the structure necessary to run RTT fairness without actually enabling it.

[!35374](https://github.com/DataDog/datadog-agent/pull/35484) is the PR set to enable this functionality, and contains a more detailed description of what the end behavior will be.
### Motivation

### Describe how you validated your changes
As there is no expected functional change from this PR, the core of its validation was performed via automated regression tests. Some key factors were confirming the connection counts remained stable for SMP runs of high latency, and confirming throughput under load remained identical to the baseline case.
Additional unit tests were introduced primarily to vet the RTT fairness algorithm
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
We assume that latency is always due to distance rather than network congestion or instability, and we assume that certain classes of http errors ("retry-able" errors) should force the worker count down to its minimum value to give ingest time to recover. Both of these assumptions can cause unideal outcomes in specific systems: network latency spiking due to bandwidth saturation will see the agent attempt to pack even more data in to the stuffed network pipe, and high latency environments that regularly see certain http errors might not provide the level of concurrency the logs throughput requires. Despite this, retaining the behavior of the batchmaxconcurrentsends config setting will allow for users experiencing these (assumedly rare) cases to correct the agent's behavior by hand.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->