### PR TITLE
Bump static quality gate auto threshold update buffer to 1 MiB

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -14,7 +14,7 @@ from tasks.libs.common.utils import is_conductor_scheduled_pipeline
 from tasks.libs.package.size import InfraError
 from tasks.static_quality_gates.lib.gates_lib import GateMetricHandler, byte_to_string, is_first_commit_of_the_day
 
-BUFFER_SIZE = 500000
+BUFFER_SIZE = 1000000
 FAIL_CHAR = "❌"
 SUCCESS_CHAR = "✅"
 

--- a/tasks/unit_tests/quality_gates_tests.py
+++ b/tasks/unit_tests/quality_gates_tests.py
@@ -37,16 +37,16 @@ class TestQualityGatesConfigUpdate(unittest.TestCase):
                     }
                 ),
             )
-        assert new_config["some_gate_high"]["max_on_wire_size"] == "48.16 MiB", print(
-            f"Expected 57.22 MiB got {new_config['some_gate_high']['max_on_wire_size']}"
+        assert new_config["some_gate_high"]["max_on_wire_size"] == "48.64 MiB", print(
+            f"Expected 48.64 MiB got {new_config['some_gate_high']['max_on_wire_size']}"
         )
-        assert new_config["some_gate_high"]["max_on_disk_size"] == "48.16 MiB", print(
-            f"Expected 57.22 MiB got {new_config['some_gate_high']['max_on_disk_size']}"
+        assert new_config["some_gate_high"]["max_on_disk_size"] == "48.64 MiB", print(
+            f"Expected 48.64 MiB got {new_config['some_gate_high']['max_on_disk_size']}"
         )
-        assert new_config["some_gate_low"]["max_on_wire_size"] == "4.29 MiB", print(
+        assert new_config["some_gate_low"]["max_on_wire_size"] == "4.77 MiB", print(
             f"Expected 4.77 MiB got {new_config['some_gate_low']['max_on_wire_size']}"
         )
-        assert new_config["some_gate_low"]["max_on_disk_size"] == "4.29 MiB", print(
+        assert new_config["some_gate_low"]["max_on_disk_size"] == "4.77 MiB", print(
             f"Expected 4.77 MiB got {new_config['some_gate_low']['max_on_disk_size']}"
         )
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Bump static quality gate auto threshold update buffer to `1 MiB` instead of `0.5 MiB`

### Motivation

Due to variation in our builds size we are increasing the buffer to avoid cutting quality gates new values too sharp. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->