### PR TITLE
Enable distributed sends and RTT fairness for core logs pipeline

### DIFF
--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -46,7 +46,20 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(nil, a.hostname)
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(a.config.GetInt("logs_config.pipelines"), auditor, diagnosticMessageReceiver, processingRules, a.endpoints, destinationsCtx, NewStatusProvider(), a.hostname, a.config, a.compression)
+	pipelineProvider := pipeline.NewProvider(
+		a.config.GetInt("logs_config.pipelines"),
+		auditor,
+		diagnosticMessageReceiver,
+		processingRules,
+		a.endpoints,
+		destinationsCtx,
+		NewStatusProvider(),
+		a.hostname,
+		a.config,
+		a.compression,
+		a.config.GetBool("logs_config.disable_distributed_senders"), // legacy
+		false, // serverless
+	)
 
 	// setup the launchers
 	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, auditor, a.tracker)

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -49,7 +49,19 @@ func (a *logAgent) SetupPipeline(
 	destinationsCtx := client.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewServerlessProvider(a.config.GetInt("logs_config.pipelines"), a.auditor, diagnosticMessageReceiver, processingRules, a.endpoints, destinationsCtx, NewStatusProvider(), a.hostname, a.config, a.compression)
+	pipelineProvider := pipeline.NewProvider(
+		a.config.GetInt("logs_config.pipelines"),
+		a.auditor,
+		diagnosticMessageReceiver,
+		processingRules, a.endpoints,
+		destinationsCtx,
+		NewStatusProvider(),
+		a.hostname,
+		a.config,
+		a.compression,
+		true, // disable distributed sending for serverless
+		true, // serverless
+	)
 
 	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, a.auditor, a.tracker)
 	lnchrs.AddLauncher(channel.NewLauncher())

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -10,6 +10,7 @@ package agentimpl
 import (
 	"bytes"
 	"context"
+	"expvar"
 	"fmt"
 	"os"
 	"strings"
@@ -158,7 +159,9 @@ func (suite *AgentTestSuite) testAgent(endpoints *config.Endpoints) {
 	assert.Equal(suite.T(), zero, metrics.LogsProcessed.Value())
 	assert.Equal(suite.T(), zero, metrics.LogsSent.Value())
 	assert.Equal(suite.T(), zero, metrics.DestinationErrors.Value())
-	assert.Equal(suite.T(), "{}", metrics.DestinationLogsDropped.String())
+	metrics.DestinationLogsDropped.Do(func(k expvar.KeyValue) {
+		assert.Equal(suite.T(), k.Value.String(), "0")
+	})
 
 	agent.startPipeline()
 	sources.AddSource(suite.source)

--- a/comp/otelcol/logsagentpipeline/go.mod
+++ b/comp/otelcol/logsagentpipeline/go.mod
@@ -2,16 +2,16 @@ module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline
 
 go 1.23.0
 
-require github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.61.0
+require github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.64.0-rc.3
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.146 // indirect
-	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel // indirect
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
@@ -23,21 +23,21 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/client v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/message v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/processor v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sds v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sender v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/client v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/message v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/processor v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sds v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sender v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/compression v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.61.0 // indirect

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
@@ -214,7 +214,20 @@ func (a *Agent) SetupPipeline(
 	destinationsCtx := client.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(a.config.GetInt("logs_config.pipelines"), auditor, &diagnostic.NoopMessageReceiver{}, processingRules, a.endpoints, destinationsCtx, NewStatusProvider(), a.hostname, a.config, a.compression)
+	pipelineProvider := pipeline.NewProvider(
+		a.config.GetInt("logs_config.pipelines"),
+		auditor,
+		&diagnostic.NoopMessageReceiver{},
+		processingRules,
+		a.endpoints,
+		destinationsCtx,
+		NewStatusProvider(),
+		a.hostname,
+		a.config,
+		a.compression,
+		a.config.GetBool("logs_config.disable_distributed_senders"),
+		false, // serverless
+	)
 
 	a.auditor = auditor
 	a.destinationsCtx = destinationsCtx

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
@@ -7,6 +7,7 @@ package logsagentpipelineimpl
 
 import (
 	"context"
+	"expvar"
 	"testing"
 	"time"
 
@@ -97,7 +98,9 @@ func (suite *AgentTestSuite) testAgent(endpoints *config.Endpoints) {
 	assert.Equal(suite.T(), zero, metrics.LogsProcessed.Value())
 	assert.Equal(suite.T(), zero, metrics.LogsSent.Value())
 	assert.Equal(suite.T(), zero, metrics.DestinationErrors.Value())
-	assert.Equal(suite.T(), "{}", metrics.DestinationLogsDropped.String())
+	metrics.DestinationLogsDropped.Do(func(k expvar.KeyValue) {
+		assert.Equal(suite.T(), k.Value.String(), "0")
+	})
 
 	agent.startPipeline()
 	suite.sendTestMessages(agent)

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/go.mod
@@ -3,23 +3,23 @@ module github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagent
 go 1.23.0
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel
-	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0
-	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel
+	github.com/DataDog/datadog-agent/comp/core/config v0.64.1
+	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/comp/core/log/mock v0.64.0-devel
-	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.61.0
-	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel
+	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/client v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/message v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.61.0
+	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/logs/client v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/logs/message v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.61.0
+	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0
 	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.61.0
 	github.com/DataDog/datadog-agent/pkg/util/option v0.64.0-devel
@@ -47,13 +47,13 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/processor v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sds v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sender v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/processor v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sds v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sender v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/compression v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.61.0 // indirect

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.64.1 // indirect
-	github.com/DataDog/datadog-agent/comp/core/status v0.59.0-rc.6 // indirect
+	github.com/DataDog/datadog-agent/comp/core/status v0.63.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/telemetry v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.64.1 // indirect
@@ -61,14 +61,13 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.64.0-devel.0.20250218192636-64fdfe7ec366 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.59.0-rc.6 // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.59.0-rc.6 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/agent/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.59.0-rc.6 // indirect
-	github.com/DataDog/datadog-agent/pkg/api v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/api v0.63.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.64.1 // indirect
@@ -167,7 +166,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/mock v1.7.0-rc.1 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v1.0.0 // indirect

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
@@ -151,8 +151,9 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 h1:f+oWsMOmNPc8JmEHVZIycC7hBoQxHH9pNKQORJNozsQ=
+github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8/go.mod h1:wcDNUvekVysuuOpQKo3191zZyTpiI6se1N1ULghS0sw=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/mock v1.7.0-rc.1 h1:YojYx61/OLFsiv6Rw1Z96LpldJIy31o+UHmwAUMJ6/U=

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.mod
@@ -3,14 +3,14 @@ module github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/da
 go 1.23.0
 
 require (
-	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.61.0
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.62.0-devel.0.20241213165407-f95df913d2b7
+	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.64.0-devel.0.20250218192636-64fdfe7ec366
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter v0.59.0-rc.6
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.61.0
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/comp/trace/agent/def v0.61.0
-	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.61.0
-	github.com/DataDog/datadog-agent/pkg/logs/message v0.61.0
-	github.com/DataDog/datadog-agent/pkg/proto v0.64.0-rc.12
+	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/logs/message v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/proto v0.64.1
 	github.com/DataDog/datadog-agent/pkg/serializer v0.59.0
 	github.com/DataDog/datadog-agent/pkg/trace v0.64.0-rc.12
 	github.com/DataDog/datadog-agent/pkg/util/otel v0.64.0
@@ -55,7 +55,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/builder v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.59.0-rc.6 // indirect
@@ -64,10 +64,11 @@ require (
 	github.com/DataDog/datadog-agent/comp/def v0.63.0 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder v0.56.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel // indirect
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/serializer/metricscompression v0.59.0-rc.6 // indirect
-	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/aggregator/ckey v0.59.0-rc.6 // indirect
 	github.com/DataDog/datadog-agent/pkg/api v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
@@ -82,36 +83,36 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/client v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/processor v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sds v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sender v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/client v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/processor v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sds v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sender v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/metrics v0.59.0-rc.6 // indirect
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.63.0-devel.0.20250123185937-1feb84b482c8 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/orchestrator/model v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/process/util/api v0.59.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/tagger/types v0.60.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/tagset v0.60.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/status/health v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/tagger/types v0.64.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/tagset v0.64.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/telemetry v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/backoff v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/buf v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/common v0.62.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.63.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.64.0-rc.12 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/http v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/compression v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/executable v0.64.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/filesystem v0.64.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/fxutil v0.64.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.64.1 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/http v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/json v0.59.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/option v0.64.0-devel // indirect
@@ -187,6 +188,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.121.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.122.0 // indirect
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/outcaste-io/ristretto v0.2.3 // indirect

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
@@ -252,8 +252,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.122.0 h
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.122.0/go.mod h1:CGWEJ9xPgqF/NKlmNpxYtCQJEBJ/8gie3Nbmemzsi0M=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0 h1:2ztsxw6DH2CbXbykCGgPSZmHHRilNuD06VOfI/z9xGs=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.119.0/go.mod h1:q5LK/pXBToCu4W+tSVWM2ST5jOWqvDMVVCB7TQqhsbY=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.119.0 h1:qSnBSa1zO4szSQOrVyinm/9Bg68oYv6NarcaV4Rusr8=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.119.0/go.mod h1:udnlBYxPMO+odronKnPfYY8M+BnxfaQFXuJgfI5miUw=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.121.0 h1:D7mQQKd4rncv3PSsbDGayNENqmVwN1dFvPo3wHFzhI4=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.121.0/go.mod h1:swPiDfFHEiy9x2TwNO3uexCkwppLWfPRVoJdpJvKIQE=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.122.0 h1:m3yOJ1aHF2qOGW3c7qhnjzccTmfNwxgTck8avStxYo0=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.122.0/go.mod h1:xRVCkxl7mUlRsp65vfpOZXsbD1WrUYBQJPeeGA4adj4=
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/sampling v0.122.0 h1:n0nWcGanaHanlih+YRp8etj1/fYZoQFRk+7+/J85dpU=

--- a/pkg/compliance/reporter.go
+++ b/pkg/compliance/reporter.go
@@ -44,7 +44,21 @@ func NewLogReporter(hostname string, sourceName, sourceType string, endpoints *c
 	auditor.Start()
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(4, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, dstcontext, &common.NoopStatusProvider{}, hostnameimpl.NewHostnameService(), pkgconfigsetup.Datadog(), compression)
+	cfg := pkgconfigsetup.Datadog()
+	pipelineProvider := pipeline.NewProvider(
+		4,
+		auditor,
+		&diagnostic.NoopMessageReceiver{},
+		nil, // processingRules
+		endpoints,
+		dstcontext,
+		&common.NoopStatusProvider{},
+		hostnameimpl.NewHostnameService(),
+		cfg,
+		compression,
+		cfg.GetBool("logs_config.disable_distributed_senders"),
+		false, // serverless
+	)
 	pipelineProvider.Start()
 
 	logSource := sources.NewLogSource(

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1515,6 +1515,8 @@ func logsagent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("logs_config.container_collect_all", false)
 	// add a socks5 proxy:
 	config.BindEnvAndSetDefault("logs_config.socks5_proxy_address", "")
+	// disable distributed senders
+	config.BindEnvAndSetDefault("logs_config.disable_distributed_senders", false, "DD_LOGS_DISABLE_DISTRIBUTED_SENDERS")
 	// specific logs-agent api-key
 	config.BindEnv("logs_config.api_key")
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1516,7 +1516,7 @@ func logsagent(config pkgconfigmodel.Setup) {
 	// add a socks5 proxy:
 	config.BindEnvAndSetDefault("logs_config.socks5_proxy_address", "")
 	// disable distributed senders
-	config.BindEnvAndSetDefault("logs_config.disable_distributed_senders", false, "DD_LOGS_DISABLE_DISTRIBUTED_SENDERS")
+	config.BindEnvAndSetDefault("logs_config.disable_distributed_senders", false)
 	// specific logs-agent api-key
 	config.BindEnv("logs_config.api_key")
 

--- a/pkg/logs/pipeline/go.mod
+++ b/pkg/logs/pipeline/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0
 	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel
+	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.1
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0
 	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.61.0
@@ -17,7 +18,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/sds v0.61.0
 	github.com/DataDog/datadog-agent/pkg/logs/sender v0.61.0
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.61.0
-	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0
 	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.1
 	github.com/DataDog/datadog-agent/pkg/util/startstop v0.61.0
@@ -37,7 +37,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.0.0-00010101000000-000000000000 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/env v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/config/mock v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/structure v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.64.1 // indirect
@@ -46,6 +45,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -8,7 +8,6 @@ package pipeline
 
 import (
 	"context"
-	"strconv"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
@@ -16,15 +15,11 @@ import (
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/logs/client"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
-	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/logs/processor"
 	"github.com/DataDog/datadog-agent/pkg/logs/sender"
-	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
 	compressioncommon "github.com/DataDog/datadog-agent/pkg/util/compression"
 )
 
@@ -34,41 +29,25 @@ type Pipeline struct {
 	flushChan       chan struct{}
 	processor       *processor.Processor
 	strategy        sender.Strategy
-	sender          *sender.Sender
 	serverless      bool
 	flushWg         *sync.WaitGroup
 	pipelineMonitor metrics.PipelineMonitor
 }
 
 // NewPipeline returns a new Pipeline
-func NewPipeline(outputChan chan *message.Payload,
+func NewPipeline(
 	processingRules []*config.ProcessingRule,
 	endpoints *config.Endpoints,
-	destinationsContext *client.DestinationsContext,
+	senderImpl sender.PipelineComponent,
 	diagnosticMessageReceiver diagnostic.MessageReceiver,
 	serverless bool,
-	pipelineID int,
-	status statusinterface.Status,
+	flushWg *sync.WaitGroup,
 	hostname hostnameinterface.Component,
 	cfg pkgconfigmodel.Reader,
 	compression logscompression.Component,
 ) *Pipeline {
-
-	var senderDoneChan chan *sync.WaitGroup
-	var flushWg *sync.WaitGroup
-	if serverless {
-		senderDoneChan = make(chan *sync.WaitGroup)
-		flushWg = &sync.WaitGroup{}
-	}
-	pipelineMonitor := metrics.NewTelemetryPipelineMonitor(strconv.Itoa(pipelineID))
-
-	mainDestinations := getDestinations(endpoints, destinationsContext, pipelineMonitor, serverless, senderDoneChan, status, cfg)
-
 	strategyInput := make(chan *message.Message, pkgconfigsetup.Datadog().GetInt("logs_config.message_channel_size"))
-	senderInput := make(chan *message.Payload, 1) // Only buffer 1 message since payloads can be large
 	flushChan := make(chan struct{})
-
-	var logsSender *sender.Sender
 
 	var encoder processor.Encoder
 	if serverless {
@@ -80,30 +59,25 @@ func NewPipeline(outputChan chan *message.Payload,
 	} else {
 		encoder = processor.RawEncoder
 	}
-
-	strategy := getStrategy(strategyInput, senderInput, flushChan, endpoints, serverless, flushWg, pipelineMonitor, compression)
-	logsSender = sender.NewSender(cfg, senderInput, outputChan, mainDestinations, pkgconfigsetup.Datadog().GetInt("logs_config.payload_channel_size"), senderDoneChan, flushWg, pipelineMonitor)
+	strategy := getStrategy(strategyInput, senderImpl.In(), flushChan, endpoints, serverless, flushWg, senderImpl.PipelineMonitor(), compression)
 
 	inputChan := make(chan *message.Message, pkgconfigsetup.Datadog().GetInt("logs_config.message_channel_size"))
-
 	processor := processor.New(cfg, inputChan, strategyInput, processingRules,
-		encoder, diagnosticMessageReceiver, hostname, pipelineMonitor)
+		encoder, diagnosticMessageReceiver, hostname, senderImpl.PipelineMonitor())
 
 	return &Pipeline{
 		InputChan:       inputChan,
 		flushChan:       flushChan,
 		processor:       processor,
 		strategy:        strategy,
-		sender:          logsSender,
 		serverless:      serverless,
 		flushWg:         flushWg,
-		pipelineMonitor: pipelineMonitor,
+		pipelineMonitor: senderImpl.PipelineMonitor(),
 	}
 }
 
 // Start launches the pipeline
 func (p *Pipeline) Start() {
-	p.sender.Start()
 	p.strategy.Start()
 	p.processor.Start()
 }
@@ -112,51 +86,12 @@ func (p *Pipeline) Start() {
 func (p *Pipeline) Stop() {
 	p.processor.Stop()
 	p.strategy.Stop()
-	p.sender.Stop()
 }
 
 // Flush flushes synchronously the processor and sender managed by this pipeline.
 func (p *Pipeline) Flush(ctx context.Context) {
 	p.flushChan <- struct{}{}
 	p.processor.Flush(ctx) // flush messages in the processor into the sender
-
-	if p.serverless {
-		// Wait for the logs sender to finish sending payloads to all destinations before allowing the flush to finish
-		p.flushWg.Wait()
-	}
-}
-
-func getDestinations(endpoints *config.Endpoints, destinationsContext *client.DestinationsContext, pipelineMonitor metrics.PipelineMonitor, serverless bool, senderDoneChan chan *sync.WaitGroup, status statusinterface.Status, cfg pkgconfigmodel.Reader) *client.Destinations {
-	reliable := []client.Destination{}
-	additionals := []client.Destination{}
-
-	if endpoints.UseHTTP {
-		for i, endpoint := range endpoints.GetReliableEndpoints() {
-			destMeta := client.NewDestinationMetadata("logs", pipelineMonitor.ID(), "reliable", strconv.Itoa(i))
-			if serverless {
-				reliable = append(reliable, http.NewSyncDestination(endpoint, http.JSONContentType, destinationsContext, senderDoneChan, destMeta, cfg))
-			} else {
-				reliable = append(reliable, http.NewDestination(endpoint, http.JSONContentType, destinationsContext, true, destMeta, cfg, endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
-			}
-		}
-		for i, endpoint := range endpoints.GetUnReliableEndpoints() {
-			destMeta := client.NewDestinationMetadata("logs", pipelineMonitor.ID(), "unreliable", strconv.Itoa(i))
-			if serverless {
-				additionals = append(additionals, http.NewSyncDestination(endpoint, http.JSONContentType, destinationsContext, senderDoneChan, destMeta, cfg))
-			} else {
-				additionals = append(additionals, http.NewDestination(endpoint, http.JSONContentType, destinationsContext, false, destMeta, cfg, endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxConcurrentSend, pipelineMonitor))
-			}
-		}
-		return client.NewDestinations(reliable, additionals)
-	}
-	for _, endpoint := range endpoints.GetReliableEndpoints() {
-		reliable = append(reliable, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext, !serverless, status))
-	}
-	for _, endpoint := range endpoints.GetUnReliableEndpoints() {
-		additionals = append(additionals, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext, false, status))
-	}
-
-	return client.NewDestinations(reliable, additionals)
 }
 
 //nolint:revive // TODO(AML) Fix revive linter

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -30,7 +30,6 @@ type Pipeline struct {
 	processor       *processor.Processor
 	strategy        sender.Strategy
 	serverless      bool
-	flushWg         *sync.WaitGroup
 	pipelineMonitor metrics.PipelineMonitor
 }
 
@@ -71,7 +70,6 @@ func NewPipeline(
 		processor:       processor,
 		strategy:        strategy,
 		serverless:      serverless,
-		flushWg:         flushWg,
 		pipelineMonitor: senderImpl.PipelineMonitor(),
 	}
 }

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -6,63 +6,339 @@
 package pipeline
 
 import (
+	"sync"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/suite"
-	"go.uber.org/atomic"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
+	"github.com/DataDog/datadog-agent/pkg/logs/message"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
+	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
 )
 
-type ProviderTestSuite struct {
-	suite.Suite
-	p *provider
-	a *auditor.RegistryAuditor
+// mockSenderFactory captures the configuration passed to NewSenderV2
+type mockSenderFactory struct {
+	queueCount      int
+	workersPerQueue int
+	minConcurrency  int
+	maxConcurrency  int
+	senderDoneChan  chan *sync.WaitGroup
+	flushWg         *sync.WaitGroup
+	isHTTP          bool
 }
 
-func (suite *ProviderTestSuite) SetupTest() {
-	suite.a = auditor.New("", auditor.DefaultRegistryFilename, time.Hour, health.RegisterLiveness("fake"))
-	suite.p = &provider{
-		numberOfPipelines:    3,
-		auditor:              suite.a,
-		pipelines:            []*Pipeline{},
-		endpoints:            config.NewEndpoints(config.Endpoint{}, nil, true, false),
-		currentPipelineIndex: atomic.NewUint32(0),
-		compression:          compressionfx.NewMockCompressor(),
+func newMockSenderFactory() *mockSenderFactory {
+	return &mockSenderFactory{}
+}
+
+func (f *mockSenderFactory) NewTCPSender(
+	_ pkgconfigmodel.Reader,
+	_ auditor.Auditor,
+	_ int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	_ *config.Endpoints,
+	_ *client.DestinationsContext,
+	_ statusinterface.Status,
+	_ bool,
+	_ string,
+	queueCount int,
+	workersPerQueue int,
+) *sender.Sender {
+	f.queueCount = queueCount
+	f.workersPerQueue = workersPerQueue
+	f.minConcurrency = 1
+	f.maxConcurrency = 1
+	f.senderDoneChan = senderDoneChan
+	f.flushWg = flushWg
+	f.isHTTP = false
+
+	return &sender.Sender{}
+}
+
+func (f *mockSenderFactory) NewHTTPSender(
+	_ pkgconfigmodel.Reader,
+	_ auditor.Auditor,
+	_ int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	_ *config.Endpoints,
+	_ *client.DestinationsContext,
+	_ bool,
+	_ string,
+	_ string,
+	queueCount int,
+	workersPerQueue int,
+	minWorkerConcurrency int,
+	maxWorkerConcurrency int,
+) *sender.Sender {
+	f.queueCount = queueCount
+	f.workersPerQueue = workersPerQueue
+	f.minConcurrency = minWorkerConcurrency
+	f.maxConcurrency = maxWorkerConcurrency
+	f.senderDoneChan = senderDoneChan
+	f.flushWg = flushWg
+	f.isHTTP = true
+
+	return &sender.Sender{}
+}
+
+func TestProviderConfigurations(t *testing.T) {
+	tests := []struct {
+		name                   string
+		useHTTP                bool
+		legacyMode             bool
+		numberOfPipelines      int
+		serverless             bool
+		expectedQueues         int
+		expectedWorkers        int
+		expectedMinConcurrency int
+		expectedMaxConcurrency int
+		batchMaxConcurrentSend int
+	}{
+		{
+			name:                   "TCP sender default",
+			useHTTP:                false,
+			legacyMode:             false,
+			numberOfPipelines:      3,
+			serverless:             false,
+			expectedQueues:         sender.DefaultQueuesCount, // 1
+			expectedWorkers:        3,                         // numberOfPipelines
+			expectedMinConcurrency: 1,
+			expectedMaxConcurrency: 1,
+			batchMaxConcurrentSend: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+		},
+		{
+			name:                   "TCP sender legacy",
+			useHTTP:                false,
+			legacyMode:             true,
+			numberOfPipelines:      3,
+			serverless:             false,
+			expectedQueues:         3, // numberOfPipelines
+			expectedWorkers:        1, // 1 worker per queue
+			expectedMinConcurrency: 1,
+			expectedMaxConcurrency: 1,
+			batchMaxConcurrentSend: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+		},
+		{
+			name:                   "HTTP sender default",
+			useHTTP:                true,
+			legacyMode:             false,
+			numberOfPipelines:      3,
+			serverless:             false,
+			expectedQueues:         sender.DefaultQueuesCount,     // 1
+			expectedWorkers:        sender.DefaultWorkersPerQueue, // 1
+			expectedMinConcurrency: 3,
+			expectedMaxConcurrency: 30,
+			batchMaxConcurrentSend: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+		},
+		{
+			name:                   "HTTP sender with batch_max_concurrent_send",
+			useHTTP:                true,
+			legacyMode:             false,
+			numberOfPipelines:      3,
+			serverless:             false,
+			expectedQueues:         sender.DefaultQueuesCount,     // 1
+			expectedWorkers:        sender.DefaultWorkersPerQueue, // 1
+			expectedMinConcurrency: 24,
+			expectedMaxConcurrency: 24,
+			batchMaxConcurrentSend: 8,
+		},
+		{
+			name:                   "Http sender legacy",
+			useHTTP:                true,
+			legacyMode:             true,
+			numberOfPipelines:      3,
+			serverless:             false,
+			expectedQueues:         3, // numberOfPipelines
+			expectedWorkers:        1, // 1 worker per queue
+			expectedMinConcurrency: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+			expectedMaxConcurrency: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+			batchMaxConcurrentSend: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+		},
+		{
+			name:                   "Http sender legacy with batch_max_concurrent_send",
+			useHTTP:                true,
+			legacyMode:             true,
+			numberOfPipelines:      3,
+			serverless:             false,
+			expectedQueues:         3, // numberOfPipelines
+			expectedWorkers:        1, // 1 worker per queue
+			expectedMinConcurrency: 8,
+			expectedMaxConcurrency: 8,
+			batchMaxConcurrentSend: 8,
+		},
+		{
+			name:                   "Serverless default",
+			useHTTP:                true,
+			legacyMode:             false,
+			numberOfPipelines:      2,
+			serverless:             true,
+			expectedQueues:         1, // 1 queue
+			expectedWorkers:        2, // numberOfPipelines
+			expectedMinConcurrency: 1,
+			expectedMaxConcurrency: 1,
+			batchMaxConcurrentSend: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+		},
+		{
+			name:                   "Serverless legacy",
+			useHTTP:                true,
+			legacyMode:             true,
+			numberOfPipelines:      2,
+			serverless:             true,
+			expectedQueues:         2, // numberOfPipelines
+			expectedWorkers:        1, // 1 workers per queue
+			expectedMinConcurrency: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+			expectedMaxConcurrency: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+			batchMaxConcurrentSend: pkgconfigsetup.DefaultBatchMaxConcurrentSend,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			cfg := configmock.New(t)
+
+			endpoints := config.NewMockEndpointsWithOptions([]config.Endpoint{config.NewMockEndpoint()}, map[string]interface{}{
+				"use_http":                  tc.useHTTP,
+				"batch_max_concurrent_send": tc.batchMaxConcurrentSend,
+			})
+
+			mockFactory := newMockSenderFactory()
+			originalHTTPFactory := httpSenderFactory
+			originalTCPFactory := tcpSenderFactory
+			httpSenderFactory = mockFactory.NewHTTPSender
+			tcpSenderFactory = mockFactory.NewTCPSender
+			defer func() {
+				httpSenderFactory = originalHTTPFactory
+				tcpSenderFactory = originalTCPFactory
+			}()
+
+			destinationsContext := &client.DestinationsContext{}
+			auditor := auditor.NewNullAuditor()
+			diagnosticMessageReceiver := &diagnostic.BufferedMessageReceiver{}
+			status := statusinterface.NewStatusProviderMock()
+			compression := compressionfx.NewMockCompressor()
+
+			providerImpl := NewProvider(
+				tc.numberOfPipelines,
+				auditor,
+				diagnosticMessageReceiver,
+				nil, // processing rules
+				endpoints,
+				destinationsContext,
+				status,
+				nil, // hostname
+				cfg,
+				compression,
+				tc.legacyMode,
+				tc.serverless,
+			)
+			require.NotNil(t, providerImpl)
+
+			// Verify sender configuration
+			assert.Equal(t, tc.expectedQueues, mockFactory.queueCount, "incorrect queue count")
+			assert.Equal(t, tc.expectedWorkers, mockFactory.workersPerQueue, "incorrect workers per queue")
+			assert.Equal(t, tc.expectedMinConcurrency, mockFactory.minConcurrency, "incorrect min concurrency")
+			assert.Equal(t, tc.expectedMaxConcurrency, mockFactory.maxConcurrency, "incorrect max concurrency")
+			assert.Equal(t, tc.useHTTP, mockFactory.isHTTP, "incorrect sender type")
+
+			if tc.serverless {
+				assert.NotNil(t, mockFactory.senderDoneChan, "serverless should have senderDoneChan")
+				assert.NotNil(t, mockFactory.flushWg, "serverless should have flushWg")
+			} else {
+				assert.Nil(t, mockFactory.senderDoneChan, "non-serverless should not have senderDoneChan")
+				assert.Nil(t, mockFactory.flushWg, "non-serverless should not have flushWg")
+			}
+		})
 	}
 }
 
-func (suite *ProviderTestSuite) TestProvider() {
-	suite.a.Start()
-	suite.p.Start()
-	suite.Equal(uint32(0), suite.p.currentPipelineIndex.Load())
-	suite.Equal(3, len(suite.p.pipelines))
+func TestPipelineChannelDistribution(t *testing.T) {
+	tests := []struct {
+		name              string
+		numberOfPipelines int
+		expectedChannels  int
+	}{
+		{
+			name:              "single pipeline",
+			numberOfPipelines: 1,
+			expectedChannels:  1,
+		},
+		{
+			name:              "multiple pipelines",
+			numberOfPipelines: 3,
+			expectedChannels:  3,
+		},
+		{
+			name:              "many pipelines",
+			numberOfPipelines: 10,
+			expectedChannels:  10,
+		},
+	}
 
-	c := suite.p.NextPipelineChan()
-	suite.Equal(uint32(1), suite.p.currentPipelineIndex.Load())
-	suite.Equal(suite.p.pipelines[1].InputChan, c)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			cfg := configmock.New(t)
+			endpoints := config.NewMockEndpointsWithOptions([]config.Endpoint{config.NewMockEndpoint()}, map[string]interface{}{
+				"use_http": true,
+			})
 
-	c = suite.p.NextPipelineChan()
-	suite.Equal(uint32(2), suite.p.currentPipelineIndex.Load())
-	suite.Equal(suite.p.pipelines[2].InputChan, c)
+			destinationsContext := &client.DestinationsContext{}
+			auditor := auditor.NewNullAuditor()
+			diagnosticMessageReceiver := &diagnostic.BufferedMessageReceiver{}
+			status := statusinterface.NewStatusProviderMock()
+			compression := compressionfx.NewMockCompressor()
 
-	c = suite.p.NextPipelineChan()
-	suite.Equal(uint32(3), suite.p.currentPipelineIndex.Load())
-	suite.Equal(suite.p.pipelines[0].InputChan, c) // wraps
+			providerImpl := NewProvider(
+				tc.numberOfPipelines,
+				auditor,
+				diagnosticMessageReceiver,
+				nil, // processing rules
+				endpoints,
+				destinationsContext,
+				status,
+				nil, // hostname
+				cfg,
+				compression,
+				false, // legacy mode
+				false, // serverless
+			)
 
-	c = suite.p.NextPipelineChan()
-	suite.Equal(uint32(4), suite.p.currentPipelineIndex.Load())
-	suite.Equal(suite.p.pipelines[1].InputChan, c)
+			require.NotNil(t, providerImpl)
+			p := providerImpl.(*provider)
 
-	suite.p.Stop()
-	suite.a.Stop()
-	suite.Nil(suite.p.NextPipelineChan())
-}
+			// Start provider and verify pipelines
+			p.Start()
+			assert.Equal(t, tc.numberOfPipelines, len(p.pipelines))
 
-func TestProviderTestSuite(t *testing.T) {
-	suite.Run(t, new(ProviderTestSuite))
+			// Test pipeline channel distribution
+			seenChannels := make(map[chan *message.Message]struct{})
+			for i := 0; i < tc.numberOfPipelines*2; i++ {
+				ch := p.NextPipelineChan()
+				require.NotNil(t, ch)
+				seenChannels[ch] = struct{}{}
+			}
+			assert.Equal(t, tc.expectedChannels, len(seenChannels), "expected %d unique channels, got %d", tc.expectedChannels, len(seenChannels))
+
+			// Test NextPipelineChanWithMonitor
+			ch, monitor := p.NextPipelineChanWithMonitor()
+			require.NotNil(t, ch)
+			require.NotNil(t, monitor)
+
+			// Cleanup
+			p.Stop()
+			assert.Empty(t, p.pipelines)
+		})
+	}
 }

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -83,7 +83,7 @@ func NewSender(
 	}
 }
 
-// NewSenderV2 returns a new sender.
+// NewSenderV2 is the default implementation of the sender factory.
 func NewSenderV2(
 	config pkgconfigmodel.Reader,
 	auditor auditor.Auditor,
@@ -96,7 +96,6 @@ func NewSenderV2(
 	pipelineMonitor metrics.PipelineMonitor,
 ) *Sender {
 	var workers []*worker
-
 	if queueCount <= 0 {
 		queueCount = DefaultQueuesCount
 	}

--- a/pkg/security/reporter/reporter.go
+++ b/pkg/security/reporter/reporter.go
@@ -52,7 +52,21 @@ func newReporter(hostname string, stopper startstop.Stopper, sourceName, sourceT
 	stopper.Add(auditor)
 
 	// setup the pipeline provider that provides pairs of processor and sender
-	pipelineProvider := pipeline.NewProvider(4, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, context, &seccommon.NoopStatusProvider{}, hostnameimpl.NewHostnameService(), pkgconfigsetup.Datadog(), compression)
+	cfg := pkgconfigsetup.Datadog()
+	pipelineProvider := pipeline.NewProvider(
+		4,
+		auditor,
+		&diagnostic.NoopMessageReceiver{},
+		nil,
+		endpoints,
+		context,
+		&seccommon.NoopStatusProvider{},
+		hostnameimpl.NewHostnameService(),
+		cfg,
+		compression,
+		cfg.GetBool("logs_config.disable_distributed_senders"),
+		false, // serverless
+	)
 	pipelineProvider.Start()
 	stopper.Add(pipelineProvider)
 

--- a/releasenotes/notes/distributed-sender-537ecca5a9e62ae0.yaml
+++ b/releasenotes/notes/distributed-sender-537ecca5a9e62ae0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Utilize distributed senders and rtt fairness algorithms to improve logs pipeline throughput and fairness.

--- a/test/otel/go.mod
+++ b/test/otel/go.mod
@@ -5,10 +5,10 @@ go 1.23.0
 toolchain go1.23.6
 
 require (
-	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel
-	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.61.0
-	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-devel
-	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.61.0
+	github.com/DataDog/datadog-agent/comp/core/config v0.64.1
+	github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/comp/core/log/def v0.64.0-rc.3
+	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.64.0-rc.3
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.61.0
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.62.0-devel.0.20241213165407-f95df913d2b7
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.61.0
@@ -17,7 +17,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/setup v0.61.0
 	github.com/DataDog/datadog-agent/pkg/proto v0.64.0-rc.12
 	github.com/DataDog/datadog-agent/pkg/trace v0.64.0-rc.12
-	github.com/DataDog/datadog-agent/pkg/util/compression v0.56.0-rc.3
+	github.com/DataDog/datadog-agent/pkg/util/compression v0.64.0-rc.3
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.122.0
 )
 
@@ -49,8 +49,8 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.7 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.63.0 // indirect
-	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-devel // indirect
+	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/comp/serializer/logscompression v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
@@ -63,21 +63,21 @@ require (
 	github.com/DataDog/datadog-agent/pkg/config/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/fips v0.0.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/client v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/message v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/processor v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sds v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sender v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/sources v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/auditor v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/client v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/diagnostic v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/message v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/metrics v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/pipeline v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/processor v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sds v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sender v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/sources v0.64.0-rc.3 // indirect
+	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.63.0-devel.0.20250123185937-1feb84b482c8 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/status/health v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.61.0 // indirect


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR enables distributed sends/RTT fairness for the majority of the codebase. Log flow in this new system is slightly different for various flavors of the pipeline.

#### Original Architecture
![original](https://github.com/user-attachments/assets/78efb0c7-7681-4edb-be09-7d0b07df5446)

In the original architecture, every log pipeline would be associated with a single sender. That sender in turn pushed each of its received logs synchronously to the intake. This model worked well when the system was cpu bound rather than network bound, as that meant that the logs pipeline was the critical time sink and the sender entities would quickly spin through whatever log backlog existed. However, in systems where the transport time to the intake was a significant limiting factor, the synchronous nature of the sender was a major hurdle that could prevent what would otherwise be a timely transfer of logs.

In order to make the system more responsive in more use cases, three points of the sender have been expanded with the option of concurrent operation: the input queues, the queue processing logic, and the destination output connections. Different use of the system are set to utilize different points of concurrency. In order to mask this behavior to the caller, the first, universal change in the system architecture is to have every pipeline interact with a singular, shared sender object. This sender can be configured to perform the right level of concurrency at the right stage of the process.

#### HTTP Mode
![http](https://github.com/user-attachments/assets/b81f090d-7540-4348-89b6-2dacd5ee2f5b)

Log pipelines pointed at http-based intakes have opted to make use of concurrency in the destination entity, as follows:

All pipelines are funneled into a single queue and worker to allow for full sender utilization, regardless of how busy individual pipelines are or are not. Each individual destination entity in the sender will be able to send multiple http payloads simultaneously via the RTT fairness algorithm. Specifically, a "minWorker" value is calculated from the number of pipelines in the provider and a "maxWorker" value is calculated as 10 times the min. A target latency (150ms at this time) is established in the code, which is the latency the minimum worker count is expected to be able to handle. Observed latency higher than the target latency will prompt the worker count to increase at the same relative amount, e.g. an observed latency 2x higher than the target latency will prompt 2x workers, up to the max worker count. 

By default the minWorker component of the destination is set equal to the pipeline count, which mirrors the original behavior of having one sender per pipeline.


#### TCP Mode
![tcp](https://github.com/user-attachments/assets/a5fd6a62-0ba8-426c-b371-a085dda0bdb9)

Log pipelines pointed at tcp-based intakes have opted to make use of concurrency at the queue processing stage, as follows:

All pipelines are funneled into a single queue within the sender, and from there dispatched to one of several worker entities. Each workers funnels a log synchronously through the destinations (destination minWorkers == maxWorkers == 1). This system requires less of an overhaul in the tcp destination entity (which isn't widely utilized and doesn't actually support > 1 worker in its pool), but still allows a level of concurrency for each individual pipeline with the queue worker count.

By default, the queue worker count is set equal to the pipeline count, which mirrors the original behavior of having one sender per pipeline.

#### Legacy Mode
![legacy](https://github.com/user-attachments/assets/1d2b82f1-1518-4565-be7b-5615530a9346)

Legacy mode (enabled via the config flag logs_config.disable_distributed_senders) will attempt to mirror the original architecture's behavior while keeping the new control flow of the sender. It does this by making use of concurrency at the queue level, as follows:

All pipelines pull a queue from the sender to pipe their output into. With legacy mode enabled, this queue will be distinct per pipeline, and every entity listening from a given queue will have concurrency set to 1 (e.g. queue worker count = 1 and destination max workers = 1). This setup is important for some systems that might not want to introduce concurrency to the logs pipeline because said concurrency will disrupt log ordering guarantees. 

#### Configuration
In addition to the new configuration option `logs_config.disable_distributed_senders`, the endpoint's `batch_max_concurrent_sends` configuration option has been integrated in to the new architecture. Agents with this option set (as a reasonable number of them do in the wild) will adjust worker pool behavior for HTTP Mode and Legacy Mode. In HTTP, a given value of x for `batch_max_concurrent_sends` will set minWorkers == maxWorkers == numberOfPipelines * `batch_max_concurrent_sends`. This is the closest reasonable mirror to the setting's impact on current production code, which produces an equivalent amount of HTTP workers spread out over a number of senders. Similarly, Legacy mode will set minWorkers == maxWorkers == `batch_max_concurrent_sends` for each of its numberOfPipelines senders. 

Utilizing this configuration as the primary method for worker adjustment comes with a bit of a tradeoff, as a user who is trying to optimize for 6 workers with the default 4 pipelines can instead only choose between 4 (`batch_max_concurrent_sends` = 1) or 8 (`batch_max_concurrent_sends` = 2). This has been judged a reasonable tradeoff for the foreseeable future, as the current architecture's behavior is no different and having excess workers allocated shouldn't translate to a noticeable resource waste.

### Motivation
Distributing the senders amongst the pipelines with an RTT fairness algorithm backing a large default concurrency increase will allow for a much larger throughput of logs data in systems operating under heavy load and high latency. Example throughput change in SMP's file_to_blackhole_1000ms_latency_linear_load regression test:
![image](https://github.com/user-attachments/assets/41e64cfd-31cd-487e-a99c-24df4498d20b)

We also see noticeable decreased RSS usage for systems under a reasonable amount of load but experiencing moderately high latency. Example RSS change in SMP's file_to_blackhole_500ms_latency regression test:
![image](https://github.com/user-attachments/assets/53470d0d-3cbd-4126-a677-aa7252125e5c)



### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Extensive performance testing had a byproduct of serving as useful correctness verification. Unit tests have been expanded where necessary to lock down specific behaviors. A number of cases have additionally been verified by hand, including reliable endpoint behavior, connection reuse for http, and destination worker reset on 429 http responses.

### Possible Drawbacks / Trade-offs
Increased connections to datadog's fabric as a result of the increased destination concurrency will be mitigated by the enablement of http2 in the fleet, but nonzero. The latency threshold after which connection counts will increase was chosen to reduce the chance of seeing a large increase in connections on release.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
For record keeping purposes, the PRs that built the underlying framework for this change are
https://github.com/DataDog/datadog-agent/pull/35351
https://github.com/DataDog/datadog-agent/pull/35329
https://github.com/DataDog/datadog-agent/pull/35483
https://github.com/DataDog/datadog-agent/pull/35685
https://github.com/DataDog/datadog-agent/pull/35374