### PR TITLE
[ha-agent] Disable HA Agent if config_id is missing

### DIFF
--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -32,7 +32,7 @@ func newHaAgentImpl(log log.Component, haAgentConfigs *haAgentConfigs) *haAgentI
 
 func (h *haAgentImpl) Enabled() bool {
 	if h.GetConfigID() == "" {
-		h.log.Error("HA Agent feature required config_id to be set")
+		h.log.Error("HA Agent feature requires config_id to be set")
 		return false
 	}
 	return h.haAgentConfigs.enabled

--- a/comp/haagent/impl/haagent.go
+++ b/comp/haagent/impl/haagent.go
@@ -31,6 +31,10 @@ func newHaAgentImpl(log log.Component, haAgentConfigs *haAgentConfigs) *haAgentI
 }
 
 func (h *haAgentImpl) Enabled() bool {
+	if h.GetConfigID() == "" {
+		h.log.Error("HA Agent feature required config_id to be set")
+		return false
+	}
 	return h.haAgentConfigs.enabled
 }
 

--- a/comp/haagent/impl/haagent_test.go
+++ b/comp/haagent/impl/haagent_test.go
@@ -31,8 +31,16 @@ func Test_Enabled(t *testing.T) {
 			name: "enabled",
 			configs: map[string]interface{}{
 				"ha_agent.enabled": true,
+				"config_id":        "foo",
 			},
 			expectedEnabled: true,
+		},
+		{
+			name: "disabled due to missing config_id",
+			configs: map[string]interface{}{
+				"ha_agent.enabled": true,
+			},
+			expectedEnabled: false,
 		},
 		{
 			name: "disabled",
@@ -83,6 +91,7 @@ func Test_RCListener(t *testing.T) {
 			name: "enabled",
 			configs: map[string]interface{}{
 				"ha_agent.enabled": true,
+				"config_id":        "foo",
 			},
 			expectRCListener: true,
 		},

--- a/pkg/collector/worker/worker_test.go
+++ b/pkg/collector/worker/worker_test.go
@@ -716,7 +716,7 @@ func TestWorker_HaIntegration(t *testing.T) {
 			agentConfigs := map[string]interface{}{
 				"hostname":         testHostname,
 				"ha_agent.enabled": tt.haAgentEnabled,
-				"ha_agent.group":   "my-group-01",
+				"config_id":        "my-config-01",
 			}
 			logComponent := logmock.New(t)
 			agentConfigComponent := fxutil.Test[config.Component](t, fx.Options(


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[ha-agent] Disable HA Agent if config_id is missing

### Motivation

Faster feedback for users when required config_id is missing

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->