### PR TITLE
fix(backport): Prevent automatic ask-review trigger on backport PR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       args: [ --fix ]
     - id: ruff-format
 - repo: https://github.com/jendrikseipp/vulture
-  rev: 44aed44e226ec0e5660851462f764ec5d5da957c # v2.3
+  rev: e454d2ef39fc23e72549ff23a1a14e31c3a75605 # v2.14
   hooks:
     - id: vulture
       args: ["--ignore-decorators", "@task", "--ignore-names", "test_*,Test*", "tasks"]

--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -49,6 +49,9 @@ def generate_model(_):
 def ask_reviews(_, pr_id):
     gh = GithubAPI()
     pr = gh.repo.get_pull(int(pr_id))
+    if 'backport' in pr.title.casefold():
+        print("This is a backport PR, we don't need to ask for reviews.")
+        return
     if any(label.name == 'ask-review' for label in pr.get_labels()):
         actor = ask_review_actor(pr)
         reviewers = [f"@datadog/{team.slug}" for team in pr.requested_teams]


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Prevent automatic ask-review trigger on backport PR
- Bump `vulture` in the `pre-commit` configuration

### Motivation
Backport PR were already approved and don't need to be reviewed a second time. We have a side effect today on backport of PR that used the `ask-review` label ([example](https://github.com/DataDog/datadog-agent/pull/35382#event-16948584476)) because this label is added automatically by the `backport` workflow (see [here](https://github.com/tibdex/backport/blob/main/src/backport.ts#L124-L133))
I also took the opportunity to bump the `vulture` used in pre-commit because of this error
```
vulture..................................................................Failed
- hook id: vulture
- exit code: 1

/Users/nicolas.schweitzer/go/src/github.com/DataDog/datadog-agent/tasks/devcontainer.py:142: invalid syntax at "match profile:"
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->