### PR TITLE
fix panic during tear down of e2e env

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -249,13 +249,15 @@ func (bs *BaseSuite[Env]) CleanupOnSetupFailure() {
 		}()
 
 		// run environment diagnose
-		if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok && diagnosableEnv != nil {
-			// at least one test failed, diagnose the environment
-			diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
-			if diagnoseErr != nil {
-				bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
-			} else {
-				bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+		if bs.env != nil {
+			if diagnosableEnv, ok := any(bs.env).(common.Diagnosable); ok && diagnosableEnv != nil {
+				// at least one test failed, diagnose the environment
+				diagnose, diagnoseErr := diagnosableEnv.Diagnose(bs.SessionOutputDir())
+				if diagnoseErr != nil {
+					bs.T().Logf("unable to diagnose environment: %v", diagnoseErr)
+				} else {
+					bs.T().Logf("Diagnose result:\n\n%s", diagnose)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes a panic calling `Diagnose` during `TearDownSuite` due to an error reconciling the environment. See https://go.dev/play/p/3_phxg5lSNb

### Motivation

If the environment failed to fully reconcile, then calling Diagnose will result in a panic due to nil pointer.

```
panic.go:262: test panicked: runtime error: invalid memory address or nil pointer dereference
        goroutine 71 [running]:
        runtime/debug.Stack()
        	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
        github.com/stretchr/testify/suite.failOnPanic(0xc0006f64e0, {0xf3a7940, 0x19b56950})
        	/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:89 +0x37
        github.com/stretchr/testify/suite.recoverAndFailOnPanic(0xc0006f64e0)
        	/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:83 +0x35
        panic({0xf3a7940?, 0x19b56950?})
        	/usr/local/go/src/runtime/panic.go:785 +0x132
        github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments.(*Host).Diagnose(0x19b5bc80?, {0xc0012fad20?, 0x0?})
        	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments/host.go:39 +0x1a
        github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e.(*BaseSuite[...]).SetupSuite.func1()
        	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e/suite.go:538 +0x1c3
        panic({0xf2a41a0?, 0xc001331470?})
        	/usr/local/go/src/runtime/panic.go:785 +0x132
        github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e.(*BaseSuite[...]).SetupSuite(0x114499c0)
        	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e/suite.go:562 +0x3d6
        github.com/DataDog/datadog-agent/test/new-e2e/tests/gpu.(*gpuBaseSuite[...]).SetupSuite(0x15)
        	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/gpu/gpu_test.go:153 +0x25
        github.com/DataDog/datadog-agent/test/new-e2e/tests/gpu.(*gpuHostSuite).SetupSuite(0xc000e1a500)
        	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/gpu/gpu_test.go:88 +0x6d
        github.com/stretchr/testify/suite.Run(0xc0006f64e0, {0x11365278, 0xc000e1a500})
        	/go/pkg/mod/github.com/stretchr/testify@v1.10.0/suite/suite.go:157 +0x757
        github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e.Run[...](0xc0006f64e0, 0xc000e1a500, {0xc000927bc8, 0x1, 0x1})
        	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e/suite.go:699 +0x1cc
        github.com/DataDog/datadog-agent/test/new-e2e/tests/gpu.TestGPUHostSuite(0xc0006f64e0)
        	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/gpu/gpu_test.go:82 +0x4ad
        testing.tRunner(0xc0006f64e0, 0x1099a5b8)
        	/usr/local/go/src/testing/testing.go:1690 +0xf4
        created by testing.(*T).Run in goroutine 1
        	/usr/local/go/src/testing/testing.go:1743 +0x390
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->