### PR TITLE
Update agent-platform install-script test to not rely on the install-script directly

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -99,7 +99,7 @@
     - !reference [.needs_new_e2e_template]
     - datadog-agent-7-x64
   variables:
-    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
+    LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
@@ -108,7 +108,7 @@
     - datadog-agent-7-x64
     - windows_msi_and_bosh_zip_x64-a7
   variables:
-    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
+    LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -97,7 +97,7 @@
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - datadog-agent-7-x64
+    - agent_deb-x64-a7
   variables:
     LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
 
@@ -105,7 +105,7 @@
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - datadog-agent-7-x64
+    - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
   variables:
     LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -702,6 +702,7 @@ new-e2e-windows-systemprobe:
     - !reference [.needs_new_e2e_template]
     - deploy_windows_testing-a7
     - tests_windows_sysprobe_x64
+    - windows_msi_and_bosh_zip_x64-a7
   variables:
     TARGETS: ./tests/sysprobe-functional
     TEAM: windows-kernel-integrations

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -106,7 +106,7 @@
   needs:
     - !reference [.needs_new_e2e_template]
     - datadog-agent-7-x64
-    - windows_msi_and_bosh_zip_x64
+    - windows_msi_and_bosh_zip_x64-a7
   variables:
     LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
 

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -97,14 +97,18 @@
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
+    - datadog-agent-7-x64
+  variables:
+    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
-    - deploy_windows_testing-a7
+    - datadog-agent-7-x64
+    - windows_msi_and_bosh_zip_x64
+  variables:
+    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -98,6 +98,7 @@
   needs:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
+    - agent_deb-x64-a7-fips
   variables:
     LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
 
@@ -107,6 +108,8 @@
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
+    - agent_deb-x64-a7-fips
+    - windows_msi_and_bosh_zip_x64-a7-fips
   variables:
     LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
 

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -705,7 +705,7 @@ new-e2e-windows-systemprobe:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_windows_testing-a7
+    - windows_msi_and_bosh_zip_x64-a7
     - tests_windows_sysprobe_x64
   variables:
     TARGETS: ./tests/sysprobe-functional
@@ -787,15 +787,29 @@ new-e2e-otel:
 new-e2e-package-signing-debian-a7-x86_64:
   extends:
     - .new_e2e_template
-    - .new-e2e_debian_a7_x86_64
     - .new-e2e_package_signing
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
+    E2E_BRANCH_OSVERS: "debian-11"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_deb-x64-a7
   rules: !reference [.on_default_new_e2e_tests]
 
 new-e2e-package-signing-suse-a7-x86_64:
   extends:
     - .new_e2e_template
-    - .new-e2e_suse_a7_x86_64
     - .new-e2e_package_signing
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "sles-12,sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_suse-x64-a7
   rules: !reference [.on_default_new_e2e_tests]
 
 new-e2e-cspm:
@@ -825,7 +839,7 @@ new-e2e-gpu:
     ON_NIGHTLY_FIPS: "true"
   needs:                                         # list of required jobs. By default gitlab waits for any previous jobs.
     - !reference [.new_e2e_template_needs_container_deploy, needs]
-    - deploy_deb_testing-a7_x64                  # agent 7 debian package
+    - agent_deb-x64-a7                  # agent 7 debian package
   parallel:
     matrix:
       - EXTRA_PARAMS: "--run TestGPUHostSuite"

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -72,6 +72,11 @@
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     E2E_RESULT_JSON: $CI_PROJECT_DIR/e2e_test_output.json
     E2E_USE_AWS_PROFILE: "true"
+<<<<<<< HEAD
+=======
+
+    LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
+>>>>>>> 29e92d6707d (Force local package everywhere and see [skip cancel])
   script:
     - dda inv -- -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -104,17 +104,30 @@
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
+<<<<<<< HEAD
     - agent_deb-x64-a7
     - agent_deb-x64-a7-fips
+=======
+    - datadog-agent-7-x64
+  variables:
+    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
+>>>>>>> 35d314bdc46 (Try with local-packages for some test)
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
+<<<<<<< HEAD
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
     - agent_deb-x64-a7-fips
     - windows_msi_and_bosh_zip_x64-a7-fips
+=======
+    - datadog-agent-7-x64
+    - windows_msi_and_bosh_zip_x64
+  variables:
+    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
+>>>>>>> 35d314bdc46 (Try with local-packages for some test)
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -124,7 +124,7 @@
     - windows_msi_and_bosh_zip_x64-a7-fips
 =======
     - datadog-agent-7-x64
-    - windows_msi_and_bosh_zip_x64
+    - windows_msi_and_bosh_zip_x64-a7
   variables:
     LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
 >>>>>>> 35d314bdc46 (Try with local-packages for some test)

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -72,9 +72,8 @@
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     E2E_RESULT_JSON: $CI_PROJECT_DIR/e2e_test_output.json
     E2E_USE_AWS_PROFILE: "true"
-    LOCAL_PACKAGE_FLAG: "--local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR"
   script:
-    - dda inv -- -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
+    - dda inv -- -e new-e2e-tests.run --local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:
     - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "junit-${CI_JOB_ID}.tgz" "$E2E_RESULT_JSON"
   artifacts:
@@ -701,7 +700,7 @@ new-e2e-windows-systemprobe:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - windows_msi_and_bosh_zip_x64-a7
+    - deploy_windows_testing-a7
     - tests_windows_sysprobe_x64
   variables:
     TARGETS: ./tests/sysprobe-functional

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -72,11 +72,7 @@
     FLAKY_PATTERNS_CONFIG: $CI_PROJECT_DIR/flaky-patterns-runtime.yaml
     E2E_RESULT_JSON: $CI_PROJECT_DIR/e2e_test_output.json
     E2E_USE_AWS_PROFILE: "true"
-<<<<<<< HEAD
-=======
-
-    LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
->>>>>>> 29e92d6707d (Force local package everywhere and see [skip cancel])
+    LOCAL_PACKAGE_FLAG: "--local-package $CI_PROJECT_DIR/$OMNIBUS_BASE_DIR"
   script:
     - dda inv -- -e new-e2e-tests.run --targets $TARGETS -c ddagent:imagePullRegistry=669783387624.dkr.ecr.us-east-1.amazonaws.com -c ddagent:imagePullUsername=AWS -c ddagent:imagePullPassword=$(aws ecr get-login-password) --result-json $E2E_RESULT_JSON --junit-tar junit-${CI_JOB_ID}.tgz ${EXTRA_PARAMS} --test-washer --logs-folder=$E2E_OUTPUT_DIR/logs --logs-post-processing --logs-post-processing-test-depth=$E2E_LOGS_PROCESSING_TEST_DEPTH
   after_script:

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -242,11 +242,11 @@ new-e2e-agent-subcommands:
       - EXTRA_PARAMS: --run "Test(Linux|Windows)RunSuite"
 
 new-e2e-fips-compliance-test:
-  extends: .new_e2e_template_needs_deb_x64
+  extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
+    - agent_deb-x64-a7-fips
     - qa_agent_fips
-    - deploy_deb_testing-a7_x64
   rules:
     - !reference [.on_arun_or_e2e_changes]
     - !reference [.manual]
@@ -263,7 +263,7 @@ new-e2e-windows-fips-compliance-test:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_agent_fips
-    - deploy_windows_testing-a7-fips
+    - windows_msi_and_bosh_zip_x64-a7-fips
   rules:
     - !reference [.on_arun_or_e2e_changes]
     - !reference [.manual]
@@ -279,7 +279,7 @@ new-e2e-windows-service-test:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_windows_testing-a7
+    - windows_msi_and_bosh_zip_x64-a7
   rules:
     - !reference [.on_windows_service_or_e2e_changes]
     - !reference [.manual]
@@ -312,9 +312,9 @@ new-e2e-npm-packages:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
-    - deploy_rpm_testing-a7_x64
-    - deploy_windows_testing-a7
+    - agent_deb-x64-a7
+    - agent_rpm-x64-a7
+    - windows_msi_and_bosh_zip_x64-a7
   variables:
     TARGETS: ./tests/npm
     TEAM: network-performance-monitoring
@@ -387,8 +387,8 @@ new-e2e-amp:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
-    - deploy_windows_testing-a7
+    - agent_deb-x64-a7
+    - windows_msi_and_bosh_zip_x64-a7
     - qa_agent
     - qa_agent_jmx
     - qa_agent_fips_jmx
@@ -405,8 +405,8 @@ new-e2e-alp:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
-    - deploy_windows_testing-a7
+    - agent_deb-x64-a7
+    - windows_msi_and_bosh_zip_x64-a7
     - qa_agent
     - qa_agent_jmx
     - qa_agent_fips_jmx
@@ -425,8 +425,8 @@ new-e2e-cws:
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
-    - deploy_windows_testing-a7
+    - agent_deb-x64-a7
+    - windows_msi_and_bosh_zip_x64-a7
     - qa_cws_instrumentation
     - qa_agent
     - qa_dca
@@ -447,7 +447,7 @@ new-e2e-discovery:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
+    - agent_deb-x64-a7
     - qa_agent
   rules:
     - !reference [.on_discovery_or_e2e_changes]
@@ -461,8 +461,8 @@ new-e2e-process:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
-    - deploy_windows_testing-a7
+    - agent_deb-x64-a7
+    - windows_msi_and_bosh_zip_x64-a7
     - qa_agent
     - qa_dca
   rules:
@@ -493,7 +493,7 @@ new-e2e-apm:
   needs:
     - !reference [.needs_new_e2e_template]
     - qa_agent
-    - deploy_deb_testing-a7_x64
+    - agent_deb-x64-a7
   variables:
     TARGETS: ./tests/apm
     TEAM: apm-agent

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -93,14 +93,19 @@
 .needs_new_e2e_template:
   - go_e2e_deps
 
+.new_e2e_template_needs_windows_x64:
+  extends: .new_e2e_template
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - windows_msi_and_bosh_zip_x64-a7
+    - windows_msi_and_bosh_zip_x64-a7-fips
+
 .new_e2e_template_needs_deb_x64:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
     - agent_deb-x64-a7-fips
-  variables:
-    LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
@@ -110,8 +115,6 @@
     - windows_msi_and_bosh_zip_x64-a7
     - agent_deb-x64-a7-fips
     - windows_msi_and_bosh_zip_x64-a7-fips
-  variables:
-    LOCAL_PACKAGE_FLAG: "--local-package $OMNIBUS_PACKAGE_DIR"
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -104,30 +104,17 @@
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-<<<<<<< HEAD
     - agent_deb-x64-a7
     - agent_deb-x64-a7-fips
-=======
-    - datadog-agent-7-x64
-  variables:
-    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
->>>>>>> 35d314bdc46 (Try with local-packages for some test)
 
 .new_e2e_template_needs_deb_windows_x64:
   extends: .new_e2e_template
   needs:
     - !reference [.needs_new_e2e_template]
-<<<<<<< HEAD
     - agent_deb-x64-a7
     - windows_msi_and_bosh_zip_x64-a7
     - agent_deb-x64-a7-fips
     - windows_msi_and_bosh_zip_x64-a7-fips
-=======
-    - datadog-agent-7-x64
-    - windows_msi_and_bosh_zip_x64-a7
-  variables:
-    LOCAL_PACKAGE_FLAG: "--local-package OMNIBUS_PACKAGE_DIR"
->>>>>>> 35d314bdc46 (Try with local-packages for some test)
 
 .new_e2e_template_needs_container_deploy:
   extends: .new_e2e_template

--- a/.gitlab/e2e_install_packages/amazonlinux.yml
+++ b/.gitlab/e2e_install_packages/amazonlinux.yml
@@ -20,7 +20,7 @@
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
     - !reference [.needs_new_e2e_template]
-    - iot_agent_rpm-x64-a7
+    - iot_agent_rpm-x64
 
 .new-e2e_amazonlinux_a7_arm64:
   variables:

--- a/.gitlab/e2e_install_packages/amazonlinux.yml
+++ b/.gitlab/e2e_install_packages/amazonlinux.yml
@@ -10,7 +10,7 @@
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_rpm_testing-a7_x64
+    - agent_deb-x64-a7
 
 .new-e2e_amazonlinux_a7_arm64:
   variables:
@@ -20,7 +20,8 @@
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_rpm_testing-a7_arm64
+    - agent_deb-arm64-a7
+
 
 new-e2e-agent-platform-install-script-amazonlinux-a7-x64:
   extends:

--- a/.gitlab/e2e_install_packages/amazonlinux.yml
+++ b/.gitlab/e2e_install_packages/amazonlinux.yml
@@ -10,7 +10,17 @@
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
     - !reference [.needs_new_e2e_template]
-    - agent_deb-x64-a7
+    - agent_rpm-x64-a7
+
+.new-e2e_amazonlinux_a7_x86_64_iot:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
+    E2E_CWS_SUPPORTED_OSVERS: "amazonlinux2-5-10,amazonlinux2022-5-15,amazonlinux2023"
+    E2E_BRANCH_OSVERS: "amazonlinux2023"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - iot_agent_rpm-x64-a7
 
 .new-e2e_amazonlinux_a7_arm64:
   variables:
@@ -20,8 +30,7 @@
     E2E_BRANCH_OSVERS: "amazonlinux2023"
   needs:
     - !reference [.needs_new_e2e_template]
-    - agent_deb-arm64-a7
-
+    - agent_rpm-arm64-a7
 
 new-e2e-agent-platform-install-script-amazonlinux-a7-x64:
   extends:
@@ -93,7 +102,7 @@ new-e2e-agent-platform-install-script-upgrade7-amazonlinux-iot-agent-x64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_amazonlinux
-    - .new-e2e_amazonlinux_a7_x86_64
+    - .new-e2e_amazonlinux_a7_x86_64_iot
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-iot-agent

--- a/.gitlab/e2e_install_packages/centos.yml
+++ b/.gitlab/e2e_install_packages/centos.yml
@@ -10,7 +10,7 @@
     E2E_BRANCH_OSVERS: "centos-79"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_rpm_testing-a7_x64
+    - agent_rpm-x64-a7
 
 .new-e2e_centos-fips_a7_x86_64:
   variables:
@@ -20,7 +20,7 @@
     E2E_BRANCH_OSVERS: "rhel-86-fips"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_rpm_testing-a7_x64
+    - agent_rpm-x64-a7
 
 .new-e2e_centos6_a7_x86_64:
   variables:
@@ -30,7 +30,7 @@
     E2E_OVERRIDE_INSTANCE_TYPE: "t2.medium" # CentOS 6 does not support ENA, so we cannot use t3 instances
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_rpm_testing-a7_x64
+    - agent_rpm-x64-a7
 
 new-e2e-agent-platform-install-script-centos-a7-x86_64:
   extends:

--- a/.gitlab/e2e_install_packages/centos.yml
+++ b/.gitlab/e2e_install_packages/centos.yml
@@ -42,7 +42,7 @@
     - !reference [.needs_new_e2e_template]
     - agent_rpm-x64-a7
 
-.new-e2e_centos_a7_x86_64_fips_iot:
+.new-e2e_centos-fips_a7_x86_64_iot:
   variables:
     E2E_ARCH: x86_64
     E2E_OSVERS: "rhel-86-fips"
@@ -52,7 +52,7 @@
     - !reference [.needs_new_e2e_template]
     - iot_agent_rpm-x64
 
-.new-e2e_centos_a7_x86_64_fips_dogstatsd:
+.new-e2e_centos-fips_a7_x86_64_dogstatsd:
   variables:
     E2E_ARCH: x86_64
     E2E_OSVERS: "rhel-86-fips"

--- a/.gitlab/e2e_install_packages/centos.yml
+++ b/.gitlab/e2e_install_packages/centos.yml
@@ -12,6 +12,26 @@
     - !reference [.needs_new_e2e_template]
     - agent_rpm-x64-a7
 
+.new-e2e_centos_a7_x86_64_iot:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "centos-79,rhel-86"
+    E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
+    E2E_BRANCH_OSVERS: "centos-79"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - iot_agent_rpm-x64
+
+.new-e2e_centos_a7_x86_64_dogstatsd:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "centos-79,rhel-86"
+    E2E_CWS_SUPPORTED_OSVERS: "centos-79,rhel-86"
+    E2E_BRANCH_OSVERS: "centos-79"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - dogstatsd_rpm-x64
+
 .new-e2e_centos-fips_a7_x86_64:
   variables:
     E2E_ARCH: x86_64
@@ -21,6 +41,26 @@
   needs:
     - !reference [.needs_new_e2e_template]
     - agent_rpm-x64-a7
+
+.new-e2e_centos_a7_x86_64_fips_iot:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "rhel-86-fips"
+    E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
+    E2E_BRANCH_OSVERS: "rhel-86-fips"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - iot_agent_rpm-x64
+
+.new-e2e_centos_a7_x86_64_fips_dogstatsd:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "rhel-86-fips"
+    E2E_CWS_SUPPORTED_OSVERS: "rhel-86-fips"
+    E2E_BRANCH_OSVERS: "rhel-86-fips"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - dogstatsd_rpm-x64
 
 .new-e2e_centos6_a7_x86_64:
   variables:
@@ -48,7 +88,7 @@ new-e2e-agent-platform-install-script-centos-iot-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
+    - .new-e2e_centos_a7_x86_64_iot
     - .new-e2e_agent_a7
   rules: !reference [.on_default_new_e2e_tests]
   variables:
@@ -59,7 +99,7 @@ new-e2e-agent-platform-install-script-centos-dogstatsd-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
+    - .new-e2e_centos_a7_x86_64_dogstatsd
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-dogstatsd
@@ -90,7 +130,7 @@ new-e2e-agent-platform-install-script-centos-fips-iot-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
+    - .new-e2e_centos-fips_a7_x86_64_iot
     - .new-e2e_agent_a7
   rules: !reference [.on_default_new_e2e_tests]
   variables:
@@ -101,7 +141,7 @@ new-e2e-agent-platform-install-script-centos-fips-dogstatsd-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
+    - .new-e2e_centos-fips_a7_x86_64_dogstatsd
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-dogstatsd
@@ -152,7 +192,7 @@ new-e2e-agent-platform-install-script-upgrade7-centos-iot-agent-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_centos
-    - .new-e2e_centos_a7_x86_64
+    - .new-e2e_centos_a7_x86_64_iot
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-iot-agent
@@ -166,7 +206,7 @@ new-e2e-agent-platform-install-script-upgrade7-centos-fips-iot-agent-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_centos
-    - .new-e2e_centos-fips_a7_x86_64
+    - .new-e2e_centos-fips_a7_x86_64_iot
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-iot-agent

--- a/.gitlab/e2e_install_packages/debian.yml
+++ b/.gitlab/e2e_install_packages/debian.yml
@@ -10,7 +10,47 @@
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
+    - agent_deb-x64-a7
+  
+.new-e2e_debian_a7_x86_64_fips:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
+    E2E_BRANCH_OSVERS: "debian-11"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_deb-x64-a7-fips
+
+.new-e2e_debian_a7_x86_64_iot:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
+    E2E_BRANCH_OSVERS: "debian-11"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - iot_agent_deb-x64
+
+.new-e2e_debian_a7_x86_64_dogstatsd:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
+    E2E_BRANCH_OSVERS: "debian-11"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - dogstatsd_deb-x64
+
+.new-e2e_debian_a7_x86_64_heroku:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "debian-9,debian-10,debian-11,debian-12"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10,debian-11"
+    E2E_BRANCH_OSVERS: "debian-11"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - heroku_agent_deb-x64
 
 .new-e2e_debian_a7_arm64:
   variables:
@@ -21,6 +61,38 @@
   needs:
     - !reference [.needs_new_e2e_template]
     - deploy_deb_testing-a7_arm64
+
+.new-e2e_debian_a7_arm64_iot:
+  variables:
+    E2E_ARCH: arm64
+    E2E_OSVERS: "debian-10"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10"
+    E2E_BRANCH_OSVERS: "debian-10"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - iot_agent_deb-arm64
+
+.new-e2e_debian_a7_arm64_dogstatsd:
+  variables:
+    E2E_ARCH: arm64
+    E2E_OSVERS: "debian-10"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10"
+    E2E_BRANCH_OSVERS: "debian-10"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - dogstatsd_deb-arm64
+  
+
+.new-e2e_debian_a7_arm64_fips:
+  variables:
+    E2E_ARCH: arm64
+    E2E_OSVERS: "debian-10"
+    E2E_CWS_SUPPORTED_OSVERS: "debian-10"
+    E2E_BRANCH_OSVERS: "debian-10"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_deb-arm64-a7-fips
+
 
 new-e2e-agent-platform-install-script-debian-a7-x86_64:
   extends:
@@ -59,7 +131,7 @@ new-e2e-agent-platform-install-script-debian-iot-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
+    - .new-e2e_debian_a7_x86_64_iot
     - .new-e2e_agent_a7
   rules: !reference [.on_default_new_e2e_tests]
   variables:
@@ -70,7 +142,7 @@ new-e2e-agent-platform-install-script-debian-dogstatsd-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
+    - .new-e2e_debian_a7_x86_64_dogstatsd
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-dogstatsd
@@ -80,7 +152,7 @@ new-e2e-agent-platform-install-script-debian-fips-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
+    - .new-e2e_debian_a7_x86_64_fips
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-fips-agent
@@ -90,7 +162,7 @@ new-e2e-agent-platform-install-script-debian-heroku-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
+    - .new-e2e_debian_a7_x86_64_heroku
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-heroku-agent
@@ -134,7 +206,7 @@ new-e2e-agent-platform-install-script-upgrade7-debian-iot-agent-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_debian
-    - .new-e2e_debian_a7_x86_64
+    - .new-e2e_debian_a7_x86_64_iot
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-iot-agent

--- a/.gitlab/e2e_install_packages/debian.yml
+++ b/.gitlab/e2e_install_packages/debian.yml
@@ -50,7 +50,7 @@
     E2E_BRANCH_OSVERS: "debian-11"
   needs:
     - !reference [.needs_new_e2e_template]
-    - heroku_agent_deb-x64
+    - agent_heroku_deb-x64-a7
 
 .new-e2e_debian_a7_arm64:
   variables:

--- a/.gitlab/e2e_install_packages/suse.yml
+++ b/.gitlab/e2e_install_packages/suse.yml
@@ -12,6 +12,36 @@
     - !reference [.needs_new_e2e_template]
     - agent_suse-x64-a7
 
+.new-e2e_suse_a7_x86_64_fips:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "sles-12,sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_suse-x64-a7-fips
+
+.new-e2e_suse_a7_x86_64_iot:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "sles-12,sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - iot_agent_suse-x64
+
+.new-e2e_suse_a7_x86_64_dogstatsd:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "sles-12,sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-12,sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - dogstatsd_suse-x64
+
 .new-e2e_suse_a7_arm64:
   variables:
     E2E_ARCH: arm64
@@ -21,6 +51,16 @@
   needs:
     - !reference [.needs_new_e2e_template]
     - agent_suse-arm64-a7
+
+.new-e2e_suse_arm64_a7_fips:
+  variables:
+    E2E_ARCH: arm64
+    E2E_OSVERS: "sles-15"
+    E2E_CWS_SUPPORTED_OSVERS: "sles-15"
+    E2E_BRANCH_OSVERS: "sles-15"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_suse-arm64-a7-fips
 
 new-e2e-agent-platform-install-script-suse-a7-x86_64:
   extends:
@@ -49,7 +89,7 @@ new-e2e-agent-platform-install-script-suse-iot-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_suse_a7_x86_64_iot
     - .new-e2e_agent_a7
   rules: !reference [.on_default_new_e2e_tests]
   variables:
@@ -60,7 +100,7 @@ new-e2e-agent-platform-install-script-suse-dogstatsd-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_suse_a7_x86_64_dogstatsd
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-dogstatsd
@@ -70,7 +110,7 @@ new-e2e-agent-platform-install-script-suse-fips-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_suse_a7_x86_64_fips
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-fips-agent
@@ -118,7 +158,7 @@ new-e2e-agent-platform-install-script-upgrade7-suse-iot-agent-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_suse
-    - .new-e2e_suse_a7_x86_64
+    - .new-e2e_suse_a7_x86_64_iot
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-iot-agent

--- a/.gitlab/e2e_install_packages/suse.yml
+++ b/.gitlab/e2e_install_packages/suse.yml
@@ -10,7 +10,7 @@
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_suse_rpm_testing_x64-a7
+    - agent_suse-x64-a7
 
 .new-e2e_suse_a7_arm64:
   variables:
@@ -20,7 +20,7 @@
     E2E_BRANCH_OSVERS: "sles-15"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_suse_rpm_testing_arm64-a7
+    - agent_suse-arm64-a7
 
 new-e2e-agent-platform-install-script-suse-a7-x86_64:
   extends:

--- a/.gitlab/e2e_install_packages/ubuntu.yml
+++ b/.gitlab/e2e_install_packages/ubuntu.yml
@@ -13,6 +13,46 @@
     - !reference [.needs_new_e2e_template]
     - agent_deb-x64-a7
 
+.new-e2e_ubuntu_a7_x86_64_fips:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04,ubuntu-24-04"
+    E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
+    E2E_BRANCH_OSVERS: "ubuntu-24-04"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_deb-x64-a7-fips
+
+.new-e2e_ubuntu_a7_x86_64_iot:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04,ubuntu-24-04"
+    E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
+    E2E_BRANCH_OSVERS: "ubuntu-24-04"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - iot_agent_deb-x64
+
+.new-e2e_ubuntu_a7_x86_64_dogstatsd:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04,ubuntu-24-04"
+    E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
+    E2E_BRANCH_OSVERS: "ubuntu-24-04"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - dogstatsd_deb-x64
+
+.new-e2e_ubuntu_a7_x86_64_heroku:
+  variables:
+    E2E_ARCH: x86_64
+    E2E_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04,ubuntu-22-04,ubuntu-24-04"
+    E2E_CWS_SUPPORTED_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-22-04"
+    E2E_BRANCH_OSVERS: "ubuntu-24-04"
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - heroku_agent_deb-x64
+
 .new-e2e_ubuntu_a7_arm64:
   variables:
     E2E_ARCH: arm64
@@ -62,7 +102,7 @@ new-e2e-agent-platform-install-script-ubuntu-iot-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
+    - .new-e2e_ubuntu_a7_x86_64_iot
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-iot-agent
@@ -72,7 +112,7 @@ new-e2e-agent-platform-install-script-ubuntu-dogstatsd-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
+    - .new-e2e_ubuntu_a7_x86_64_dogstatsd
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-dogstatsd
@@ -82,7 +122,7 @@ new-e2e-agent-platform-install-script-ubuntu-heroku-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
+    - .new-e2e_ubuntu_a7_x86_64_heroku
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-heroku-agent
@@ -92,7 +132,7 @@ new-e2e-agent-platform-install-script-ubuntu-fips-agent-a7-x86_64:
     - .new_e2e_template
     - .new-e2e_install_script
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
+    - .new-e2e_ubuntu_a7_x86_64_fips
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-fips-agent
@@ -136,7 +176,7 @@ new-e2e-agent-platform-install-script-upgrade7-ubuntu-iot-agent-x86_64:
     - .new_e2e_template
     - .new-e2e_script_upgrade7
     - .new-e2e_os_ubuntu
-    - .new-e2e_ubuntu_a7_x86_64
+    - .new-e2e_ubuntu_a7_x86_64_iot
     - .new-e2e_agent_a7
   variables:
     FLAVOR: datadog-iot-agent

--- a/.gitlab/e2e_install_packages/ubuntu.yml
+++ b/.gitlab/e2e_install_packages/ubuntu.yml
@@ -11,7 +11,7 @@
     E2E_BRANCH_OSVERS: "ubuntu-24-04"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_x64
+    - agent_deb-x64-a7
 
 .new-e2e_ubuntu_a7_arm64:
   variables:
@@ -21,7 +21,7 @@
     E2E_BRANCH_OSVERS: "ubuntu-20-04"
   needs:
     - !reference [.needs_new_e2e_template]
-    - deploy_deb_testing-a7_arm64
+    - agent_deb-arm64-a7
 
 new-e2e-agent-platform-install-script-ubuntu-a7-x86_64:
   extends:

--- a/.gitlab/e2e_install_packages/ubuntu.yml
+++ b/.gitlab/e2e_install_packages/ubuntu.yml
@@ -51,7 +51,7 @@
     E2E_BRANCH_OSVERS: "ubuntu-24-04"
   needs:
     - !reference [.needs_new_e2e_template]
-    - heroku_agent_deb-x64
+    - agent_heroku_deb-x64-a7
 
 .new-e2e_ubuntu_a7_arm64:
   variables:

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -122,6 +122,17 @@ def run(
                 code=1,
             )
         parsed_params[parts[0]] = parts[1]
+    if local_package and running_in_ci():
+        files = os.listdir(local_package)
+        if len(files) == 0:
+            raise Exit(f"Local package {local_package} should contain files", 1)
+        print("Removing debug package")
+        for file in files:
+            if "-dbg_" in file:
+                os.remove(os.path.join(local_package, file))
+        new_files = os.listdir(local_package)
+        print("Using the following files for tests:", new_files)
+
     if local_package:
         parsed_params["ddagent:localPackage"] = local_package
 

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -123,16 +123,19 @@ def run(
             )
         parsed_params[parts[0]] = parts[1]
     if local_package and running_in_ci():
-        files = os.listdir(local_package)
-        if len(files) == 0:
-            print("Warning: --local-package is set but no files found in the directory")
-        else:
-            print("Removing debug package")
-            for file in files:
-                if "-dbg_" in file:
-                    os.remove(os.path.join(local_package, file))
-            new_files = os.listdir(local_package)
-            print("Using the following files for tests:", new_files)
+        try:
+            files = os.listdir(local_package)
+            if len(files) == 0:
+                print("Warning: --local-package is set but no files found in the directory")
+            else:
+                print("Removing debug package")
+                for file in files:
+                    if "-dbg_" in file:
+                        os.remove(os.path.join(local_package, file))
+                new_files = os.listdir(local_package)
+                print("Using the following files for tests:", new_files)
+        except FileNotFoundError:
+            print("Warning: --local-package is set but the directory does not exist")
 
     if local_package:
         parsed_params["E2E_LOCAL_PACKAGE_PATH"] = local_package

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -124,7 +124,7 @@ def run(
         parsed_params[parts[0]] = parts[1]
 
     if local_package:
-        parsed_params["E2E_LOCAL_PACKAGE_PATH"] = local_package
+        env_vars["E2E_LOCAL_PACKAGE_PATH"] = local_package
 
     if agent_image:
         parsed_params["ddagent:fullImagePath"] = agent_image

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -125,13 +125,14 @@ def run(
     if local_package and running_in_ci():
         files = os.listdir(local_package)
         if len(files) == 0:
-            raise Exit(f"Local package {local_package} should contain files", 1)
-        print("Removing debug package")
-        for file in files:
-            if "-dbg_" in file:
-                os.remove(os.path.join(local_package, file))
-        new_files = os.listdir(local_package)
-        print("Using the following files for tests:", new_files)
+            print("Warning: --local-package is set but no files found in the directory")
+        else:
+            print("Removing debug package")
+            for file in files:
+                if "-dbg_" in file:
+                    os.remove(os.path.join(local_package, file))
+            new_files = os.listdir(local_package)
+            print("Using the following files for tests:", new_files)
 
     if local_package:
         parsed_params["E2E_LOCAL_PACKAGE_PATH"] = local_package

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -122,20 +122,6 @@ def run(
                 code=1,
             )
         parsed_params[parts[0]] = parts[1]
-    if local_package and running_in_ci():
-        try:
-            files = os.listdir(local_package)
-            if len(files) == 0:
-                print("Warning: --local-package is set but no files found in the directory")
-            else:
-                print("Removing debug package")
-                for file in files:
-                    if "-dbg_" in file:
-                        os.remove(os.path.join(local_package, file))
-                new_files = os.listdir(local_package)
-                print("Using the following files for tests:", new_files)
-        except FileNotFoundError:
-            print("Warning: --local-package is set but the directory does not exist")
 
     if local_package:
         parsed_params["E2E_LOCAL_PACKAGE_PATH"] = local_package

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -134,7 +134,7 @@ def run(
         print("Using the following files for tests:", new_files)
 
     if local_package:
-        parsed_params["ddagent:localPackage"] = local_package
+        parsed_params["E2E_LOCAL_PACKAGE_PATH"] = local_package
 
     if agent_image:
         parsed_params["ddagent:fullImagePath"] = agent_image

--- a/test/new-e2e/pkg/runner/configmap.go
+++ b/test/new-e2e/pkg/runner/configmap.go
@@ -33,6 +33,8 @@ const (
 	AgentCommitSHA = commonconfig.DDAgentConfigNamespace + ":" + commonconfig.DDAgentCommitSHA
 	// AgentFIPS pulumi config parameter name
 	AgentFIPS = commonconfig.DDAgentConfigNamespace + ":" + commonconfig.DDAgentFIPS
+	// AgentLocalPackagePath pulumi config parameter name
+	AgentLocalPackagePath = commonconfig.DDAgentConfigNamespace + ":" + commonconfig.DDAgentLocalPackage
 
 	// InfraEnvironmentVariables pulumi config parameter name
 	InfraEnvironmentVariables = commonconfig.DDInfraConfigNamespace + ":" + commonconfig.DDInfraEnvironment
@@ -143,6 +145,7 @@ func BuildStackParameters(profile Profile, scenarioConfig ConfigMap) (ConfigMap,
 		parameters.MajorVersion:        {AgentMajorVersion},
 		parameters.CommitSHA:           {AgentCommitSHA},
 		parameters.InitOnly:            {InfraInitOnly},
+		parameters.LocalPackagePath:    {AgentLocalPackagePath},
 	}
 
 	for storeKey, configMapKeys := range params {

--- a/test/new-e2e/pkg/runner/configmap_test.go
+++ b/test/new-e2e/pkg/runner/configmap_test.go
@@ -50,6 +50,7 @@ func Test_BuildStackParameters(t *testing.T) {
 		"ddagent:pipeline_id":                   auto.ConfigValue{Value: "pipeline_id", Secret: false},
 		"ddagent:commit_sha":                    auto.ConfigValue{Value: "commit_sha", Secret: false},
 		"ddagent:majorVersion":                  auto.ConfigValue{Value: "major_version", Secret: false},
+		"ddagent:localPackagePath":              auto.ConfigValue{Value: "local_package_path", Secret: false},
 		"ddagent:fips":                          auto.ConfigValue{Value: "fips", Secret: false},
 	}, configMap)
 }

--- a/test/new-e2e/pkg/runner/configmap_test.go
+++ b/test/new-e2e/pkg/runner/configmap_test.go
@@ -50,7 +50,7 @@ func Test_BuildStackParameters(t *testing.T) {
 		"ddagent:pipeline_id":                   auto.ConfigValue{Value: "pipeline_id", Secret: false},
 		"ddagent:commit_sha":                    auto.ConfigValue{Value: "commit_sha", Secret: false},
 		"ddagent:majorVersion":                  auto.ConfigValue{Value: "major_version", Secret: false},
-		"ddagent:localPackagePath":              auto.ConfigValue{Value: "local_package_path", Secret: false},
+		"ddagent:localPackage":                  auto.ConfigValue{Value: "local_package_path", Secret: false},
 		"ddagent:fips":                          auto.ConfigValue{Value: "fips", Secret: false},
 	}, configMap)
 }

--- a/test/new-e2e/pkg/runner/parameters/const.go
+++ b/test/new-e2e/pkg/runner/parameters/const.go
@@ -73,6 +73,8 @@ const (
 	MajorVersion StoreKey = "major_version"
 	// FIPS config flag parameter name
 	FIPS StoreKey = "fips"
+	// LocalPackagePath config flag parameter name
+	LocalPackagePath StoreKey = "local_package_path"
 )
 
 const (

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -593,6 +593,7 @@ func convertPathSeparatorFactory(osFamily oscomp.Family) convertPathSeparatorFn 
 	}
 }
 
+// InstallAgentFromLocalPackage installs the agent from a local package
 func (h *Host) InstallAgentFromLocalPackage(localPath string) error {
 	cmd := fmt.Sprintf("sudo dpkg -i %s", localPath)
 	_, err := h.Execute(cmd)

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -592,3 +592,9 @@ func convertPathSeparatorFactory(osFamily oscomp.Family) convertPathSeparatorFn 
 		return s
 	}
 }
+
+func (h *Host) InstallAgentFromLocalPackage(localPath string) error {
+	cmd := fmt.Sprintf("sudo dpkg -i %s", localPath)
+	_, err := h.Execute(cmd)
+	return err
+}

--- a/test/new-e2e/pkg/utils/e2e/client/host.go
+++ b/test/new-e2e/pkg/utils/e2e/client/host.go
@@ -592,10 +592,3 @@ func convertPathSeparatorFactory(osFamily oscomp.Family) convertPathSeparatorFn 
 		return s
 	}
 }
-
-// InstallAgentFromLocalPackage installs the agent from a local package
-func (h *Host) InstallAgentFromLocalPackage(localPath string) error {
-	cmd := fmt.Sprintf("sudo dpkg -i %s", localPath)
-	_, err := h.Execute(cmd)
-	return err
-}

--- a/test/new-e2e/tests/agent-platform/common/agent_install.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_install.go
@@ -14,7 +14,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 // CheckInstallation run tests to check the installation of the agent
@@ -73,39 +72,6 @@ func (client *TestClient) CheckAgentVersion(t *testing.T, expected string) bool 
 		require.NoErrorf(t, err, "invalid actual version %s", matchList[1])
 
 		require.Equal(t, expectedVersion.GetNumberAndPre(), actualVersion.GetNumberAndPre(), "Expected datadog-agent version %s got %s", expectedVersion, actualVersion)
-	})
-}
-
-// CheckInstallationInstallScript run tests to check the installation of the agent with the install script
-func CheckInstallationInstallScript(t *testing.T, client *TestClient) {
-	t.Run("site config attribute", func(tt *testing.T) {
-		configFilePath := client.Helper.GetConfigFolder() + client.Helper.GetConfigFileName()
-
-		var configYAML map[string]any
-		config, err := client.FileManager.ReadFile(configFilePath)
-		require.NoError(tt, err)
-
-		err = yaml.Unmarshal([]byte(config), &configYAML)
-		require.NoError(tt, err)
-		require.Equal(tt, configYAML["site"], "datadoghq.eu")
-	})
-
-	t.Run("install info file", func(tt *testing.T) {
-		installInfoFilePath := client.Helper.GetConfigFolder() + "install_info"
-
-		var installInfoYaml map[string]map[string]string
-		installInfo, err := client.FileManager.ReadFile(installInfoFilePath)
-		require.NoError(tt, err)
-
-		err = yaml.Unmarshal([]byte(installInfo), &installInfoYaml)
-		require.NoError(tt, err)
-		toolVersionRegex := regexp.MustCompile(`^install_script_agent\d+$`)
-		installerVersionRegex := regexp.MustCompile(`^install_script-\d+\.\d+\.\d+(.post)?$`)
-		installMethodJSON := installInfoYaml["install_method"]
-
-		require.True(tt, toolVersionRegex.MatchString(installMethodJSON["tool_version"]))
-		require.True(tt, installerVersionRegex.MatchString(installMethodJSON["installer_version"]))
-		require.Equal(tt, installMethodJSON["tool"], "install_script")
 	})
 }
 

--- a/test/new-e2e/tests/agent-platform/common/agent_integration.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_integration.go
@@ -18,7 +18,7 @@ import (
 
 // CheckIntegrationInstall run test to test installation of integrations
 func CheckIntegrationInstall(t *testing.T, client *TestClient) {
-	flake.Mark(t)
+	// flake.Mark(t)
 	requirementIntegrationPath := client.Helper.GetInstallFolder() + "requirements-agent-release.txt"
 
 	ciliumRegex := regexp.MustCompile(`datadog-cilium==.*`)

--- a/test/new-e2e/tests/agent-platform/common/agent_integration.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_integration.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
-	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
 
 // CheckIntegrationInstall run test to test installation of integrations

--- a/test/new-e2e/tests/agent-platform/common/pkg-manager/apt.go
+++ b/test/new-e2e/tests/agent-platform/common/pkg-manager/apt.go
@@ -27,3 +27,8 @@ func NewApt(host *components.RemoteHost) *Apt {
 func (s *Apt) Remove(pkg string) (string, error) {
 	return s.host.Execute(fmt.Sprintf("sudo apt remove -q -y %s", pkg))
 }
+
+// Install call install from apt
+func (s *Apt) Install(pkg string) (string, error) {
+	return s.host.Execute(fmt.Sprintf("sudo apt install -q -y %s", pkg))
+}

--- a/test/new-e2e/tests/agent-platform/common/pkg-manager/types.go
+++ b/test/new-e2e/tests/agent-platform/common/pkg-manager/types.go
@@ -9,4 +9,5 @@ package pkgmanager
 // PackageManager generic interface
 type PackageManager interface {
 	Remove(pkg string) (string, error)
+	Install(pkg string) (string, error)
 }

--- a/test/new-e2e/tests/agent-platform/common/pkg-manager/yum.go
+++ b/test/new-e2e/tests/agent-platform/common/pkg-manager/yum.go
@@ -25,3 +25,8 @@ func NewYum(host *components.RemoteHost) *Yum {
 func (s *Yum) Remove(pkg string) (string, error) {
 	return s.host.Execute("sudo yum remove -y " + pkg)
 }
+
+// Install executes install command from yum
+func (s *Yum) Install(pkg string) (string, error) {
+	return s.host.Execute("sudo yum install -y " + pkg)
+}

--- a/test/new-e2e/tests/agent-platform/common/pkg-manager/zypper.go
+++ b/test/new-e2e/tests/agent-platform/common/pkg-manager/zypper.go
@@ -25,3 +25,8 @@ func NewZypper(host *components.RemoteHost) *Zypper {
 func (s *Zypper) Remove(pkg string) (string, error) {
 	return s.host.Execute("sudo zypper remove -y " + pkg)
 }
+
+// Install executes install command from zypper
+func (s *Zypper) Install(pkg string) (string, error) {
+	return s.host.Execute("sudo zypper install -y " + pkg)
+}

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/test-infra-definitions/components/agent"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	componentos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	componentos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -182,6 +183,20 @@ func (c *TestClient) ExecuteWithRetry(cmd string) (string, error) {
 	return execWithRetry(func(cmd string) (string, error) { return c.Host.Execute(cmd) }, cmd)
 }
 
+func (c *TestClient) InstallAgentFromLocalPackage(localPath string, agentFlavor string) error {
+	packagePath, err := utils.GetPackagePath(localPath, c.Host.OSFlavor, agentFlavor)
+	if err != nil {
+		return err
+	}
+
+	c.Host.CopyFile(packagePath, "./")
+	_, err = c.PkgManager.Install(packagePath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // NewWindowsTestClient create a TestClient for Windows VM
 func NewWindowsTestClient(context common.Context, host *components.RemoteHost) *TestClient {
 	fileManager := filemanager.NewRemoteHost(host)
@@ -314,6 +329,11 @@ func (c *DockerTestClient) Execute(command string) (output string, err error) {
 // ExecuteWithRetry execute the command with retry
 func (c *DockerTestClient) ExecuteWithRetry(cmd string) (output string, err error) {
 	return execWithRetry(c.Execute, cmd)
+}
+
+// InstallAgentFromLocalPackage installs the agent from a local package
+func (c *DockerTestClient) InstallAgentFromLocalPackage(localPath string) error {
+	panic("not implemented")
 }
 
 func execWithRetry(exec func(string) (string, error), cmd string) (string, error) {

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -332,7 +332,7 @@ func (c *DockerTestClient) ExecuteWithRetry(cmd string) (output string, err erro
 }
 
 // InstallAgentFromLocalPackage installs the agent from a local package
-func (c *DockerTestClient) InstallAgentFromLocalPackage(localPath string) error {
+func (c *DockerTestClient) InstallAgentFromLocalPackage(_localPath string, _agentFlavor string) error {
 	panic("not implemented")
 }
 

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/agent"
 	componentos "github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -184,7 +184,7 @@ func (c *TestClient) ExecuteWithRetry(cmd string) (string, error) {
 }
 
 func (c *TestClient) InstallAgentFromLocalPackage(localPath string, agentFlavor string) error {
-	packagePath, err := utils.GetPackagePath(localPath, c.Host.OSFlavor, agentFlavor)
+	packagePath, err := agent.GetPackagePath(localPath, c.Host.OSFlavor, agentFlavor)
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -184,7 +184,7 @@ func (c *TestClient) ExecuteWithRetry(cmd string) (string, error) {
 }
 
 func (c *TestClient) InstallAgentFromLocalPackage(localPath string, agentFlavor string) error {
-	packagePath, err := agent.GetPackagePath(localPath, c.Host.OSFlavor, agentFlavor)
+	packagePath, err := agent.GetPackagePath(localPath, c.Host.OSFlavor, agentFlavor, componentos.AMD64Arch) // Will be changed with c.Host.Architecture when it is exposed
 	if err != nil {
 		return err
 	}

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -184,6 +184,7 @@ func (c *TestClient) ExecuteWithRetry(cmd string) (string, error) {
 	return execWithRetry(func(cmd string) (string, error) { return c.Host.Execute(cmd) }, cmd)
 }
 
+// InstallAgentFromLocalPackage installs the agent from a local package
 func (c *TestClient) InstallAgentFromLocalPackage(localPath string, agentFlavor string) error {
 	packagePath, err := agent.GetPackagePath(localPath, c.Host.OSFlavor, agentFlavor, componentos.AMD64Arch) // Will be changed with c.Host.Architecture when it is exposed
 	if err != nil {

--- a/test/new-e2e/tests/agent-platform/common/test_client.go
+++ b/test/new-e2e/tests/agent-platform/common/test_client.go
@@ -192,7 +192,12 @@ func (c *TestClient) InstallAgentFromLocalPackage(localPath string, agentFlavor 
 	}
 
 	c.Host.CopyFile(packagePath, path.Base(packagePath))
-	_, err = c.PkgManager.Install("./" + path.Base(packagePath))
+	if c.Host.OSVersion == "ubuntu-14-04" {
+		_, err = c.ExecuteWithRetry("sudo dpkg -i ./" + path.Base(packagePath))
+	} else {
+		_, err = c.PkgManager.Install("./" + path.Base(packagePath))
+	}
+
 	if err != nil {
 		return err
 	}
@@ -201,10 +206,7 @@ func (c *TestClient) InstallAgentFromLocalPackage(localPath string, agentFlavor 
 
 	_ = c.Host.MustExecute(fmt.Sprintf("sudo sed -i 's/api_key:.*/api_key: %s/' %sdatadog.yaml", "deadbeefdeadbeefdeadbeefdeadbeef", configFolder))
 
-	_, err = c.SvcManager.Start(c.Helper.GetServiceName())
-	if err != nil {
-		return err
-	}
+	_, _ = c.SvcManager.Start(c.Helper.GetServiceName())
 
 	return nil
 }

--- a/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
+++ b/test/new-e2e/tests/agent-platform/install-script/install_script_test.go
@@ -169,7 +169,6 @@ func (is *installScriptSuite) AgentTest(flavor string) {
 			common.CheckCWSBehaviour(is.T(), client)
 		}
 	}
-	common.CheckInstallationInstallScript(is.T(), client)
 	is.testUninstall(client, flavor)
 }
 
@@ -190,7 +189,6 @@ func (is *installScriptSuite) IotAgentTest() {
 	common.CheckAgentStops(is.T(), client)
 	common.CheckAgentRestarts(is.T(), client)
 
-	common.CheckInstallationInstallScript(is.T(), client)
 	is.testUninstall(client, "datadog-iot-agent")
 }
 
@@ -210,7 +208,6 @@ func (is *installScriptSuite) DogstatsdAgentTest() {
 	common.CheckDogstatdAgentBehaviour(is.T(), client)
 	common.CheckDogstatsdAgentStops(is.T(), client)
 	common.CheckDogstatsdAgentRestarts(is.T(), client)
-	common.CheckInstallationInstallScript(is.T(), client)
 	is.testUninstall(client, "datadog-dogstatsd")
 }
 

--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -19,12 +19,17 @@ import (
 // ExecutorWithRetry represents a type that can execute a command and return its output
 type ExecutorWithRetry interface {
 	ExecuteWithRetry(command string) (output string, err error)
+	InstallAgentFromLocalPackage(localPath string, flavor string) error
 }
 
 // Unix install the agent from install script, by default will install the agent 7 build corresponding to the CI if running in the CI, else the latest Agent 7 version
 func Unix(t *testing.T, client ExecutorWithRetry, options ...installparams.Option) {
 	params := installparams.NewParams(options...)
 	commandLine := ""
+
+	if params.LocalPath != "" {
+		client.InstallAgentFromLocalPackage(params.LocalPath, params.Flavor)
+	}
 
 	if params.PipelineID != "" && params.MajorVersion != "5" {
 		testEnvVars := []string{}

--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -27,10 +27,6 @@ func Unix(t *testing.T, client ExecutorWithRetry, options ...installparams.Optio
 	params := installparams.NewParams(options...)
 	commandLine := ""
 
-	if params.LocalPath != "" {
-		client.InstallAgentFromLocalPackage(params.LocalPath, params.Flavor)
-	}
-
 	if params.PipelineID != "" && params.MajorVersion != "5" {
 		testEnvVars := []string{}
 		testEnvVars = append(testEnvVars, "TESTING_APT_URL=apttesting.datad0g.com")
@@ -73,6 +69,12 @@ func Unix(t *testing.T, client ExecutorWithRetry, options ...installparams.Optio
 		} else {
 			source = "dd-agent repository"
 			downloadCmd = "curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh > installscript.sh"
+		}
+
+		if params.LocalPath != "" {
+			err := client.InstallAgentFromLocalPackage(params.LocalPath, params.Flavor)
+			require.NoError(tt, err, "failed to install agent from local package: ", err)
+			return
 		}
 
 		_, err := client.ExecuteWithRetry(downloadCmd)

--- a/test/new-e2e/tests/agent-platform/install/installparams/install_params.go
+++ b/test/new-e2e/tests/agent-platform/install/installparams/install_params.go
@@ -6,7 +6,13 @@
 // Package installparams implements function parameters for agent install functions
 package installparams
 
-import "os"
+import (
+	"fmt"
+	"os"
+
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner"
+	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/runner/parameters"
+)
 
 // Params defines the parameters for the Agent client.
 // The Params configuration uses the [Functional options pattern].
@@ -16,6 +22,7 @@ import "os"
 
 // Params struct containing install params
 type Params struct {
+	LocalPath    string
 	PipelineID   string
 	MajorVersion string
 	Arch         string
@@ -37,7 +44,14 @@ func NewParams(options ...Option) *Params {
 		majorVersion = defaultMajorVersion
 	}
 
+	localPathFromEnv, err := runner.GetProfile().ParamStore().Get(parameters.LocalPackagePath)
+	if err != nil {
+		fmt.Printf("Error getting local package path from env: %v", err)
+		localPathFromEnv = ""
+	}
+
 	p := &Params{
+		LocalPath:    localPathFromEnv,
 		PipelineID:   os.Getenv("E2E_PIPELINE_ID"),
 		MajorVersion: majorVersion,
 		Arch:         "x86_64",
@@ -91,5 +105,11 @@ func WithAPIKey(apiKey string) Option {
 func WithPipelineID(id string) Option {
 	return func(p *Params) {
 		p.PipelineID = id
+	}
+}
+
+func WithLocalPackagePath(localPath string) Option {
+	return func(p *Params) {
+		p.LocalPath = localPath
 	}
 }

--- a/test/new-e2e/tests/agent-platform/install/installparams/install_params.go
+++ b/test/new-e2e/tests/agent-platform/install/installparams/install_params.go
@@ -108,6 +108,7 @@ func WithPipelineID(id string) Option {
 	}
 }
 
+// WithLocalPackagePath specify a custom local package path to use when installing the agent
 func WithLocalPackagePath(localPath string) Option {
 	return func(p *Params) {
 		p.LocalPath = localPath

--- a/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
+++ b/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
@@ -94,6 +94,7 @@ func TestPackageSigningComponent(t *testing.T) {
 func (is *packageSigningTestSuite) TestPackageSigning() {
 	// Install the signing keys
 	if is.osName == "ubuntu" || is.osName == "debian" {
+		is.Env().RemoteHost.MustExecute("sudo apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg")
 		aptUsrShareKeyring := "/usr/share/keyrings/datadog-archive-keyring.gpg"
 		is.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo touch %s && sudo chmod a+r %s", aptUsrShareKeyring, aptUsrShareKeyring))
 		keys := []string{"DATADOG_APT_KEY_CURRENT.public", "DATADOG_APT_KEY_C0962C7D.public", "DATADOG_APT_KEY_F14F620E.public", "DATADOG_APT_KEY_382E94DE.public"}

--- a/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
+++ b/test/new-e2e/tests/agent-platform/package-signing/package_signing_test.go
@@ -102,6 +102,8 @@ func (is *packageSigningTestSuite) TestPackageSigning() {
 			is.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo curl --retry 5 -o \"/tmp/%s\" \"https://keys.datadoghq.com/%s\"", key, key))
 			is.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo cat \"/tmp/%s\" | sudo gpg --import --batch --no-default-keyring --keyring \"%s\"", key, aptUsrShareKeyring))
 		}
+		aptTrustedDKeyring := "/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
+		is.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo cp %s %s", aptUsrShareKeyring, aptTrustedDKeyring))
 	} else {
 		keys := []string{"DATADOG_RPM_KEY_E09422B3.public", "DATADOG_RPM_KEY_CURRENT.public", "DATADOG_RPM_KEY_FD4BF915.public", "DATADOG_RPM_KEY_E09422B3.public"}
 		for _, key := range keys {

--- a/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
+++ b/test/new-e2e/tests/agent-platform/upgrade/upgrade_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
 	awshost "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/host"
@@ -66,7 +65,7 @@ func TestUpgradeScript(t *testing.T) {
 		}
 
 		t.Run(fmt.Sprintf("test upgrade on %s %s", osVers, *architecture), func(tt *testing.T) {
-			flake.Mark(tt)
+			// flake.Mark(tt)
 			tt.Parallel()
 			tt.Logf("Testing %s", osVers)
 
@@ -98,7 +97,7 @@ func (is *upgradeSuite) TestUpgrade() {
 }
 
 func (is *upgradeSuite) SetupAgentStartVersion(VMclient *common.TestClient) {
-	install.Unix(is.T(), VMclient, installparams.WithArch(*architecture), installparams.WithFlavor(*flavorName), installparams.WithMajorVersion(is.srcVersion), installparams.WithAPIKey(os.Getenv("DATADOG_AGENT_API_KEY")), installparams.WithPipelineID(""))
+	install.Unix(is.T(), VMclient, installparams.WithArch(*architecture), installparams.WithFlavor(*flavorName), installparams.WithMajorVersion(is.srcVersion), installparams.WithAPIKey(os.Getenv("DATADOG_AGENT_API_KEY")), installparams.WithPipelineID(""), installparams.WithLocalPackagePath(""))
 	var err error
 	if is.srcVersion == "5" {
 		_, err = VMclient.Host.Execute("sudo /etc/init.d/datadog-agent stop")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We want to stop relying on the install-script to install the agent in the e2e test framework.
The main reason is that we now want to support installing unsigned packages built from dev laptops. The install-script expect your package to be available on a apt/yum repository and signed properly.

https://docs.google.com/document/d/1_L07m7Xxg_xuG6Y2d-PE18Ezu_bEoLlGqFBMCxOSQTQ/edit?tab=t.0

These tests should also be renamed at some point, because their goal is more to test that the agent can be installed properly than testing that the install-script works. Testing the install-script is already covered by e2e tests running on agent-linux-install-script repository.
It might also reduce the cost of the e2e tests infrastructure because pulling the agent from public Cloudfront should bring more traffic through the NAT Gateway that represent most of the cost of the infra.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->