### PR TITLE
Fix deadlock and stability issues in Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
+++ b/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
@@ -114,22 +114,6 @@ int {{.GetBPFFuncName}}(struct pt_regs *ctx)
         return 0;
     }
 
-    u32 cpu = bpf_get_smp_processor_id();
-
-    void *param_stack_map;
-    switch (cpu) {
-        {{- range $i, $val := until .InstrumentationInfo.InstrumentationOptions.NumCPUs }}
-        case {{$i}}: param_stack_map = &param_stack_cpu_{{$i}};
-        {{- end }}
-        default: param_stack_map = NULL;
-    }
-
-    if (!param_stack_map)
-    {
-        log_debug("there is no `param_stack` map associated with currently executing cpu %d", cpu);
-        bpf_ringbuf_discard(event, 0);
-        return 0;
-    }
 
     expression_context_t context = {
         .ctx = ctx,
@@ -138,7 +122,6 @@ int {{.GetBPFFuncName}}(struct pt_regs *ctx)
         .zero_string = zero_string,
         .output_offset = 0,
         .stack_counter = 0,
-        .param_stack = param_stack_map,
     };
 
     {{ .InstrumentationInfo.BPFParametersSourceCode }}
@@ -151,7 +134,7 @@ int {{.GetBPFFuncName}}(struct pt_regs *ctx)
     __u64 placeholder;
     long pop_ret = 0;
     for (m = 0; m < context.stack_counter; m++) {
-        pop_ret = bpf_map_pop_elem(&context.param_stack, &placeholder);
+        pop_ret = bpf_map_pop_elem(&param_stack, &placeholder);
         if (pop_ret != 0) {
             break;
         }

--- a/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
+++ b/pkg/dynamicinstrumentation/codegen/c/dynamicinstrumentation.c
@@ -114,6 +114,13 @@ int {{.GetBPFFuncName}}(struct pt_regs *ctx)
         return 0;
     }
 
+    u32 cpu = bpf_get_smp_processor_id();
+    struct bpf_map *param_stack = (struct bpf_map*)bpf_map_lookup_elem(&param_stacks, &cpu);
+    if (!param_stack) {
+        log_debug("could not lookup param stack for cpu %d", cpu);
+        bpf_ringbuf_discard(event, 0);
+        return 0;
+    }
 
     expression_context_t context = {
         .ctx = ctx,
@@ -122,6 +129,7 @@ int {{.GetBPFFuncName}}(struct pt_regs *ctx)
         .zero_string = zero_string,
         .output_offset = 0,
         .stack_counter = 0,
+        .param_stack = param_stack,
     };
 
     {{ .InstrumentationInfo.BPFParametersSourceCode }}
@@ -134,7 +142,7 @@ int {{.GetBPFFuncName}}(struct pt_regs *ctx)
     __u64 placeholder;
     long pop_ret = 0;
     for (m = 0; m < context.stack_counter; m++) {
-        pop_ret = bpf_map_pop_elem(&param_stack, &placeholder);
+        pop_ret = bpf_map_pop_elem(context.param_stack, &placeholder);
         if (pop_ret != 0) {
             break;
         }

--- a/pkg/dynamicinstrumentation/codegen/c/event.h
+++ b/pkg/dynamicinstrumentation/codegen/c/event.h
@@ -20,6 +20,7 @@ typedef struct expression_context {
     event_t *event;  // output event allocated on ringbuffer
     __u64 *temp_storage;  // temporary storage array on heap used by some location expressions
     char *zero_string;    // array of zero's used to zero out buffers
+    struct bpf_map* param_stack;
 } expression_context_t;
 
 #endif

--- a/pkg/dynamicinstrumentation/codegen/c/event.h
+++ b/pkg/dynamicinstrumentation/codegen/c/event.h
@@ -14,13 +14,12 @@ typedef struct event {
 // expression_context contains state that is meant to be shared across location expressions
 // during execution of the full bpf program.
 typedef struct expression_context {
-    __u64 output_offset;    // current offset within the output buffer to write to
-    __u8 stack_counter;     // current size of the bpf parameter stack, used for emptying stack
+    __u64 output_offset; // current offset within the output buffer to write to
+    __u8 stack_counter;  // current size of the bpf parameter stack, used for emptying stack
     struct pt_regs *ctx;
-    event_t *event;         // output event allocated on ringbuffer
-    __u64 *temp_storage;    // temporary storage array on heap used by some location expressions
-    char *zero_string;      // array of zero's used to zero out buffers
-    void *param_stack;      // a pointer to the `param_stack` map of the cpu currently executing the bpf program
+    event_t *event;  // output event allocated on ringbuffer
+    __u64 *temp_storage;  // temporary storage array on heap used by some location expressions
+    char *zero_string;    // array of zero's used to zero out buffers
 } expression_context_t;
 
 #endif

--- a/pkg/dynamicinstrumentation/codegen/c/expressions.h
+++ b/pkg/dynamicinstrumentation/codegen/c/expressions.h
@@ -11,7 +11,7 @@ static __always_inline int read_register(expression_context_t *context, __u64 re
     if (err != 0) {
         log_debug("error when reading data from register: %ld", err);
     }
-    bpf_map_push_elem(&context->param_stack, &valueHolder, 0);
+    bpf_map_push_elem(&param_stack, &valueHolder, 0);
     context->stack_counter += 1;
     return err;
 }
@@ -26,7 +26,7 @@ static __always_inline int read_stack(expression_context_t *context, size_t stac
     if (err != 0) {
         log_debug("error when reading data from stack: %ld", err);
     }
-    bpf_map_push_elem(&context->param_stack, &valueHolder, 0);
+    bpf_map_push_elem(&param_stack, &valueHolder, 0);
     context->stack_counter += 1;
     return err;
 }
@@ -66,7 +66,7 @@ static __always_inline int pop(expression_context_t *context, __u64 num_elements
     int i;
     __u8 num_elements_byte = (__u8)num_elements;
     for(i = 0; i < num_elements_byte; i++) {
-        bpf_map_pop_elem(&context->param_stack, &valueHolder);
+        bpf_map_pop_elem(&param_stack, &valueHolder);
         context->stack_counter -= 1;
         log_debug("Popping to output: %llu", valueHolder);
         err = bpf_probe_read_kernel(&context->event->output[(context->output_offset)+i], element_size, &valueHolder);
@@ -87,7 +87,7 @@ static __always_inline int dereference(expression_context_t *context, __u32 elem
 {
     long err;
     __u64 addressHolder = 0;
-    err = bpf_map_pop_elem(&context->param_stack, &addressHolder);
+    err = bpf_map_pop_elem(&param_stack, &addressHolder);
     if (err != 0) {
         log_debug("Error popping: %ld", err);
     } else {
@@ -104,7 +104,7 @@ static __always_inline int dereference(expression_context_t *context, __u32 elem
     __u64 mask = (element_size == 8) ? ~0ULL : (1ULL << (8 * element_size)) - 1;
     __u64 encodedValueHolder = valueHolder & mask;
 
-    bpf_map_push_elem(&context->param_stack, &encodedValueHolder, 0);
+    bpf_map_push_elem(&param_stack, &encodedValueHolder, 0);
     context->stack_counter += 1;
     return err;
 }
@@ -118,7 +118,7 @@ static __always_inline int dereference_to_output(expression_context_t *context, 
     long return_err;
     long err;
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&context->param_stack, &addressHolder);
+    bpf_map_pop_elem(&param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     __u64 valueHolder = 0;
@@ -152,7 +152,7 @@ static __always_inline int dereference_large(expression_context_t *context, __u3
     long return_err;
     long err;
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&context->param_stack, &addressHolder);
+    bpf_map_pop_elem(&param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     int i;
@@ -173,7 +173,7 @@ static __always_inline int dereference_large(expression_context_t *context, __u3
     }
 
     for (int i = 0; i < num_chunks; i++) {
-        bpf_map_push_elem(&context->param_stack, &context->temp_storage[i], 0);
+        bpf_map_push_elem(&param_stack, &context->temp_storage[i], 0);
         context->stack_counter += 1;
     }
 
@@ -193,7 +193,7 @@ static __always_inline int dereference_large_to_output(expression_context_t *con
 {
     long err;
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&context->param_stack, &addressHolder);
+    bpf_map_pop_elem(&param_stack, &addressHolder);
     context->stack_counter -= 1;
     err = bpf_probe_read_user(&context->event->output[(context->output_offset)], element_size, (void*)(addressHolder));
     if (err != 0) {
@@ -207,11 +207,11 @@ static __always_inline int dereference_large_to_output(expression_context_t *con
 static __always_inline int apply_offset(expression_context_t *context, size_t offset)
 {
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&context->param_stack, &addressHolder);
+    bpf_map_pop_elem(&param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     addressHolder += offset;
-    bpf_map_push_elem(&context->param_stack, &addressHolder, 0);
+    bpf_map_push_elem(&param_stack, &addressHolder, 0);
     context->stack_counter += 1;
     return 0;
 }
@@ -223,11 +223,11 @@ static __always_inline int dereference_dynamic_to_output(expression_context_t *c
 {
     long err = 0;
     __u64 lengthToRead = 0;
-    bpf_map_pop_elem(&context->param_stack, &lengthToRead);
+    bpf_map_pop_elem(&param_stack, &lengthToRead);
     context->stack_counter -= 1;
 
     __u64 addressHolder = 0;
-    bpf_map_pop_elem(&context->param_stack, &addressHolder);
+    bpf_map_pop_elem(&param_stack, &addressHolder);
     context->stack_counter -= 1;
 
     __u32 collection_size;
@@ -255,7 +255,7 @@ static __always_inline int set_limit_entry(expression_context_t *context, __u16 
 {
     // Read the 2 byte length from top of the stack, then set collectionLimit to the minimum of the two
     __u64 length;
-    bpf_map_pop_elem(&context->param_stack, &length);
+    bpf_map_pop_elem(&param_stack, &length);
     context->stack_counter -= 1;
 
     __u16 lengthShort = (__u16)length;
@@ -277,21 +277,21 @@ static __always_inline int set_limit_entry(expression_context_t *context, __u16 
 static __always_inline int copy(expression_context_t *context)
 {
     __u64 holder;
-    bpf_map_peek_elem(&context->param_stack, &holder);
-    bpf_map_push_elem(&context->param_stack, &holder, 0);
+    bpf_map_peek_elem(&param_stack, &holder);
+    bpf_map_push_elem(&param_stack, &holder, 0);
     context->stack_counter += 1;
     return 0;
 }
 
 // read_str_to_output reads a Go string to the output buffer, limited in length by `limit`.
-// In Go, strings are internally implemented as structs with two fields. The fields are length,
+// In Go, strings are internally implemented as structs with two fields. The fields are length, 
 // and a pointer to a character array. This expression expects the address of the string struct
 // itself to be on the top of the stack.
 static __always_inline int read_str_to_output(expression_context_t *context, __u16 limit)
 {
     long err;
     __u64 stringStructAddressHolder = 0;
-    err = bpf_map_pop_elem(&context->param_stack, &stringStructAddressHolder);
+    err = bpf_map_pop_elem(&param_stack, &stringStructAddressHolder);
     if (err != 0) {
         log_debug("error popping string struct addr: %ld", err);
         return err;

--- a/pkg/dynamicinstrumentation/codegen/c/maps.h
+++ b/pkg/dynamicinstrumentation/codegen/c/maps.h
@@ -25,10 +25,7 @@ BPF_PERCPU_ARRAY_MAP(temp_storage_array, __u64[4000], 1);
 // when reading the values in the collection.
 BPF_HASH_MAP(collection_limits, char[6], __u16, 1024);
 
-// The param_stack_cpu_<i> map is used as a stack for the location expressions
-// to operate on values and addresses. We use templating to create per-cpu map
-{{- range $i, $val := until .InstrumentationInfo.InstrumentationOptions.NumCPUs }}
-BPF_STACK_MAP(param_stack_cpu_{{$i}}, __u64, 2048);
-{{- end }}
-
+// The param_stack map is used as a stack for the location expressions
+// to operate on values and addresses.
+BPF_STACK_MAP(param_stack, __u64, 2048);
 #endif

--- a/pkg/dynamicinstrumentation/codegen/c/maps.h
+++ b/pkg/dynamicinstrumentation/codegen/c/maps.h
@@ -22,7 +22,7 @@ struct inner_param_stack {
 // The param_stacks map is to set up a unique stack for each CPU.
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
-    __uint(max_entries, 32); // we arbitrarily set this to support 32 CPUs
+    __uint(max_entries, 0);
     __uint(key_size, sizeof(__u32));
     __array(values, struct inner_param_stack);
 } param_stacks SEC(".maps");

--- a/pkg/dynamicinstrumentation/codegen/c/maps.h
+++ b/pkg/dynamicinstrumentation/codegen/c/maps.h
@@ -10,6 +10,23 @@ struct {
     __uint(max_entries, 1 << 24);
 } events SEC(".maps");
 
+
+// The param_stack map is used as a stack for the location expressions
+// to operate on values and addresses.
+struct inner_param_stack {
+    __uint(type, BPF_MAP_TYPE_STACK);
+    __uint(max_entries, 2048);
+    __uint(value_size, sizeof(__u64));
+};
+
+// The param_stacks map is to set up a unique stack for each CPU.
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+    __uint(max_entries, 32); // we arbitrarily set this to support 32 CPUs
+    __uint(key_size, sizeof(__u32));
+    __array(values, struct inner_param_stack);
+} param_stacks SEC(".maps");
+
 // The zeroval map is used to have pre-zero'd data which bpf code can
 // use to zero out event buffers (similar to memset, but verifier friendly).
 BPF_ARRAY_MAP(zeroval, char[PARAM_BUFFER_SIZE], 1);
@@ -24,8 +41,4 @@ BPF_PERCPU_ARRAY_MAP(temp_storage_array, __u64[4000], 1);
 // of collections such as slices so that they can later be referenced
 // when reading the values in the collection.
 BPF_HASH_MAP(collection_limits, char[6], __u16, 1024);
-
-// The param_stack map is used as a stack for the location expressions
-// to operate on values and addresses.
-BPF_STACK_MAP(param_stack, __u64, 2048);
 #endif

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -25,12 +25,14 @@ func inspectGoBinaries(configEvent ditypes.DIProcs) error {
 	var err error
 	var inspectedAtLeastOneBinary bool
 	for i := range configEvent {
+		configEvent[i].Lock()
 		err = AnalyzeBinary(configEvent[i])
 		if err != nil {
 			log.Info("inspection of PID %d (path=%s) failed: %w", configEvent[i].PID, configEvent[i].BinaryPath, err)
 		} else {
 			inspectedAtLeastOneBinary = true
 		}
+		configEvent[i].Unlock()
 	}
 
 	if !inspectedAtLeastOneBinary {

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -25,14 +25,12 @@ func inspectGoBinaries(configEvent ditypes.DIProcs) error {
 	var err error
 	var inspectedAtLeastOneBinary bool
 	for i := range configEvent {
-		configEvent[i].Lock()
 		err = AnalyzeBinary(configEvent[i])
 		if err != nil {
 			log.Info("inspection of PID %d (path=%s) failed: %w", configEvent[i].PID, configEvent[i].BinaryPath, err)
 		} else {
 			inspectedAtLeastOneBinary = true
 		}
-		configEvent[i].Unlock()
 	}
 
 	if !inspectedAtLeastOneBinary {

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection_test.go
@@ -61,7 +61,7 @@ func TestAnalyzeBinary(t *testing.T) {
 			procInfo := ditypes.ProcessInfo{
 				BinaryPath: binPath,
 				ProbesByID: func() *ditypes.ProbesByID {
-					p := &ditypes.ProbesByID{}
+					p := ditypes.NewProbesByID()
 					p.Set(testCases[i].FuncName, &ditypes.Probe{
 						ServiceName: "sample",
 						FuncName:    testCases[i].FuncName,

--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection_test.go
@@ -60,12 +60,14 @@ func TestAnalyzeBinary(t *testing.T) {
 
 			procInfo := ditypes.ProcessInfo{
 				BinaryPath: binPath,
-				ProbesByID: ditypes.ProbesByID{
-					testCases[i].FuncName: &ditypes.Probe{
+				ProbesByID: func() *ditypes.ProbesByID {
+					p := &ditypes.ProbesByID{}
+					p.Set(testCases[i].FuncName, &ditypes.Probe{
 						ServiceName: "sample",
 						FuncName:    testCases[i].FuncName,
-					},
-				},
+					})
+					return p
+				}(),
 			}
 			err = AnalyzeBinary(&procInfo)
 			if err != nil {

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -12,7 +12,6 @@ package diconfig
 import (
 	"encoding/json"
 	"fmt"
-	"runtime"
 
 	"github.com/cilium/ebpf/ringbuf"
 	"github.com/google/uuid"
@@ -226,7 +225,6 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 			StringMaxSize:     ditypes.StringMaxSize,
 			MaxReferenceDepth: conf.Capture.MaxReferenceDepth,
 			MaxFieldCount:     conf.Capture.MaxFieldCount,
-			NumCPUs:           runtime.NumCPU(),
 		}
 
 		probe, probeExists := procInfo.ProbesByID[configPath.ProbeUUID.String()]
@@ -303,7 +301,6 @@ func newConfigProbe() *ditypes.Probe {
 				MaxFieldCount:     int(ditypes.MaxFieldCount),
 				MaxReferenceDepth: 8,
 				CaptureParameters: true,
-				NumCPUs:           runtime.NumCPU(),
 			},
 		},
 		RateLimiter: ratelimiter.NewSingleEventRateLimiter(0),

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -126,7 +126,7 @@ func (cm *RCConfigManager) installConfigProbe(procInfo *ditypes.ProcessInfo) err
 
 	svcConfigProbe := *configProbe
 	svcConfigProbe.ServiceName = procInfo.ServiceName
-	procInfo.ProbesByID[configProbe.ID] = &svcConfigProbe
+	procInfo.ProbesByID.Set(configProbe.ID, &svcConfigProbe)
 
 	log.Infof("Installing config probe for service: %s", svcConfigProbe.ServiceName)
 	procInfo.TypeMap = &ditypes.TypeMap{
@@ -227,11 +227,11 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 			MaxFieldCount:     conf.Capture.MaxFieldCount,
 		}
 
-		probe, probeExists := procInfo.ProbesByID[configPath.ProbeUUID.String()]
-		if !probeExists {
+		probe := procInfo.ProbesByID.Get(configPath.ProbeUUID.String())
+		if probe == nil {
 			cm.diProcs.SetProbe(procInfo.PID, procInfo.ServiceName, conf.Where.TypeName, conf.Where.MethodName, configPath.ProbeUUID, runtimeID, opts)
 			diagnostics.Diagnostics.SetStatus(procInfo.ServiceName, runtimeID.String(), configPath.ProbeUUID.String(), ditypes.StatusReceived)
-			probe = procInfo.ProbesByID[configPath.ProbeUUID.String()]
+			probe = procInfo.ProbesByID.Get(configPath.ProbeUUID.String())
 		}
 
 		// Check hash to see if the configuration changed

--- a/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
@@ -73,15 +73,13 @@ func (cm *ReaderConfigManager) update() error {
 			// If a config exists relevant to this proc
 			if proc.ServiceName == serviceName {
 				updatedState[pid] = &ditypes.ProcessInfo{
-					PID:                    proc.PID,
-					ServiceName:            proc.ServiceName,
-					RuntimeID:              proc.RuntimeID,
-					BinaryPath:             proc.BinaryPath,
-					TypeMap:                proc.TypeMap,
-					ConfigurationUprobe:    proc.ConfigurationUprobe,
-					InstrumentationUprobes: proc.InstrumentationUprobes,
-					InstrumentationObjects: proc.InstrumentationObjects,
-					ProbesByID:             convert(serviceName, configsByID),
+					PID:                 proc.PID,
+					ServiceName:         proc.ServiceName,
+					RuntimeID:           proc.RuntimeID,
+					BinaryPath:          proc.BinaryPath,
+					TypeMap:             proc.TypeMap,
+					ConfigurationUprobe: proc.ConfigurationUprobe,
+					ProbesByID:          convert(serviceName, configsByID),
 				}
 			}
 		}
@@ -205,10 +203,10 @@ func (r *ConfigWriter) UpdateProcesses(procs ditypes.DIProcs) {
 	}
 }
 
-func convert(service string, configsByID map[ditypes.ProbeID]rcConfig) map[ditypes.ProbeID]*ditypes.Probe {
-	probesByID := map[ditypes.ProbeID]*ditypes.Probe{}
+func convert(service string, configsByID map[ditypes.ProbeID]rcConfig) *ditypes.ProbesByID {
+	probesByID := &ditypes.ProbesByID{}
 	for id, config := range configsByID {
-		probesByID[id] = config.toProbe(service)
+		probesByID.Set(id, config.toProbe(service))
 	}
 	return probesByID
 }

--- a/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"runtime"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
@@ -227,7 +226,6 @@ func (rc *rcConfig) toProbe(service string) *ditypes.Probe {
 				SliceMaxLength:    ditypes.SliceMaxLength,
 				MaxReferenceDepth: rc.Capture.MaxReferenceDepth,
 				MaxFieldCount:     rc.Capture.MaxFieldCount,
-				NumCPUs:           runtime.NumCPU(),
 			},
 		},
 	}

--- a/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/mem_config_manager.go
@@ -94,15 +94,12 @@ func (cm *ReaderConfigManager) update() error {
 		for pid, procInfo := range cm.state {
 			// cleanup dead procs
 			if _, running := updatedState[pid]; !running {
-				procInfo.Lock()
 				procInfo.CloseAllUprobeLinks()
 				delete(cm.state, pid)
-				procInfo.Unlock()
 			}
 		}
 
 		for pid, procInfo := range updatedState {
-			procInfo.Lock()
 			if _, tracked := cm.state[pid]; !tracked {
 				for _, probe := range procInfo.GetProbes() {
 					// install all probes from new process
@@ -117,7 +114,6 @@ func (cm *ReaderConfigManager) update() error {
 					cm.callback(procInfo, updatedProbe)
 				}
 			}
-			procInfo.Unlock()
 		}
 		cm.state = updatedState
 	}

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -139,13 +138,10 @@ type ProcessInfo struct {
 	ProbesByID             ProbesByID
 	InstrumentationUprobes map[ProbeID]*link.Link
 	InstrumentationObjects map[ProbeID]*ebpf.Collection
-	mu                     sync.RWMutex
 }
 
 // SetupConfigUprobe sets the configuration probe for the process
 func (pi *ProcessInfo) SetupConfigUprobe() (*ebpf.Map, error) {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
 
 	configProbe, ok := pi.ProbesByID[ConfigBPFProbeID]
 	if !ok {
@@ -177,16 +173,12 @@ func (pi *ProcessInfo) CloseConfigUprobe() error {
 // SetUprobeLink associates the uprobe link with the specified probe
 // in the tracked process
 func (pi *ProcessInfo) SetUprobeLink(probeID ProbeID, l *link.Link) {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
 	pi.InstrumentationUprobes[probeID] = l
 }
 
 // CloseUprobeLink closes the probe and deletes the link for the probe
 // in the tracked process
 func (pi *ProcessInfo) CloseUprobeLink(probeID ProbeID) error {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
 	if l, ok := pi.InstrumentationUprobes[probeID]; ok {
 		err := (*l).Close()
 		delete(pi.InstrumentationUprobes, probeID)
@@ -198,8 +190,6 @@ func (pi *ProcessInfo) CloseUprobeLink(probeID ProbeID) error {
 // CloseAllUprobeLinks closes all probes and deletes their links for all probes
 // in the tracked process
 func (pi *ProcessInfo) CloseAllUprobeLinks() {
-	pi.mu.Lock()
-	defer pi.mu.Unlock()
 
 	for probeID := range pi.InstrumentationUprobes {
 		if err := pi.CloseUprobeLink(probeID); err != nil {
@@ -270,7 +260,6 @@ type InstrumentationOptions struct {
 	MaxReferenceDepth int
 	MaxFieldCount     int
 	SliceMaxLength    int
-	NumCPUs           int
 }
 
 // Probe represents a location in a GoProgram that can be instrumented

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -14,7 +14,6 @@ import (
 	"io"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -299,7 +298,6 @@ type ProcessInfo struct {
 
 	TypeMap *TypeMap
 
-	sync.RWMutex
 	ConfigurationUprobe    *link.Link
 	ProbesByID             *ProbesByID
 	InstrumentationUprobes *InstrumentationUprobesMap

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -96,7 +96,7 @@ func (p *ProbesByID) Delete(id ProbeID) {
 
 // Range calls f sequentially for each key and value present in the map
 func (p *ProbesByID) Range(f func(id ProbeID, probe *Probe) bool) {
-	p.Map.Range(func(key, value interface{}) bool {
+	p.Map.Range(func(key, value any) bool {
 		return f(key.(ProbeID), value.(*Probe))
 	})
 }
@@ -104,7 +104,7 @@ func (p *ProbesByID) Range(f func(id ProbeID, probe *Probe) bool) {
 // Len returns the number of items in the map
 func (p *ProbesByID) Len() int {
 	count := 0
-	p.Range(func(id ProbeID, probe *Probe) bool {
+	p.Range(func(_ ProbeID, _ *Probe) bool {
 		count++
 		return true
 	})
@@ -193,7 +193,7 @@ func (p *InstrumentationUprobesMap) Delete(id ProbeID) {
 
 // Range calls f sequentially for each key and value present in the map
 func (p *InstrumentationUprobesMap) Range(f func(id ProbeID, l *link.Link) bool) {
-	p.Map.Range(func(key, value interface{}) bool {
+	p.Map.Range(func(key, value any) bool {
 		return f(key.(ProbeID), value.(*link.Link))
 	})
 }
@@ -223,7 +223,7 @@ func (p *InstrumentationObjectsMap) Delete(id ProbeID) {
 
 // Range calls f sequentially for each key and value present in the map
 func (p *InstrumentationObjectsMap) Range(f func(id ProbeID, c *ebpf.Collection) bool) {
-	p.Map.Range(func(key, value interface{}) bool {
+	p.Map.Range(func(key, value any) bool {
 		return f(key.(ProbeID), value.(*ebpf.Collection))
 	})
 }
@@ -315,7 +315,7 @@ func (pi *ProcessInfo) CloseAllUprobeLinks() {
 	if pi.InstrumentationUprobes == nil {
 		return
 	}
-	pi.InstrumentationUprobes.Range(func(id ProbeID, l *link.Link) bool {
+	pi.InstrumentationUprobes.Range(func(id ProbeID, _ *link.Link) bool {
 		if err := pi.CloseUprobeLink(id); err != nil {
 			log.Info("Failed to close uprobe link for probe", pi.BinaryPath, pi.PID, id, err)
 		}
@@ -333,7 +333,7 @@ func (pi *ProcessInfo) GetProbes() []*Probe {
 		return nil
 	}
 	probes := make([]*Probe, 0, pi.ProbesByID.Len())
-	pi.ProbesByID.Range(func(id ProbeID, probe *Probe) bool {
+	pi.ProbesByID.Range(func(_ ProbeID, probe *Probe) bool {
 		probes = append(probes, probe)
 		return true
 	})

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -125,15 +125,6 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 	return nil
 }
 
-// until generates a slice of integers from 0 to n-1
-func until(n int) []int {
-	arr := make([]int, n)
-	for i := 0; i < n; i++ {
-		arr[i] = i
-	}
-	return arr
-}
-
 // CompileBPFProgram compiles the code for a single probe
 func CompileBPFProgram(probe *ditypes.Probe) error {
 	f := func(in io.Reader, out io.Writer) error {
@@ -141,10 +132,7 @@ func CompileBPFProgram(probe *ditypes.Probe) error {
 		if err != nil {
 			return err
 		}
-		programTemplate := template.New("program_template").Funcs(template.FuncMap{
-			"until": until,
-		})
-		programTemplate, err = programTemplate.Parse(string(fileContents))
+		programTemplate, err := template.New("program_template").Parse(string(fileContents))
 		if err != nil {
 			return err
 		}

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -123,7 +123,7 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 	}
 
 	if procInfo.InstrumentationObjects == nil {
-		procInfo.InstrumentationObjects = &ditypes.InstrumentationObjectsMap{}
+		procInfo.InstrumentationObjects = ditypes.NewInstrumentationObjectsMap()
 	}
 	procInfo.InstrumentationObjects.Set(probe.ID, bpfObject)
 

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -15,14 +15,13 @@ import (
 	"io"
 	"text/template"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/link"
-
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/diagnostics"
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	ebpfruntime "github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 )
 
 // SetupEventsMap creates the ringbuffer which all programs will use for sending output
@@ -54,7 +53,43 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 		return fmt.Errorf("could not create bpf collection for probe %s: %w", probe.ID, err)
 	}
 
-	mapReplacements := map[string]*ebpf.Map{}
+	inner := &ebpf.MapSpec{
+		Type:       ebpf.Stack,
+		MaxEntries: 2048,
+		ValueSize:  8,
+	}
+
+	outer := &ebpf.MapSpec{
+		Name:       "param_stacks",
+		InnerMap:   inner,
+		Type:       ebpf.ArrayOfMaps,
+		MaxEntries: uint32(32), // we arbitrarily set this to support 32 CPUs
+		KeySize:    4,
+	}
+
+	for i := range outer.MaxEntries {
+		innerMap, err := ebpf.NewMap(inner)
+		if err != nil {
+			return fmt.Errorf("could not create bpf map for reading memory content: %w", err)
+		}
+		outer.Contents = append(outer.Contents,
+			ebpf.MapKV{
+				Key:   uint32(i),
+				Value: innerMap,
+			},
+		)
+	}
+
+	paramStacks, err := ebpf.NewMap(outer)
+	if err != nil {
+		diagnostics.Diagnostics.SetError(procInfo.ServiceName, procInfo.RuntimeID, probe.ID, "ATTACH_ERROR", "could not create bpf map for reading memory content")
+		return fmt.Errorf("could not create bpf map for reading memory content: %w", err)
+	}
+
+	mapReplacements := map[string]*ebpf.Map{
+		"param_stacks": paramStacks,
+	}
+
 	if probe.ID != ditypes.ConfigBPFProbeID {
 		// config probe is special and should not be on the same ringbuffer
 		// as the rest of regular events. Despite having the same "events" name,
@@ -147,12 +182,12 @@ func CompileBPFProgram(probe *ditypes.Probe) error {
 	}
 
 	cfg := ddebpf.NewConfig()
-	opts := runtime.CompileOptions{
+	opts := ebpfruntime.CompileOptions{
 		AdditionalFlags:  getCFlags(cfg),
 		ModifyCallback:   f,
 		UseKernelHeaders: true,
 	}
-	compiledOutput, err := runtime.Dynamicinstrumentation.CompileWithOptions(cfg, opts)
+	compiledOutput, err := ebpfruntime.Dynamicinstrumentation.CompileWithOptions(cfg, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -87,7 +87,10 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 		return fmt.Errorf("could not load bpf collection for probe %s: %w", probe.ID, err)
 	}
 
-	procInfo.InstrumentationObjects[probe.ID] = bpfObject
+	if procInfo.InstrumentationObjects == nil {
+		procInfo.InstrumentationObjects = &ditypes.InstrumentationObjectsMap{}
+	}
+	procInfo.InstrumentationObjects.Set(probe.ID, bpfObject)
 
 	// Populate map used for zero'ing out regions of memory
 	zeroValMap, ok := bpfObject.Maps["zeroval"]

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -247,6 +247,9 @@ func (pt *ProcessTracker) currentState() map[ditypes.PID]*ditypes.ProcessInfo {
 			PID:         pid,
 			BinaryPath:  bin.binaryPath,
 			ServiceName: bin.serviceName,
+			ProbesByID:  ditypes.NewProbesByID(),
+			InstrumentationUprobes: ditypes.NewInstrumentationUprobesMap(),
+			InstrumentationObjects: ditypes.NewInstrumentationObjectsMap(),
 		}
 	}
 	return state

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -18,8 +18,6 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/link"
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
@@ -249,10 +247,6 @@ func (pt *ProcessTracker) currentState() map[ditypes.PID]*ditypes.ProcessInfo {
 			PID:         pid,
 			BinaryPath:  bin.binaryPath,
 			ServiceName: bin.serviceName,
-
-			ProbesByID:             make(map[ditypes.ProbeID]*ditypes.Probe),
-			InstrumentationUprobes: make(map[ditypes.ProbeID]*link.Link),
-			InstrumentationObjects: make(map[ditypes.ProbeID]*ebpf.Collection),
 		}
 	}
 	return state

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -244,10 +244,10 @@ func (pt *ProcessTracker) currentState() map[ditypes.PID]*ditypes.ProcessInfo {
 	for pid, binID := range pt.processes {
 		bin := pt.binaries[binID]
 		state[pid] = &ditypes.ProcessInfo{
-			PID:         pid,
-			BinaryPath:  bin.binaryPath,
-			ServiceName: bin.serviceName,
-			ProbesByID:  ditypes.NewProbesByID(),
+			PID:                    pid,
+			BinaryPath:             bin.binaryPath,
+			ServiceName:            bin.serviceName,
+			ProbesByID:             ditypes.NewProbesByID(),
 			InstrumentationUprobes: ditypes.NewInstrumentationUprobesMap(),
 			InstrumentationObjects: ditypes.NewInstrumentationObjectsMap(),
 		}

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -39,7 +39,7 @@ var basicCaptures = fixtures{
 		},
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"x": &ditypes.CapturedValue{
+				"x": {
 					NotCapturedReason: "depth",
 					Type:              "bool",
 				}},
@@ -432,7 +432,7 @@ var pointerCaptures = fixtures{
 		},
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"x": &ditypes.CapturedValue{
+				"x": {
 					NotCapturedReason: "depth",
 					Type:              "*uint",
 				},
@@ -617,7 +617,7 @@ func mergeMaps(maps ...fixtures) fixtures {
 var expectedCaptures = mergeMaps(
 	basicCaptures,
 	stringCaptures,
-	// arrayCaptures,
+	arrayCaptures,
 	structCaptures,
 	sliceCaptures,
 	pointerCaptures,

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -617,7 +617,7 @@ func mergeMaps(maps ...fixtures) fixtures {
 var expectedCaptures = mergeMaps(
 	basicCaptures,
 	stringCaptures,
-	// arrayCaptures,
+	arrayCaptures,
 	structCaptures,
 	sliceCaptures,
 	pointerCaptures,

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -617,7 +617,7 @@ func mergeMaps(maps ...fixtures) fixtures {
 var expectedCaptures = mergeMaps(
 	basicCaptures,
 	stringCaptures,
-	arrayCaptures,
+	// arrayCaptures,
 	structCaptures,
 	sliceCaptures,
 	pointerCaptures,

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -38,8 +38,12 @@ var basicCaptures = fixtures{
 			Options:          TestInstrumentationOptions{CaptureDepth: 10},
 		},
 		{
-			CapturedValueMap: nil,
-			Options:          TestInstrumentationOptions{CaptureDepth: 0},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": &ditypes.CapturedValue{
+					NotCapturedReason: "depth",
+					Type:              "bool",
+				}},
+			Options: TestInstrumentationOptions{CaptureDepth: 0},
 		},
 	},
 
@@ -214,11 +218,11 @@ var arrayCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_array_of_structs": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{"a": {Type: "array", Fields: fieldMap{
-				"[2]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct[0]": {Type: "struct", Fields: fieldMap{
+				"[2]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct[0]": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct", Fields: fieldMap{
 					"anotherInt":    capturedValue("int", "42"),
 					"anotherString": capturedValue("string", "foo"),
 				}},
-				"[2]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct[1]": {Type: "struct", Fields: fieldMap{
+				"[2]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct[1]": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct", Fields: fieldMap{
 					"anotherInt":    capturedValue("int", "24"),
 					"anotherString": capturedValue("string", "bar"),
 				}},
@@ -274,17 +278,17 @@ var sliceCaptures = fixtures{
 					Type: "[]struct",
 					Fields: fieldMap{
 						"[0]struct": &ditypes.CapturedValue{
-							Type: "struct",
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
 							Fields: fieldMap{
-								"arg_0": capturedValue("uint8", "42"),
-								"arg_1": capturedValue("bool", "true"),
+								"aUint8": capturedValue("uint8", "42"),
+								"aBool":  capturedValue("bool", "true"),
 							},
 						},
 						"[1]struct": &ditypes.CapturedValue{
-							Type: "struct",
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
 							Fields: fieldMap{
-								"arg_0": capturedValue("uint8", "24"),
-								"arg_1": capturedValue("bool", "true"),
+								"aUint8": capturedValue("uint8", "24"),
+								"aBool":  capturedValue("bool", "true"),
 							},
 						},
 					},
@@ -298,7 +302,7 @@ var sliceCaptures = fixtures{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"a": capturedValue("int", "2"),
 				"xs": {
-					Type:   "[]struct",
+					Type:   "[]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings",
 					Fields: nil,
 				},
 			},
@@ -310,7 +314,7 @@ var sliceCaptures = fixtures{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"a": capturedValue("int", "5"),
 				"xs": {
-					Type:   "[]struct",
+					Type:   "[]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings",
 					Fields: nil,
 				},
 			},
@@ -335,11 +339,15 @@ var sliceCaptures = fixtures{
 var structCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_struct": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"t": {Type: "struct", Fields: fieldMap{
-				"arg_0": capturedValue("string", "a"),
-				"arg_1": capturedValue("string", "bb"),
-				"arg_2": capturedValue("string", "ccc"),
-			}}},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"t": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.threestrings", Fields: fieldMap{
+						"a": capturedValue("string", "a"),
+						"b": capturedValue("string", "bb"),
+						"c": capturedValue("string", "ccc"),
+					},
+				},
+			},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
@@ -347,8 +355,8 @@ var structCaptures = fixtures{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"r": {
-					Type: "struct", Fields: fieldMap{
-						"arg_0": capturedValue("uint", "1"),
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.receiver", Fields: fieldMap{
+						"u": capturedValue("uint", "1"),
 					}},
 				"a": capturedValue("int", "2"),
 			},
@@ -357,43 +365,53 @@ var structCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nonembedded_struct": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "struct", Fields: fieldMap{
-				"arg_0": capturedValue("bool", "true"),
-				"arg_1": capturedValue("int", "1"),
-				"arg_2": capturedValue("int16", "2"),
-			}}},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
+					Fields: fieldMap{
+						"aBool":  capturedValue("bool", "true"),
+						"aInt":   capturedValue("int", "1"),
+						"aInt16": capturedValue("int16", "2"),
+					}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_pointer": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "ptr", Fields: fieldMap{
-				"arg_0": {
-					Type: "struct", Fields: fieldMap{
-						"arg_0": capturedValue("bool", "true"),
-						"arg_1": capturedValue("int", "1"),
-						"arg_2": capturedValue("int16", "2"),
-					}},
-			}}},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": {
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
+					Fields: fieldMap{
+						"arg_0": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct", Fields: fieldMap{
+								"aBool":  capturedValue("bool", "true"),
+								"aInt":   capturedValue("int", "1"),
+								"aInt16": capturedValue("int16", "2"),
+							}},
+					}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_multiple_embedded_struct": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"b": {Type: "struct", Fields: fieldMap{
-				"arg_0": capturedValue("int16", "42"),
-				"arg_1": {Type: "struct", Fields: fieldMap{
-					"arg_0": capturedValue("bool", "true"),
-					"arg_1": capturedValue("string", "one"),
-					"arg_2": capturedValue("int", "2"),
-					"arg_3": {Type: "struct", Fields: fieldMap{
-						"arg_0": capturedValue("int", "3"),
-						"arg_1": capturedValue("string", "four"),
-					}},
-				}},
-				"arg_2": capturedValue("bool", "true"),
-				"arg_3": capturedValue("int32", "31"),
-			}}},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"b": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.bStruct",
+					Fields: fieldMap{
+						"aInt16": capturedValue("int16", "42"),
+						"nested": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.aStruct", Fields: fieldMap{
+								"aBool":   capturedValue("bool", "true"),
+								"aString": capturedValue("string", "one"),
+								"aNumber": capturedValue("int", "2"),
+								"nested": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct", Fields: fieldMap{
+									"anotherInt":    capturedValue("int", "3"),
+									"anotherString": capturedValue("string", "four"),
+								}},
+							}},
+						"aBool":  capturedValue("bool", "true"),
+						"aInt32": capturedValue("int32", "31"),
+					}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
@@ -413,8 +431,13 @@ var pointerCaptures = fixtures{
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 		{
-			CapturedValueMap: nil,
-			Options:          TestInstrumentationOptions{CaptureDepth: 0},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": &ditypes.CapturedValue{
+					NotCapturedReason: "depth",
+					Type:              "*uint",
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 0},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nil_pointer": []CapturedValueMapWithOptions{
@@ -428,16 +451,19 @@ var pointerCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_pointer": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "*struct", Fields: fieldMap{
-				"arg_0": &ditypes.CapturedValue{
-					Type: "struct",
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": {
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
 					Fields: fieldMap{
-						"arg_0": capturedValue("bool", "true"),
-						"arg_1": capturedValue("int", "1"),
-						"arg_2": capturedValue("int16", "2"),
-					},
-				},
-			}}},
+						"arg_0": &ditypes.CapturedValue{
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
+							Fields: fieldMap{
+								"aBool":  capturedValue("bool", "true"),
+								"aInt":   capturedValue("int", "1"),
+								"aInt16": capturedValue("int16", "2"),
+							},
+						},
+					}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
@@ -445,7 +471,7 @@ var pointerCaptures = fixtures{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"a": {Type: "int", Value: strPtr("5")},
-				"x": {Type: "*struct"},
+				"x": {Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct"},
 				"z": {Type: "uint", Value: strPtr("4")},
 			},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
@@ -453,12 +479,13 @@ var pointerCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_pointer": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"z": {
-				Type: "*string",
-				Fields: fieldMap{
-					"arg_0": capturedValue("string", "abc"),
-				},
-			}},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"z": {
+					Type: "*string",
+					Fields: fieldMap{
+						"arg_0": capturedValue("string", "abc"),
+					},
+				}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
@@ -466,13 +493,13 @@ var pointerCaptures = fixtures{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"s": {
-					Type: "*struct",
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithAString",
 					Fields: fieldMap{
 						"arg_0": &ditypes.CapturedValue{
-							Type: "struct",
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithAString",
 							Fields: fieldMap{
-								"arg_0": capturedValue("int", "5"),
-								"arg_1": capturedValue("string", "abcdef"),
+								"x": capturedValue("int", "5"),
+								"s": capturedValue("string", "abcdef"),
 							},
 						},
 					},
@@ -485,13 +512,13 @@ var pointerCaptures = fixtures{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"s": {
-					Type: "*struct",
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithASlice",
 					Fields: fieldMap{
 						"arg_0": &ditypes.CapturedValue{
-							Type: "struct",
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithASlice",
 							Fields: fieldMap{
-								"arg_0": capturedValue("int", "5"),
-								"arg_1": &ditypes.CapturedValue{
+								"x": capturedValue("int", "5"),
+								"slice": &ditypes.CapturedValue{
 									Type: "[]uint8",
 									Fields: fieldMap{
 										"[0]uint8": capturedValue("uint8", "2"),
@@ -499,7 +526,7 @@ var pointerCaptures = fixtures{
 										"[2]uint8": capturedValue("uint8", "4"),
 									},
 								},
-								"arg_2": capturedValue("uint64", "5"),
+								"z": capturedValue("uint64", "5"),
 							},
 						},
 					},
@@ -514,14 +541,14 @@ var captureDepthCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_multiple_struct_tiers": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"a": {Type: "struct", Fields: fieldMap{
-					"arg_0": capturedValue("int", "1"),
-					"arg_1": {Type: "struct", Fields: fieldMap{
-						"arg_0": capturedValue("int", "2"),
-						"arg_1": {Type: "struct", Fields: fieldMap{
-							"arg_0": capturedValue("int", "3"),
-							"arg_1": {Type: "struct", Fields: fieldMap{
-								"arg_0": capturedValue("int", "4"),
+				"a": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierA", Fields: fieldMap{
+					"a": capturedValue("int", "1"),
+					"b": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierB", Fields: fieldMap{
+						"c": capturedValue("int", "2"),
+						"d": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierC", Fields: fieldMap{
+							"e": capturedValue("int", "3"),
+							"f": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierD", Fields: fieldMap{
+								"g": capturedValue("int", "4"),
 							}},
 						}},
 					}},
@@ -531,12 +558,13 @@ var captureDepthCaptures = fixtures{
 		},
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"a": {Type: "struct", Fields: fieldMap{
-					"arg_0": capturedValue("int", "1"),
-					"arg_1": {Type: "struct", Fields: fieldMap{
-						"arg_0": capturedValue("int", "2"),
-						"arg_1": {Type: "struct", Fields: fieldMap{
-							"arg_0": capturedValue("int", "3"),
+				"a": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierA", Fields: fieldMap{
+					"a": capturedValue("int", "1"),
+					"b": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierB", Fields: fieldMap{
+						"c": capturedValue("int", "2"),
+						"d": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierC", Fields: fieldMap{
+							"e": capturedValue("int", "3"),
+							"f": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierD", NotCapturedReason: "depth"},
 						}},
 					}},
 				}},
@@ -545,10 +573,11 @@ var captureDepthCaptures = fixtures{
 		},
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"a": {Type: "struct", Fields: fieldMap{
-					"arg_0": capturedValue("int", "1"),
-					"arg_1": {Type: "struct", Fields: fieldMap{
-						"arg_0": capturedValue("int", "2"),
+				"a": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierA", Fields: fieldMap{
+					"a": capturedValue("int", "1"),
+					"b": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierB", Fields: fieldMap{
+						"c": capturedValue("int", "2"),
+						"d": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierC", NotCapturedReason: "depth"},
 					}},
 				}},
 			},
@@ -556,15 +585,20 @@ var captureDepthCaptures = fixtures{
 		},
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"a": {Type: "struct", Fields: fieldMap{
-					"arg_0": capturedValue("int", "1"),
+				"a": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierA", Fields: fieldMap{
+					"a": capturedValue("int", "1"),
+					"b": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierB", NotCapturedReason: "depth"},
 				}},
 			},
 			Options: TestInstrumentationOptions{CaptureDepth: 2},
 		},
 		{
-			CapturedValueMap: nil,
-			Options:          TestInstrumentationOptions{CaptureDepth: 1},
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": {
+					Type:              "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tierA",
+					NotCapturedReason: "depth",
+				},
+			}, Options: TestInstrumentationOptions{CaptureDepth: 1},
 		},
 	},
 }
@@ -583,7 +617,7 @@ func mergeMaps(maps ...fixtures) fixtures {
 var expectedCaptures = mergeMaps(
 	basicCaptures,
 	stringCaptures,
-	arrayCaptures,
+	// arrayCaptures,
 	structCaptures,
 	sliceCaptures,
 	pointerCaptures,

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -277,15 +277,15 @@ var sliceCaptures = fixtures{
 				"xs": {
 					Type: "[]struct",
 					Fields: fieldMap{
-						"[0]struct": &ditypes.CapturedValue{
-							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
+						"[0]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings": &ditypes.CapturedValue{
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings",
 							Fields: fieldMap{
 								"aUint8": capturedValue("uint8", "42"),
 								"aBool":  capturedValue("bool", "true"),
 							},
 						},
-						"[1]struct": &ditypes.CapturedValue{
-							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
+						"[1]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings": &ditypes.CapturedValue{
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings",
 							Fields: fieldMap{
 								"aUint8": capturedValue("uint8", "24"),
 								"aBool":  capturedValue("bool", "true"),

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -106,7 +106,6 @@ func reportCaptureError(defs []*ditypes.Parameter) ditypes.Captures {
 
 func convertArgs(defs []*ditypes.Parameter, captures []*ditypes.Param) map[string]*ditypes.CapturedValue {
 	args := make(map[string]*ditypes.CapturedValue)
-
 	for idx, def := range defs {
 		argName := def.Name
 		if argName == "" {
@@ -142,7 +141,7 @@ func convertArgs(defs []*ditypes.Parameter, captures []*ditypes.Param) map[strin
 		if capture.Fields != nil && def.ParameterPieces != nil {
 			// For slice types, use convertSlice helper which already exists
 			if uint(capture.Kind) == uint(reflect.Slice) {
-				args[argName] = convertSlice(capture)
+				args[argName] = convertSlice(capture, def)
 			} else {
 				// For struct types, recursively process fields
 				cv.Fields = convertArgs(def.ParameterPieces, capture.Fields)
@@ -172,26 +171,46 @@ func convertArgs(defs []*ditypes.Parameter, captures []*ditypes.Param) map[strin
 	return args
 }
 
-func convertSlice(capture *ditypes.Param) *ditypes.CapturedValue {
+func convertSlice(capture *ditypes.Param, def *ditypes.Parameter) *ditypes.CapturedValue {
+	// The actual definition of the slice elements is in def.ParameterPieces[0].ParameterPieces[0]
+	// So we need to copy it based on the length of capture.Fields
 	defs := []*ditypes.Parameter{}
-	for i := range capture.Fields {
-		var (
-			fieldType string
-			fieldKind uint
-			fieldSize int64
-		)
-		if capture.Fields[i] != nil {
-			fieldType = capture.Fields[i].Type
-			fieldKind = uint(capture.Fields[i].Kind)
-			fieldSize = int64(capture.Fields[i].Size)
+
+	if def == nil || def.ParameterPieces == nil || len(def.ParameterPieces) == 0 ||
+		def.ParameterPieces[0] == nil || def.ParameterPieces[0].ParameterPieces == nil || len(def.ParameterPieces[0].ParameterPieces) == 0 {
+
+		for i := range capture.Fields {
+			var (
+				fieldType string
+				fieldKind uint
+				fieldSize int64
+			)
+			if capture.Fields[i] != nil {
+				fieldType = capture.Fields[i].Type
+				fieldKind = uint(capture.Fields[i].Kind)
+				fieldSize = int64(capture.Fields[i].Size)
+			}
+			defs = append(defs, &ditypes.Parameter{
+				Name:      fmt.Sprintf("[%d]%s", i, fieldType),
+				Type:      fieldType,
+				Kind:      fieldKind,
+				TotalSize: fieldSize,
+			})
 		}
-		defs = append(defs, &ditypes.Parameter{
-			Name:      fmt.Sprintf("[%d]%s", i, fieldType),
-			Type:      fieldType,
-			Kind:      fieldKind,
-			TotalSize: fieldSize,
-		})
+	} else {
+		c := []*ditypes.Parameter{def.ParameterPieces[0].ParameterPieces[0]}
+		for i := range capture.Fields {
+			dst := []*ditypes.Parameter{}
+			copyTree(&dst, &c)
+			if len(dst) != 1 {
+				log.Tracef("error while parsing slice definition")
+				break
+			}
+			dst[0].Name = fmt.Sprintf("[%d]%s", i, dst[0].Type)
+			defs = append(defs, dst[0])
+		}
 	}
+
 	sliceValue := &ditypes.CapturedValue{
 		Type:   capture.Type,
 		Fields: convertArgs(defs, capture.Fields),
@@ -226,4 +245,60 @@ func getProbeUUID(probeID string) string {
 	// we could also validate that the extracted string is a valid UUID,
 	// but it's not necessary since we tolerate IDs that don't parse
 	return parts[1]
+}
+
+func copyTree(dst, src *[]*ditypes.Parameter) {
+	if dst == nil || src == nil || len(*src) == 0 {
+		return
+	}
+	*dst = make([]*ditypes.Parameter, len(*src))
+	for i := range *src {
+		if (*src)[i] == nil {
+			continue
+		}
+
+		// Create a new Parameter object for each element
+		srcParam := (*src)[i]
+		(*dst)[i] = &ditypes.Parameter{
+			Name:             srcParam.Name,
+			ID:               srcParam.ID,
+			Type:             srcParam.Type,
+			TotalSize:        srcParam.TotalSize,
+			Kind:             srcParam.Kind,
+			FieldOffset:      srcParam.FieldOffset,
+			DoNotCapture:     srcParam.DoNotCapture,
+			NotCaptureReason: srcParam.NotCaptureReason,
+		}
+
+		// Deep copy the Location if present
+		if srcParam.Location != nil {
+			(*dst)[i].Location = &ditypes.Location{
+				InReg:            srcParam.Location.InReg,
+				StackOffset:      srcParam.Location.StackOffset,
+				Register:         srcParam.Location.Register,
+				NeedsDereference: srcParam.Location.NeedsDereference,
+				PointerOffset:    srcParam.Location.PointerOffset,
+			}
+		}
+
+		// Deep copy the LocationExpressions slice
+		if len(srcParam.LocationExpressions) > 0 {
+			(*dst)[i].LocationExpressions = make([]ditypes.LocationExpression, len(srcParam.LocationExpressions))
+			for j, expr := range srcParam.LocationExpressions {
+				// Copy the LocationExpression struct
+				(*dst)[i].LocationExpressions[j] = expr
+
+				// Deep copy any IncludedExpressions
+				if len(expr.IncludedExpressions) > 0 {
+					(*dst)[i].LocationExpressions[j].IncludedExpressions = make([]ditypes.LocationExpression, len(expr.IncludedExpressions))
+					copy((*dst)[i].LocationExpressions[j].IncludedExpressions, expr.IncludedExpressions)
+				}
+			}
+		}
+
+		// Recursively copy ParameterPieces
+		if len(srcParam.ParameterPieces) > 0 {
+			copyTree(&((*dst)[i].ParameterPieces), &(srcParam.ParameterPieces))
+		}
+	}
 }


### PR DESCRIPTION
### What does this PR do?

This fixes a deadlock, a couple of other bugs, and updates tests. The bugs are:

- A deadlock occurs when probe configuration is updated. A mutex is shared to guard 3 different maps. Updating configuration doesn't work as a result.
    - This was fixed by using sync.Map instead.
- Slices were not properly being converted to captured values before being uploaded to datadog backend.
- A more difficult to understand bug occurs in bpf space with the param stack maps. Instrumentation would occasionally not work at all until I did a full rebuild. Checking kernel logs I would see a lot of these errors:

```
sample_service-2611190 [002] ....1 7050153.972650: bpf_trace_printk: github_com_DataDog_datadog_agent_pkg_dynamicinstrumentation_testutil_sample_test_struct probe in go-di-sample-service has triggered
  sample_service-2611190 [002] ....1 7050153.972711: bpf_trace_printk: there is no `param_stack` map associated with currently executing cpu 2
```

I fixed this by changing to the idiomatic way of populating the bpf array of maps in user space.

- Updates test fixtures in accordance with my most recent PR.

### Motivation

Ensure stability.

### Describe how you validated your changes

Ran e2e tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
