### PR TITLE
[CWS] windows handle operation end & refactor approver/discarder

### DIFF
--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// Microsoft-Windows-Kernel-File - https://github.com/repnz/etw-providers-docs/blob/master/Manifests-Win10-17134/Microsoft-Windows-Kernel-File.xml
 const (
 	idNameCreate       = uint16(10)
 	idNameDelete       = uint16(11)
@@ -53,26 +54,30 @@ var (
 )
 
 /*
-		<template tid="CreateArgs">
-	      <data name="Irp" inType="win:Pointer"/>
-	      <data name="ThreadId" inType="win:Pointer"/>
-	      <data name="FileObject" inType="win:Pointer"/>
-	      <data name="CreateOptions" inType="win:UInt32"/>
-	      <data name="CreateAttributes" inType="win:UInt32"/>
-	      <data name="ShareAccess" inType="win:UInt32"/>
-	      <data name="FileName" inType="win:UnicodeString"/>
-	    </template>
+<template tid="CreateArgs">
+
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="ThreadId" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="CreateOptions" inType="win:UInt32"/>
+	<data name="CreateAttributes" inType="win:UInt32"/>
+	<data name="ShareAccess" inType="win:UInt32"/>
+	<data name="FileName" inType="win:UnicodeString"/>
+
+</template>
+<template tid="CreateArgs">
+
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="IssuingThreadId" inType="win:UInt32"/>
+	<data name="CreateOptions" inType="win:UInt32"/>
+	<data name="CreateAttributes" inType="win:UInt32"/>
+	<data name="ShareAccess" inType="win:UInt32"/>
+	<data name="FileName" inType="win:UnicodeString"/>
+
+</template>
 */
-/*
- 	<data name="Irp" inType="win:Pointer"/>
-      <data name="FileObject" inType="win:Pointer"/>
-      <data name="IssuingThreadId" inType="win:UInt32"/>
-      <data name="CreateOptions" inType="win:UInt32"/>
-      <data name="CreateAttributes" inType="win:UInt32"/>
-      <data name="ShareAccess" inType="win:UInt32"/>
-      <data name="FileName" inType="win:UnicodeString"/>
-*/
-type createHandleArgs struct {
+type createArgs struct {
 	etw.DDEventHeader
 	irp              uint64            // actually a pointer
 	fileObject       fileObjectPointer // pointer
@@ -120,7 +125,7 @@ const (
 	kernelCreateOpts_FILE_NO_COMPRESSION         = uint32(0x00008000) // nolint:unused,revive
 )
 
-type createNewFileArgs createHandleArgs
+type createNewFileArgs createArgs
 
 /*
 The Parameters.Create.Options member is a ULONG value that describes the options that are used
@@ -136,12 +141,14 @@ The Parameters.Create.FileAttributes and Parameters.Create.EaLength members are 
 	by file systems and file system filter drivers. For more information, see the IRP_MJ_CREATE topic in
 	the Installable File System (IFS) documentation.
 */
-func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHandleArgs, error) {
-	ca := &createHandleArgs{
+func (wp *WindowsProbe) _parseCreateArgs(e *etw.DDEventRecord) (*createArgs, error) {
+	ca := &createArgs{
 		DDEventHeader: e.EventHeader,
 	}
+
 	data := etwimpl.GetUserData(e)
-	if e.EventHeader.EventDescriptor.Version == 0 {
+	switch e.EventHeader.EventDescriptor.Version {
+	case 0:
 		ca.irp = data.GetUint64(0)
 		ca.threadID = data.GetUint64(8)
 		ca.fileObject = fileObjectPointer(data.GetUint64(16))
@@ -150,8 +157,7 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 		ca.shareAccess = data.GetUint32(32)
 
 		ca.fileName, _, _, _ = data.ParseUnicodeString(36)
-	} else if e.EventHeader.EventDescriptor.Version == 1 {
-
+	case 1:
 		ca.irp = data.GetUint64(0)
 		ca.fileObject = fileObjectPointer(data.GetUint64(8))
 		ca.threadID = uint64(data.GetUint32(16))
@@ -160,39 +166,16 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 		ca.shareAccess = data.GetUint32(28)
 
 		ca.fileName, _, _, _ = data.ParseUnicodeString(32)
-	} else {
+	default:
 		return nil, fmt.Errorf("unknown version %v", e.EventHeader.EventDescriptor.Version)
 	}
 
-	// invalidate the path resolver entry
+	// invalidate the path resolver entry and other cache entries
+	wp.discardedFileHandles.Remove(fileObjectPointer(ca.fileObject))
 	wp.filePathResolver.Remove(ca.fileObject)
-
-	// not amazing to double compute the basename.
-	basename := filepath.Base(ca.fileName)
-
-	if !wp.approveFimBasename(basename) {
-		wp.discardedFileHandles.Add(fileObjectPointer(ca.fileObject), struct{}{})
-		wp.stats.createFileApproverRejects++
-		return nil, errDiscardedPath
-	}
-
-	if _, ok := wp.discardedPaths.Get(ca.fileName); ok {
-		wp.discardedFileHandles.Add(fileObjectPointer(ca.fileObject), struct{}{})
-		wp.stats.fileCreateSkippedDiscardedPaths++
-		return nil, errDiscardedPath
-	}
+	wp.createArgsCache.Remove(ca.irp)
 
 	ca.userFileName = wp.mustConvertDrivePath(ca.fileName)
-	if _, ok := wp.discardedUserPaths.Get(ca.userFileName); ok {
-		wp.stats.fileCreateSkippedDiscardedPaths++
-		return nil, errDiscardedPath
-	}
-
-	if _, ok := wp.discardedBasenames.Get(basename); ok {
-		wp.discardedFileHandles.Add(fileObjectPointer(ca.fileObject), struct{}{})
-		wp.stats.fileCreateSkippedDiscardedBasenames++
-		return nil, errDiscardedPath
-	}
 
 	// lru is thread safe, has its own locking
 	fc := fileCache{
@@ -202,15 +185,24 @@ func (wp *WindowsProbe) parseCreateHandleArgs(e *etw.DDEventRecord) (*createHand
 	if wp.filePathResolver.Add(ca.fileObject, fc) {
 		wp.stats.fileNameCacheEvictions++
 	}
-	// if we get here, we have a new file handle. Remove it from the discarder cache in case
-	// we missed the close notification
-	wp.discardedFileHandles.Remove(fileObjectPointer(ca.fileObject))
+
+	return ca, nil
+}
+
+func (wp *WindowsProbe) parseCreateArgs(e *etw.DDEventRecord) (*createArgs, error) {
+	ca, err := wp._parseCreateArgs(e)
+	if err != nil {
+		return nil, err
+	}
+
+	// add it the createArgs cache so that it can be remove later from the operationEnd handling
+	wp.createArgsCache.Add(ca.irp, ca.fileObject)
 
 	return ca, nil
 }
 
 func (wp *WindowsProbe) parseCreateNewFileArgs(e *etw.DDEventRecord) (*createNewFileArgs, error) {
-	ca, err := wp.parseCreateHandleArgs(e)
+	ca, err := wp._parseCreateArgs(e)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +210,7 @@ func (wp *WindowsProbe) parseCreateNewFileArgs(e *etw.DDEventRecord) (*createNew
 }
 
 // nolint: unused
-func (ca *createHandleArgs) string(t string) string {
+func (ca *createArgs) string(t string) string {
 	var output strings.Builder
 
 	output.WriteString(t + " PID: " + strconv.Itoa(int(ca.ProcessID)) + ", ")
@@ -230,33 +222,35 @@ func (ca *createHandleArgs) string(t string) string {
 }
 
 // nolint: unused
-func (ca *createHandleArgs) String() string {
+func (ca *createArgs) String() string {
 	return ca.string("CREATE")
 }
 
 // nolint: unused
 func (ca *createNewFileArgs) String() string {
-	return (*createHandleArgs)(ca).string("CREATE_NEW_FILE")
+	return (*createArgs)(ca).string("CREATE_NEW_FILE")
 }
 
 /*
-  <template tid="SetInformationArgs">
-      <data name="Irp" inType="win:Pointer"/>
-      <data name="ThreadId" inType="win:Pointer"/>
-      <data name="FileObject" inType="win:Pointer"/>
-      <data name="FileKey" inType="win:Pointer"/>
-      <data name="ExtraInformation" inType="win:Pointer"/>
-      <data name="InfoClass" inType="win:UInt32"/>
-     </template>
+<template tid="SetInformationArgs">
 
-	 <template tid="SetInformationArgs_V1">
-      <data name="Irp" inType="win:Pointer"/>
-      <data name="FileObject" inType="win:Pointer"/>
-      <data name="FileKey" inType="win:Pointer"/>
-      <data name="ExtraInformation" inType="win:Pointer"/>
-      <data name="IssuingThreadId" inType="win:UInt32"/>
-      <data name="InfoClass" inType="win:UInt32"/>
-     </template>
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="ThreadId" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="FileKey" inType="win:Pointer"/>
+	<data name="ExtraInformation" inType="win:Pointer"/>
+	<data name="InfoClass" inType="win:UInt32"/>
+
+</template>
+<template tid="SetInformationArgs_V1">
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="FileKey" inType="win:Pointer"/>
+	<data name="ExtraInformation" inType="win:Pointer"/>
+	<data name="IssuingThreadId" inType="win:UInt32"/>
+	<data name="InfoClass" inType="win:UInt32"/>
+
+</template>
 */
 // nolint: unused
 type setInformationArgs struct {
@@ -388,21 +382,23 @@ func (fa *fsctlArgs) String() string {
 }
 
 /*
-	<template tid="CleanupArgs">
-      <data name="Irp" inType="win:Pointer"/>
-      <data name="threadID" inType="win:Pointer"/>
-      <data name="FileObject" inType="win:Pointer"/>
-      <data name="FileKey" inType="win:Pointer"/>
-     </template>
+<template tid="CleanupArgs">
 
- 	<template tid="CleanupArgs_V1">
-      <data name="Irp" inType="win:Pointer"/>
-      <data name="FileObject" inType="win:Pointer"/>
-      <data name="FileKey" inType="win:Pointer"/>
-      <data name="IssuingThreadId" inType="win:UInt32"/>
-     </template>
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="threadID" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="FileKey" inType="win:Pointer"/>
+
+</template>
+<template tid="CleanupArgs_V1">
+
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="FileKey" inType="win:Pointer"/>
+	<data name="IssuingThreadId" inType="win:UInt32"/>
+
+</template>
 */
-
 type cleanupArgs struct {
 	etw.DDEventHeader
 	irp          uint64
@@ -419,6 +415,22 @@ type closeArgs cleanupArgs
 // nolint: unused
 type flushArgs cleanupArgs
 
+/*
+<template tid="OperationEndArgs">
+
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="ExtraInformation" inType="win:Pointer"/>
+	<data name="Status" inType="win:UInt32"/>
+
+</template>
+*/
+type operationEndArgs struct {
+	etw.DDEventHeader
+	irp              uint64
+	extraInformation uint64
+	status           uint32
+}
+
 func (wp *WindowsProbe) parseCleanupArgs(e *etw.DDEventRecord) (*cleanupArgs, error) {
 	ca := &cleanupArgs{
 		DDEventHeader: e.EventHeader,
@@ -429,7 +441,6 @@ func (wp *WindowsProbe) parseCleanupArgs(e *etw.DDEventRecord) (*cleanupArgs, er
 		ca.threadID = data.GetUint64(8)
 		ca.fileObject = fileObjectPointer(data.GetUint64(16))
 		ca.fileKey = data.GetUint64(24)
-
 	} else if e.EventHeader.EventDescriptor.Version == 1 {
 		ca.irp = data.GetUint64(0)
 		ca.fileObject = fileObjectPointer(data.GetUint64(8))
@@ -449,6 +460,19 @@ func (wp *WindowsProbe) parseCleanupArgs(e *etw.DDEventRecord) (*cleanupArgs, er
 	}
 
 	return ca, nil
+}
+
+func (wp *WindowsProbe) parseOperationEndArgs(e *etw.DDEventRecord) (*operationEndArgs, error) {
+	oe := &operationEndArgs{
+		DDEventHeader: e.EventHeader,
+	}
+	data := etwimpl.GetUserData(e)
+
+	oe.irp = data.GetUint64(0)
+	oe.extraInformation = data.GetUint64(8)
+	oe.status = data.GetUint32(16)
+
+	return oe, nil
 }
 
 // nolint: unused
@@ -581,24 +605,28 @@ func (wa *writeArgs) String() string {
 }
 
 /*
-	     <template tid="DeletePathArgs">
-	      <data name="Irp" inType="win:Pointer"/>
-	      <data name="ThreadId" inType="win:Pointer"/>
-	      <data name="FileObject" inType="win:Pointer"/>
-	      <data name="FileKey" inType="win:Pointer"/>
-	      <data name="ExtraInformation" inType="win:Pointer"/>
-	      <data name="InfoClass" inType="win:UInt32"/>
-	      <data name="FilePath" inType="win:UnicodeString"/>
-	     </template>
-		      <template tid="DeletePathArgs_V1">
-	      <data name="Irp" inType="win:Pointer"/>
-	      <data name="FileObject" inType="win:Pointer"/>
-	      <data name="FileKey" inType="win:Pointer"/>
-	      <data name="ExtraInformation" inType="win:Pointer"/>
-	      <data name="IssuingThreadId" inType="win:UInt32"/>
-	      <data name="InfoClass" inType="win:UInt32"/>
-	      <data name="FilePath" inType="win:UnicodeString"/>
-	     </template>
+<template tid="DeletePathArgs">
+
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="ThreadId" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="FileKey" inType="win:Pointer"/>
+	<data name="ExtraInformation" inType="win:Pointer"/>
+	<data name="InfoClass" inType="win:UInt32"/>
+	<data name="FilePath" inType="win:UnicodeString"/>
+
+</template>
+<template tid="DeletePathArgs_V1">
+
+	<data name="Irp" inType="win:Pointer"/>
+	<data name="FileObject" inType="win:Pointer"/>
+	<data name="FileKey" inType="win:Pointer"/>
+	<data name="ExtraInformation" inType="win:Pointer"/>
+	<data name="IssuingThreadId" inType="win:UInt32"/>
+	<data name="InfoClass" inType="win:UInt32"/>
+	<data name="FilePath" inType="win:UnicodeString"/>
+
+</template>
 */
 type deletePathArgs struct {
 	etw.DDEventHeader
@@ -715,13 +743,11 @@ func (wp *WindowsProbe) parseNameCreateArgs(e *etw.DDEventRecord) (*nameCreateAr
 		DDEventHeader: e.EventHeader,
 	}
 	data := etwimpl.GetUserData(e)
-	if e.EventHeader.EventDescriptor.Version == 0 {
+	switch e.EventHeader.EventDescriptor.Version {
+	case 0, 1:
 		ca.fileKey = fileObjectPointer(data.GetUint64(0))
 		ca.fileName, _, _, _ = data.ParseUnicodeString(8)
-	} else if e.EventHeader.EventDescriptor.Version == 1 {
-		ca.fileKey = fileObjectPointer(data.GetUint64(0))
-		ca.fileName, _, _, _ = data.ParseUnicodeString(8)
-	} else {
+	default:
 		return nil, fmt.Errorf("unknown version number %v", e.EventHeader.EventDescriptor.Version)
 	}
 	ca.userFileName = wp.mustConvertDrivePath(ca.fileName)
@@ -783,6 +809,36 @@ func (wp *WindowsProbe) mustConvertDrivePath(devicefilename string) string {
 		return devicefilename
 	}
 	return userPath
+}
+
+func (wp *WindowsProbe) isPathAccepted(fileObject fileObjectPointer, fileName string, userFileName string) bool {
+	// not amazing to double compute the basename.
+	basename := filepath.Base(fileName)
+
+	if !wp.approveFimBasename(basename) {
+		wp.discardedFileHandles.Add(fileObjectPointer(fileObject), struct{}{})
+		wp.stats.createFileApproverRejects++
+		return false
+	}
+
+	if _, ok := wp.discardedPaths.Get(fileName); ok {
+		wp.discardedFileHandles.Add(fileObjectPointer(fileObject), struct{}{})
+		wp.stats.fileCreateSkippedDiscardedPaths++
+		return false
+	}
+
+	if _, ok := wp.discardedUserPaths.Get(userFileName); ok {
+		wp.stats.fileCreateSkippedDiscardedPaths++
+		return false
+	}
+
+	if _, ok := wp.discardedBasenames.Get(basename); ok {
+		wp.discardedFileHandles.Add(fileObjectPointer(fileObject), struct{}{})
+		wp.stats.fileCreateSkippedDiscardedBasenames++
+		return false
+	}
+
+	return true
 }
 
 func (wp *WindowsProbe) initializeVolumeMap() error {

--- a/pkg/security/probe/probe_kernel_file_windows.go
+++ b/pkg/security/probe/probe_kernel_file_windows.go
@@ -172,8 +172,6 @@ func (wp *WindowsProbe) _parseCreateArgs(e *etw.DDEventRecord) (*createArgs, err
 
 	// invalidate the path resolver entry and other cache entries
 	wp.discardedFileHandles.Remove(fileObjectPointer(ca.fileObject))
-	wp.filePathResolver.Remove(ca.fileObject)
-	wp.createArgsCache.Remove(ca.irp)
 
 	ca.userFileName = wp.mustConvertDrivePath(ca.fileName)
 
@@ -206,6 +204,8 @@ func (wp *WindowsProbe) parseCreateNewFileArgs(e *etw.DDEventRecord) (*createNew
 	if err != nil {
 		return nil, err
 	}
+	wp.createArgsCache.Remove(ca.irp)
+
 	return (*createNewFileArgs)(ca), nil
 }
 

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -117,7 +117,7 @@ func processUntil(t *testing.T, et *etwTester, target interface{}, count int) {
 
 		case n := <-et.notify:
 			switch n.(type) {
-			case *createHandleArgs, *createNewFileArgs, *cleanupArgs, *closeArgs, *writeArgs, *setDeleteArgs, *deletePathArgs, *renameArgs, *renamePath:
+			case *createArgs, *createNewFileArgs, *cleanupArgs, *closeArgs, *writeArgs, *setDeleteArgs, *deletePathArgs, *renameArgs, *renamePath:
 				et.notifications = append(et.notifications, n)
 				if reflect.TypeOf(n) == reflect.TypeOf(target) {
 					targetcount++
@@ -148,7 +148,7 @@ func processUntilAllClosed(t *testing.T, et *etwTester) {
 		case n := <-et.notify:
 			notify := false
 			switch n.(type) {
-			case *createHandleArgs, *createNewFileArgs:
+			case *createArgs, *createNewFileArgs:
 				opencount++
 				notify = true
 
@@ -235,7 +235,7 @@ func testSimpleCreate(t *testing.T, et *etwTester, testfilename string) {
 
 	assert.Equal(t, 4, len(et.notifications), "expected 4 notifications, got %d", len(et.notifications))
 
-	if c, ok := et.notifications[0].(*createHandleArgs); ok {
+	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
@@ -244,7 +244,7 @@ func testSimpleCreate(t *testing.T, et *etwTester, testfilename string) {
 	if cf, ok := et.notifications[1].(*createNewFileArgs); ok {
 		assert.True(t, isSameFile(testfilename, cf.fileName), "expected %s, got %s", testfilename, cf.fileName)
 	} else {
-		t.Errorf("expected createNewFileArgs, got %T", et.notifications[1])
+		t.Errorf("expected CreateArgs, got %T", et.notifications[1])
 	}
 
 	if cu, ok := et.notifications[2].(*cleanupArgs); ok {
@@ -315,7 +315,7 @@ func testSimpleFileWrite(t *testing.T, et *etwTester, testfilename string) {
 
 	assert.Equal(t, 3, len(et.notifications), "expected 3 notifications, got %d", len(et.notifications))
 
-	if c, ok := et.notifications[0].(*createHandleArgs); ok {
+	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
@@ -379,7 +379,7 @@ func testSimpleFileDelete(t *testing.T, et *etwTester, testfilename string) {
 			return
 		}
 	*/
-	if c, ok := et.notifications[0].(*createHandleArgs); ok {
+	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
@@ -437,7 +437,7 @@ func testSimpleFileRename(t *testing.T, et *etwTester, testfilename, testfileren
 
 	//assert.Equal(t, 4, len(et.notifications), "expected 4 notifications, got %d", len(et.notifications))
 
-	if c, ok := et.notifications[0].(*createHandleArgs); ok {
+	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
 		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
@@ -507,7 +507,7 @@ func testFileOpen(t *testing.T, et *etwTester, testfilename string) {
 	// we expect a handle create (12), a cleanup and a close.
 	assert.Equal(t, 3, len(et.notifications), "expected 3 notifications, got %d", len(et.notifications))
 
-	if c, ok := et.notifications[0].(*createHandleArgs); ok {
+	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 		// this should be same as sharing argument to Createfile
 		assert.Equal(t, uint32(windows.FILE_SHARE_READ), c.shareAccess, "Sharing mode did not match")

--- a/pkg/security/probe/probe_kernel_file_windows_test.go
+++ b/pkg/security/probe/probe_kernel_file_windows_test.go
@@ -238,13 +238,13 @@ func testSimpleCreate(t *testing.T, et *etwTester, testfilename string) {
 	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
-		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
+		t.Errorf("expected createArgs, got %T", et.notifications[0])
 	}
 
 	if cf, ok := et.notifications[1].(*createNewFileArgs); ok {
 		assert.True(t, isSameFile(testfilename, cf.fileName), "expected %s, got %s", testfilename, cf.fileName)
 	} else {
-		t.Errorf("expected CreateArgs, got %T", et.notifications[1])
+		t.Errorf("expected createNewFileArgs, got %T", et.notifications[1])
 	}
 
 	if cu, ok := et.notifications[2].(*cleanupArgs); ok {
@@ -318,7 +318,7 @@ func testSimpleFileWrite(t *testing.T, et *etwTester, testfilename string) {
 	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
-		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
+		t.Errorf("expected createArgs, got %T", et.notifications[0])
 	}
 
 	if wa, ok := et.notifications[1].(*writeArgs); ok {
@@ -382,7 +382,7 @@ func testSimpleFileDelete(t *testing.T, et *etwTester, testfilename string) {
 	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
-		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
+		t.Errorf("expected createArgs, got %T", et.notifications[0])
 	}
 
 	if wa, ok := et.notifications[1].(*setDeleteArgs); ok {
@@ -440,7 +440,7 @@ func testSimpleFileRename(t *testing.T, et *etwTester, testfilename, testfileren
 	if c, ok := et.notifications[0].(*createArgs); ok {
 		assert.True(t, isSameFile(testfilename, c.fileName), "expected %s, got %s", testfilename, c.fileName)
 	} else {
-		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
+		t.Errorf("expected createArgs, got %T", et.notifications[0])
 	}
 
 	// there are a variable number of notifications depending on OS.  FOr some reason, at least on Win11
@@ -514,7 +514,7 @@ func testFileOpen(t *testing.T, et *etwTester, testfilename string) {
 		assert.Equal(t, expectedCreateOptions, c.createOptions, "Create options did not match")
 
 	} else {
-		t.Errorf("expected createHandleArgs, got %T", et.notifications[0])
+		t.Errorf("expected createArgs, got %T", et.notifications[0])
 	}
 
 	if cu, ok := et.notifications[1].(*cleanupArgs); ok {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR : 
* handles idOperationEnd to check the return code and not cache non existing path
* move the approver/discarder logic later in the stack so that all the create/delete/rename can update the path name cache

This aims to limit the impact of invalid cache entry because of event loss, file activity not properly tracked.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->