### PR TITLE
Change FailNow() in Fail() to make sure the error is displayed in the panic

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -250,7 +250,7 @@ func (bs *BaseSuite[Env]) UpdateEnv(newProvisioners ...provisioners.Provisioner)
 		targetProvisioners[provisioner.ID()] = provisioner
 	}
 	if err := bs.reconcileEnv(targetProvisioners); err != nil {
-		bs.T().FailNow() // We need to call FailNow otherwise bs.T().Failed() will be false in AfterTest
+		bs.T().Fail() // We need to call Fail otherwise bs.T().Failed() will be false in AfterTest
 		panic(err)
 	}
 }
@@ -584,7 +584,7 @@ func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 	// In `Test` scope we can `panic`, it will be recovered and `AfterTest` will be called.
 	// Next tests will be called as well
 	if err := bs.reconcileEnv(bs.originalProvisioners); err != nil {
-		bs.T().FailNow() // We need to call FailNow otherwise bs.T().Failed() will be false in AfterTest
+		bs.T().Fail() // We need to call Failotherwise bs.T().Failed() will be false in AfterTest
 		panic(err)
 	}
 }

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -584,7 +584,7 @@ func (bs *BaseSuite[Env]) BeforeTest(string, string) {
 	// In `Test` scope we can `panic`, it will be recovered and `AfterTest` will be called.
 	// Next tests will be called as well
 	if err := bs.reconcileEnv(bs.originalProvisioners); err != nil {
-		bs.T().Fail() // We need to call Failotherwise bs.T().Failed() will be false in AfterTest
+		bs.T().Fail() // We need to call Fail otherwise bs.T().Failed() will be false in AfterTest
 		panic(err)
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Call Fail() instead of FailNow() otherwise the execution of the function is interrupted and panic(err) is never called, preventing displaying the actual error. 
The panic(err) will then interrupt execution anyway

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->