### PR TITLE
[ebpf] simplify system-probe config imports

### DIFF
--- a/cmd/system-probe/config/config_linux.go
+++ b/cmd/system-probe/config/config_linux.go
@@ -3,44 +3,18 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build linux
+//go:build linux && !linux_bpf
 
 package config
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
-	ebpfkernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-)
-
-var (
-	allowPrebuiltFallbackKey    = spNS("allow_prebuilt_fallback")
-	allowPrecompiledFallbackKey = spNS("allow_precompiled_fallback")
 )
 
 // ProcessEventDataStreamSupported returns true if process event data stream is supported
 func ProcessEventDataStreamSupported() bool {
-	kernelVersion, err := ebpfkernel.NewKernelVersion()
-	if err != nil {
-		log.Errorf("unable to detect the kernel version: %s", err)
-		return false
-	}
-	// This is different from the check VerifyOSVersion in probe_ebpf.go
-	// We ran tests on 4.14 and realize we are able to support it for that kernel version
-	// Since we have a large customer base with 4.14, we decided to enable for them
-	if !kernelVersion.IsRH7Kernel() && kernelVersion.Code < ebpfkernel.Kernel4_14 {
-		return false
-	}
-
-	return true
+	return false
 }
 
-func allowPrebuiltEbpfFallback(cfg model.Config) {
-	// only allow falling back to prebuilt eBPF if the config
-	// is not explicitly set and prebuilt eBPF is not deprecated
-	// on the platform
-	if !cfg.IsSet(allowPrebuiltFallbackKey) && !prebuilt.IsDeprecated() {
-		cfg.Set(allowPrebuiltFallbackKey, true, model.SourceAgentRuntime)
-	}
+func allowPrebuiltEbpfFallback(_ model.Config) {
 }

--- a/cmd/system-probe/config/config_linux_bpf.go
+++ b/cmd/system-probe/config/config_linux_bpf.go
@@ -1,0 +1,46 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && linux_bpf
+
+package config
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/prebuilt"
+	ebpfkernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	allowPrebuiltFallbackKey    = spNS("allow_prebuilt_fallback")
+	allowPrecompiledFallbackKey = spNS("allow_precompiled_fallback")
+)
+
+// ProcessEventDataStreamSupported returns true if process event data stream is supported
+func ProcessEventDataStreamSupported() bool {
+	kernelVersion, err := ebpfkernel.NewKernelVersion()
+	if err != nil {
+		log.Errorf("unable to detect the kernel version: %s", err)
+		return false
+	}
+	// This is different from the check VerifyOSVersion in probe_ebpf.go
+	// We ran tests on 4.14 and realize we are able to support it for that kernel version
+	// Since we have a large customer base with 4.14, we decided to enable for them
+	if !kernelVersion.IsRH7Kernel() && kernelVersion.Code < ebpfkernel.Kernel4_14 {
+		return false
+	}
+
+	return true
+}
+
+func allowPrebuiltEbpfFallback(cfg model.Config) {
+	// only allow falling back to prebuilt eBPF if the config
+	// is not explicitly set and prebuilt eBPF is not deprecated
+	// on the platform
+	if !cfg.IsSet(allowPrebuiltFallbackKey) && !prebuilt.IsDeprecated() {
+		cfg.Set(allowPrebuiltFallbackKey, true, model.SourceAgentRuntime)
+	}
+}

--- a/cmd/system-probe/config/config_linux_bpf_test.go
+++ b/cmd/system-probe/config/config_linux_bpf_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux && linux_bpf
+
 package config
 
 import (

--- a/cmd/system-probe/config/config_unsupported.go
+++ b/cmd/system-probe/config/config_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !unix && !linux_bpf && !windows
+//go:build !unix && !windows
 
 package config
 

--- a/cmd/system-probe/config/config_unsupported.go
+++ b/cmd/system-probe/config/config_unsupported.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build !unix && !windows
+//go:build !unix && !linux_bpf && !windows
 
 package config
 


### PR DESCRIPTION
### What does this PR do?

Introduces a new `config_linux_bpf.go` to use the ebpf imports only for system-probe builds
otherwise fallback to config_linux which doesn't support ProcessEventDataStream and ebpf prebuild fallback 

### Motivation

prevent importing ebpf related imports into the core-agent (that is using system-probe/config pkg)

### Describe how you validated your changes
linter and tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes

helper PR for the larger [refactor](https://github.com/DataDog/datadog-agent/pull/35454)