### PR TITLE
Go DI capture depth backoff

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -230,6 +230,10 @@ func resolveLocationExpressionTemplate(locationExpression ditypes.LocationExpres
 		return template.New("comment").Parse(commentText)
 	case ditypes.OpSetParameterIndex:
 		return template.New("set_parameter_index").Parse(setParameterIndexText)
+	case ditypes.OpCompilerError:
+		return template.New("compiler_error").Parse(compilerErrorText)
+	case ditypes.OpVerifierError:
+		return template.New("verifier_error").Parse(verifierErrorText)
 	default:
 		return nil, errors.New("invalid location expression opcode")
 	}

--- a/pkg/dynamicinstrumentation/codegen/expression_templates.go
+++ b/pkg/dynamicinstrumentation/codegen/expression_templates.go
@@ -117,3 +117,14 @@ var setParameterIndexText = `
 bpf_printk("Setting param index %d to %d", {{.Arg1}}, context.output_offset);
 event->base.param_indicies[{{.Arg1}}] = context.output_offset;
 `
+
+var compilerErrorText = `
+!@#$%^
+`
+
+var verifierErrorText = `
+for (int i=0; i==0;) {
+    i++;
+    i--;
+}
+`

--- a/pkg/dynamicinstrumentation/codegen/expression_templates.go
+++ b/pkg/dynamicinstrumentation/codegen/expression_templates.go
@@ -118,10 +118,12 @@ bpf_printk("Setting param index %d to %d", {{.Arg1}}, context.output_offset);
 event->base.param_indicies[{{.Arg1}}] = context.output_offset;
 `
 
+// This causes a compiler error which is used in testing
 var compilerErrorText = `
 !@#$%^
 `
 
+// This causes a verifier error which is used in testing
 var verifierErrorText = `
 for (int i=0; i==0;) {
     i++;

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -263,44 +263,75 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 
 func applyConfigUpdate(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) {
 	log.Tracef("Applying config update: %v\n", probe)
+	for {
+		if err := tryGenerateAndAttach(procInfo, probe); err == nil {
+			return
+		}
+	}
+}
 
-generateCompileAttach:
+// tryGenerateAndAttach attempts to generate and attach the BPF program for the probe
+// it will decrement the reference depth of the probe if it fails to generate and attach
+// the BPF program and try again until the reference depth is 0
+func tryGenerateAndAttach(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error {
 	err := codegen.GenerateBPFParamsCode(procInfo, probe)
 	if err != nil {
-		log.Info("Couldn't generate BPF programs", err)
-		if !probe.InstrumentationInfo.AttemptedRebuild {
-			log.Info("Removing parameters and attempting to rebuild BPF object", err)
-			probe.InstrumentationInfo.AttemptedRebuild = true
-			probe.InstrumentationInfo.InstrumentationOptions.CaptureParameters = false
-			goto generateCompileAttach
+		log.Errorf("Couldn't generate BPF programs: %v", err)
+		if !haveExhaustedReferenceDepthDecrementing(procInfo, probe) {
+			return err
 		}
-		return
+		return nil
 	}
 
 	err = ebpf.CompileBPFProgram(probe)
 	if err != nil {
-		// TODO: Emit diagnostic?
-		log.Info("Couldn't compile BPF object", err)
-		if !probe.InstrumentationInfo.AttemptedRebuild {
-			log.Info("Removing parameters and attempting to rebuild BPF object", err)
-			probe.InstrumentationInfo.AttemptedRebuild = true
-			probe.InstrumentationInfo.InstrumentationOptions.CaptureParameters = false
-			goto generateCompileAttach
+		log.Errorf("Couldn't compile BPF object: %v", err)
+		if !haveExhaustedReferenceDepthDecrementing(procInfo, probe) {
+			return err
 		}
-		return
-	}
-	err = ebpf.AttachBPFUprobe(procInfo, probe)
-	if err != nil {
-		log.Info("Couldn't load and attach bpf programs", err)
-		if !probe.InstrumentationInfo.AttemptedRebuild {
-			log.Info("Removing parameters and attempting to rebuild BPF object", err)
-			probe.InstrumentationInfo.AttemptedRebuild = true
-			probe.InstrumentationInfo.InstrumentationOptions.CaptureParameters = false
-			goto generateCompileAttach
-		}
-		return
+		return nil
 	}
 
+	err = ebpf.AttachBPFUprobe(procInfo, probe)
+	if err != nil {
+		log.Errorf("Couldn't load and attach bpf programs: %v", err)
+		if !haveExhaustedReferenceDepthDecrementing(procInfo, probe) {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+// haveExhaustedReferenceDepthDecrementing checks if the reference depth has been exhausted
+// in the process of decrementing itand if so, marks all parameters as not captured
+func haveExhaustedReferenceDepthDecrementing(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) bool {
+	if !checkAndDecrementReferenceDepth(probe) {
+		markAllParametersNotCaptured(procInfo)
+		return true
+	}
+	return false
+}
+
+func markAllParametersNotCaptured(procInfo *ditypes.ProcessInfo) {
+	for _, params := range procInfo.TypeMap.Functions {
+		for _, param := range params {
+			param.DoNotCapture = true
+			param.NotCaptureReason = ditypes.FieldLimitReached
+		}
+	}
+}
+
+// checkAndDecrementReferenceDepth decrements the reference depth of the probe
+// and returns true if the reference depth is still greater than 0
+func checkAndDecrementReferenceDepth(probe *ditypes.Probe) bool {
+	if !probe.InstrumentationInfo.InstrumentationOptions.CaptureParameters ||
+		probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth <= 0 {
+		return false
+	}
+	probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth--
+	log.Tracef("Retrying after decrementing capture depth to: %d", probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth)
+	return true
 }
 
 func newConfigProbe() *ditypes.Probe {

--- a/pkg/dynamicinstrumentation/diconfig/config_manager_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux_bpf
+
 package diconfig
 
 import (

--- a/pkg/dynamicinstrumentation/diconfig/config_manager_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager_test.go
@@ -1,0 +1,88 @@
+package diconfig
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/diagnostics"
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
+)
+
+func TestBackOff(t *testing.T) {
+
+	compilerErrorProbe := &ditypes.Probe{
+		ID:       "abc123",
+		FuncName: "compilerError",
+		InstrumentationInfo: &ditypes.InstrumentationInfo{
+			InstrumentationOptions: &ditypes.InstrumentationOptions{
+				CaptureParameters: true,
+				MaxReferenceDepth: 5,
+			},
+		},
+	}
+
+	verifierErrorProbe := &ditypes.Probe{
+		ID:       "xyz789",
+		FuncName: "verifierError",
+		InstrumentationInfo: &ditypes.InstrumentationInfo{
+			InstrumentationOptions: &ditypes.InstrumentationOptions{
+				CaptureParameters: true,
+				MaxReferenceDepth: 5,
+			},
+		},
+	}
+
+	procInfo := &ditypes.ProcessInfo{
+		PID:        0,
+		BinaryPath: "blahblahblah",
+		TypeMap: &ditypes.TypeMap{
+			Functions: map[string][]*ditypes.Parameter{
+				"compilerError": {
+					{
+						Name:     "a",
+						Type:     "int",
+						Kind:     uint(reflect.Int),
+						Location: &ditypes.Location{},
+						LocationExpressions: []ditypes.LocationExpression{
+							ditypes.CompilerErrorLocationExpression(),
+						},
+					},
+				},
+				"verifierError": {
+					{
+						Name:     "a",
+						Type:     "int",
+						Kind:     uint(reflect.Int),
+						Location: &ditypes.Location{},
+						LocationExpressions: []ditypes.LocationExpression{
+							ditypes.VerifierErrorLocationExpression(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	go func() {
+		// Need to consume diagnostics updates to avoid blocking
+		for {
+			<-diagnostics.Diagnostics.Updates
+		}
+	}()
+
+	applyConfigUpdate(procInfo, compilerErrorProbe)
+	if compilerErrorProbe.InstrumentationInfo.InstrumentationOptions.CaptureParameters != false {
+		t.Errorf("expected capture parameters to be false, got true")
+	}
+	if compilerErrorProbe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth != 0 {
+		t.Errorf("expected max reference depth to be 0, got %d", compilerErrorProbe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth)
+	}
+
+	applyConfigUpdate(procInfo, verifierErrorProbe)
+	if verifierErrorProbe.InstrumentationInfo.InstrumentationOptions.CaptureParameters != false {
+		t.Errorf("expected capture parameters to be false, got true")
+	}
+	if verifierErrorProbe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth != 0 {
+		t.Errorf("expected max reference depth to be 0, got %d", verifierErrorProbe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth)
+	}
+}

--- a/pkg/dynamicinstrumentation/diconfig/config_manager_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 package diconfig
 
 import (

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -10,6 +10,7 @@ package ditypes
 import (
 	"debug/dwarf"
 	"fmt"
+	"math"
 )
 
 // TypeMap contains all the information about functions and their parameters
@@ -155,6 +156,11 @@ const (
 	OpPopPointerAddress
 	// OpSetParameterIndex sets the parameter index in the base event's param_indicies array field
 	OpSetParameterIndex
+
+	// OpCompilerError represents an operation to insert a compiler error for the sake of testing
+	OpCompilerError = math.MaxUint - 1
+	// OpVerifierError represents an operation to insert a verifier error for the sake of testing
+	OpVerifierError = math.MaxUint
 )
 
 func (op LocationExpressionOpcode) String() string {
@@ -201,6 +207,10 @@ func (op LocationExpressionOpcode) String() string {
 		return "JumpIfGreaterThanLimit"
 	case OpSetParameterIndex:
 		return "SetParamIndex"
+	case OpCompilerError:
+		return "CompilerError"
+	case OpVerifierError:
+		return "VerifierError"
 	default:
 		return fmt.Sprintf("LocationExpressionOpcode(%d)", int(op))
 	}
@@ -414,6 +424,18 @@ func SetParameterIndexLocationExpression(index uint16) LocationExpression {
 		Opcode: OpSetParameterIndex,
 		Arg1:   uint(index),
 	}
+}
+
+// CompilerErrorLocationExpression creates an expression which
+// inserts a compiler error into the bpf program
+func CompilerErrorLocationExpression() LocationExpression {
+	return LocationExpression{Opcode: OpCompilerError}
+}
+
+// VerifierErrorLocationExpression creates an expression which
+// inserts a verifier error into the bpf program
+func VerifierErrorLocationExpression() LocationExpression {
+	return LocationExpression{Opcode: OpVerifierError}
 }
 
 // LocationExpression is an operation which will be executed in bpf with the purpose


### PR DESCRIPTION
### What does this PR do?

Adds logic to BPF program generation/compilation/attachment where the capture depth is decremented and the steps are retried in cases of compilation, verifier, or attachment errors. This is to increase reliability of partial snapshots. The idea is that if one layer breaks something (for some unpredicted reason), we can hopefully try to capture as much data as possible.

### Motivation

Increased reliability of capturing at least partial snapshots.

### Describe how you validated your changes

Added test.

### Possible Drawbacks / Trade-offs

### Additional Notes

We may also want to add logic for capturing one parameter but not another?
