### PR TITLE
Revert `slices.Delete` when the slice is referenced multiple times

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/internal/fetch/fetch_scalar.go
@@ -8,7 +8,6 @@ package fetch
 import (
 	"fmt"
 	"maps"
-	"slices"
 	"sort"
 	"strings"
 
@@ -97,7 +96,7 @@ func doFetchScalarOids(session session.Session, oids []string) (*gosnmp.SnmpPack
 				if (zeroBaseIndex < 0) || (zeroBaseIndex > len(oids)-1) {
 					return nil, fmt.Errorf("invalid ErrorIndex `%d` when fetching oids `%v`", scalarOids.ErrorIndex, oids)
 				}
-				oids = slices.Delete(oids, zeroBaseIndex, zeroBaseIndex+1)
+				oids = append(oids[:zeroBaseIndex], oids[zeroBaseIndex+1:]...)
 				if len(oids) == 0 {
 					// If all oids are not found, return an empty packet with no variable and no error
 					return &gosnmp.SnmpPacket{}, nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Revert some part of https://github.com/DataDog/datadog-agent/pull/34507 related to the `slices.Delete` function.

### Motivation
The `slices.Delete` function clears the elements which become out of the slice after it shrinks.
It means if the slice is referenced multiple times this can actually lead to unexpected behavior.

Such a case was caught in CI around the SNMP check, so I spot-checked all uses of `slices.Delete` introduced by the PR, and found only a couple where it wasn't obvious whether the slice had other references, so I reverted those.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Revert to a previous implementation so CI should be enough.
Ideally a unit test should be added in snmp code to catch the issue.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->