### PR TITLE
[CWS] fix possible panic in `NewSECLVariable` when fetching the scope

### DIFF
--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -810,6 +810,9 @@ func (v *ScopedVariables) Len() int {
 func (v *ScopedVariables) NewSECLVariable(name string, value interface{}, opts VariableOpts) (SECLVariable, error) {
 	getVariable := func(ctx *Context) MutableSECLVariable {
 		scope := v.scoper(ctx)
+		if scope == nil {
+			return nil
+		}
 		key := scope.Hash()
 		v := v.vars[key]
 		return v[name]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

https://github.com/DataDog/datadog-agent/commit/acbc746876870c14a81d47e832771d4195dc5547#diff-eca6ad69c3859e85d2ee8b8b49707f8c92404458b81eb4e08edb74647b6c0a0aL778 removed the check, but the check is important. Let's reintroduce it.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->