### PR TITLE
Fix issue where discovery client erroring would permenantly break KSM

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -347,11 +347,6 @@ func (k *KSMCheck) Configure(senderManager sender.SenderManager, integrationConf
 					return err
 				}
 
-				apiServerClient, err := apiserver.GetAPIClient()
-				if err != nil {
-					return err
-				}
-
 				err = apiserver.InitializeGlobalResourceTypeCache(apiServerClient.Cl.Discovery())
 				if err != nil {
 					return err

--- a/pkg/util/kubernetes/apiserver/resourcetypes.go
+++ b/pkg/util/kubernetes/apiserver/resourcetypes.go
@@ -63,6 +63,10 @@ func InitializeGlobalResourceTypeCache(discoveryClient discovery.DiscoveryInterf
 			cacheErr = fmt.Errorf("failed to initialize resource type cache: %w", err)
 		}
 	})
+
+	if cacheErr != nil {
+		return cacheErr
+	}
 	return initRetry.TriggerRetry()
 }
 

--- a/pkg/util/kubernetes/apiserver/resourcetypes.go
+++ b/pkg/util/kubernetes/apiserver/resourcetypes.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
 
 	"k8s.io/client-go/discovery"
 )
@@ -20,6 +22,7 @@ import (
 var (
 	resourceCache *ResourceTypeCache
 	cacheOnce     sync.Once
+	initRetry     retry.Retrier
 	cacheErr      error
 )
 
@@ -43,12 +46,24 @@ func InitializeGlobalResourceTypeCache(discoveryClient discovery.DiscoveryInterf
 			discoveryClient: discoveryClient,
 		}
 
-		err := resourceCache.prepopulateCache()
+		err := initRetry.SetupRetrier(&retry.Config{
+			Name: "ResourceTypeCache_configuration",
+			AttemptMethod: func() error {
+				err := resourceCache.prepopulateCache()
+				if err != nil {
+					return fmt.Errorf("failed to prepopulate resource type cache: %w", err)
+				}
+				return nil
+			},
+			Strategy:          retry.Backoff,
+			InitialRetryDelay: 30 * time.Second,
+			MaxRetryDelay:     5 * time.Minute,
+		})
 		if err != nil {
-			cacheErr = fmt.Errorf("failed to prepopulate resource type cache: %w", err)
+			cacheErr = fmt.Errorf("failed to initialize resource type cache: %w", err)
 		}
 	})
-	return cacheErr
+	return initRetry.TriggerRetry()
 }
 
 // GetResourceType retrieves the resource type for the given kind and group.

--- a/pkg/util/kubernetes/apiserver/resourcetypes.go
+++ b/pkg/util/kubernetes/apiserver/resourcetypes.go
@@ -67,7 +67,11 @@ func InitializeGlobalResourceTypeCache(discoveryClient discovery.DiscoveryInterf
 	if cacheErr != nil {
 		return cacheErr
 	}
-	return initRetry.TriggerRetry()
+	err := initRetry.TriggerRetry()
+	if err != nil {
+		return err.Unwrap()
+	}
+	return nil
 }
 
 // GetResourceType retrieves the resource type for the given kind and group.


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with the `GlobalResourceTypeCache` where it could wind up in a permanent error state if the discovery client call failed during initialization. This would result in the KSM check permanently being unable to start until manual action was taken.

### Motivation

See [this notebook](https://app.datadoghq.com/notebook/11964057/ksm-alert-investigation-3-21?view=view-mode) detailing the investigation following an alert

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->