### PR TITLE
AGNTLOG-2 - reduce payload memory usage in the logs pipeline

### DIFF
--- a/comp/logs/auditor/impl/auditor.go
+++ b/comp/logs/auditor/impl/auditor.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	"github.com/DataDog/datadog-agent/comp/logs/auditor/def"
+	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
@@ -194,7 +194,7 @@ func (a *registryAuditor) run() {
 				return
 			}
 			// update the registry with the new entry
-			for _, msg := range payload.Messages {
+			for _, msg := range payload.MessageMetas {
 				a.updateRegistry(msg.Origin.Identifier, msg.Origin.Offset, msg.Origin.LogSource.Config.TailingMode, msg.IngestionTimestamp)
 			}
 		case <-cleanUpTicker.C:

--- a/pkg/logs/auditor/auditor.go
+++ b/pkg/logs/auditor/auditor.go
@@ -171,7 +171,7 @@ func (a *RegistryAuditor) run() {
 				return
 			}
 			// update the registry with new entry
-			for _, msg := range payload.Messages {
+			for _, msg := range payload.MessageMetas {
 				a.updateRegistry(msg.Origin.Identifier, msg.Origin.Offset, msg.Origin.LogSource.Config.TailingMode, msg.IngestionTimestamp)
 			}
 		case <-cleanUpTicker.C:

--- a/pkg/logs/client/http/sync_destination.go
+++ b/pkg/logs/client/http/sync_destination.go
@@ -83,8 +83,8 @@ func (d *SyncDestination) run(input chan *message.Payload, output chan *message.
 			senderDoneWg.Done()
 		}
 
-		metrics.LogsSent.Add(int64(len(p.Messages)))
-		metrics.TlmLogsSent.Add(float64(len(p.Messages)))
+		metrics.LogsSent.Add(p.Count())
+		metrics.TlmLogsSent.Add(float64(p.Count()))
 		output <- p
 
 		inUse := float64(time.Since(startInUse) / time.Millisecond)

--- a/pkg/logs/internal/framer/framer.go
+++ b/pkg/logs/internal/framer/framer.go
@@ -10,8 +10,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"go.uber.org/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
 )
 
 // Framing describes the kind of framing applied to the byte stream being broken.
@@ -179,11 +180,13 @@ func (fr *Framer) Process(input *message.Message) {
 			MessageContent: message.MessageContent{
 				State: message.StateUnstructured,
 			},
-			Origin:             input.Origin,
-			Status:             input.Status,
-			IngestionTimestamp: input.IngestionTimestamp,
-			ParsingExtra:       input.ParsingExtra,
-			ServerlessExtra:    input.ServerlessExtra,
+			MessageMetadata: message.MessageMetadata{
+				Origin:             input.Origin,
+				Status:             input.Status,
+				IngestionTimestamp: input.IngestionTimestamp,
+				ParsingExtra:       input.ParsingExtra,
+				ServerlessExtra:    input.ServerlessExtra,
+			},
 		}
 		c.SetContent(owned)
 

--- a/pkg/logs/message/message_test.go
+++ b/pkg/logs/message/message_test.go
@@ -6,12 +6,14 @@
 package message
 
 import (
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-// XXX(remy): all unit tests related to structured/unstructured, the state, etc.
 
 func TestMessage(t *testing.T) {
 
@@ -21,5 +23,98 @@ func TestMessage(t *testing.T) {
 	message.SetContent([]byte("world"))
 	assert.Equal(t, "world", string(message.GetContent()))
 	assert.Equal(t, StatusInfo, message.GetStatus())
+}
 
+func TestNewPayload(t *testing.T) {
+	messages := []*Message{
+		NewMessage([]byte("hello"), nil, "", 0),
+		NewMessage([]byte("world"), nil, "", 0),
+		NewMessage([]byte("test"), nil, "", 0),
+	}
+	encoded := []byte("encoded content")
+	encoding := "gzip"
+	unencodedSize := 100
+
+	payload := NewPayload(messages, encoded, encoding, unencodedSize)
+
+	// Test basic payload properties
+	assert.Equal(t, 3, len(payload.MessageMetas))
+	assert.Equal(t, encoded, payload.Encoded)
+	assert.Equal(t, encoding, payload.Encoding)
+	assert.Equal(t, unencodedSize, payload.UnencodedSize)
+
+	// Test Count method
+	assert.Equal(t, int64(3), payload.Count())
+
+	// Test Size method (each message is 5, 5, and 4 bytes respectively)
+	assert.Equal(t, int64(14), payload.Size())
+}
+func TestPayloadPreservesMessageOrder(t *testing.T) {
+	messages := []*Message{
+		NewMessage([]byte("1"), nil, "", 1),    // datalen = 1
+		NewMessage([]byte("22"), nil, "", 2),   // datalen = 2
+		NewMessage([]byte("333"), nil, "", 3),  // datalen = 3
+		NewMessage([]byte("4444"), nil, "", 4), // datalen = 4
+	}
+	payload := NewPayload(messages, []byte(""), "", 0)
+
+	expectedLengths := []int{1, 2, 3, 4}
+	assert.Equal(t, len(expectedLengths), len(payload.MessageMetas), "Should have same number of message metas")
+
+	for i, msg := range messages {
+		assert.Equal(t, msg.RawDataLen, payload.MessageMetas[i].RawDataLen, "Message at index %d should have RawDataLen of %d", i, msg.GetContent())
+		assert.Equal(t, msg.IngestionTimestamp, payload.MessageMetas[i].IngestionTimestamp, "Message at index %d should have ingestion timestamp %d", i, msg.IngestionTimestamp)
+	}
+}
+
+func TestPayloadAllowsMessageContentGC(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Create a function to track when our test content gets GC'd
+	wasGCd := false
+	trackGC := func(_ *[]byte) {
+		wasGCd = true
+		wg.Done()
+	}
+
+	var payload *Payload
+
+	// Create scope to allow message to be GC'd
+	func() {
+		// Create message with content we want to track
+		content := make([]byte, 1000000) // Large enough to be noticeable for GC
+		message := NewMessage(content, nil, "", 2)
+
+		// Set up finalizer to track when content is GC'd
+		runtime.SetFinalizer(&message.content, trackGC)
+
+		// Create payload from message
+		payload = NewPayload([]*Message{message}, []byte("encoded"), "", 0)
+
+		// Ensure payload captured metadata
+		require.Equal(t, 1, len(payload.MessageMetas))
+		require.Equal(t, int64(2), payload.MessageMetas[0].IngestionTimestamp)
+	}()
+
+	// Clear any references and force GC
+	runtime.GC()
+
+	// Wait for finalizer with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		assert.True(t, wasGCd, "Message content should have been garbage collected")
+	case <-time.After(time.Second):
+		t.Fatal("Message content was not garbage collected")
+	}
+
+	// Verify payload metadata still intact
+	assert.Equal(t, 1, len(payload.MessageMetas))
+	assert.Equal(t, int64(2), payload.MessageMetas[0].IngestionTimestamp)
 }

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -196,12 +196,8 @@ func (s *batchStrategy) sendMessages(messages []*message.Message, outputChan cha
 		s.flushWg.Add(1)
 	}
 
-	p := &message.Payload{
-		Messages:      messages,
-		Encoded:       encodedPayload.Bytes(),
-		Encoding:      s.compression.ContentEncoding(),
-		UnencodedSize: unencodedSize,
-	}
+	p := message.NewPayload(messages, encodedPayload.Bytes(), s.compression.ContentEncoding(), unencodedSize)
+
 	s.utilization.Stop()
 	outputChan <- p
 	s.pipelineMonitor.ReportComponentEgress(p, "strategy")

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -114,7 +114,7 @@ func (s *Sender) run() {
 			if !destSender.lastSendSucceeded {
 				if !destSender.NonBlockingSend(payload) {
 					tlmPayloadsDropped.Inc("true", strconv.Itoa(i))
-					tlmMessagesDropped.Add(float64(len(payload.Messages)), "true", strconv.Itoa(i))
+					tlmMessagesDropped.Add(float64(payload.Count()), "true", strconv.Itoa(i))
 				}
 			}
 		}
@@ -123,7 +123,7 @@ func (s *Sender) run() {
 		for i, destSender := range unreliableDestinations {
 			if !destSender.NonBlockingSend(payload) {
 				tlmPayloadsDropped.Inc("false", strconv.Itoa(i))
-				tlmMessagesDropped.Add(float64(len(payload.Messages)), "false", strconv.Itoa(i))
+				tlmMessagesDropped.Add(float64(payload.Count()), "false", strconv.Itoa(i))
 				if s.senderDoneChan != nil {
 					senderDoneWg.Add(1)
 					s.senderDoneChan <- senderDoneWg

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -24,9 +24,9 @@ import (
 
 func newMessage(content []byte, source *sources.LogSource, status string) *message.Payload {
 	return &message.Payload{
-		Messages: []*message.Message{message.NewMessageWithSource(content, status, source, 0)},
-		Encoded:  content,
-		Encoding: "identity",
+		MessageMetas: []*message.MessageMetadata{&message.NewMessageWithSource(content, status, source, 0).MessageMetadata},
+		Encoded:      content,
+		Encoding:     "identity",
 	}
 }
 

--- a/pkg/logs/sender/stream_strategy.go
+++ b/pkg/logs/sender/stream_strategy.go
@@ -45,12 +45,8 @@ func (s *streamStrategy) Start() {
 				return
 			}
 
-			s.outputChan <- &message.Payload{
-				Messages:      []*message.Message{msg},
-				Encoded:       encodedPayload,
-				Encoding:      s.compression.ContentEncoding(),
-				UnencodedSize: len(msg.GetContent()),
-			}
+			unencodedSize := len(msg.GetContent())
+			s.outputChan <- message.NewPayload([]*message.Message{msg}, encodedPayload, s.compression.ContentEncoding(), unencodedSize)
 		}
 		s.done <- struct{}{}
 	}()

--- a/pkg/logs/sender/stream_strategy_test.go
+++ b/pkg/logs/sender/stream_strategy_test.go
@@ -22,13 +22,13 @@ func TestStreamStrategy(t *testing.T) {
 	s := NewStreamStrategy(input, output, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1))
 	s.Start()
 
-	content := []byte("a")
+	content := []byte("aa")
 	message1 := message.NewMessage(content, nil, "", 0)
 	input <- message1
 
 	payload := <-output
-	assert.Equal(t, message1, payload.Messages[0])
-	assert.Equal(t, 1, payload.UnencodedSize)
+	assert.Equal(t, &message1.MessageMetadata, payload.MessageMetas[0])
+	assert.Equal(t, 2, payload.UnencodedSize)
 	assert.Equal(t, content, payload.Encoded)
 
 	content = []byte("b")
@@ -36,7 +36,7 @@ func TestStreamStrategy(t *testing.T) {
 	input <- message2
 
 	payload = <-output
-	assert.Equal(t, message2, payload.Messages[0])
+	assert.Equal(t, &message2.MessageMetadata, payload.MessageMetas[0])
 	assert.Equal(t, 1, payload.UnencodedSize)
 	assert.Equal(t, content, payload.Encoded)
 	s.Stop()

--- a/releasenotes/notes/reduce-log-payload-size-08e9360896a0d710.yaml
+++ b/releasenotes/notes/reduce-log-payload-size-08e9360896a0d710.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Reduce the memory footprint of the logs pipeline by eliminating unnecessary fields in the log payload.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
The logs payload entity stores metadata for all of the respective messages batched within, but also stores the message contents themselves. This isn't required, all consumers of the logs payload will interact with the encoded bytes buffer rather than the raw contents. Additionally, dropping these message contents on payload construction can save considerable amounts of RSS memory for log agents experiencing enough load to buffer multiple payloads. 

This PR shallow copies the message metadata into each payload, rather than injecting the whole message entity.

### Motivation

### Describe how you validated your changes
Validation was completed by a combination of 1. unit test additions, 2. successful code compilation, 3. SMP performance runs

### Possible Drawbacks / Trade-offs
Adding memory allocation in the critical path (for the metadata shallow copy) isn't ideal, but given we're already allocating a new array for the entirety of the contents in the same code path its impact shouldn't be noticeable.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The memory savings for a system under heavy load is extreme. Attached is the memory comparison used in the file_to_blackhole_1000ms_latency_linear_load regression test:
<img width="696" alt="Screenshot 2025-03-21 at 11 25 17 AM" src="https://github.com/user-attachments/assets/b0e53475-16c3-42ab-b875-6e9e99da38c8" />
