### PR TITLE
[CWS] use system-probe runtime CLI in new e2e tests

### DIFF
--- a/test/new-e2e/tests/cws/common.go
+++ b/test/new-e2e/tests/cws/common.go
@@ -36,8 +36,8 @@ const (
 	// systemProbeStartLog is the log corresponding to a successful start of the system-probe
 	systemProbeStartLog = "runtime security started"
 
-	// securityAgentPath is the path of the security-agent binary
-	securityAgentPath = "/opt/datadog-agent/embedded/bin/security-agent"
+	// systemProbePath is the path of the system-probe binary
+	systemProbePath = "/opt/datadog-agent/embedded/bin/system-probe"
 
 	// policiesPath is the path of the default runtime security policies
 	policiesPath = "/etc/datadog-agent/runtime-security.d/test.policy"
@@ -157,7 +157,7 @@ func (a *agentSuite) Test03OpenSignal() {
 
 	var policies string
 	require.EventuallyWithT(a.T(), func(c *assert.CollectT) {
-		policies = a.Env().RemoteHost.MustExecute(fmt.Sprintf("DD_APP_KEY=%s DD_API_KEY=%s %s runtime policy download >| temp.txt && cat temp.txt", appKey, apiKey, securityAgentPath))
+		policies = a.Env().RemoteHost.MustExecute(fmt.Sprintf("DD_APP_KEY=%s DD_API_KEY=%s %s runtime policy download >| temp.txt && cat temp.txt", appKey, apiKey, systemProbePath))
 		assert.NotEmpty(c, policies, "should not be empty")
 	}, 1*time.Minute, 1*time.Second)
 
@@ -170,7 +170,7 @@ func (a *agentSuite) Test03OpenSignal() {
 	require.Contains(a.T(), policiesFile, desc, "The policies file should contain the created rule")
 
 	// Reload policies
-	a.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo %s runtime policy reload", securityAgentPath))
+	a.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo %s runtime policy reload", systemProbePath))
 
 	// Check if the policy is loaded
 	policyName := path.Base(policiesPath)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR migrates the new CWS e2e tests to use the system-probe binary to do `runtime policy download` and `runtime policy reload` operations.

This is part of the plan to deprecate and remove the `security-agent runtime` CLI.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->