### PR TITLE
Clean up shadowed err declarations in apminject

### DIFF
--- a/pkg/fleet/installer/packages/apminject/apm_inject.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject.go
@@ -89,7 +89,7 @@ func (a *InjectorInstaller) Finish(err error) {
 func (a *InjectorInstaller) Setup(ctx context.Context) error {
 	var err error
 
-	if err := setupAppArmor(ctx); err != nil {
+	if err = setupAppArmor(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/fleet/installer/packages/apminject/apm_sockets.go
+++ b/pkg/fleet/installer/packages/apminject/apm_sockets.go
@@ -59,7 +59,7 @@ func getSocketsPath() (string, string, error) {
 	}
 
 	var cfg socketConfig
-	if err := yaml.Unmarshal(rawCfg, &cfg); err != nil {
+	if err = yaml.Unmarshal(rawCfg, &cfg); err != nil {
 		log.Warn("Failed to unmarshal agent configuration, using default installer sockets")
 		return apmSocket, statsdSocket, nil
 	}
@@ -82,15 +82,15 @@ func (a *InjectorInstaller) configureSocketsEnv(ctx context.Context) (retErr err
 	}
 	a.rollbacks = append(a.rollbacks, rollback)
 	// Make sure the file is word readable
-	if err := os.Chmod(envFilePath, 0644); err != nil {
+	if err = os.Chmod(envFilePath, 0644); err != nil {
 		return fmt.Errorf("error changing permissions of %s: %w", envFilePath, err)
 	}
 
 	// Symlinks for sysvinit
-	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent-trace"); err != nil && !os.IsExist(err) {
+	if err = os.Symlink(envFilePath, "/etc/default/datadog-agent-trace"); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent-trace: %w", envFilePath, err)
 	}
-	if err := os.Symlink(envFilePath, "/etc/default/datadog-agent"); err != nil && !os.IsExist(err) {
+	if err = os.Symlink(envFilePath, "/etc/default/datadog-agent"); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("failed to symlink %s to /etc/default/datadog-agent: %w", envFilePath, err)
 	}
 	systemdRunning, err := systemd.IsRunning()
@@ -98,19 +98,19 @@ func (a *InjectorInstaller) configureSocketsEnv(ctx context.Context) (retErr err
 		return fmt.Errorf("failed to check if systemd is running: %w", err)
 	}
 	if systemdRunning {
-		if err := addSystemDEnvOverrides(ctx, "datadog-agent.service"); err != nil {
+		if err = addSystemDEnvOverrides(ctx, "datadog-agent.service"); err != nil {
 			return err
 		}
-		if err := addSystemDEnvOverrides(ctx, "datadog-agent-exp.service"); err != nil {
+		if err = addSystemDEnvOverrides(ctx, "datadog-agent-exp.service"); err != nil {
 			return err
 		}
-		if err := addSystemDEnvOverrides(ctx, "datadog-agent-trace.service"); err != nil {
+		if err = addSystemDEnvOverrides(ctx, "datadog-agent-trace.service"); err != nil {
 			return err
 		}
-		if err := addSystemDEnvOverrides(ctx, "datadog-agent-trace-exp.service"); err != nil {
+		if err = addSystemDEnvOverrides(ctx, "datadog-agent-trace-exp.service"); err != nil {
 			return err
 		}
-		if err := systemd.Reload(ctx); err != nil {
+		if err = systemd.Reload(ctx); err != nil {
 			return err
 		}
 	}

--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -73,7 +73,7 @@ func patchBaseProfileWithDatadogInclude(filename string) error {
 		}
 	}
 
-	if err := scanner.Err(); err != nil {
+	if err = scanner.Err(); err != nil {
 		return err
 	}
 
@@ -97,7 +97,7 @@ func setupAppArmor(ctx context.Context) (err error) {
 	}
 
 	// make sure base profile exists before we continue
-	if _, err := os.Stat(appArmorBaseProfile); errors.Is(err, os.ErrNotExist) {
+	if _, err = os.Stat(appArmorBaseProfile); errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 

--- a/pkg/fleet/installer/packages/apminject/file.go
+++ b/pkg/fleet/installer/packages/apminject/file.go
@@ -111,8 +111,8 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 	// validate final file if validation function provided
 	if ft.validateFinal != nil {
 		if err = ft.validateFinal(); err != nil {
-			if err = rollback(); err != nil {
-				log.Errorf("could not rollback file %s: %s", ft.path, err)
+			if rollbackErr := rollback(); rollbackErr != nil {
+				log.Errorf("could not rollback file %s: %s", ft.path, rollbackErr)
 			}
 			return nil, err
 		}

--- a/pkg/fleet/installer/packages/apminject/file.go
+++ b/pkg/fleet/installer/packages/apminject/file.go
@@ -84,19 +84,19 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 		return rollbackNoop, nil
 	}
 
-	if err := writeFile(ft.pathTmp, res); err != nil {
+	if err = writeFile(ft.pathTmp, res); err != nil {
 		return nil, fmt.Errorf("could not write file %s: %s", ft.pathTmp, err)
 
 	}
 
 	// validate temporary file if validation function provided
 	if ft.validateTemp != nil {
-		if err := ft.validateTemp(); err != nil {
+		if err = ft.validateTemp(); err != nil {
 			return nil, fmt.Errorf("could not validate temporary file %s: %s", ft.pathTmp, err)
 		}
 	}
 
-	if err := os.Rename(ft.pathTmp, ft.path); err != nil {
+	if err = os.Rename(ft.pathTmp, ft.path); err != nil {
 		return nil, fmt.Errorf("could not rename temporary file %s to %s: %s", ft.pathTmp, ft.path, err)
 	}
 
@@ -111,7 +111,7 @@ func (ft *fileMutator) mutate(ctx context.Context) (rollback func() error, err e
 	// validate final file if validation function provided
 	if ft.validateFinal != nil {
 		if err = ft.validateFinal(); err != nil {
-			if err := rollback(); err != nil {
+			if err = rollback(); err != nil {
 				log.Errorf("could not rollback file %s: %s", ft.path, err)
 			}
 			return nil, err


### PR DESCRIPTION
### What does this PR do?

Cleans up shadowed `err :=` declarations in the `apminject` package.  
Replaces repeated short variable declarations with `err =` assignments to improve code clarity and prevent subtle bugs related to variable shadowing.

No functional changes are introduced.

### Motivation

Simplify error handling by removing unnecessary re-declarations.

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
