### PR TITLE
[workloadmeta/collectors/internal/ecs] Use retry option for ECS collector client when getting resource tags

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
@@ -109,7 +109,11 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 
 	// This only exists to allow overriding for testing
 	c.metaV3or4 = func(metaURI, metaVersion string) v3or4.Client {
-		return v3or4.NewClient(metaURI, metaVersion)
+		return v3or4.NewClient(metaURI, metaVersion, v3or4.WithTryOption(
+			c.metadataRetryInitialInterval,
+			c.metadataRetryMaxElapsedTime,
+			func(d time.Duration) time.Duration { return time.Duration(c.metadataRetryTimeoutFactor) * d }),
+		)
 	}
 
 	c.hasResourceTags = ecsutil.HasEC2ResourceTags()

--- a/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v1parser.go
@@ -198,9 +198,9 @@ func (c *collector) getResourceTags(ctx context.Context, entity *workloadmeta.EC
 	if err != nil {
 		// If it's a timeout error, log it as debug to avoid spamming the logs as the data can be fetched in next run
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Debugf("timeout while getting task with tags from metadata v4 API: %s", err)
+			log.Debugf("timeout while getting task with tags from metadata %s API: %s", metaVersion, err)
 		} else {
-			log.Warnf("failed to get task with tags from metadata v4 API: %s", err)
+			log.Warnf("failed to get task with tags from metadata %s API: %s", metaVersion, err)
 		}
 		return rt
 	}

--- a/comp/core/workloadmeta/collectors/internal/ecs/v4parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v4parser.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -82,11 +81,7 @@ func (c *collector) getTaskWithTagsFromV4Endpoint(ctx context.Context, task v1.T
 		return v1TaskToV4Task(task), errors.New(err)
 	}
 
-	taskWithTags, err := v3or4.NewClient(metaURI, "v4", v3or4.WithTryOption(
-		c.metadataRetryInitialInterval,
-		c.metadataRetryMaxElapsedTime,
-		func(d time.Duration) time.Duration { return time.Duration(c.metadataRetryTimeoutFactor) * d }),
-	).GetTaskWithTags(ctx)
+	taskWithTags, err := c.metaV3or4(metaURI, "v4").GetTaskWithTags(ctx)
 	if err != nil {
 		// If it's a timeout error, log it as debug to avoid spamming the logs as the data can be fetched in next run
 		if errors.Is(err, context.DeadlineExceeded) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add retry option when `DD_ECS_COLLECT_RESOURCE_TAGS_EC2` enabled to prevent throttling issues.

### Motivation

This change makes use of the same retry configuration introduced for `DD_ECS_TASK_COLLECTION_ENABLED` here: https://github.com/DataDog/datadog-agent/pull/28130 to avoid throttling when customers set `DD_ECS_TASK_COLLECTION_ENABLED` to `true`.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Deployed the changes on an ECS cluster and verified that metrics/etc. still seemed to be collected
2. Basic usage should also be covered by E2E tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I tried to throttle a workload but was not able to hit a timeout while fetching resource tags to validate that this fix is working.