### PR TITLE
Move t.Fatal after TearDownSuite

### DIFF
--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -246,7 +246,6 @@ func (bs *BaseSuite[Env]) CleanupOnSetupFailure() {
 		defer func() {
 			bs.TearDownSuite()
 			bs.T().Fatal("SetupSuite failed, aborted test suite and called TearDownSuite")
-
 		}()
 
 		// run environment diagnose

--- a/test/new-e2e/pkg/e2e/suite.go
+++ b/test/new-e2e/pkg/e2e/suite.go
@@ -244,8 +244,9 @@ func (bs *BaseSuite[Env]) CleanupOnSetupFailure() {
 	if err := recover(); err != nil || bs.T().Failed() {
 		bs.firstFailTest = "Initial provisioning SetupSuite" // This is required to handle skipDeleteOnFailure
 		defer func() {
-			bs.T().Fatalf("SetupSuite failed, aborting test suite and calling TearDownSuite")
 			bs.TearDownSuite()
+			bs.T().Fatal("SetupSuite failed, aborted test suite and called TearDownSuite")
+
 		}()
 
 		// run environment diagnose


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We need to call `Fatal` after `TearDownSuite` otherwise the suite is never destroyed on SetupFailure.
Calling only `Error` would not work because it does prevent test from being executed after Tearing down the suite

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->