### PR TITLE
[EBPF] gpu: cache tags for the event telemetry

### DIFF
--- a/pkg/gpu/e2e_events_test.go
+++ b/pkg/gpu/e2e_events_test.go
@@ -43,11 +43,12 @@ func injectEventsToConsumer(tb testing.TB, consumer *cudaEventConsumer, events *
 
 func TestPytorchBatchedKernels(t *testing.T) {
 	cfg := config.New()
-	ctx, err := getSystemContext(testutil.GetBasicNvmlMock(), kernel.ProcFSRoot(), testutil.GetWorkloadMetaMock(t), testutil.GetTelemetryMock(t))
+	telemetryMock := testutil.GetTelemetryMock(t)
+	ctx, err := getSystemContext(testutil.GetBasicNvmlMock(), kernel.ProcFSRoot(), testutil.GetWorkloadMetaMock(t), telemetryMock)
 	require.NoError(t, err)
 
-	handlers := newStreamCollection(ctx, testutil.GetTelemetryMock(t))
-	consumer := newCudaEventConsumer(ctx, handlers, nil, cfg, testutil.GetTelemetryMock(t))
+	handlers := newStreamCollection(ctx, telemetryMock)
+	consumer := newCudaEventConsumer(ctx, handlers, nil, cfg, telemetryMock)
 	require.NotNil(t, consumer)
 
 	events := testutil.GetGPUTestEvents(t, testutil.DataSamplePytorchBatchedKernels)
@@ -61,6 +62,16 @@ func TestPytorchBatchedKernels(t *testing.T) {
 
 	// Check that the consumer has the expected number of streams
 	require.Equal(t, 1, handlers.streamCount())
+
+	telemetryMetrics, err := telemetryMock.GetCountMetric("gpu__consumer", "events")
+	require.NoError(t, err)
+	require.Equal(t, 4, len(telemetryMetrics)) // one for each event type
+	expectedEventsByType := testutil.DataSampleInfos[testutil.DataSamplePytorchBatchedKernels].EventByType
+	for _, metric := range telemetryMetrics {
+		eventTypeTag := metric.Tags()["event_type"]
+		require.NotEmpty(t, eventTypeTag)
+		require.Equal(t, expectedEventsByType[eventTypeTag], int(metric.Value()))
+	}
 
 	// Check the state of those streams. As there's only one we can just get it
 	// by iterating over the map

--- a/pkg/gpu/ebpf/c/types.h
+++ b/pkg/gpu/ebpf/c/types.h
@@ -12,6 +12,7 @@ typedef enum {
     cuda_memory_event,
     cuda_sync,
     cuda_set_device,
+    cuda_event_type_count,
 } cuda_event_type_t;
 
 #define MAX_CONTAINER_ID_LEN 129

--- a/pkg/gpu/ebpf/kprobe_types.go
+++ b/pkg/gpu/ebpf/kprobe_types.go
@@ -34,6 +34,7 @@ const CudaEventTypeKernelLaunch CudaEventType = C.cuda_kernel_launch
 const CudaEventTypeMemory CudaEventType = C.cuda_memory_event
 const CudaEventTypeSync CudaEventType = C.cuda_sync
 const CudaEventTypeSetDevice CudaEventType = C.cuda_set_device
+const CudaEventTypeCount CudaEventType = C.cuda_event_type_count
 
 const CudaMemAlloc = C.cudaMalloc
 const CudaMemFree = C.cudaFree

--- a/pkg/gpu/ebpf/kprobe_types_linux.go
+++ b/pkg/gpu/ebpf/kprobe_types_linux.go
@@ -60,6 +60,7 @@ const CudaEventTypeKernelLaunch CudaEventType = 0x0
 const CudaEventTypeMemory CudaEventType = 0x1
 const CudaEventTypeSync CudaEventType = 0x2
 const CudaEventTypeSetDevice CudaEventType = 0x3
+const CudaEventTypeCount CudaEventType = 0x4
 
 const CudaMemAlloc = 0x0
 const CudaMemFree = 0x1

--- a/pkg/gpu/testutil/events.go
+++ b/pkg/gpu/testutil/events.go
@@ -40,6 +40,9 @@ type DataSampleInfo struct {
 
 	// EventCount is the number of events in the data sample
 	EventCount int
+
+	// EventByType is the number of events in the data sample by type
+	EventByType map[string]int
 }
 
 // DataSampleInfos contains information about the data samples available in the testdata directory,
@@ -48,6 +51,12 @@ var DataSampleInfos = map[dataSample]DataSampleInfo{
 	DataSamplePytorchBatchedKernels: {
 		ActivePID:  24920,
 		EventCount: 990,
+		EventByType: map[string]int{
+			"CudaEventTypeKernelLaunch": 848,
+			"CudaEventTypeMemory":       0,
+			"CudaEventTypeSync":         142,
+			"CudaEventTypeSetDevice":    0,
+		},
 	},
 }
 

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -170,8 +170,8 @@ func GetWorkloadMetaMock(t testing.TB) workloadmetamock.Mock {
 }
 
 // GetTelemetryMock returns a mock of the telemetry.Component.
-func GetTelemetryMock(t testing.TB) telemetry.Component {
-	return fxutil.Test[telemetry.Component](t, telemetryimpl.MockModule())
+func GetTelemetryMock(t testing.TB) telemetry.Mock {
+	return fxutil.Test[telemetry.Mock](t, telemetryimpl.MockModule())
 }
 
 // RequireDevicesEqual checks that the two devices are equal by comparing their UUIDs, which gives a better


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Pre-computes the telemetry counters for each event type to avoid having to generate the tags on every event.

### Motivation

Improve performance of the consumption routine, as the code was spending a significant part of the time just generating the label values.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Added CI test checking that the telemetry reports the correct values. 

Benchmarks:

Before (on `main`):

``` 
BenchmarkConsumer/fatbinParsingDisabled-8                2331670               555.6 ns/op           919 B/op          3 allocs/op
```

After

``` 
BenchmarkConsumer/fatbinParsingDisabled-8                2697770               435.0 ns/op           903 B/op          2 allocs/op
``` 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->