### PR TITLE
[CONTP-727] add csi as a new option for inject_config.mode

### DIFF
--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -43,6 +43,7 @@ const (
 	hostIP  = "hostip"
 	socket  = "socket"
 	service = "service"
+	csi     = "csi"
 
 	// DatadogVolumeName is the name of the volume used to mount the sockets when the volume source is a directory
 	DatadogVolumeName = "datadog"

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -43,7 +43,9 @@ const (
 	hostIP  = "hostip"
 	socket  = "socket"
 	service = "service"
-	csi     = "csi"
+	// csi mode allows mounting datadog sockets using CSI volumes instead of hostpath volumes
+	// in case CSI is disabled globally, the mutator will default to use 'socket' mode instead
+	csi = "csi"
 
 	// DatadogVolumeName is the name of the volume used to mount the sockets when the volume source is a directory
 	DatadogVolumeName = "datadog"

--- a/pkg/clusteragent/admission/mutate/config/mutator.go
+++ b/pkg/clusteragent/admission/mutate/config/mutator.go
@@ -26,34 +26,26 @@ import (
 
 // MutatorConfig contains the settings for the config injector.
 type MutatorConfig struct {
+	csiEnabled        bool
 	mode              string
 	localServiceName  string
 	traceAgentSocket  string
 	dogStatsDSocket   string
 	socketPath        string
 	typeSocketVolumes bool
-	csiEnabled        bool
 	csiDriver         string
-}
-
-// shouldUseCSI returns true only if csi is enabled globally, on the admission controller level
-// and on the inject_config mutator level
-func shouldUseCSI(datadogConfig config.Component) bool {
-	return datadogConfig.GetBool("csi.enabled") &&
-		datadogConfig.GetBool("admission_controller.csi.enabled") &&
-		datadogConfig.GetBool("admission_controller.inject_config.csi.enabled")
 }
 
 // NewMutatorConfig instantiates the required settings for the mutator from the datadog config.
 func NewMutatorConfig(datadogConfig config.Component) *MutatorConfig {
 	return &MutatorConfig{
+		csiEnabled:        datadogConfig.GetBool("csi.enabled"),
 		mode:              datadogConfig.GetString("admission_controller.inject_config.mode"),
 		localServiceName:  datadogConfig.GetString("admission_controller.inject_config.local_service_name"),
 		traceAgentSocket:  datadogConfig.GetString("admission_controller.inject_config.trace_agent_socket"),
 		dogStatsDSocket:   datadogConfig.GetString("admission_controller.inject_config.dogstatsd_socket"),
 		socketPath:        datadogConfig.GetString("admission_controller.inject_config.socket_path"),
 		typeSocketVolumes: datadogConfig.GetBool("admission_controller.inject_config.type_socket_volumes"),
-		csiEnabled:        shouldUseCSI(datadogConfig),
 		csiDriver:         datadogConfig.GetString("csi.driver"),
 	}
 }
@@ -125,13 +117,18 @@ func (i *Mutator) MutatePod(pod *corev1.Pod, _ string, _ dynamic.Interface) (boo
 	}
 
 	// Inject DD_AGENT_HOST
-	switch injectionMode(pod, i.config.mode) {
+	switch injectionMode(pod, i.config.mode, i.config.csiEnabled) {
 	case hostIP:
 		injectedConfig = mutatecommon.InjectEnv(pod, agentHostIPEnvVar)
 	case service:
 		injectedConfig = mutatecommon.InjectEnv(pod, agentHostServiceEnvVar)
 	case socket:
-		injectedVolumes := i.injectSocketVolumes(pod)
+		injectedVolumes := i.injectSocketVolumes(pod, false)
+		injectedEnv := mutatecommon.InjectEnv(pod, traceURLSocketEnvVar)
+		injectedEnv = mutatecommon.InjectEnv(pod, dogstatsdURLSocketEnvVar) || injectedEnv
+		injectedConfig = injectedVolumes || injectedEnv
+	case csi:
+		injectedVolumes := i.injectSocketVolumes(pod, true)
 		injectedEnv := mutatecommon.InjectEnv(pod, traceURLSocketEnvVar)
 		injectedEnv = mutatecommon.InjectEnv(pod, dogstatsdURLSocketEnvVar) || injectedEnv
 		injectedConfig = injectedVolumes || injectedEnv
@@ -156,8 +153,11 @@ func (i *Mutator) MutatePod(pod *corev1.Pod, _ string, _ dynamic.Interface) (boo
 // socket ensures no lost traces or dogstatsd metrics but can cause the pod to
 // wait if the agent has issues that prevent it from creating the sockets.
 //
+// If withCSI is true, a CSI volume is injected. Otherwise, a normal hostpath
+// volume is injected.
+//
 // This function returns true if at least one volume was injected.
-func (i *Mutator) injectSocketVolumes(pod *corev1.Pod) bool {
+func (i *Mutator) injectSocketVolumes(pod *corev1.Pod, withCSI bool) bool {
 	var injectedVolNames []string
 
 	if i.config.typeSocketVolumes {
@@ -173,7 +173,7 @@ func (i *Mutator) injectSocketVolumes(pod *corev1.Pod) bool {
 		for volumeName, volumePath := range volumes {
 			var volume corev1.Volume
 			var volumeMount corev1.VolumeMount
-			if i.config.csiEnabled {
+			if withCSI {
 				volume, volumeMount = buildCSIVolume(volumeName, volumePath, csiModeSocket, true, i.config.csiDriver)
 			} else {
 				volume, volumeMount = buildHostPathVolume(volumeName, volumePath, corev1.HostPathSocket, true)
@@ -186,7 +186,7 @@ func (i *Mutator) injectSocketVolumes(pod *corev1.Pod) bool {
 	} else {
 		var volume corev1.Volume
 		var volumeMount corev1.VolumeMount
-		if i.config.csiEnabled {
+		if withCSI {
 			volume, volumeMount = buildCSIVolume(DatadogVolumeName, i.config.socketPath, csiModeLocal, true, i.config.csiDriver)
 		} else {
 			volume, volumeMount = buildHostPathVolume(
@@ -210,19 +210,28 @@ func (i *Mutator) injectSocketVolumes(pod *corev1.Pod) bool {
 }
 
 // injectionMode returns the injection mode based on the global mode and pod labels
-func injectionMode(pod *corev1.Pod, globalMode string) string {
+func injectionMode(pod *corev1.Pod, globalMode string, csiEnabled bool) string {
+	decidedMode := globalMode
+
 	if val, found := pod.GetLabels()[common.InjectionModeLabelKey]; found {
 		mode := strings.ToLower(val)
 		switch mode {
-		case hostIP, service, socket:
-			return mode
+		case hostIP, service, socket, csi:
+			decidedMode = mode
 		default:
-			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'hostip', 'service' or 'socket', defaulting to %q", common.InjectionModeLabelKey, val, mutatecommon.PodString(pod), globalMode)
-			return globalMode
+			log.Warnf("Invalid label value '%s=%s' on pod %s should be either 'hostip', 'service', 'socket' or 'csi', defaulting to %q", common.InjectionModeLabelKey, val, mutatecommon.PodString(pod), globalMode)
+			decidedMode = globalMode
 		}
 	}
 
-	return globalMode
+	if decidedMode == csi {
+		if !csiEnabled {
+			log.Warnf("Unable to use CSI mode because CSI is disabled, defaulting to 'socket'")
+			decidedMode = socket
+		}
+	}
+
+	return decidedMode
 }
 
 // buildExternalEnv generate an External Data environment variable.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -771,7 +771,6 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// Admission controller
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
-	config.BindEnvAndSetDefault("admission_controller.csi.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.validation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.mutation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
@@ -784,9 +783,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.certificate.secret_name", "webhook-certificate") // name of the Secret object containing the webhook certificate
 	config.BindEnvAndSetDefault("admission_controller.webhook_name", "datadog-webhook")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.enabled", true)
-	config.BindEnvAndSetDefault("admission_controller.inject_config.csi.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.inject_config.endpoint", "/injectconfig")
-	config.BindEnvAndSetDefault("admission_controller.inject_config.mode", "hostip") // possible values: hostip / service / socket
+	config.BindEnvAndSetDefault("admission_controller.inject_config.mode", "hostip") // possible values: hostip / service / socket / csi
 	config.BindEnvAndSetDefault("admission_controller.inject_config.local_service_name", "datadog")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.socket_path", "/var/run/datadog")
 	config.BindEnvAndSetDefault("admission_controller.inject_config.trace_agent_socket", "unix:///var/run/datadog/apm.socket")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds `csi` is a new option for `inject_config.mode` in the config webhook.

If the user configures the webhook with csi mode (or sets the mode to `csi` on the pod level via pod labels) while `csi.enabled` is `false` (i.e. csi is not enabled), the config webhook will default to `socket` mode.

### Motivation

Existing modes include:
- hostip
- socket
- service

We want to allow users to leverage CSI driver to mount sockets.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests are updated. 

E2E tests are already in place to validate the webhook default behaviour in the absence of CSI. 

The following steps can be used to verify the behaviour when csi mode is used:

Use the following to deploy the cluster agent with different configurations:

**ATTENTION: it is expected that pods that get a CSI volume are stuck in ContainerCreating phase because there is no CSI driver to process the volume mount request. This is okay. In this QA we need to verify that the correct mutation is done only. You can force delete the pod using `kubectl delete pod --force <pod-name>`**

```
clusterAgent:
  image:
    repository: adelhajhassan918/dd-dca-csi
    tag: v1
    imagePullPolicy: Always
    doNotCheckTag: true
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: csi
   envDict:
     DD_CSI_ENABLED: <true or false, default is false>
     DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TYPE_SOCKET_VOLUMES: <true or false, default is false>
```

#### Case 1: CSI not enabled

In this case, the admission controller should default to mode `socket` and emit a warning.

To test this, use:
```
clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: csi
```

Deploy any pod.

Verify the pod got /var/run/datadog mounted as DirectoryOrCreate:
```
  - hostPath:
      path: /var/run/datadog
      type: DirectoryOrCreate
    name: datadog
```

Verify the DCA shows a warning as follows in the logs:
```
2025-04-01 10:21:50 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/mutate/config/mutator.go:229 in injectionMode) | Unable to use CSI mode because CSI is disabled, defaulting to 'socket'
```

#### Case 2: CSI enabled - mounting socket using CSI

For this, we need to enable CSI driver:

##### Scenario 1: global config mode is csi
```
clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: csi
  envDict:
     DD_CSI_ENABLED: true
```

You should find the following volume in the pod:
```
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: true
      volumeAttributes:
        mode: local
        path: /var/run/datadog
    name: datadog
```


#### Scenario 2: global config mode is not csi

Use the following:
```
clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: hostip
  envDict:
     DD_CSI_ENABLED: true
```

Deploy a pod having a label that sets csi as a config mode for the pod:
```
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  labels:
    admission.datadoghq.com/config.mode: csi
```

You should expect seeing csi volume in the pod:

```
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: true
      volumeAttributes:
        mode: local
        path: /var/run/datadog
    name: datadog
```



### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->