### PR TITLE
[ADXT-1000] Make sure go test command remain under the maximum length on Windows

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -835,7 +835,7 @@ def format_packages(ctx: Context, impacted_packages: set[str], build_tags: list[
 
     # We need to make sure the CLI length is not too long
     packages = compute_gotestsum_cli_args(modules_to_test.values())
-    if sys.platform "win32" and len(packages) > WINDOWS_MAX_CLI_LENGTH:
+    if sys.platform == "win32" and len(packages) > WINDOWS_MAX_CLI_LENGTH:
         print("CLI length is too long, skipping fast tests")
         return get_default_modules().values()
 

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -44,6 +44,7 @@ from tasks.testwasher import TestWasher
 from tasks.update_go import PATTERN_MAJOR_MINOR_BUGFIX, update_file
 
 WINDOWS_MAX_PACKAGES_NUMBER = 150
+WINDOWS_MAX_CLI_LENGTH = 8000  # Windows has a max command line length of 8192 characters
 TRIGGER_ALL_TESTS_PATHS = ["tasks/gotest.py", "tasks/build_tags.py", ".gitlab/source_test/*"]
 OTEL_UPSTREAM_GO_MOD_PATH = (
     f"https://raw.githubusercontent.com/open-telemetry/opentelemetry-collector-contrib/v{OCB_VERSION}/go.mod"
@@ -149,17 +150,7 @@ def test_flavor(
         args["junit_file_flag"] = junit_file_flag
 
     # Compute full list of targets to run tests against
-    targets = []
-    for module in modules:
-        if not module.should_test():
-            continue
-        for target in module.test_targets:
-            target_path = os.path.join(module.path, target)
-            if not target_path.startswith('./'):
-                target_path = f"./{target_path}"
-            targets.append(target_path)
-
-    packages = ' '.join(f"{t}/..." if not t.endswith("/...") else t for t in targets)
+    packages = compute_gotestsum_cli_args(modules)
 
     with CodecovWorkaround(ctx, result.path, coverage, packages, args) as cov_test_path:
         res = ctx.run(
@@ -842,6 +833,12 @@ def format_packages(ctx: Context, impacted_packages: set[str], build_tags: list[
         for module in modules_to_test:
             print(f"- {module}: {modules_to_test[module].test_targets}")
 
+    # We need to make sure the CLI length is not too long
+    packages = compute_gotestsum_cli_args(modules_to_test.values())
+    if len(packages) > WINDOWS_MAX_CLI_LENGTH:
+        print("CLI length is too long, skipping fast tests")
+        return get_default_modules().values()
+
     return modules_to_test.values()
 
 
@@ -873,6 +870,21 @@ def get_go_modified_files(ctx):
         if file.find("unit_tests/testdata/components_src") == -1
         and (file.endswith(".go") or file.endswith(".mod") or file.endswith(".sum"))
     ]
+
+
+def compute_gotestsum_cli_args(modules: list[GoModule]):
+    targets = []
+    for module in modules:
+        if not module.should_test():
+            continue
+        for target in module.test_targets:
+            target_path = os.path.join(module.path, target)
+            if not target_path.startswith('./'):
+                target_path = f"./{target_path}"
+            targets.append(target_path)
+
+    packages = ' '.join(f"{t}/..." if not t.endswith("/...") else t for t in targets)
+    return packages
 
 
 @task

--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -835,7 +835,7 @@ def format_packages(ctx: Context, impacted_packages: set[str], build_tags: list[
 
     # We need to make sure the CLI length is not too long
     packages = compute_gotestsum_cli_args(modules_to_test.values())
-    if len(packages) > WINDOWS_MAX_CLI_LENGTH:
+    if sys.platform "win32" and len(packages) > WINDOWS_MAX_CLI_LENGTH:
         print("CLI length is too long, skipping fast tests")
         return get_default_modules().values()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Now that all the tests are executed with a single command, we are very likely to hit the max CLI length on Windows. Add a safeguard to make sure that we disable fast test if the command become too long.

Tested here: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/876879287


### Motivation

Avoid broken tests because of too long CLI command

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->