### PR TITLE
WMeta: normalize gpu tags retrieved from the tagger

### DIFF
--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -623,9 +623,9 @@ func (c *WorkloadMetaCollector) handleGPU(ev workloadmeta.Event) []*types.TagInf
 
 	tagList := taglist.NewTagList()
 
-	tagList.AddLow(tags.KubeGPUVendor, gpu.Vendor)
-	tagList.AddLow(tags.KubeGPUDevice, gpu.Device)
-	tagList.AddLow(tags.KubeGPUUUID, gpu.ID)
+	tagList.AddLow(tags.KubeGPUVendor, strings.ToLower(gpu.Vendor))
+	tagList.AddLow(tags.KubeGPUDevice, strings.ToLower(strings.ReplaceAll(gpu.Device, " ", "-")))
+	tagList.AddLow(tags.KubeGPUUUID, strings.ToLower(gpu.ID))
 	tagList.AddLow(tags.GPUDriverVersion, gpu.DriverVersion)
 
 	low, orch, high, standard := tagList.Compute()

--- a/comp/core/tagger/collectors/workloadmeta_extract.go
+++ b/comp/core/tagger/collectors/workloadmeta_extract.go
@@ -624,7 +624,7 @@ func (c *WorkloadMetaCollector) handleGPU(ev workloadmeta.Event) []*types.TagInf
 	tagList := taglist.NewTagList()
 
 	tagList.AddLow(tags.KubeGPUVendor, strings.ToLower(gpu.Vendor))
-	tagList.AddLow(tags.KubeGPUDevice, strings.ToLower(strings.ReplaceAll(gpu.Device, " ", "-")))
+	tagList.AddLow(tags.KubeGPUDevice, strings.ToLower(strings.ReplaceAll(gpu.Device, " ", "_")))
 	tagList.AddLow(tags.KubeGPUUUID, strings.ToLower(gpu.ID))
 	tagList.AddLow(tags.GPUDriverVersion, gpu.DriverVersion)
 

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -2355,6 +2355,34 @@ func TestHandleGPU(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "tags normalization",
+			gpu: workloadmeta.GPU{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindGPU,
+					ID:   "GPU-1234",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: "GPU-1234",
+				},
+				Vendor: "Nvidia",
+				Device: "Tesla v100",
+			},
+			expected: []*types.TagInfo{
+				{
+					Source:               gpuSource,
+					EntityID:             types.NewEntityID(types.GPU, "GPU-1234"),
+					HighCardTags:         []string{},
+					OrchestratorCardTags: []string{},
+					LowCardTags: []string{
+						"gpu_vendor:nvidia",
+						"gpu_device:tesla-v100",
+						"gpu_uuid:gpu-1234",
+					},
+					StandardTags: []string{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/comp/core/tagger/collectors/workloadmeta_test.go
+++ b/comp/core/tagger/collectors/workloadmeta_test.go
@@ -2376,7 +2376,7 @@ func TestHandleGPU(t *testing.T) {
 					OrchestratorCardTags: []string{},
 					LowCardTags: []string{
 						"gpu_vendor:nvidia",
-						"gpu_device:tesla-v100",
+						"gpu_device:tesla_v100",
 						"gpu_uuid:gpu-1234",
 					},
 					StandardTags: []string{},


### PR DESCRIPTION
### What does this PR do?

[Jira ticket](https://datadoghq.atlassian.net/browse/EBPF-687)

normalizes gpu_uuid, gpu_device and gpu_vendor tags, by lower casing the strings.
for the gpu_device tag we also replace all spaces with dashes `-`.

Examples:

"gpu_uuid:GPU-00000000-1234-1234-1234-123456789012" -> "gpu-00000000-1234-1234-1234-123456789012"
"gpu_vendor:Nvidia" -> "gpu_vendor:nvidia"
"gpu_device:Tesla T4" -> "gpu_device:tesla-t4"

### Motivation

consistency between different products (GPUM and Processes)

### Describe how you validated your changes
added new UT 
existing UTs and e2e tests should still pass

### Possible Drawbacks / Trade-offs

### Additional Notes
This will allow consistency also between different hosts
The GPU uuid is also used as a key to store and retrieve GPUEntity and its tags. we don't normalize the key, but only the emitted tags by the tagger, this to avoid potentially breaking existing entities in WMS that use the same tagger API