### PR TITLE
[CWS] make sure `packet.filter` fields can be validate when pcap is disabled

### DIFF
--- a/pkg/security/secl/model/oo_packet_filter_common.go
+++ b/pkg/security/secl/model/oo_packet_filter_common.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package model holds model related files
+package model
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+var errNonStaticPacketFilterField = errors.New("packet filter fields only support matching a single static")
+
+func errorNonStaticPacketFilterField(a eval.Evaluator, b eval.Evaluator) error {
+	var field string
+	if a.IsStatic() {
+		field = b.GetField()
+	} else if b.IsStatic() {
+		field = a.GetField()
+	} else {
+		return errNonStaticPacketFilterField
+	}
+	return fmt.Errorf("field `%s` only supports matching a single static value", field)
+}

--- a/pkg/security/secl/model/oo_packet_filter_unix.go
+++ b/pkg/security/secl/model/oo_packet_filter_unix.go
@@ -9,7 +9,6 @@
 package model
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/google/gopacket/layers"
@@ -17,20 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
-
-var errNonStaticPacketFilterField = errors.New("packet filter fields only support matching a single static")
-
-func errorNonStaticPacketFilterField(a eval.Evaluator, b eval.Evaluator) error {
-	var field string
-	if a.IsStatic() {
-		field = b.GetField()
-	} else if b.IsStatic() {
-		field = a.GetField()
-	} else {
-		return errNonStaticPacketFilterField
-	}
-	return fmt.Errorf("field `%s` only supports matching a single static value", field)
-}
 
 func newPacketFilterEvaluator(field string, value string, state *eval.State) (*eval.BoolEvaluator, error) {
 	switch field {

--- a/pkg/security/secl/model/oo_packet_filter_unsupported.go
+++ b/pkg/security/secl/model/oo_packet_filter_unsupported.go
@@ -9,25 +9,27 @@
 package model
 
 import (
-	"errors"
-
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
-var errUnsupportedPacketFilter = errors.New("packet filter fields are not supported")
-
 // PacketFilterMatching is a set of overrides for packet filter fields, it only supports matching a single static value
 var PacketFilterMatching = &eval.OpOverrides{
-	StringEquals: func(_ *eval.StringEvaluator, _ *eval.StringEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
-		return nil, errUnsupportedPacketFilter
+	StringEquals: func(a *eval.StringEvaluator, b *eval.StringEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
+		if a.IsStatic() || b.IsStatic() {
+			return &eval.BoolEvaluator{
+				Value: false,
+			}, nil
+		}
+
+		return nil, errorNonStaticPacketFilterField(a, b)
 	},
-	StringValuesContains: func(_ *eval.StringEvaluator, _ *eval.StringValuesEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
-		return nil, errUnsupportedPacketFilter
+	StringValuesContains: func(a *eval.StringEvaluator, b *eval.StringValuesEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
+		return nil, errorNonStaticPacketFilterField(a, b)
 	},
-	StringArrayContains: func(_ *eval.StringEvaluator, _ *eval.StringArrayEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
-		return nil, errUnsupportedPacketFilter
+	StringArrayContains: func(a *eval.StringEvaluator, b *eval.StringArrayEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
+		return nil, errorNonStaticPacketFilterField(a, b)
 	},
-	StringArrayMatches: func(_ *eval.StringArrayEvaluator, _ *eval.StringValuesEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
-		return nil, errUnsupportedPacketFilter
+	StringArrayMatches: func(a *eval.StringArrayEvaluator, b *eval.StringValuesEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
+		return nil, errorNonStaticPacketFilterField(a, b)
 	},
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

When  the`pcap` build tag is disabled, the rule loader will outright reject pcap rules. This is especially an issue with the backend because it prevents the backend from accepting raw packets rules (since the backend cannot use the pcap build tag).

To fix this issue, this PR make sure pcap rules are still accepted, but will always evaluate to false instead (not amazing, but his code is not loaded in the agent anyway). 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->