### PR TITLE
[EBPF] gpu: use singleton for NVML access

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -263,8 +263,9 @@ func (c *collector) Pull(_ context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get NVML library: %w", err)
 	}
+	c.nvmlLib = nvmlLib
 
-	count, ret := nvmlLib.DeviceGetCount()
+	count, ret := c.nvmlLib.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		return fmt.Errorf("failed to get device count: %v", nvml.ErrorString(ret))
 	}
@@ -282,7 +283,7 @@ func (c *collector) Pull(_ context.Context) error {
 
 	var events []workloadmeta.CollectorEvent
 	for i := 0; i < count; i++ {
-		dev, ret := nvmlLib.DeviceGetHandleByIndex(i)
+		dev, ret := c.nvmlLib.DeviceGetHandleByIndex(i)
 		if ret != nvml.SUCCESS {
 			return fmt.Errorf("failed to get device handle for index %d: %v", i, nvml.ErrorString(ret))
 		}

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -29,7 +29,7 @@ func TestPull(t *testing.T) {
 		store:   wmetaMock,
 	}
 
-	ddnvml.SetSingletonForTest(t, nvmlMock)
+	ddnvml.WithMockNVML(t, nvmlMock)
 
 	c.Pull(context.Background())
 
@@ -88,7 +88,7 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 		store:   wmetaMock,
 	}
 
-	ddnvml.SetSingletonForTest(t, nvmlMock)
+	ddnvml.WithMockNVML(t, nvmlMock)
 
 	// First pull to populate the store with initial PIDs
 	c.Pull(context.Background())

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 
@@ -26,8 +27,9 @@ func TestPull(t *testing.T) {
 		id:      collectorID,
 		catalog: workloadmeta.NodeAgent,
 		store:   wmetaMock,
-		nvmlLib: nvmlMock,
 	}
+
+	ddnvml.SetSingletonForTest(t, nvmlMock)
 
 	c.Pull(context.Background())
 
@@ -84,8 +86,9 @@ func TestGpuProcessInfoUpdate(t *testing.T) {
 		id:      collectorID,
 		catalog: workloadmeta.NodeAgent,
 		store:   wmetaMock,
-		nvmlLib: nvmlMock,
 	}
+
+	ddnvml.SetSingletonForTest(t, nvmlMock)
 
 	// First pull to populate the store with initial PIDs
 	c.Pull(context.Background())

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -29,6 +29,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/nvidia"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 	ddmetrics "github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -113,13 +114,9 @@ func (c *Check) ensureInitNVML() error {
 		return nil
 	}
 
-	// Initialize NVML library. if the config parameter doesn't exist or is
-	// empty string, the default value is used as defined in go-nvml library
-	// https://github.com/NVIDIA/go-nvml/blob/main/pkg/nvml/lib.go#L30
-	nvmlLib := nvml.New(nvml.WithLibraryPath(c.config.NVMLLibraryPath))
-	ret := nvmlLib.Init()
-	if ret != nvml.SUCCESS {
-		return fmt.Errorf("failed to initialize NVML library: %s", nvml.ErrorString(ret))
+	nvmlLib, err := ddnvml.GetNvmlLib()
+	if err != nil {
+		return fmt.Errorf("failed to get NVML library: %w", err)
 	}
 
 	c.nvmlLib = nvmlLib

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -34,8 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
-
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 )
 
 const (

--- a/pkg/gpu/nvml/testutil.go
+++ b/pkg/gpu/nvml/testutil.go
@@ -13,10 +13,10 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
 
-// SetSingletonForTest sets the singleton NVML library for testing purposes.
+// WithMockNVML sets the singleton NVML library for testing purposes.
 // This is useful to test the NVML library without having to initialize it
 // manually. It automatically restores the original NVML library on test
-func SetSingletonForTest(t *testing.T, lib nvml.Interface) {
+func WithMockNVML(t *testing.T, lib nvml.Interface) {
 	singleton.mu.Lock()
 	defer singleton.mu.Unlock()
 

--- a/pkg/gpu/nvml/testutil.go
+++ b/pkg/gpu/nvml/testutil.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && test && nvml
+
+package nvml
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// SetSingletonForTest sets the singleton NVML library for testing purposes.
+// This is useful to test the NVML library without having to initialize it
+// manually. It automatically restores the original NVML library on test
+func SetSingletonForTest(t *testing.T, lib nvml.Interface) {
+	singleton.mu.Lock()
+	defer singleton.mu.Unlock()
+
+	singleton.lib = lib
+	singleton.isInitialized = true
+
+	t.Cleanup(func() {
+		singleton.mu.Lock()
+		defer singleton.mu.Unlock()
+
+		singleton.lib = nil
+		singleton.isInitialized = false
+	})
+}

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -105,7 +105,7 @@ type ProbeDependencies struct {
 }
 
 // NewProbeDependencies creates a new ProbeDependencies instance
-func NewProbeDependencies(cfg *config.Config, telemetry telemetry.Component, processMonitor uprobes.ProcessMonitor, workloadMeta workloadmeta.Component) (ProbeDependencies, error) {
+func NewProbeDependencies(telemetry telemetry.Component, processMonitor uprobes.ProcessMonitor, workloadMeta workloadmeta.Component) (ProbeDependencies, error) {
 	nvmlLib, err := ddnvml.GetNvmlLib()
 	if err != nil {
 		return ProbeDependencies{}, fmt.Errorf("unable to get NVML library: %w", err)

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -31,6 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 	"github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -104,11 +105,10 @@ type ProbeDependencies struct {
 }
 
 // NewProbeDependencies creates a new ProbeDependencies instance
-func NewProbeDependencies(telemetry telemetry.Component, processMonitor uprobes.ProcessMonitor, workloadMeta workloadmeta.Component) (ProbeDependencies, error) {
-	nvmlLib := nvml.New()
-	ret := nvmlLib.Init()
-	if ret != nvml.SUCCESS && ret != nvml.ERROR_ALREADY_INITIALIZED {
-		return ProbeDependencies{}, fmt.Errorf("unable to initialize NVML library: %w", ret)
+func NewProbeDependencies(cfg *config.Config, telemetry telemetry.Component, processMonitor uprobes.ProcessMonitor, workloadMeta workloadmeta.Component) (ProbeDependencies, error) {
+	nvmlLib, err := ddnvml.GetNvmlLib()
+	if err != nil {
+		return ProbeDependencies{}, fmt.Errorf("unable to get NVML library: %w", err)
 	}
 
 	return ProbeDependencies{


### PR DESCRIPTION
<!-- start git-machete generated -->

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR is based on #35400 and replaces all instantiations of the NVML library with a call to the singleton.

### Motivation

Single entry point for NVML creation, centralize code and parameters.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Existing tests should pass.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->