### PR TITLE
[E2E test] k8s test with DCA leader election

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -379,15 +379,6 @@ func (suite *k8sSuite) testAgentCLI() {
 }
 
 func (suite *k8sSuite) testClusterAgentCLI() {
-	ctx := context.Background()
-
-	pod, err := suite.Env().KubernetesCluster.Client().CoreV1().Pods("datadog").List(ctx, metav1.ListOptions{
-		LabelSelector: fields.OneTermEqualSelector("app", suite.Env().Agent.LinuxClusterAgent.LabelSelectors["app"]).String(),
-		Limit:         1,
-	})
-	suite.Require().NoError(err)
-	suite.Require().Len(pod.Items, 1)
-
 	leaderDcaPodName := suite.testDCALeaderElection(false) //check cluster agent leaderelection without restart
 	suite.Require().NotEmpty(leaderDcaPodName, "Leader DCA pod name should not be empty")
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds an E2E test to verify the leader election status using the `cluster-agent status --json` output.

1. Get leader pod name from any dca pod
2. Connect to leader pod
3. Use leader pod for the rest of E2E tests on dca status check. 

### Motivation
The current [integration test](https://github.com/DataDog/datadog-agent/blob/e0c94ee83df20740e1289b7bb757fe5a247a1e9a/test/integration/util/leaderelection/leaderelection_test.go#L255) for leader election is being deprecated. This PR introduces a new E2E test to validate the leader election status.

Currently, the test infrastructure only launches a single Cluster Agent pod, which will always assume leadership. In the next version of test-infra-definitions, the number of Cluster Agent pods will increase to two. This allows us to retrieve the leader pod name from any DCA pod status and then verify that pod's leadership status.

Note: Validation of re-election is not supported in either the integration test or the new E2E test, as triggering re-election would interfere with other parts of the E2E suite.

We don't support validation on reelection in integration test or new e2e test yet. Doing so will cause other part of e2e test fail. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
E2e test
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->