### PR TITLE
usm: kafka: tests: Remove duplicated option for setting a dialer

### DIFF
--- a/pkg/network/protocols/kafka/client.go
+++ b/pkg/network/protocols/kafka/client.go
@@ -24,7 +24,6 @@ const (
 // Options is a struct to hold the options for the kafka client
 type Options struct {
 	ServerAddress string
-	Dialer        *net.Dialer
 	DialFn        func(context.Context, string, string) (net.Conn, error)
 	CustomOptions []kgo.Opt
 }
@@ -38,9 +37,8 @@ type Client struct {
 func NewClient(opts Options) (*Client, error) {
 	kafkaOptions := []kgo.Opt{kgo.SeedBrokers(opts.ServerAddress)}
 	kafkaOptions = append(kafkaOptions, opts.CustomOptions...)
-	if opts.Dialer != nil {
-		kafkaOptions = append(kafkaOptions, kgo.Dialer(opts.Dialer.DialContext))
-	} else if opts.DialFn != nil {
+
+	if opts.DialFn != nil {
 		kafkaOptions = append(kafkaOptions, kgo.Dialer(opts.DialFn))
 	}
 	client, err := kgo.NewClient(kafkaOptions...)

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -857,7 +857,7 @@ func testKafkaProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 			postTracerSetup: func(t *testing.T, ctx testContext) {
 				client, err := kafka.NewClient(kafka.Options{
 					ServerAddress: ctx.targetAddress,
-					Dialer:        defaultDialer,
+					DialFn:        defaultDialer.DialContext,
 					CustomOptions: []kgo.Opt{kgo.MaxVersions(kversion.V0_10_1())},
 				})
 				require.NoError(t, err)
@@ -879,7 +879,7 @@ func testKafkaProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 			preTracerSetup: func(t *testing.T, ctx testContext) {
 				client, err := kafka.NewClient(kafka.Options{
 					ServerAddress: ctx.targetAddress,
-					Dialer:        defaultDialer,
+					DialFn:        defaultDialer.DialContext,
 					CustomOptions: []kgo.Opt{kgo.MaxVersions(kversion.V0_10_1())},
 				})
 				require.NoError(t, err)
@@ -905,7 +905,7 @@ func testKafkaProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 			preTracerSetup: func(t *testing.T, ctx testContext) {
 				client, err := kafka.NewClient(kafka.Options{
 					ServerAddress: ctx.targetAddress,
-					Dialer:        defaultDialer,
+					DialFn:        defaultDialer.DialContext,
 					CustomOptions: []kgo.Opt{kgo.ClientID(""), kgo.MaxVersions(kversion.V0_10_1())},
 				})
 				require.NoError(t, err)
@@ -936,7 +936,7 @@ func testKafkaProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 			preTracerSetup: func(t *testing.T, ctx testContext) {
 				client, err := kafka.NewClient(kafka.Options{
 					ServerAddress: ctx.targetAddress,
-					Dialer:        defaultDialer,
+					DialFn:        defaultDialer.DialContext,
 					CustomOptions: []kgo.Opt{kgo.ClientID(""), kgo.MaxVersions(kversion.V0_10_1())},
 				})
 				require.NoError(t, err)
@@ -1048,13 +1048,13 @@ func testKafkaProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 			preTracerSetup: func(t *testing.T, ctx testContext) {
 				produceClient, err := kafka.NewClient(kafka.Options{
 					ServerAddress: ctx.targetAddress,
-					Dialer:        defaultDialer,
+					DialFn:        defaultDialer.DialContext,
 					CustomOptions: []kgo.Opt{kgo.MaxVersions(version), kgo.ConsumeTopics(ctx.extras["topic_name"].(string))},
 				})
 				require.NoError(t, err)
 				fetchClient, err := kafka.NewClient(kafka.Options{
 					ServerAddress: ctx.targetAddress,
-					Dialer:        defaultDialer,
+					DialFn:        defaultDialer.DialContext,
 					CustomOptions: []kgo.Opt{kgo.MaxVersions(version), kgo.ConsumeTopics(ctx.extras["topic_name"].(string))},
 				})
 				require.NoError(t, err)


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Remove duplicated option for setting a dialer

### Motivation

We had both Dialer and DialFn options, which served the same purpose. The change removes Dialer and keeps DialFn as the sole option to set a custom dialing method.

The purpose is to simplify the codebase

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->