### PR TITLE
Fix `inv` argument passthrough

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -91,13 +91,13 @@ build do
       do_windows_sysprobe = "--windows-sysprobe"
     end
     command "dda inv -e rtloader.clean"
-    command "dda inv -e rtloader.make --install-prefix \"#{windows_safe_path(python_3_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\" \\\"-DPython3_EXECUTABLE=#{windows_safe_path(python_3_embedded)}\\python.exe\"\"", :env => env
+    command "dda inv -e rtloader.make --install-prefix \"#{windows_safe_path(python_3_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\" \\\"-DPython3_EXECUTABLE=#{windows_safe_path(python_3_embedded)}\\python.exe\\\"\"", :env => env
     command "mv rtloader/bin/*.dll  #{install_dir}/bin/agent/"
     command "dda inv -e agent.build --exclude-rtloader --major-version #{major_version_arg} --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded #{do_windows_sysprobe} --flavor #{flavor_arg}", env: env
     command "dda inv -e systray.build --major-version #{major_version_arg}", env: env
   else
     command "dda inv -e rtloader.clean"
-    command "dda inv -e rtloader.make --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER -DPython3_EXECUTABLE=#{install_dir}/embedded/bin/python3'", :env => env
+    command "dda inv -- -e rtloader.make --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER -DPython3_EXECUTABLE=#{install_dir}/embedded/bin/python3'", :env => env
     command "dda inv -e rtloader.install"
     bundle_arg = bundled_agents.map { |k| "--bundle #{k}" }.join(" ")
 


### PR DESCRIPTION
### Motivation

This [PR](https://github.com/DataDog/datadog-agent-dev/pull/43) added options to the `inv` command and now escaping quotes must be resilient to being parsed twice. The Windows line here was simply missing the final escape and was working accidentally. The non-Windows line I couldn't get to work so I added `--` to treat everything that follows as arguments which seems to prevent processing.

### Notes

It's technically more proper to do `--` everywhere in CI but upon attempting the `dda` upgrade it appears that this is the only place that is broken/where we do complex shell escaping. The benefit of not doing that everywhere is reduced user confusion about what that means and folks cargo culting the syntax which adds a bit of friction in day-to-day usage.