### PR TITLE
[CWS] disable logger in `system-probe runtime policy download`

### DIFF
--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -199,7 +199,7 @@ func downloadPolicyCommands(globalParams *command.GlobalParams) []*cobra.Command
 				fx.Supply(core.BundleParams{
 					ConfigParams: config.NewAgentParams(globalParams.ConfFilePath),
 					SecretParams: secrets.NewDisabledParams(),
-					LogParams:    log.ForOneShot("SYS-PROBE", "info", true)}),
+					LogParams:    log.ForOneShot("SYS-PROBE", "off", false)}),
 				core.Bundle(),
 			)
 		},

--- a/cmd/system-probe/subcommands/runtime/command_test.go
+++ b/cmd/system-probe/subcommands/runtime/command_test.go
@@ -34,7 +34,7 @@ func TestDownloadCommand(t *testing.T) {
 			check: func(_ *downloadPolicyCliParams, params core.BundleParams) {
 				// Verify logger defaults
 				require.Equal(t, "SYS-PROBE", params.LoggerName(), "logger name not matching")
-				require.Equal(t, "info", params.LogLevelFn(nil), "log level not matching")
+				require.Equal(t, "off", params.LogLevelFn(nil), "log level not matching")
 			},
 		},
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Done for 2 reasons:
- common behavior with security agent CLI
- new-e2e do `<binary> runtime policy download |> temp.txt` and this requires the logger to be off to get valid yaml in `temp.txt`

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->