### PR TITLE
fix(installer): Make system probe read env from /etc/datadog-agent/environment

### DIFF
--- a/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe-exp.service
@@ -10,6 +10,7 @@ ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/experiment/system-
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 Restart=on-failure
+EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/experiment"
 ExecStart=/opt/datadog-packages/datadog-agent/experiment/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/experiment/run/system-probe.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,

--- a/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/datadog-agent-sysprobe.service
@@ -11,6 +11,7 @@ ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/system-prob
 Type=simple
 PIDFile=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 Restart=on-failure
+EnvironmentFile=-/etc/datadog-agent/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent/managed/datadog-agent/stable"
 ExecStart=/opt/datadog-packages/datadog-agent/stable/embedded/bin/system-probe run --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-packages/datadog-agent/stable/run/system-probe.pid
 # Since systemd 229, should be in [Unit] but in order to support systemd <229,


### PR DESCRIPTION
### What does this PR do?
Makes system probe read env from /etc/datadog-agent/environment

### Motivation
The non-installer unit does it

### Describe how you validated your changes
Manual test

### Possible Drawbacks / Trade-offs

### Additional Notes
