### PR TITLE
[CWS] Add raw packet test on ELF magic number

### DIFF
--- a/pkg/security/ebpf/tests/raw_packet_test.go
+++ b/pkg/security/ebpf/tests/raw_packet_test.go
@@ -191,4 +191,14 @@ func TestRawPacketTailCalls(t *testing.T) {
 
 		testRawPacketFilter(t, filters, 2, 2, opts, false)
 	})
+
+	t.Run("tcp-elf-magic-number", func(t *testing.T) {
+		filters := []rawpacket.Filter{
+			{
+				RuleID:    "ok",
+				BPFFilter: "tcp[((tcp[12] & 0xf0) >> 2):4] = 0x7f454c46",
+			},
+		}
+		testRawPacketFilter(t, filters, 0, 1, rawpacket.DefaultProgOpts(), true)
+	})
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a new raw packet unit test for ELF magic number matching. 

### Motivation

Make sure we can properly compile `pcap -> bpf -> ebpf` for this raw packet use-case.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->