### PR TITLE
Update config_template.yaml to include keep_values for credit card obfuscation

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1206,7 +1206,7 @@ api_key:
   ##        @param DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN - boolean - optional
   ##        Enables a Luhn checksum check in order to eliminate false negatives. Disabled by default.
   #         luhn: false
-  ##        @param DD_APM_OBFUSCATION_CREDITCARDS_KEEP_VALUES - object - optional
+  ##        @param DD_APM_OBFUSCATION_CREDIT_CARDS_KEEP_VALUES - object - optional
   ##        List of keys that should not be obfuscated.
   #         keep_values:
   #             - client_id

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1206,6 +1206,10 @@ api_key:
   ##        @param DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN - boolean - optional
   ##        Enables a Luhn checksum check in order to eliminate false negatives. Disabled by default.
   #         luhn: false
+  ##        @param DD_APM_OBFUSCATION_CREDITCARDS_KEEP_VALUES - object - optional
+  ##        List of keys that should not be obfuscated.
+  #         keep_values:
+  #             - client_id
   #
   #     elasticsearch:
   ##        @param DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED - boolean - optional


### PR DESCRIPTION
this is in response to https://datadoghq.atlassian.net/browse/APMS-15208. by adding the `DD_APM_OBFUSCATION_CREDIT_CARDS_KEEP_VALUES` config option, we prevent cases like this in the future.