### PR TITLE
Update non-FIPS internal Agent image builds to image template with ADP support.

### DIFF
--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -14,12 +14,13 @@ docker_trigger_internal:
   tags: ["arch:amd64"]
   variables:
     DYNAMIC_BUILD_RENDER_RULES: agent-build-only # fake rule to not trigger the ones in the images repo
-    IMAGE_VERSION: tmpl-v12
+    IMAGE_VERSION: tmpl-v13
     IMAGE_NAME: datadog-agent
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx
     TMPL_SRC_REPO: ci/datadog-agent/agent
+    TMPL_ADP_VERSION: 0.1.2
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
@@ -106,12 +107,13 @@ docker_trigger_internal-ot:
   tags: ["arch:amd64"]
   variables:
     DYNAMIC_BUILD_RENDER_RULES: agent-build-only # fake rule to not trigger the ones in the images repo
-    IMAGE_VERSION: tmpl-v12
+    IMAGE_VERSION: tmpl-v13
     IMAGE_NAME: datadog-agent
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-ot-beta-jmx
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-ot-beta-jmx
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx
     TMPL_SRC_REPO: ci/datadog-agent/agent
+    TMPL_ADP_VERSION: 0.1.2
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
@@ -246,12 +248,13 @@ docker_trigger_internal-full:
   tags: ["arch:amd64"]
   variables:
     DYNAMIC_BUILD_RENDER_RULES: agent-build-only # fake rule to not trigger the ones in the images repo
-    IMAGE_VERSION: tmpl-v12
+    IMAGE_VERSION: tmpl-v13
     IMAGE_NAME: datadog-agent
     RELEASE_TAG: ${CI_COMMIT_REF_SLUG}-full
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-full
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full
     TMPL_SRC_REPO: ci/datadog-agent/agent
+    TMPL_ADP_VERSION: 0.1.2
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN

--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -38,6 +38,7 @@ docker_trigger_internal:
       --variable BUILD_TAG
       --variable TMPL_SRC_IMAGE
       --variable TMPL_SRC_REPO
+      --variable TMPL_ADP_VERSION
       --variable RELEASE_STAGING
       --variable RELEASE_PROD
       --variable DYNAMIC_BUILD_RENDER_RULES
@@ -131,6 +132,7 @@ docker_trigger_internal-ot:
       --variable BUILD_TAG
       --variable TMPL_SRC_IMAGE
       --variable TMPL_SRC_REPO
+      --variable TMPL_ADP_VERSION
       --variable RELEASE_STAGING
       --variable RELEASE_PROD
       --variable DYNAMIC_BUILD_RENDER_RULES
@@ -272,6 +274,7 @@ docker_trigger_internal-full:
       --variable BUILD_TAG
       --variable TMPL_SRC_IMAGE
       --variable TMPL_SRC_REPO
+      --variable TMPL_ADP_VERSION
       --variable RELEASE_STAGING
       --variable RELEASE_PROD
       --variable DYNAMIC_BUILD_RENDER_RULES


### PR DESCRIPTION
### What does this PR do?

Adds support for building internal Agent images with Agent Data Plane bundled in.

### Motivation

This change is necessary to bundle Agent Data Plane with both custom (developer-specific) Agent builds, as well as Agent RC builds, such that clusters running ADP do not stifle the ability for those clusters to be used for testing.

We had originally intended to accomplish this purely with an Operator-based change (https://github.com/DataDog/datadog-operator/pull/1730) but this won't be available until we release the next Operator version, which will be a few weeks from now... and is too far out for us to wait.

### Describe how you validated your changes

We'll be manually testing this when CI runs for this PR itself.

### Possible Drawbacks / Trade-offs

### Additional Notes

This PR specifically avoids updating the FIPS-specific internal Agent image jobs, as the changed image template does not support using the FIPS-compliant build of ADP. That will be a follow-up PR to the image template (and subsequently here) to do so.
