### PR TITLE
[AGENTCFG-177] Setting config keys according to binding order instead of randomly

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -462,7 +462,7 @@ func (c *ntmConfig) buildEnvVars() {
 				if err := c.insertNodeFromString(root, configKey, value); err != nil {
 					envWarnings = append(envWarnings, fmt.Sprintf("inserting env var: %s", err))
 				} else {
-					// Stop looping since we set the config key with the value of the highest precendence env var
+					// Stop looping since we set the config key with the value of the highest precedence env var
 					break
 				}
 			}

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -851,9 +851,8 @@ func TestEnvVarOrdering(t *testing.T) {
 	// Test scenario 1: DD_DD_URL set before DD_URL
 	t.Run("DD_DD_URL set first", func(t *testing.T) {
 		config := NewConfig("test", "TEST", strings.NewReplacer(".", "_"))
-		config.BindEnv("DD_API_KEY", "fakeapikey")
+		config.BindEnv("fakeapikey", "DD_API_KEY")
 		config.BindEnv("dd_url", "DD_DD_URL", "DD_URL")
-		config.BindEnv("DD_EXTERNAL_CONFIG_EXTERNAL_AGENT_DD_URL", "https://custom.external-agent.datadoghq.com")
 		t.Setenv("DD_DD_URL", "https://app.datadoghq.dd_dd_url.eu")
 		t.Setenv("DD_URL", "https://app.datadoghq.dd_url.eu")
 		config.BuildSchema()
@@ -865,14 +864,25 @@ func TestEnvVarOrdering(t *testing.T) {
 	// Test scenario 2: DD_URL set before DD_DD_URL
 	t.Run("DD_URL set first", func(t *testing.T) {
 		config := NewConfig("test", "TEST", strings.NewReplacer(".", "_"))
-		config.BindEnv("DD_API_KEY", "fakeapikey")
+		config.BindEnv("fakeapikey", "DD_API_KEY")
 		config.BindEnv("dd_url", "DD_DD_URL", "DD_URL")
-		config.BindEnv("DD_EXTERNAL_CONFIG_EXTERNAL_AGENT_DD_URL", "https://custom.external-agent.datadoghq.com")
 		t.Setenv("DD_URL", "https://app.datadoghq.dd_url.eu")
 		t.Setenv("DD_DD_URL", "https://app.datadoghq.dd_dd_url.eu")
 		config.BuildSchema()
 
 		assert.Equal(t, true, config.IsConfigured("dd_url"))
 		assert.Equal(t, "https://app.datadoghq.dd_dd_url.eu", config.GetString("dd_url"))
+	})
+
+	// Test scenario 3: Only DD_URL is set (DD_DD_URL is missing)
+	t.Run("Only DD_URL is set", func(t *testing.T) {
+		config := NewConfig("test", "TEST", strings.NewReplacer(".", "_"))
+		config.BindEnv("fakeapikey", "DD_API_KEY")
+		config.BindEnv("dd_url", "DD_DD_URL", "DD_URL")
+		t.Setenv("DD_URL", "https://app.datadoghq.dd_url.eu")
+		config.BuildSchema()
+
+		assert.Equal(t, true, config.IsConfigured("dd_url"))
+		assert.Equal(t, "https://app.datadoghq.dd_url.eu", config.GetString("dd_url"))
 	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Currently in nodetreemodel, if two env vars are set for a particular config key, the config key will choose the value of the env var that was set first (i.e. the order of `os.Environ()`). However, we want the order to be specified by the `BindEnv` command instead.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->