### PR TITLE
usm: tests: Cleanup protocol map before running the tests

### DIFF
--- a/pkg/network/usm/tests/tracer_usm_kafka_classification_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_kafka_classification_linux_test.go
@@ -284,13 +284,7 @@ func testKafkaProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			originalPostTracer := tt.postTracerSetup
-			wrapperPostTracer := func(t *testing.T, ctx testContext) {
-				cleanProtocolMapByProtocol(t, tr, protocols.Kafka)
-				originalPostTracer(t, ctx)
-			}
-			tt.postTracerSetup = wrapperPostTracer
-			testProtocolClassificationInner(t, tt, tr)
+			testProtocolClassificationInnerWithProtocolCleanup(t, tt, tr, protocols.Kafka)
 		})
 	}
 }

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -1155,6 +1155,12 @@ func testMySQLProtocolClassificationInner(t *testing.T, tr *tracer.Tracer, clien
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			originalPostTracer := tt.postTracerSetup
+			wrapperPostTracer := func(t *testing.T, ctx testContext) {
+				cleanProtocolMapByProtocol(t, tr, protocols.MySQL)
+				originalPostTracer(t, ctx)
+			}
+			tt.postTracerSetup = wrapperPostTracer
 			testProtocolClassificationInner(t, tt, tr)
 		})
 	}
@@ -1401,6 +1407,12 @@ func testPostgresProtocolClassification(t *testing.T, tr *tracer.Tracer, clientH
 				serverAddress: serverAddress,
 				extras:        make(map[string]interface{}),
 			}
+			originalPostTracer := tt.postTracerSetup
+			wrapperPostTracer := func(t *testing.T, ctx testContext) {
+				cleanProtocolMapByProtocol(t, tr, protocols.Postgres)
+				originalPostTracer(t, ctx)
+			}
+			tt.postTracerSetup = wrapperPostTracer
 			testProtocolClassificationInner(t, tt, tr)
 		})
 	}
@@ -1561,6 +1573,12 @@ func testMongoProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			originalPostTracer := tt.postTracerSetup
+			wrapperPostTracer := func(t *testing.T, ctx testContext) {
+				cleanProtocolMapByProtocol(t, tr, protocols.Mongo)
+				originalPostTracer(t, ctx)
+			}
+			tt.postTracerSetup = wrapperPostTracer
 			testProtocolClassificationInner(t, tt, tr)
 		})
 	}
@@ -1748,6 +1766,12 @@ func testRedisProtocolClassificationInner(t *testing.T, tr *tracer.Tracer, clien
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			originalPostTracer := tt.postTracerSetup
+			wrapperPostTracer := func(t *testing.T, ctx testContext) {
+				cleanProtocolMapByProtocol(t, tr, protocols.Redis)
+				originalPostTracer(t, ctx)
+			}
+			tt.postTracerSetup = wrapperPostTracer
 			testProtocolClassificationInner(t, tt, tr)
 		})
 	}
@@ -1922,6 +1946,12 @@ func testAMQPProtocolClassificationInner(t *testing.T, tr *tracer.Tracer, client
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			originalPostTracer := tt.postTracerSetup
+			wrapperPostTracer := func(t *testing.T, ctx testContext) {
+				cleanProtocolMapByProtocol(t, tr, protocols.AMQP)
+				originalPostTracer(t, ctx)
+			}
+			tt.postTracerSetup = wrapperPostTracer
 			testProtocolClassificationInner(t, tt, tr)
 		})
 	}
@@ -2190,6 +2220,13 @@ func testHTTP2ProtocolClassification(t *testing.T, tr *tracer.Tracer, clientHost
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			originalPostTracer := tt.postTracerSetup
+			wrapperPostTracer := func(t *testing.T, ctx testContext) {
+				cleanProtocolMapByProtocol(t, tr, protocols.HTTP2)
+				cleanProtocolMapByProtocol(t, tr, protocols.GRPC)
+				originalPostTracer(t, ctx)
+			}
+			tt.postTracerSetup = wrapperPostTracer
 			testProtocolClassificationInner(t, tt, tr)
 		})
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Clenaup entries from `connection_protocol` map before running each classification test

### Motivation

Ensure no "leaks" between tests, as we run a single monitor/tracer for all classification tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->