### PR TITLE
Update lading to 0.25.8

### DIFF
--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.7
+  version: 0.25.8
 
 target:
 


### PR DESCRIPTION
### What does this PR do?

More details in the [release notes](https://github.com/DataDog/lading/releases/tag/v0.25.8).
