### PR TITLE
discovery: use wmeta and tagger directly

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/config_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/config_test.go
@@ -57,7 +57,7 @@ func TestConfigIgnoredComms(t *testing.T) {
 			commsStr := strings.Join(test.comms, "   ") // intentionally multiple spaces for sensitivity testing
 			mockSystemProbe.SetWithoutSource("discovery.ignored_command_names", commsStr)
 
-			discovery := newDiscovery(nil, nil)
+			discovery := newDiscovery(t, nil)
 			require.NotEmpty(t, discovery)
 
 			require.Equal(t, len(discovery.config.ignoreComms), len(test.comms))
@@ -74,7 +74,7 @@ func TestConfigIgnoredComms(t *testing.T) {
 
 	t.Run("check default config length", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		discovery := newDiscovery(nil, nil)
+		discovery := newDiscovery(t, nil)
 		require.NotEmpty(t, discovery)
 
 		assert.Equal(t, len(discovery.config.ignoreComms), 10)
@@ -84,7 +84,7 @@ func TestConfigIgnoredComms(t *testing.T) {
 		mock.NewSystemProbe(t)
 		t.Setenv("DD_DISCOVERY_IGNORED_COMMAND_NAMES", "dummy1 dummy2")
 
-		discovery := newDiscovery(nil, nil)
+		discovery := newDiscovery(t, nil)
 		require.NotEmpty(t, discovery)
 
 		_, found := discovery.config.ignoreComms["dummy1"]
@@ -120,7 +120,7 @@ func TestConfigIgnoredServices(t *testing.T) {
 			servicesStr := strings.Join(test.services, "   ") // intentionally multiple spaces for sensitivity testing
 			mockSystemProbe.SetWithoutSource("discovery.ignored_services", servicesStr)
 
-			discovery := newDiscovery(nil, nil)
+			discovery := newDiscovery(t, nil)
 			require.NotEmpty(t, discovery)
 
 			require.Equal(t, len(discovery.config.ignoreServices), len(test.services))
@@ -134,7 +134,7 @@ func TestConfigIgnoredServices(t *testing.T) {
 
 	t.Run("check default number of services", func(t *testing.T) {
 		mock.NewSystemProbe(t)
-		discovery := newDiscovery(nil, nil)
+		discovery := newDiscovery(t, nil)
 		require.NotEmpty(t, discovery)
 
 		assert.Equal(t, len(discovery.config.ignoreServices), 6)
@@ -144,7 +144,7 @@ func TestConfigIgnoredServices(t *testing.T) {
 		mock.NewSystemProbe(t)
 		t.Setenv("DD_DISCOVERY_IGNORED_SERVICES", "service1 service2")
 
-		discovery := newDiscovery(nil, nil)
+		discovery := newDiscovery(t, nil)
 		require.NotEmpty(t, discovery)
 
 		_, found := discovery.config.ignoreServices["service1"]

--- a/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
@@ -66,7 +66,7 @@ func TestShouldIgnorePid(t *testing.T) {
 				_ = cmd.Process.Kill()
 			})
 
-			discovery := newDiscovery(nil, nil)
+			discovery := newDiscovery(t, nil)
 			require.NotEmpty(t, discovery)
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -20,12 +20,14 @@ import (
 	"sync"
 	"time"
 
-	agentPayload "github.com/DataDog/agent-payload/v5/process"
 	"github.com/shirou/gopsutil/v4/process"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	sysconfigtypes "github.com/DataDog/datadog-agent/cmd/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/apm"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/detector"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/language"
@@ -35,7 +37,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/languagedetection/privileged"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
-	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel/netns"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -183,14 +184,16 @@ type discovery struct {
 
 	lastNetworkStatsUpdate time.Time
 
-	containerProvider proccontainers.ContainerProvider
-	timeProvider      timeProvider
-	network           networkCollector
+	wmeta  workloadmeta.Component
+	tagger tagger.Component
+
+	timeProvider timeProvider
+	network      networkCollector
 }
 
 type networkCollectorFactory func(cfg *discoveryConfig) (networkCollector, error)
 
-func newDiscoveryWithNetwork(containerProvider proccontainers.ContainerProvider, tp timeProvider, getNetworkCollector networkCollectorFactory) *discovery {
+func newDiscoveryWithNetwork(wmeta workloadmeta.Component, tagger tagger.Component, tp timeProvider, getNetworkCollector networkCollectorFactory) *discovery {
 	cfg := newConfig()
 
 	var network networkCollector
@@ -216,7 +219,8 @@ func newDiscoveryWithNetwork(containerProvider proccontainers.ContainerProvider,
 		ignorePids:         make(pidSet),
 		privilegedDetector: privileged.NewLanguageDetector(),
 		scrubber:           procutil.NewDefaultDataScrubber(),
-		containerProvider:  containerProvider,
+		wmeta:              wmeta,
+		tagger:             tagger,
 		timeProvider:       tp,
 		network:            network,
 	}
@@ -224,8 +228,7 @@ func newDiscoveryWithNetwork(containerProvider proccontainers.ContainerProvider,
 
 // NewDiscoveryModule creates a new discovery system probe module.
 func NewDiscoveryModule(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
-	sharedContainerProvider := proccontainers.InitSharedContainerProvider(deps.WMeta, deps.Tagger)
-	d := newDiscoveryWithNetwork(sharedContainerProvider, realTime{}, newNetworkCollector)
+	d := newDiscoveryWithNetwork(deps.WMeta, deps.Tagger, realTime{}, newNetworkCollector)
 
 	return d, nil
 }
@@ -281,24 +284,13 @@ func (s *discovery) handleDebugEndpoint(w http.ResponseWriter, _ *http.Request) 
 		netNsInfo: make(map[uint32]*namespaceInfo),
 	}
 
-	containers, _, pidToCid, err := s.containerProvider.GetContainers(containerCacheValidity, nil)
-	if err != nil {
-		log.Errorf("could not get containers: %s", err)
-	}
-
-	// Build mapping of Container ID to container object to avoid traversal of
-	// the containers slice for every services.
-	containersMap := make(map[string]*agentPayload.Container, len(containers))
-	for _, c := range containers {
-		containersMap[c.Id] = c
-	}
-
+	containers := s.getContainersMap()
 	for _, pid := range pids {
 		service := s.getService(context, pid)
 		if service == nil {
 			continue
 		}
-		s.enrichContainerData(service, containersMap, pidToCid)
+		s.enrichContainerData(service, containers)
 
 		services = append(services, *service)
 	}
@@ -928,26 +920,50 @@ func getServiceNameFromContainerTags(tags []string) (string, string) {
 	return "", ""
 }
 
-func (s *discovery) enrichContainerData(service *model.Service, containers map[string]*agentPayload.Container, pidToCid map[int]string) {
-	id, ok := pidToCid[service.PID]
+func (s *discovery) getContainersMap() map[int]*workloadmeta.Container {
+	containers := s.wmeta.ListContainers()
+	containersMap := make(map[int]*workloadmeta.Container)
+	for _, container := range containers {
+		containersMap[int(container.PID)] = container
+	}
+	return containersMap
+}
+
+func (s *discovery) getProcessContainerInfo(pid int, containers map[int]*workloadmeta.Container) (string, []string, error) {
+	container, ok := containers[pid]
 	if !ok {
+		return "", nil, fmt.Errorf("container not found for pid %d", pid)
+	}
+
+	containerID := container.EntityID.ID
+	collectorTags := container.CollectorTags
+
+	entityID := types.NewEntityID(types.ContainerID, containerID)
+	entityTags, err := s.tagger.Tag(entityID, types.HighCardinality)
+	if err != nil {
+		log.Tracef("Could not get tags for container %s: %v", containerID, err)
+		return containerID, collectorTags, nil
+	}
+	tags := append(collectorTags, entityTags...)
+
+	return containerID, tags, nil
+}
+
+func (s *discovery) enrichContainerData(service *model.Service, containers map[int]*workloadmeta.Container) {
+	containerID, containerTags, err := s.getProcessContainerInfo(service.PID, containers)
+	if err != nil {
 		return
 	}
 
-	container, ok := containers[id]
-	if !ok {
-		return
-	}
-
-	service.ContainerID = id
-	service.ContainerTags = container.Tags
+	service.ContainerID = containerID
+	service.ContainerTags = containerTags
 
 	// We checked the container tags before, no need to do it again.
 	if service.CheckedContainerData {
 		return
 	}
 
-	tagName, serviceName := getServiceNameFromContainerTags(container.Tags)
+	tagName, serviceName := getServiceNameFromContainerTags(containerTags)
 	service.ContainerServiceName = serviceName
 	service.ContainerServiceNameSource = tagName
 	service.CheckedContainerData = true
@@ -957,7 +973,7 @@ func (s *discovery) enrichContainerData(service *model.Service, containers map[s
 		serviceInfo.containerServiceName = serviceName
 		serviceInfo.containerServiceNameSource = tagName
 		serviceInfo.checkedContainerData = true
-		serviceInfo.containerID = id
+		serviceInfo.containerID = containerID
 	}
 }
 
@@ -1031,17 +1047,7 @@ func (s *discovery) getServices(params params) (*model.ServicesResponse, error) 
 	}
 
 	alivePids := make(pidSet, len(pids))
-	containers, _, pidToCid, err := s.containerProvider.GetContainers(containerCacheValidity, nil)
-	if err != nil {
-		log.Errorf("could not get containers: %s", err)
-	}
-
-	// Build mapping of Container ID to container object to avoid traversal of
-	// the containers slice for every services.
-	containersMap := make(map[string]*agentPayload.Container, len(containers))
-	for _, c := range containers {
-		containersMap[c.Id] = c
-	}
+	containers := s.getContainersMap()
 
 	now := s.timeProvider.Now()
 
@@ -1068,7 +1074,7 @@ func (s *discovery) getServices(params params) (*model.ServicesResponse, error) 
 		if service == nil {
 			continue
 		}
-		s.enrichContainerData(service, containersMap, pidToCid)
+		s.enrichContainerData(service, containers)
 
 		if knownService {
 			service.LastHeartbeat = now.Unix()

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -1066,10 +1066,6 @@ func TestCache(t *testing.T) {
 }
 
 func TestMaxPortCheck(t *testing.T) {
-	_, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
-
 	// Start a process that will be ignored due to no ports
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -1086,7 +1082,9 @@ func TestMaxPortCheck(t *testing.T) {
 	params := defaultParams()
 	params.heartbeatTime = 0
 
-	discovery := newDiscovery(mockContainerProvider, mTimeProvider)
+	mockCtrl := gomock.NewController(t)
+	mTimeProvider := servicediscovery.NewMocktimer(mockCtrl)
+	discovery := newDiscovery(t, mTimeProvider)
 
 	for i := 0; i < maxPortCheckTries-5; i++ {
 		_, err = discovery.getServices(params)

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -1084,6 +1084,7 @@ func TestMaxPortCheck(t *testing.T) {
 
 	mockCtrl := gomock.NewController(t)
 	mTimeProvider := servicediscovery.NewMocktimer(mockCtrl)
+	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 	discovery := newDiscovery(t, mTimeProvider)
 
 	for i := 0; i < maxPortCheckTries-5; i++ {

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -91,6 +91,7 @@ func (m *testDiscoveryModule) setProcessContainer(pid int, containerID string, c
 		},
 		PID:           pid,
 		CollectorTags: collectorTags,
+		State:         workloadmeta.ContainerState{Running: true},
 	}
 	m.mockWmeta.Set(container)
 

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	agentPayload "github.com/DataDog/agent-payload/v5/process"
 	"github.com/golang/mock/gomock"
 	gorillamux "github.com/gorilla/mux"
 	"github.com/prometheus/procfs"
@@ -36,9 +35,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netns"
+	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/comp/core"
+	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
+	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
+	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/apm"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/language"
@@ -49,8 +56,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/tls/nodejs"
 	fileopener "github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/testutil"
 	usmtestutil "github.com/DataDog/datadog-agent/pkg/network/usm/testutil"
-	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
-	proccontainersmocks "github.com/DataDog/datadog-agent/pkg/process/util/containers/mocks"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	dockerutils "github.com/DataDog/datadog-agent/pkg/util/testutil/docker"
@@ -68,17 +74,45 @@ func findService(pid int, services []model.Service) *model.Service {
 	return nil
 }
 
-func setupDiscoveryModuleWithNetwork(t *testing.T, getNetworkCollector networkCollectorFactory) (string, *proccontainersmocks.MockContainerProvider, *servicediscovery.Mocktimer) {
+type testDiscoveryModule struct {
+	url              string
+	mockWmeta        workloadmetamock.Mock
+	mockTagger       taggermock.Mock
+	mockTimeProvider *servicediscovery.Mocktimer
+}
+
+// setProcessContainer creates mock process and container entities in workloadmeta for testing.
+func (m *testDiscoveryModule) setProcessContainer(pid int, containerID string, collectorTags []string, taggerTags []string) {
+	// Create a container entity
+	container := &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   containerID,
+		},
+		PID:           pid,
+		CollectorTags: collectorTags,
+	}
+	m.mockWmeta.Set(container)
+
+	// Set tagger tags as high cardinality tags
+	m.mockTagger.SetTags(types.NewEntityID(types.ContainerID, containerID), "fake", nil, nil, taggerTags, nil)
+}
+
+func setupDiscoveryModuleWithNetwork(t *testing.T, getNetworkCollector networkCollectorFactory) *testDiscoveryModule {
 	t.Helper()
-
 	mockCtrl := gomock.NewController(t)
-	mockContainerProvider := proccontainersmocks.NewMockContainerProvider(mockCtrl)
 
+	mockWmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	mockTagger := taggerfxmock.SetupFakeTagger(t)
 	mTimeProvider := servicediscovery.NewMocktimer(mockCtrl)
 
 	mux := gorillamux.NewRouter()
 
-	discovery := newDiscoveryWithNetwork(mockContainerProvider, mTimeProvider, getNetworkCollector)
+	discovery := newDiscoveryWithNetwork(mockWmeta, mockTagger, mTimeProvider, getNetworkCollector)
 	discovery.config.cpuUsageUpdateDelay = time.Second
 	discovery.config.networkStatsPeriod = time.Second
 	discovery.Register(module.NewRouter(string(config.DiscoveryModule), mux))
@@ -86,10 +120,16 @@ func setupDiscoveryModuleWithNetwork(t *testing.T, getNetworkCollector networkCo
 
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv.URL, mockContainerProvider, mTimeProvider
+
+	return &testDiscoveryModule{
+		url:              srv.URL,
+		mockWmeta:        mockWmeta,
+		mockTagger:       mockTagger,
+		mockTimeProvider: mTimeProvider,
+	}
 }
 
-func setupDiscoveryModule(t *testing.T) (string, *proccontainersmocks.MockContainerProvider, *servicediscovery.Mocktimer) {
+func setupDiscoveryModule(t *testing.T) *testDiscoveryModule {
 	t.Helper()
 	return setupDiscoveryModuleWithNetwork(t, newNetworkCollector)
 }
@@ -192,9 +232,8 @@ func startProcessWithFile(t *testing.T, f *os.File) *exec.Cmd {
 
 // Check that we get (only) listening processes for all expected protocols.
 func TestBasic(t *testing.T) {
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	var expectedPIDs []int
 	var unexpectedPIDs []int
@@ -230,7 +269,7 @@ func TestBasic(t *testing.T) {
 	seen := make(map[int]model.Service)
 	// Eventually to give the processes time to start
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServices(collect, url)
+		resp := getServices(collect, discovery.url)
 		for _, s := range resp.StartedServices {
 			seen[s.PID] = s
 		}
@@ -249,9 +288,8 @@ func TestBasic(t *testing.T) {
 
 // Check that we get all listening ports for a process
 func TestPorts(t *testing.T) {
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	var expectedPorts []uint16
 	var unexpectedPorts []uint16
@@ -288,9 +326,9 @@ func TestPorts(t *testing.T) {
 	expectedPortsMap := make(map[uint16]struct{}, len(expectedPorts))
 
 	pid := os.Getpid()
-	// Firt call will not return anything, as all services will be potentials.
-	_ = getServices(t, url)
-	resp := getServices(t, url)
+	// First call will not return anything, as all services will be potentials.
+	_ = getServices(t, discovery.url)
+	resp := getServices(t, discovery.url)
 	startEvent := findService(pid, resp.StartedServices)
 	require.NotNilf(t, startEvent, "could not find start event for pid %v", pid)
 
@@ -317,9 +355,8 @@ func TestPorts(t *testing.T) {
 }
 
 func TestPortsLimits(t *testing.T) {
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	var expectedPorts []int
 
@@ -343,8 +380,8 @@ func TestPortsLimits(t *testing.T) {
 	pid := os.Getpid()
 
 	// Firt call will not return anything, as all services will be potentials.
-	_ = getServices(t, url)
-	resp := getServices(t, url)
+	_ = getServices(t, discovery.url)
+	resp := getServices(t, discovery.url)
 	startEvent := findService(pid, resp.StartedServices)
 	require.NotNilf(t, startEvent, "could not find start event for pid %v", pid)
 
@@ -357,9 +394,8 @@ func TestPortsLimits(t *testing.T) {
 }
 
 func TestServiceName(t *testing.T) {
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	listener, err := net.Listen("tcp", "")
 	require.NoError(t, err)
@@ -386,7 +422,7 @@ func TestServiceName(t *testing.T) {
 	pid := cmd.Process.Pid
 	// Eventually to give the processes time to start
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServices(collect, url)
+		resp := getServices(collect, discovery.url)
 		startEvent := findService(pid, resp.StartedServices)
 		require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 
@@ -443,15 +479,14 @@ func TestServiceLifetime(t *testing.T) {
 	}
 
 	t.Run("stop", func(t *testing.T) {
-		url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-		mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-		mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+		discovery := setupDiscoveryModule(t)
+		discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 		// Start the service and check we found it.
 		cmd, cancel := startService()
 		pid := cmd.Process.Pid
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			resp := getServices(collect, url)
+			resp := getServices(collect, discovery.url)
 			startEvent := findService(pid, resp.StartedServices)
 			require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 			checkService(collect, startEvent, mockedTime)
@@ -460,7 +495,7 @@ func TestServiceLifetime(t *testing.T) {
 		// Stop the service, and look for the stop event.
 		stopService(cmd, cancel)
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			resp := getServices(collect, url)
+			resp := getServices(collect, discovery.url)
 			stopEvent := findService(pid, resp.StoppedServices)
 			t.Logf("stopped service: %+v", resp.StoppedServices)
 			require.NotNilf(collect, stopEvent, "could not find stop event for pid %v", pid)
@@ -469,12 +504,11 @@ func TestServiceLifetime(t *testing.T) {
 	})
 
 	t.Run("heartbeat", func(t *testing.T) {
-		url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-		mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
+		discovery := setupDiscoveryModule(t)
 
 		startEventSeen := false
 
-		mTimeProvider.EXPECT().Now().DoAndReturn(func() time.Time {
+		discovery.mockTimeProvider.EXPECT().Now().DoAndReturn(func() time.Time {
 			if !startEventSeen {
 				return mockedTime
 			}
@@ -487,16 +521,16 @@ func TestServiceLifetime(t *testing.T) {
 
 		pid := cmd.Process.Pid
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			resp := getServices(collect, url)
+			resp := getServices(collect, discovery.url)
 			startEvent := findService(pid, resp.StartedServices)
 			require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 			checkService(collect, startEvent, mockedTime)
 		}, 30*time.Second, 100*time.Millisecond)
 
 		startEventSeen = true
-		resp := getServices(t, url)
+		resp := getServices(t, discovery.url)
 		heartbeatEvent := findService(pid, resp.HeartbeatServices)
-		require.NotNilf(t, heartbeatEvent, "could not find hearteat event for pid %v", pid)
+		require.NotNilf(t, heartbeatEvent, "could not find heartbeat event for pid %v", pid)
 		checkService(t, heartbeatEvent, mockedTime.Add(heartbeatTime))
 	})
 }
@@ -581,13 +615,12 @@ func testCaptureWrappedCommands(t *testing.T, script string, commandWrapper []st
 	}
 	t.Cleanup(func() { _ = proc.Kill() })
 
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	pid := int(proc.Pid)
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServices(collect, url)
+		resp := getServices(collect, discovery.url)
 		startEvent := findService(pid, resp.StartedServices)
 		require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 		assert.True(collect, validator(*startEvent))
@@ -625,9 +658,8 @@ func TestAPMInstrumentationProvided(t *testing.T) {
 	}
 
 	serverDir := buildFakeServer(t)
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -646,7 +678,7 @@ func TestAPMInstrumentationProvided(t *testing.T) {
 			require.NoError(t, err, "could not create gopsutil process handle")
 
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				resp := getServices(collect, url)
+				resp := getServices(collect, discovery.url)
 				startEvent := findService(pid, resp.StartedServices)
 				require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 
@@ -699,9 +731,8 @@ func assertStat(t assert.TestingT, svc model.Service) {
 
 func TestCommandLineSanitization(t *testing.T) {
 	serverDir := buildFakeServer(t)
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })
@@ -718,7 +749,7 @@ func TestCommandLineSanitization(t *testing.T) {
 	pid := cmd.Process.Pid
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServices(collect, url)
+		resp := getServices(collect, discovery.url)
 		startEvent := findService(pid, resp.StartedServices)
 		require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 		assert.Equal(collect, sanitizedCommandLine, startEvent.CommandLine)
@@ -733,9 +764,8 @@ func TestNodeDocker(t *testing.T) {
 	nodeJSPID, err := nodejs.GetNodeJSDockerPID()
 	require.NoError(t, err)
 
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	pid := int(nodeJSPID)
 
@@ -743,7 +773,7 @@ func TestNodeDocker(t *testing.T) {
 	require.NoError(t, err, "could not create gopsutil process handle")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServices(collect, url)
+		resp := getServices(collect, discovery.url)
 		startEvent := findService(pid, resp.StartedServices)
 		require.NotNilf(collect, startEvent, "could not find start event for pid %v", pid)
 
@@ -803,13 +833,12 @@ func TestAPMInstrumentationProvidedWithMaps(t *testing.T) {
 			cmd, err := fileopener.OpenFromProcess(t, fake, test.lib)
 			require.NoError(t, err)
 
-			url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-			mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-			mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+			discovery := setupDiscoveryModule(t)
+			discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 			pid := cmd.Process.Pid
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				resp := getServices(collect, url)
+				resp := getServices(collect, discovery.url)
 
 				// Start event assert
 				startEvent := findService(pid, resp.StartedServices)
@@ -824,9 +853,8 @@ func TestAPMInstrumentationProvidedWithMaps(t *testing.T) {
 
 // Check that we can get listening processes in other namespaces.
 func TestNamespaces(t *testing.T) {
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	// Needed when changing namespaces
 	runtime.LockOSThread()
@@ -873,7 +901,7 @@ func TestNamespaces(t *testing.T) {
 	seen := make(map[int]model.Service)
 	// Eventually to give the processes time to start
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		resp := getServices(collect, url)
+		resp := getServices(collect, discovery.url)
 		for _, s := range resp.StartedServices {
 			seen[s.PID] = s
 		}
@@ -887,8 +915,8 @@ func TestNamespaces(t *testing.T) {
 
 // Check that we are able to find services inside Docker containers.
 func TestDocker(t *testing.T) {
-	url, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
-	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+	discovery := setupDiscoveryModule(t)
+	discovery.mockTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
 
 	dir, _ := testutil.CurDir()
 	scanner, err := globalutils.NewScanner(regexp.MustCompile("Serving.*"), globalutils.NoPattern)
@@ -915,23 +943,17 @@ func TestDocker(t *testing.T) {
 			}
 			if comm == "python-1111" {
 				pid1111 = process.PID
-				mockContainerProvider.
-					EXPECT().
-					GetContainers(containerCacheValidity, nil).
-					Return(
-						[]*agentPayload.Container{
-							{Id: "dummyCID", Tags: []string{
-								"sometag:somevalue",
-								"kube_service:kube_foo", // Should not have priority compared to app tag, for service naming
-								"app:foo_from_app_tag",
-							}},
-						},
-						nil,
-						map[int]string{
-							pid1111: "dummyCID",
-						}, nil).
-					AnyTimes()
-
+				discovery.setProcessContainer(
+					pid1111,
+					"dummyCID",
+					[]string{ // Collector tags from container
+						"sometag:somevalue",
+					},
+					[]string{ // Tags from tagger
+						"kube_service:kube_foo", // Should not have priority compared to app tag, for service naming
+						"app:foo_from_app_tag",
+					},
+				)
 				break
 			}
 		}
@@ -940,8 +962,8 @@ func TestDocker(t *testing.T) {
 
 	// First endpoint call will not contain any events, because the service is
 	// still consider a potential service. The second call will have the events.
-	_ = getServices(t, url)
-	resp := getServices(t, url)
+	_ = getServices(t, discovery.url)
+	resp := getServices(t, discovery.url)
 
 	// Assert events
 	startEvent := findService(pid1111, resp.StartedServices)
@@ -962,8 +984,15 @@ func TestDocker(t *testing.T) {
 	require.Equal(t, startEvent.LastHeartbeat, mockedTime.Unix())
 }
 
-func newDiscovery(containerProvider proccontainers.ContainerProvider, tp timeProvider) *discovery {
-	return newDiscoveryWithNetwork(containerProvider, tp, func(_ *discoveryConfig) (networkCollector, error) {
+func newDiscovery(t testing.TB, tp timeProvider) *discovery {
+	mockWmeta := fxutil.Test[workloadmetamock.Mock](t, fx.Options(
+		core.MockBundle(),
+		fx.Supply(context.Background()),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	))
+	mockTagger := taggerfxmock.SetupFakeTagger(t)
+
+	return newDiscoveryWithNetwork(mockWmeta, mockTagger, tp, func(_ *discoveryConfig) (networkCollector, error) {
 		return nil, nil
 	})
 }
@@ -972,10 +1001,7 @@ func newDiscovery(containerProvider proccontainers.ContainerProvider, tp timePro
 func TestCache(t *testing.T) {
 	var err error
 
-	mockCtrl := gomock.NewController(t)
-	mockContainerProvider := proccontainersmocks.NewMockContainerProvider(mockCtrl)
-	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).MinTimes(1)
-	discovery := newDiscovery(mockContainerProvider, realTime{})
+	discovery := newDiscovery(t, realTime{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes how the Service Discovery module gets container information from workloadmeta and the tagger. Until now we have been using the `GetContainers` wrapper from `pkg/process/util/containers`, which fetches a lot of info about containers that we do not need for service discovery, and does it for all containers on the host, including those we do not care about.

This PR removes the use of this helper, and instead fetches the info we need from workloadmeta and the tagger, only for the services we detected. This results in a reduction of CPU and memory usage: [Profiler link](https://ddstaging.datadoghq.com/profiling/comparison?query=service%3Asystem-probe%20kube_cluster_name%3Avaporeon-a&agg_m=%40prof_go_cpu_cores&agg_m_source=base&agg_t=sum&compare_end_A=1743512400000&compare_end_B=1743514859999&compare_query_A=service%3Asystem-probe%20kube_cluster_name%3Avaporeon-a%20version%3A7.65.0-rc.5%20env%3Astaging&compare_query_B=service%3Asystem-probe%20kube_cluster_name%3Avaporeon-a%20version%3A7.65.0-rc.5_git.1.114cf47%20env%3Astaging&compare_start_A=1743447600000&compare_start_B=1743511967307.6562&compareValuesMode=absolute&extra_search_fields=%7B%22filters_query%22%3A%22%22%2C%22sample_type%22%3A%22cpu-time%22%7D&my_code=disabled&op_filter=focus_on%28function%3A%22%28%2Adiscovery%29.handleServices%22%29&overview_facet=log_prof_go_cpu_cores&profile_type=heap-live-size&refresh_mode=paused&viz=flame_graph&from_ts=1743511212652&to_ts=1743514812652&live=false)

Side-effect of this is also reducing a bit the number of imported packages in system-probe.

### Motivation

Optimise resource usage

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Dogfooding + profiling + correctness checked by unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->