### PR TITLE
windows allowed versions

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -578,6 +578,7 @@ new-e2e-installer-windows:
       # install-script
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallAgentPackage$"
       - EXTRA_PARAMS: --run "TestInstallScript$/TestInstallFromOldInstaller$"
+      - EXTRA_PARAMS: --run "TestInstallScript$/TestFailedUnsupportedVersion$"
       - EXTRA_PARAMS: --run "TestInstallScriptWithAgentUser$"
       # installer-package
       - EXTRA_PARAMS: --run "TestInstaller$"

--- a/pkg/fleet/installer/bootstrap/bootstrap_nix.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_nix.go
@@ -81,10 +81,10 @@ func downloadInstaller(ctx context.Context, env *env.Env, url string, tmpDir str
 	return exec.NewInstallerExec(env, installerBinPath), nil
 }
 
-func getInstallerOCI(_ context.Context, env *env.Env) string {
+func getInstallerOCI(_ context.Context, env *env.Env) (string, error) {
 	version := "latest"
 	if env.DefaultPackagesVersionOverride[InstallerPackage] != "" {
 		version = env.DefaultPackagesVersionOverride[InstallerPackage]
 	}
-	return oci.PackageURL(env, InstallerPackage, version)
+	return oci.PackageURL(env, InstallerPackage, version), nil
 }

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -147,5 +147,10 @@ func getInstallerOCI(_ context.Context, env *env.Env) (string, error) {
 			return "", fmt.Errorf("agent version %s does not support fleet automation", agentVersion)
 		}
 	}
+	// This override is used for testing purposes
+	// It allows us to specify a pipeline version to install
+	if env.DefaultPackagesVersionOverride[AgentPackage] != "" {
+		agentVersion = env.DefaultPackagesVersionOverride[AgentPackage]
+	}
 	return oci.PackageURL(env, AgentPackage, agentVersion), nil
 }

--- a/pkg/fleet/installer/bootstrap/bootstrap_windows.go
+++ b/pkg/fleet/installer/bootstrap/bootstrap_windows.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/msi"
+	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
@@ -135,10 +136,16 @@ func getInstallerFromOCI(tmpDir string) (string, error) {
 	return installers[0], nil
 }
 
-func getInstallerOCI(_ context.Context, env *env.Env) string {
-	version := "latest"
-	if env.DefaultPackagesVersionOverride[AgentPackage] != "" {
-		version = env.DefaultPackagesVersionOverride[AgentPackage]
+func getInstallerOCI(_ context.Context, env *env.Env) (string, error) {
+	agentVersion := env.GetAgentVersion()
+	if agentVersion != "latest" {
+		ver, err := version.New(agentVersion, "")
+		if err != nil {
+			return "", fmt.Errorf("failed to parse agent version: %w", err)
+		}
+		if ver.Major < 7 || (ver.Major == 7 && ver.Minor < 65) {
+			return "", fmt.Errorf("agent version %s does not support fleet automation", agentVersion)
+		}
 	}
-	return oci.PackageURL(env, AgentPackage, version)
+	return oci.PackageURL(env, AgentPackage, agentVersion), nil
 }

--- a/pkg/fleet/installer/bootstrap/bootstrapper.go
+++ b/pkg/fleet/installer/bootstrap/bootstrapper.go
@@ -16,8 +16,11 @@ import (
 
 // Bootstrap bootstraps the installer and uses it to install the default packages.
 func Bootstrap(ctx context.Context, env *env.Env) error {
-	installerURL := getInstallerOCI(ctx, env)
-	err := Install(ctx, env, installerURL)
+	installerURL, err := getInstallerOCI(ctx, env)
+	if err != nil {
+		return fmt.Errorf("failed to get the installer URL: %w", err)
+	}
+	err = Install(ctx, env, installerURL)
 	if err != nil {
 		return fmt.Errorf("failed to bootstrap the installer: %w", err)
 	}

--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -162,15 +162,5 @@ func packageToLanguage(packageName string) env.ApmLibLanguage {
 }
 
 func agentVersion(_ Package, e *env.Env) string {
-	minorVersion := e.AgentMinorVersion
-	if strings.Contains(minorVersion, ".") && !strings.HasSuffix(minorVersion, "-1") {
-		minorVersion = minorVersion + "-1"
-	}
-	if e.AgentMajorVersion != "" && minorVersion != "" {
-		return e.AgentMajorVersion + "." + minorVersion
-	}
-	if minorVersion != "" {
-		return "7." + minorVersion
-	}
-	return "latest"
+	return e.GetAgentVersion()
 }

--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -445,3 +445,18 @@ func ValidateAPMInstrumentationEnabled(value string) error {
 	}
 	return nil
 }
+
+// GetAgentVersion returns the agent version from the environment variables.
+func (e *Env) GetAgentVersion() string {
+	minorVersion := e.AgentMinorVersion
+	if strings.Contains(minorVersion, ".") && !strings.HasSuffix(minorVersion, "-1") {
+		minorVersion = minorVersion + "-1"
+	}
+	if e.AgentMajorVersion != "" && minorVersion != "" {
+		return e.AgentMajorVersion + "." + minorVersion
+	}
+	if minorVersion != "" {
+		return "7." + minorVersion
+	}
+	return "latest"
+}

--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -150,7 +150,7 @@ func (s *testInstallScriptSuite) installOldInstallerAndAgent() {
 func (s *testInstallScriptSuite) installUnsupportedAgent() {
 	// Arrange
 	// Act
-	output, err := s.InstallScript().Run(
+	_, err := s.InstallScript().Run(
 		installerwindows.WithExtraEnvVars(map[string]string{
 			// install pre 7.65 version
 			"DD_AGENT_MAJOR_VERSION": "7",
@@ -159,7 +159,5 @@ func (s *testInstallScriptSuite) installUnsupportedAgent() {
 	)
 
 	// Assert that the installation failed
-	s.Require().Error(err)
-	s.T().Log(output)
-	s.Require().Contains(output, "does not support fleet automation")
+	s.Require().ErrorContains(err, "does not support fleet automation")
 }

--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -61,7 +61,7 @@ func (s *testInstallScriptSuite) TestInstallFromOldInstaller() {
 
 // TestFailedUnsupportedVersion Test that version <65 fails to install
 func (s *testInstallScriptSuite) TestFailedUnsupportedVersion() {
-	s.Run("Install from old installer", func() {
+	s.Run("Install unsupported agent", func() {
 		s.installUnsupportedAgent()
 	})
 }
@@ -160,5 +160,6 @@ func (s *testInstallScriptSuite) installUnsupportedAgent() {
 
 	// Assert that the installation failed
 	s.Require().Error(err)
-	s.Require().Contains(output, "agent version 7.64.0 does not support fleet automation")
+	s.T().Log(output)
+	s.Require().Contains(output, "does not support fleet automation")
 }

--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -59,6 +59,13 @@ func (s *testInstallScriptSuite) TestInstallFromOldInstaller() {
 	})
 }
 
+// TestFailedUnsupportedVersion Test that version <65 fails to install
+func (s *testInstallScriptSuite) TestFailedUnsupportedVersion() {
+	s.Run("Install from old installer", func() {
+		s.installUnsupportedAgent()
+	})
+}
+
 func (s *testInstallScriptSuite) mustInstallScriptVersion(versionPredicate string, opts ...installerwindows.PackageOption) {
 	// Arrange
 	packageConfig, err := installerwindows.NewPackageConfig(opts...)
@@ -138,4 +145,20 @@ func (s *testInstallScriptSuite) installOldInstallerAndAgent() {
 		WithVersionMatchPredicate(func(version string) {
 			s.Require().Contains(version, oldAgentVersion)
 		})
+}
+
+func (s *testInstallScriptSuite) installUnsupportedAgent() {
+	// Arrange
+	// Act
+	output, err := s.InstallScript().Run(
+		installerwindows.WithExtraEnvVars(map[string]string{
+			// install pre 7.65 version
+			"DD_AGENT_MAJOR_VERSION": "7",
+			"DD_AGENT_MINOR_VERSION": "64.0",
+		}),
+	)
+
+	// Assert that the installation failed
+	s.Require().Error(err)
+	s.Require().Contains(output, "agent version 7.64.0 does not support fleet automation")
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes problems with passed in versions to windows install script. Also pins a minimum version `7.65`. This is where we combined the installer + MSI. Previous versions will not work with FLEET.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1346

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added e2e to try older version that fails and previous E2E tests that install other versions of the agent. 

Manually testes with following command:
```
$env:DD_AGENT_MAJOR_VERSION = '7';
$env:DD_AGENT_MINOR_VERSION = '65.0-devel.git.579.0000ac2.pipeline.59404687';
$env:DD_INSTALLER_REGISTRY_URL_AGENT_PACKAGE='installtesting.datad0g.com';
$env:DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE='installtesting.datad0g.com';
.\datadog-installer.exe bootstrap
```
(this uses the published staging version to make sure that version and download works)


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Note there are two ways to overwrite the Agent Version:
- Exposed: `DD_AGENT_MAJOR_VERSION` and `DD_AGENT_MINOR_VERSION`
- Non Exposed for testing: `DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_AGENT`
   - This is needed because version used in testing are form of `pipeline-ID` and not a version string

Another test might want to be added that installs a specific version of the agent, but we need a stable agent release for this. 
