### PR TITLE
[OTEL-2526] Fix "ignore resources" logic in OTLP ingest

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -244,18 +244,6 @@ func (o *OTLPReceiver) receiveResourceSpansV2(ctx context.Context, rspans ptrace
 		libspans := rspans.ScopeSpans().At(i)
 		for j := 0; j < libspans.Spans().Len(); j++ {
 			otelspan := libspans.Spans().At(j)
-			resourceName := traceutil.GetOTelAttrValInResAndSpanAttrs(otelspan, otelres, true, transform.KeyDatadogResource)
-			if resourceName == "" && !o.conf.OTLPReceiver.IgnoreMissingDatadogFields {
-				if transform.OperationAndResourceNameV2Enabled(o.conf) {
-					resourceName = traceutil.GetOTelResourceV2(otelspan, otelres)
-				} else {
-					resourceName = traceutil.GetOTelResourceV1(otelspan, otelres)
-				}
-			}
-			if _, exists := o.ignoreResNames[resourceName]; exists {
-				continue
-			}
-
 			spancount++
 			traceID := traceutil.OTelTraceIDToUint64(otelspan.TraceID())
 			if tracesByID[traceID] == nil {

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -51,14 +51,13 @@ var _ (ptraceotlp.GRPCServer) = (*OTLPReceiver)(nil)
 // data on two ports for both plain HTTP and gRPC.
 type OTLPReceiver struct {
 	ptraceotlp.UnimplementedGRPCServer
-	wg             sync.WaitGroup      // waits for a graceful shutdown
-	grpcsrv        *grpc.Server        // the running GRPC server on a started receiver, if enabled
-	out            chan<- *Payload     // the outgoing payload channel
-	conf           *config.AgentConfig // receiver config
-	cidProvider    IDProvider          // container ID provider
-	statsd         statsd.ClientInterface
-	timing         timing.Reporter
-	ignoreResNames map[string]struct{}
+	wg          sync.WaitGroup      // waits for a graceful shutdown
+	grpcsrv     *grpc.Server        // the running GRPC server on a started receiver, if enabled
+	out         chan<- *Payload     // the outgoing payload channel
+	conf        *config.AgentConfig // receiver config
+	cidProvider IDProvider          // container ID provider
+	statsd      statsd.ClientInterface
+	timing      timing.Reporter
 }
 
 // NewOTLPReceiver returns a new OTLPReceiver which sends any incoming traces down the out channel.
@@ -94,17 +93,13 @@ func NewOTLPReceiver(out chan<- *Payload, cfg *config.AgentConfig, statsd statsd
 	if cfg.HasFeature("enable_otlp_compute_top_level_by_span_kind") {
 		computeTopLevelBySpanKindVal = 1.0
 	}
-	ignoreResNames := make(map[string]struct{})
-	for _, resName := range cfg.Ignore["resource"] {
-		ignoreResNames[resName] = struct{}{}
-	}
 	_ = statsd.Gauge("datadog.trace_agent.otlp.compute_top_level_by_span_kind", computeTopLevelBySpanKindVal, nil, 1)
 	enableReceiveResourceSpansV2Val := 1.0
 	if cfg.HasFeature("disable_receive_resource_spans_v2") {
 		enableReceiveResourceSpansV2Val = 0.0
 	}
 	_ = statsd.Gauge("datadog.trace_agent.otlp.enable_receive_resource_spans_v2", enableReceiveResourceSpansV2Val, nil, 1)
-	return &OTLPReceiver{out: out, conf: cfg, cidProvider: NewIDProvider(cfg.ContainerProcRoot, cfg.ContainerIDFromOriginInfo), statsd: statsd, timing: timing, ignoreResNames: ignoreResNames}
+	return &OTLPReceiver{out: out, conf: cfg, cidProvider: NewIDProvider(cfg.ContainerProcRoot, cfg.ContainerIDFromOriginInfo), statsd: statsd, timing: timing}
 }
 
 // Start starts the OTLPReceiver, if any of the servers were configured as active.

--- a/releasenotes/notes/apm-otlp-fix-ignore-resources-b43baa885ef48082.yaml
+++ b/releasenotes/notes/apm-otlp-fix-ignore-resources-b43baa885ef48082.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix an issue where `apm_config.ignore_resources` only removes the root
+    span instead of discarding the whole trace when using OTLP ingestion.


### PR DESCRIPTION
### What does this PR do?

The `apm_config.ignore_resources` Agent config discards traces whose root spans matches a list of regexes. By mistake, #29435 introduced logic which discards individual spans in the OTLP receiver, which leads to the root span behind discarded but not the rest of the trace. Since spans received in the OTLP receiver are passed to the trace agent anyway, this PR removes this part of the code.

### Motivation

A customer encountered this bug, which led to an escalation.

### Describe how you validated your changes

The structure of the OTLP receiver does not make it easy to write a test of the ignore_resources feature with that ingest method, unfortunately. I wrote a terrible and invasive test to validate that 1. the current behavior is broken, and 2. my change fixes it, but I'd rather not commit it. Since the behavior of the ignore resources logic in the trace agent already has a test, the only thing remaining to test would be that we... no longer do anything in the OTLP receiver, which doesn't seem worth a test. If you think we need such a regression test, I can try to add one anyway.
