### PR TITLE
Fix remote-tagger initialization log

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -446,11 +446,13 @@ func (t *remoteTagger) run() {
 		default:
 		}
 
+		taggerStreamInitialized := false
 		if t.stream == nil {
 			if err := t.startTaggerStream(noTimeout); err != nil {
 				t.log.Warnf("error received trying to start stream with target %q: %s", t.options.Target, err)
 				continue
 			}
+			taggerStreamInitialized = true
 		}
 
 		var response *pb.StreamTagsResponse
@@ -477,7 +479,9 @@ func (t *remoteTagger) run() {
 			continue
 		}
 
-		t.log.Info("tagger stream successfully initialized")
+		if taggerStreamInitialized {
+			t.log.Info("tagger stream successfully initialized")
+		}
 
 		t.telemetryStore.Receives.Inc()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes an excessive log printing in the remote-tagger loop.

### Motivation
Currently the Agent is printing `tagger stream successfully initialized` on every remote-tagger fetching loop.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
This change have been manually tested on a VM.
