### PR TITLE
Add framework to support the distributed sends architecture

### DIFF
--- a/pkg/logs/sender/go.mod
+++ b/pkg/logs/sender/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel
+	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/logs/client v0.61.0
 	github.com/DataDog/datadog-agent/pkg/logs/message v0.61.0
 	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.61.0
@@ -17,6 +18,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel
 	github.com/benbjohnson/clock v1.3.5
 	github.com/stretchr/testify v1.10.0
+	go.uber.org/atomic v1.11.0
 )
 
 require (
@@ -36,6 +38,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.0.0-20250218170314-8625d1ac5ae7 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0 // indirect
@@ -87,7 +90,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.18.1 // indirect
 	go.uber.org/fx v1.23.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -6,171 +6,157 @@
 package sender
 
 import (
-	"strconv"
 	"sync"
-	"time"
 
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"go.uber.org/atomic"
 )
 
-var (
-	tlmPayloadsDropped = telemetry.NewCounterWithOpts("logs_sender", "payloads_dropped", []string{"reliable", "destination"}, "Payloads dropped", telemetry.Options{DefaultMetric: true})
-	tlmMessagesDropped = telemetry.NewCounterWithOpts("logs_sender", "messages_dropped", []string{"reliable", "destination"}, "Messages dropped", telemetry.Options{DefaultMetric: true})
-	tlmSendWaitTime    = telemetry.NewCounter("logs_sender", "send_wait", []string{}, "Time spent waiting for all sends to finish")
+const (
+	// DefaultWorkersPerQueue - By default most pipelines will only require a single sender worker, as the single worker itself can
+	// concurrently transmit multiple http requests at once. This value is not intended to be configurable, but legacy
+	// usages of the sender will override this value where necessary. If there is a desire to edit the concurrency of the senders
+	// via config, see the BatchMaxConcurrentSend endpoint setting.
+	DefaultWorkersPerQueue = 1
+
+	// DefaultQueuesCount - By default most pipelines will only require a single queue, as the single queue itself can
+	// concurrently transmit multiple http requests at once. Systems forced in to a legacy mode will override this value.
+	DefaultQueuesCount = 1
 )
 
-// Sender sends logs to different destinations. Destinations can be either
-// reliable or unreliable. The sender ensures that logs are sent to at least
-// one reliable destination and will block the pipeline if they are in an
-// error state. Unreliable destinations will only send logs when at least
-// one reliable destination is also sending logs. However they do not update
-// the auditor or block the pipeline if they fail. There will always be at
-// least 1 reliable destination (the main destination).
+// PipelineComponent abstracts a pipeline component
+type PipelineComponent interface {
+	In() chan *message.Payload
+	PipelineMonitor() metrics.PipelineMonitor
+	Start()
+	Stop()
+}
+
+// Sender can distribute payloads on multiple
+// underlying workers
 type Sender struct {
-	config         pkgconfigmodel.Reader
-	inputChan      chan *message.Payload
-	outputChan     chan *message.Payload
-	destinations   *client.Destinations
-	done           chan struct{}
-	bufferSize     int
-	senderDoneChan chan *sync.WaitGroup
-	flushWg        *sync.WaitGroup
+	workers []*worker
+	queues  []chan *message.Payload
 
 	pipelineMonitor metrics.PipelineMonitor
-	utilization     metrics.UtilizationMonitor
+	flushWg         *sync.WaitGroup
+	idx             *atomic.Uint32
 }
 
-// NewSender returns a new sender.
-func NewSender(config pkgconfigmodel.Reader, inputChan chan *message.Payload, outputChan chan *message.Payload, destinations *client.Destinations, bufferSize int, senderDoneChan chan *sync.WaitGroup, flushWg *sync.WaitGroup, pipelineMonitor metrics.PipelineMonitor) *Sender {
+// DestinationFactory used to generate client destinations on each call.
+type DestinationFactory func() *client.Destinations
+
+// NewSender is the legacy sender.
+func NewSender(
+	config pkgconfigmodel.Reader,
+	inputChan chan *message.Payload,
+	outputChan chan *message.Payload,
+	destinations *client.Destinations,
+	bufferSize int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	pipelineMonitor metrics.PipelineMonitor,
+) *Sender {
+	w := newWorkerLegacy(
+		config,
+		inputChan,
+		outputChan,
+		destinations,
+		bufferSize,
+		senderDoneChan,
+		flushWg,
+		pipelineMonitor,
+	)
+
 	return &Sender{
-		config:         config,
-		inputChan:      inputChan,
-		outputChan:     outputChan,
-		destinations:   destinations,
-		done:           make(chan struct{}),
-		bufferSize:     bufferSize,
-		senderDoneChan: senderDoneChan,
-		flushWg:        flushWg,
-
-		// Telemetry
+		workers:         []*worker{w},
 		pipelineMonitor: pipelineMonitor,
-		utilization:     pipelineMonitor.MakeUtilizationMonitor("sender"),
+		queues:          []chan *message.Payload{inputChan},
+		flushWg:         flushWg,
+		idx:             &atomic.Uint32{},
 	}
 }
 
-// Start starts the sender.
+// NewSenderV2 returns a new sender.
+func NewSenderV2(
+	config pkgconfigmodel.Reader,
+	auditor auditor.Auditor,
+	destinationFactory DestinationFactory,
+	bufferSize int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	queueCount int,
+	workersPerQueue int,
+	pipelineMonitor metrics.PipelineMonitor,
+) *Sender {
+	var workers []*worker
+
+	if queueCount <= 0 {
+		queueCount = DefaultQueuesCount
+	}
+
+	if workersPerQueue <= 0 {
+		workersPerQueue = DefaultWorkersPerQueue
+	}
+
+	queues := make([]chan *message.Payload, queueCount)
+	for idx := range queueCount {
+		queues[idx] = make(chan *message.Payload, workersPerQueue+1)
+		for range workersPerQueue {
+			worker := newWorker(
+				config,
+				queues[idx],
+				auditor,
+				destinationFactory(),
+				bufferSize,
+				senderDoneChan,
+				flushWg,
+				pipelineMonitor,
+			)
+			workers = append(workers, worker)
+		}
+	}
+
+	return &Sender{
+		workers:         workers,
+		pipelineMonitor: pipelineMonitor,
+		queues:          queues,
+		flushWg:         flushWg,
+		idx:             &atomic.Uint32{},
+	}
+}
+
+// In is the input channel of a worker set.
+func (s *Sender) In() chan *message.Payload {
+	idx := s.idx.Inc() % uint32(len(s.queues))
+	return s.queues[idx]
+}
+
+// PipelineMonitor returns the pipeline monitor of the sender workers.
+func (s *Sender) PipelineMonitor() metrics.PipelineMonitor {
+	return s.pipelineMonitor
+}
+
+// Start starts all sender workers.
 func (s *Sender) Start() {
-	go s.run()
+	for _, worker := range s.workers {
+		worker.start()
+	}
 }
 
-// Stop stops the sender,
-// this call blocks until inputChan is flushed
+// Stop stops all sender workers
 func (s *Sender) Stop() {
-	close(s.inputChan)
-	<-s.done
-}
-
-func (s *Sender) run() {
-	reliableDestinations := buildDestinationSenders(s.config, s.destinations.Reliable, s.outputChan, s.bufferSize)
-
-	sink := additionalDestinationsSink(s.bufferSize)
-	unreliableDestinations := buildDestinationSenders(s.config, s.destinations.Unreliable, sink, s.bufferSize)
-
-	for payload := range s.inputChan {
-		s.utilization.Start()
-		var startInUse = time.Now()
-		senderDoneWg := &sync.WaitGroup{}
-
-		sent := false
-		for !sent {
-			for _, destSender := range reliableDestinations {
-				if destSender.Send(payload) {
-					if destSender.destination.Metadata().ReportingEnabled {
-						s.pipelineMonitor.ReportComponentIngress(payload, destSender.destination.Metadata().MonitorTag())
-					}
-					sent = true
-					if s.senderDoneChan != nil {
-						senderDoneWg.Add(1)
-						s.senderDoneChan <- senderDoneWg
-					}
-				}
-			}
-
-			if !sent {
-				// Throttle the poll loop while waiting for a send to succeed
-				// This will only happen when all reliable destinations
-				// are blocked so logs have no where to go.
-				time.Sleep(100 * time.Millisecond)
-			}
-		}
-
-		for i, destSender := range reliableDestinations {
-			// If an endpoint is stuck in the previous step, try to buffer the payloads if we have room to mitigate
-			// loss on intermittent failures.
-			if !destSender.lastSendSucceeded {
-				if !destSender.NonBlockingSend(payload) {
-					tlmPayloadsDropped.Inc("true", strconv.Itoa(i))
-					tlmMessagesDropped.Add(float64(payload.Count()), "true", strconv.Itoa(i))
-				}
-			}
-		}
-
-		// Attempt to send to unreliable destinations
-		for i, destSender := range unreliableDestinations {
-			if !destSender.NonBlockingSend(payload) {
-				tlmPayloadsDropped.Inc("false", strconv.Itoa(i))
-				tlmMessagesDropped.Add(float64(payload.Count()), "false", strconv.Itoa(i))
-				if s.senderDoneChan != nil {
-					senderDoneWg.Add(1)
-					s.senderDoneChan <- senderDoneWg
-				}
-			}
-		}
-
-		inUse := float64(time.Since(startInUse) / time.Millisecond)
-		tlmSendWaitTime.Add(inUse)
-		s.utilization.Stop()
-
-		if s.senderDoneChan != nil && s.flushWg != nil {
-			// Wait for all destinations to finish sending the payload
-			senderDoneWg.Wait()
-			// Decrement the wait group when this payload has been sent
-			s.flushWg.Done()
-		}
-		s.pipelineMonitor.ReportComponentEgress(payload, "sender")
+	log.Debug("sender mux stopping")
+	for _, s := range s.workers {
+		s.stop()
 	}
-
-	// Cleanup the destinations
-	for _, destSender := range reliableDestinations {
-		destSender.Stop()
+	for _, q := range s.queues {
+		close(q)
 	}
-	for _, destSender := range unreliableDestinations {
-		destSender.Stop()
-	}
-	close(sink)
-	s.done <- struct{}{}
-}
-
-// Drains the output channel from destinations that don't update the auditor.
-func additionalDestinationsSink(bufferSize int) chan *message.Payload {
-	sink := make(chan *message.Payload, bufferSize)
-	go func() {
-		// drain channel, stop when channel is closed
-		//nolint:revive // TODO(AML) Fix revive linter
-		for range sink {
-		}
-	}()
-	return sink
-}
-
-func buildDestinationSenders(config pkgconfigmodel.Reader, destinations []client.Destination, output chan *message.Payload, bufferSize int) []*DestinationSender {
-	destinationSenders := []*DestinationSender{}
-	for _, destination := range destinations {
-		destinationSenders = append(destinationSenders, NewDestinationSender(config, destination, output, bufferSize))
-	}
-	return destinationSenders
 }

--- a/pkg/logs/sender/sender_mock.go
+++ b/pkg/logs/sender/sender_mock.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package sender
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+)
+
+// NewMockSender generates a mock sender
+func NewMockSender() *Mock {
+	return &Mock{
+		inChan:  make(chan *message.Payload, 1),
+		monitor: metrics.NewNoopPipelineMonitor("mock_monitor"),
+	}
+}
+
+// Mock represents a mocked sender that fulfills the pipeline component interface
+type Mock struct {
+	inChan  chan *message.Payload
+	monitor metrics.PipelineMonitor
+}
+
+// In returns a self-emptying chan
+func (s *Mock) In() chan *message.Payload {
+	return s.inChan
+}
+
+// PipelineMonitor returns an instance of NoopPipelineMonitor
+func (s *Mock) PipelineMonitor() metrics.PipelineMonitor {
+	return s.monitor
+}
+
+// Start begins the routine that empties the In channel
+func (s *Mock) Start() {
+	go func() {
+		for range s.inChan { //revive:disable-line:empty-block
+		}
+	}()
+}
+
+// Stop closes the in channel
+func (s *Mock) Stop() {
+	close(s.inChan)
+
+}

--- a/pkg/logs/sender/sender_test.go
+++ b/pkg/logs/sender/sender_test.go
@@ -1,319 +1,77 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2025-present Datadog, Inc.
 
 package sender
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/mock"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
-	"github.com/DataDog/datadog-agent/pkg/logs/sources"
-	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
 )
 
-func newMessage(content []byte, source *sources.LogSource, status string) *message.Payload {
-	return &message.Payload{
-		MessageMetas: []*message.MessageMetadata{&message.NewMessageWithSource(content, status, source, 0).MessageMetadata},
-		Encoded:      content,
-		Encoding:     "identity",
-	}
-}
-
-func TestSender(t *testing.T) {
-	l := mock.NewMockLogsIntake(t)
-	defer l.Close()
-
-	source := sources.NewLogSource("", &config.LogsConfig{})
-
-	input := make(chan *message.Payload, 1)
-	output := make(chan *message.Payload, 1)
-
-	destinationsCtx := client.NewDestinationsContext()
-	destinationsCtx.Start()
-
-	destination := tcp.AddrToDestination(l.Addr(), destinationsCtx, statusinterface.NewStatusProviderMock())
-	destinations := client.NewDestinations([]client.Destination{destination}, nil)
-
-	cfg := configmock.New(t)
-	sender := NewSender(cfg, input, output, destinations, 0, nil, nil, metrics.NewNoopPipelineMonitor(""))
-	sender.Start()
-
-	expectedMessage := newMessage([]byte("fake line"), source, "")
-
-	// Write to the output should relay the message to the output (after sending it on the wire)
-	input <- expectedMessage
-	message, ok := <-output
-
-	assert.True(t, ok)
-	assert.Equal(t, message, expectedMessage)
-
-	sender.Stop()
-	destinationsCtx.Stop()
-}
-
-//nolint:revive // TODO(AML) Fix revive linter
-func TestSenderSingleDestination(t *testing.T) {
-	cfg := configmock.New(t)
-	input := make(chan *message.Payload, 1)
-	output := make(chan *message.Payload, 1)
-
-	respondChan := make(chan int)
-
-	server := http.NewTestServerWithOptions(200, 0, true, respondChan, cfg)
-
-	destinations := client.NewDestinations([]client.Destination{server.Destination}, nil)
-
-	sender := NewSender(cfg, input, output, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
-	sender.Start()
-
-	input <- &message.Payload{}
-	input <- &message.Payload{}
-
-	<-respondChan
-	<-output
-
-	<-respondChan
-	<-output
-
-	server.Stop()
-	sender.Stop()
-}
-
-//nolint:revive // TODO(AML) Fix revive linter
-func TestSenderDualReliableDestination(t *testing.T) {
-	cfg := configmock.New(t)
-	input := make(chan *message.Payload, 1)
-	output := make(chan *message.Payload, 1)
-
-	respondChan1 := make(chan int)
-	server1 := http.NewTestServerWithOptions(200, 0, true, respondChan1, cfg)
-
-	respondChan2 := make(chan int)
-	server2 := http.NewTestServerWithOptions(200, 0, true, respondChan2, cfg)
-
-	destinations := client.NewDestinations([]client.Destination{server1.Destination, server2.Destination}, nil)
-
-	sender := NewSender(cfg, input, output, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
-	sender.Start()
-
-	input <- &message.Payload{}
-	input <- &message.Payload{}
-
-	<-respondChan1
-	<-respondChan2
-	<-output
-	<-output
-
-	<-respondChan1
-	<-respondChan2
-	<-output
-	<-output
-
-	server1.Stop()
-	server2.Stop()
-	sender.Stop()
-}
-
-//nolint:revive // TODO(AML) Fix revive linter
-func TestSenderUnreliableAdditionalDestination(t *testing.T) {
-	cfg := configmock.New(t)
-	input := make(chan *message.Payload, 1)
-	output := make(chan *message.Payload, 1)
-
-	respondChan1 := make(chan int)
-	server1 := http.NewTestServerWithOptions(200, 0, true, respondChan1, cfg)
-
-	respondChan2 := make(chan int)
-	server2 := http.NewTestServerWithOptions(200, 0, false, respondChan2, cfg)
-
-	destinations := client.NewDestinations([]client.Destination{server1.Destination}, []client.Destination{server2.Destination})
-
-	sender := NewSender(cfg, input, output, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
-	sender.Start()
-
-	input <- &message.Payload{}
-	input <- &message.Payload{}
-
-	<-respondChan1
-	<-respondChan2
-	<-output
-
-	<-respondChan1
-	<-respondChan2
-	<-output
-
-	server1.Stop()
-	server2.Stop()
-	sender.Stop()
-}
-
-func TestSenderUnreliableStopsWhenMainFails(t *testing.T) {
-	cfg := configmock.New(t)
-	input := make(chan *message.Payload, 1)
-	output := make(chan *message.Payload, 1)
-
-	reliableRespond := make(chan int)
-	reliableServer := http.NewTestServerWithOptions(200, 0, true, reliableRespond, cfg)
-
-	unreliableRespond := make(chan int)
-	unreliableServer := http.NewTestServerWithOptions(200, 0, false, unreliableRespond, cfg)
-
-	destinations := client.NewDestinations([]client.Destination{reliableServer.Destination}, []client.Destination{unreliableServer.Destination})
-
-	sender := NewSender(cfg, input, output, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
-	sender.Start()
-
-	input <- &message.Payload{}
-
-	<-reliableRespond
-	<-unreliableRespond
-	<-output
-
-	reliableServer.ChangeStatus(500)
-
-	input <- &message.Payload{}
-
-	<-reliableRespond   // let it respond 500 once
-	<-unreliableRespond // unreliable gets this log line because it hasn't fallen into a retry loop yet.
-	<-reliableRespond   // its in a loop now, once we respond 500 a second time we know the sender has marked the endpoint as retrying
-
-	// send another log
-	input <- &message.Payload{}
-
-	// reliable still stuck in retry loop - responding 500 over and over again.
-	<-reliableRespond
-
-	// unreliable should not be sending since all the reliable endpoints are failing.
-	select {
-	case <-unreliableRespond:
-		assert.Fail(t, "unreliable sender should be waiting for main sender")
-	default:
+func TestNewSenderWorkerDistribution(t *testing.T) {
+	tests := []struct {
+		name            string
+		workersPerQueue int
+		queuesCount     int
+		expectedWorkers int
+	}{
+		{
+			name:            "default worker count",
+			workersPerQueue: DefaultWorkersPerQueue,
+			queuesCount:     DefaultQueuesCount,
+			expectedWorkers: 1,
+		},
+		{
+			name:            "custom worker count",
+			workersPerQueue: 3,
+			queuesCount:     2,
+			expectedWorkers: 6,
+		},
 	}
 
-	reliableServer.Stop()
-	unreliableServer.Stop()
-	sender.Stop()
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			config := configmock.New(t)
+			auditor := auditor.NewNullAuditor()
+			destinations := &client.Destinations{}
+			destFactory := func() *client.Destinations { return destinations }
+			bufferSize := 100
+			senderDoneChan := make(chan *sync.WaitGroup)
+			flushWg := &sync.WaitGroup{}
+			pipelineMonitor := metrics.NewNoopPipelineMonitor("test")
 
-//nolint:revive // TODO(AML) Fix revive linter
-func TestSenderReliableContinuseWhenOneFails(t *testing.T) {
-	cfg := configmock.New(t)
-	input := make(chan *message.Payload, 1)
-	output := make(chan *message.Payload, 1)
+			// Create sender
+			sender := NewSenderV2(
+				config,
+				auditor,
+				destFactory,
+				bufferSize,
+				senderDoneChan,
+				flushWg,
+				tc.queuesCount,
+				tc.workersPerQueue,
+				pipelineMonitor,
+			)
 
-	reliableRespond1 := make(chan int)
-	reliableServer1 := http.NewTestServerWithOptions(200, 0, true, reliableRespond1, cfg)
+			assert.Equal(t, tc.expectedWorkers, len(sender.workers))
 
-	reliableRespond2 := make(chan int)
-	reliableServer2 := http.NewTestServerWithOptions(200, 0, false, reliableRespond2, cfg)
+			chanMap := make(map[chan *message.Payload]struct{})
+			for range 20 {
+				chanMap[sender.In()] = struct{}{}
+			}
 
-	destinations := client.NewDestinations([]client.Destination{reliableServer1.Destination, reliableServer2.Destination}, nil)
-
-	sender := NewSender(cfg, input, output, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
-	sender.Start()
-
-	input <- &message.Payload{}
-
-	<-reliableRespond1
-	<-reliableRespond2
-	<-output
-	<-output
-
-	reliableServer1.ChangeStatus(500)
-
-	input <- &message.Payload{}
-
-	<-reliableRespond1 // let it respond 500 once
-	<-reliableRespond2 // Second endpoint gets the log line
-	<-output
-	<-reliableRespond1 // its in a loop now, once we respond 500 a second time we know the sender has marked the endpoint as retrying
-
-	// send another log
-	input <- &message.Payload{}
-
-	// reliable still stuck in retry loop - responding 500 over and over again.
-	<-reliableRespond1
-	<-reliableRespond2 // Second output gets the line again
-	<-output
-
-	reliableServer1.Stop()
-	reliableServer2.Stop()
-	sender.Stop()
-}
-
-//nolint:revive // TODO(AML) Fix revive linter
-func TestSenderReliableWhenOneFailsAndRecovers(t *testing.T) {
-	cfg := configmock.New(t)
-	input := make(chan *message.Payload, 1)
-	output := make(chan *message.Payload, 1)
-
-	reliableRespond1 := make(chan int)
-	reliableServer1 := http.NewTestServerWithOptions(200, 0, true, reliableRespond1, cfg)
-
-	reliableRespond2 := make(chan int)
-	reliableServer2 := http.NewTestServerWithOptions(200, 0, false, reliableRespond2, cfg)
-
-	destinations := client.NewDestinations([]client.Destination{reliableServer1.Destination, reliableServer2.Destination}, nil)
-
-	sender := NewSender(cfg, input, output, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
-	sender.Start()
-
-	input <- &message.Payload{}
-
-	<-reliableRespond1
-	<-reliableRespond2
-	<-output
-	<-output
-
-	reliableServer1.ChangeStatus(500)
-
-	input <- &message.Payload{}
-
-	<-reliableRespond1 // let it respond 500 once
-	<-reliableRespond2 // Second endpoint gets the log line
-	<-output
-	<-reliableRespond1 // its in a loop now, once we respond 500 a second time we know the sender has marked the endpoint as retrying
-
-	// send another log
-	input <- &message.Payload{}
-
-	// reliable still stuck in retry loop - responding 500 over and over again.
-	<-reliableRespond1
-	<-reliableRespond2 // Second output gets the line again
-	<-output
-
-	// Recover the first server
-	reliableServer1.ChangeStatus(200)
-
-	// Drain any retries
-	for {
-		if (<-reliableRespond1) == 200 {
-			break
-		}
+			assert.Equal(t, tc.queuesCount, len(chanMap))
+		})
 	}
-
-	<-output // get the buffered log line that was stuck
-
-	// Make sure everything is unblocked
-	input <- &message.Payload{}
-
-	<-reliableRespond1
-	<-reliableRespond2
-	<-output
-	<-output
-
-	reliableServer1.Stop()
-	reliableServer2.Stop()
-	sender.Stop()
 }

--- a/pkg/logs/sender/worker.go
+++ b/pkg/logs/sender/worker.go
@@ -1,0 +1,224 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package sender
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+)
+
+var (
+	tlmPayloadsDropped = telemetry.NewCounterWithOpts("logs_sender", "payloads_dropped", []string{"reliable", "destination"}, "Payloads dropped", telemetry.Options{DefaultMetric: true})
+	tlmMessagesDropped = telemetry.NewCounterWithOpts("logs_sender", "messages_dropped", []string{"reliable", "destination"}, "Messages dropped", telemetry.Options{DefaultMetric: true})
+	tlmSendWaitTime    = telemetry.NewCounter("logs_sender", "send_wait", []string{}, "Time spent waiting for all sends to finish")
+)
+
+// worker sends logs to different destinations. Destinations can be either
+// reliable or unreliable. The worker ensures that logs are sent to at least
+// one reliable destination and will block the pipeline if they are in an
+// error state. Unreliable destinations will only send logs when at least
+// one reliable destination is also sending logs. However they do not update
+// the auditor or block the pipeline if they fail. There will always be at
+// least 1 reliable destination (the main destination).
+type worker struct {
+	auditor        auditor.Auditor
+	config         pkgconfigmodel.Reader
+	inputChan      chan *message.Payload
+	outputChan     chan *message.Payload
+	destinations   *client.Destinations
+	done           chan struct{}
+	finished       chan struct{}
+	bufferSize     int
+	senderDoneChan chan *sync.WaitGroup
+	flushWg        *sync.WaitGroup
+
+	pipelineMonitor metrics.PipelineMonitor
+	utilization     metrics.UtilizationMonitor
+}
+
+func newWorkerLegacy(
+	config pkgconfigmodel.Reader,
+	inputChan chan *message.Payload,
+	outputChan chan *message.Payload,
+	destinations *client.Destinations,
+	bufferSize int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	pipelineMonitor metrics.PipelineMonitor,
+) *worker {
+	return &worker{
+		outputChan:     outputChan,
+		config:         config,
+		inputChan:      inputChan,
+		destinations:   destinations,
+		bufferSize:     bufferSize,
+		senderDoneChan: senderDoneChan,
+		flushWg:        flushWg,
+		done:           make(chan struct{}),
+		finished:       make(chan struct{}),
+
+		// Telemetry
+		pipelineMonitor: pipelineMonitor,
+		utilization:     pipelineMonitor.MakeUtilizationMonitor("sender"),
+	}
+}
+
+func newWorker(
+	config pkgconfigmodel.Reader,
+	inputChan chan *message.Payload,
+	auditor auditor.Auditor,
+	destinations *client.Destinations,
+	bufferSize int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	pipelineMonitor metrics.PipelineMonitor,
+) *worker {
+	return &worker{
+		auditor:        auditor,
+		config:         config,
+		inputChan:      inputChan,
+		destinations:   destinations,
+		bufferSize:     bufferSize,
+		senderDoneChan: senderDoneChan,
+		flushWg:        flushWg,
+		done:           make(chan struct{}),
+		finished:       make(chan struct{}),
+
+		// Telemetry
+		pipelineMonitor: pipelineMonitor,
+		utilization:     pipelineMonitor.MakeUtilizationMonitor("sender"),
+	}
+}
+
+// Start starts the worker.
+func (s *worker) start() {
+	if s.auditor != nil {
+		s.outputChan = s.auditor.Channel()
+	}
+
+	go s.run()
+}
+
+// Stop stops the worker,
+// this call blocks until inputChan is flushed
+func (s *worker) stop() {
+	s.done <- struct{}{}
+	<-s.finished
+}
+
+func (s *worker) run() {
+	reliableDestinations := buildDestinationSenders(s.config, s.destinations.Reliable, s.outputChan, s.bufferSize)
+
+	sink := additionalDestinationsSink(s.bufferSize)
+	unreliableDestinations := buildDestinationSenders(s.config, s.destinations.Unreliable, sink, s.bufferSize)
+	continueLoop := true
+	for continueLoop {
+		select {
+		case payload := <-s.inputChan:
+			s.utilization.Start()
+			var startInUse = time.Now()
+			senderDoneWg := &sync.WaitGroup{}
+
+			sent := false
+			for !sent {
+				for _, destSender := range reliableDestinations {
+					if destSender.Send(payload) {
+						if destSender.destination.Metadata().ReportingEnabled {
+							s.pipelineMonitor.ReportComponentIngress(payload, destSender.destination.Metadata().MonitorTag())
+						}
+						sent = true
+						if s.senderDoneChan != nil {
+							senderDoneWg.Add(1)
+							s.senderDoneChan <- senderDoneWg
+						}
+					}
+				}
+
+				if !sent {
+					// Throttle the poll loop while waiting for a send to succeed
+					// This will only happen when all reliable destinations
+					// are blocked so logs have no where to go.
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+
+			for i, destSender := range reliableDestinations {
+				// If an endpoint is stuck in the previous step, try to buffer the payloads if we have room to mitigate
+				// loss on intermittent failures.
+				if !destSender.lastSendSucceeded {
+					if !destSender.NonBlockingSend(payload) {
+						tlmPayloadsDropped.Inc("true", strconv.Itoa(i))
+						tlmMessagesDropped.Add(float64(payload.Count()), "true", strconv.Itoa(i))
+					}
+				}
+			}
+
+			// Attempt to send to unreliable destinations
+			for i, destSender := range unreliableDestinations {
+				if !destSender.NonBlockingSend(payload) {
+					tlmPayloadsDropped.Inc("false", strconv.Itoa(i))
+					tlmMessagesDropped.Add(float64(payload.Count()), "false", strconv.Itoa(i))
+					if s.senderDoneChan != nil {
+						senderDoneWg.Add(1)
+						s.senderDoneChan <- senderDoneWg
+					}
+				}
+			}
+
+			inUse := float64(time.Since(startInUse) / time.Millisecond)
+			tlmSendWaitTime.Add(inUse)
+			s.utilization.Stop()
+
+			if s.senderDoneChan != nil && s.flushWg != nil {
+				// Wait for all destinations to finish sending the payload
+				senderDoneWg.Wait()
+				// Decrement the wait group when this payload has been sent
+				s.flushWg.Done()
+			}
+			s.pipelineMonitor.ReportComponentEgress(payload, "sender")
+		case <-s.done:
+			continueLoop = false
+		}
+	}
+
+	// Cleanup the destinations
+	for _, destSender := range reliableDestinations {
+		destSender.Stop()
+	}
+	for _, destSender := range unreliableDestinations {
+		destSender.Stop()
+	}
+	close(sink)
+	s.finished <- struct{}{}
+}
+
+// Drains the output channel from destinations that don't update the auditor.
+func additionalDestinationsSink(bufferSize int) chan *message.Payload {
+	sink := make(chan *message.Payload, bufferSize)
+	go func() {
+		// drain channel, stop when channel is closed
+		//nolint:revive // TODO(AML) Fix revive linter
+		for range sink {
+		}
+	}()
+	return sink
+}
+
+func buildDestinationSenders(config pkgconfigmodel.Reader, destinations []client.Destination, output chan *message.Payload, bufferSize int) []*DestinationSender {
+	destinationSenders := []*DestinationSender{}
+	for _, destination := range destinations {
+		destinationSenders = append(destinationSenders, NewDestinationSender(config, destination, output, bufferSize))
+	}
+	return destinationSenders
+}

--- a/pkg/logs/sender/worker_test.go
+++ b/pkg/logs/sender/worker_test.go
@@ -1,0 +1,347 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package sender
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sources"
+	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
+)
+
+type testAuditor struct {
+	output chan *message.Payload
+}
+
+func (a *testAuditor) Channel() chan *message.Payload {
+	return a.output
+}
+func (a *testAuditor) Start() {
+}
+func (a *testAuditor) Stop() {
+}
+func (a *testAuditor) GetOffset(_ string) string      { return "" }
+func (a *testAuditor) GetTailingMode(_ string) string { return "" }
+
+func newMessage(content []byte, source *sources.LogSource, status string) *message.Payload {
+	return &message.Payload{
+		MessageMetas: []*message.MessageMetadata{&message.NewMessageWithSource(content, status, source, 0).MessageMetadata},
+		Encoded:      content,
+		Encoding:     "identity",
+	}
+}
+
+func TestSender(t *testing.T) {
+	l := mock.NewMockLogsIntake(t)
+	defer l.Close()
+
+	source := sources.NewLogSource("", &config.LogsConfig{})
+
+	input := make(chan *message.Payload, 1)
+	auditor := &testAuditor{
+		output: make(chan *message.Payload, 1),
+	}
+
+	destinationsCtx := client.NewDestinationsContext()
+	destinationsCtx.Start()
+
+	destination := tcp.AddrToDestination(l.Addr(), destinationsCtx, statusinterface.NewStatusProviderMock())
+	destinations := client.NewDestinations([]client.Destination{destination}, nil)
+
+	cfg := configmock.New(t)
+	worker := newWorker(cfg, input, auditor, destinations, 0, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker.start()
+
+	expectedMessage := newMessage([]byte("fake line"), source, "")
+
+	// Write to the output should relay the message to the output (after sending it on the wire)
+	input <- expectedMessage
+	message, ok := <-auditor.output
+
+	assert.True(t, ok)
+	assert.Equal(t, message, expectedMessage)
+
+	worker.stop()
+	destinationsCtx.Stop()
+}
+
+//nolint:revive // TODO(AML) Fix revive linter
+func TestSenderSingleDestination(t *testing.T) {
+	cfg := configmock.New(t)
+	input := make(chan *message.Payload, 1)
+	auditor := &testAuditor{
+		output: make(chan *message.Payload, 1),
+	}
+
+	respondChan := make(chan int)
+
+	server := http.NewTestServerWithOptions(200, 1, true, respondChan, cfg)
+
+	destinations := client.NewDestinations([]client.Destination{server.Destination}, nil)
+
+	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker.start()
+
+	input <- &message.Payload{}
+	input <- &message.Payload{}
+
+	<-respondChan
+	<-auditor.output
+
+	<-respondChan
+	<-auditor.output
+
+	server.Stop()
+	worker.stop()
+}
+
+//nolint:revive // TODO(AML) Fix revive linter
+func TestSenderDualReliableDestination(t *testing.T) {
+	cfg := configmock.New(t)
+	input := make(chan *message.Payload, 1)
+	auditor := &testAuditor{
+		output: make(chan *message.Payload, 1),
+	}
+
+	respondChan1 := make(chan int)
+	server1 := http.NewTestServerWithOptions(200, 1, true, respondChan1, cfg)
+
+	respondChan2 := make(chan int)
+	server2 := http.NewTestServerWithOptions(200, 1, true, respondChan2, cfg)
+
+	destinations := client.NewDestinations([]client.Destination{server1.Destination, server2.Destination}, nil)
+
+	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker.start()
+
+	input <- &message.Payload{}
+	input <- &message.Payload{}
+
+	<-respondChan1
+	<-respondChan2
+	<-auditor.output
+	<-auditor.output
+
+	<-respondChan1
+	<-respondChan2
+	<-auditor.output
+	<-auditor.output
+
+	server1.Stop()
+	server2.Stop()
+	worker.stop()
+}
+
+//nolint:revive // TODO(AML) Fix revive linter
+func TestSenderUnreliableAdditionalDestination(t *testing.T) {
+	cfg := configmock.New(t)
+	input := make(chan *message.Payload, 1)
+	auditor := &testAuditor{
+		output: make(chan *message.Payload, 1),
+	}
+
+	respondChan1 := make(chan int)
+	server1 := http.NewTestServerWithOptions(200, 1, true, respondChan1, cfg)
+
+	respondChan2 := make(chan int)
+	server2 := http.NewTestServerWithOptions(200, 1, false, respondChan2, cfg)
+
+	destinations := client.NewDestinations([]client.Destination{server1.Destination}, []client.Destination{server2.Destination})
+
+	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker.start()
+
+	input <- &message.Payload{}
+	input <- &message.Payload{}
+
+	<-respondChan1
+	<-respondChan2
+	<-auditor.output
+
+	<-respondChan1
+	<-respondChan2
+	<-auditor.output
+
+	server1.Stop()
+	server2.Stop()
+	worker.stop()
+}
+
+func TestSenderUnreliableStopsWhenMainFails(t *testing.T) {
+	cfg := configmock.New(t)
+	input := make(chan *message.Payload, 1)
+	auditor := &testAuditor{
+		output: make(chan *message.Payload, 1),
+	}
+
+	reliableRespond := make(chan int)
+	reliableServer := http.NewTestServerWithOptions(200, 1, true, reliableRespond, cfg)
+
+	unreliableRespond := make(chan int)
+	unreliableServer := http.NewTestServerWithOptions(200, 1, false, unreliableRespond, cfg)
+
+	destinations := client.NewDestinations([]client.Destination{reliableServer.Destination}, []client.Destination{unreliableServer.Destination})
+
+	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker.start()
+
+	input <- &message.Payload{}
+
+	<-reliableRespond
+	<-unreliableRespond
+	<-auditor.output
+
+	reliableServer.ChangeStatus(500)
+
+	input <- &message.Payload{}
+
+	<-reliableRespond   // let it respond 500 once
+	<-unreliableRespond // unreliable gets this log line because it hasn't fallen into a retry loop yet.
+	<-reliableRespond   // its in a loop now, once we respond 500 a second time we know the sender has marked the endpoint as retrying
+
+	// send another log
+	input <- &message.Payload{}
+
+	// reliable still stuck in retry loop - responding 500 over and over again.
+	<-reliableRespond
+
+	// unreliable should not be sending since all the reliable endpoints are failing.
+	select {
+	case <-unreliableRespond:
+		assert.Fail(t, "unreliable sender should be waiting for main sender")
+	default:
+	}
+
+	reliableServer.Stop()
+	unreliableServer.Stop()
+	worker.stop()
+}
+
+//nolint:revive // TODO(AML) Fix revive linter
+func TestSenderReliableContinuseWhenOneFails(t *testing.T) {
+	cfg := configmock.New(t)
+	input := make(chan *message.Payload, 1)
+	auditor := &testAuditor{
+		output: make(chan *message.Payload, 1),
+	}
+
+	reliableRespond1 := make(chan int)
+	reliableServer1 := http.NewTestServerWithOptions(200, 1, true, reliableRespond1, cfg)
+
+	reliableRespond2 := make(chan int)
+	reliableServer2 := http.NewTestServerWithOptions(200, 1, false, reliableRespond2, cfg)
+
+	destinations := client.NewDestinations([]client.Destination{reliableServer1.Destination, reliableServer2.Destination}, nil)
+
+	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker.start()
+
+	input <- &message.Payload{}
+
+	<-reliableRespond1
+	<-reliableRespond2
+	<-auditor.output
+	<-auditor.output
+
+	reliableServer1.ChangeStatus(500)
+
+	input <- &message.Payload{}
+
+	<-reliableRespond1 // let it respond 500 once
+	<-reliableRespond2 // Second endpoint gets the log line
+	<-auditor.output
+	<-reliableRespond1 // its in a loop now, once we respond 500 a second time we know the sender has marked the endpoint as retrying
+
+	// send another log
+	input <- &message.Payload{}
+
+	// reliable still stuck in retry loop - responding 500 over and over again.
+	<-reliableRespond1
+	<-reliableRespond2 // Second output gets the line again
+	<-auditor.output
+
+	reliableServer1.Stop()
+	reliableServer2.Stop()
+	worker.stop()
+}
+
+//nolint:revive // TODO(AML) Fix revive linter
+func TestSenderReliableWhenOneFailsAndRecovers(t *testing.T) {
+	cfg := configmock.New(t)
+	input := make(chan *message.Payload, 1)
+	auditor := &testAuditor{
+		output: make(chan *message.Payload, 1),
+	}
+
+	reliableRespond1 := make(chan int)
+	reliableServer1 := http.NewTestServerWithOptions(200, 1, true, reliableRespond1, cfg)
+
+	reliableRespond2 := make(chan int)
+	reliableServer2 := http.NewTestServerWithOptions(200, 1, false, reliableRespond2, cfg)
+
+	destinations := client.NewDestinations([]client.Destination{reliableServer1.Destination, reliableServer2.Destination}, nil)
+
+	worker := newWorker(cfg, input, auditor, destinations, 10, nil, nil, metrics.NewNoopPipelineMonitor(""))
+	worker.start()
+
+	input <- &message.Payload{}
+
+	<-reliableRespond1
+	<-reliableRespond2
+	<-auditor.output
+	<-auditor.output
+
+	reliableServer1.ChangeStatus(500)
+
+	input <- &message.Payload{}
+
+	<-reliableRespond1 // let it respond 500 once
+	<-reliableRespond2 // Second endpoint gets the log line
+	<-auditor.output
+	<-reliableRespond1 // its in a loop now, once we respond 500 a second time we know the sender has marked the endpoint as retrying
+
+	// send another log
+	input <- &message.Payload{}
+
+	// reliable still stuck in retry loop - responding 500 over and over again.
+	<-reliableRespond1
+	<-reliableRespond2 // Second output gets the line again
+	<-auditor.output
+
+	// Recover the first server
+	reliableServer1.ChangeStatus(200)
+
+	// Drain any retries
+	for {
+		if (<-reliableRespond1) == 200 {
+			break
+		}
+	}
+
+	<-auditor.output // get the buffered log line that was stuck
+
+	// Make sure everything is unblocked
+	input <- &message.Payload{}
+
+	<-reliableRespond1
+	<-reliableRespond2
+	<-auditor.output
+	<-auditor.output
+
+	reliableServer1.Stop()
+	reliableServer2.Stop()
+	worker.stop()
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR introduces a nonfunctional architectural shift that brings the underlying codebase closer to the enablement of RTT Fairness/Distributed Sends. PR that enables these features and documents the full change scope is https://github.com/DataDog/datadog-agent/pull/35484

 The crux of this PR is the multiplexing of the sender object in the logs pipeline. Specifically a single "sender" instance can now possess a variety of payload queues and workers for those queues. Each "worker" has the full functionality of the older sender objects, and this architectural shift allows for the abstraction and separation of sender count from pipeline count.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Unit test coverage was expanded, and existing test cases were largely relied upon to verify that no regressions were introduced in this change. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->