### PR TITLE
Add system-probe agent flavor

### DIFF
--- a/cmd/agent/system_probe.go
+++ b/cmd/agent/system_probe.go
@@ -9,13 +9,16 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	sysprobecommand "github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	sysprobesubcommands "github.com/DataDog/datadog-agent/cmd/system-probe/subcommands"
-	"github.com/spf13/cobra"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 func init() {
 	registerAgent([]string{"system-probe"}, func() *cobra.Command {
+		flavor.SetFlavor(flavor.SystemProbe)
 		rootCmd := sysprobecommand.MakeCommand(sysprobesubcommands.SysprobeSubcommands())
 		sysprobecommand.SetDefaultCommandIfNonePresent(rootCmd)
 		return rootCmd

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/internal/runcmd"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/command"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/subcommands"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 )
 
 func main() {

--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -17,6 +17,7 @@ import (
 )
 
 func main() {
+	flavor.SetFlavor(flavor.SystemProbe)
 	rootCmd := command.MakeCommand(subcommands.SysprobeSubcommands())
 	command.SetDefaultCommandIfNonePresent(rootCmd)
 	os.Exit(runcmd.Run(rootCmd))

--- a/pkg/util/flavor/flavor.go
+++ b/pkg/util/flavor/flavor.go
@@ -29,6 +29,8 @@ const (
 	TraceAgent = "trace_agent"
 	// OTelAgent is the OpenTelemetry Collector flavor
 	OTelAgent = "otel_agent"
+	// SystemProbe is the System Probe flavor
+	SystemProbe = "system_probe"
 )
 
 var agentFlavors = map[string]string{
@@ -42,6 +44,7 @@ var agentFlavors = map[string]string{
 	ProcessAgent:    "Process Agent",
 	TraceAgent:      "Trace Agent",
 	OTelAgent:       "OpenTelemetry Collector",
+	SystemProbe:     "System Probe",
 }
 
 const unknownAgent = "Unknown Agent"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds the SystemProbe flavor to the list of recognized agent flavors

### Motivation

Allow runtime detection of the agent we're running in, for example to select different configurations.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests/e2e tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->