### PR TITLE
Remove single_machine_performance-full-amd64-a7

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -73,19 +73,6 @@ single_machine_performance-amd64-a7:
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
     IMG_DESTINATIONS: 08450328-agent:${CI_COMMIT_SHA}-7-amd64
 
-single_machine_performance-full-amd64-a7:
-  extends: .docker_publish_job_definition
-  stage: container_build
-  rules:
-    - !reference [.except_mergequeue]
-    - when: on_success
-  needs:
-    - docker_build_agent7_full
-  variables:
-    IMG_REGISTRIES: internal-aws-smp
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64
-    IMG_DESTINATIONS: 08450328-agent:${CI_COMMIT_SHA}-7-full-amd64
-
 docker_build_agent7_arm64:
   extends: [.docker_build_job_definition_arm64, .docker_build_artifact]
   rules:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove `single_machine_performance-full-amd64-a7` job

### Motivation
Avoid creating unnecessary docker images in SMP registry.
Note: I have to investigate why there is a regression on https://github.com/DataDog/datadog-agent/pull/35185. As I cannot merge it quickly I decided to remove `single_machine_performance-full-amd64-a7`

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->