### PR TITLE
KMT: change default init behavior, images explicitly required

### DIFF
--- a/tasks/kernel_matrix_testing/README.md
+++ b/tasks/kernel_matrix_testing/README.md
@@ -38,20 +38,17 @@ This will download all the resources required to launch the VMs, and install all
 > This step should be done only once.
 
 ```bash
-dda inv -e kmt.init
-```
-
-> You may significantly speed up this part by only downloading specific VM images. Refer to [Listing possible VMs](#Listing Possible VMs) to see how to list available images and how to provide their names.
-
-```bash
+# Initialize with specific VM images
 dda inv -e kmt.init --images=ubuntu_22.04,debian_10
-```
 
-> You may skip the downloading part if you are not setting up VMs locally.
+# Initialize with all available VM images
+dda inv -e kmt.init --all-images
 
-```bash
+# Or initialize without downloading any images (lite mode)
 dda inv -e kmt.init --lite
 ```
+
+The `--images` parameter is required unless `--lite` or `--all-images` is specified. You can use `dda inv -e kmt.ls` to see available images.
 
 This command will also ask you for the default SSH key to use, so it does not need to be provided every time. You can configure the SSH key again at any time running `dda inv -e kmt.config-ssh-key`. See more details below
 

--- a/tasks/kernel_matrix_testing/init_kmt.py
+++ b/tasks/kernel_matrix_testing/init_kmt.py
@@ -24,7 +24,7 @@ def gen_ssh_key(ctx: Context, kmt_dir: PathOrStr):
     ctx.run(f"chmod 600 {kmt_dir}/ddvm_rsa")
 
 
-def init_kernel_matrix_testing_system(ctx: Context, lite: bool, images):
+def init_kernel_matrix_testing_system(ctx: Context, lite: bool, images: str | None = None, all_images: bool = False):
     kmt_os = get_kmt_os()
 
     info("[+] Installing OS-specific general requirements...")
@@ -102,7 +102,11 @@ def init_kernel_matrix_testing_system(ctx: Context, lite: bool, images):
     # download dependencies
     if not lite:
         info("[+] Downloading VM images")
-        download_rootfs(ctx, kmt_os.rootfs_dir, "system-probe", arch=None, images=images)
+        if not all_images and not images:
+            raise Exit(
+                "No images specified for download. Use --images parameter to specify which images to download, or --all-images to download all images."
+            )
+        download_rootfs(ctx, kmt_os.rootfs_dir, "system-probe", arch=None, images=None if all_images else images)
 
     # Copy the SSH key we use to connect
     gen_ssh_key(ctx, kmt_os.kmt_dir)

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -354,12 +354,17 @@ def ls(_, distro=True, custom=False):
 @task(
     help={
         "lite": "If set, then do not download any VM images locally",
-        "images": "Comma separated list of images to update, instead of everything. The format of each image is '<os_id>-<os_version>'. Refer to platforms.json for the appropriate values for <os_id> and <os_version>.",
+        "images": "Comma separated list of images to download. The format of each image is '<os_id>-<os_version>'. Refer to platforms.json for the appropriate values for <os_id> and <os_version>. This parameter is required unless --lite or --all-images is specified.",
+        "all-images": "Download all available VM images for the current architecture. This is equivalent to the previous default behavior.",
     }
 )
-def init(ctx: Context, lite=False, images: str | None = None):
+def init(ctx: Context, lite=False, images: str | None = None, all_images=False):
+    if not lite and not all_images and images is None:
+        raise Exit(
+            "The --images parameter is required unless --lite or --all-images is specified. Use 'dda inv kmt.ls' to see available images."
+        )
     try:
-        init_kernel_matrix_testing_system(ctx, lite, images)
+        init_kernel_matrix_testing_system(ctx, lite, images, all_images)
     except Exception as e:
         error(f"[-] Error initializing kernel matrix testing system: {e}")
         raise e


### PR DESCRIPTION
## What does this PR do?

This PR changes the default behavior of the `kmt.init` command to make image downloads more explicit and controlled:

- **Breaking Change**: The command no longer downloads all images by default
- New flags:
  - `--all-images`: Downloads all images (replaces previous default behavior)
  - `--lite`: Skips image downloads entirely
  - Users must now explicitly specify which images they want to download

## Motivation

This change improves the `kmt` CLI experience by:
- Reducing initial setup time by not downloading unnecessary images
- Making image downloads more intentional and transparent
- Giving users more control over their local development environment
- Preventing unnecessary bandwidth usage and storage consumption

## Testing

- Manually tested the CLI with various flag combinations
- Verified behavior with both explicit image lists and the new flags
- Confirmed backward compatibility with existing workflows using `--all-images`

## Additional Notes

This is a breaking change that requires users to update their workflows to explicitly specify image downloads. The `--all-images` flag can be used to maintain the previous behavior.