### PR TITLE
[EBPF] gpu: do not embed nvml.Device in custom device type

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -92,7 +92,7 @@ func buildCollectors(deps *CollectorDependencies, builders map[CollectorName]sub
 
 	for _, dev := range deps.DeviceCache.All() {
 		for name, builder := range builders {
-			c, err := builder(dev)
+			c, err := builder(dev.NVMLDevice)
 			if errors.Is(err, errUnsupportedDevice) {
 				log.Warnf("device %s does not support collector %s", dev.UUID, name)
 				continue

--- a/pkg/gpu/nvml/devices.go
+++ b/pkg/gpu/nvml/devices.go
@@ -18,7 +18,12 @@ import (
 
 // Device represents a GPU device with some properties already computed
 type Device struct {
-	nvml.Device
+	// NVMLDevice is the underlying NVML device. While it would make more sense to embed it,
+	// that causes this type to include all the methods of the nvml.Device, which makes it
+	// heavier than it needs to be and causes a binary size increase. As we're not using this
+	// type as a drop-in replacement for the nvml.Device in too many places, it is not
+	// too problematic to have it as a separate field.
+	NVMLDevice nvml.Device
 
 	SMVersion uint32
 	UUID      string
@@ -56,12 +61,12 @@ func NewDevice(dev nvml.Device) (*Device, error) {
 	}
 
 	return &Device{
-		Device:    dev,
-		SMVersion: smVersion,
-		UUID:      uuid,
-		CoreCount: cores,
-		Index:     index,
-		Memory:    memInfo.Total,
+		NVMLDevice: dev,
+		SMVersion:  smVersion,
+		UUID:       uuid,
+		CoreCount:  cores,
+		Index:      index,
+		Memory:     memInfo.Total,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the embedding of `nvml.Device` in `pkg/gpu/nvml.Device` to have it instead as a field.

### Motivation

Reduce binary size (#incident-36580). This embedding alone caused 350KB of size increase in the packages, due to the fact that embedding meant replicating all of the `nvml.Device` functions and caused the `pkg/gpu/nvml` package to be 115KB in size (the increase was due to both agent and system-probe binaries including it).

Considering that our custom device type was only being used as a drop-in replacement for `nvml.Device` in one place in the code, it doesn't seem too problematic to make this change to avoid the size increase.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passing and reduction in binary size.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->