### PR TITLE
[NPM-4279] Add socket filter to linux TCP traceroutes

### DIFF
--- a/pkg/networkpath/traceroute/common/common.go
+++ b/pkg/networkpath/traceroute/common/common.go
@@ -10,6 +10,7 @@ package common
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"strconv"
 	"time"
 
@@ -83,4 +84,10 @@ func LocalAddrForHost(destIP net.IP, destPort uint16) (*net.UDPAddr, net.Conn, e
 	}
 
 	return localUDPAddr, conn, nil
+}
+
+// UnmappedAddrFromSlice is the same as netip.AddrFromSlice but it also gets rid of mapped ipv6 addresses.
+func UnmappedAddrFromSlice(slice []byte) (netip.Addr, bool) {
+	addr, ok := netip.AddrFromSlice(slice)
+	return addr.Unmap(), ok
 }

--- a/pkg/networkpath/traceroute/common/common_test.go
+++ b/pkg/networkpath/traceroute/common/common_test.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmappedAddrFromSliceZero(t *testing.T) {
+	// zero value
+	addr, ok := UnmappedAddrFromSlice(nil)
+	require.Equal(t, netip.Addr{}, addr)
+	require.False(t, ok)
+}
+
+func TestUnmappedAddrFromSliceIPv4(t *testing.T) {
+	addr, ok := UnmappedAddrFromSlice(net.ParseIP("192.168.1.1"))
+	require.Equal(t, netip.MustParseAddr("192.168.1.1"), addr)
+	require.True(t, ok)
+}
+
+func TestUnmappedAddrFromSliceIPv6(t *testing.T) {
+	addr, ok := UnmappedAddrFromSlice(net.ParseIP("::1"))
+	require.Equal(t, netip.MustParseAddr("::1"), addr)
+	require.True(t, ok)
+}
+
+func TestUnmappedAddrFromSliceMappedIPv4(t *testing.T) {
+	addr, ok := UnmappedAddrFromSlice(net.ParseIP("::ffff:54.146.50.212"))
+	require.Equal(t, netip.MustParseAddr("54.146.50.212"), addr)
+	require.True(t, ok)
+}

--- a/pkg/networkpath/traceroute/filter/attach.go
+++ b/pkg/networkpath/traceroute/filter/attach.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package filter
+
+import "errors"
+
+// ErrAttachBPFNotSupported indicates that attaching classic BPF filters is not supported
+var ErrAttachBPFNotSupported = errors.New("attaching BPF filters is not supported on this platform")

--- a/pkg/networkpath/traceroute/filter/attach_linux.go
+++ b/pkg/networkpath/traceroute/filter/attach_linux.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package filter
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/net/bpf"
+	"golang.org/x/sys/unix"
+)
+
+// SetBPF attaches a BPF filter to the underlying socket
+func SetBPF(c syscall.RawConn, filter []bpf.RawInstruction) error {
+	var p unix.SockFprog
+	if len(filter) > math.MaxUint16 {
+		return errors.New("filter too large")
+	}
+	p.Len = uint16(len(filter))
+	p.Filter = (*unix.SockFilter)(unsafe.Pointer(&filter[0]))
+
+	var sockoptErr error
+	err := c.Control(func(fd uintptr) {
+		sockoptErr = unix.SetsockoptSockFprog(int(fd), unix.SOL_SOCKET, unix.SO_ATTACH_FILTER, &p)
+	})
+	err = errors.Join(err, sockoptErr)
+	if err != nil {
+		return fmt.Errorf("SetBPF failed to attach filter: %w", err)
+	}
+	return nil
+}
+
+// this is a simple BPF program that drops all packets no matter what
+var dropAllFilter = []bpf.RawInstruction{
+	{Op: 0x6, Jt: 0, Jf: 0, K: 0x00000000},
+}
+
+// SetBPFAndDrain sets the filter for a raw socket and drains old data, so that
+// new packets are guaranteed to match the filter
+func SetBPFAndDrain(c syscall.RawConn, filter []bpf.RawInstruction) error {
+	// unfortunately there is truly no way to atomically create a raw socket and attach a filter.
+	// when there is a lot of traffic, unwanted packets will always come through during initialization.
+	// this means we have to do some hijinks to guarantee the correctness of socket reading.
+	// details in this fantastic blog post: https://natanyellin.com/posts/ebpf-filtering-done-right/
+
+	// first, stop new traffic from coming in by dropping everything
+	err := SetBPF(c, dropAllFilter)
+	if err != nil {
+		return err
+	}
+
+	// then, drain this socket so there is no data
+	var recvErr error
+	err = c.Control(func(fd uintptr) {
+		var buf [1]byte
+
+		var n int
+		for n >= 0 {
+			n, _, recvErr = syscall.Recvfrom(int(fd), buf[:], syscall.MSG_DONTWAIT)
+		}
+	})
+	if err != nil {
+		return fmt.Errorf("SetBPFAndDrain control failed: %w", err)
+	}
+	if recvErr != syscall.EAGAIN {
+		return fmt.Errorf("SetBPFAndDrain failed to drain: %w", err)
+	}
+
+	// lastly, set the intended filter and it's ready to go
+	err = SetBPF(c, filter)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/networkpath/traceroute/filter/attach_nolinux.go
+++ b/pkg/networkpath/traceroute/filter/attach_nolinux.go
@@ -15,10 +15,10 @@ import (
 
 // SetBPF is not supported
 func SetBPF(_c syscall.RawConn, _filter []bpf.RawInstruction) error {
-	return &ErrAttachBPFNotSupported{}
+	return ErrAttachBPFNotSupported
 }
 
 // SetBPFAndDrain is not supported
 func SetBPFAndDrain(_c syscall.RawConn, _filter []bpf.RawInstruction) error {
-	return &ErrAttachBPFNotSupported{}
+	return ErrAttachBPFNotSupported
 }

--- a/pkg/networkpath/traceroute/filter/attach_nolinux.go
+++ b/pkg/networkpath/traceroute/filter/attach_nolinux.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package filter
+
+import (
+	"syscall"
+
+	"golang.org/x/net/bpf"
+)
+
+// SetBPF is a no-op on this platform
+func SetBPF(_c syscall.RawConn, _filter []bpf.RawInstruction) error {
+	return nil
+}
+
+// SetBPF is a no-op on this platform
+func SetBPFAndDrain(_c syscall.RawConn, _filter []bpf.RawInstruction) error {
+	return nil
+}

--- a/pkg/networkpath/traceroute/filter/attach_nolinux.go
+++ b/pkg/networkpath/traceroute/filter/attach_nolinux.go
@@ -13,12 +13,12 @@ import (
 	"golang.org/x/net/bpf"
 )
 
-// SetBPF is a no-op on this platform
+// SetBPF is not supported
 func SetBPF(_c syscall.RawConn, _filter []bpf.RawInstruction) error {
-	return nil
+	return &ErrAttachBPFNotSupported{}
 }
 
-// SetBPF is a no-op on this platform
+// SetBPFAndDrain is not supported
 func SetBPFAndDrain(_c syscall.RawConn, _filter []bpf.RawInstruction) error {
-	return nil
+	return &ErrAttachBPFNotSupported{}
 }

--- a/pkg/networkpath/traceroute/filter/rawconn.go
+++ b/pkg/networkpath/traceroute/filter/rawconn.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package filter
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+
+	"golang.org/x/net/ipv4"
+)
+
+// MakeRawConn returns an ipv4.RawConn for the provided network/address
+func MakeRawConn(ctx context.Context, lc *net.ListenConfig, network string, localAddr netip.Addr) (*ipv4.RawConn, error) {
+	if !localAddr.Is4() {
+		return nil, fmt.Errorf("MakeRawConn only supports IPv4 (for now)")
+	}
+	conn, err := lc.ListenPacket(ctx, network, localAddr.String())
+	if err != nil {
+		return nil, fmt.Errorf("makeRawConn failed to ListenPacket: %w", err)
+	}
+	rawConn, err := ipv4.NewRawConn(conn)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("makeRawConn failed to make NewRawConn: %w", err)
+	}
+
+	return rawConn, nil
+}

--- a/pkg/networkpath/traceroute/filter/tcp.go
+++ b/pkg/networkpath/traceroute/filter/tcp.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package filter has BPF filters for sockets useful for traceroutes
+package filter
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net/netip"
+
+	"golang.org/x/net/bpf"
+)
+
+// TCP4FilterConfig is the config for GenerateTCP4Filter
+type TCP4FilterConfig struct {
+	Src netip.AddrPort
+	Dst netip.AddrPort
+}
+
+const ethHeaderSize = 14
+
+// GenerateTCP4Filter creates a classic BPF filter for TCP SOCK_RAW sockets.
+// It will only allow packets whose tuple matches the given config.
+func (c TCP4FilterConfig) GenerateTCP4Filter() ([]bpf.RawInstruction, error) {
+	if !c.Src.Addr().Is4() || !c.Dst.Addr().Is4() {
+		return nil, fmt.Errorf("GenerateTCP4Filter2: src=%s and dst=%s must be IPv4", c.Src.Addr(), c.Dst.Addr())
+	}
+	srcAddr := binary.BigEndian.Uint32(c.Src.Addr().AsSlice())
+	dstAddr := binary.BigEndian.Uint32(c.Dst.Addr().AsSlice())
+	srcPort := uint32(c.Src.Port())
+	dstPort := uint32(c.Dst.Port())
+
+	// Process to derive the following program:
+	// 1. Generate the BPF program with placeholder values:
+	//    tcpdump -i eth0 -d 'ip and tcp and src 2.4.6.8 and dst 1.3.5.7 and src port 1234 and dst port 5678'
+	// 2. Remove the first two instructions that check the ethernet header, since tcpdump uses AF_PACKET and we do not
+	// 3. Subtract the ethernet header size from all LoadAbsolutes
+	// 4. Replace the placeholder values with src/dst AddrPorts
+	return bpf.Assemble([]bpf.Instruction{
+		// (002) ldb      [23] -- load Protocol
+		bpf.LoadAbsolute{Size: 1, Off: 23 - ethHeaderSize},
+		// (003) jeq      #0x6             jt 4	jf 16 -- if TCP, goto 4, else 16
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x6, SkipTrue: 0, SkipFalse: 12},
+		// (004) ld       [26] -- load source IP
+		bpf.LoadAbsolute{Size: 4, Off: 26 - ethHeaderSize},
+		// (005) jeq      #0x2040608       jt 6	jf 16 -- if srcAddr matches, goto 6, else 16
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: srcAddr, SkipTrue: 0, SkipFalse: 10},
+		// (006) ld       [30] -- load destination IP
+		bpf.LoadAbsolute{Size: 4, Off: 30 - ethHeaderSize},
+		// (007) jeq      #0x1030507       jt 8	jf 16 -- if dstAddr matches, goto 8, else 16
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: dstAddr, SkipTrue: 0, SkipFalse: 8},
+		// (008) ldh      [20] -- load Fragment Offset
+		bpf.LoadAbsolute{Size: 2, Off: 20 - ethHeaderSize},
+		// (009) jset     #0x1fff          jt 16	jf 10 -- if fragmented, goto 16, else 10
+		bpf.JumpIf{Cond: bpf.JumpBitsSet, Val: 0x1fff, SkipTrue: 6, SkipFalse: 0},
+		// (010) ldxb     4*([14]&0xf) -- x = IP header length
+		bpf.LoadMemShift{Off: 14 - ethHeaderSize},
+		// (011) ldh      [x + 14] -- load source port
+		bpf.LoadIndirect{Size: 2, Off: 14 - ethHeaderSize},
+		// (012) jeq      #0x4d2           jt 13	jf 16 -- if srcPort matches, goto 13, else 16
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: srcPort, SkipTrue: 0, SkipFalse: 3},
+		// (013) ldh      [x + 16] -- load destination port
+		bpf.LoadIndirect{Size: 2, Off: 16 - ethHeaderSize},
+		// (014) jeq      #0x162e          jt 15	jf 16 -- if dstPort matches, goto 15, else 16
+		bpf.JumpIf{Cond: bpf.JumpEqual, Val: dstPort, SkipTrue: 0, SkipFalse: 1},
+		// (015) ret      #262144 -- accept packet
+		bpf.RetConstant{Val: 262144},
+		// (016) ret      #0 -- drop packet
+		bpf.RetConstant{Val: 0},
+	})
+}

--- a/pkg/networkpath/traceroute/filter/tcp_test.go
+++ b/pkg/networkpath/traceroute/filter/tcp_test.go
@@ -29,6 +29,9 @@ type tcpTestCase struct {
 }
 
 func doTestCase(t *testing.T, tc tcpTestCase) {
+	// we use bound ports on the server and the client so this should be safe to parallelize
+	t.Parallel()
+
 	server := testutil.NewTCPServerOnAddress("127.0.0.42:0", func(c net.Conn) {
 		r := bufio.NewReader(c)
 		r.ReadBytes(byte('\n'))
@@ -74,7 +77,7 @@ func doTestCase(t *testing.T, tc tcpTestCase) {
 
 	buffer := make([]byte, 1024)
 
-	rawConn.SetDeadline(time.Now().Add(200 * time.Millisecond))
+	rawConn.SetDeadline(time.Now().Add(500 * time.Millisecond))
 	n, addr, err := rawConn.ReadFromIP(buffer)
 	if !errors.Is(err, os.ErrDeadlineExceeded) {
 		// ErrDeadlineExceeded is what the test checks for, so we should only blow up on real errors

--- a/pkg/networkpath/traceroute/filter/tcp_test.go
+++ b/pkg/networkpath/traceroute/filter/tcp_test.go
@@ -1,0 +1,146 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build test && linux && linux_bpf
+
+package filter
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
+)
+
+type tcpTestCase struct {
+	filterConfig  func(server, client netip.AddrPort) TCP4FilterConfig
+	shouldCapture bool
+}
+
+func doTestCase(t *testing.T, tc tcpTestCase) {
+	server := testutil.NewTCPServerOnAddress("127.0.0.42:0", func(c net.Conn) {
+		r := bufio.NewReader(c)
+		r.ReadBytes(byte('\n'))
+		c.Write([]byte("foo\n"))
+		testutil.GracefulCloseTCP(c)
+	})
+	t.Cleanup(server.Shutdown)
+	require.NoError(t, server.Run())
+
+	dialer := net.Dialer{
+		Timeout: time.Minute,
+		LocalAddr: &net.TCPAddr{
+			// make it different from the server IP
+			IP: net.ParseIP("127.0.0.43"),
+		},
+	}
+
+	conn, err := dialer.Dial("tcp", server.Address())
+	require.NoError(t, err)
+	defer testutil.GracefulCloseTCP(conn)
+
+	serverAddrPort, err := netip.ParseAddrPort(server.Address())
+	require.NoError(t, err)
+	clientAddrPort, err := netip.ParseAddrPort(conn.LocalAddr().String())
+	require.NoError(t, err)
+
+	cfg := tc.filterConfig(serverAddrPort, clientAddrPort)
+	filter, err := cfg.GenerateTCP4Filter()
+	require.NoError(t, err)
+
+	lc := &net.ListenConfig{
+		Control: func(_network, _address string, c syscall.RawConn) error {
+			err := SetBPFAndDrain(c, filter)
+			require.NoError(t, err)
+			return err
+		},
+	}
+
+	rawConn, err := MakeRawConn(context.Background(), lc, "ip:tcp", cfg.Dst.Addr())
+	require.NoError(t, err)
+
+	conn.Write([]byte("bar\n"))
+
+	buffer := make([]byte, 1024)
+
+	rawConn.SetDeadline(time.Now().Add(200 * time.Millisecond))
+	n, addr, err := rawConn.ReadFromIP(buffer)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		// ErrDeadlineExceeded is what the test checks for, so we should only blow up on real errors
+		require.NoError(t, err)
+		require.NotZero(t, n)
+	}
+
+	hasCaptured := !errors.Is(err, os.ErrDeadlineExceeded)
+	if tc.shouldCapture {
+		require.True(t, hasCaptured, "expected to see a packet, but found nothing")
+		require.Equal(t, addr.IP, net.IP(cfg.Src.Addr().AsSlice()))
+	} else {
+		require.False(t, hasCaptured, "expected not to see a packet, but found one from %s", addr)
+	}
+
+}
+func TestTCPFilterMatch(t *testing.T) {
+	doTestCase(t, tcpTestCase{
+		filterConfig: func(server, client netip.AddrPort) TCP4FilterConfig {
+			return TCP4FilterConfig{Src: server, Dst: client}
+		},
+		shouldCapture: true,
+	})
+}
+
+func mangleIP(ap netip.AddrPort) netip.AddrPort {
+	reservedIP := netip.MustParseAddr("233.252.0.0")
+	return netip.AddrPortFrom(reservedIP, ap.Port())
+}
+func manglePort(ap netip.AddrPort) netip.AddrPort {
+	const reservedPort = 47
+	return netip.AddrPortFrom(ap.Addr(), reservedPort)
+}
+
+func TestTCPFilterBadServerIP(t *testing.T) {
+	doTestCase(t, tcpTestCase{
+		filterConfig: func(server, client netip.AddrPort) TCP4FilterConfig {
+			return TCP4FilterConfig{Src: mangleIP(server), Dst: client}
+		},
+		shouldCapture: false,
+	})
+}
+
+func TestTCPFilterBadServerPort(t *testing.T) {
+	doTestCase(t, tcpTestCase{
+		filterConfig: func(server, client netip.AddrPort) TCP4FilterConfig {
+			return TCP4FilterConfig{Src: manglePort(server), Dst: client}
+		},
+		shouldCapture: false,
+	})
+}
+
+func TestTCPFilterBadClientIP(t *testing.T) {
+	doTestCase(t, tcpTestCase{
+		filterConfig: func(server, client netip.AddrPort) TCP4FilterConfig {
+			return TCP4FilterConfig{Src: server, Dst: mangleIP(client)}
+		},
+		shouldCapture: false,
+	})
+}
+
+func TestTCPFilterBadClientPort(t *testing.T) {
+	doTestCase(t, tcpTestCase{
+		filterConfig: func(server, client netip.AddrPort) TCP4FilterConfig {
+			return TCP4FilterConfig{Src: server, Dst: manglePort(client)}
+		},
+		shouldCapture: false,
+	})
+}

--- a/pkg/networkpath/traceroute/filter/tcp_test.go
+++ b/pkg/networkpath/traceroute/filter/tcp_test.go
@@ -70,7 +70,7 @@ func doTestCase(t *testing.T, tc tcpTestCase) {
 		},
 	}
 
-	rawConn, err := MakeRawConn(context.Background(), lc, "ip:tcp", cfg.Dst.Addr())
+	rawConn, err := MakeRawConn(context.Background(), lc, "ip:tcp", clientAddrPort.Addr())
 	require.NoError(t, err)
 
 	conn.Write([]byte("bar\n"))

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -48,11 +48,11 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 	}
 	conn.Close() // we don't need the UDP port here
 	t.srcIP = addr.IP
-	localAddr, ok := netip.AddrFromSlice(addr.IP)
+	localAddr, ok := common.UnmappedAddrFromSlice(addr.IP)
 	if !ok {
 		return nil, fmt.Errorf("failed to get netipAddr for source %s", addr)
 	}
-	targetAddr, ok := netip.AddrFromSlice(t.Target)
+	targetAddr, ok := common.UnmappedAddrFromSlice(t.Target)
 	if !ok {
 		return nil, fmt.Errorf("failed to get netipAddr for target %s", t.Target)
 	}

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -9,14 +9,18 @@
 package tcp
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"net"
+	"net/netip"
+	"syscall"
 	"time"
 
 	"golang.org/x/net/ipv4"
 
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/filter"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -44,22 +48,13 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 	}
 	conn.Close() // we don't need the UDP port here
 	t.srcIP = addr.IP
-
-	// So far I haven't had success trying to simply create a socket
-	// using syscalls directly, but in theory doing so would allow us
-	// to avoid creating two listeners since we could see all IP traffic
-	// this way
-	//
-	// Create a raw ICMP listener to catch ICMP responses
-	icmpConn, err := net.ListenPacket("ip4:icmp", addr.IP.String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create ICMP listener: %w", err)
+	localAddr, ok := netip.AddrFromSlice(addr.IP)
+	if !ok {
+		return nil, fmt.Errorf("failed to get netipAddr for source %s", addr)
 	}
-	defer icmpConn.Close()
-	// RawConn is necessary to set the TTL and ID fields
-	rawIcmpConn, err := ipv4.NewRawConn(icmpConn)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get raw ICMP listener: %w", err)
+	targetAddr, ok := netip.AddrFromSlice(t.Target)
+	if !ok {
+		return nil, fmt.Errorf("failed to get netipAddr for target %s", t.Target)
 	}
 
 	// Create a TCP listener with port 0 to get a random port from the OS
@@ -71,19 +66,33 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 	defer tcpListener.Close()
 	t.srcPort = port
 
-	// Create a raw TCP listener to catch the TCP response from our final
-	// hop if we get one
-	tcpConn, err := net.ListenPacket("ip4:tcp", addr.IP.String())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create TCP listener: %w", err)
+	// create a socket filter for TCP to reduce CPU usage
+	filterCfg := filter.TCP4FilterConfig{
+		Src: netip.AddrPortFrom(targetAddr, t.DestPort),
+		Dst: netip.AddrPortFrom(localAddr, port),
 	}
-	defer tcpConn.Close()
-	log.Tracef("Listening for TCP on: %s\n", addr.IP.String()+":"+addr.AddrPort().String())
-	// RawConn is necessary to set the TTL and ID fields
-	rawTCPConn, err := ipv4.NewRawConn(tcpConn)
+	filterProg, err := filterCfg.GenerateTCP4Filter()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get raw TCP listener: %w", err)
+		return nil, fmt.Errorf("failed to generate TCP4 filter: %w", err)
 	}
+	tcpLc := &net.ListenConfig{
+		Control: func(_network, _address string, c syscall.RawConn) error {
+			return filter.SetBPFAndDrain(c, filterProg)
+		},
+	}
+	log.Tracef("filtered on: %+v", filterCfg)
+
+	// create raw sockets to listen to TCP and ICMP
+	rawIcmpConn, err := filter.MakeRawConn(context.Background(), &net.ListenConfig{}, "ip4:icmp", localAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make ICMP raw socket: %w", err)
+	}
+	rawTCPConn, err := filter.MakeRawConn(context.Background(), tcpLc, "ip4:tcp", localAddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make TCP raw socket: %w", err)
+	}
+
+	log.Tracef("Listening for TCP on: %s\n", addr.IP.String())
 
 	// hops should be of length # of hops
 	hops := make([]*common.Hop, 0, t.MaxTTL-t.MinTTL)

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -58,6 +58,7 @@ TEST_PACKAGES_LIST = [
     "./pkg/gpu/...",
     "./pkg/system-probe/config/...",
     "./comp/metadata/inventoryagent/...",
+    "./pkg/networkpath/traceroute/filter/...",
 ]
 TEST_PACKAGES = " ".join(TEST_PACKAGES_LIST)
 # change `timeouts` in `test/new-e2e/system-probe/test-runner/main.go` if you change them here


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a socket filter to linux TCP traceroutes, which should reduce the amount of packets we capture to userspace.

### Motivation
We want to reduce system-probe CPU usage of dynamic path

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
`sudo go test -tags test,linux,linux_bpf github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/filter -count 10`

TCP traceroutes should still work in e2e tests:
```
aws-vault exec sso-agent-sandbox-account-admin -- inv new-e2e-tests.run --targets=tests/netpath --run=TestFakeTracerouteSuite
```

### Possible Drawbacks / Trade-offs
When the SOCK_RAW socket is first created, it has no filter and will still capture all packets for a brief moment, before the filter gets attached. There's truly no way around this besides holding onto SOCK_RAW sockets in a pool, which I don't think is worth the complexity.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->