### PR TITLE
Remove use of ValueTuple that breaks on .NET Framework 4.6.2

### DIFF
--- a/tools/windows/DatadogAgentInstaller/CustomActions/InstallOciPackages.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/InstallOciPackages.cs
@@ -53,16 +53,16 @@ namespace Datadog.CustomActions
             }
         }
 
-        private (string Name, string Version) ParseVersion(string library)
+        private NameVersionPair ParseVersion(string library)
         {
             library = library.Trim();
             var index = library.IndexOf(':');
             if (index == -1)
             {
-                return (library, string.Empty);
+                return new NameVersionPair(library, string.Empty);
             }
 
-            return (library.Substring(0, index), library.Substring(index + 1));
+            return new NameVersionPair(library.Substring(0, index), library.Substring(index + 1));
         }
 
         private Dictionary<string, string> InstallerEnvironmentVariables()
@@ -172,6 +172,18 @@ namespace Datadog.CustomActions
         public static ActionResult RollbackActions(Session session)
         {
             return new InstallOciPackages(new SessionWrapper(session)).RollbackState();
+        }
+
+        private class NameVersionPair
+        {
+            public NameVersionPair(string name, string version)
+            {
+                Name = name;
+                Version = version;
+            }
+
+            public string Name { get; }
+            public string Version { get; }
         }
     }
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes problematic code that requires .NET Framework 4.7.2 to 4.6.2.

### Motivation

Windows Server 2016 ships with .NET Framework 4.6.2. While the 4.7.2 installer will run on this older framework, it's strongly discouraged, as if you reference anything not available in the earlier version, you will crash and fail installation.

Recent changes implicitly added a new dependency by using the `ValueTuple` type which is used under the hood when you use the C# syntax:

```csharp
         // 👇 Converted to value tuple
private (string Name, string Version) ParseVersion(string library)
{
}
```

This change was only introduced recently, hence why the problem has not previously appeared. 

### Describe how you validated your changes

The existing tests should validate that the installer still works as expected. The fact that this was caught in manual testing shows that there is a test missing here, but automating tests for Windows Server 2016 could be challenging (I will defer to the agent team if they deem them to be required)

### Possible Drawbacks / Trade-offs

This is a quick stopgap to fix the issue, a more complete fix (that will requires updating the build images) is in https://github.com/DataDog/datadog-agent/pull/35365

### Additional Notes

While removing `ValueTuple` code should solve the immediate issue, without downgrading the project TFMs there's a risk that a similar change will be introduced again, especially as validating on old TFMs is generally tricky (this was only caught during manual testing).

As a general rule, compiling for earlier TFMs and running on later versions is safe, whereas the reverse is not safe.

Therefore we should look to implement, test and merge https://github.com/DataDog/datadog-agent/pull/35365 soon too