### PR TITLE
[CWS] Improve error message when we failed to download policies

### DIFF
--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"runtime"
@@ -720,13 +721,37 @@ func downloadPolicy(log log.Component, config config.Component, _ secrets.Compon
 	}
 
 	ctx := context.Background()
-	res, err := httputils.Get(ctx, downloadURL, headers, 10*time.Second, config)
+
+	client := http.Client{
+		Transport: httputils.CreateHTTPTransport(config),
+		Timeout:   10 * time.Second,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return err
 	}
 
+	for header, value := range headers {
+		req.Header.Add(header, value)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	resBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("failed to download policies: %s (error code %d)", string(resBytes), res.StatusCode)
+	}
+	defer res.Body.Close()
+
 	// Unzip the downloaded file containing both default and custom policies
-	resBytes := []byte(res)
 	reader, err := zip.NewReader(bytes.NewReader(resBytes), int64(len(resBytes)))
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Display error returned by the backend when we failed to download policies.

### Motivation

Error messages returned by the backend (for instance for a 403 error when using a scoped app key)
were not properly surfaced to the user.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->