### PR TITLE
feat(autoinstrumentation): support `valueFrom`

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -304,16 +304,19 @@ func (n NamespaceSelector) AsLabelSelector() (labels.Selector, error) {
 // variables to the workload that matches targeting.
 type TracerConfig struct {
 	// Name is the name of the environment variable.
-	Name string `mapstructure:"name" json:"name"`
+	Name string `json:"name,omitempty"`
 	// Value is the value to use.
-	Value string `mapstructure:"value" json:"value"`
+	Value string `json:"value,omitempty"`
+	// ValueFrom is the source for the environment variable's value.
+	ValueFrom *corev1.EnvVarSource `json:"valueFrom,omitempty"`
 }
 
 // AsEnvVar converts the TracerConfig to a corev1.EnvVar.
 func (c *TracerConfig) AsEnvVar() corev1.EnvVar {
 	return corev1.EnvVar{
-		Name:  c.Name,
-		Value: c.Value,
+		Name:      c.Name,
+		Value:     c.Value,
+		ValueFrom: c.ValueFrom,
 	}
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -368,6 +368,24 @@ func TestTargetEnvVar(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "target with env valueFrom",
+			expected: []Target{
+				{
+					Name: "default-target",
+					TracerConfigs: []TracerConfig{
+						{
+							Name: "DD_SERVICE",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "metadata.labels['foo-bar']",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 )
@@ -158,6 +159,33 @@ func TestNewInstrumentationConfig(t *testing.T) {
 							{
 								Name:  "DD_DATA_JOBS_ENABLED",
 								Value: "true",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:       "can provide DD_SERVICE from arbitrary label",
+			configPath: "testdata/filter_service_env_var_from.yaml",
+			expected: &InstrumentationConfig{
+				Enabled:            true,
+				EnabledNamespaces:  []string{},
+				DisabledNamespaces: []string{},
+				InjectorImageTag:   "0",
+				Version:            "v2",
+				LibVersions:        map[string]string{},
+				Targets: []Target{
+					{
+						Name: "name-services",
+						TracerConfigs: []TracerConfig{
+							{
+								Name: "DD_SERVICE",
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "metadata.labels['app.kubernetes.io/name']",
+									},
+								},
 							},
 						},
 					},

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_service_env_var_from.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_service_env_var_from.yaml
@@ -1,0 +1,11 @@
+---
+apm_config:
+  instrumentation:
+    enabled: true
+    targets:
+      - name: "name-services"
+        ddTraceConfigs:
+          - name: "DD_SERVICE"
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['app.kubernetes.io/name']

--- a/releasenotes-dca/notes/autoinstru-value-from-31d1e9b41d52dcfd.yaml
+++ b/releasenotes-dca/notes/autoinstru-value-from-31d1e9b41d52dcfd.yaml
@@ -8,6 +8,6 @@
 ---
 features:
   - |
-    For workload selection in autoinstrumentation, users can now use kubernetes native ``valueFrom``
-    as an alternative to ``value`` in ``ddTraceConfigs``, which enabled dynamic, user-defined label
-    based value propagation to the tracing SDKs, like ``DD_SERVICE``.
+    For workload selection in auto-instrumentation, users can now use the Kubernetes native ``valueFrom``
+    as an alternative to ``value`` in ``ddTraceConfigs``. This enables dynamic, user-defined and label
+   -based value propagation to the tracing SDKs, like ``DD_SERVICE``.

--- a/releasenotes-dca/notes/autoinstru-value-from-31d1e9b41d52dcfd.yaml
+++ b/releasenotes-dca/notes/autoinstru-value-from-31d1e9b41d52dcfd.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    For workload selection in autoinstrumentation, users can now use kubernetes native ``valueFrom``
+    as an alternative to ``value`` in ``ddTraceConfigs``, which enabled dynamic, user-defined label
+    based value propagation to the tracing SDKs, like ``DD_SERVICE``.


### PR DESCRIPTION
### What does this PR do?

Workload selection targets allow us to specify environment variables as specified by the trace configs. This is built directly on top of the kubernetes `EnvVar` struct. This change adds compatibility for `valueFrom` so that users can configure datadog to pull these values from _any_ arbitrary label they need.

Because we are forwarding/using kubernetes basic building blocks here we can support everything that k8s supports here by re-using the same structs.

### Motivation

We want to give users the ability to configure their service names using datadog and _without_ having to label their infrastructure. 

This expands on the already present support for `DD_` environment variables in autoinstrumentation workload targets to include `valueFrom`.

### Describe how you validated your changes

Using [`injector-dev`](https://github.com/DataDog/injector-dev) and the following scenario:

```yaml
helm:
  apps:
  - name: python
    namespace: application
    values:
      env:
      - name: DD_TRACE_DEBUG
        value: "true"
      - name: DD_APM_INSTRUMENTATION_DEBUG
        value: "true"
      podLabels:
        tags.datadoghq.com/env: local
        i-set-this-one: "fancy"
  versions:
    agent: 7.64.1
    cluster_agent: v59963805-583609e0-arm64
    injector: "0.35.0"
  config:
    datadog:
      apm:
        instrumentation:
          enabled: true
          targets:
            - name: "service-named"
              ddTraceVersions:
                python: "default"
              ddTraceConfigs:
                - name: "DD_SERVICE"
                  valueFrom:
                    fieldRef:
                      fieldPath: "metadata.labels['i-set-this-one']"
```

I can see this work as expected: 

<img width="766" alt="Screenshot 2025-03-25 at 5 24 23 PM" src="https://github.com/user-attachments/assets/9250efa4-8b23-4bcc-bc27-ef803f656f27" />

### Possible Drawbacks / Trade-offs

??

### Additional Notes

- `mapstructure` is not-used when we're using `json` tags per: https://github.com/DataDog/datadog-agent/blob/fadb2983d96a1869cc6748396894cc85faf3fbd1/pkg/config/structure/unmarshal.go#L156-L166
