### PR TITLE
use map/prog type as string in ebpf check

### DIFF
--- a/pkg/collector/corechecks/ebpf/ebpf.go
+++ b/pkg/collector/corechecks/ebpf/ebpf.go
@@ -97,7 +97,7 @@ func (m *EBPFCheck) Run() error {
 
 		tags := []string{
 			"map_name:" + mapStats.Name,
-			"map_type:" + mapStats.Type.String(),
+			"map_type:" + mapStats.Type,
 			"module:" + mapStats.Module,
 		}
 		sender.Gauge("ebpf.maps.memory_max", float64(mapStats.MaxSize), "", tags)
@@ -117,7 +117,7 @@ func (m *EBPFCheck) Run() error {
 		moduleTotalMapMaxSize[mapStats.Module] += mapStats.MaxSize
 		moduleTotalMapRSS[mapStats.Module] += mapStats.RSS
 
-		log.Tracef("ebpf check: map=%s maxsize=%d type=%s", mapStats.Name, mapStats.MaxSize, mapStats.Type.String())
+		log.Tracef("ebpf check: map=%s maxsize=%d type=%s", mapStats.Name, mapStats.MaxSize, mapStats.Type)
 	}
 
 	for _, mapInfo := range stats.Maps {
@@ -155,12 +155,12 @@ func (m *EBPFCheck) Run() error {
 
 		tags := []string{
 			"program_name:" + progInfo.Name,
-			"program_type:" + progInfo.Type.String(),
+			"program_type:" + progInfo.Type,
 			"module:" + progInfo.Module,
 		}
 		var debuglogs []string
 		if log.ShouldLog(log.TraceLvl) {
-			debuglogs = []string{"program=" + progInfo.Name, "type=" + progInfo.Type.String()}
+			debuglogs = []string{"program=" + progInfo.Name, "type=" + progInfo.Type}
 		}
 
 		gauges := map[string]float64{

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model/types.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/model/types.go
@@ -8,8 +8,6 @@ package model
 
 import (
 	"time"
-
-	"github.com/cilium/ebpf"
 )
 
 // EBPFStats contains the statistics from the ebpf check
@@ -26,7 +24,7 @@ type EBPFMapStats struct {
 	Module     string
 	RSS        uint64
 	MaxSize    uint64
-	Type       ebpf.MapType
+	Type       string
 	Entries    int64 // Allow negative values to indicate that the number of entries could not be calculated
 
 	// used only for tests
@@ -45,5 +43,5 @@ type EBPFProgramStats struct {
 	RecursionMisses uint64
 	Runtime         time.Duration
 	VerifiedInsns   uint32
-	Type            ebpf.ProgramType
+	Type            string
 }

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -249,7 +249,7 @@ type programKey struct {
 func progKey(ps model.EBPFProgramStats) programKey {
 	return programKey{
 		name:   ps.Name,
-		typ:    ps.Type.String(),
+		typ:    ps.Type,
 		module: ps.Module,
 	}
 }
@@ -301,7 +301,7 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 			Name:            name,
 			Module:          module,
 			Tag:             tag,
-			Type:            ebpf.ProgramType(info.Type),
+			Type:            ebpf.ProgramType(info.Type).String(),
 			XlatedProgLen:   info.XlatedProgLen,
 			RSS:             uint64(roundUp(info.XlatedProgLen, uint32(pageSize))),
 			VerifiedInsns:   info.VerifiedInsns,
@@ -320,7 +320,7 @@ func (k *Probe) getProgramStats(stats *model.EBPFStats) error {
 	if log.ShouldLog(log.TraceLvl) {
 		log.Tracef("found %d programs", len(stats.Programs))
 		for _, ps := range stats.Programs {
-			log.Tracef("name=%s prog_id=%d type=%s", ps.Name, ps.ID, ps.Type.String())
+			log.Tracef("name=%s prog_id=%d type=%s", ps.Name, ps.ID, ps.Type)
 		}
 	}
 
@@ -370,7 +370,7 @@ func (k *Probe) getMapStats(stats *model.EBPFStats) error {
 			ID:         uint32(mapid),
 			Name:       name,
 			Module:     module,
-			Type:       info.Type,
+			Type:       info.Type.String(),
 			MaxEntries: info.MaxEntries,
 			Entries:    -1, // Indicates no entries were calculated
 		}

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe_test.go
@@ -62,7 +62,7 @@ func TestEBPFPerfBufferLength(t *testing.T) {
 		require.Eventually(t, func() bool {
 			stats := probe.GetAndFlush()
 			for _, s := range stats.Maps {
-				if s.Type == ebpf.PerfEventArray && s.Name == "ebpf_test_perf" {
+				if s.Type == ebpf.PerfEventArray.String() && s.Name == "ebpf_test_perf" {
 					result = s
 					return true
 				}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes the type of ebpfcheck map/program type from `ebpf.MapType` and `ebpf.ProgramType` to `string`

### Motivation

No need to import `github.com/cilium/ebpf` when we only use it as a string.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->