### PR TITLE
Fix the tests in setup/config_test.go for non-linux OSes

### DIFF
--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -1201,6 +1201,10 @@ func TestConfigAssignAtPath(t *testing.T) {
 
 	config := newTestConf()
 	config.SetWithoutSource("use_proxy_for_cloud_metadata", true)
+	// This setting is required because overrideRunInCoreAgentConfig in pkg/config/setup/process.go adds
+	// it for non-linux OSes. By adding it here the test passes on all OSes.
+	config.Set("process_config.run_in_core_agent.enabled", false, pkgconfigmodel.SourceAgentRuntime)
+
 	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
 	os.WriteFile(configPath, testExampleConf, 0o600)
 	config.SetConfigFile(configPath)
@@ -1230,6 +1234,8 @@ process_config:
     - fifth
     https://url2.eu:
     - modified
+  run_in_core_agent:
+    enabled: false
 secret_backend_command: different
 use_proxy_for_cloud_metadata: true
 `
@@ -1253,6 +1259,7 @@ func TestConfigAssignAtPathWorksWithGet(t *testing.T) {
 
 	config := newTestConf()
 	config.SetWithoutSource("use_proxy_for_cloud_metadata", true)
+	config.Set("process_config.run_in_core_agent.enabled", false, pkgconfigmodel.SourceAgentRuntime)
 	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
 	os.WriteFile(configPath, testExampleConf, 0o600)
 	config.SetConfigFile(configPath)
@@ -1282,7 +1289,10 @@ func TestConfigAssignAtPathWorksWithGet(t *testing.T) {
 	require.Equal(t, expected, res)
 }
 
-var testSimpleConf = []byte(`secret_backend_command: some command
+var testSimpleConf = []byte(`process_config:
+  run_in_core_agent:
+    enabled: false
+secret_backend_command: some command
 secret_backend_arguments:
 - ENC[pass1]
 `)
@@ -1293,6 +1303,7 @@ func TestConfigAssignAtPathSimple(t *testing.T) {
 
 	config := newTestConf()
 	config.SetWithoutSource("use_proxy_for_cloud_metadata", true)
+	config.Set("process_config.run_in_core_agent.enabled", false, pkgconfigmodel.SourceAgentRuntime)
 	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
 	os.WriteFile(configPath, testSimpleConf, 0o600)
 	config.SetConfigFile(configPath)
@@ -1303,7 +1314,10 @@ func TestConfigAssignAtPathSimple(t *testing.T) {
 	err = configAssignAtPath(config, []string{"secret_backend_arguments", "0"}, "password1")
 	assert.NoError(t, err)
 
-	expectedYaml := `secret_backend_arguments:
+	expectedYaml := `process_config:
+  run_in_core_agent:
+    enabled: false
+secret_backend_arguments:
 - password1
 secret_backend_command: some command
 use_proxy_for_cloud_metadata: true
@@ -1405,6 +1419,7 @@ additional_endpoints:
 `)
 	config := newTestConf()
 	config.SetWithoutSource("use_proxy_for_cloud_metadata", true)
+	config.Set("process_config.run_in_core_agent.enabled", false, pkgconfigmodel.SourceAgentRuntime)
 	configPath := filepath.Join(t.TempDir(), "datadog.yaml")
 	os.WriteFile(configPath, testIntKeysConf, 0o600)
 	config.SetConfigFile(configPath)
@@ -1419,6 +1434,9 @@ additional_endpoints:
   "0": apple
   "1": banana
   "2": cherry
+process_config:
+  run_in_core_agent:
+    enabled: false
 use_proxy_for_cloud_metadata: true
 `
 	yamlConf, err := yaml.Marshal(config.AllSettingsWithoutDefault())

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -286,7 +286,9 @@ func TestProcessAgentChecks(t *testing.T) {
 
 	t.Run("without process-agent running", func(t *testing.T) {
 		mock := flarehelpers.NewFlareBuilderMock(t, false)
-		getChecksFromProcessAgent(mock, func() (string, error) { return "fake:1337", nil })
+		// Use a hostname that will fail to resolve even with AppGate enabled,
+		// otherwise this test will timeout
+		getChecksFromProcessAgent(mock, func() (string, error) { return "[invalid][host]:1337", nil })
 		mock.AssertFileContentMatch("error collecting data for 'process_discovery_check_output.json': .*", "process_discovery_check_output.json")
 	})
 	t.Run("with process-agent running", func(t *testing.T) {

--- a/pkg/trace/api/dogstatsd_test.go
+++ b/pkg/trace/api/dogstatsd_test.go
@@ -37,7 +37,9 @@ func TestDogStatsDReverseProxy(t *testing.T) {
 		{
 			"bad statsd host",
 			func(cfg *config.AgentConfig) {
-				cfg.StatsdHost = "this[is[invalid"
+				// Use a hostname that will fail to resolve even with AppGate enabled,
+				// otherwise this test will timeout
+				cfg.StatsdHost = "[invalid][host]"
 			},
 			http.StatusInternalServerError,
 		},


### PR DESCRIPTION
### What does this PR do?

Improve a couple of unit tests so that they can pass on non-linux OSes

### Motivation

Expanding on the fix from https://github.com/DataDog/datadog-agent/pull/24298 for `pkg/trace`, and making similar improvements for `pkg/flare` and `pkg/config/setup`.

### Describe how you validated your changes

Unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
