### PR TITLE
[Backport 7.64.x] Fix remote-tagger initialization log

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -477,11 +477,13 @@ func (t *remoteTagger) run() {
 		default:
 		}
 
+		taggerStreamInitialized := false
 		if t.stream == nil {
 			if err := t.startTaggerStream(noTimeout); err != nil {
 				t.log.Warnf("error received trying to start stream with target %q: %s", t.options.Target, err)
 				continue
 			}
+			taggerStreamInitialized = true
 		}
 
 		var response *pb.StreamTagsResponse
@@ -508,7 +510,9 @@ func (t *remoteTagger) run() {
 			continue
 		}
 
-		t.log.Info("tagger stream successfully initialized")
+		if taggerStreamInitialized {
+			t.log.Info("tagger stream successfully initialized")
+		}
 
 		t.telemetryStore.Receives.Inc()
 

--- a/releasenotes/notes/fix_remote_tagger_log-1566152c8fa91bd0.yaml
+++ b/releasenotes/notes/fix_remote_tagger_log-1566152c8fa91bd0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix remote tagger initialization log message to be logged only once.


### PR DESCRIPTION
Backport d56d0fa9c33a8203d02a10cf7d3406164d2e8e1f from #35762.
___

### What does this PR do?
This PR fixes an excessive log printing in the remote-tagger loop.

### Motivation
Currently the Agent is printing `tagger stream successfully initialized` on every remote-tagger fetching loop.

### Describe how you validated your changes
This change have been manually tested on a VM.