### PR TITLE
[RC] Remove CreationTime from RC DB metadata tests

### DIFF
--- a/pkg/config/remote/service/util_test.go
+++ b/pkg/config/remote/service/util_test.go
@@ -159,7 +159,6 @@ func TestRemoteConfigChangedAPIKey(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEqual(t, metadata0.APIKeyHash, metadata1.APIKeyHash)
-	require.NotEqual(t, metadata0.CreationTime, metadata1.CreationTime)
 }
 
 func TestRemoteConfigReopenNoVersionChange(t *testing.T) {
@@ -239,5 +238,4 @@ func TestRemoteConfigChangedURL(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotEqual(t, metadata0.URL, metadata1.URL)
-	require.NotEqual(t, metadata0.CreationTime, metadata1.CreationTime)
 }


### PR DESCRIPTION
Tests involving the creation time have flaked recently due to a test running quicker than expected for the granularity of time with which we are testing for. We don't actually use this value in any logic for making decisions about rebuilding the DB, it's primarily for debugging, so rather than force this to be mockable we can just remove the condition check from the unit tests.