### PR TITLE
fix(release): Improve version computation for the first RC

### DIFF
--- a/tasks/libs/releasing/version.py
+++ b/tasks/libs/releasing/version.py
@@ -115,9 +115,10 @@ def current_version_for_release_branch(ctx, release_branch) -> Version:
     assert match, f"Invalid release branch name: {release_branch} (should be X.YY.x)"
 
     # Get all the versions for this release X.YY
-    cmd = rf"git tag | grep -E '^{match.group(1)}\.{match.group(2)}\.[0-9]+(-rc\.[0-9]+)?$'"
+    cmd = rf"git tag | grep -E '^{match.group(1)}\.{match.group(2)}\.[0-9]+(-rc\.[0-9]+)?(-devel)?$'"
     res = ctx.run(cmd, hide=True, warn=True)
     res = res.stdout.strip().split('\n') if res else []
+    print(f"Found tags: {res}")
 
     # from_tag might return None, ignore those
     versions = [v for v in sorted(Version.from_tag(tag) for tag in res) if v]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Correctly send the `next_rc_version` when we are dealing with the first RC.
Previously, when only the `-devel` tag was set on a release branch, we had
```
>>> n = next_rc_version(c, '7.65.x')
>>> print(n)
7.66.0-rc.1
```
Now, we are considering `-devel` as a valid tag
```
>>> n = next_rc_version(c, '7.65.x')
>>> print(n)
7.65.0-rc.1
```

### Motivation
Fix the `create_rc` behaviour, which is [silently failing here](https://github.com/DataDog/datadog-agent/actions/runs/13989009527/job/39168536227)

### Describe how you validated your changes
Added tests
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->