### PR TITLE
fix build tags for traceroute runner

### DIFF
--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -9,13 +9,9 @@ package runner
 import (
 	"context"
 	"fmt"
-	"math"
 	"math/rand"
 	"net"
-	"os"
 	"time"
-
-	"github.com/vishvananda/netns"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
@@ -28,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	cloudprovidersnetwork "github.com/DataDog/datadog-agent/pkg/util/cloudproviders/network"
-	netnsutil "github.com/DataDog/datadog-agent/pkg/util/kernel/netns"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -256,26 +251,6 @@ func getPorts(configDestPort uint16) (uint16, uint16, bool) {
 	}
 	srcPort = DefaultSourcePort + uint16(rand.Intn(10000))
 	return destPort, srcPort, useSourcePort
-}
-
-func createGatewayLookup(telemetryComp telemetryComponent.Component) (network.GatewayLookup, uint32, error) {
-	rootNs, err := rootNsLookup()
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to look up root network namespace: %w", err)
-	}
-	defer rootNs.Close()
-
-	nsIno, err := netnsutil.GetInoForNs(rootNs)
-	if err != nil {
-		return nil, 0, fmt.Errorf("failed to get inode number: %w", err)
-	}
-
-	gatewayLookup := network.NewGatewayLookup(rootNsLookup, math.MaxUint32, telemetryComp)
-	return gatewayLookup, nsIno, nil
-}
-
-func rootNsLookup() (netns.NsHandle, error) {
-	return netns.GetFromPid(os.Getpid())
 }
 
 // retryGetNetworkID attempts to get the network ID from the cloud provider or config with a few retries

--- a/pkg/networkpath/traceroute/runner/runner_linux.go
+++ b/pkg/networkpath/traceroute/runner/runner_linux.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package runner
+
+import (
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/vishvananda/netns"
+
+	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	netnsutil "github.com/DataDog/datadog-agent/pkg/util/kernel/netns"
+)
+
+func createGatewayLookup(telemetryComp telemetryComponent.Component) (network.GatewayLookup, uint32, error) {
+	rootNs, err := rootNsLookup()
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to look up root network namespace: %w", err)
+	}
+	defer rootNs.Close()
+
+	nsIno, err := netnsutil.GetInoForNs(rootNs)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to get inode number: %w", err)
+	}
+
+	gatewayLookup := network.NewGatewayLookup(rootNsLookup, math.MaxUint32, telemetryComp)
+	return gatewayLookup, nsIno, nil
+}
+
+func rootNsLookup() (netns.NsHandle, error) {
+	return netns.GetFromPid(os.Getpid())
+}

--- a/pkg/networkpath/traceroute/runner/runner_nolinux.go
+++ b/pkg/networkpath/traceroute/runner/runner_nolinux.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package runner
+
+import (
+	telemetryComponent "github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/network"
+)
+
+func createGatewayLookup(telemetryComp telemetryComponent.Component) (network.GatewayLookup, uint32, error) {
+	return nil, 0, nil
+}

--- a/pkg/networkpath/traceroute/runner/runner_nolinux.go
+++ b/pkg/networkpath/traceroute/runner/runner_nolinux.go
@@ -12,6 +12,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 )
 
-func createGatewayLookup(telemetryComp telemetryComponent.Component) (network.GatewayLookup, uint32, error) {
+func createGatewayLookup(_ telemetryComponent.Component) (network.GatewayLookup, uint32, error) {
 	return nil, 0, nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Uses build tags to avoid importing the `pkg/util/kernel/netns` package when not running on Linux.

### Motivation

It makes it clear that the gateway lookup is not supported on non-Linux, but may also enable us to reduce external imports for non-Linux in the future.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->