### PR TITLE
fix(add_reviewers): Use GH App and remove cache

### DIFF
--- a/.github/workflows/add_reviewer_bot_pr.yml
+++ b/.github/workflows/add_reviewer_bot_pr.yml
@@ -26,9 +26,13 @@ jobs:
   add_reviewers:
     if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1.11.6
+        id: app-token
+        with:
+          app-id: ${{ vars.DD_GITHUB_TOKEN_GENERATOR_APP_ID }}
+          private-key: ${{ secrets.DD_GITHUB_TOKEN_GENERATOR_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -38,8 +42,6 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version-file: .python-version
-          cache: 'pip'
-          cache-dependency-path: '.dda/version'
 
       - name: Install dda
         uses: ./.github/actions/install-dda
@@ -49,5 +51,5 @@ jobs:
       - name: Add reviewers
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: dda inv -e issue.add-reviewers -p $PR_NUMBER


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Use a token generated from the Github App instead of the `GITHUB_TOKEN`
- Remove usage of the cache

### Motivation
We are experiencing 2 failures in this workflow currently:
- Problem [when adding reviewers](https://github.com/DataDog/datadog-agent/actions/runs/14080995556/job/39433716665?pr=35431)
- Problem when handling [post operations on cache](https://github.com/DataDog/datadog-agent/actions/runs/14080559453/job/39432348694?pr=35456)

The first situation is most probably because of a permission issue with the GITHUB_TOKEN (see [here](https://github.com/peter-evans/create-pull-request/issues/155))
The second one is probably linked to the `dda` migration and the way we handle dependencies. I deactivate the cache in this workflow pending a better solution.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->