### PR TITLE
retry network ID fetch in netpath

### DIFF
--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	cloudprovidersnetwork "github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
-	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -68,13 +67,9 @@ type Runner struct {
 
 // New initializes a new traceroute runner
 func New(telemetryComp telemetryComponent.Component, hostnameService hostname.Component) (*Runner, error) {
-	var err error
-	var networkID string
-	if ec2.IsRunningOn(context.TODO()) {
-		networkID, err = cloudprovidersnetwork.GetNetworkID(context.Background())
-		if err != nil {
-			log.Errorf("failed to get network ID: %s", err.Error())
-		}
+	networkID, err := retryGetNetworkID()
+	if err != nil {
+		log.Errorf("failed to get network ID: %s", err.Error())
 	}
 
 	gatewayLookup, nsIno, err := createGatewayLookup(telemetryComp)
@@ -281,4 +276,26 @@ func createGatewayLookup(telemetryComp telemetryComponent.Component) (network.Ga
 
 func rootNsLookup() (netns.NsHandle, error) {
 	return netns.GetFromPid(os.Getpid())
+}
+
+// retryGetNetworkID attempts to get the network ID from the cloud provider or config with a few retries
+// as the endpoint is sometimes unavailable during host startup
+func retryGetNetworkID() (string, error) {
+	const maxRetries = 3
+	var err error
+	var networkID string
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		networkID, err = cloudprovidersnetwork.GetNetworkID(context.Background())
+		if err == nil {
+			return networkID, nil
+		}
+		log.Debugf(
+			"failed to fetch network ID (attempt %d/%d): %s",
+			attempt,
+			maxRetries,
+			err,
+		)
+		time.Sleep(time.Duration(250*attempt) * time.Millisecond)
+	}
+	return "", fmt.Errorf("failed to get network ID after %d attempts: %w", maxRetries, err)
 }

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -281,7 +281,7 @@ func rootNsLookup() (netns.NsHandle, error) {
 // retryGetNetworkID attempts to get the network ID from the cloud provider or config with a few retries
 // as the endpoint is sometimes unavailable during host startup
 func retryGetNetworkID() (string, error) {
-	const maxRetries = 3
+	const maxRetries = 4
 	var err error
 	var networkID string
 	for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -295,7 +295,9 @@ func retryGetNetworkID() (string, error) {
 			maxRetries,
 			err,
 		)
-		time.Sleep(time.Duration(250*attempt) * time.Millisecond)
+		if attempt < maxRetries {
+			time.Sleep(time.Duration(250*attempt) * time.Millisecond)
+		}
 	}
 	return "", fmt.Errorf("failed to get network ID after %d attempts: %w", maxRetries, err)
 }

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -511,7 +511,7 @@ func retryGetNetworkID(sysProbeClient *http.Client) (string, error) {
 		)
 		time.Sleep(time.Duration(250*attempt) * time.Millisecond)
 	}
-	return "", fmt.Errorf("failed to get network ID after %d attempts: %s", maxRetries, err)
+	return "", fmt.Errorf("failed to get network ID after %d attempts: %w", maxRetries, err)
 }
 
 // getNetworkID fetches network_id from the current netNS or from the system probe if necessary, where the root netNS is used

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -494,8 +494,9 @@ func convertAndEnrichWithServiceCtx(tags []string, tagOffsets []uint32, serviceC
 }
 
 // retryGetNetworkID attempts to fetch the network_id maxRetries times before failing
+// as the endpoint is sometimes unavailable during host startup
 func retryGetNetworkID(sysProbeClient *http.Client) (string, error) {
-	const maxRetries = 3
+	const maxRetries = 4
 	var err error
 	var networkID string
 	for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -509,7 +510,9 @@ func retryGetNetworkID(sysProbeClient *http.Client) (string, error) {
 			maxRetries,
 			err,
 		)
-		time.Sleep(time.Duration(250*attempt) * time.Millisecond)
+		if attempt < maxRetries {
+			time.Sleep(time.Duration(250*attempt) * time.Millisecond)
+		}
 	}
 	return "", fmt.Errorf("failed to get network ID after %d attempts: %w", maxRetries, err)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

we already have similar retry logic in the network tracer, but netpath can benefit too because it often fails to fetch a network ID. also it was only checking on EC2, but it should use the helper logic to get it from user provided config or GCE

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->