### PR TITLE
feat: move shouldUseFips for serverless to build-time

### DIFF
--- a/pkg/serverless/apikey/api_key.go
+++ b/pkg/serverless/apikey/api_key.go
@@ -32,9 +32,6 @@ const encryptionContextKey = "LambdaFunctionName"
 // functionNameEnvVar is the environment variable that stores the function name.
 const functionNameEnvVar = "AWS_LAMBDA_FUNCTION_NAME"
 
-// lambdaRegionEnvVar is the environment variable that holds which region the Lambda is currently in.
-const lambdaRegionEnvVar = "AWS_REGION"
-
 // one of those env variable must be set
 const apiKeyEnvVar = "DD_API_KEY"
 const apiKeySecretManagerEnvVar = "DD_API_KEY_SECRET_ARN"


### PR DESCRIPTION
### What does this PR do?
Makes the FIPS aws endpoint decision a compile-time one rather than a runtime one for serverless.

### Motivation
Consistency in the FIPS choice for the agent in serverless.

### Describe how you validated your changes
Deploying to self-monitoring.