### PR TITLE
Log error instead of returning it in case of DI module failing to run

### DIFF
--- a/pkg/dynamicinstrumentation/module/module.go
+++ b/pkg/dynamicinstrumentation/module/module.go
@@ -35,7 +35,16 @@ func NewModule(_ *Config) (*Module, error) {
 		},
 	})
 	if err != nil {
-		return nil, err
+		// FIXME: Logging the error instead of returning it is a temporary fix to avoid
+		// having the system-probe get caught in a restart loop when either the environment lacks
+		// the bpf feature requirements or the system-probe is not run with needeed permissions.
+		// The DI module can be mistakenly turned on as it shares the same environment variable
+		// as all DI runtimes, leading to problematic behavior.
+		//
+		// This means that legitimate errors will be logged, but not cause the module to restart
+		// as it should.
+		log.Errorf("Failed to start dynamic instrumentation: %v", err)
+		return &Module{}, nil
 	}
 	return &Module{godi}, nil
 }


### PR DESCRIPTION
### What does this PR do?

Resolves incident 36701. A summary is as follows:
- If DI fails to start (such as if bpf features can't be used for permission reasons), and is the only sysprobe module enabled , the sysprobe can be caught in a restart loop which creates tons of logs.
- This can easily happen inadvertently as the DI module uses the same environment variable as all DI runtime libraries.

The temporary fix introduced by this PR is to have Go DI log errors but return nil, putting it into an error state, but without the system-probe being aware. Follow up PR will be opened to:

1) Revert this.
2) Change logic so the ringbuffer (the map which fails) is loaded only when a probe is enabled.
3) Rename the env variable for enabling the Go DI module

### Motivation

Incident

### Describe how you validated your changes

Manual testing

### Possible Drawbacks / Trade-offs

### Additional Notes
