### PR TITLE
[CWS] reduce flakyness of ondemand tests

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1382,6 +1382,11 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 			return
 		}
 	case model.OnDemandEventType:
+		if p.onDemandManager.isDisabled() {
+			seclog.Debugf("on-demand event received but on-demand probes are disabled")
+			return
+		}
+
 		if !p.onDemandRateLimiter.Allow() {
 			seclog.Errorf("on-demand event rate limit reached, disabling on-demand probes to protect the system")
 			p.onDemandManager.disable()

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -153,7 +153,7 @@ func TestOnDemandMprotect(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_mprotect",
-			Expression: `ondemand.name == "security_file_mprotect" && (ondemand.arg3.uint & (VM_READ|VM_WRITE)) == (VM_READ|VM_WRITE) && process.file.name == "testsuite"`,
+			Expression: `ondemand.name == "security_file_mprotect" && (ondemand.arg3.uint & (PROT_READ|PROT_WRITE)) == (PROT_READ|PROT_WRITE) && process.file.name == "testsuite"`,
 		},
 	}
 

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -173,6 +173,11 @@ func TestOnDemandMprotect(t *testing.T) {
 		if err = unix.Mprotect(data, unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC); err != nil {
 			return fmt.Errorf("couldn't mprotect segment: %w", err)
 		}
+
+		if err := unix.Munmap(data); err != nil {
+			return fmt.Errorf("couldn't unmap segment: %w", err)
+		}
+
 		return nil
 	}, func(event *model.Event, _ *rules.Rule) {
 		assert.Equal(t, "ondemand", event.GetType(), "wrong event type")

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -132,6 +132,8 @@ func TestOnDemandChdir(t *testing.T) {
 }
 
 func TestOnDemandMprotect(t *testing.T) {
+	t.Skip("skipping mprotect test, because mprotect are too frequent globally to not trip the rate limiter")
+
 	SkipIfNotAvailable(t)
 
 	onDemands := []rules.OnDemandHookPoint{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes a few issues with on-demand tests:
- it makes sure to use the correct constant type in mprotect test
- it makes sure to correctly unmap the mapping after the mprotect test
- it ensures we are not spamming the logs with messages about the on-demand rate limiter

This PR also skips the mprotect test altogether, since mprotect is a widely used syscall, and any process using it on the machine can trigger the rate limiter.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->