### PR TITLE
Ignore go.mod files for tests and lints in pre-commit

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -446,6 +446,9 @@ def get_modified_packages(ctx, build_tags=None, lint=False) -> list[GoModule]:
     go_mod_modified_modules = set()
 
     for modified_file in modified_go_files:
+        if modified_file.endswith(".mod") or modified_file.endswith(".sum"):
+            continue
+
         best_module_path = Path(get_go_module(modified_file))
 
         # Check if the package is in the target list of the module we want to test
@@ -464,12 +467,6 @@ def get_modified_packages(ctx, build_tags=None, lint=False) -> list[GoModule]:
 
         # If go mod was modified in the module we run the test for the whole module so we do not need to add modified packages to targets
         if best_module_path in go_mod_modified_modules:
-            continue
-
-        # If we modify the go.mod or go.sum we run the tests for the whole module
-        if modified_file.endswith(".mod") or modified_file.endswith(".sum"):
-            modules_to_test[best_module_path] = get_module_by_path(best_module_path)
-            go_mod_modified_modules.add(best_module_path)
             continue
 
         # If the package has been deleted we do not try to run tests


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Ignore go.mod and go.sum files to determine which tests and lints to run in pre-commit.

### Motivation
Before this change, any dependency update runs a lot of tests and lints in pre-commit, which is really inconvenient.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
`get_modified_packages` is only used by the `test` and `linter.go` tasks when running in pre-commits. 
It shouldn't have any impact on CI.