### PR TITLE
[CWS] do not pre-allocate the mount deletion open queue with the number of mounts

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -174,12 +174,14 @@ func (mr *Resolver) syncCache(mountID uint32, pids []uint32) error {
 	return err
 }
 
+const openQueuePreAllocSize = 32 // should be enough to handle most of in queue mounts waiting to be deleted
+
 func (mr *Resolver) delete(mount *model.Mount) {
 	now := time.Now()
 
 	mr.deleteOne(mount, now)
 
-	openQueue := make([]uint32, 0, mr.mounts.Len())
+	openQueue := make([]uint32, 0, openQueuePreAllocSize)
 	openQueue = append(openQueue, mount.MountID)
 
 	for len(openQueue) != 0 {


### PR DESCRIPTION
### What does this PR do?

Pre-allocating the open queue with the number of total mounts in the resolver made sense before recent refactoring of this code, but it can cause a big spike in allocation. This PR reduces the open queue start size to 32, which should be enough to handle most cases, and allows to skip the first grow-iteration of the slice in the case that we have more mounts. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->