### PR TITLE
AGNTLOG-4 Refactor tcp/http destination support for logs pipeline

### DIFF
--- a/comp/logs/agent/config/endpoints_mock.go
+++ b/comp/logs/agent/config/endpoints_mock.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+// NewMockEndpoint creates a new reliable endpoint with default test values
+func NewMockEndpoint() Endpoint {
+	return Endpoint{
+		apiKey:            atomic.NewString("mock-api-key"),
+		configSettingPath: "api_key",
+		Host:              "localhost",
+		Port:              443,
+		useSSL:            true,
+		isReliable:        true,
+		UseCompression:    true,
+		CompressionLevel:  6,
+	}
+}
+
+// NewMockEndpoints creates a new Endpoints struct with a single reliable endpoint
+func NewMockEndpoints(endpoints []Endpoint) *Endpoints {
+	main := NewMockEndpoint()
+	return &Endpoints{
+		Main:                   main,
+		Endpoints:              endpoints,
+		UseHTTP:                true,
+		BatchWait:              5 * time.Second,
+		BatchMaxSize:           100,
+		BatchMaxContentSize:    1000000,
+		BatchMaxConcurrentSend: 20,
+		InputChanSize:          100,
+	}
+}
+
+// NewMockEndpointsWithOptions creates a new Endpoints struct with customizable individual endpoints and options
+func NewMockEndpointsWithOptions(endpointArray []Endpoint, opts map[string]interface{}) *Endpoints {
+	endpoints := NewMockEndpoints(endpointArray)
+
+	if useHTTP, ok := opts["use_http"].(bool); ok {
+		endpoints.UseHTTP = useHTTP
+	}
+	if batchMaxConcurrentSend, ok := opts["batch_max_concurrent_send"].(int); ok {
+		endpoints.BatchMaxConcurrentSend = batchMaxConcurrentSend
+	}
+
+	return endpoints
+}
+
+// NewMockEndpointWithOptions creates a new reliable endpoint with customizable options
+func NewMockEndpointWithOptions(opts map[string]interface{}) Endpoint {
+	e := NewMockEndpoint()
+
+	if host, ok := opts["host"].(string); ok {
+		e.Host = host
+	}
+	if port, ok := opts["port"].(int); ok {
+		e.Port = port
+	}
+	if apiKey, ok := opts["api_key"].(string); ok {
+		e.apiKey = atomic.NewString(apiKey)
+	}
+	if useSSL, ok := opts["use_ssl"].(bool); ok {
+		e.useSSL = useSSL
+	}
+	if useCompression, ok := opts["use_compression"].(bool); ok {
+		e.UseCompression = useCompression
+	}
+	if compressionLevel, ok := opts["compression_level"].(int); ok {
+		e.CompressionLevel = compressionLevel
+	}
+	if isReliable, ok := opts["is_reliable"].(bool); ok {
+		e.isReliable = isReliable
+	}
+
+	return e
+}

--- a/pkg/logs/sender/http/http_sender.go
+++ b/pkg/logs/sender/http/http_sender.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package http manages creation of http-based senders
+package http
+
+import (
+	"strconv"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// NewHTTPSender returns a new http sender.
+func NewHTTPSender(
+	config pkgconfigmodel.Reader,
+	auditor auditor.Auditor,
+	bufferSize int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	endpoints *config.Endpoints,
+	destinationsCtx *client.DestinationsContext,
+	serverless bool,
+	componentName string,
+	contentType string,
+	queueCount int,
+	workersPerQueue int,
+	minWorkerConcurrency int,
+	maxWorkerConcurrency int,
+) *sender.Sender {
+	log.Debugf(
+		"Creating a new sender for component %s with %d queues, %d http workers, %d min sender concurrency, and %d max sender concurrency",
+		componentName,
+		queueCount,
+		workersPerQueue,
+		minWorkerConcurrency,
+		maxWorkerConcurrency,
+	)
+	pipelineMonitor := metrics.NewTelemetryPipelineMonitor("http_sender")
+
+	destinationFactory := httpDestinationFactory(
+		endpoints,
+		destinationsCtx,
+		pipelineMonitor,
+		serverless,
+		senderDoneChan,
+		config,
+		componentName,
+		contentType,
+		minWorkerConcurrency,
+		maxWorkerConcurrency,
+	)
+
+	return sender.NewSenderV2(
+		config,
+		auditor,
+		destinationFactory,
+		bufferSize,
+		senderDoneChan,
+		flushWg,
+		queueCount,
+		workersPerQueue,
+		pipelineMonitor,
+	)
+}
+
+func httpDestinationFactory(
+	endpoints *config.Endpoints,
+	destinationsContext *client.DestinationsContext,
+	pipelineMonitor metrics.PipelineMonitor,
+	serverless bool,
+	senderDoneChan chan *sync.WaitGroup,
+	cfg pkgconfigmodel.Reader,
+	componentName string,
+	contentyType string,
+	minConcurrency int,
+	maxConcurrency int,
+) sender.DestinationFactory {
+	return func() *client.Destinations {
+		reliable := []client.Destination{}
+		additionals := []client.Destination{}
+		for i, endpoint := range endpoints.GetReliableEndpoints() {
+			destMeta := client.NewDestinationMetadata(componentName, pipelineMonitor.ID(), "reliable", strconv.Itoa(i))
+			if serverless {
+				reliable = append(reliable, http.NewSyncDestination(endpoint, contentyType, destinationsContext, senderDoneChan, destMeta, cfg))
+			} else {
+				reliable = append(reliable, http.NewDestination(endpoint, contentyType, destinationsContext, true, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor))
+			}
+		}
+		for i, endpoint := range endpoints.GetUnReliableEndpoints() {
+			destMeta := client.NewDestinationMetadata(componentName, pipelineMonitor.ID(), "unreliable", strconv.Itoa(i))
+			if serverless {
+				additionals = append(additionals, http.NewSyncDestination(endpoint, contentyType, destinationsContext, senderDoneChan, destMeta, cfg))
+			} else {
+				additionals = append(additionals, http.NewDestination(endpoint, contentyType, destinationsContext, false, destMeta, cfg, minConcurrency, maxConcurrency, pipelineMonitor))
+			}
+		}
+		return client.NewDestinations(reliable, additionals)
+	}
+}

--- a/pkg/logs/sender/http/http_sender_test.go
+++ b/pkg/logs/sender/http/http_sender_test.go
@@ -1,0 +1,150 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package http
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+)
+
+func TestHttpDestinationFactory(t *testing.T) {
+	tests := []struct {
+		name               string
+		endpoints          []config.Endpoint
+		serverless         bool
+		expectedReliable   int
+		expectedUnreliable int
+	}{
+		{
+			name: "standard configuration with multiple endpoints",
+			endpoints: []config.Endpoint{
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:8080",
+					"is_reliable": true,
+				}),
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:8081",
+					"is_reliable": true,
+				}),
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:8082",
+					"is_reliable": false,
+				}),
+			},
+			serverless:         false,
+			expectedReliable:   2,
+			expectedUnreliable: 1,
+		},
+		{
+			name: "single endpoint configuration",
+			endpoints: []config.Endpoint{
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:8080",
+					"is_reliable": true,
+				}),
+			},
+			serverless:         false,
+			expectedReliable:   1,
+			expectedUnreliable: 0,
+		},
+		{
+			name:               "empty endpoints",
+			endpoints:          []config.Endpoint{},
+			serverless:         false,
+			expectedReliable:   0,
+			expectedUnreliable: 0,
+		},
+		{
+			name: "serverless configuration",
+			endpoints: []config.Endpoint{
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:8080",
+					"is_reliable": true,
+				}),
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:8081",
+					"is_reliable": false,
+				}),
+			},
+			serverless:         true,
+			expectedReliable:   1,
+			expectedUnreliable: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			endpoints := config.NewMockEndpoints(tc.endpoints)
+			destinationsCtx := client.NewDestinationsContext()
+			pipelineMonitor := metrics.NewNoopPipelineMonitor("test")
+			senderDoneChan := make(chan *sync.WaitGroup)
+			mockConfig := configmock.New(t)
+
+			factory := httpDestinationFactory(
+				endpoints,
+				destinationsCtx,
+				pipelineMonitor,
+				tc.serverless,
+				senderDoneChan,
+				mockConfig,
+				"test-component",
+				"application/json",
+				1,
+				10,
+			)
+
+			// Test 1: Verify first call creates destinations
+			destinations1 := factory()
+			assert.NotNil(t, destinations1)
+
+			// Verify destination quantities
+			reliable := destinations1.Reliable
+			unreliable := destinations1.Unreliable
+
+			assert.Equal(t, tc.expectedReliable, len(reliable),
+				"Expected %d reliable destinations, got %d",
+				tc.expectedReliable, len(reliable))
+			assert.Equal(t, tc.expectedUnreliable, len(unreliable),
+				"Expected %d unreliable destinations, got %d",
+				tc.expectedUnreliable, len(unreliable))
+
+			// Verify all destinations are of correct type based on serverless flag
+			for _, dest := range reliable {
+				if tc.serverless {
+					assert.IsType(t, &http.SyncDestination{}, dest,
+						"Expected reliable destination to be of type *http.SyncDestination in serverless mode")
+				} else {
+					assert.IsType(t, &http.Destination{}, dest,
+						"Expected reliable destination to be of type *http.Destination in normal mode")
+				}
+			}
+			for _, dest := range unreliable {
+				if tc.serverless {
+					assert.IsType(t, &http.SyncDestination{}, dest,
+						"Expected unreliable destination to be of type *http.SyncDestination in serverless mode")
+				} else {
+					assert.IsType(t, &http.Destination{}, dest,
+						"Expected unreliable destination to be of type *http.Destination in normal mode")
+				}
+			}
+
+			// Test 2: Verify second call creates new destination instances
+			destinations2 := factory()
+			assert.NotNil(t, destinations2)
+			assert.NotSame(t, destinations1, destinations2,
+				"Factory should create new destinations instance")
+		})
+	}
+}

--- a/pkg/logs/sender/sender.go
+++ b/pkg/logs/sender/sender.go
@@ -107,7 +107,8 @@ func NewSenderV2(
 
 	queues := make([]chan *message.Payload, queueCount)
 	for idx := range queueCount {
-		queues[idx] = make(chan *message.Payload, workersPerQueue+1)
+		// Payloads are large, so the buffer will only hold one per worker
+		queues[idx] = make(chan *message.Payload, workersPerQueue)
 		for range workersPerQueue {
 			worker := newWorker(
 				config,

--- a/pkg/logs/sender/tcp/tcp_sender.go
+++ b/pkg/logs/sender/tcp/tcp_sender.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package tcp manages creation of tcp-based senders
+package tcp
+
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/logs/sender"
+	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// NewTCPSender returns a new tcp sender.
+func NewTCPSender(
+	config pkgconfigmodel.Reader,
+	auditor auditor.Auditor,
+	bufferSize int,
+	senderDoneChan chan *sync.WaitGroup,
+	flushWg *sync.WaitGroup,
+	endpoints *config.Endpoints,
+	destinationsCtx *client.DestinationsContext,
+	status statusinterface.Status,
+	serverless bool,
+	componentName string,
+	queueCount int,
+	workersPerQueue int,
+) *sender.Sender {
+	log.Debugf("Creating a new sender for component %s with %d queues, %d tcp workers", componentName, queueCount, workersPerQueue)
+	pipelineMonitor := metrics.NewTelemetryPipelineMonitor("tcp_sender")
+
+	destinationFactory := tcpDestinationFactory(endpoints, destinationsCtx, serverless, status)
+
+	return sender.NewSenderV2(
+		config,
+		auditor,
+		destinationFactory,
+		bufferSize,
+		senderDoneChan,
+		flushWg,
+		queueCount,
+		workersPerQueue,
+		pipelineMonitor,
+	)
+}
+
+func tcpDestinationFactory(
+	endpoints *config.Endpoints,
+	destinationsContext *client.DestinationsContext,
+	serverless bool,
+	status statusinterface.Status,
+) sender.DestinationFactory {
+	return func() *client.Destinations {
+		reliable := []client.Destination{}
+		additionals := []client.Destination{}
+		for _, endpoint := range endpoints.GetReliableEndpoints() {
+			reliable = append(reliable, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext, !serverless, status))
+		}
+		for _, endpoint := range endpoints.GetUnReliableEndpoints() {
+			additionals = append(additionals, tcp.NewDestination(endpoint, endpoints.UseProto, destinationsContext, false, status))
+		}
+
+		return client.NewDestinations(reliable, additionals)
+	}
+}

--- a/pkg/logs/sender/tcp/tcp_sender_test.go
+++ b/pkg/logs/sender/tcp/tcp_sender_test.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+package tcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/client"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
+	"github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface"
+)
+
+func TestTCPDestinationFactory(t *testing.T) {
+	tests := []struct {
+		name               string
+		endpoints          []config.Endpoint
+		serverless         bool
+		expectedReliable   int
+		expectedUnreliable int
+	}{
+		{
+			name: "standard configuration with multiple endpoints",
+			endpoints: []config.Endpoint{
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:10516",
+					"is_reliable": true,
+				}),
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:10517",
+					"is_reliable": true,
+				}),
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:10518",
+					"is_reliable": false,
+				}),
+			},
+			serverless:         false,
+			expectedReliable:   2,
+			expectedUnreliable: 1,
+		},
+		{
+			name: "single endpoint configuration",
+			endpoints: []config.Endpoint{
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:10516",
+					"is_reliable": true,
+				}),
+			},
+			serverless:         false,
+			expectedReliable:   1,
+			expectedUnreliable: 0,
+		},
+		{
+			name:               "empty endpoints",
+			endpoints:          []config.Endpoint{},
+			serverless:         false,
+			expectedReliable:   0,
+			expectedUnreliable: 0,
+		},
+		{
+			name: "serverless configuration",
+			endpoints: []config.Endpoint{
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:10516",
+					"is_reliable": true,
+				}),
+				config.NewMockEndpointWithOptions(map[string]interface{}{
+					"host":        "localhost:10517",
+					"is_reliable": false,
+				}),
+			},
+			serverless:         true,
+			expectedReliable:   1,
+			expectedUnreliable: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			endpoints := config.NewMockEndpoints(tc.endpoints)
+			destinationsCtx := client.NewDestinationsContext()
+			status := statusinterface.NewStatusProviderMock()
+
+			factory := tcpDestinationFactory(
+				endpoints,
+				destinationsCtx,
+				tc.serverless,
+				status,
+			)
+
+			// Test 1: Verify first call creates destinations
+			destinations1 := factory()
+			assert.NotNil(t, destinations1)
+
+			// Verify destination quantities
+			reliable := destinations1.Reliable
+			unreliable := destinations1.Unreliable
+
+			assert.Equal(t, tc.expectedReliable, len(reliable),
+				"Expected %d reliable destinations, got %d",
+				tc.expectedReliable, len(reliable))
+			assert.Equal(t, tc.expectedUnreliable, len(unreliable),
+				"Expected %d unreliable destinations, got %d",
+				tc.expectedUnreliable, len(unreliable))
+
+			// Verify all destinations are of type *Destination
+			for _, dest := range reliable {
+				assert.IsType(t, &tcp.Destination{}, dest,
+					"Expected reliable destination to be of type *tcp.Destination")
+			}
+			for _, dest := range unreliable {
+				assert.IsType(t, &tcp.Destination{}, dest,
+					"Expected unreliable destination to be of type *tcp.Destination")
+			}
+
+			// Test 2: Verify second call creates new destination instances
+			destinations2 := factory()
+			assert.NotNil(t, destinations2)
+			assert.NotSame(t, destinations1, destinations2,
+				"Factory should create new destinations instance")
+		})
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds nonfunction tcp/http sender constructors, with each split in to its own sub package to prevent consumers of sender from being forced to pull in the entirety of either the http or tcp dependency stack if they do not require both.

### Motivation
This MR serves as part of the RTT Fairness/Distributed Sends chain, with the overall feature set enablement MR found at https://github.com/DataDog/datadog-agent/pull/35484. This feature requires destination construction in the core pipeline to be moved, as the sender object is no longer constructed at runtime within a new pipeline. Additionally, this refactor itself allows us to abstract away the concept of destinations and how to create/manipulate them from users of the log pipeline.
### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
No QA required for this change, as the entities added are either testing additions or currently unreachable code. 
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->