### PR TITLE
AGNTLOG-148 - retire legacy log sender components and harden serverless behavior

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
+	httpsender "github.com/DataDog/datadog-agent/pkg/logs/sender/http"
 	compressioncommon "github.com/DataDog/datadog-agent/pkg/util/compression"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -419,19 +420,25 @@ func newHTTPPassthroughPipeline(
 
 	pipelineMonitor := metrics.NewNoopPipelineMonitor(strconv.Itoa(pipelineID))
 
-	reliable := []client.Destination{}
-	for i, endpoint := range endpoints.GetReliableEndpoints() {
-		destMeta := client.NewDestinationMetadata(desc.eventType, pipelineMonitor.ID(), "reliable", strconv.Itoa(i))
-		reliable = append(reliable, logshttp.NewDestination(endpoint, desc.contentType, destinationsContext, true, destMeta, pkgconfigsetup.Datadog(), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
-	}
-	additionals := []client.Destination{}
-	for i, endpoint := range endpoints.GetUnReliableEndpoints() {
-		destMeta := client.NewDestinationMetadata(desc.eventType, pipelineMonitor.ID(), "unreliable", strconv.Itoa(i))
-		additionals = append(additionals, logshttp.NewDestination(endpoint, desc.contentType, destinationsContext, false, destMeta, pkgconfigsetup.Datadog(), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
-	}
-	destinations := client.NewDestinations(reliable, additionals)
 	inputChan := make(chan *message.Message, endpoints.InputChanSize)
-	senderInput := make(chan *message.Payload, 1) // Only buffer 1 message since payloads can be large
+
+	a := auditor.NewNullAuditor()
+	senderImpl := httpsender.NewHTTPSender(
+		coreConfig,
+		a,
+		10,  // Buffer Size
+		nil, // senderDoneChan, required only for serverless
+		nil, // flushWg, required only for serverless
+		endpoints,
+		destinationsContext,
+		false,
+		desc.eventType,
+		desc.contentType,
+		sender.DefaultQueuesCount,
+		sender.DefaultWorkersPerQueue,
+		endpoints.BatchMaxConcurrentSend,
+		endpoints.BatchMaxConcurrentSend,
+	)
 
 	var encoder compressioncommon.Compressor
 	encoder = compressor.NewCompressor("none", 0)
@@ -441,10 +448,10 @@ func newHTTPPassthroughPipeline(
 
 	var strategy sender.Strategy
 	if desc.contentType == logshttp.ProtobufContentType {
-		strategy = sender.NewStreamStrategy(inputChan, senderInput, encoder)
+		strategy = sender.NewStreamStrategy(inputChan, senderImpl.In(), encoder)
 	} else {
 		strategy = sender.NewBatchStrategy(inputChan,
-			senderInput,
+			senderImpl.In(),
 			make(chan struct{}),
 			false,
 			nil,
@@ -457,11 +464,10 @@ func newHTTPPassthroughPipeline(
 			pipelineMonitor)
 	}
 
-	a := auditor.NewNullAuditor()
 	log.Debugf("Initialized event platform forwarder pipeline. eventType=%s mainHosts=%s additionalHosts=%s batch_max_concurrent_send=%d batch_max_content_size=%d batch_max_size=%d, input_chan_size=%d",
 		desc.eventType, joinHosts(endpoints.GetReliableEndpoints()), joinHosts(endpoints.GetUnReliableEndpoints()), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxContentSize, endpoints.BatchMaxSize, endpoints.InputChanSize)
 	return &passthroughPipeline{
-		sender:                sender.NewSender(coreConfig, senderInput, a.Channel(), destinations, 10, nil, nil, pipelineMonitor),
+		sender:                senderImpl,
 		strategy:              strategy,
 		in:                    inputChan,
 		auditor:               a,

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -76,8 +76,8 @@ var (
 	//nolint:revive // TODO(AML) Fix revive linter
 	TlmDestinationHttpRespByStatusAndUrl = telemetry.NewCounter("logs", "destination_http_resp", []string{"status_code", "url"}, "Count of http responses by status code and destination url")
 
-	// TlmAutoMultilineAggregatorFlush Count of each line flushed from the auto mulitline aggregator.
-	TlmAutoMultilineAggregatorFlush = telemetry.NewCounter("logs", "auto_multi_line_aggregator_flush", []string{"truncated", "line_type"}, "Count of each line flushed from the auto mulitline aggregator")
+	// TlmAutoMultilineAggregatorFlush Count of each line flushed from the auto multiline aggregator.
+	TlmAutoMultilineAggregatorFlush = telemetry.NewCounter("logs", "auto_multi_line_aggregator_flush", []string{"truncated", "line_type"}, "Count of each line flushed from the auto multiline aggregator")
 
 	// TlmLogsDiscardedFromSDSBuffer how many messages were dropped when waiting for an SDS configuration because the buffer is full
 	TlmLogsDiscardedFromSDSBuffer = telemetry.NewCounter("logs", "sds__dropped_from_buffer", nil, "Count of messages dropped from the buffer while waiting for an SDS configuration")

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -23,7 +23,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
 
-	s := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), LineSerializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
 	s.Start()
 
 	message1 := message.NewMessage([]byte("a"), nil, "", 0)
@@ -55,7 +55,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 	timerInterval := 100 * time.Millisecond
 
 	clk := clock.NewMock()
-	s := newBatchStrategyWithClock(input, output, flushChan, false, nil, LineSerializer, timerInterval, 100, 100, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := newBatchStrategyWithClock(input, output, flushChan, NewMockServerlessMeta(false), LineSerializer, timerInterval, 100, 100, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
 	s.Start()
 
 	for round := 0; round < 3; round++ {
@@ -80,7 +80,7 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 	flushChan := make(chan struct{})
 
 	clk := clock.NewMock()
-	s := newBatchStrategyWithClock(input, output, flushChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := newBatchStrategyWithClock(input, output, flushChan, NewMockServerlessMeta(false), LineSerializer, 100*time.Millisecond, 2, 2, "test", clk, compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
 	s.Start()
 
 	message := message.NewMessage([]byte("a"), nil, "", 0)
@@ -105,7 +105,7 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 	output := make(chan *message.Payload)
 	flushChan := make(chan struct{})
 
-	s := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	s := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), LineSerializer, 100*time.Millisecond, 2, 2, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
 	s.Start()
 	message := message.NewMessage([]byte{}, nil, "", 0)
 
@@ -129,7 +129,7 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	strategy := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), LineSerializer, time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
 	strategy.Start()
 
 	// all of these messages will get buffered
@@ -177,7 +177,7 @@ func TestBatchStrategyFlushChannel(t *testing.T) {
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := NewBatchStrategy(input, output, flushChan, false, nil, LineSerializer, time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
+	strategy := NewBatchStrategy(input, output, flushChan, NewMockServerlessMeta(false), LineSerializer, time.Hour, 100, 100, "test", compressionfx.NewMockCompressor().NewCompressor(compression.NoneKind, 1), metrics.NewNoopPipelineMonitor(""))
 	strategy.Start()
 
 	// all of these messages will get buffered

--- a/pkg/logs/sender/http/http_sender.go
+++ b/pkg/logs/sender/http/http_sender.go
@@ -60,7 +60,7 @@ func NewHTTPSender(
 		maxWorkerConcurrency,
 	)
 
-	return sender.NewSenderV2(
+	return sender.NewSender(
 		config,
 		auditor,
 		destinationFactory,

--- a/pkg/logs/sender/http/http_sender.go
+++ b/pkg/logs/sender/http/http_sender.go
@@ -8,7 +8,6 @@ package http
 
 import (
 	"strconv"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
@@ -25,11 +24,9 @@ func NewHTTPSender(
 	config pkgconfigmodel.Reader,
 	auditor auditor.Auditor,
 	bufferSize int,
-	senderDoneChan chan *sync.WaitGroup,
-	flushWg *sync.WaitGroup,
+	serverlessMeta sender.ServerlessMeta,
 	endpoints *config.Endpoints,
 	destinationsCtx *client.DestinationsContext,
-	serverless bool,
 	componentName string,
 	contentType string,
 	queueCount int,
@@ -51,8 +48,7 @@ func NewHTTPSender(
 		endpoints,
 		destinationsCtx,
 		pipelineMonitor,
-		serverless,
-		senderDoneChan,
+		serverlessMeta,
 		config,
 		componentName,
 		contentType,
@@ -65,8 +61,7 @@ func NewHTTPSender(
 		auditor,
 		destinationFactory,
 		bufferSize,
-		senderDoneChan,
-		flushWg,
+		serverlessMeta,
 		queueCount,
 		workersPerQueue,
 		pipelineMonitor,
@@ -77,8 +72,7 @@ func httpDestinationFactory(
 	endpoints *config.Endpoints,
 	destinationsContext *client.DestinationsContext,
 	pipelineMonitor metrics.PipelineMonitor,
-	serverless bool,
-	senderDoneChan chan *sync.WaitGroup,
+	serverlessMeta sender.ServerlessMeta,
 	cfg pkgconfigmodel.Reader,
 	componentName string,
 	contentyType string,
@@ -90,16 +84,16 @@ func httpDestinationFactory(
 		additionals := []client.Destination{}
 		for i, endpoint := range endpoints.GetReliableEndpoints() {
 			destMeta := client.NewDestinationMetadata(componentName, pipelineMonitor.ID(), "reliable", strconv.Itoa(i))
-			if serverless {
-				reliable = append(reliable, http.NewSyncDestination(endpoint, contentyType, destinationsContext, senderDoneChan, destMeta, cfg))
+			if serverlessMeta.IsEnabled() {
+				reliable = append(reliable, http.NewSyncDestination(endpoint, contentyType, destinationsContext, serverlessMeta.SenderDoneChan(), destMeta, cfg))
 			} else {
 				reliable = append(reliable, http.NewDestination(endpoint, contentyType, destinationsContext, true, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor))
 			}
 		}
 		for i, endpoint := range endpoints.GetUnReliableEndpoints() {
 			destMeta := client.NewDestinationMetadata(componentName, pipelineMonitor.ID(), "unreliable", strconv.Itoa(i))
-			if serverless {
-				additionals = append(additionals, http.NewSyncDestination(endpoint, contentyType, destinationsContext, senderDoneChan, destMeta, cfg))
+			if serverlessMeta.IsEnabled() {
+				additionals = append(additionals, http.NewSyncDestination(endpoint, contentyType, destinationsContext, serverlessMeta.SenderDoneChan(), destMeta, cfg))
 			} else {
 				additionals = append(additionals, http.NewDestination(endpoint, contentyType, destinationsContext, false, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor))
 			}

--- a/pkg/logs/sender/http/http_sender_test.go
+++ b/pkg/logs/sender/http/http_sender_test.go
@@ -6,7 +6,6 @@
 package http
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
 )
 
 func TestHttpDestinationFactory(t *testing.T) {
@@ -89,15 +89,13 @@ func TestHttpDestinationFactory(t *testing.T) {
 			endpoints := config.NewMockEndpoints(tc.endpoints)
 			destinationsCtx := client.NewDestinationsContext()
 			pipelineMonitor := metrics.NewNoopPipelineMonitor("test")
-			senderDoneChan := make(chan *sync.WaitGroup)
 			mockConfig := configmock.New(t)
 
 			factory := httpDestinationFactory(
 				endpoints,
 				destinationsCtx,
 				pipelineMonitor,
-				tc.serverless,
-				senderDoneChan,
+				sender.NewMockServerlessMeta(tc.serverless),
 				mockConfig,
 				"test-component",
 				"application/json",

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -52,39 +52,8 @@ type Sender struct {
 // DestinationFactory used to generate client destinations on each call.
 type DestinationFactory func() *client.Destinations
 
-// NewSender is the legacy sender.
+// NewSender returns a new sender.
 func NewSender(
-	config pkgconfigmodel.Reader,
-	inputChan chan *message.Payload,
-	outputChan chan *message.Payload,
-	destinations *client.Destinations,
-	bufferSize int,
-	senderDoneChan chan *sync.WaitGroup,
-	flushWg *sync.WaitGroup,
-	pipelineMonitor metrics.PipelineMonitor,
-) *Sender {
-	w := newWorkerLegacy(
-		config,
-		inputChan,
-		outputChan,
-		destinations,
-		bufferSize,
-		senderDoneChan,
-		flushWg,
-		pipelineMonitor,
-	)
-
-	return &Sender{
-		workers:         []*worker{w},
-		pipelineMonitor: pipelineMonitor,
-		queues:          []chan *message.Payload{inputChan},
-		flushWg:         flushWg,
-		idx:             &atomic.Uint32{},
-	}
-}
-
-// NewSenderV2 is the default implementation of the sender factory.
-func NewSenderV2(
 	config pkgconfigmodel.Reader,
 	auditor auditor.Auditor,
 	destinationFactory DestinationFactory,

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -45,8 +45,52 @@ type Sender struct {
 	queues  []chan *message.Payload
 
 	pipelineMonitor metrics.PipelineMonitor
-	flushWg         *sync.WaitGroup
 	idx             *atomic.Uint32
+}
+
+// ServerlessMeta is a struct that contains essential control structures for serverless mode.
+// Do not access any methods on this interface without checking IsEnabled first.
+type ServerlessMeta interface {
+	Lock()
+	Unlock()
+	WaitGroup() *sync.WaitGroup
+	SenderDoneChan() chan *sync.WaitGroup
+	IsEnabled() bool
+}
+
+// NewServerlessMeta creates a new ServerlessMeta instance.
+func NewServerlessMeta(isEnabled bool) ServerlessMeta {
+	if isEnabled {
+		return &serverlessMetaImpl{sync.Mutex{}, sync.WaitGroup{}, make(chan *sync.WaitGroup), isEnabled}
+	}
+	return &serverlessMetaImpl{}
+}
+
+// serverlessMetaImpl is a struct that contains essential control structures for serverless mode.
+type serverlessMetaImpl struct {
+	sync.Mutex
+	wg             sync.WaitGroup
+	senderDoneChan chan *sync.WaitGroup
+	enabled        bool
+}
+
+// WaitGroup returns the wait group for the serverless mode, used to block the pipeline flush until all payloads are sent.
+func (s *serverlessMetaImpl) WaitGroup() *sync.WaitGroup {
+	return &s.wg
+}
+
+// SenderDoneChan returns the channel is used to transfer wait groups from the sync_destination to the sender.
+func (s *serverlessMetaImpl) SenderDoneChan() chan *sync.WaitGroup {
+	return s.senderDoneChan
+}
+
+// IsEnabled returns true if the serverless mode is enabled.
+// This is used to check if the serverless mode is enabled before accessing any of the methods on this struct.
+func (s *serverlessMetaImpl) IsEnabled() bool {
+	if s == nil {
+		return false
+	}
+	return s.enabled
 }
 
 // DestinationFactory used to generate client destinations on each call.
@@ -58,8 +102,7 @@ func NewSender(
 	auditor auditor.Auditor,
 	destinationFactory DestinationFactory,
 	bufferSize int,
-	senderDoneChan chan *sync.WaitGroup,
-	flushWg *sync.WaitGroup,
+	serverlessMeta ServerlessMeta,
 	queueCount int,
 	workersPerQueue int,
 	pipelineMonitor metrics.PipelineMonitor,
@@ -84,8 +127,7 @@ func NewSender(
 				auditor,
 				destinationFactory(),
 				bufferSize,
-				senderDoneChan,
-				flushWg,
+				serverlessMeta,
 				pipelineMonitor,
 			)
 			workers = append(workers, worker)
@@ -96,7 +138,6 @@ func NewSender(
 		workers:         workers,
 		pipelineMonitor: pipelineMonitor,
 		queues:          queues,
-		flushWg:         flushWg,
 		idx:             &atomic.Uint32{},
 	}
 }

--- a/pkg/logs/sender/sender_mock.go
+++ b/pkg/logs/sender/sender_mock.go
@@ -6,6 +6,8 @@
 package sender
 
 import (
+	"sync"
+
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 )
@@ -46,4 +48,51 @@ func (s *Mock) Start() {
 func (s *Mock) Stop() {
 	close(s.inChan)
 
+}
+
+// NewMockServerlessMeta returns a new MockServerlessMeta
+func NewMockServerlessMeta(isEnabled bool) *MockServerlessMeta {
+	if isEnabled {
+		return &MockServerlessMeta{
+			wg:        &sync.WaitGroup{},
+			doneChan:  make(chan *sync.WaitGroup),
+			isEnabled: isEnabled,
+		}
+	}
+	return &MockServerlessMeta{
+		wg:        nil,
+		doneChan:  nil,
+		isEnabled: isEnabled,
+	}
+}
+
+// MockServerlessMeta is a struct that contains essential control structures for serverless mode.
+// Do not access any methods on this struct without checking IsEnabled first.
+type MockServerlessMeta struct {
+	wg        *sync.WaitGroup
+	doneChan  chan *sync.WaitGroup
+	isEnabled bool
+}
+
+// IsEnabled returns true if the serverless mode is enabled.
+func (s *MockServerlessMeta) IsEnabled() bool {
+	return s.isEnabled
+}
+
+// Lock is a no-op for the mock serverless meta.
+func (s *MockServerlessMeta) Lock() {
+}
+
+// Unlock is a no-op for the mock serverless meta.
+func (s *MockServerlessMeta) Unlock() {
+}
+
+// WaitGroup returns the wait group for the serverless mode.
+func (s *MockServerlessMeta) WaitGroup() *sync.WaitGroup {
+	return s.wg
+}
+
+// SenderDoneChan returns the channel is used to transfer wait groups from the sync_destination to the sender.
+func (s *MockServerlessMeta) SenderDoneChan() chan *sync.WaitGroup {
+	return s.doneChan
 }

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -52,7 +52,7 @@ func TestNewSenderWorkerDistribution(t *testing.T) {
 			pipelineMonitor := metrics.NewNoopPipelineMonitor("test")
 
 			// Create sender
-			sender := NewSenderV2(
+			sender := NewSender(
 				config,
 				auditor,
 				destFactory,

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -6,7 +6,6 @@
 package sender
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,8 +46,6 @@ func TestNewSenderWorkerDistribution(t *testing.T) {
 			destinations := &client.Destinations{}
 			destFactory := func() *client.Destinations { return destinations }
 			bufferSize := 100
-			senderDoneChan := make(chan *sync.WaitGroup)
-			flushWg := &sync.WaitGroup{}
 			pipelineMonitor := metrics.NewNoopPipelineMonitor("test")
 
 			// Create sender
@@ -57,8 +54,7 @@ func TestNewSenderWorkerDistribution(t *testing.T) {
 				auditor,
 				destFactory,
 				bufferSize,
-				senderDoneChan,
-				flushWg,
+				NewMockServerlessMeta(false),
 				tc.queuesCount,
 				tc.workersPerQueue,
 				pipelineMonitor,

--- a/pkg/logs/sender/tcp/tcp_sender.go
+++ b/pkg/logs/sender/tcp/tcp_sender.go
@@ -40,7 +40,7 @@ func NewTCPSender(
 
 	destinationFactory := tcpDestinationFactory(endpoints, destinationsCtx, serverless, status)
 
-	return sender.NewSenderV2(
+	return sender.NewSender(
 		config,
 		auditor,
 		destinationFactory,

--- a/pkg/logs/sender/tcp/tcp_sender.go
+++ b/pkg/logs/sender/tcp/tcp_sender.go
@@ -7,8 +7,6 @@
 package tcp
 
 import (
-	"sync"
-
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
@@ -25,12 +23,10 @@ func NewTCPSender(
 	config pkgconfigmodel.Reader,
 	auditor auditor.Auditor,
 	bufferSize int,
-	senderDoneChan chan *sync.WaitGroup,
-	flushWg *sync.WaitGroup,
+	serverlessMeta sender.ServerlessMeta,
 	endpoints *config.Endpoints,
 	destinationsCtx *client.DestinationsContext,
 	status statusinterface.Status,
-	serverless bool,
 	componentName string,
 	queueCount int,
 	workersPerQueue int,
@@ -38,15 +34,14 @@ func NewTCPSender(
 	log.Debugf("Creating a new sender for component %s with %d queues, %d tcp workers", componentName, queueCount, workersPerQueue)
 	pipelineMonitor := metrics.NewTelemetryPipelineMonitor("tcp_sender")
 
-	destinationFactory := tcpDestinationFactory(endpoints, destinationsCtx, serverless, status)
+	destinationFactory := tcpDestinationFactory(endpoints, destinationsCtx, serverlessMeta, status)
 
 	return sender.NewSender(
 		config,
 		auditor,
 		destinationFactory,
 		bufferSize,
-		senderDoneChan,
-		flushWg,
+		serverlessMeta,
 		queueCount,
 		workersPerQueue,
 		pipelineMonitor,
@@ -56,14 +51,15 @@ func NewTCPSender(
 func tcpDestinationFactory(
 	endpoints *config.Endpoints,
 	destinationsContext *client.DestinationsContext,
-	serverless bool,
+	serverlessMeta sender.ServerlessMeta,
 	status statusinterface.Status,
 ) sender.DestinationFactory {
+	isServerless := serverlessMeta != nil
 	return func() *client.Destinations {
 		reliable := []client.Destination{}
 		additionals := []client.Destination{}
 		for _, endpoint := range endpoints.GetReliableEndpoints() {
-			reliable = append(reliable, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext, !serverless, status))
+			reliable = append(reliable, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext, !isServerless, status))
 		}
 		for _, endpoint := range endpoints.GetUnReliableEndpoints() {
 			additionals = append(additionals, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext, false, status))

--- a/pkg/logs/sender/tcp/tcp_sender_test.go
+++ b/pkg/logs/sender/tcp/tcp_sender_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
 	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
 )
 
@@ -90,7 +91,7 @@ func TestTCPDestinationFactory(t *testing.T) {
 			factory := tcpDestinationFactory(
 				endpoints,
 				destinationsCtx,
-				tc.serverless,
+				sender.NewMockServerlessMeta(tc.serverless),
 				status,
 			)
 

--- a/pkg/logs/sender/worker.go
+++ b/pkg/logs/sender/worker.go
@@ -47,33 +47,6 @@ type worker struct {
 	utilization     metrics.UtilizationMonitor
 }
 
-func newWorkerLegacy(
-	config pkgconfigmodel.Reader,
-	inputChan chan *message.Payload,
-	outputChan chan *message.Payload,
-	destinations *client.Destinations,
-	bufferSize int,
-	senderDoneChan chan *sync.WaitGroup,
-	flushWg *sync.WaitGroup,
-	pipelineMonitor metrics.PipelineMonitor,
-) *worker {
-	return &worker{
-		outputChan:     outputChan,
-		config:         config,
-		inputChan:      inputChan,
-		destinations:   destinations,
-		bufferSize:     bufferSize,
-		senderDoneChan: senderDoneChan,
-		flushWg:        flushWg,
-		done:           make(chan struct{}),
-		finished:       make(chan struct{}),
-
-		// Telemetry
-		pipelineMonitor: pipelineMonitor,
-		utilization:     pipelineMonitor.MakeUtilizationMonitor("sender"),
-	}
-}
-
 func newWorker(
 	config pkgconfigmodel.Reader,
 	inputChan chan *message.Payload,
@@ -103,9 +76,7 @@ func newWorker(
 
 // Start starts the worker.
 func (s *worker) start() {
-	if s.auditor != nil {
-		s.outputChan = s.auditor.Channel()
-	}
+	s.outputChan = s.auditor.Channel()
 
 	go s.run()
 }

--- a/pkg/logs/sender/worker.go
+++ b/pkg/logs/sender/worker.go
@@ -53,10 +53,16 @@ func newWorker(
 	auditor auditor.Auditor,
 	destinations *client.Destinations,
 	bufferSize int,
-	senderDoneChan chan *sync.WaitGroup,
-	flushWg *sync.WaitGroup,
+	serverlessMeta ServerlessMeta,
 	pipelineMonitor metrics.PipelineMonitor,
 ) *worker {
+	var senderDoneChan chan *sync.WaitGroup
+	var flushWg *sync.WaitGroup
+
+	if serverlessMeta.IsEnabled() {
+		senderDoneChan = serverlessMeta.SenderDoneChan()
+		flushWg = serverlessMeta.WaitGroup()
+	}
 	return &worker{
 		auditor:        auditor,
 		config:         config,

--- a/pkg/logs/sender/worker_test.go
+++ b/pkg/logs/sender/worker_test.go
@@ -62,7 +62,7 @@ func TestSender(t *testing.T) {
 	destinations := client.NewDestinations([]client.Destination{destination}, nil)
 
 	cfg := configmock.New(t)
-	worker := newWorker(cfg, input, auditor, destinations, 0, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker := newWorker(cfg, input, auditor, destinations, 0, NewMockServerlessMeta(false), metrics.NewNoopPipelineMonitor(""))
 	worker.start()
 
 	expectedMessage := newMessage([]byte("fake line"), source, "")
@@ -92,7 +92,7 @@ func TestSenderSingleDestination(t *testing.T) {
 
 	destinations := client.NewDestinations([]client.Destination{server.Destination}, nil)
 
-	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker := newWorker(cfg, input, auditor, destinations, 10, NewMockServerlessMeta(false), metrics.NewNoopPipelineMonitor(""))
 	worker.start()
 
 	input <- &message.Payload{}
@@ -124,7 +124,7 @@ func TestSenderDualReliableDestination(t *testing.T) {
 
 	destinations := client.NewDestinations([]client.Destination{server1.Destination, server2.Destination}, nil)
 
-	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker := newWorker(cfg, input, auditor, destinations, 10, NewMockServerlessMeta(false), metrics.NewNoopPipelineMonitor(""))
 	worker.start()
 
 	input <- &message.Payload{}
@@ -161,7 +161,7 @@ func TestSenderUnreliableAdditionalDestination(t *testing.T) {
 
 	destinations := client.NewDestinations([]client.Destination{server1.Destination}, []client.Destination{server2.Destination})
 
-	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker := newWorker(cfg, input, auditor, destinations, 10, NewMockServerlessMeta(false), metrics.NewNoopPipelineMonitor(""))
 	worker.start()
 
 	input <- &message.Payload{}
@@ -195,7 +195,7 @@ func TestSenderUnreliableStopsWhenMainFails(t *testing.T) {
 
 	destinations := client.NewDestinations([]client.Destination{reliableServer.Destination}, []client.Destination{unreliableServer.Destination})
 
-	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker := newWorker(cfg, input, auditor, destinations, 10, NewMockServerlessMeta(false), metrics.NewNoopPipelineMonitor(""))
 	worker.start()
 
 	input <- &message.Payload{}
@@ -246,7 +246,7 @@ func TestSenderReliableContinuseWhenOneFails(t *testing.T) {
 
 	destinations := client.NewDestinations([]client.Destination{reliableServer1.Destination, reliableServer2.Destination}, nil)
 
-	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker := newWorker(cfg, input, auditor, destinations, 10, NewMockServerlessMeta(false), metrics.NewNoopPipelineMonitor(""))
 	worker.start()
 
 	input <- &message.Payload{}
@@ -294,7 +294,7 @@ func TestSenderReliableWhenOneFailsAndRecovers(t *testing.T) {
 
 	destinations := client.NewDestinations([]client.Destination{reliableServer1.Destination, reliableServer2.Destination}, nil)
 
-	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker := newWorker(cfg, input, auditor, destinations, 10, NewMockServerlessMeta(false), metrics.NewNoopPipelineMonitor(""))
 	worker.start()
 
 	input <- &message.Payload{}

--- a/releasenotes/notes/serverless-distributed-sender-7833281e4f101395.yaml
+++ b/releasenotes/notes/serverless-distributed-sender-7833281e4f101395.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    fix rare panic in the flush mechanism of the serverless logs pipeline

--- a/releasenotes/notes/serverless-distributed-sender-7833281e4f101395.yaml
+++ b/releasenotes/notes/serverless-distributed-sender-7833281e4f101395.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    fix rare panic in the flush mechanism of the serverless logs pipeline
+    Fix rare panic in the flush mechanism of the serverless logs pipeline


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
1. Perform a final, nonfunctional retirement of the legacy logs pipeline sender flow. All systems should already be explicitly using the new logic except for epforwarder, which this MR shifts to an equivalent function in the new sender logic.
2. Add logic to harden serverless behavior, with the goal of preventing race conditions on the wait group used for serverless flushing. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Validation was performed via a soak in the serverless testing environment - log throughput and accuracy was judged correct, and we no longer observed panics in the serverless runtime. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->