### PR TITLE
Create a MarkOnLogRegex function

### DIFF
--- a/pkg/util/testutil/flake/flake.go
+++ b/pkg/util/testutil/flake/flake.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"testing"
 
+	"regexp"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -67,8 +69,14 @@ func getPackageName() (string, error) {
 	return packageName, nil
 }
 
-// MarkOnLog marks the test as flaky when the `pattern` regular expression is found in its logs.
-func MarkOnLog(t testing.TB, pattern string) {
+// MarkOnLog marks the test as flaky when the 'text' log is found, if you need to use regex see [MarkOnLogRegex]
+func MarkOnLog(t testing.TB, text string) {
+	t.Helper()
+	MarkOnLogRegex(t, regexp.QuoteMeta(text))
+}
+
+// MarkOnLogRegex marks the test as flaky when the `pattern` regular expression is found in its logs.
+func MarkOnLogRegex(t testing.TB, pattern string) {
 	// Types for the yaml file
 	type testEntry struct {
 		Test  string `yaml:"test"`

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -77,7 +77,7 @@ func shouldSkipInstallMethod(methods []InstallMethodOption, method InstallMethod
 
 func TestPackages(t *testing.T) {
 	// INCIDENT(35594): This will match rate limits. Please remove me once this is fixed
-	flake.MarkOnLog(t, "error: read \"\\.pulumi/meta.yaml\":.*429")
+	flake.MarkOnLogRegex(t, "error: read \"\\.pulumi/meta.yaml\":.*429")
 	if _, ok := os.LookupEnv("E2E_PIPELINE_ID"); !ok {
 		t.Log("E2E_PIPELINE_ID env var is not set, this test requires this variable to be set to work")
 		t.FailNow()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

`MarkOnLog` was accepting regex, which is not intuitive if you just want to mark a Log containing regex special characters (`(` `)` `?` ...)
This PR create two different function, one explicitly taking Regex, the other will escape all the regex characters

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->