### PR TITLE
Fix panic in KSM check on check cancel

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -670,7 +670,9 @@ func (k *KSMCheck) Run() error {
 // Cancel is called when the check is unscheduled, it stops the informers used by the metrics store
 func (k *KSMCheck) Cancel() {
 	log.Infof("Shutting down informers used by the check '%s'", k.ID())
-	k.cancel()
+	if k.cancel != nil {
+		k.cancel()
+	}
 }
 
 // processMetrics attaches tags and forwards metrics to the aggregator


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes a panic that could occur if the KSM check is cancelled before being able to start up properly

### Motivation

Fixes this panic:
```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x31aeef8]
goroutine 81344 [running]:
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm.(*KSMCheck).Cancel(0x4001564fc0)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go:673 +0x98
github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware.(*CheckWrapper).Cancel(0x40138ebbf0)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go:54 +0x30
github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl.(*collectorImpl).cancelCheck.func1()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/collector.go:311 +0x30
created by github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl.(*collectorImpl).cancelCheck in goroutine 354
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/collector.go:310 +0x94
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->