### PR TITLE
Exclude files by path always

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -40,12 +40,9 @@ def get_staged_files(ctx, commit="HEAD", include_deleted_files=False) -> Iterabl
     files = ctx.run(f"git diff --name-only --staged {commit}", hide=True).stdout.strip().splitlines()
     repo_root = ctx.run("git rev-parse --show-toplevel", hide=True).stdout.strip()
 
-    if include_deleted_files:
-        yield from files
-    else:
-        for file in files:
-            if os.path.isfile(file):
-                yield os.path.join(repo_root, file)
+    for file in files:
+        if include_deleted_files or os.path.isfile(file):
+            yield os.path.join(repo_root, file)
 
 
 def get_unstaged_files(ctx, re_filter=None, include_deleted_files=False) -> Iterable[str]:

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -38,13 +38,14 @@ def get_staged_files(ctx, commit="HEAD", include_deleted_files=False) -> Iterabl
     """
 
     files = ctx.run(f"git diff --name-only --staged {commit}", hide=True).stdout.strip().splitlines()
+    repo_root = ctx.run("git rev-parse --show-toplevel", hide=True).stdout.strip()
 
     if include_deleted_files:
         yield from files
     else:
         for file in files:
             if os.path.isfile(file):
-                yield file
+                yield os.path.join(repo_root, file)
 
 
 def get_unstaged_files(ctx, re_filter=None, include_deleted_files=False) -> Iterable[str]:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Always exclude configured paths from copyright checking

### Motivation
When the list of files to be processed is received, the exclusion by path is not considered, which is considered if the list is not received and has to be created.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Touch the file `internal/third_party/golang/expansion/expand.go` and then run:

`inv linter.copyrights --only-staged-files --debug`
`inv linter.copyrights --debug`

And checking that file is excluded in all cases

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
This is a clear example where our tests are coupled to the implementation, and simply fixing a bug without changing the requirements means we have to change the tests.