### PR TITLE
[CWS] Testing a fake eBPF heap with unions

### DIFF
--- a/pkg/security/ebpf/c/include/constants/custom.h
+++ b/pkg/security/ebpf/c/include/constants/custom.h
@@ -74,7 +74,6 @@ enum TC_RAWPACKET_KEYS {
 
 #define DNS_MAX_LENGTH 256
 #define DNS_RECEIVE_MAX_LENGTH 512
-#define DNS_EVENT_KEY 0
 
 #define EGRESS 1
 #define INGRESS 2

--- a/pkg/security/ebpf/c/include/helpers/network/dns.h
+++ b/pkg/security/ebpf/c/include/helpers/network/dns.h
@@ -11,8 +11,9 @@
 #include "maps.h"
 
 __attribute__((always_inline)) struct dns_event_t *get_dns_event() {
-    u32 key = DNS_EVENT_KEY;
-    return bpf_map_lookup_elem(&dns_event, &key);
+    u32 key = 0;
+    union union_heap_t* uh = bpf_map_lookup_elem(&union_heap, &key);
+    return &uh->dns_event;
 }
 
 __attribute__((always_inline)) struct dns_event_t *reset_dns_event(struct __sk_buff *skb, struct packet_t *pkt) {
@@ -53,8 +54,9 @@ __attribute__((always_inline)) struct dns_event_t *reset_dns_event(struct __sk_b
 }
 
 __attribute__((always_inline)) struct dns_response_event_t *get_dns_response_event() {
-    const u32 key = DNS_EVENT_KEY;
-    return bpf_map_lookup_elem(&dns_response_event, &key);
+    const u32 key = 0;
+    union union_heap_t* uh = bpf_map_lookup_elem(&union_heap, &key);
+    return &uh->dns_response_event;
 }
 
 __attribute__((always_inline)) struct dns_response_event_t *reset_dns_response_event() {

--- a/pkg/security/ebpf/c/include/helpers/network/imds.h
+++ b/pkg/security/ebpf/c/include/helpers/network/imds.h
@@ -10,7 +10,8 @@
 
 __attribute__((always_inline)) struct imds_event_t *get_imds_event() {
     u32 key = IMDS_EVENT_KEY;
-    return bpf_map_lookup_elem(&imds_event, &key);
+    union union_heap_t* uh = bpf_map_lookup_elem(&union_heap, &key);
+    return &uh->imds_event;
 }
 
 __attribute__((always_inline)) struct imds_event_t *reset_imds_event(struct __sk_buff *skb, struct packet_t *pkt) {

--- a/pkg/security/ebpf/c/include/helpers/network/stats.h
+++ b/pkg/security/ebpf/c/include/helpers/network/stats.h
@@ -6,9 +6,9 @@
 
 __attribute__((always_inline)) struct network_flow_monitor_event_t *get_network_flow_monitor_event() {
     u32 key = 0;
-    struct network_flow_monitor_event_t *evt = bpf_map_lookup_elem(&network_flow_monitor_event_gen, &key);
+    union union_heap_t* uh = bpf_map_lookup_elem(&union_heap, &key);
     // __builtin_memset doesn't work here because evt is too large and memset is allocating too much memory
-    return evt;
+    return &uh->network_flow_monitor_event;
 }
 
 __attribute__((always_inline)) struct active_flows_t *get_empty_active_flows() {

--- a/pkg/security/ebpf/c/include/helpers/sysctl.h
+++ b/pkg/security/ebpf/c/include/helpers/sysctl.h
@@ -10,12 +10,14 @@
 
 __attribute__((always_inline)) struct sysctl_event_t *get_sysctl_event() {
     u32 key = SYSCTL_EVENT_GEN_KEY;
-    return bpf_map_lookup_elem(&sysctl_event_gen, &key);
+    union union_heap_t* uh = bpf_map_lookup_elem(&union_heap, &key);
+    return &uh->sysctl_event;
 }
 
 __attribute__((always_inline)) struct sysctl_event_t *reset_sysctl_event() {
     u32 key = SYSCTL_EVENT_GEN_KEY;
-    struct sysctl_event_t *evt = bpf_map_lookup_elem(&sysctl_event_gen, &key);
+    union union_heap_t* uh = bpf_map_lookup_elem(&union_heap, &key);
+    struct sysctl_event_t *evt = &uh->sysctl_event;
     if (evt == NULL) {
         // should never happen
         return NULL;

--- a/pkg/security/ebpf/c/include/maps.h
+++ b/pkg/security/ebpf/c/include/maps.h
@@ -104,18 +104,25 @@ BPF_PERCPU_ARRAY_MAP(process_event_gen, struct process_event_t, EVENT_GEN_SIZE)
 BPF_PERCPU_ARRAY_MAP(dr_erpc_stats_fb, struct dr_erpc_stats_t, 6)
 BPF_PERCPU_ARRAY_MAP(dr_erpc_stats_bb, struct dr_erpc_stats_t, 6)
 BPF_PERCPU_ARRAY_MAP(is_discarded_by_inode_gen, struct is_discarded_by_inode_t, 1)
-BPF_PERCPU_ARRAY_MAP(dns_event, struct dns_event_t, 1)
-BPF_PERCPU_ARRAY_MAP(dns_response_event, struct dns_response_event_t, 1)
-BPF_PERCPU_ARRAY_MAP(imds_event, struct imds_event_t, 1)
 BPF_PERCPU_ARRAY_MAP(packets, struct packet_t, 1)
 BPF_PERCPU_ARRAY_MAP(selinux_write_buffer, struct selinux_write_buffer_t, 1)
 BPF_PERCPU_ARRAY_MAP(is_new_kthread, u32, 1)
 BPF_PERCPU_ARRAY_MAP(syscalls_stats, struct syscalls_stats_t, EVENT_MAX)
 BPF_PERCPU_ARRAY_MAP(raw_packet_event, struct raw_packet_event_t, 1)
-BPF_PERCPU_ARRAY_MAP(network_flow_monitor_event_gen, struct network_flow_monitor_event_t, 1)
 BPF_PERCPU_ARRAY_MAP(active_flows_gen, struct active_flows_t, 1)
 BPF_PERCPU_ARRAY_MAP(raw_packet_enabled, u32, 1)
-BPF_PERCPU_ARRAY_MAP(sysctl_event_gen, struct sysctl_event_t, 1)
+
+//Heap:
+union union_heap_t {
+    struct dns_event_t dns_event;
+    struct dns_response_event_t dns_response_event;
+    struct imds_event_t imds_event;
+    struct network_flow_monitor_event_t network_flow_monitor_event;
+    struct sysctl_event_t sysctl_event;
+};
+
+BPF_PERCPU_ARRAY_MAP(union_heap, union union_heap_t, 1)
+
 
 BPF_PROG_ARRAY(args_envs_progs, 3)
 BPF_PROG_ARRAY(dentry_resolver_kprobe_or_fentry_callbacks, EVENT_MAX)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
* Coalesces all the structs into a union such that we only allocate the space of the biggest object of the union per cpu, instead of having an allocation for each struct per cpu

### Motivation
* Use less memory

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->