### PR TITLE
[kubelet/podwatcher] Report changes in container states

### DIFF
--- a/releasenotes/notes/fix-kubernetes-podwatcher-container-state-6c469104778275a2.yaml
+++ b/releasenotes/notes/fix-kubernetes-podwatcher-container-state-6c469104778275a2.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed an issue in the KSM check where, when using ``pod_collection_mode:
+    node_kubelet``, the Agent reported incorrect values for the
+    ``kubernetes_state.container.status_report.count.waiting`` metric.


### PR DESCRIPTION
### What does this PR do?

Fixes an issue in the Kubelet pod watcher where changes in container state (Waiting, Running, or Terminated) were not being reported.

This affected the KSM check when running with the `pod_collection_mode: node_kubelet` option, because it relies on the Kubelet pod watcher as a data source.

As a result, the `kubernetes_state.container.status_report.count.waiting` metric could report incorrect values. For example, in cases where a container is in a crash loop backoff, its state frequently transitions between Waiting, Running, and Terminated, but these changes were not consistently detected by the pod watcher.

### Describe how you validated your changes

I added a unit test and also manually verified that `kubernetes_state.container.status_report.count.waiting` is now correct when KSM is configured with `pod_collection_mode: node_kubelet` and there's a pod in CrashLoopBackOff.