### PR TITLE
Updated ConnectionKey's String method to use a value receiver

### DIFF
--- a/pkg/network/types/connection_key.go
+++ b/pkg/network/types/connection_key.go
@@ -26,7 +26,7 @@ type ConnectionKey struct {
 }
 
 // String returns a string representation of the ConnectionKey
-func (c *ConnectionKey) String() string {
+func (c ConnectionKey) String() string {
 	return fmt.Sprintf(
 		"[%v:%d ⇄ %v:%d]",
 		util.FromLowHigh(c.SrcIPLow, c.SrcIPHigh),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Updated ConnectionKey's String method to use a value receiver

### Motivation
We log `ConnectionKey` [here](https://github.com/DataDog/datadog-agent/blob/886af76ebfb032ec39f946e0ada27d1cbdd179e0/pkg/network/encoding/marshal/usm.go#L194), but since the String() method had a pointer receiver, it wasn't being called. This fixes that by switching to a value receiver.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->