### PR TITLE
[CWS] Fix multiple off-by-one kernel version checks for eBPF features

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -322,7 +322,6 @@ func (k *Version) IsInRangeCloseOpen(begin kernel.Version, end kernel.Version) b
 // HaveMmapableMaps returns whether the kernel supports mmapable maps.
 func (k *Version) HaveMmapableMaps() bool {
 	return features.HaveMapFlag(features.BPF_F_MMAPABLE) == nil
-
 }
 
 // HaveRingBuffers returns whether the kernel supports ring buffer.
@@ -380,7 +379,7 @@ func (k *Version) HasSKStorage() bool {
 		return true
 	}
 
-	return k.Code != 0 && k.Code > Kernel5_2
+	return k.Code != 0 && k.Code >= Kernel5_2
 }
 
 // HasSKStorageInTracingPrograms returns true if the kernel supports SK_STORAGE maps in tracing programs
@@ -399,13 +398,13 @@ func (k *Version) HasSKStorageInTracingPrograms() bool {
 	if features.HaveProgramHelper(ebpf.Tracing, asm.FnSkStorageGet) == nil {
 		return true
 	}
-	return k.Code != 0 && k.Code > Kernel5_11
+	return k.Code != 0 && k.Code >= Kernel5_11
 }
 
 // IsMapValuesToMapHelpersAllowed returns true if the kernel supports passing map values to map helpers
 // See https://github.com/torvalds/linux/commit/d71962f3e627b5941804036755c844fabfb65ff5
 func (k *Version) IsMapValuesToMapHelpersAllowed() bool {
-	return k.Code != 0 && k.Code > Kernel4_18
+	return k.Code != 0 && k.Code >= Kernel4_18
 }
 
 // HasBPFForEachMapElemHelper returns true if the kernel support the bpf_for_each_map_elem helper
@@ -414,7 +413,7 @@ func (k *Version) HasBPFForEachMapElemHelper() bool {
 	if features.HaveProgramHelper(ebpf.PerfEvent, asm.FnForEachMapElem) == nil {
 		return true
 	}
-	return k.Code != 0 && k.Code > Kernel5_13
+	return k.Code != 0 && k.Code >= Kernel5_13
 }
 
 // HavePIDLinkStruct returns whether the kernel uses the pid_link struct, which was removed in 4.19


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes sure to include the kernel version in which a particular eBPF feature was introduced when checking against the running kernel version.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->