### PR TITLE
[EBPF] build: fix system-probe build tags for tests/KMT

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -61,7 +61,7 @@ from tasks.system_probe import (
     check_for_ninja,
     get_ebpf_build_dir,
     get_ebpf_runtime_dir,
-    get_sysprobe_buildtags,
+    get_sysprobe_test_buildtags,
     get_test_timeout,
     go_package_dirs,
     ninja_generate,
@@ -639,7 +639,7 @@ def ninja_build_dependencies(ctx: Context, nw: NinjaWriter, kmt_paths: KMTPaths,
             "go": go_path,
             "chdir": "true",
             "env": env_str,
-            "tags": f"-tags=\"{','.join(get_sysprobe_buildtags(False, False))}\"",
+            "tags": f"-tags=\"{','.join(get_sysprobe_test_buildtags(False, False))}\"",
         },
     )
 
@@ -968,7 +968,7 @@ def kmt_sysprobe_prepare(
     build_object_files(ctx, f"{kmt_paths.arch_dir}/kmt-object-files.ninja", arch)
 
     info("[+] Computing Go dependencies for test packages...")
-    build_tags = get_sysprobe_buildtags(False, False)
+    build_tags = get_sysprobe_test_buildtags(False, False)
     target_packages = build_target_packages(filter_pkgs, build_tags)
     pkg_deps = compute_package_dependencies(ctx, target_packages, build_tags)
 
@@ -989,7 +989,7 @@ def kmt_sysprobe_prepare(
         ninja_build_dependencies(ctx, nw, kmt_paths, go_path, arch)
         ninja_copy_ebpf_files(nw, "system-probe", kmt_paths, arch)
 
-        build_tags = get_sysprobe_buildtags(False, False)
+        build_tags = get_sysprobe_test_buildtags(False, False)
         for pkg in target_packages:
             pkg_name = os.path.relpath(pkg, os.getcwd())
             target_path = os.path.join(kmt_paths.sysprobe_tests, pkg_name)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -822,7 +822,7 @@ def build_sysprobe_binary(
     ctx.run(cmd.format(**args), env=env)
 
 
-def get_sysprobe_buildtags(is_windows, bundle_ebpf):
+def get_sysprobe_test_buildtags(is_windows, bundle_ebpf):
     platform = "windows" if is_windows else "linux"
     build_tags = get_default_build_tags(build="system-probe", platform=platform)
 
@@ -866,7 +866,7 @@ def test(
             kernel_release=kernel_release,
         )
 
-    build_tags = get_sysprobe_buildtags(is_windows, bundle_ebpf)
+    build_tags = get_sysprobe_test_buildtags(is_windows, bundle_ebpf)
 
     args = get_common_test_args(build_tags, failfast)
     args["output_params"] = f"-c -o {output_path}" if output_path else ""

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -823,12 +823,14 @@ def build_sysprobe_binary(
 
 
 def get_sysprobe_buildtags(is_windows, bundle_ebpf):
-    build_tags = [NPM_TAG]
+    platform = "windows" if is_windows else "linux"
+    build_tags = get_default_build_tags(build="system-probe", platform=platform)
+
+    if not is_windows and bundle_ebpf:
+        build_tags.append(BUNDLE_TAG)
+
     build_tags.extend(UNIT_TEST_TAGS)
-    if not is_windows:
-        build_tags.append(BPF_TAG)
-        if bundle_ebpf:
-            build_tags.append(BUNDLE_TAG)
+
     return build_tags
 
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -829,10 +829,15 @@ def get_sysprobe_test_buildtags(is_windows, bundle_ebpf):
     if not is_windows and bundle_ebpf:
         build_tags.append(BUNDLE_TAG)
 
-    # Temporary until we have a way to build libpcap dependencies on KMT
-    # and we understand whether it's needed or not
-    if "pcap" in build_tags:
-        build_tags.remove("pcap")
+    # Some flags are not supported on KMT testing, so we remove them
+    # until we have extra fixes (mainly coming from the unified build images)
+    temporarily_unsupported_build_tags = [
+        "pcap",  # libpcap headers not supported yet, specially for cross-compilation
+        "trivy",  # trivy introduces dependencies on a higher version of glibc
+    ]
+    for tag in temporarily_unsupported_build_tags:
+        if tag in build_tags:
+            build_tags.remove(tag)
 
     build_tags.extend(UNIT_TEST_TAGS)
 

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -829,6 +829,11 @@ def get_sysprobe_test_buildtags(is_windows, bundle_ebpf):
     if not is_windows and bundle_ebpf:
         build_tags.append(BUNDLE_TAG)
 
+    # Temporary until we have a way to build libpcap dependencies on KMT
+    # and we understand whether it's needed or not
+    if "pcap" in build_tags:
+        build_tags.remove("pcap")
+
     build_tags.extend(UNIT_TEST_TAGS)
 
     return build_tags


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the build tags that are returned by the `get_sysprobe_buildtags` function (which is now renamed to `get_sysprobe_test_buildtags` for clarity) so that we build with the same tags as the rest of the workflows.

The `pcap` build tag is still excluded, as including it requires changes in the build images and we need to validate whether it's actually used for tests or not.

`trivy` is excluded as well as it causes the tests to build against a newer version of glibc, causing failures in CI. This should be resolved when we migrate to single-toolchain buildimages to avoid glibc issues in general.

### Motivation

Some tests were not being executed in KMT after the introduction of the `nvml` build tag in https://github.com/DataDog/datadog-agent/pull/35265

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passing, manually checked that `pkg/gpu` tests are being executed again.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->