### PR TITLE
[clusteragent] Fix wrong computation of the init container resources

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1472,7 +1472,41 @@ func TestInjectLibInitContainer(t *testing.T) {
 			wantMem: "151Mi",
 		},
 		{
-			name: "request_greater_than_limit",
+			name: "init_container_request_greater_than_limit",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "java-pod",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "i1", Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{}, // No limits
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					}}},
+					Containers: []corev1.Container{{Name: "c1", Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					}}},
+				},
+			},
+			image:    "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:     java,
+			wantErr:  false,
+			wantCPU:  "200m",
+			wantMem:  "200Mi",
+			limitCPU: "200m",
+			limitMem: "200Mi",
+		},
+		{
+			name: "containers_request_greater_than_limit",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "java-pod",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1052,6 +1052,8 @@ func TestInjectLibInitContainer(t *testing.T) {
 		wantErr                   bool
 		wantCPU                   string
 		wantMem                   string
+		limitCPU                  string
+		limitMem                  string
 		secCtx                    *corev1.SecurityContext
 	}{
 		{
@@ -1470,6 +1472,90 @@ func TestInjectLibInitContainer(t *testing.T) {
 			wantMem: "151Mi",
 		},
 		{
+			name: "request_greater_than_limit",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "java-pod",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "i1", Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("100Mi"),
+						},
+					}}},
+					Containers: []corev1.Container{{Name: "c1", Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{}, // No limits
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("200Mi"),
+						},
+					}}},
+				},
+			},
+			image:    "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:     java,
+			wantErr:  false,
+			wantCPU:  "200m",
+			wantMem:  "200Mi",
+			limitCPU: "200m",
+			limitMem: "200Mi",
+		},
+		{
+			name: "sidecar_container_request_greater_than_limit",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "java-pod",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name: "init-container-1",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("501m"),
+									corev1.ResourceMemory: resource.MustParse("101Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("501m"),
+									corev1.ResourceMemory: resource.MustParse("101Mi"),
+								},
+							},
+						}, {
+							Name:          "sidecar-container-1",
+							RestartPolicy: pointer.Ptr(corev1.ContainerRestartPolicyAlways),
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+						},
+					},
+					Containers: []corev1.Container{{Name: "c1", Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("101Mi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("101Mi"),
+						},
+					}}},
+				},
+			},
+			image:   "gcr.io/datadoghq/dd-lib-java-init:v1",
+			lang:    java,
+			wantErr: false,
+			wantCPU: "700m",
+			wantMem: "151Mi",
+		},
+		{
 			name: "todo",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1579,17 +1665,27 @@ func TestInjectLibInitContainer(t *testing.T) {
 
 			req := tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Requests[corev1.ResourceCPU]
 			lim := tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Limits[corev1.ResourceCPU]
-			wantCPUQuantity := resource.MustParse(tt.wantCPU)
-			t.Log("CPU wants:", wantCPUQuantity.String(), "actual lim: ", lim.String())
-			require.Zero(t, wantCPUQuantity.Cmp(req)) // Cmp returns 0 if equal
-			require.Zero(t, wantCPUQuantity.Cmp(lim))
+			requestCPUQuantity := resource.MustParse(tt.wantCPU)
+			limitCPUQuantity := requestCPUQuantity
+			if tt.limitCPU != "" {
+				limitCPUQuantity = resource.MustParse(tt.limitCPU)
+			}
+
+			t.Log("expected CPU request/limit:", requestCPUQuantity.String(), "/", limitCPUQuantity.String(), ", actual request/limit:", req.String(), "/", lim.String())
+			require.Zero(t, requestCPUQuantity.Cmp(req), "expected CPU request: %s, actual: %s", requestCPUQuantity.String(), req.String()) // Cmp returns 0 if equal
+			require.Zero(t, limitCPUQuantity.Cmp(lim), "expected CPU limit: %s, actual: %s", limitCPUQuantity.String(), lim.String())
 
 			req = tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Requests[corev1.ResourceMemory]
 			lim = tt.pod.Spec.InitContainers[initalInitContainerCount].Resources.Limits[corev1.ResourceMemory]
-			wantMemQuantity := resource.MustParse(tt.wantMem)
-			t.Log("memeory wants:", wantMemQuantity.String(), "actual lim: ", lim.String())
-			require.Zero(t, wantMemQuantity.Cmp(req))
-			require.Zero(t, wantMemQuantity.Cmp(lim))
+			requestMemQuantity := resource.MustParse(tt.wantMem)
+			limitMemQuantity := requestMemQuantity
+			if tt.limitMem != "" {
+				limitMemQuantity = resource.MustParse(tt.limitMem)
+			}
+
+			t.Log("expected memory request/limit:", requestMemQuantity.String(), "/", limitMemQuantity.String(), ", actual request/limit:", req.String(), "/", lim.String())
+			require.Zero(t, requestMemQuantity.Cmp(req), "expected memory request: %s, actual: %s", requestMemQuantity.String(), req.String())
+			require.Zero(t, limitMemQuantity.Cmp(lim), "expected memory limit: %s, actual: %s", limitMemQuantity.String(), lim.String())
 
 			expSecCtx := tt.pod.Spec.InitContainers[0].SecurityContext
 			require.Equal(t, tt.secCtx, expSecCtx)

--- a/releasenotes-dca/notes/autoinstrumentation-fix-resources-computation-9f00f3aa904f5b5d.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-fix-resources-computation-9f00f3aa904f5b5d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix wrong computation of the init container resources in the autoinstrumentation webhook.


### PR DESCRIPTION
### What does this PR do?

Fix wrong computation of the init container resources, introduced in https://github.com/DataDog/datadog-agent/pull/30266

If a request was set but not the limit, the computed request for the init containers could be higher than the computed limit. This is invalid and causes the deployment to fail.

To fix that, in case there is a request but no limit, we use the request as the limit.

### Motivation

Fix https://github.com/DataDog/datadog-agent/issues/35170 / https://datadoghq.atlassian.net/browse/CONS-7154 / https://datadoghq.atlassian.net/browse/INPLAT-529

### Describe how you validated your changes

Unit test
+
manually using
```
# values.yaml
datadog:
  logLevel: DEBUG
  clusterName: my-test-cluster
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  logs:
    enabled: true
    containerCollectAll: true
    containerCollectUsingFiles: true
  kubelet:
    tlsVerify: false
  apm:
    instrumentation:
      enabled: true
clusterAgent:
  admissionController:
    enabled: true


# deploy.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: demo
  namespace: init
  labels:
    app: init-container-test
spec:
  replicas: 1
  selector:
    matchLabels:
      app: init-container-test
  template:
    metadata:
      labels:
        app: init-container-test
    spec:
      containers:
        - name: container1
          image: busybox
          command: ["sleep", "3600"]
          resources:
            limits:
              cpu: 100m
              memory: 128Mi
            requests:
              cpu: 100m
              memory: 128Mi
        - name: container2
          image: busybox
          command: ["sleep", "3600"]
          resources:
            limits:
              # cpu: 50m    <- uncommenting this allows the pod to be created
              memory: 128Mi
            requests:
              cpu: 50m
              memory: 128Mi
```

With cluster agent 7.64, the deployment of the app results in a failure:
```
Pod "demo-57667dd664-q8h7z" is invalid: [spec.initContainers[0].resources.requests: Invalid value: "150m": must be less than or equal to cpu limit of 100m, spec.initContainers[1].resources.requests: Invalid value: "150m": must be less than or equal to cpu limit of 100m,
```

With this PR, the deployment is successful.


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->