### PR TITLE
[Bug fix] Add shared compression kind for different pipeline

### DIFF
--- a/releasenotes/notes/log-compression-pipeline-bugfix-1d60e62cabb210f9.yaml
+++ b/releasenotes/notes/log-compression-pipeline-bugfix-1d60e62cabb210f9.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue where non-logs pipelines (agent_telemetry, database_monitoring, 
+    network_device, container, sbom, service_discovery, compliance, runtime_security) 
+    were not properly inheriting the shared pipeline compression settings from 
+    logs_config.compression_kind.
+


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where event platform pipelines don't properly inherit the compression settings from `logs_config.compression_kind`. Previously, pipelines with specialized prefixes (eg `service_discovery.forwarder`, `agent_telemetry`, etc.) would default to using `DefaultLogCompressionKind `(gzip) even when `logs_config.compression_kind` was set to `zstd`. This created inconsistent compression across different pipelines.
The fix modifies the `compressionKind()` method to first check the pipeline-specific setting, then fall back to the global `logs_config.compression_kind` setting, and only if both are missing use the hardcoded default.


### Motivation
This change ensures consistent compression behavior across all agent pipelines. When a user configures logs_config.compression_kind: zstd, all pipelines should respect that setting instead of silently using different compression algorithms for different data types. This was causing confusion and poor performance due to inconsistent compression settings between data pipelines.


### Describe how you validated your changes
1. Turn on agent debug log
2. Set logs_config.compression_kind to zstd or something that is different from the the defaultLogCompressionKind (currently gzip)
3. Turn on the agent and check for this debug log:
```
log.Debugf("Using shared pipeline compression kind: %s for %s", sharedPipelineCompressionKind, l.prefix)
```

and see if its correctly using the `logs_config.compression_kind` instead of the `DefaultLogCompressionKind`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->