### PR TITLE
[NPM-4334] Silence misleading error in ebpfless

### DIFF
--- a/pkg/network/netlink/conntrack.go
+++ b/pkg/network/netlink/conntrack.go
@@ -23,11 +23,6 @@ type Conntrack interface {
 	// Exists checks if a connection exists in the conntrack
 	// table based on matches to `conn.Origin` or `conn.Reply`.
 	Exists(conn *Con) (bool, error)
-	// Dump dumps the conntrack table.
-	Dump() ([]Con, error)
-	// Get gets the conntrack record for a connection. Similar to
-	// Exists, but returns the full connection information.
-	Get(conn *Con) (Con, error)
 	// Close closes the conntrack object
 	Close() error
 }
@@ -105,14 +100,6 @@ func (c *conntrack) Exists(conn *Con) (bool, error) {
 	}
 
 	return false, fmt.Errorf("no replies received from netlink call")
-}
-
-func (c *conntrack) Dump() ([]Con, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (c *conntrack) Get(_ *Con) (Con, error) {
-	return Con{}, fmt.Errorf("not implemented")
 }
 
 func (c *conntrack) Close() error {

--- a/pkg/network/netlink/conntrack_noop.go
+++ b/pkg/network/netlink/conntrack_noop.go
@@ -14,6 +14,13 @@ func NewNoOpConntrack(_ netns.NsHandle) (Conntrack, error) {
 	return &noOpConntrack{}, nil
 }
 
+// IsNoOpConntrack checks if a Conntrack instance is a no-op.
+// This is used to verify behavior during tests
+func IsNoOpConntrack(ct Conntrack) bool {
+	_, ok := ct.(*noOpConntrack)
+	return ok
+}
+
 type noOpConntrack struct{}
 
 var _ Conntrack = &noOpConntrack{}

--- a/pkg/network/netlink/conntrack_noop.go
+++ b/pkg/network/netlink/conntrack_noop.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package netlink
+
+import "github.com/vishvananda/netns"
+
+// NewNoOpConntrack returns a new no-op conntrack implementation.
+func NewNoOpConntrack(_ netns.NsHandle) (Conntrack, error) {
+	return &noOpConntrack{}, nil
+}
+
+type noOpConntrack struct{}
+
+var _ Conntrack = &noOpConntrack{}
+
+func (c *noOpConntrack) Close() error {
+	return nil
+}
+
+func (c *noOpConntrack) Exists(_ *Con) (bool, error) {
+	return false, nil
+}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -533,7 +533,12 @@ func (t *Tracer) getRuntimeCompilationTelemetry() map[string]network.RuntimeComp
 // getConnections returns all the active connections in the ebpf maps along with the latest timestamp.  It takes
 // a reusable buffer for appending the active connections so that this doesn't continuously allocate
 func (t *Tracer) getConnections(activeBuffer *network.ConnectionBuffer) (latestUint uint64, activeConnections []network.ConnectionStats, err error) {
-	cachedConntrack := newCachedConntrack(t.config.ProcRoot, netlink.NewConntrack, 128)
+	newConntrack := netlink.NewConntrack
+	// if we already established that netlink conntracker is not supported, don't try again
+	if t.conntracker.GetType() == "" {
+		newConntrack = netlink.NewNoOpConntrack
+	}
+	cachedConntrack := newCachedConntrack(t.config.ProcRoot, newConntrack, 128)
 	defer func() { _ = cachedConntrack.Close() }()
 
 	latestTime, err := ddebpf.NowNanoseconds()

--- a/releasenotes/notes/fargate-netlink-50bce98a12f466b9.yaml
+++ b/releasenotes/notes/fargate-netlink-50bce98a12f466b9.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue where the system-probe would spuriously log the error ``netlink conntracker requires NET_ADMIN capability`` on the Fargate CNM preview.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This changes `conntrackCache` to use a no-op implementation in ebpfless

### Motivation
Customer reported seeing errors in logs after letting ebpfless run for a while. These don't break the ebpfless tracer but better to not show this either way.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Added this test: `TestTracerEbpflessConntrack`

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->