### PR TITLE
[EBPF]: changed gpu deviceCache to be a global singleton

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -38,10 +38,11 @@ func TestCollectorsStillInitIfOneFails(t *testing.T) {
 	}
 
 	nvmlMock := testutil.GetBasicNvmlMock()
-	deviceCache, err := ddnvml.NewDeviceCacheWithOptions(nvmlMock)
+	ddnvml.WithMockDeviceCache(t, nvmlMock)
+	deviceCache, err := ddnvml.GetDeviceCache()
 	require.NoError(t, err)
-	deps := &CollectorDependencies{NVML: nvmlMock, DeviceCache: deviceCache}
-	collectors, err := buildCollectors(deps, map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
+	require.NotNil(t, deviceCache)
+	collectors, err := buildCollectors(map[CollectorName]subsystemBuilder{"ok": factory, "fail": factory})
 	require.NotNil(t, collectors)
 	require.NoError(t, err)
 
@@ -125,9 +126,11 @@ func TestGetDeviceTagsMapping(t *testing.T) {
 			nvmlMock, fakeTagger := tc.mockSetup()
 
 			// Execute
-			deviceCache, err := ddnvml.NewDeviceCacheWithOptions(nvmlMock)
+			ddnvml.WithMockDeviceCache(t, nvmlMock)
+			deviceCache, err := ddnvml.GetDeviceCache()
 			require.NoError(t, err)
-			tagsMapping := GetDeviceTagsMapping(deviceCache, fakeTagger)
+			require.NotNil(t, deviceCache)
+			tagsMapping := GetDeviceTagsMapping(fakeTagger)
 
 			// Assert
 			tc.expected(t, tagsMapping)

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -123,7 +123,7 @@ func getSystemContext(nvmlLib nvml.Interface, procRoot string, wmeta workloadmet
 	}
 
 	var err error
-	ctx.deviceCache, err = ddnvml.NewDeviceCacheWithOptions(nvmlLib)
+	ctx.deviceCache, err = ddnvml.GetDeviceCache()
 	if err != nil {
 		return nil, fmt.Errorf("error creating device cache: %w", err)
 	}

--- a/pkg/gpu/nvml/devices_mock.go
+++ b/pkg/gpu/nvml/devices_mock.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux && nvml && test
+
+package nvml
+
+import "github.com/NVIDIA/go-nvml/pkg/nvml"
+
+// testingT is an interface matching the necessary testing.T methods we need
+type testingT interface {
+	Cleanup(func())
+	Errorf(format string, args ...any)
+}
+
+// WithMockDeviceCache sets up a mock device cache for testing and ensures cleanup
+// This should only be used in tests
+func WithMockDeviceCache(t testingT, mock nvml.Interface) {
+	if mock == nil {
+		return
+	}
+
+	original, _ := GetDeviceCache()
+	t.Cleanup(func() {
+		resetDeviceCache(original)
+	})
+	mockCache, err := newDeviceCacheWithOptions(mock)
+	if err != nil {
+		t.Errorf("error creating mock device cache: %v", err)
+	}
+	resetDeviceCache(mockCache)
+
+}
+
+// For testing purposes only
+func resetDeviceCache(dc DeviceCache) {
+	initMutex.Lock()
+	defer initMutex.Unlock()
+	globalDeviceCache.Store(&dc)
+}

--- a/pkg/gpu/nvml/devices_test.go
+++ b/pkg/gpu/nvml/devices_test.go
@@ -57,7 +57,7 @@ func TestNewDeviceUUIDFailure(t *testing.T) {
 
 func TestNewDeviceCache(t *testing.T) {
 	mockNvml := testutil.GetBasicNvmlMock()
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	cache, err := newDeviceCacheWithOptions(mockNvml)
 	require.NoError(t, err)
 	require.NotNil(t, cache)
 	require.Equal(t, len(testutil.GPUUUIDs), cache.Count())
@@ -77,7 +77,9 @@ func TestNewDeviceCachePartialFailure(t *testing.T) {
 		},
 	}
 
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	WithMockDeviceCache(t, mockNvml)
+	cache, err := GetDeviceCache()
+	require.NoError(t, err)
 	require.NoError(t, err)
 	require.NotNil(t, cache)
 	require.Equal(t, 2, cache.Count())
@@ -127,7 +129,8 @@ func TestNewDeviceCacheDeviceUUIDFailure(t *testing.T) {
 		},
 	}
 
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	WithMockDeviceCache(t, mockNvml)
+	cache, err := GetDeviceCache()
 	require.NoError(t, err)
 	require.NotNil(t, cache)
 	require.Equal(t, 1, cache.Count())
@@ -144,7 +147,8 @@ func TestNewDeviceCacheDeviceUUIDFailure(t *testing.T) {
 
 func TestDeviceCacheGetByUUID(t *testing.T) {
 	mockNvml := testutil.GetBasicNvmlMock()
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	WithMockDeviceCache(t, mockNvml)
+	cache, err := GetDeviceCache()
 	require.NoError(t, err)
 
 	device, ok := cache.GetByUUID(testutil.DefaultGpuUUID)
@@ -157,7 +161,8 @@ func TestDeviceCacheGetByUUID(t *testing.T) {
 
 func TestDeviceCacheGetByIndex(t *testing.T) {
 	mockNvml := testutil.GetBasicNvmlMock()
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	WithMockDeviceCache(t, mockNvml)
+	cache, err := GetDeviceCache()
 	require.NoError(t, err)
 
 	device, err := cache.GetByIndex(0)
@@ -170,7 +175,8 @@ func TestDeviceCacheGetByIndex(t *testing.T) {
 
 func TestDeviceCacheSMVersionSet(t *testing.T) {
 	mockNvml := testutil.GetBasicNvmlMock()
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	WithMockDeviceCache(t, mockNvml)
+	cache, err := GetDeviceCache()
 	require.NoError(t, err)
 
 	smVersions := cache.SMVersionSet()
@@ -181,7 +187,8 @@ func TestDeviceCacheSMVersionSet(t *testing.T) {
 
 func TestDeviceCacheAll(t *testing.T) {
 	mockNvml := testutil.GetBasicNvmlMock()
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	WithMockDeviceCache(t, mockNvml)
+	cache, err := GetDeviceCache()
 	require.NoError(t, err)
 
 	devices := cache.All()
@@ -194,7 +201,8 @@ func TestDeviceCacheAll(t *testing.T) {
 
 func TestDeviceCacheCores(t *testing.T) {
 	mockNvml := testutil.GetBasicNvmlMock()
-	cache, err := NewDeviceCacheWithOptions(mockNvml)
+	WithMockDeviceCache(t, mockNvml)
+	cache, err := GetDeviceCache()
 	require.NoError(t, err)
 
 	cores, err := cache.Cores(testutil.DefaultGpuUUID)


### PR DESCRIPTION
### What does this PR do?

changes the deviceCache API to be a global singleton.

### Motivation

Simplify the code by removing some parameters propagation

### Describe how you validated your changes

modified the tests to use a new mock API for the deviceCache
existing tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
using the double-lock pattern to prevent locks contentions on a hot-path, but also provide thread safety when accessed from different go-routines during the init phase