### PR TITLE
feat(kmt): provide an additional Locally Downloaded Images table

### DIFF
--- a/tasks/kernel_matrix_testing/vmconfig.py
+++ b/tasks/kernel_matrix_testing/vmconfig.py
@@ -129,6 +129,7 @@ def get_image_list(distro: bool, custom: bool) -> list[list[str]]:
         "Alternative names",
         "Example VM tags to use with --vms (fuzzy matching)",
     ]
+
     custom_kernels: list[list[str]] = []
     for k in sorted(kernels, key=lambda x: tuple(map(int, x.split('.')))):
         if lte_414(k):
@@ -143,6 +144,7 @@ def get_image_list(distro: bool, custom: bool) -> list[list[str]]:
     distro_kernels: list[list[str]] = []
     platforms = get_platforms()
     mappings = get_distribution_mappings()
+
     # Group kernels by name and kernel version, show whether one or two architectures are supported
     for arch in KMT_SUPPORTED_ARCHS:
         for name, platinfo in platforms[arch].items():
@@ -155,6 +157,7 @@ def get_image_list(distro: bool, custom: bool) -> list[list[str]]:
                 if row[0] == name and row[4] == platinfo.get('kernel'):
                     entry = row
                     break
+
             if entry is None:
                 names = {k for k, v in mappings.items() if v == name}
                 # Take two random names for the table so users get an idea of possible mappings
@@ -173,6 +176,7 @@ def get_image_list(distro: bool, custom: bool) -> list[list[str]]:
                 ]
                 distro_kernels.append(entry)
 
+            # Set architecture support
             if arch == "x86_64":
                 entry[5] = TICK
             else:
@@ -186,6 +190,86 @@ def get_image_list(distro: bool, custom: bool) -> list[list[str]]:
         table += distro_kernels
     if custom:
         table += custom_kernels
+
+    return table
+
+
+def get_local_image_list(distro: bool, custom: bool) -> list[list[str]]:
+    headers = [
+        "VM name",
+        "OS ID",
+        "OS Name",
+        "OS Version",
+        "Kernel",
+        "Architecture",
+        "Alternative names",
+        "Last Update",
+        "Up to Date",
+    ]
+
+    custom_kernels: list[list[str]] = []
+    for k in sorted(kernels, key=lambda x: tuple(map(int, x.split('.')))):
+        if lte_414(k):
+            custom_kernels.append([f"custom-{k}", "debian", "Debian", "Custom", k, "x86_64", "", "N/A", "N/A"])
+        else:
+            custom_kernels.append([f"custom-{k}", "debian", "Debian", "Custom", k, "x86_64", "", "N/A", "N/A"])
+            custom_kernels.append([f"custom-{k}", "debian", "Debian", "Custom", k, "arm64", "", "N/A", "N/A"])
+
+    local_distro_kernels: list[list[str]] = []
+    platforms = get_platforms()
+
+    # Group kernels by name and kernel version, show whether one or two architectures are supported
+    for arch in KMT_SUPPORTED_ARCHS:
+        for name, platinfo in platforms[arch].items():
+            if isinstance(platinfo, str):
+                continue  # Old format
+
+            # Check if image is available locally
+            if "image" in platinfo and "image_version" in platinfo:
+                kernel_path = f"{platinfo['image_version']}/{platinfo['image']}"
+                kernel_name = xz_suffix_removed(os.path.basename(kernel_path))
+                local_path = os.path.join(get_kmt_os().rootfs_dir, kernel_name)
+                if os.path.exists(local_path):
+                    # Create a new entry for this architecture
+                    local_entry = [
+                        name,
+                        platinfo.get("os_id"),
+                        platinfo.get("os_name"),
+                        platinfo.get("os_version"),
+                        platinfo.get("kernel"),
+                        arch,
+                        ", ".join(platinfo.get("alt_version_names", [])),
+                        "N/A",  # Last Update column
+                        "N/A",  # Up to Date column
+                    ]
+
+                    # Get last update time from manifest file
+                    manifest_file = '.'.join(platinfo["image"].split('.')[:-2]) + ".manifest"
+                    manifest_path = os.path.join(get_kmt_os().rootfs_dir, manifest_file)
+                    local_entry[7] = get_image_age(manifest_path)
+
+                    # Check if image is up to date using hash comparison
+                    try:
+                        local_entry[8] = is_image_up_to_date_hash(
+                            platforms["url_base"],
+                            get_kmt_os().rootfs_dir,
+                            platinfo["image"],
+                            platinfo.get('image_version', 'master'),
+                        )
+                    except Exception:
+                        local_entry[8] = "?"
+
+                    local_distro_kernels.append(local_entry)
+
+    # Sort by name and architecture
+    local_distro_kernels.sort(key=lambda x: (x[0], x[5]))
+    local_custom_kernels = [row for row in custom_kernels if row[5] in ["x86_64", "arm64"]]
+
+    table = [headers]
+    if distro:
+        table += local_distro_kernels
+    if custom:
+        table += local_custom_kernels
 
     return table
 
@@ -774,3 +858,69 @@ def gen_config(
 
     with open(output_file, "w") as f:
         f.write(json.dumps(vm_config, indent=4))
+
+
+def get_image_age(manifest_path: str) -> str:
+    if not os.path.exists(manifest_path):
+        return "Unknown"
+
+    try:
+        with open(manifest_path) as f:
+            for line in f:
+                if line.startswith("BUILD_DATE="):
+                    build_date = line.strip().split('=')[1].strip('"')
+                    try:
+                        from datetime import datetime
+
+                        # Parse the date format: "Thu Oct  3 11:11:55 UTC 2024"
+                        build_datetime = datetime.strptime(build_date, "%a %b %d %H:%M:%S UTC %Y")
+                        age = datetime.now() - build_datetime
+                        days = age.days
+
+                        # Show original date format with days difference
+                        return f"{build_date} ({days}d ago)"
+                    except ValueError:
+                        return build_date
+    except Exception:
+        return "Unknown"
+    return "Unknown"
+
+
+def has_checksum_changed(url_base: str, rootfs_dir: str, image: str, branch: str) -> bool:
+    import requests
+
+    if requests is None:
+        raise Exit("requests module is not installed, please install it to continue")
+
+    sum_url = os.path.join(url_base, branch, image + ".sum")
+
+    try:
+        r = requests.get(sum_url)
+        r.raise_for_status()  # Raise an exception for bad status codes
+        new_sum = r.text.rstrip().split(' ')[0]
+    except requests.exceptions.RequestException:
+        raise
+
+    local_sum_path = os.path.join(rootfs_dir, f"{image}.sum")
+
+    if not os.path.exists(local_sum_path):
+        return True
+
+    try:
+        with open(local_sum_path) as f:
+            original_sum = f.read().rstrip().split(' ')[0]
+    except Exception:
+        raise
+
+    if new_sum != original_sum:
+        return True
+
+    return False
+
+
+def is_image_up_to_date_hash(url_base: str, rootfs_dir: str, image: str, branch: str) -> str:
+    try:
+        needs_update = has_checksum_changed(url_base, rootfs_dir, image, branch)
+        return CROSS if needs_update else TICK
+    except Exception:
+        return "?"

--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -348,7 +348,11 @@ def ls(_, distro=True, custom=False):
     if tabulate is None:
         raise Exit("tabulate module is not installed, please install it to continue")
 
+    print("\nAll Available Images:")
     print(tabulate(vmconfig.get_image_list(distro, custom), headers='firstrow', tablefmt='fancy_grid'))
+
+    print("\nLocally Downloaded Images:")
+    print(tabulate(vmconfig.get_local_image_list(distro, custom), headers='firstrow', tablefmt='fancy_grid'))
 
 
 @task(


### PR DESCRIPTION
### What does this PR do?
Adds a new "Locally Downloaded Images" table to the `kmt.ls` command output that shows:
- List of VM images downloaded to the local system
- Last update timestamp for each image
- Whether images are up to date with remote versions
- Architecture support for each image

### Motivation
This change improves developer experience by making it easier to:
- Track which VM images are available locally
- Identify outdated images that need updating
- Verify architecture support for each image
- Reduce time spent checking image status manually

### Testing
- Manually tested with various combinations of:
  - Multiple architectures (x86_64 and arm64)
  - Both up-to-date and outdated images
  - Network-connected and offline scenarios

### Drawbacks
- Requires network connectivity to check remote image versions
- May slightly increase command execution time due to remote checks

### Additional Notes
Here is an extended table example

```
> dda inv -e kmt.ls                                       

All Available Images:
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| VM name       | OS ID         | OS Name             | OS Version   | Kernel                    | x86_64   | arm64   | Alternative names   | Example VM tags to use with --vms (fuzzy matching)      |
+===============+===============+=====================+==============+===========================+==========+=========+=====================+=========================================================+
| amazon_2023   | amzn          | Amazon Linux        | 2023         | 6.1.77-99.164.amzn2023    | ✓        | ✓       |                     | distro-amazon_2023-x86_64                               |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| amazon_4.14   | amzn          | Amazon Linux        | 2            | 4.14.314-237.533.amzn2    | ✓        | ✓       |                     | distro-amazon_4.14-x86_64, distro-amazon_414-x86_64     |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| amazon_5.10   | amzn          | Amazon Linux        | 2            | 5.10.226-214.879.amzn2    | ✓        | ✓       |                     | distro-amazon_510-x86_64, distro-amazon_5.10-x86_64     |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| amazon_5.4    | amzn          | Amazon Linux        | 2            | 5.4.284-196.380.amzn2     | ✓        | ✓       |                     | distro-amazon_5.4-x86_64, distro-amazon_5.4-x86_64      |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| centos_7.9    | centos        | CentOS Linux        | 7.9.2009     | 3.10.0-1160.80.1.el7      | ✓        | ✘       |                     | distro-centos_7.9-x86_64, distro-centos_79-x86_64       |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| centos_7.9    | centos        | CentOS Linux        | 7.9.2009     | 4.18.0-348.20.1.el7       | ✘        | ✓       |                     | distro-centos_79-arm64, distro-centos_79-arm64          |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| centos_8      | centos        | CentOS Stream       | 8            | 4.18.0-552.3.1.el8        | ✓        | ✓       |                     | distro-centos_8-x86_64                                  |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| debian_10     | debian        | Debian GNU/Linux    | 10           | 4.19.0-27                 | ✓        | ✓       | buster              | distro-buster-x86_64, distro-buster-x86_64              |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| debian_11     | debian        | Debian GNU/Linux    | 11           | 5.10.0-32                 | ✓        | ✓       | bullseye            | distro-debian_11-x86_64, distro-bullseye-x86_64         |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| debian_12     | debian        | Debian GNU/Linux    | 12           | 6.1.0-25                  | ✓        | ✓       | bookworm            | distro-bookworm-x86_64, distro-bookworm-x86_64          |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| debian_9      | debian        | Debian GNU/Linux    | 9            | 4.9.0-19                  | ✓        | ✘       | stretch             | distro-stretch-x86_64, distro-debian_9-x86_64           |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| fedora_37     | fedora        | Fedora Linux        | 37           | 6.0.7-301.fc37            | ✓        | ✓       |                     | distro-fedora_37-x86_64                                 |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| fedora_38     | fedora        | Fedora Linux        | 38           | 6.2.9-300.fc38            | ✓        | ✓       |                     | distro-fedora_38-x86_64                                 |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| fedora_40     | fedora        | Fedora Linux        | 40           | 6.8.5-301.fc40            | ✓        | ✓       |                     | distro-fedora_40-x86_64                                 |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| opensuse_15.3 | opensuse-leap | openSUSE Leap       | 15.3         | 5.3.18-150300.59.106.1    | ✓        | ✓       |                     | distro-opensuse_153-x86_64, distro-opensuse_153-x86_64  |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| opensuse_15.5 | opensuse-leap | openSUSE Leap       | 15.5         | 5.14.21-150500.55.80.2    | ✓        | ✓       |                     | distro-opensuse_15.5-x86_64, distro-opensuse_155-x86_64 |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| oracle_7.9    | ol            | Oracle Linux Server | 7.9          | 3.10.0-1160.105.1.0.1.el7 | ✓        | ✘       |                     | distro-oracle_7.9-x86_64, distro-oracle_79-x86_64       |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| oracle_8.9    | ol            | Oracle Linux Server | 8.9          | 5.15.0-200.131.27.el8uek  | ✓        | ✓       |                     | distro-oracle_89-x86_64, distro-oracle_8.9-x86_64       |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| oracle_9.3    | ol            | Oracle Linux Server | 9.3          | 5.15.0-200.131.27.el9uek  | ✓        | ✓       |                     | distro-oracle_9.3-x86_64, distro-oracle_9.3-x86_64      |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| rocky_8.4     | rocky         | Rocky Linux         | 8.4          | 4.18.0-305.3.1.el8_4      | ✓        | ✘       |                     | distro-rocky_8.4-x86_64, distro-rocky_84-x86_64         |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| rocky_8.5     | rocky         | Rocky Linux         | 8.5          | 4.18.0-348.el8.0.2        | ✓        | ✓       |                     | distro-rocky_8.5-x86_64, distro-rocky_85-x86_64         |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| rocky_9.3     | rocky         | Rocky Linux         | 9.3          | 5.14.0-362.8.1.el9_3      | ✓        | ✓       |                     | distro-rocky_9.3-x86_64, distro-rocky_93-x86_64         |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| rocky_9.4     | rocky         | Rocky Linux         | 9.4          | 5.14.0-503.15.1.el9_5     | ✓        | ✓       |                     | distro-rocky_94-x86_64, distro-rocky_94-x86_64          |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| suse_12.5     | sles          | SLES                | 12.5         | 4.12.14-122.228.1         | ✓        | ✓       |                     | distro-suse_12.5-x86_64, distro-suse_125-x86_64         |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| ubuntu_16.04  | ubuntu        | Ubuntu              | 16.04        | 4.4.0-210-generic         | ✓        | ✘       | xenial              | distro-xenial-x86_64, distro-ubuntu_1604-x86_64         |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| ubuntu_18.04  | ubuntu        | Ubuntu              | 18.04        | 4.18.0-25-generic         | ✓        | ✓       | bionic              | distro-ubuntu_18.04-x86_64, distro-ubuntu_1804-x86_64   |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| ubuntu_20.04  | ubuntu        | Ubuntu              | 20.04        | 5.4.0-167-generic         | ✓        | ✓       | focal               | distro-focal-x86_64, distro-focal-x86_64                |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| ubuntu_22.04  | ubuntu        | Ubuntu              | 22.04        | 5.15.0-91-generic         | ✓        | ✓       | jammy               | distro-ubuntu_2204-x86_64, distro-jammy-x86_64          |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| ubuntu_23.10  | ubuntu        | Ubuntu              | 23.10        | 6.5.0-44-generic          | ✓        | ✓       | mantic              | distro-mantic-x86_64, distro-ubuntu_2310-x86_64         |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| ubuntu_24.04  | ubuntu        | Ubuntu              | 24.04        | 6.8.0-31-generic          | ✓        | ✓       | noble               | distro-ubuntu_2404-x86_64, distro-noble-x86_64          |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+
| ubuntu_24.10  | ubuntu        | Ubuntu              | 24.10        | 6.11.0-8-generic          | ✓        | ✓       | oracular            | distro-oracular-x86_64, distro-ubuntu_2410-x86_64       |
+---------------+---------------+---------------------+--------------+---------------------------+----------+---------+---------------------+---------------------------------------------------------+

Locally Downloaded Images:
+--------------+---------+------------------+--------------+-------------------+----------------+---------------------+-----------------------------------------+--------------+
| VM name      | OS ID   | OS Name          |   OS Version | Kernel            | Architecture   | Alternative names   | Last Update                             | Up to Date   |
+==============+=========+==================+==============+===================+================+=====================+=========================================+==============+
| debian_10    | debian  | Debian GNU/Linux |        10    | 4.19.0-27         | arm64          | buster              | Thu Oct  3 11:11:55 UTC 2024 (179d ago) | ✓            |
+--------------+---------+------------------+--------------+-------------------+----------------+---------------------+-----------------------------------------+--------------+
| ubuntu_22.04 | ubuntu  | Ubuntu           |        22.04 | 5.15.0-91-generic | arm64          | jammy               | Thu Oct  3 11:14:14 UTC 2024 (179d ago) | ✓            |
+--------------+---------+------------------+--------------+-------------------+----------------+---------------------+-----------------------------------------+--------------+
| ubuntu_22.04 | ubuntu  | Ubuntu           |        22.04 | 5.15.0-91-generic | x86_64         | jammy               | Thu Oct  3 11:11:33 UTC 2024 (179d ago) | ✓            |
+--------------+---------+------------------+--------------+-------------------+----------------+---------------------+-----------------------------------------+--------------+
```