### PR TITLE
[NPM-4178] Add second goroutine to ParallelTraceroute for ICMP

### DIFF
--- a/pkg/networkpath/traceroute/common/traceroute_parallel.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel.go
@@ -11,14 +11,26 @@ import (
 	"fmt"
 	"net/netip"
 	"slices"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/errgroup"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ErrReceiveProbeNoPkt is returned when ReceiveProbe() didn't find anything new.
 // This is normal if the RTT is long
 var ErrReceiveProbeNoPkt = errors.New("ReceiveProbe() doesn't have new packets")
+
+// BadPacketError is a non-fatal error that occurs when a packet is malformed.
+type BadPacketError struct {
+	Err error
+}
+
+func (e *BadPacketError) Error() string {
+	return fmt.Sprintf("Failed to parse packet: %s", e.Err)
+}
 
 // ProbeResponse is the response of a single probe in a traceroute
 type ProbeResponse struct {
@@ -38,6 +50,8 @@ type TracerouteDriver interface {
 	SendProbe(ttl uint8) error
 	// ReceiveProbe polls to get a traceroute response with a timeout
 	ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
+	// ReceiveICMPProbe is identical to ReceiveProbe, just running in another goroutine
+	ReceiveICMPProbe(timeout time.Duration) (*ProbeResponse, error)
 }
 
 // TracerouteParallelParams are the parameters for TracerouteParallel
@@ -54,16 +68,43 @@ type TracerouteParallelParams struct {
 	SendDelay time.Duration
 }
 
+// ProbeCount returns the number of probes that will be sent
+func (p TracerouteParallelParams) ProbeCount() int {
+	if p.MinTTL > p.MaxTTL {
+		return 0
+	}
+	return int(p.MaxTTL) - int(p.MinTTL) + 1
+}
+
+// MaxTimeout combines the timeout+probe delays into a total timeout for the traceroute
+func (p TracerouteParallelParams) MaxTimeout() time.Duration {
+	delaySum := p.SendDelay * time.Duration(p.ProbeCount())
+	return p.TracerouteTimeout + delaySum
+}
+
 // TracerouteParallel runs a traceroute in parallel
 func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TracerouteParallelParams) ([]*ProbeResponse, error) {
 	if p.MinTTL > p.MaxTTL {
 		return nil, fmt.Errorf("min TTL must be less than or equal to max TTL")
 	}
+	if p.MinTTL < 1 {
+		return nil, fmt.Errorf("min TTL must be at least 1")
+	}
 
-	results := make([]*ProbeResponse, int(p.MaxTTL-p.MinTTL+1))
+	results := make([]*ProbeResponse, int(p.MaxTTL)+1)
+	resultsMu := sync.Mutex{}
+	writeProbe := func(probe *ProbeResponse) {
+		log.Tracef("found probe %+v", probe)
+		resultsMu.Lock()
+		defer resultsMu.Unlock()
+		// packets can get delivered twice - only use the first received probe to avoid overestimating RTT.
+		// this is also important for SACK because SACK traceroute returns the lowest TTL found from ACKs
+		if results[probe.TTL] == nil {
+			results[probe.TTL] = probe
+		}
+	}
 
-	delaySum := p.SendDelay * time.Duration(len(results))
-	timeoutCtx, cancel := context.WithTimeout(ctx, p.TracerouteTimeout+delaySum)
+	timeoutCtx, cancel := context.WithTimeout(ctx, p.MaxTimeout())
 	defer cancel()
 
 	g, groupCtx := errgroup.WithContext(timeoutCtx)
@@ -90,38 +131,40 @@ func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TraceroutePar
 		return nil
 	})
 
-	// poll for ReceiveProbe() in a loop and write it to results[]
-	g.Go(func() error {
-		for {
-			// leave if we got cancelled, SendProbe() failed, etc
-			select {
-			// doesn't use writerCtx because even if we writerCancel(), we want to keep reading
-			case <-groupCtx.Done():
-				return nil
-			default:
-			}
+	handleProbeFunc := func(funcName string, probeFunc func(timeout time.Duration) (*ProbeResponse, error)) {
+		g.Go(func() error {
+			for {
+				// leave if we got cancelled, SendProbe() failed, etc
+				select {
+				// doesn't use writerCtx because even if we writerCancel(), we want to keep reading
+				case <-groupCtx.Done():
+					return nil
+				default:
+				}
 
-			probe, err := t.ReceiveProbe(p.PollFrequency)
-			if errors.Is(err, ErrReceiveProbeNoPkt) {
-				continue
-			}
-			if err != nil {
-				return err
-			}
-			if probe == nil {
-				return fmt.Errorf("ReceiveProbe() returned nil without an error (this indicates a bug in the TracerouteDriver)")
-			}
-			if probe.TTL < p.MinTTL || probe.TTL > p.MaxTTL {
-				return fmt.Errorf("received an invalid TTL (expected TTL in [%d, %d]): %d", p.MinTTL, p.MaxTTL, probe.TTL)
-			}
+				probe, err := probeFunc(p.PollFrequency)
+				if CheckParallelRetryable(funcName, err) {
+					continue
+				} else if err != nil {
+					return err
+				}
+				if probe == nil {
+					return fmt.Errorf("%s() returned nil without an error (this indicates a bug in the TracerouteDriver)", funcName)
+				}
+				if probe.TTL < p.MinTTL || probe.TTL > p.MaxTTL {
+					return fmt.Errorf("%s() received an invalid TTL (expected TTL in [%d, %d]): %d", funcName, p.MinTTL, p.MaxTTL, probe.TTL)
+				}
 
-			results[probe.TTL-p.MinTTL] = probe
-			// no need to send more probes if we found the destination
-			if probe.IsDest {
-				writerCancel()
+				writeProbe(probe)
+				// no need to send more probes if we found the destination
+				if probe.IsDest {
+					writerCancel()
+				}
 			}
-		}
-	})
+		})
+	}
+	handleProbeFunc("ReceiveProbe", t.ReceiveProbe)
+	handleProbeFunc("ReceiveICMPProbe", t.ReceiveICMPProbe)
 
 	// check for an error from the goroutines
 	err := g.Wait()
@@ -142,5 +185,39 @@ func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TraceroutePar
 		results = slices.Clip(results[:destIdx+1])
 	}
 
-	return results, nil
+	return results[p.MinTTL:], nil
+}
+
+// ToHops converts a list of ProbeResponses to a Results
+// TODO remove this, and use a single type to represent results
+func ToHops(p TracerouteParallelParams, probes []*ProbeResponse) ([]*Hop, error) {
+	if p.MinTTL != 1 {
+		return nil, fmt.Errorf("ToHops: processResults() requires MinTTL == 1")
+	}
+	hops := make([]*Hop, len(probes))
+	for i, probe := range probes {
+		hops[i] = &Hop{}
+		if probe != nil {
+			hops[i].IP = probe.IP.AsSlice()
+			hops[i].RTT = probe.RTT
+			hops[i].IsDest = probe.IsDest
+		}
+	}
+	return hops, nil
+}
+
+var logOnce sync.Once
+
+// CheckParallelRetryable returns whether ReceiveProbe failed due to a real error or just an irrelevant packet
+func CheckParallelRetryable(funcName string, err error) bool {
+	badPktErr := &BadPacketError{}
+	if errors.Is(err, ErrReceiveProbeNoPkt) {
+		return true
+	} else if errors.As(err, &badPktErr) {
+		logOnce.Do(func() {
+			log.Warnf("%s() saw a malformed packet (this will only log once): %s", funcName, err)
+		})
+		return true
+	}
+	return false
 }

--- a/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
@@ -25,8 +25,9 @@ type MockDriver struct {
 
 	sentTTLs map[uint8]struct{}
 
-	sendHandler    func(ttl uint8) error
-	receiveHandler func() (*ProbeResponse, error)
+	sendHandler        func(ttl uint8) error
+	receiveHandler     func() (*ProbeResponse, error)
+	icmpReceiveHandler func() (*ProbeResponse, error)
 }
 
 func initMockDriver(t *testing.T, params TracerouteParallelParams) *MockDriver {
@@ -59,6 +60,19 @@ func (m *MockDriver) ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
 	res, err := m.receiveHandler()
 	if !errors.Is(err, ErrReceiveProbeNoPkt) {
 		m.t.Logf("read %+v, %v\n", res, err)
+	}
+	return res, err
+}
+
+func (m *MockDriver) ReceiveICMPProbe(timeout time.Duration) (*ProbeResponse, error) {
+	require.Equal(m.t, m.params.PollFrequency, timeout)
+
+	if m.icmpReceiveHandler == nil {
+		return nil, ErrReceiveProbeNoPkt
+	}
+	res, err := m.icmpReceiveHandler()
+	if !errors.Is(err, ErrReceiveProbeNoPkt) {
+		m.t.Logf("icmp read %+v, %v\n", res, err)
 	}
 	return res, err
 }
@@ -129,7 +143,11 @@ func TestParallelTraceroute(t *testing.T) {
 	require.Len(t, results, mockDestTTL)
 }
 
-func testParallelTracerouteShuffled(t *testing.T, seed int64) {
+type targets struct {
+	useRegular, useIcmp bool
+}
+
+func testParallelTracerouteShuffled(t *testing.T, seed int64, getTargets func(uint8) targets) {
 	// similar to TestParallelTraceroute, except it shuffles the received probes
 	// and expects them to come back in the correct order
 	r := rand.New(rand.NewSource(seed))
@@ -138,6 +156,7 @@ func testParallelTracerouteShuffled(t *testing.T, seed int64) {
 
 	var expectedResults []*ProbeResponse
 	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+	icmpProbes := make(chan *ProbeResponse, testParams.MaxTTL)
 
 	m.sendHandler = func(ttl uint8) error {
 		result := mockResult(ttl)
@@ -146,9 +165,16 @@ func testParallelTracerouteShuffled(t *testing.T, seed int64) {
 
 			if result.IsDest {
 				for _, p := range r.Perm(len(expectedResults)) {
-					receiveProbes <- expectedResults[p]
+					targets := getTargets(ttl)
+					if targets.useRegular {
+						receiveProbes <- expectedResults[p]
+					}
+					if targets.useIcmp {
+						icmpProbes <- expectedResults[p]
+					}
 				}
 				close(receiveProbes)
+				close(icmpProbes)
 			}
 		}
 
@@ -162,16 +188,52 @@ func testParallelTracerouteShuffled(t *testing.T, seed int64) {
 		return probe, nil
 	}
 
+	m.icmpReceiveHandler = func() (*ProbeResponse, error) {
+		probe, ok := <-icmpProbes
+		if !ok {
+			return noData(testParams.PollFrequency)
+		}
+		return probe, nil
+	}
+
 	results, err := TracerouteParallel(context.Background(), m, testParams)
 	require.NoError(t, err)
 	require.Equal(t, expectedResults, results)
 	require.Len(t, results, mockDestTTL)
 }
 func TestParallelTracerouteShuffled(t *testing.T) {
-	for seed := range 3 {
-		t.Run(fmt.Sprintf("seed=%d", seed), func(t *testing.T) {
-			testParallelTracerouteShuffled(t, int64(seed))
+	seed := int64(0)
+	for range 3 {
+		t.Run(fmt.Sprintf("seed=%d, regular", seed), func(t *testing.T) {
+			regular := func(uint8) targets { return targets{useRegular: true} }
+			testParallelTracerouteShuffled(t, seed, regular)
 		})
+		seed++
+	}
+	for range 3 {
+		t.Run(fmt.Sprintf("seed=%d, icmp", seed), func(t *testing.T) {
+			icmp := func(uint8) targets { return targets{useIcmp: true} }
+			testParallelTracerouteShuffled(t, seed, icmp)
+		})
+		seed++
+	}
+	for range 3 {
+		t.Run(fmt.Sprintf("seed=%d, mixed", seed), func(t *testing.T) {
+			getTargets := func(ttl uint8) targets {
+				useRegular := ttl%2 == 0
+				return targets{useRegular: useRegular, useIcmp: !useRegular}
+			}
+			testParallelTracerouteShuffled(t, seed, getTargets)
+		})
+		seed++
+	}
+	for range 3 {
+		t.Run(fmt.Sprintf("seed=%d, both", seed), func(t *testing.T) {
+			// send it to both - that way we exercise the mutex in writeProbe()
+			both := func(uint8) targets { return targets{useRegular: true, useIcmp: true} }
+			testParallelTracerouteShuffled(t, seed, both)
+		})
+		seed++
 	}
 }
 
@@ -417,4 +479,58 @@ func TestParallelTracerouteProbeReturnValueCheck(t *testing.T) {
 	results, err := TracerouteParallel(context.Background(), m, testParams)
 	require.Nil(t, results)
 	require.ErrorContains(t, err, "ReceiveProbe() returned nil without an error")
+}
+
+func TestParallelTracerouteDoubleReceive(t *testing.T) {
+	// same as TestParallelTraceroute but receives the probes a second time, with a larger RTT.
+	// it should not overwrite the RTT
+	m := initMockDriver(t, testParams)
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, 2*testParams.MaxTTL)
+
+	expectedTTL := uint8(1)
+	m.sendHandler = func(ttl uint8) error {
+		require.Equal(t, expectedTTL, ttl)
+		expectedTTL++
+
+		result := mockResult(ttl)
+
+		if result != nil {
+			expectedResults = append(expectedResults, result)
+
+			slowerProbe := *result
+			slowerProbe.RTT *= 2
+			// sanity check
+			require.NotEqual(t, slowerProbe.RTT, result.RTT)
+
+			receiveProbes <- result
+			receiveProbes <- &slowerProbe
+			if result.IsDest {
+				close(receiveProbes)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		probe, ok := <-receiveProbes
+		if !ok {
+			return noData(testParams.PollFrequency)
+		}
+		return probe, nil
+	}
+
+	results, err := TracerouteParallel(context.Background(), m, testParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL)
+}
+
+func TestCheckParallelRetryable(t *testing.T) {
+	require.True(t, CheckParallelRetryable("test", ErrReceiveProbeNoPkt))
+	require.True(t, CheckParallelRetryable("test", &BadPacketError{fmt.Errorf("foo")}))
+
+	require.False(t, CheckParallelRetryable("test", fmt.Errorf("foo")))
+	require.False(t, CheckParallelRetryable("test", nil))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds another receive goroutine to the parallel traceroute logic.
### Motivation
We are using raw sockets instead of gopacket, so we need to read from two sockets at once (TCP and ICMP).

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
New tests should pass with race enabled:
```
go test -race -timeout 10s -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common -count=1
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->