### PR TITLE
[Static Quality Gates] Thresholds update is now on the first commit of the day instead of the nightly pipelines

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -10,8 +10,8 @@ from invoke.exceptions import Exit
 from tasks.github_tasks import pr_commenter
 from tasks.libs.ciproviders.github_api import GithubAPI, create_datadog_agent_pr
 from tasks.libs.common.color import color_message
-from tasks.libs.package.size import InfraError
 from tasks.libs.common.utils import is_conductor_scheduled_pipeline
+from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.lib.gates_lib import GateMetricHandler, byte_to_string, is_first_commit_of_the_day
 
 BUFFER_SIZE = 500000

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -10,9 +10,9 @@ from invoke.exceptions import Exit
 from tasks.github_tasks import pr_commenter
 from tasks.libs.ciproviders.github_api import GithubAPI, create_datadog_agent_pr
 from tasks.libs.common.color import color_message
-from tasks.libs.common.utils import is_conductor_scheduled_pipeline
 from tasks.libs.package.size import InfraError
-from tasks.static_quality_gates.lib.gates_lib import GateMetricHandler, byte_to_string
+from tasks.libs.common.utils import is_conductor_scheduled_pipeline
+from tasks.static_quality_gates.lib.gates_lib import GateMetricHandler, byte_to_string, is_first_commit_of_the_day
 
 BUFFER_SIZE = 500000
 FAIL_CHAR = "❌"
@@ -118,8 +118,14 @@ def parse_and_trigger_gates(ctx, config_path="test/static/static_quality_gates.y
     final_state = "success"
     gate_states = []
 
+    threshold_update_run = False
     nightly_run = False
     branch = os.environ["CI_COMMIT_BRANCH"]
+    bucket_branch = os.environ["BUCKET_BRANCH"]
+    # we avoid nightly pipelines because they have different package size than the main branch
+    if branch == "main" and bucket_branch != "nightly" and is_first_commit_of_the_day(ctx):
+        threshold_update_run = True
+
     DDR_WORKFLOW_ID = os.environ.get("DDR_WORKFLOW_ID")
     if DDR_WORKFLOW_ID and branch == "main" and is_conductor_scheduled_pipeline():
         nightly_run = True
@@ -159,11 +165,12 @@ def parse_and_trigger_gates(ctx, config_path="test/static/static_quality_gates.y
         display_pr_comment(ctx, final_state == "success", gate_states, metric_handler)
 
     # Generate PR to update static quality gates threshold once per day (scheduled main pipeline by conductor)
-    if nightly_run:
+    if threshold_update_run:
         pr_url = update_quality_gates_threshold(ctx, metric_handler, github)
         notify_threshold_update(pr_url)
 
-    if final_state != "success":
+    # Nightly pipelines have different package size and gates thresholds are unreliable for nightly pipelines
+    if final_state != "success" and not nightly_run:
         raise Exit(code=1)
 
 

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -64,6 +64,10 @@ def read_byte_input(byte_input):
     else:
         return byte_input
 
+def is_first_commit_of_the_day(ctx) -> bool:
+    out = ctx.run("git log --since=today.midnight | grep -E \"commit [a-z0-9]+\" | wc -l ")
+    return out.stdout.strip() == "1"
+
 
 def find_package_path(flavor, package_os, arch, extension=None):
     package_dir = os.environ['OMNIBUS_PACKAGE_DIR']

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -64,6 +64,7 @@ def read_byte_input(byte_input):
     else:
         return byte_input
 
+
 def is_first_commit_of_the_day(ctx) -> bool:
     out = ctx.run("git log --since=today.midnight | grep -E \"commit [a-z0-9]+\" | wc -l ")
     return out.stdout.strip() == "1"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Nightly pipelines have different package size than the main branch. They are unreliable and can't be used to re-align static quality gates thresholds. Also disable enforcement on nightly pipelines since their size doesn't represent the real size quality gates are testing against.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->