### PR TITLE
[OTEL-2506] Convert OTel instrumentation scope attributes to span attributes

### DIFF
--- a/pkg/trace/transform/transform.go
+++ b/pkg/trace/transform/transform.go
@@ -259,6 +259,10 @@ func OtelSpanToDDSpan(
 		return true
 	})
 
+	for k, v := range lib.Attributes().Range {
+		ddspan.Meta[k] = v.AsString()
+	}
+
 	traceID := otelspan.TraceID()
 	ddspan.Meta["otel.trace_id"] = hex.EncodeToString(traceID[:])
 	if !spanMetaHasKey(ddspan, "version") {

--- a/releasenotes/notes/apm-otlp-trace-scope-attributes-9e85ffe44cc513f2.yaml
+++ b/releasenotes/notes/apm-otlp-trace-scope-attributes-9e85ffe44cc513f2.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    OpenTelemetry instrumentation scope attributes are now converted into span
+    attributes.


### PR DESCRIPTION
### What does this PR do?

Adds support for OTel instrumentation scope attributes in `pkg/trace/transform` by converting them to Datadog span attributes. This is meant to be similar to our handling of resource attributes.

### Motivation

Since today's release, the OTel Collector has a feature gate which enables injecting scope attributes in its internal telemetry to clearly identify which Collector component emitted it. This makes it important for Datadog to be able to read and display these attributes to the user.

### Describe how you validated your changes

I added a test case to `pkg/trace/api/otlp_test.go` to test the conversion. I wasn't sure what data to put in the test case, so I based it on an actual span emitted by the Collector. I also did a quick manual test by feeding the Collector's telemetry into an Agent.

### Possible Drawbacks / Trade-offs

Collisions between scope attributes and resource/span attributes are technically possible, but considering how rarely used scope attributes are, this shouldn't be any more of an issue than for resource attributes.
