### PR TITLE
[Backport 7.65.x] autodiscovery: only detect NVML library if a feature flag is enabled

### DIFF
--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -74,7 +74,7 @@ func detectContainerFeatures(features FeatureMap, cfg model.Reader) {
 	detectCloudFoundry(features, cfg)
 	detectPodman(features, cfg)
 	detectPodResources(features, cfg)
-	detectNVML(features)
+	detectNVML(features, cfg)
 }
 
 func detectKubernetes(features FeatureMap, cfg model.Reader) {
@@ -248,7 +248,11 @@ func detectPodResources(features FeatureMap, cfg model.Reader) {
 	}
 }
 
-func detectNVML(features FeatureMap) {
+func detectNVML(features FeatureMap, cfg model.Reader) {
+	if !cfg.GetBool("enable_nvml_detection") {
+		return
+	}
+
 	// Use dlopen to search for the library to avoid importing the go-nvml package here,
 	// which is 1MB in size and would increase the agent binary size, when we don't really
 	// need it for anything else.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -625,6 +625,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 
 	// GPU
 	config.BindEnvAndSetDefault("collect_gpu_tags", false)
+	config.BindEnvAndSetDefault("enable_nvml_detection", false)
+
 	// Cloud Foundry BBS
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.url", "https://bbs.service.cf.internal:8889")
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.poll_interval", 15)

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -91,6 +91,10 @@ agents:
       env:
         - name: HOST_PROC
           value: "/host/root/proc"
+    agent:
+      env:
+        - name: DD_ENABLE_NVML_DETECTION
+          value: "true"
 `
 
 type provisionerParams struct {
@@ -106,6 +110,7 @@ func getDefaultProvisionerParams() *provisionerParams {
 	return &provisionerParams{
 		agentOptions: []agentparams.Option{
 			agentparams.WithSystemProbeConfig(defaultSysprobeConfig),
+			agentparams.WithAgentConfig("enable_nvml_detection: true"),
 		},
 		kubernetesAgentOptions: nil,
 		ami:                    gpuEnabledAMI,


### PR DESCRIPTION
### What does this PR do?
This PR changes the NVML feature detection to have a feature flag gate, so that for now all GPU monitoring features are gated and only enabled explicitly by the customer.

### Motivation
Avoid enabling by default preview features. Backported to reduce risk for customers.

### Describe how you validated your changes
E2E tests changed to adapt to this situation.

### Possible Drawbacks / Trade-offs
### Additional Notes