### PR TITLE
gitlab-ci.yml: Use a variable for compare_to

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -159,6 +159,7 @@ variables:
   S3_DD_AGENT_OMNIBUS_BTFS_URI: s3://dd-agent-omnibus/btfs
   S3_DD_AGENT_OMNIBUS_JAVA_URI: s3://dd-agent-omnibus/openjdk
   BTFHUB_ARCHIVE_BRANCH: main
+  COMPARE_TO_BRANCH: main
   GENERAL_ARTIFACTS_CACHE_BUCKET_URL: https://dd-agent-omnibus.s3.amazonaws.com
   S3_DSD6_URI: s3://dsd6-staging
   RELEASE_VERSION: nightly
@@ -668,7 +669,7 @@ workflow:
   - <<: *if_run_all_kmt_tests
   - changes:
       paths: *security_agent_change_paths
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
   - when: manual
     allow_failure: true
 
@@ -686,7 +687,7 @@ workflow:
         - omnibus/config/software/**/*
         - omnibus/config/templates/**/*
         - release.json
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .except_windows_installer_changes:
   - <<: *if_windows_installer_changes
@@ -720,7 +721,7 @@ workflow:
   - <<: *if_run_all_kmt_tests
   - changes:
       paths: *system_probe_change_paths
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 # New E2E related rules
 
@@ -742,7 +743,7 @@ workflow:
         - test/new-e2e/pkg/**/*
         - test/new-e2e/go.mod
         - flakes.yaml
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_e2e_or_windows_installer_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -753,14 +754,14 @@ workflow:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       <<: *fakeintake_paths
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     variables:
       FAKEINTAKE_IMAGE_OVERRIDE: "public.ecr.aws/datadog/fakeintake:v$CI_COMMIT_SHORT_SHA"
     when: on_success
   - changes:
       paths:
         - test/new-e2e/test-infra-definition/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
   - when: manual
     allow_failure: true
@@ -791,7 +792,7 @@ workflow:
         - pkg/util/trivy/**/*
         - test/new-e2e/tests/containers/**/*
         - test/new-e2e/go.mod
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_rc_or_e2e_changes:
@@ -801,7 +802,7 @@ workflow:
         - pkg/config/remote/**/*
         - comp/remote-config/**/*
         - test/new-e2e/tests/remote-config/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_arun_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -811,7 +812,7 @@ workflow:
         - pkg/**/*
         - comp/**/*
         - test/new-e2e/tests/agent-runtimes/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_acfg_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -821,7 +822,7 @@ workflow:
         - pkg/**/*
         - comp/**/*
         - test/new-e2e/tests/agent-configuration//**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_subcommands_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -831,7 +832,7 @@ workflow:
         - pkg/**/*
         - comp/**/*
         - test/new-e2e/tests/agent-subcommands/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_language-detection_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -839,7 +840,7 @@ workflow:
       paths:
         # TODO: Add paths that should trigger tests for language detection
         - test/new-e2e/tests/language-detection/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_npm_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -848,7 +849,7 @@ workflow:
         # TODO: Add paths that should trigger tests for npm
         - pkg/network/**/*
         - test/new-e2e/tests/npm/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_discovery_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -858,7 +859,7 @@ workflow:
         - test/new-e2e/tests/discovery/**/*
         - pkg/collector/corechecks/servicediscovery/**/*
         - pkg/discovery/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_amp_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -882,7 +883,7 @@ workflow:
         - pkg/persistentcache/**/*
         - pkg/serializer/**/*
         - rtloader/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_alp_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -895,13 +896,13 @@ workflow:
         - comp/core/autodiscovery/providers/file*.go
         - comp/logs/**/*
         - pkg/logs/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_cws_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths: *security_agent_change_paths
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_process_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -912,7 +913,7 @@ workflow:
         - comp/process/**/*
         - pkg/process/**/*
         - pkg/config/setup/process.go
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_orchestrator_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -921,7 +922,7 @@ workflow:
         - pkg/collector/corechecks/cluster/orchestrator/**/*
         - pkg/collector/corechecks/orchestrator/**/*
         - test/new-e2e/tests/orchestrator/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_apm_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
@@ -932,7 +933,7 @@ workflow:
         - comp/trace/**/*
         - test/new-e2e/tests/apm/**/*
         - test/new-e2e/go.mod
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_installer_or_e2e_changes:
@@ -945,7 +946,7 @@ workflow:
         - cmd/installer/**/*
         - test/new-e2e/tests/installer/**/*
         - tasks/installer.py
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_ndm_netflow_or_e2e_changes:
@@ -955,7 +956,7 @@ workflow:
         - comp/netflow/**/*
         - test/new-e2e/tests/ndm/netflow/**/*
         - test/new-e2e/go.mod
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_ndm_snmp_or_e2e_changes:
@@ -965,7 +966,7 @@ workflow:
         - pkg/collector/corechecks/snmp/**/*
         - test/new-e2e/tests/ndm/snmp/**/*
         - test/new-e2e/go.mod
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
   - when: manual
     allow_failure: true
@@ -978,7 +979,7 @@ workflow:
         - pkg/aggregator/**/*
         - test/new-e2e/tests/ha-agent/**/*
         - test/new-e2e/go.mod
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_netpath_or_e2e_changes:
@@ -988,7 +989,7 @@ workflow:
         - pkg/collector/corechecks/networkpath/**/*
         - test/new-e2e/tests/netpath/**/*
         - test/new-e2e/go.mod
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_otel_or_e2e_changes:
@@ -1001,7 +1002,7 @@ workflow:
         - pkg/trace/stats/otel_util.go
         - pkg/trace/transform/transform.go
         - test/new-e2e/tests/otel/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_windows_service_or_e2e_changes:
@@ -1013,7 +1014,7 @@ workflow:
         - pkg/util/winutil/messagestrings/**/*
         - tasks/windows_resources.py
         - test/new-e2e/tests/windows/service-test/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_trace_agent_changes_or_manual:
@@ -1022,7 +1023,7 @@ workflow:
       paths:
         - pkg/trace/**/*
         - .gitlab/benchmarks/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
   - when: manual
     allow_failure: true
@@ -1033,7 +1034,7 @@ workflow:
       paths:
         - pkg/security/**/*
         - test/new-e2e/tests/cspm/**/* #TODO: Add other paths that should trigger the execution of CSPM e2e tests
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_windows_systemprobe_or_e2e_changes:
@@ -1045,7 +1046,7 @@ workflow:
         - pkg/process/monitor/*
         - pkg/util/kernel/**/*
         - test/new-e2e/tests/sysprobe-functional/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_windows_security_or_e2e_changes:
@@ -1055,7 +1056,7 @@ workflow:
         - pkg/security/**/*
         - pkg/eventmonitor/**/*
         - test/new-e2e/tests/security-agent-functional/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
 .on_scheduled_main:
@@ -1085,7 +1086,7 @@ workflow:
   - changes:
       paths:
         - comp/core/gui/guiimpl/systray/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_packaging_change:
   - !reference [.except_mergequeue] # The prerequisites are not run in the mergequeue pipeline so we need to skip this rule
@@ -1095,19 +1096,19 @@ workflow:
         - .gitlab-ci.yml
         - release.json
         - .gitlab/package_build/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_go-version_change:
   - !reference [.except_mergequeue] # The prerequisites are not run in the mergequeue pipeline so we need to skip this rule
   - changes:
       paths:
         - .go-version
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_fakeintake_changes:
   - changes:
       <<: *fakeintake_paths
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_fakeintake_changes_on_main:
   - changes:
@@ -1147,7 +1148,7 @@ workflow:
       - .gitlab-ci.yml
       - .gitlab/**/*
       - .gitlab/**/.*
-    compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+    compare_to: $COMPARE_TO_BRANCH
 
 .on_gitlab_changes_or_mergequeue_or_main:
   - !reference [.on_gitlab_changes]
@@ -1159,14 +1160,14 @@ workflow:
   - changes:
       paths:
         - tasks/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_powershell_module_or_e2e_changes_or_manual:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
         - test/new-e2e/tests/windows/powershell-module-test/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
   - when: manual
     allow_failure: true
 
@@ -1180,7 +1181,7 @@ workflow:
         - comp/core/workloadmeta/collectors/internal/nvml/**/*
         - comp/core/autodiscovery/providers/gpu.go
         - pkg/config/autodiscovery/autodiscovery.go
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
 
 .on_installer_systemd_changes:
   - <<: *if_main_branch
@@ -1188,7 +1189,7 @@ workflow:
   - changes:
       paths:
         - pkg/fleet/installer/packages/embedded/*.service
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: $COMPARE_TO_BRANCH
   - when: manual
     allow_failure: true
 

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -103,7 +103,7 @@ lint_github_actions_shellcheck:
     - changes:
         paths:
           - .github/workflows/**/*.yml
-        compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+        compare_to: $COMPARE_TO_BRANCH
       when: on_success
   allow_failure: true
   script:

--- a/.gitlab/notify/notify.yml
+++ b/.gitlab/notify/notify.yml
@@ -64,7 +64,7 @@ notify_github:
       changes:
         paths:
           - '**/*.go'
-        compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+        compare_to: $COMPARE_TO_BRANCH
       when: on_success
     - when: never
   needs:
@@ -98,7 +98,7 @@ notify_gitlab_ci_changes:
         paths:
           - .gitlab-ci.yml
           - .gitlab/**/*.yml
-        compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+        compare_to: $COMPARE_TO_BRANCH
   script:
     # Python 3.12 changes default behavior how packages are installed.
     # In particular, --break-system-packages command line option is

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -850,11 +850,11 @@ def compare_to_itself(ctx):
 
     release_json = load_release_json()
 
-    for file in ['.gitlab-ci.yml', '.gitlab/notify/notify.yml']:
-        with open(file) as f:
-            content = f.read()
-        with open(file, 'w') as f:
-            f.write(content.replace(f'compare_to: {release_json["base_branch"]}', f'compare_to: {new_branch}'))
+    with open('.gitlab-ci.yml', 'w') as f:
+        content = f.read()
+        f.write(
+            content.replace(f'COMPARE_TO_BRANCH: {release_json["base_branch"]}', f'COMPARE_TO_BRANCH: {new_branch}')
+        )
 
     ctx.run("git commit -am 'Commit to compare to itself'", hide=True)
     ctx.run(f"git push origin {new_branch}", hide=True)

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -8,7 +8,6 @@ Notes about Agent6:
 
 import json
 import os
-import re
 import sys
 import tempfile
 import time
@@ -83,11 +82,6 @@ from tasks.libs.releasing.version import (
 from tasks.notify import post_message
 from tasks.pipeline import edit_schedule, run
 from tasks.release_metrics.metrics import get_prs_metrics, get_release_lead_time
-
-GITLAB_FILES_TO_UPDATE = [
-    ".gitlab-ci.yml",
-    ".gitlab/notify/notify.yml",
-]
 
 BACKPORT_LABEL_COLOR = "5319e7"
 TAG_BATCH_SIZE = 3
@@ -806,16 +800,11 @@ def create_release_branches(
         set_new_release_branch(release_branch)
 
         # Step 1.2 - In datadog-agent repo update gitlab-ci.yaml and notify.yml jobs
-        for file in GITLAB_FILES_TO_UPDATE:
-            with open(file) as gl:
-                file_content = gl.readlines()
-
-            with open(file, "w") as gl:
-                for line in file_content:
-                    if re.search(rf"compare_to: {get_default_branch()}", line):
-                        gl.write(line.replace(get_default_branch(), f"{release_branch}"))
-                    else:
-                        gl.write(line)
+        with open(".gitlab-ci.yml", "w") as f:
+            content = f.read()
+            f.write(
+                content.replace(f'COMPARE_TO_BRANCH: {get_default_branch()}', f'COMPARE_TO_BRANCH: {release_branch}')
+            )
 
         # Step 1.3 - Commit new changes
         ctx.run("git add release.json .gitlab-ci.yml .gitlab/notify/notify.yml")

--- a/tasks/unit_tests/testdata/ci_config_with_reference.yml
+++ b/tasks/unit_tests/testdata/ci_config_with_reference.yml
@@ -90,7 +90,7 @@ workflow:
       paths:
         - test/new-e2e/pkg/**/*
         - test/new-e2e/go.mod
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: main
 
 .on_container_or_e2e_changes_or_manual:
   - !reference [.on_e2e_main_release_or_rc]
@@ -98,7 +98,7 @@ workflow:
       paths:
         - comp/core/tagger/**/*
         - comp/core/workloadmeta/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: main
     when: on_success
   - when: manual
     allow_failure: true
@@ -108,7 +108,7 @@ workflow:
   - changes:
       paths:
         - pkg/config/remote/**/*
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: main
   - when: manual
     allow_failure: true
 
@@ -138,4 +138,4 @@ workflow:
       paths:
         - omnibus/**/*
         - .gitlab-ci.yml
-      compare_to: main # TODO: use a variable, when this is supported https://gitlab.com/gitlab-org/gitlab/-/issues/369916
+      compare_to: main


### PR DESCRIPTION
### What does this PR do?
Remove a TODO by replacing the hardcoded branch name with a variable.

### Motivation
It's supported since Gitlab 17.2, as stated in the linked issue https://gitlab.com/gitlab-org/gitlab/-/issues/369916
