### PR TITLE
[AGENTCFG-154][Backport 7.65.x] fetching fips_mode metadata for every payload instead of once at startup

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -182,12 +182,6 @@ func (ia *inventoryagent) initData() {
 	ia.data["agent_version"] = version.AgentVersion
 	ia.data["agent_startup_time_ms"] = pkgconfigsetup.StartTime.UnixMilli()
 	ia.data["flavor"] = flavor.GetFlavor()
-	if val, err := fips.Enabled(); err == nil {
-		ia.data["fips_mode"] = val
-	} else {
-		ia.data["fips_mode"] = false
-		ia.log.Warnf("could not check if fips is enabled: %s", err)
-	}
 }
 
 type configGetter interface {
@@ -258,6 +252,14 @@ func (ia *inventoryagent) fetchCoreAgentMetadata() {
 	ia.data["config_eks_fargate"] = eksFargate
 	if eksFargate {
 		ia.data["eks_fargate_cluster_name"] = ia.conf.GetString("cluster_name")
+	}
+
+	// FIPS mode
+	if val, err := fips.Enabled(); err == nil {
+		ia.data["fips_mode"] = val
+	} else {
+		ia.data["fips_mode"] = false
+		ia.log.Warnf("could not check if fips is enabled: %s", err)
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
We [added a new metadata field](https://github.com/DataDog/datadog-agent/pull/35032) called `fips_mode` to 7.65, which would be reported once at agent startup. However, we found out that customers are able to change the fips mode of their windows machine while the agent is running, so we need to report the fips_mode payload every time a payload is sent.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I am able to query for the fips_mode of an agent in DDSQL in the relevant site.
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->