### PR TITLE
service discovery: Ignore portless processes after 10 mins

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -1030,8 +1030,70 @@ func TestCache(t *testing.T) {
 		require.NotContains(t, discovery.cache, int32(pid))
 	}
 
+	// Add some PIDs to noPortTries to verify it gets cleaned up
+	discovery.noPortTries[int32(1)] = 0
+
 	discovery.Close()
 	require.Empty(t, discovery.cache)
+	require.Empty(t, discovery.noPortTries)
+}
+
+func TestMaxPortCheck(t *testing.T) {
+	_, mockContainerProvider, mTimeProvider := setupDiscoveryModule(t)
+	mockContainerProvider.EXPECT().GetContainers(containerCacheValidity, nil).AnyTimes()
+	mTimeProvider.EXPECT().Now().Return(mockedTime).AnyTimes()
+
+	// Start a process that will be ignored due to no ports
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	cmd := exec.CommandContext(ctx, "sleep", "100")
+	err := cmd.Start()
+	require.NoError(t, err)
+	pid := int32(cmd.Process.Pid)
+
+	serverf, _ := startTCPServer(t, "tcp4", "")
+	t.Cleanup(func() { serverf.Close() })
+
+	selfPid := os.Getpid()
+
+	params := defaultParams()
+	params.heartbeatTime = 0
+
+	discovery := newDiscovery(mockContainerProvider, mTimeProvider)
+
+	for i := 0; i < maxPortCheckTries-5; i++ {
+		_, err = discovery.getServices(params)
+		require.NoError(t, err)
+	}
+
+	discovery.mux.RLock()
+	require.Contains(t, discovery.noPortTries, pid, "process should be in noPortTries")
+	require.NotContains(t, discovery.noPortTries, selfPid, "self should not be in noPortTries")
+	discovery.mux.RUnlock()
+
+	for i := 0; i < 5; i++ {
+		_, err = discovery.getServices(params)
+		require.NoError(t, err)
+	}
+
+	discovery.mux.RLock()
+	require.NotContains(t, discovery.noPortTries, pid, "process should be removed from noPortTries")
+	require.Contains(t, discovery.ignorePids, pid, "process should be in ignorePids")
+	discovery.mux.RUnlock()
+
+	err = cmd.Process.Kill()
+	require.NoError(t, err)
+	err = cmd.Wait()
+	require.Error(t, err)
+
+	// Call getServices to trigger cleanup
+	_, err = discovery.getServices(params)
+	require.NoError(t, err)
+
+	discovery.mux.RLock()
+	require.NotContains(t, discovery.noPortTries, pid, "process should be removed from noPortTries")
+	require.NotContains(t, discovery.ignorePids, pid, "process should not be in ignorePids")
+	discovery.mux.RUnlock()
 }
 
 func TestTagsPriority(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

    Currently, if a process doesn't have open ports, we keep checking the
    process again and again on every call to the endpoint, so once every
    minute. This has a significant CPU cost, so stop checking a process
    after 10 attempts (10 minutes) of it not having open ports.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-81

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Automated tests added.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->