### PR TITLE
fix(junit): Prevent crash when reading test file

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -92,7 +92,8 @@
   - !reference [.tag_kmt_ci_job]
 
 .upload_junit_kmt:
-  - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "$DD_AGENT_TESTING_DIR/junit-*.tar.gz"
+  - tar -xzvf $DD_AGENT_TESTING_DIR/testjson-*.tar.gz
+  - $CI_PROJECT_DIR/tools/ci/junit_upload.sh "$DD_AGENT_TESTING_DIR/junit-*.tar.gz" out.json
 
 # Important: this job needs DD_API_KEY to be set. Some caveats:
 # - if this command is called in the after_script section, note that variables exported in the before_script and


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Extract the test output file before passing it to the junit upload script on KMT tests.

### Motivation
Prevent [crash](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/872153886#L3040) (introduced by #35176) when running the `junit_upload` task. 
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/__main__.py", line 3, in <module>
    program.run()
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/program.py", line 398, in run
    self.execute()
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/program.py", line 583, in execute
    executor.execute(*self.tasks)
  File "/root/miniforge3/envs/ddpy3/lib/python3.12/site-packages/invoke/executor.py", line 140, in execute
    result = call.task(*args, **call.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/custom_task/custom_task.py", line 149, in custom__call__
    result = self.body(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/junit_tasks.py", line 12, in junit_upload
    junit_upload_from_tgz(tgz_path, result_json)
  File "/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/junit_upload_core.py", line 83, in junit_upload_from_tgz
    flaky_failures, marked_flaky_tests = get_flaky_failures_and_marked_flaky_tests_from_test_output(result_json)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/junit_upload_core.py", line 119, in get_flaky_failures_and_marked_flaky_tests_from_test_output
    flaky_failures.update(tw.get_flaky_failures())
                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/go/src/github.com/DataDog/datadog-agent/tasks/testwasher.py", line 107, in get_flaky_failures
    with open(self.test_output_json_file, encoding='utf-8') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: 'test_output.json'
Error: Junit upload failed
```
This is preventing display of test executions in Datadog.

### Describe how you validated your changes
[Pipeline execution with no error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/874202669)
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->