### PR TITLE
fix(installer): Handle "connection reset by peer" using error text

### DIFF
--- a/pkg/fleet/installer/oci/download.go
+++ b/pkg/fleet/installer/oci/download.go
@@ -413,6 +413,10 @@ func isRetryableNetworkError(err error) bool {
 		}
 	}
 
+	if strings.Contains(err.Error(), "connection reset by peer") {
+		return true
+	}
+
 	return isStreamResetError(err)
 }
 


### PR DESCRIPTION
### What does this PR do?
As https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/860907265#L2080 has proven, trying to handle gracefully the connection reset by peer error fails. 

So let's do it the dirty way by catching the text in the error message.

### Motivation
CI stability

### Describe how you validated your changes
E2E

### Possible Drawbacks / Trade-offs

### Additional Notes
