### PR TITLE
docker check: make sure the container filter is checked against nil

### DIFF
--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -240,7 +240,10 @@ func (d *DockerCheck) runDockerCustom(sender sender.Sender, du docker.Client, ra
 			annotations = pod.Annotations
 		}
 
-		isContainerExcluded := d.containerFilter.IsExcluded(annotations, containerName, resolvedImageName, rawContainer.Labels[kubernetes.CriContainerNamespaceLabel])
+		isContainerExcluded := false
+		if d.containerFilter != nil {
+			isContainerExcluded = d.containerFilter.IsExcluded(annotations, containerName, resolvedImageName, rawContainer.Labels[kubernetes.CriContainerNamespaceLabel])
+		}
 		isContainerRunning := rawContainer.State == string(workloadmeta.ContainerStatusRunning)
 		taggerEntityID := types.NewEntityID(types.ContainerID, rawContainer.ID)
 		tags, err := d.getImageTagsFromContainer(taggerEntityID, resolvedImageName, isContainerExcluded || !isContainerRunning)


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/commit/d5a84b2612bdfaa746f5f8b0ed99d27806d5c1fe#diff-06a76d6a9193f55ac9d062533ce6ada1dbde63e9dd18e0a63c22546c7cf8687eL72 removed the fetch of the shared metric filter when initialising the docker util. This means that the docker check can run even with a wrong filter which was not the case before.

This also means that https://github.com/DataDog/datadog-agent/blob/bc440834eb87760fc55cc998f423043115de1f2d/pkg/collector/corechecks/containers/docker/check.go#L131 can actually fail and `d.containerFilter` be nil and this case is currently not handled.

This PR makes sure `d.containerFilter == nil` is correct handled (with no filter).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->