### PR TITLE
service discovery: Only refresh service info on heartbeat

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -1005,18 +1005,31 @@ func (s *discovery) getServices(params params) (*model.ServicesResponse, error) 
 	for _, pid := range pids {
 		alivePids.add(pid)
 
+		_, knownService := s.runningServices[pid]
+		if knownService {
+			info, ok := s.cache[pid]
+			if !ok {
+				// Should never happen
+				continue
+			}
+
+			serviceHeartbeatTime := time.Unix(info.lastHeartbeat, 0)
+			if now.Sub(serviceHeartbeatTime).Truncate(time.Minute) < params.heartbeatTime {
+				// We only need to refresh the service info (ports, etc.) for
+				// this service if it's time to send a heartbeat.
+				continue
+			}
+		}
+
 		service := s.getService(context, pid)
 		if service == nil {
 			continue
 		}
 		s.enrichContainerData(service, containersMap, pidToCid)
 
-		if _, ok := s.runningServices[pid]; ok {
-			if serviceHeartbeatTime := time.Unix(service.LastHeartbeat, 0); now.Sub(serviceHeartbeatTime).Truncate(time.Minute) >= params.heartbeatTime {
-				service.LastHeartbeat = now.Unix()
-				response.HeartbeatServices = append(response.HeartbeatServices, *service)
-			}
-
+		if knownService {
+			service.LastHeartbeat = now.Unix()
+			response.HeartbeatServices = append(response.HeartbeatServices, *service)
 			continue
 		}
 


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

If we already know about a service, we only send out info about it in the heartbeat, so there is no need to refresh things like the port list during other invocations of the endpoint when it's not yet time to send the heartbeat, since the information will anyway be discarded.

### Motivation

Reduce CPU load.
https://datadoghq.atlassian.net/browse/DSCVR-81

### Describe how you validated your changes

Heartbeat generation covered by automated tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->