### PR TITLE
Fix stack trace accuracy in Go DI system probe module

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -84,6 +84,7 @@ entryLoop:
 			if cuLineReader != nil {
 				for _, file := range cuLineReader.Files() {
 					if file == nil {
+						files = append(files, &dwarf.LineFile{Name: "no file", Mtime: 0, Length: 0})
 						continue
 					}
 

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -191,7 +192,7 @@ func convertSlice(capture *ditypes.Param, def *ditypes.Parameter) *ditypes.Captu
 				fieldSize = int64(capture.Fields[i].Size)
 			}
 			defs = append(defs, &ditypes.Parameter{
-				Name:      fmt.Sprintf("[%d]%s", i, fieldType),
+				Name:      strconv.Itoa(i),
 				Type:      fieldType,
 				Kind:      fieldKind,
 				TotalSize: fieldSize,
@@ -210,10 +211,16 @@ func convertSlice(capture *ditypes.Param, def *ditypes.Parameter) *ditypes.Captu
 			defs = append(defs, dst[0])
 		}
 	}
+	//FIXME: this should be optimized to avoid O(n^2) assignment for every event
+	elements := convertArgs(defs, capture.Fields)
+	elementsSlice := []ditypes.CapturedValue{}
+	for _, element := range elements {
+		elementsSlice = append(elementsSlice, *element)
+	}
 
 	sliceValue := &ditypes.CapturedValue{
-		Type:   capture.Type,
-		Fields: convertArgs(defs, capture.Fields),
+		Type:     capture.Type,
+		Elements: elementsSlice,
 	}
 	return sliceValue
 }


### PR DESCRIPTION
### What does this PR do?

There were issues with stack traces in system-probe introduced with a recent refactor where file names were not appearing correctly. This was due to an off-by-one error caused by skipping a null file structure that should be intentional included.

It also fixes how we populate the event structure that's sent to the debugger-backend. For slices, the elements should be in the 'elements' slice, instead of the 'fields' slice. This allows the UI to properly display the element name, rather than trying to do it ourselves which actually breaks what the UI expects.

### Motivation

Fix broken UX for stack traces and value display.

### Describe how you validated your changes

e2e testing for stack traces, manual testing for UI bug.

### Possible Drawbacks / Trade-offs

### Additional Notes

I don't think copying the structures for the sake of doing string.Clone is actually needed but want to circle back around to this when I have time.