### PR TITLE
[Backport 7.65.x] Fix panic in KSM check on check cancel (#35659)

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -670,7 +670,9 @@ func (k *KSMCheck) Run() error {
 // Cancel is called when the check is unscheduled, it stops the informers used by the metrics store
 func (k *KSMCheck) Cancel() {
 	log.Infof("Shutting down informers used by the check '%s'", k.ID())
-	k.cancel()
+	if k.cancel != nil {
+		k.cancel()
+	}
 }
 
 // processMetrics attaches tags and forwards metrics to the aggregator


### PR DESCRIPTION
(cherry picked from commit ad592acfb535dd6f9062787c038bee61c6495865)

### What does this PR do?

This PR fixes a panic that could occur if the KSM check is cancelled before being able to start up properly

### Motivation

Fixes this panic:

```
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x31aeef8]
goroutine 81344 [running]:
github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm.(*KSMCheck).Cancel(0x4001564fc0)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go:673 +0x98
github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware.(*CheckWrapper).Cancel(0x40138ebbf0)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go:54 +0x30
github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl.(*collectorImpl).cancelCheck.func1()
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/collector.go:311 +0x30
created by github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl.(*collectorImpl).cancelCheck in goroutine 354
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/collector.go:310 +0x94
```

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

* This is a backport of #35659.