### PR TITLE
Mark TestAgentUpgrades/TestExperimentForNonExistingPackageFails as flaky

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
@@ -127,6 +128,8 @@ func (s *testAgentUpgradeSuite) TestStopExperiment() {
 // with a non-existing package version fails and can be stopped.
 func (s *testAgentUpgradeSuite) TestExperimentForNonExistingPackageFails() {
 	// Arrange
+	flake.Mark(s.T())
+
 	s.setAgentConfig()
 	s.installCurrentAgentVersion()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Test is highly flaky/broken. Let's silence it
https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20env%3Aprod%20%40git.repository.id%3Agitlab.ddbuild.io%2FDataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40test.name%3ATestAgentUpgrades%2FTestExperimentForNonExistingPackageFails&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1741956223951&end=1742561023951&paused=false

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->