### PR TITLE
CI: increase staging release job timeout to 2h30

### DIFF
--- a/.gitlab/trigger_release/trigger_release.yml
+++ b/.gitlab/trigger_release/trigger_release.yml
@@ -33,6 +33,7 @@
 
 trigger_auto_staging_release:
   extends: .agent_release_management_trigger
+  timeout: 2h 30
   variables:
     AUTO_RELEASE: "true"
     TARGET_REPO: staging
@@ -43,6 +44,7 @@ trigger_auto_staging_release:
 
 trigger_auto_staging_release_on_failure:
   extends: .agent_release_management_trigger
+  timeout: 2h 30
   variables:
     AUTO_RELEASE: "false"
     TARGET_REPO: staging


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increase the timeout for staging promotion jobs.

### Motivation

The job are increasing in duration everytime we promote a new version. Until we improve the performances, we need to tolerate the duration increase

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This should be temporary until we address https://datadoghq.atlassian.net/browse/BARX-830