### PR TITLE
[APM] Attach ContainerID on aggregated CSS payloads (#35464)

### DIFF
--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -303,6 +303,7 @@ func (b *bucket) aggregationToPayloads() []*pb.ClientStatsPayload {
 			Version:      payloadKey.Version,
 			ImageTag:     payloadKey.ImageTag,
 			GitCommitSha: payloadKey.GitCommitSha,
+			ContainerID:  payloadKey.ContainerID,
 			Stats:        clientBuckets,
 		})
 	}

--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -683,6 +683,69 @@ func TestAggregationVersionData(t *testing.T) {
 	})
 }
 
+func TestAggregationContainerID(t *testing.T) {
+	t.Run("ContainerID empty", func(t *testing.T) {
+		assert := assert.New(t)
+		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.writer = msw
+		testTime := time.Unix(time.Now().Unix(), 0)
+
+		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
+		c1 := payloadWithCounts(testTime, bak, "", "test-version", "abc", "abc123", 11, 7, 100)
+		c2 := payloadWithCounts(testTime, bak, "", "test-version", "abc", "abc123", 27, 2, 300)
+		c3 := payloadWithCounts(testTime, bak, "", "test-version", "abc", "abc123", 5, 10, 3)
+		keyDefault := BucketsAggregationKey{}
+		cDefault := payloadWithCounts(testTime, keyDefault, "", "test-version", "abc", "abc123", 0, 2, 4)
+
+		assert.Len(msw.payloads, 0)
+		a.add(testTime, deepCopy(c1))
+		a.add(testTime, deepCopy(c2))
+		a.add(testTime, deepCopy(c3))
+		a.add(testTime, deepCopy(cDefault))
+		assert.Len(msw.payloads, 0)
+		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+		require.Len(t, msw.payloads, 1)
+
+		aggCounts := msw.payloads[0]
+		assertAggCountsPayload(t, aggCounts)
+
+		assert.Equal(aggCounts.Stats[0].ContainerID, "")
+		assert.Len(a.buckets, 0)
+	})
+
+	t.Run("ContainerID not empty", func(t *testing.T) {
+		assert := assert.New(t)
+		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.writer = msw
+		testTime := time.Unix(time.Now().Unix(), 0)
+
+		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
+		c1 := payloadWithCounts(testTime, bak, "1", "test-version", "abc", "abc123", 11, 7, 100)
+		c2 := payloadWithCounts(testTime, bak, "1", "test-version", "abc", "abc123", 27, 2, 300)
+		c3 := payloadWithCounts(testTime, bak, "1", "test-version", "abc", "abc123", 5, 10, 3)
+		keyDefault := BucketsAggregationKey{}
+		cDefault := payloadWithCounts(testTime, keyDefault, "1", "test-version", "abc", "abc123", 0, 2, 4)
+
+		assert.Len(msw.payloads, 0)
+		a.add(testTime, deepCopy(c1))
+		a.add(testTime, deepCopy(c2))
+		a.add(testTime, deepCopy(c3))
+		a.add(testTime, deepCopy(cDefault))
+		assert.Len(msw.payloads, 0)
+		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+		require.Len(t, msw.payloads, 1)
+
+		aggCounts := msw.payloads[0]
+		assertAggCountsPayload(t, aggCounts)
+
+		assert.Equal(aggCounts.Stats[0].ContainerID, "1")
+		assert.Len(a.buckets, 0)
+	})
+
+}
+
 func TestNewBucketAggregationKeyPeerTags(t *testing.T) {
 	// The hash of "peer.service:remote-service".
 	peerTagsHash := uint64(3430395298086625290)

--- a/test/new-e2e/tests/apm/docker_test.go
+++ b/test/new-e2e/tests/apm/docker_test.go
@@ -160,9 +160,14 @@ func (s *DockerFakeintakeSuite) testStatsForService(enableClientSideStats bool) 
 		addSpanTags:           addSpanTags,
 		enableClientSideStats: enableClientSideStats,
 	})()
+
 	s.EventuallyWithTf(func(c *assert.CollectT) {
 		testStatsForService(s.T(), c, service, expectPeerTag, s.Env().FakeIntake)
 	}, 2*time.Minute, 10*time.Second, "Failed finding stats")
+
+	s.EventuallyWithTf(func(c *assert.CollectT) {
+		testStatsHaveContainerTags(s.T(), c, service, s.Env().FakeIntake)
+	}, 2*time.Minute, 10*time.Second, "Failed finding container ID on stats")
 }
 
 func (s *DockerFakeintakeSuite) TestBasicTrace() {

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -203,7 +203,13 @@ func (s *VMFakeintakeSuite) testStatsForService(enableClientSideStats bool) {
 		s.logStatus()
 		testStatsForService(s.T(), c, service, expectPeerTag, s.Env().FakeIntake)
 		s.logJournal(false)
-	}, 3*time.Minute, 10*time.Second, "Failed finding stats")
+	}, 2*time.Minute, 10*time.Second, "Failed finding stats")
+
+	s.EventuallyWithTf(func(c *assert.CollectT) {
+		s.logStatus()
+		testStatsHaveContainerTags(s.T(), c, service, s.Env().FakeIntake)
+		s.logJournal(false)
+	}, 2*time.Minute, 10*time.Second, "Failed finding container ID on stats")
 }
 
 func (s *VMFakeintakeSuite) TestAutoVersionTraces() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/35464

Flushing ClientStat buckets on the ClientStatsAggregator was missing this field, which is kept on the aggregation key.

This PR ensures that the ContainerID used during the aggregation is also propagated when flushing the payloads.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->