### PR TITLE
fix(installer): Don't display SSI status if injector isn't installed

### DIFF
--- a/pkg/fleet/installer/commands/status.tmpl
+++ b/pkg/fleet/installer/commands/status.tmpl
@@ -27,6 +27,7 @@ Packages installed:
 {{- end }}
 
 {{ with index .Packages.States "datadog-apm-inject" -}}
+{{- if ne .Stable "" -}}
 APM SSI is installed. Instrumentation status:
 {{- if eq $.ApmInjectionStatus.HostInstrumented true }}
     {{ greenText "●" }} Host: Instrumented
@@ -39,5 +40,6 @@ APM SSI is installed. Instrumentation status:
     {{ greenText "●" }} Docker: Instrumented
 {{- else }}
     {{ redText "●" }} Docker: Not instrumented
+{{- end -}}
 {{- end -}}
 {{- end }}


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where we displayed the SSI instrumentation status even if the injector isn't installed

### Motivation

### Describe how you validated your changes
Manual QA on a VM

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->