### PR TITLE
[Backport 7.65.x] Fix flaky OTel e2e tests using telemetrygen (#35072)

### DIFF
--- a/test/new-e2e/tests/otel/otel-agent/receive_resource_spans_v2_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/receive_resource_spans_v2_test.go
@@ -39,7 +39,7 @@ agents:
 
 func (s *otelAgentSpanReceiverV2TestSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
-	utils.SetupSampleTraces(s)
+	utils.TestCalendarApp(s, false, utils.CalendarService)
 }
 
 func (s *otelAgentSpanReceiverV2TestSuite) TestTracesWithSpanReceiverV2() {

--- a/test/new-e2e/tests/otel/otel-agent/sampling_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/sampling_test.go
@@ -30,6 +30,11 @@ func TestOTelAgentSampling(t *testing.T) {
 	e2e.Run(t, &samplingTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(samplingConfig)))))
 }
 
+func (s *samplingTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	utils.TestCalendarApp(s, false, utils.CalendarService)
+}
+
 func (s *samplingTestSuite) TestSampling() {
 	utils.TestSampling(s, true)
 }

--- a/test/new-e2e/tests/otel/otlp-ingest/operation_and_resource_name_logic_v2_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/operation_and_resource_name_logic_v2_test.go
@@ -46,11 +46,11 @@ agents:
 
 func (s *otlpIngestOpNameV2RecvrV1TestSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
-	utils.SetupSampleTraces(s)
+	utils.TestCalendarApp(s, false, utils.CalendarService)
 }
 
 func (s *otlpIngestOpNameV2RecvrV1TestSuite) TestTraces() {
-	utils.TestTracesWithOperationAndResourceName(s, "client.request", "lets-go", "server.request", "okey-dokey-0")
+	utils.TestTracesWithOperationAndResourceName(s, "client.request", "getDate", "http.server.request", "GET")
 }
 
 type otlpIngestOpNameV2RecvrV2TestSuite struct {
@@ -83,11 +83,11 @@ agents:
 
 func (s *otlpIngestOpNameV2RecvrV2TestSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
-	utils.SetupSampleTraces(s)
+	utils.TestCalendarApp(s, false, utils.CalendarService)
 }
 
 func (s *otlpIngestOpNameV2RecvrV2TestSuite) TestTraces() {
-	utils.TestTracesWithOperationAndResourceName(s, "client.request", "lets-go", "server.request", "okey-dokey-0")
+	utils.TestTracesWithOperationAndResourceName(s, "client.request", "getDate", "http.server.request", "GET")
 }
 
 type otlpIngestOpNameV2SpanAsResNameTestSuite struct {
@@ -122,11 +122,11 @@ agents:
 
 func (s *otlpIngestOpNameV2SpanAsResNameTestSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
-	utils.SetupSampleTraces(s)
+	utils.TestCalendarApp(s, false, utils.CalendarService)
 }
 
 func (s *otlpIngestOpNameV2SpanAsResNameTestSuite) TestTraces() {
-	utils.TestTracesWithOperationAndResourceName(s, "lets_go", "lets-go", "okey_dokey_0", "okey-dokey-0")
+	utils.TestTracesWithOperationAndResourceName(s, "getDate", "getDate", "CalendarHandler", "GET")
 }
 
 type otlpIngestOpNameV2RemappingTestSuite struct {
@@ -153,7 +153,7 @@ agents:
         - name: DD_APM_FEATURES
           value: 'enable_operation_and_resource_name_logic_v2'
         - name: DD_OTLP_CONFIG_TRACES_SPAN_NAME_REMAPPINGS
-          value: '{"telemetrygen.client":"mapping.output","server.request":"telemetrygen.server"}'
+          value: '{"calendar-rest-go.client":"mapping.output","go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.server":"calendar.server"}'
 `
 	t.Parallel()
 	ts := &otlpIngestOpNameV2RemappingTestSuite{}
@@ -162,9 +162,9 @@ agents:
 
 func (s *otlpIngestOpNameV2RemappingTestSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
-	utils.SetupSampleTraces(s)
+	utils.TestCalendarApp(s, false, utils.CalendarService)
 }
 
 func (s *otlpIngestOpNameV2RemappingTestSuite) TestTraces() {
-	utils.TestTracesWithOperationAndResourceName(s, "mapping.output", "lets-go", "telemetrygen.server", "okey-dokey-0")
+	utils.TestTracesWithOperationAndResourceName(s, "mapping.output", "getDate", "calendar.server", "GET")
 }

--- a/test/new-e2e/tests/otel/otlp-ingest/pipelines_sampling_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/pipelines_sampling_test.go
@@ -49,6 +49,11 @@ agents:
 	e2e.Run(t, &otlpIngestSamplingTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values)))))
 }
 
+func (s *otlpIngestSamplingTestSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	utils.TestCalendarApp(s, false, utils.CalendarService)
+}
+
 func (s *otlpIngestSamplingTestSuite) TestSampling() {
 	utils.TestSampling(s, false)
 }

--- a/test/new-e2e/tests/otel/otlp-ingest/receive_resource_spans_v2_test.go
+++ b/test/new-e2e/tests/otel/otlp-ingest/receive_resource_spans_v2_test.go
@@ -6,13 +6,13 @@
 package otlpingest
 
 import (
-	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
 	"testing"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/otel/utils"
 )
 
@@ -46,7 +46,7 @@ agents:
 
 func (s *otlpIngestSpanReceiverV2TestSuite) SetupSuite() {
 	s.BaseSuite.SetupSuite()
-	utils.SetupSampleTraces(s)
+	utils.TestCalendarApp(s, false, utils.CalendarService)
 }
 
 func (s *otlpIngestSpanReceiverV2TestSuite) TestTracesWithSpanReceiverV2() {

--- a/test/new-e2e/tests/otel/utils/docker_pipelines_utils.go
+++ b/test/new-e2e/tests/otel/utils/docker_pipelines_utils.go
@@ -82,7 +82,11 @@ func TestTracesDocker(s OTelDockerTestSuite) {
 		assert.Equal(s.T(), env, sp.Meta["env"])
 		assert.Equal(s.T(), version, sp.Meta["version"])
 		assert.Equal(s.T(), customAttributeValue, sp.Meta[customAttribute])
-		assert.Equal(s.T(), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp", sp.Meta["otel.library.name"])
+		if sp.Meta["span.kind"] == "client" {
+			assert.Equal(s.T(), "calendar-rest-go", sp.Meta["otel.library.name"])
+		} else {
+			assert.Equal(s.T(), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp", sp.Meta["otel.library.name"])
+		}
 		assert.Equal(s.T(), traces[0].HostName, tp.Hostname)
 	}
 }

--- a/test/new-e2e/tests/otel/utils/pipelines_utils.go
+++ b/test/new-e2e/tests/otel/utils/pipelines_utils.go
@@ -18,14 +18,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
 	fakeintake "github.com/DataDog/datadog-agent/test/fakeintake/client"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
@@ -33,15 +31,14 @@ import (
 
 const (
 	// CalendarService is the default service value for the calendar app
-	CalendarService = "calendar-rest-go"
+	CalendarService          = "calendar-rest-go"
+	calendarTopLevelResource = "GET"
 
-	telemetrygenService          = "telemetrygen-job"
-	telemetrygenTopLevelResource = "lets-go"
-	env                          = "e2e"
-	version                      = "1.0"
-	customAttribute              = "custom.attribute"
-	customAttributeValue         = "true"
-	logBody                      = "random date"
+	env                  = "e2e"
+	version              = "1.0"
+	customAttribute      = "custom.attribute"
+	customAttributeValue = "true"
+	logBody              = "random date"
 )
 
 // OTelTestSuite is an interface for the OTel e2e test suite.
@@ -110,8 +107,12 @@ func TestTraces(s OTelTestSuite, iaParams IAParams) {
 		assert.Equal(s.T(), env, sp.Meta["env"])
 		assert.Equal(s.T(), version, sp.Meta["version"])
 		assert.Equal(s.T(), customAttributeValue, sp.Meta[customAttribute])
-		assert.Equal(s.T(), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp", sp.Meta["otel.library.name"])
 		assert.Equal(s.T(), sp.Meta["k8s.node.name"], tp.Hostname)
+		if sp.Meta["span.kind"] == "client" {
+			assert.Equal(s.T(), "calendar-rest-go", sp.Meta["otel.library.name"])
+		} else {
+			assert.Equal(s.T(), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp", sp.Meta["otel.library.name"])
+		}
 		ctags, ok := getContainerTags(s.T(), tp)
 		assert.True(s.T(), ok)
 		assert.Equal(s.T(), sp.Meta["k8s.container.name"], ctags["kube_container_name"])
@@ -128,17 +129,17 @@ func TestTraces(s OTelTestSuite, iaParams IAParams) {
 
 // TestTracesWithSpanReceiverV2 tests that OTLP traces are received through OTel pipelines as expected with updated OTLP span receiver
 func TestTracesWithSpanReceiverV2(s OTelTestSuite) {
-	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-	require.NoError(s.T(), err)
-
+	var err error
 	var traces []*aggregator.TracePayload
 	s.T().Log("Waiting for traces")
 	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		traces, err = s.Env().FakeIntake.Client().GetTraces()
 		if !assert.NoError(c, err) {
+			s.T().Log("Error getting traces", s.T().Name(), err)
 			return
 		}
 		if !assert.NotEmpty(c, traces) {
+			s.T().Log("Traces empty", s.T().Name())
 			return
 		}
 		trace := traces[0]
@@ -152,7 +153,7 @@ func TestTracesWithSpanReceiverV2(s OTelTestSuite) {
 		if !assert.NotEmpty(s.T(), tp.Chunks[0].Spans) {
 			return
 		}
-		assert.Equal(s.T(), telemetrygenService, tp.Chunks[0].Spans[0].Service)
+		assert.Equal(s.T(), CalendarService, tp.Chunks[0].Spans[0].Service)
 	}, 5*time.Minute, 10*time.Second)
 	require.NotEmpty(s.T(), traces)
 	s.T().Log("Got traces", s.T().Name(), traces)
@@ -161,35 +162,35 @@ func TestTracesWithSpanReceiverV2(s OTelTestSuite) {
 	tp := traces[0].TracerPayloads[0]
 	assert.Equal(s.T(), env, tp.Env)
 	assert.Equal(s.T(), version, tp.AppVersion)
-	assert.Empty(s.T(), tp.ContainerID)
 	require.NotEmpty(s.T(), tp.Chunks)
 	require.NotEmpty(s.T(), tp.Chunks[0].Spans)
 	spans := tp.Chunks[0].Spans
 	ctags, ok := getContainerTags(s.T(), tp)
 
 	for _, sp := range spans {
-		assert.Equal(s.T(), telemetrygenService, sp.Service)
+		assert.Equal(s.T(), CalendarService, sp.Service)
 		assert.Equal(s.T(), env, sp.Meta["env"])
 		assert.Equal(s.T(), version, sp.Meta["version"])
 		assert.Equal(s.T(), customAttributeValue, sp.Meta[customAttribute])
 		if sp.Meta["span.kind"] == "client" {
 			assert.Equal(s.T(), "client.request", sp.Name)
-			assert.Equal(s.T(), "lets-go", sp.Resource)
+			assert.Equal(s.T(), "getDate", sp.Resource)
 			assert.Equal(s.T(), "http", sp.Type)
-			assert.Zero(s.T(), sp.ParentID)
-		} else {
-			assert.Equal(s.T(), "server", sp.Meta["span.kind"])
-			assert.Equal(s.T(), "server.request", sp.Name)
-			assert.Equal(s.T(), "okey-dokey-0", sp.Resource)
-			assert.Equal(s.T(), "web", sp.Type)
 			assert.IsType(s.T(), uint64(0), sp.ParentID)
 			assert.NotZero(s.T(), sp.ParentID)
+			assert.Equal(s.T(), "calendar-rest-go", sp.Meta["otel.library.name"])
+		} else {
+			assert.Equal(s.T(), "server", sp.Meta["span.kind"])
+			assert.Equal(s.T(), "http.server.request", sp.Name)
+			assert.Equal(s.T(), "GET", sp.Resource)
+			assert.Equal(s.T(), "web", sp.Type)
+			assert.Zero(s.T(), sp.ParentID)
+			assert.Equal(s.T(), "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp", sp.Meta["otel.library.name"])
 		}
 		assert.IsType(s.T(), uint64(0), sp.TraceID)
 		assert.NotZero(s.T(), sp.TraceID)
 		assert.IsType(s.T(), uint64(0), sp.SpanID)
 		assert.NotZero(s.T(), sp.SpanID)
-		assert.Equal(s.T(), "telemetrygen", sp.Meta["otel.library.name"])
 		assert.Equal(s.T(), sp.Meta["k8s.node.name"], tp.Hostname)
 		assert.True(s.T(), ok)
 		assert.Equal(s.T(), sp.Meta["k8s.container.name"], ctags["kube_container_name"])
@@ -206,17 +207,17 @@ func TestTracesWithOperationAndResourceName(
 	serverOperationName string,
 	serverResourceName string,
 ) {
-	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-	require.NoError(s.T(), err)
-
+	var err error
 	var traces []*aggregator.TracePayload
 	s.T().Log("Waiting for traces")
 	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		traces, err = s.Env().FakeIntake.Client().GetTraces()
 		if !assert.NoError(c, err) {
+			s.T().Log("Error getting traces", s.T().Name(), err)
 			return
 		}
 		if !assert.NotEmpty(c, traces) {
+			s.T().Log("Traces empty", s.T().Name())
 			return
 		}
 		trace := traces[0]
@@ -230,7 +231,7 @@ func TestTracesWithOperationAndResourceName(
 		if !assert.NotEmpty(s.T(), tp.Chunks[0].Spans) {
 			return
 		}
-		assert.Equal(s.T(), telemetrygenService, tp.Chunks[0].Spans[0].Service)
+		assert.Equal(s.T(), CalendarService, tp.Chunks[0].Spans[0].Service)
 	}, 5*time.Minute, 10*time.Second)
 	require.NotEmpty(s.T(), traces)
 	s.T().Log("Got traces", s.T().Name(), traces)
@@ -386,38 +387,35 @@ func TestHosts(s OTelTestSuite) {
 
 // TestSampling tests that APM stats are correct when using probabilistic sampling
 func TestSampling(s OTelTestSuite, computeTopLevelBySpanKind bool) {
-	SetupSampleTraces(s)
-
-	TestAPMStats(s, 10, computeTopLevelBySpanKind)
-}
-
-// TestAPMStats checks that APM stats are received with the correct number of hits per traces given
-func TestAPMStats(s OTelTestSuite, numTraces int, computeTopLevelBySpanKind bool) {
 	s.T().Log("Waiting for APM stats")
 	var stats []*aggregator.APMStatsPayload
 	var err error
 	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		stats, err = s.Env().FakeIntake.Client().GetAPMStats()
-		assert.NoError(c, err)
-		assert.NotEmpty(c, stats)
+		require.NoError(c, err)
+		require.NotEmpty(c, stats)
 		hasStatsForService := false
 		for _, payload := range stats {
 			for _, csp := range payload.StatsPayload.Stats {
 				for _, bucket := range csp.Stats {
 					for _, cgs := range bucket.Stats {
-						if cgs.Service == telemetrygenService {
+						if cgs.Service == CalendarService {
 							hasStatsForService = true
-							assert.EqualValues(c, cgs.Hits, numTraces)
-							if computeTopLevelBySpanKind || cgs.Resource == telemetrygenTopLevelResource {
-								assert.EqualValues(c, cgs.TopLevelHits, numTraces)
+							// TODO: Add functionality in example app to verify exact number of hits
+							require.True(c, cgs.Hits > 0)
+							if computeTopLevelBySpanKind && cgs.SpanKind == "client" {
+								require.EqualValues(c, cgs.TopLevelHits, 0)
+							}
+							if (computeTopLevelBySpanKind && cgs.SpanKind == "server") || cgs.Resource == calendarTopLevelResource {
+								require.EqualValues(c, cgs.Hits, cgs.TopLevelHits)
 							}
 						}
 					}
 				}
 			}
 		}
-		assert.True(c, hasStatsForService)
-	}, 2*time.Minute, 10*time.Second)
+		require.True(c, hasStatsForService)
+	}, 5*time.Minute, 10*time.Second)
 	s.T().Log("Got APM stats", stats)
 }
 
@@ -567,78 +565,6 @@ func TestLoadBalancing(s OTelTestSuite) {
 	}
 }
 
-// SetupSampleTraces flushes the intake server and starts a telemetrygen job to generate traces
-func SetupSampleTraces(s OTelTestSuite) {
-	flake.Mark(s.T())
-	ctx := context.Background()
-	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
-	require.NoError(s.T(), err)
-	numTraces := 10
-
-	s.T().Log("Starting telemetrygen")
-	createTelemetrygenJob(ctx, s, "traces", []string{"--traces", fmt.Sprint(numTraces)})
-}
-
-func createTelemetrygenJob(ctx context.Context, s OTelTestSuite, telemetry string, options []string) {
-	var ttlSecondsAfterFinished int32 = 0 //nolint:revive // We want to see this is explicitly set to 0
-	var backOffLimit int32 = 4
-
-	otlpEndpoint := fmt.Sprintf("%v:4317", s.Env().Agent.LinuxNodeAgent.LabelSelectors["app"])
-	jobSpec := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("telemetrygen-job-%v-%v", telemetry, strings.ReplaceAll(strings.ToLower(s.T().Name()), "/", "-")),
-			Namespace: "datadog",
-		},
-		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: &ttlSecondsAfterFinished,
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Env: []corev1.EnvVar{{
-								Name:  "OTEL_SERVICE_NAME",
-								Value: telemetrygenService,
-							}, {
-								Name:      "OTEL_K8S_POD_ID",
-								ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"}},
-							}, {
-								Name:      "OTEL_K8S_NAMESPACE",
-								ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
-							}, {
-								Name:      "OTEL_K8S_NODE_NAME",
-								ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"}},
-							}, {
-								Name:      "OTEL_K8S_POD_NAME",
-								ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}},
-							}},
-							Name:  "telemetrygen-job",
-							Image: "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.107.0",
-							Command: append([]string{
-								"/telemetrygen", telemetry, "--otlp-endpoint", otlpEndpoint, "--otlp-insecure",
-								"--telemetry-attributes", fmt.Sprintf("%v=%v", customAttribute, customAttributeValue),
-								"--telemetry-attributes", "k8s.pod.uid=\"$(OTEL_K8S_POD_ID)\"",
-								"--otlp-attributes", "service.name=\"$(OTEL_SERVICE_NAME)\"",
-								"--otlp-attributes", "host.name=\"$(OTEL_K8S_NODE_NAME)\"",
-								"--otlp-attributes", fmt.Sprintf("deployment.environment=\"%v\"", env),
-								"--otlp-attributes", fmt.Sprintf("service.version=\"%v\"", version),
-								"--otlp-attributes", "k8s.namespace.name=\"$(OTEL_K8S_NAMESPACE)\"",
-								"--otlp-attributes", "k8s.node.name=\"$(OTEL_K8S_NODE_NAME)\"",
-								"--otlp-attributes", "k8s.pod.name=\"$(OTEL_K8S_POD_NAME)\"",
-								"--otlp-attributes", "k8s.container.name=\"telemetrygen-job\"",
-							}, options...),
-						},
-					},
-					RestartPolicy: corev1.RestartPolicyNever,
-				},
-			},
-			BackoffLimit: &backOffLimit,
-		},
-	}
-
-	_, err := s.Env().KubernetesCluster.Client().BatchV1().Jobs("datadog").Create(ctx, jobSpec, metav1.CreateOptions{})
-	require.NoError(s.T(), err, "Could not properly start job")
-}
-
 // TestCalendarApp starts the calendar app to send telemetry for e2e tests
 func TestCalendarApp(s OTelTestSuite, ust bool, service string) {
 	ctx := context.Background()
@@ -728,7 +654,7 @@ func createCalendarApp(ctx context.Context, s OTelTestSuite, ust bool, service s
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:            name,
-						Image:           "ghcr.io/datadog/apps-calendar-go:main",
+						Image:           "ghcr.io/datadog/apps-calendar-go:main@sha256:5334a3b5940aa2a213a5c8970cc8d91899deafddf32e8df27cb0441dd9d4bc0f",
 						ImagePullPolicy: "IfNotPresent",
 						Ports: []corev1.ContainerPort{{
 							Name:          "http",


### PR DESCRIPTION
(cherry picked from commit 89cf9a048c59ad56e480f6b476aa7364d46f2dc3)

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Backport https://github.com/DataDog/datadog-agent/pull/35072 to 7.65.x

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->