### PR TITLE
Use AWS profile by default for e2e

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -70,6 +70,8 @@
     EXTERNAL_LINKS_PATH: external_links_$CI_JOB_ID.json
     E2E_LOGS_PROCESSING_TEST_DEPTH: 1
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
+    E2E_USE_AWS_PROFILE: "true"
+
   script:
     - dda inv -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
@@ -169,7 +171,6 @@ new-e2e-containers-eks:
     TEAM: container-integrations
     EXTRA_PARAMS: --run TestEKSSuite
     E2E_PRE_INITIALIZED: "true"
-    E2E_USE_AWS_PROFILE: "true"
     ON_NIGHTLY_FIPS: "true"
 
 new-e2e-remote-config:
@@ -199,7 +200,6 @@ new-e2e-agent-runtimes:
   variables:
     TARGETS: ./tests/agent-runtimes
     TEAM: agent-runtimes
-    E2E_USE_AWS_PROFILE: "true"
     ON_NIGHTLY_FIPS: "true"
 
 new-e2e-agent-subcommands:
@@ -302,7 +302,6 @@ new-e2e-npm-packages:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
     EXTRA_PARAMS: --run "TestEC2(VM|VMSELinux|VMWKit)Suite"
-    E2E_USE_AWS_PROFILE: "true"
     ON_NIGHTLY_FIPS: "true"
 
 new-e2e-npm-docker:
@@ -318,7 +317,6 @@ new-e2e-npm-docker:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
     EXTRA_PARAMS: --run "Test(ECSVM|EC2VMContainerized)Suite"
-    E2E_USE_AWS_PROFILE: "true"
     ON_NIGHTLY_FIPS: "true"
 
 new-e2e-npm-eks-init:
@@ -509,6 +507,7 @@ new-e2e-installer-script:
     TARGETS: ./tests/installer/script
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
+    E2E_USE_AWS_PROFILE: "false"
 
 new-e2e-installer:
   extends: .new_e2e_template
@@ -530,6 +529,7 @@ new-e2e-installer:
     TEAM: fleet
     FLEET_INSTALL_METHOD: "install_script"
     E2E_LOGS_PROCESSING_TEST_DEPTH: 2
+    E2E_USE_AWS_PROFILE: "false"
   retry: 1  # Force retry on this specific job to limit flakiness
 
 new-e2e-installer-windows:
@@ -556,6 +556,7 @@ new-e2e-installer-windows:
     TARGETS: ./tests/installer/windows
     TEAM: fleet
     FLEET_INSTALL_METHOD: "windows"
+    E2E_USE_AWS_PROFILE: "false"
   parallel:
     matrix:
       # agent-package
@@ -594,6 +595,7 @@ new-e2e-installer-ansible:
     TARGETS: ./tests/installer/unix
     TEAM: fleet
     FLEET_INSTALL_METHOD: "ansible"
+    E2E_USE_AWS_PROFILE: "false"
   retry: 1  # Force retry on this specific job to limit flakiness
 
 new-e2e-ndm-netflow:
@@ -719,7 +721,6 @@ new-e2e-otel:
     TARGETS: ./tests/otel
     EXTRA_PARAMS: --skip "TestOTelAgentIA(EKS|USTEKS)"
     TEAM: otel
-    E2E_USE_AWS_PROFILE: "true"
     ON_NIGHTLY_FIPS: "true"
 
 .new-e2e_package_signing:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We use credentials generated at the beginning of the job because we got ratelimited on job that run a lot of test in parallel. Let's put the default to AWS profile back, and use the pre-generated creds only for job with numerous test in parallel.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->