### PR TITLE
chore(tagger): remove LegacyTag() method

### DIFF
--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -19,11 +19,6 @@ import (
 // Component is the component type.
 type Component interface {
 	GetTaggerTelemetryStore() *telemetry.Store
-	// LegacyTag has the same behaviour as the Tag method, but it receives the entity id as a string and parses it.
-	// If possible, avoid using this function, and use the Tag method instead.
-	// This function exists in order not to break backward compatibility with rtloader and python
-	// integrations using the tagger
-	LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error)
 	Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error)
 	GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error)
 	AccumulateTagsFor(entityID types.EntityID, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error

--- a/comp/core/tagger/impl-noop/tagger.go
+++ b/comp/core/tagger/impl-noop/tagger.go
@@ -32,10 +32,6 @@ func (n *noopTagger) Tag(types.EntityID, types.TagCardinality) ([]string, error)
 	return nil, nil
 }
 
-func (n *noopTagger) LegacyTag(string, types.TagCardinality) ([]string, error) {
-	return nil, nil
-}
-
 // GenerateContainerIDFromOriginInfo generates a container ID from Origin Info.
 // This is a no-op for the noop tagger
 func (n *noopTagger) GenerateContainerIDFromOriginInfo(origindetection.OriginInfo) (string, error) {

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -266,20 +266,6 @@ func (t *remoteTagger) Tag(entityID types.EntityID, cardinality types.TagCardina
 	return []string{}, nil
 }
 
-// LegacyTag has the same behaviour as the Tag method, but it receives the entity id as a string and parses it.
-// If possible, avoid using this function, and use the Tag method instead.
-// This function exists in order not to break backward compatibility with rtloader and python
-// integrations using the tagger
-func (t *remoteTagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	prefix, id, err := types.ExtractPrefixAndID(entity)
-	if err != nil {
-		return nil, err
-	}
-
-	entityID := types.NewEntityID(prefix, id)
-	return t.Tag(entityID, cardinality)
-}
-
 // GenerateContainerIDFromOriginInfo returns a container ID for the given Origin Info.
 func (t *remoteTagger) GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error) {
 	fail := true

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -279,20 +279,6 @@ func (t *localTagger) GenerateContainerIDFromOriginInfo(originInfo origindetecti
 	return "", fmt.Errorf("unable to resolve container ID from OriginInfo: %+v", originInfo)
 }
 
-// LegacyTag has the same behaviour as the Tag method, but it receives the entity id as a string and parses it.
-// If possible, avoid using this function, and use the Tag method instead.
-// This function exists in order not to break backward compatibility with rtloader and python
-// integrations using the tagger
-func (t *localTagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	prefix, id, err := types.ExtractPrefixAndID(entity)
-	if err != nil {
-		return nil, err
-	}
-
-	entityID := types.NewEntityID(prefix, id)
-	return t.Tag(entityID, cardinality)
-}
-
 // Standard returns standard tags for a given entity
 // It triggers a tagger fetch if the no tags are found
 func (t *localTagger) Standard(entityID types.EntityID) ([]string, error) {

--- a/comp/core/tagger/impl/tagger_mock.go
+++ b/comp/core/tagger/impl/tagger_mock.go
@@ -110,11 +110,6 @@ func (f *fakeTagger) GetTaggerTelemetryStore() *telemetry.Store {
 	return f.tagger.GetTaggerTelemetryStore()
 }
 
-// LegacyTag calls tagger.LegacyTag().
-func (f *fakeTagger) LegacyTag(entity string, cardinality types.TagCardinality) ([]string, error) {
-	return f.tagger.LegacyTag(entity, cardinality)
-}
-
 // Tag calls tagger.Tag().
 func (f *fakeTagger) Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error) {
 	return f.tagger.Tag(entityID, cardinality)

--- a/pkg/collector/python/tagger.go
+++ b/pkg/collector/python/tagger.go
@@ -36,7 +36,16 @@ func Tags(id *C.char, cardinality C.int) **C.char {
 	goID := C.GoString(id)
 	var tags []string
 
-	tags, _ = checkContext.tagger.LegacyTag(goID, types.TagCardinality(cardinality))
+	// Generate EntityID from the entity ID string.
+	// This is done for backward compatibility with the Python checks as the Tags() signature cannot be changed.
+	prefix, eid, err := types.ExtractPrefixAndID(goID)
+	if err != nil {
+		log.Errorf("could not extract prefix and ID from id string: %v. Using LegacyTag.", err)
+		return nil
+	}
+	entityID := types.NewEntityID(prefix, eid)
+
+	tags, _ = checkContext.tagger.Tag(entityID, types.TagCardinality(cardinality))
 
 	length := len(tags)
 	if length == 0 {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes the `LegacyTags()` method that was exclusively used for Python Checks. The following checks are using the Python `Tags()` method:
* [Kubelet](https://github.com/DataDog/integrations-core/tree/master/kubelet)
* [EKS Fargate](https://github.com/DataDog/integrations-core/tree/master/eks_fargate)

### Motivation

This allows us to clean the `Tagger` interface.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by E2E tests. Manual testing was done with:
```
➜ kex daemonsets/datadog-agent -- agent config | grep kubelet_core_check_enabled
Defaulted container "agent" out of: agent, trace-agent, process-agent, security-agent, system-probe, init-volume (init), init-config (init), seccomp-setup (init)
kubelet_core_check_enabled: false
```

```
    kubelet (9.1.0)
    ---------------
      Instance ID: kubelet:2b9bec749170d31d [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/kubelet.d/conf.yaml.default
      Total Runs: 3
      Metric Samples: Last Run: 632, Total: 1,878
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 6, Total: 18
      Average Execution Time : 210ms
      Last Execution Date : 2025-03-21 15:44:38 UTC (1742571878000)
      Last Successful Execution Date : 2025-03-21 15:44:38 UTC (1742571878000)
```

```
➜ klo daemonsets/datadog-agent | grep "could not extract prefix and ID from id string"
Defaulted container "agent" out of: agent, trace-agent, process-agent, security-agent, system-probe, init-volume (init), init-config (init), seccomp-setup (init)
```

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A