### PR TITLE
autodiscovery: only detect NVML library if a feature flag is enabled

### DIFF
--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -74,7 +74,7 @@ func detectContainerFeatures(features FeatureMap, cfg model.Reader) {
 	detectCloudFoundry(features, cfg)
 	detectPodman(features, cfg)
 	detectPodResources(features, cfg)
-	detectNVML(features)
+	detectNVML(features, cfg)
 }
 
 func detectKubernetes(features FeatureMap, cfg model.Reader) {
@@ -248,7 +248,11 @@ func detectPodResources(features FeatureMap, cfg model.Reader) {
 	}
 }
 
-func detectNVML(features FeatureMap) {
+func detectNVML(features FeatureMap, cfg model.Reader) {
+	if !cfg.GetBool("enable_nvml_detection") {
+		return
+	}
+
 	// Use dlopen to search for the library to avoid importing the go-nvml package here,
 	// which is 1MB in size and would increase the agent binary size, when we don't really
 	// need it for anything else.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -622,6 +622,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// GPU
 	config.BindEnvAndSetDefault("collect_gpu_tags", false)
 	config.BindEnvAndSetDefault("nvml_lib_path", "")
+	config.BindEnvAndSetDefault("enable_nvml_detection", false)
 
 	// Cloud Foundry BBS
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.url", "https://bbs.service.cf.internal:8889")

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -91,6 +91,10 @@ agents:
       env:
         - name: HOST_PROC
           value: "/host/root/proc"
+    agent:
+      env:
+        - name: DD_ENABLE_NVML_DETECTION
+          value: "true"
 `
 
 const dockerPullMaxRetries = 3
@@ -108,6 +112,7 @@ func getDefaultProvisionerParams() *provisionerParams {
 	return &provisionerParams{
 		agentOptions: []agentparams.Option{
 			agentparams.WithSystemProbeConfig(defaultSysprobeConfig),
+			agentparams.WithAgentConfig("enable_nvml_detection: true"),
 		},
 		kubernetesAgentOptions: nil,
 		ami:                    gpuEnabledAMI,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the NVML feature detection to have a feature flag gate, so that for now all GPU monitoring features are gated and only enabled explicitly by the customer.

### Motivation

Avoid enabling by default preview features.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

E2E tests changed to adapt to this situation.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->