### PR TITLE
feat(autoinstrumentation): dont mutate istio-proxy

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -70,6 +70,20 @@ func defaultLibrariesFor(languages ...string) map[string]string {
 }
 
 func TestInjectAutoInstruConfigV2(t *testing.T) {
+	buildRequireEnv := func(c corev1.Container) func(t *testing.T, k string, ok bool, val string) {
+		envsByName := map[string]corev1.EnvVar{}
+		for _, env := range c.Env {
+			envsByName[env.Name] = env
+		}
+
+		return func(t *testing.T, key string, ok bool, value string) {
+			t.Helper()
+			val, exists := envsByName[key]
+			require.Equal(t, ok, exists, "expected env %v exists to = %v", key, ok)
+			require.Equal(t, value, val.Value, "expected env %v = %v", key, val)
+		}
+	}
+
 	tests := []struct {
 		name                    string
 		pod                     *corev1.Pod
@@ -82,6 +96,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 		config                  func(c model.Config)
 		expectedLdPreload       string
 		expectedLibConfigEnvs   map[string]string
+		assertExtraContainer    func(*testing.T, corev1.Container)
 	}{
 		{
 			name: "no libs, no injection",
@@ -329,6 +344,26 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				"DD_TRACE_SAMPLE_RATE":       "0.30",
 			},
 		},
+		{
+			name: "istio-proxy",
+			pod: common.FakePodSpec{
+				Containers: []corev1.Container{{Name: "istio-proxy"}},
+			}.Create(),
+			expectedInjectorImage:   commonRegistry + "/apm-inject:0",
+			expectedSecurityContext: &corev1.SecurityContext{},
+			libInfo: extractedPodLibInfo{
+				libs: []libInfo{
+					java.libInfo("", "gcr.io/datadoghq/dd-lib-java-init:v1"),
+				},
+			},
+			assertExtraContainer: func(t *testing.T, c corev1.Container) {
+				t.Helper()
+				requireEnv := buildRequireEnv(c)
+				require.Equal(t, 0, len(c.VolumeMounts), "expected no volume mounts")
+				requireEnv(t, "LD_PRELOAD", false, "")
+				require.Equal(t, corev1.Container{Name: "istio-proxy"}, c, "container should be untouched")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -371,18 +406,7 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 				return
 			}
 
-			envsByName := map[string]corev1.EnvVar{}
-			for _, env := range tt.pod.Spec.Containers[0].Env {
-				envsByName[env.Name] = env
-			}
-
-			requireEnv := func(t *testing.T, key string, ok bool, value string) {
-				t.Helper()
-				val, exists := envsByName[key]
-				require.Equal(t, ok, exists, "expected env %v exists to = %v", key, ok)
-				require.Equal(t, value, val.Value, "expected env %v = %v", key, val)
-			}
-
+			requireEnv := buildRequireEnv(tt.pod.Spec.Containers[0])
 			for _, env := range injectAllEnvs() {
 				requireEnv(t, env.Name, false, "")
 			}
@@ -485,6 +509,10 @@ func TestInjectAutoInstruConfigV2(t *testing.T) {
 
 			for k, v := range tt.expectedLibConfigEnvs {
 				requireEnv(t, k, true, v)
+			}
+
+			if len(tt.pod.Spec.Containers) > 1 {
+				tt.assertExtraContainer(t, tt.pod.Spec.Containers[1])
 			}
 		})
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/env_vars_test.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestEnvVars(t *testing.T) {
+	initial := corev1.EnvVar{
+		Name:  "INITIAL",
+		Value: "initial",
+	}
+	testdata := []struct {
+		name     string
+		mutator  envVar
+		expected []corev1.EnvVar
+	}{
+		{
+			name: "raw env var works as prepend",
+			mutator: envVarMutator(corev1.EnvVar{
+				Name: "PREPEND_ME",
+			}),
+			expected: []corev1.EnvVar{
+				{Name: "PREPEND_ME"},
+				initial,
+			},
+		},
+		{
+			name: "legacy env var appends",
+			mutator: envVar{
+				key:     "APPEND_ME",
+				valFunc: identityValFunc(""),
+			},
+			expected: []corev1.EnvVar{
+				initial,
+				{Name: "APPEND_ME"},
+			},
+		},
+		{
+			name: "prefer initial values",
+			mutator: envVar{
+				key:     "INITIAL",
+				valFunc: useExistingEnvValOr("new"),
+			},
+			expected: []corev1.EnvVar{
+				initial,
+			},
+		},
+		{
+			name: "we can overwrite",
+			mutator: envVar{
+				key:     "INITIAL",
+				valFunc: identityValFunc("new"),
+			},
+			expected: []corev1.EnvVar{
+				{Name: "INITIAL", Value: "new"},
+			},
+		},
+	}
+
+	for _, tt := range testdata {
+		t.Run(tt.name, func(t *testing.T) {
+			c := corev1.Container{
+				Name: "container",
+				Env:  []corev1.EnvVar{initial},
+			}
+			require.NoError(t, tt.mutator.mutateContainer(&c))
+			require.Equal(t, tt.expected, c.Env)
+		})
+	}
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_requirement.go
@@ -15,6 +15,7 @@ type libRequirementOptions struct {
 	initContainerMutators containerMutators
 	containerMutators     containerMutators
 	podMutators           []podMutator
+	containerFilter       containerFilter
 }
 
 type libRequirement struct {
@@ -28,6 +29,10 @@ type libRequirement struct {
 
 func (reqs libRequirement) injectPod(pod *corev1.Pod, ctrName string) error {
 	for i, ctr := range pod.Spec.Containers {
+
+		if reqs.containerFilter != nil && !reqs.containerFilter(&ctr) {
+			continue
+		}
 
 		if ctrName == "" || ctrName == ctr.Name {
 			for _, v := range reqs.envVars {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -181,19 +181,17 @@ func appendOrPrepend[T any](item T, toList []T, prepend bool) []T {
 }
 
 func newConfigEnvVarFromBoolMutator(key string, val *bool) envVar {
-	value := strconv.FormatBool(valueOrZero(val))
-	return envVar{
-		key:     key,
-		valFunc: useExistingEnvValOr(value),
-	}
+	return envVarMutator(corev1.EnvVar{
+		Name:  key,
+		Value: strconv.FormatBool(valueOrZero(val)),
+	})
 }
 
 func newConfigEnvVarFromStringMutator(key string, val *string) envVar {
-	value := valueOrZero(val)
-	return envVar{
-		key:     key,
-		valFunc: useExistingEnvValOr(value),
-	}
+	return envVarMutator(corev1.EnvVar{
+		Name:  key,
+		Value: valueOrZero(val),
+	})
 }
 
 // containerFilter is a predicate function that evaluates
@@ -216,12 +214,16 @@ func filteredContainerMutator(f containerFilter, m containerMutator) containerMu
 // envVarMutator uses the envVar containerMutator to set the
 // raw EnvVar as given.
 //
-// It will prepend the environment variable for parity with mutate.InjectEnv.
+// It will prepend the environment variable and if the variable already
+// is in the container it will not add it.
+//
+// This is for parity for common.InjectEnv.
 func envVarMutator(env corev1.EnvVar) envVar {
 	return envVar{
-		key:       env.Name,
-		rawEnvVar: &env,
-		prepend:   true,
+		key:           env.Name,
+		rawEnvVar:     &env,
+		prepend:       true,
+		dontOverwrite: true,
 	}
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators.go
@@ -30,8 +30,8 @@ func (f containerMutatorFunc) mutateContainer(c *corev1.Container) error {
 
 type containerMutators []containerMutator
 
-func (mutators containerMutators) mutateContainer(c *corev1.Container) error {
-	for _, m := range mutators {
+func (ms containerMutators) mutateContainer(c *corev1.Container) error {
+	for _, m := range ms {
 		if err := m.mutateContainer(c); err != nil {
 			return err
 		}
@@ -51,6 +51,26 @@ type podMutatorFunc func(*corev1.Pod) error
 // mutatePod implements podMutator.
 func (f podMutatorFunc) mutatePod(pod *corev1.Pod) error {
 	return f(pod)
+}
+
+// mutatePodContainers applies a containerMutator to all of
+// the containers of a pod (init and not).
+func mutatePodContainers(pod *corev1.Pod, mutator containerMutator) error {
+	for idx, c := range pod.Spec.InitContainers {
+		if err := mutator.mutateContainer(&c); err != nil {
+			return err
+		}
+		pod.Spec.InitContainers[idx] = c
+	}
+
+	for idx, c := range pod.Spec.Containers {
+		if err := mutator.mutateContainer(&c); err != nil {
+			return err
+		}
+		pod.Spec.Containers[idx] = c
+	}
+
+	return nil
 }
 
 // initContainer is a podMutator which adds the container to a pod as an
@@ -160,41 +180,49 @@ func appendOrPrepend[T any](item T, toList []T, prepend bool) []T {
 	return append(toList, item)
 }
 
-type configKeyEnvVarMutator struct {
-	envKey string
-	envVal string
+func newConfigEnvVarFromBoolMutator(key string, val *bool) envVar {
+	value := strconv.FormatBool(valueOrZero(val))
+	return envVar{
+		key:     key,
+		valFunc: useExistingEnvValOr(value),
+	}
 }
 
-func newConfigEnvVarFromBoolMutator(key string, val *bool) configKeyEnvVarMutator {
-	m := configKeyEnvVarMutator{
-		envKey: key,
+func newConfigEnvVarFromStringMutator(key string, val *string) envVar {
+	value := valueOrZero(val)
+	return envVar{
+		key:     key,
+		valFunc: useExistingEnvValOr(value),
 	}
-
-	if val == nil {
-		m.envVal = strconv.FormatBool(false)
-	} else {
-		m.envVal = strconv.FormatBool(*val)
-	}
-
-	return m
 }
 
-func newConfigEnvVarFromStringlMutator(key string, val *string) configKeyEnvVarMutator {
-	m := configKeyEnvVarMutator{
-		envKey: key,
-	}
+// containerFilter is a predicate function that evaluates
+// a container and returns true or false.
+//
+// Used by filteredContainerMutator.
+type containerFilter func(c *corev1.Container) bool
 
-	if val != nil {
-		m.envVal = *val
-	}
-
-	return m
+// filteredContainerMutator applies a containerFilter to the given
+// containerMutator, producing a containerMutator.
+func filteredContainerMutator(f containerFilter, m containerMutator) containerMutator {
+	return containerMutatorFunc(func(c *corev1.Container) error {
+		if f != nil && !f(c) {
+			return nil
+		}
+		return m.mutateContainer(c)
+	})
 }
 
-func (c configKeyEnvVarMutator) mutatePod(pod *corev1.Pod) error {
-	_ = common.InjectEnv(pod, corev1.EnvVar{Name: c.envKey, Value: c.envVal})
-
-	return nil
+// envVarMutator uses the envVar containerMutator to set the
+// raw EnvVar as given.
+//
+// It will prepend the environment variable for parity with mutate.InjectEnv.
+func envVarMutator(env corev1.EnvVar) envVar {
+	return envVar{
+		key:       env.Name,
+		rawEnvVar: &env,
+		prepend:   true,
+	}
 }
 
 type containerSecurityContext struct {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/mutators_test.go
@@ -52,7 +52,6 @@ func TestVolumeMount(t *testing.T) {
 			m2.VolumeMount,
 			{Name: "banana"},
 		}, c.VolumeMounts, "attach a volume mount")
-
 	})
 }
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -33,13 +33,13 @@ const (
 
 // TargetMutator is an autoinstrumentation mutator that filters pods based on the target based workload selection.
 type TargetMutator struct {
-	enabled                           bool
-	core                              *mutatorCore
-	targets                           []targetInternal
-	disabledNamespaces                map[string]bool
-	securityClientLibraryPodMutators  []podMutator
-	profilingClientLibraryPodMutators []podMutator
-	containerRegistry                 string
+	enabled                       bool
+	core                          *mutatorCore
+	targets                       []targetInternal
+	disabledNamespaces            map[string]bool
+	securityClientLibraryMutator  containerMutator
+	profilingClientLibraryMutator containerMutator
+	containerRegistry             string
 }
 
 // NewTargetMutator creates a new mutator for target based workload selection. We convert the targets to a more
@@ -125,15 +125,16 @@ func NewTargetMutator(config *Config, wmeta workloadmeta.Component) (*TargetMuta
 	}
 
 	m := &TargetMutator{
-		enabled:                           config.Instrumentation.Enabled,
-		targets:                           internalTargets,
-		disabledNamespaces:                disabledNamespacesMap,
-		securityClientLibraryPodMutators:  config.securityClientLibraryPodMutators,
-		profilingClientLibraryPodMutators: config.profilingClientLibraryPodMutators,
-		containerRegistry:                 config.containerRegistry,
+		enabled:                       config.Instrumentation.Enabled,
+		targets:                       internalTargets,
+		disabledNamespaces:            disabledNamespacesMap,
+		securityClientLibraryMutator:  config.securityClientLibraryMutator,
+		profilingClientLibraryMutator: config.profilingClientLibraryMutator,
+		containerRegistry:             config.containerRegistry,
 	}
 
-	// Create the core mutator. This is a bit gross. The target mutator is also the filter which we are passing in.
+	// Create the core mutator. This is a bit gross.
+	// The target mutator is also the filter which we are passing in.
 	core := newMutatorCore(config, wmeta, m)
 	m.core = core
 
@@ -179,23 +180,19 @@ func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interfac
 	extracted := m.core.initExtractedLibInfo(pod).withLibs(target.libVersions)
 
 	// Add the configuration for the security client library.
-	for _, mutator := range m.securityClientLibraryPodMutators {
-		if err := mutator.mutatePod(pod); err != nil {
-			return false, fmt.Errorf("error mutating pod for security client: %w", err)
-		}
+	if err := m.core.mutatePodContainers(pod, m.securityClientLibraryMutator); err != nil {
+		return false, fmt.Errorf("error mutating pod for security client: %w", err)
 	}
 
 	// Add the configuration for profiling.
-	for _, mutator := range m.profilingClientLibraryPodMutators {
-		if err := mutator.mutatePod(pod); err != nil {
-			return false, fmt.Errorf("error mutating pod for profiling client: %w", err)
-		}
+	if err := m.core.mutatePodContainers(pod, m.profilingClientLibraryMutator); err != nil {
+		return false, fmt.Errorf("error mutating pod for profiling client: %w", err)
 	}
 
 	// Inject the tracer configs. We do this before lib injection to ensure DD_SERVICE is set if the user configures it
 	// in the target.
 	for _, envVar := range target.envVars {
-		mutatecommon.InjectEnv(pod, envVar)
+		_ = m.core.mutatePodContainers(pod, envVarMutator(envVar))
 	}
 
 	// Inject the libraries.
@@ -205,10 +202,10 @@ func (m *TargetMutator) MutatePod(pod *corev1.Pod, ns string, _ dynamic.Interfac
 	}
 
 	// Inject the target json. The is added so that the injector can make use of the target information.
-	mutatecommon.InjectEnv(pod, corev1.EnvVar{
+	_ = m.core.mutatePodContainers(pod, envVarMutator(corev1.EnvVar{
 		Name:  AppliedTargetEnvVar,
 		Value: target.json,
-	})
+	}))
 
 	// Add the annotations to the pod.
 	mutatecommon.AddAnnotation(pod, AppliedTargetAnnotation, target.json)

--- a/pkg/clusteragent/admission/mutate/common/test_utils.go
+++ b/pkg/clusteragent/admission/mutate/common/test_utils.go
@@ -130,6 +130,7 @@ type FakePodSpec struct {
 	Envs        []corev1.EnvVar
 	ParentKind  string
 	ParentName  string
+	Containers  []corev1.Container
 }
 
 // Create makes a Pod from a FakePodSpec setting up sane defaults.
@@ -140,7 +141,13 @@ func (f FakePodSpec) Create() *corev1.Pod {
 	if f.Name == "" {
 		f.Name = "pod"
 	}
-	return fakePodWithParent(f.NS, f.Name, f.Annotations, f.Labels, f.Envs, f.ParentKind, f.ParentName)
+	pod := fakePodWithParent(f.NS, f.Name, f.Annotations, f.Labels, f.Envs, f.ParentKind, f.ParentName)
+
+	if len(f.Containers) > 0 {
+		pod.Spec.Containers = append(pod.Spec.Containers, f.Containers...)
+	}
+
+	return pod
 }
 
 // fakePodWithParent returns a pod with the given parent kind and name

--- a/releasenotes-dca/notes/autoinstrumentation-skip-istio-proxy-faffc955bd087a93.yaml
+++ b/releasenotes-dca/notes/autoinstrumentation-skip-istio-proxy-faffc955bd087a93.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The auto-instrumentation webhook no longer mutates the ``istio-proxy`` container.
+    This fixes an issue with Kubernetes-native sidecars and the istio service mesh
+    where a standard sidecar is moved to be the first init container by istio after it
+    was mutated by auto-instrumentation.


### PR DESCRIPTION
### What does this PR do?

This excludes `istio-proxy` from mutation via auto-instrumentation.

The technical approach here is to _stop using_ the `mutatecommon` package for environment variable mutations and _instead_ make `containerMutator`s that can use a `containerFilter` built on top of configuration so that something that mutates a pod can be composed of a filter and container mutators.

### Motivation

- https://datadoghq.atlassian.net/browse/INPLAT-454
- Closes #33296

There are cases with auto-instrumentation where you want to skip entire containers in a pod.

An alternative here would be to build container targeting into workload selection. That feels a lot heavier and if you're running a something like `istio` (something with another mutating controller) you'll need to change every target to explicitly choose a container.

There are _known_ container names (like `istio-proxy`) that will not be supported for auto-instrumentation (C++) in the near future and when conflating with an issue like #33296 where the `istio` controller will take a sidecar container and move to be a new kubernetes-native "sidecar container" (https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/).

This doesn't fix the issue _fully_ (IE there are probably other containers where it's possible for another mutating controller to cause this issue) but will give people the flexibility to disable injection at a container+cluster level.

We can expose this kind of option in the future but for now having something that prevents the issue from happening is a good start.

### Including Changes

- Introduces a concept of a `containerPredicate` for the `containerMutator`
- Changes how we parameterize both the namespace and target mutators so that they are `containerMutator` instead of `podMutator`. This means we can a `containerPredicate`
- migrate places that use `mutatecommon.InjectEnv` (which currently operates on the pod wholly) to use `predicate(envVar)` 
- update `envVar` to be the basic and common building block for the ways we do mutation in the autoinstrumentation webhook (+ tests) since we had two ways of approaching this problem. This is complicated because of in-tree support for instrumentationv1 (which is deprecated and slated for removal/cleanup) https://datadoghq.atlassian.net/browse/INPLAT-489


### Describe how you validated your changes

- [x] Added unit tests for the cases we support.
- [ ] an end to end test with injector dev

### Possible Drawbacks / Trade-offs

