### PR TITLE
fix(pre-commit): Force GOTOOLCHAIN to prevent pre-commit errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -93,7 +93,7 @@ repos:
     - id: go-test
       name: go-test
       description: run go test on modified packages
-      entry: 'dda inv test --only-modified-packages'
+      entry: bash -c 'GOTOOLCHAIN=go"$(cat .go-version)" dda inv test --only-modified-packages'
       language: system
       require_serial: true
       always_run: true
@@ -102,7 +102,7 @@ repos:
     - id: go-linter
       name: go-linter
       description: run go linter on modified packages
-      entry: 'dda inv linter.go --only-modified-packages'
+      entry: bash -c 'GOTOOLCHAIN=go"$(cat .go-version)" dda inv linter.go --only-modified-packages'
       language: system
       require_serial: true
       always_run: true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Force `GOTOOLCHAIN` to the `.go-version` version

### Motivation
Prevent failures
```
go: error loading go.work:
go.work:9: unknown godebug "tlskyber"

=== Errors
go: error loading go.work:
go.work:9: unknown godebug "tlskyber"

```
when running the `go test` pre-commit hook.
Similar issue can happen with the `go-linter` hook

### Describe how you validated your changes
The pre-commit passed on this modification
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->