### PR TITLE
Experimental: Use nodetreemodel by default, to run tests in CI

### DIFF
--- a/cmd/otel-agent/config/agent_config.go
+++ b/cmd/otel-agent/config/agent_config.go
@@ -99,6 +99,11 @@ func NewConfigComponent(ctx context.Context, ddCfg string, uris []string) (confi
 	// Set the global agent config
 	pkgconfig := pkgconfigsetup.Datadog()
 
+	// NOTE: This call is required for nodetreemodel to allow the schema to be
+	// modified after it has been constructed.
+	// TODO: Fix this usage of the config and then remove this call
+	pkgconfig.SetTestOnlyDynamicSchema(true)
+
 	pkgconfig.SetConfigName("OTel")
 	pkgconfig.SetEnvPrefix("DD")
 	pkgconfig.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/comp/core/configsync/configsyncimpl/sync_integration_test.go
+++ b/comp/core/configsync/configsyncimpl/sync_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"go.uber.org/atomic"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	viperconfig "github.com/DataDog/datadog-agent/pkg/config/viperconfig"
+	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 )
 
 func TestRunWithChan(t *testing.T) {
@@ -91,6 +91,7 @@ func TestRunWithChan(t *testing.T) {
 func TestRunWithInterval(t *testing.T) {
 	// Legitimate use for NewConfig case where we want to have 2 independent config object mimicing 2 process communicating
 	configCore := viperconfig.NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
+	configCore.SetTestOnlyDynamicSchema(true)
 	configCore.Set("api_key", "api_key_core1", pkgconfigmodel.SourceFile)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/comp/core/configsync/configsyncimpl/sync_integration_test.go
+++ b/comp/core/configsync/configsyncimpl/sync_integration_test.go
@@ -18,7 +18,7 @@ import (
 	"go.uber.org/atomic"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
+	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
 )
 
 func TestRunWithChan(t *testing.T) {
@@ -90,7 +90,7 @@ func TestRunWithChan(t *testing.T) {
 
 func TestRunWithInterval(t *testing.T) {
 	// Legitimate use for NewConfig case where we want to have 2 independent config object mimicing 2 process communicating
-	configCore := viperconfig.NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
+	configCore := nodetreemodel.NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo
 	configCore.SetTestOnlyDynamicSchema(true)
 	configCore.Set("api_key", "api_key_core1", pkgconfigmodel.SourceFile)
 

--- a/comp/core/configsync/go.mod
+++ b/comp/core/configsync/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/api v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel
-	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.0.0-20250218170314-8625d1ac5ae7
+	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.61.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/atomic v1.11.0
@@ -25,11 +25,11 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.0.0-20250218170314-8625d1ac5ae7 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0 // indirect

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -1050,7 +1050,7 @@ func TestGetValidatingWebhookSkeletonV1(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.timeout != nil {
 				mockConfig.SetWithoutSource("admission_controller.timeout_seconds", *tt.timeout)
-				defer mockConfig.SetDefault("admission_controller.timeout_seconds", defaultTimeout)
+				defer mockConfig.UnsetForSource("admission_controller.timeout_seconds", model.SourceUnknown)
 			}
 
 			c := &ControllerV1{}

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestNewCheckConfig(t *testing.T) {
-	setup.Datadog().SetDefault("network_devices.namespace", "my-namespace")
+	setup.Datadog().SetWithoutSource("network_devices.namespace", "my-namespace")
 	tests := []struct {
 		name           string
 		rawInstance    integration.Data

--- a/pkg/config/mock/go.mod
+++ b/pkg/config/mock/go.mod
@@ -4,8 +4,8 @@ go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel
+	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0
-	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.0.0-20250218170314-8625d1ac5ae7
 	github.com/stretchr/testify v1.10.0
 )
 
@@ -13,9 +13,9 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.0.0-20250218170314-8625d1ac5ae7 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0 // indirect

--- a/pkg/config/mock/mock.go
+++ b/pkg/config/mock/mock.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
-	viperconfig "github.com/DataDog/datadog-agent/pkg/config/viperconfig"
+	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 )
 
 var (
@@ -53,6 +53,7 @@ func New(t testing.TB) model.Config {
 	// Configuration defaults
 	setup.SetDatadog(newCfg) // nolint forbidigo legitimate use of SetDatadog
 	setup.InitConfig(newCfg)
+	newCfg.SetTestOnlyDynamicSchema(true)
 	return &mockConfig{newCfg}
 }
 
@@ -102,5 +103,6 @@ func NewSystemProbe(t testing.TB) model.Config {
 	setup.SetSystemProbe(viperconfig.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))) // nolint forbidigo legitimate use of NewConfig and SetSystemProbe
 	// Configuration defaults
 	setup.InitSystemProbeConfig(setup.SystemProbe())
+	setup.SystemProbe().SetTestOnlyDynamicSchema(true)
 	return &mockConfig{setup.SystemProbe()}
 }

--- a/pkg/config/mock/mock.go
+++ b/pkg/config/mock/mock.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
 	"github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 )
 
 var (
@@ -49,7 +49,7 @@ func New(t testing.TB) model.Config {
 	})
 
 	// Configure Datadog global configuration
-	newCfg := viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legitimate use of NewConfig
+	newCfg := nodetreemodel.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legitimate use of NewConfig
 	// Configuration defaults
 	setup.SetDatadog(newCfg) // nolint forbidigo legitimate use of SetDatadog
 	setup.InitConfig(newCfg)
@@ -100,7 +100,7 @@ func NewSystemProbe(t testing.TB) model.Config {
 	}
 
 	// Configure Datadog global configuration
-	setup.SetSystemProbe(viperconfig.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))) // nolint forbidigo legitimate use of NewConfig and SetSystemProbe
+	setup.SetSystemProbe(nodetreemodel.NewConfig("system-probe", "DD", strings.NewReplacer(".", "_"))) // nolint forbidigo legitimate use of NewConfig and SetSystemProbe
 	// Configuration defaults
 	setup.InitSystemProbeConfig(setup.SystemProbe())
 	setup.SystemProbe().SetTestOnlyDynamicSchema(true)

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -157,6 +157,11 @@ type Reader interface {
 	// Note that it returns the keys lowercased.
 	AllKeysLowercased() []string
 
+	// SetTestOnlyDynamicSchema is used by tests to disable validation of the config schema
+	// This lets tests use the config is more flexible ways (can add to the schema at any point,
+	// can modify env vars and the config will rebuild itself, etc)
+	SetTestOnlyDynamicSchema(allow bool)
+
 	// IsSet return true if a non nil values is found in the configuration, including defaults. This is legacy
 	// behavior from viper and don't answer the need to know if something was set by the user (see IsConfigured for
 	// this).

--- a/pkg/config/nodetreemodel/getter.go
+++ b/pkg/config/nodetreemodel/getter.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (c *ntmConfig) leafAtPath(key string) LeafNode {
-	if !c.isReady() && !c.allowDynamicSchema {
+	if !c.isReady() && !c.allowDynamicSchema.Load() {
 		log.Errorf("attempt to read key before config is constructed: %s", key)
 		return missingLeaf
 	}
@@ -131,7 +131,7 @@ simplyCopy:
 }
 
 func (c *ntmConfig) getNodeValue(key string) interface{} {
-	if !c.isReady() && !c.allowDynamicSchema {
+	if !c.isReady() && !c.allowDynamicSchema.Load() {
 		log.Errorf("attempt to read key before config is constructed: %s", key)
 		return missingLeaf
 	}

--- a/pkg/config/nodetreemodel/getter.go
+++ b/pkg/config/nodetreemodel/getter.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (c *ntmConfig) leafAtPath(key string) LeafNode {
-	if !c.isReady() {
+	if !c.isReady() && !c.allowDynamicSchema {
 		log.Errorf("attempt to read key before config is constructed: %s", key)
 		return missingLeaf
 	}
@@ -131,10 +131,11 @@ simplyCopy:
 }
 
 func (c *ntmConfig) getNodeValue(key string) interface{} {
-	if !c.isReady() {
+	if !c.isReady() && !c.allowDynamicSchema {
 		log.Errorf("attempt to read key before config is constructed: %s", key)
 		return missingLeaf
 	}
+	c.maybeRebuild()
 
 	node := c.nodeAtPathFromNode(key, c.root)
 

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -33,7 +33,7 @@ func (c *ntmConfig) findConfigFile() {
 
 // ReadInConfig wraps Viper for concurrent access
 func (c *ntmConfig) ReadInConfig() error {
-	if !c.isReady() && !c.allowDynamicSchema {
+	if !c.isReady() && !c.allowDynamicSchema.Load() {
 		return log.Errorf("attempt to ReadInConfig before config is constructed")
 	}
 
@@ -57,7 +57,7 @@ func (c *ntmConfig) ReadInConfig() error {
 
 // ReadConfig wraps Viper for concurrent access
 func (c *ntmConfig) ReadConfig(in io.Reader) error {
-	if !c.isReady() && !c.allowDynamicSchema {
+	if !c.isReady() && !c.allowDynamicSchema.Load() {
 		return log.Errorf("attempt to ReadConfig before config is constructed")
 	}
 
@@ -91,7 +91,7 @@ func (c *ntmConfig) readConfigurationContent(target InnerNode, source model.Sour
 			return err
 		}
 	}
-	c.warnings = append(c.warnings, loadYamlInto(target, source, inData, "", c.schema, c.allowDynamicSchema)...)
+	c.warnings = append(c.warnings, loadYamlInto(target, source, inData, "", c.schema, c.allowDynamicSchema.Load())...)
 	return nil
 }
 

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -33,7 +33,7 @@ func (c *ntmConfig) findConfigFile() {
 
 // ReadInConfig wraps Viper for concurrent access
 func (c *ntmConfig) ReadInConfig() error {
-	if !c.isReady() {
+	if !c.isReady() && !c.allowDynamicSchema {
 		return log.Errorf("attempt to ReadInConfig before config is constructed")
 	}
 
@@ -57,7 +57,7 @@ func (c *ntmConfig) ReadInConfig() error {
 
 // ReadConfig wraps Viper for concurrent access
 func (c *ntmConfig) ReadConfig(in io.Reader) error {
-	if !c.isReady() {
+	if !c.isReady() && !c.allowDynamicSchema {
 		return log.Errorf("attempt to ReadConfig before config is constructed")
 	}
 
@@ -91,7 +91,7 @@ func (c *ntmConfig) readConfigurationContent(target InnerNode, source model.Sour
 			return err
 		}
 	}
-	c.warnings = append(c.warnings, loadYamlInto(target, source, inData, "", c.schema)...)
+	c.warnings = append(c.warnings, loadYamlInto(target, source, inData, "", c.schema, c.allowDynamicSchema)...)
 	return nil
 }
 
@@ -122,7 +122,7 @@ func toMapStringInterface(data any, path string) (map[string]interface{}, error)
 
 // loadYamlInto traverses input data parsed from YAML, checking if each node is defined by the schema.
 // If found, the value from the YAML blob is imported into the 'dest' tree. Otherwise, a warning will be created.
-func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interface{}, atPath string, schema InnerNode) []string {
+func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interface{}, atPath string, schema InnerNode, allowDynamicSchema bool) []string {
 	warnings := []string{}
 	for key, value := range inData {
 		key = strings.ToLower(key)
@@ -132,7 +132,13 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 		schemaChild, err := schema.GetChild(key)
 		if err != nil {
 			warnings = append(warnings, fmt.Sprintf("unknown key from YAML: %s", currPath))
-			continue
+			if !allowDynamicSchema {
+				continue
+			} else if isScalar(value) {
+				schemaChild = newLeafNode(value, model.SourceSchema)
+			} else {
+				schemaChild = newInnerNode(make(map[string]Node))
+			}
 		}
 
 		// if the node in the schema is a leaf, then we create a new leaf in dest
@@ -157,7 +163,7 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 
 		if !dest.HasChild(key) {
 			destChildInner := newInnerNode(nil)
-			warnings = append(warnings, loadYamlInto(destChildInner, source, childValue, currPath, schemaInner)...)
+			warnings = append(warnings, loadYamlInto(destChildInner, source, childValue, currPath, schemaInner, allowDynamicSchema)...)
 			dest.InsertChildNode(key, destChildInner)
 			continue
 		}
@@ -169,7 +175,7 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 			warnings = append(warnings, "invalid tree: default and dest tree don't have the same layout")
 			continue
 		}
-		warnings = append(warnings, loadYamlInto(destChildInner, source, childValue, currPath, schemaInner)...)
+		warnings = append(warnings, loadYamlInto(destChildInner, source, childValue, currPath, schemaInner, allowDynamicSchema)...)
 	}
 	return warnings
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -261,7 +261,7 @@ func newConfigChooseImpl(name string) pkgconfigmodel.Config {
 	//                nodetreemodel internals
 	// - other:       Use viper for the config
 	var cfg pkgconfigmodel.Config
-	if envvar == "enable" {
+	if envvar == "enable" || envvar == "" {
 		cfg = nodetreemodel.NewConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 	} else if envvar == "tee" {
 		viperImpl := viperconfig.NewConfig(name, "DD", strings.NewReplacer(".", "_"))      // nolint: forbidigo // legit use case

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
 	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
@@ -1075,7 +1074,7 @@ func TestPeerTagsEnv(t *testing.T) {
 
 func TestLogDefaults(t *testing.T) {
 	// New config
-	c := viperconfig.NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	c := newConfigChooseImpl("test")
 	require.Equal(t, 0, c.GetInt("log_file_max_rolls"))
 	require.Equal(t, "", c.GetString("log_file_max_size"))
 	require.Equal(t, "", c.GetString("log_file"))
@@ -1094,7 +1093,7 @@ func TestLogDefaults(t *testing.T) {
 
 	// SystemProbe config
 
-	SystemProbe := viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	SystemProbe := newConfigChooseImpl("datadog")
 	InitSystemProbeConfig(SystemProbe)
 
 	require.Equal(t, 1, SystemProbe.GetInt("log_file_max_rolls"))
@@ -1435,7 +1434,7 @@ func TestServerlessConfigNumComponents(t *testing.T) {
 }
 
 func TestServerlessConfigInit(t *testing.T) {
-	conf := viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	conf := newConfigChooseImpl("datadog")
 
 	initCommonWithServerless(conf)
 
@@ -1451,7 +1450,7 @@ func TestServerlessConfigInit(t *testing.T) {
 
 func TestDisableCoreAgent(t *testing.T) {
 	pkgconfigmodel.CleanOverride(t)
-	conf := viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	conf := newConfigChooseImpl("datadog")
 	pkgconfigmodel.AddOverrideFunc(toggleDefaultPayloads)
 
 	InitConfig(conf)
@@ -1474,7 +1473,7 @@ func TestDisableCoreAgent(t *testing.T) {
 
 func TestAPMObfuscationDefaultValue(t *testing.T) {
 	pkgconfigmodel.CleanOverride(t)
-	conf := viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	conf := newConfigChooseImpl("datadog")
 
 	InitConfig(conf)
 	assert.True(t, conf.GetBool("apm_config.obfuscation.elasticsearch.enabled"))
@@ -1517,7 +1516,7 @@ func TestAgentConfigInit(t *testing.T) {
 
 func TestENVAdditionalKeysToScrubber(t *testing.T) {
 	// Test that the scrubber is correctly configured with the expected keys
-	cfg := viperconfig.NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	cfg := newConfigChooseImpl("test")
 
 	data := `scrubber.additional_keys:
 - yet_another_key

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
 	nooptelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	viperconfig "github.com/DataDog/datadog-agent/pkg/config/viperconfig"
+	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"

--- a/pkg/config/setup/ipc_address_test.go
+++ b/pkg/config/setup/ipc_address_test.go
@@ -6,13 +6,11 @@
 package setup
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
-	viperconfig "github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 )
 
 const (
@@ -71,7 +69,7 @@ func TestGetIPCAddress(t *testing.T) {
 }
 
 func getConfig() model.Config {
-	cfg := viperconfig.NewConfig("test", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	cfg := newConfigChooseImpl("test")
 	cfg.BindEnv("ipc_address")
 	cfg.BindEnvAndSetDefault("cmd_host", localhostStr)
 	return cfg

--- a/pkg/config/setup/test_helpers.go
+++ b/pkg/config/setup/test_helpers.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	viperconfig "github.com/DataDog/datadog-agent/pkg/config/viperconfig"
+	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 )
 
 // newTestConf generates and returns a new configuration
 func newTestConf() pkgconfigmodel.Config {
 	conf := viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 	InitConfig(conf)
+	conf.SetTestOnlyDynamicSchema(true)
 	conf.SetConfigFile("")
 	pkgconfigmodel.ApplyOverrideFuncs(conf)
 	return conf

--- a/pkg/config/setup/test_helpers.go
+++ b/pkg/config/setup/test_helpers.go
@@ -8,15 +8,12 @@
 package setup
 
 import (
-	"strings"
-
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/config/viperconfig"
 )
 
 // newTestConf generates and returns a new configuration
 func newTestConf() pkgconfigmodel.Config {
-	conf := viperconfig.NewConfig("datadog", "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	conf := newConfigChooseImpl("datadog")
 	InitConfig(conf)
 	conf.SetTestOnlyDynamicSchema(true)
 	conf.SetConfigFile("")

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -240,8 +240,8 @@ func copyMap(target reflect.Value, source nodetreemodel.Node, fs *featureSet) er
 	mtype := reflect.MapOf(ktype, vtype)
 	results := reflect.MakeMap(mtype)
 
-	if fs.convertArrayToMap {
-		if leaf, ok := source.(nodetreemodel.LeafNode); ok {
+	if leaf, ok := source.(nodetreemodel.LeafNode); ok {
+		if fs.convertArrayToMap {
 			thing := leaf.Get()
 			if arr, ok := thing.([]interface{}); ok {
 				// convert []interface{} to map[interface{}]bool
@@ -255,6 +255,13 @@ func copyMap(target reflect.Value, source nodetreemodel.Node, fs *featureSet) er
 					return err
 				}
 				source = converted
+			}
+		}
+		if m, ok := leaf.Get().(map[string]interface{}); ok {
+			var err error
+			source, err = nodetreemodel.NewNodeTree(m, model.SourceUnknown)
+			if err != nil {
+				return err
 			}
 		}
 	}

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -85,7 +85,7 @@ var legacyConvertArrayToMap = func(c *mapstructure.DecoderConfig) {
 // Else the viper/legacy version is used.
 func UnmarshalKey(cfg model.Reader, key string, target interface{}, opts ...UnmarshalKeyOption) error {
 	nodetreemodel := os.Getenv("DD_CONF_NODETREEMODEL")
-	if nodetreemodel == "enable" || nodetreemodel == "unmarshal" {
+	if nodetreemodel == "enable" || nodetreemodel == "unmarshal" || nodetreemodel == "" {
 		return unmarshalKeyReflection(cfg, key, target, opts...)
 	}
 

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -46,6 +46,12 @@ func (t *teeConfig) OnUpdate(callback model.NotificationReceiver) {
 	t.compare.OnUpdate(callback)
 }
 
+// SetTestOnlyDynamicSchema allows more flexible usage of the config, should only be used by tests
+func (t *teeConfig) SetTestOnlyDynamicSchema(allow bool) {
+	t.baseline.SetTestOnlyDynamicSchema(allow)
+	t.compare.SetTestOnlyDynamicSchema(allow)
+}
+
 // Set wraps Viper for concurrent access
 func (t *teeConfig) Set(key string, newValue interface{}, source model.Source) {
 	t.baseline.Set(key, newValue, source)

--- a/pkg/config/utils/endpoints_test.go
+++ b/pkg/config/utils/endpoints_test.go
@@ -299,6 +299,7 @@ func TestDDURLEnvVar(t *testing.T) {
 	t.Setenv("DD_EXTERNAL_CONFIG_EXTERNAL_AGENT_DD_URL", "https://custom.external-agent.datadoghq.com")
 	testConfig := mock.New(t)
 	testConfig.BindEnv("external_config.external_agent_dd_url")
+	testConfig.BuildSchema()
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
@@ -320,6 +321,7 @@ func TestDDDDURLEnvVar(t *testing.T) {
 	t.Setenv("DD_EXTERNAL_CONFIG_EXTERNAL_AGENT_DD_URL", "https://custom.external-agent.datadoghq.com")
 	testConfig := mock.New(t)
 	testConfig.BindEnv("external_config.external_agent_dd_url")
+	testConfig.BuildSchema()
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")
@@ -345,6 +347,7 @@ func TestDDURLAndDDDDURLEnvVar(t *testing.T) {
 	t.Setenv("DD_EXTERNAL_CONFIG_EXTERNAL_AGENT_DD_URL", "https://custom.external-agent.datadoghq.com")
 	testConfig := mock.New(t)
 	testConfig.BindEnv("external_config.external_agent_dd_url")
+	testConfig.BuildSchema()
 
 	multipleEndpoints, err := GetMultipleEndpoints(testConfig)
 	externalAgentURL := GetMainEndpoint(testConfig, "https://external-agent.", "external_config.external_agent_dd_url")

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -839,3 +839,6 @@ func (c *safeConfig) ExtraConfigFilesUsed() []string {
 	copy(res, c.extraConfigFilePaths)
 	return res
 }
+
+func (c *safeConfig) SetTestOnlyDynamicSchema(_ bool) {
+}

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -444,9 +444,9 @@ func TestIsExcludedByAnnotation(t *testing.T) {
 }
 
 func TestNewMetricFilterFromConfig(t *testing.T) {
-	pkgconfigsetup.Datadog().SetDefault("exclude_pause_container", true)
-	pkgconfigsetup.Datadog().SetDefault("ac_include", []string{"image:apache.*"})
-	pkgconfigsetup.Datadog().SetDefault("ac_exclude", []string{"name:dd-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("exclude_pause_container", true)
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_include", []string{"image:apache.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_exclude", []string{"name:dd-.*"})
 
 	f, err := newMetricFilterFromConfig()
 	require.NoError(t, err)
@@ -457,20 +457,20 @@ func TestNewMetricFilterFromConfig(t *testing.T) {
 	assert.True(t, f.IsExcluded(nil, "dummy", "k8s.gcr.io/pause-amd64:3.1", ""))
 	assert.True(t, f.IsExcluded(nil, "dummy", "rancher/pause-amd64:3.1", ""))
 
-	pkgconfigsetup.Datadog().SetDefault("exclude_pause_container", false)
+	pkgconfigsetup.Datadog().SetWithoutSource("exclude_pause_container", false)
 	f, err = newMetricFilterFromConfig()
 	require.NoError(t, err)
 	assert.False(t, f.IsExcluded(nil, "dummy", "k8s.gcr.io/pause-amd64:3.1", ""))
 
-	pkgconfigsetup.Datadog().SetDefault("exclude_pause_container", true)
-	pkgconfigsetup.Datadog().SetDefault("ac_include", []string{})
-	pkgconfigsetup.Datadog().SetDefault("ac_exclude", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("exclude_pause_container", true)
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_include", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_exclude", []string{})
 
-	pkgconfigsetup.Datadog().SetDefault("exclude_pause_container", false)
-	pkgconfigsetup.Datadog().SetDefault("container_include", []string{"image:apache.*"})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude", []string{"name:dd-.*"})
-	pkgconfigsetup.Datadog().SetDefault("container_include_metrics", []string{"image:nginx.*"})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude_metrics", []string{"name:ddmetric-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("exclude_pause_container", false)
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include", []string{"image:apache.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude", []string{"name:dd-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include_metrics", []string{"image:nginx.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude_metrics", []string{"name:ddmetric-.*"})
 
 	f, err = newMetricFilterFromConfig()
 	require.NoError(t, err)
@@ -486,8 +486,8 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 	resetConfig()
 
 	// Global - legacy config
-	pkgconfigsetup.Datadog().SetDefault("ac_include", []string{"image:apache.*"})
-	pkgconfigsetup.Datadog().SetDefault("ac_exclude", []string{"name:dd-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_include", []string{"image:apache.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_exclude", []string{"name:dd-.*"})
 
 	f := NewAutodiscoveryFilter(GlobalFilter)
 	assert.Emptyf(t, f.Errors, "Expected no errors.")
@@ -500,10 +500,10 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 	resetConfig()
 
 	// Global - new config - legacy config ignored
-	pkgconfigsetup.Datadog().SetDefault("container_include", []string{"image:apache.*"})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude", []string{"name:dd-.*"})
-	pkgconfigsetup.Datadog().SetDefault("ac_include", []string{"image:apache/legacy.*"})
-	pkgconfigsetup.Datadog().SetDefault("ac_exclude", []string{"name:dd/legacy-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include", []string{"image:apache.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude", []string{"name:dd-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_include", []string{"image:apache/legacy.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_exclude", []string{"name:dd/legacy-.*"})
 
 	f = NewAutodiscoveryFilter(GlobalFilter)
 	assert.Emptyf(t, f.Errors, "Expected no errors.")
@@ -517,8 +517,8 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 	resetConfig()
 
 	// Metrics
-	pkgconfigsetup.Datadog().SetDefault("container_include_metrics", []string{"image:apache.*"})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude_metrics", []string{"name:dd-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include_metrics", []string{"image:apache.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude_metrics", []string{"name:dd-.*"})
 
 	f = NewAutodiscoveryFilter(MetricsFilter)
 	assert.Emptyf(t, f.Errors, "Expected no errors.")
@@ -531,8 +531,8 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 	resetConfig()
 
 	// Logs
-	pkgconfigsetup.Datadog().SetDefault("container_include_logs", []string{"image:apache.*"})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude_logs", []string{"name:dd-.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include_logs", []string{"image:apache.*"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude_logs", []string{"name:dd-.*"})
 
 	f = NewAutodiscoveryFilter(LogsFilter)
 	assert.Emptyf(t, f.Errors, "Expected no errors.")
@@ -545,8 +545,8 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 	resetConfig()
 
 	// Filter errors - non-duplicate error messages
-	pkgconfigsetup.Datadog().SetDefault("container_include", []string{"image:apache.*", "invalid"})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude", []string{"name:dd-.*", "invalid"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include", []string{"image:apache.*", "invalid"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude", []string{"name:dd-.*", "invalid"})
 
 	f = NewAutodiscoveryFilter(GlobalFilter)
 
@@ -563,8 +563,8 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 	resetConfig()
 
 	// Filter errors - invalid regex
-	pkgconfigsetup.Datadog().SetDefault("container_include", []string{"image:apache.*", "kube_namespace:?"})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude", []string{"name:dd-.*", "invalid"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include", []string{"image:apache.*", "kube_namespace:?"})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude", []string{"name:dd-.*", "invalid"})
 
 	f = NewAutodiscoveryFilter(GlobalFilter)
 	_, errFound := f.Errors["invalid regex '?': error parsing regexp: missing argument to repetition operator: `?`"]
@@ -701,13 +701,13 @@ func TestParseFilters(t *testing.T) {
 }
 
 func resetConfig() {
-	pkgconfigsetup.Datadog().SetDefault("exclude_pause_container", true)
-	pkgconfigsetup.Datadog().SetDefault("container_include", []string{})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude", []string{})
-	pkgconfigsetup.Datadog().SetDefault("container_include_metrics", []string{})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude_metrics", []string{})
-	pkgconfigsetup.Datadog().SetDefault("container_include_logs", []string{})
-	pkgconfigsetup.Datadog().SetDefault("container_exclude_logs", []string{})
-	pkgconfigsetup.Datadog().SetDefault("ac_include", []string{})
-	pkgconfigsetup.Datadog().SetDefault("ac_exclude", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("exclude_pause_container", true)
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include_metrics", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude_metrics", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_include_logs", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("container_exclude_logs", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_include", []string{})
+	pkgconfigsetup.Datadog().SetWithoutSource("ac_exclude", []string{})
 }


### PR DESCRIPTION
### What does this PR do?

Experimental only, enable nodetreemodel as the default config implementation.

### Motivation

Establish a baseline to see what tests are broken, develop against this branch in order to fix the tests before we move forward with nodetreemodel.

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
