### PR TITLE
[Backport 7.65.x] [EBPF] gpu: increase ringbuffer size

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -438,6 +438,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault(join(gpuNS, "initial_process_sync"), true)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "configure_cgroup_perms"), false)
 	cfg.BindEnvAndSetDefault(join(gpuNS, "enable_fatbin_parsing"), false)
+	cfg.BindEnvAndSetDefault(join(gpuNS, "ring_buffer_pages_per_device"), 32) // 32 pages = 128KB by default per device
 
 	initCWSSystemProbeConfig(cfg)
 }

--- a/pkg/gpu/config/config.go
+++ b/pkg/gpu/config/config.go
@@ -36,18 +36,21 @@ type Config struct {
 	ConfigureCgroupPerms bool
 	// EnableFatbinParsing indicates whether the probe should enable fatbin parsing.
 	EnableFatbinParsing bool
+	// RingBufferSizePagesPerDevice is the number of pages to use for the ring buffer per device.
+	RingBufferSizePagesPerDevice int
 }
 
 // New generates a new configuration for the GPU monitoring probe.
 func New() *Config {
 	spCfg := pkgconfigsetup.SystemProbe()
 	return &Config{
-		Config:                *ebpf.NewConfig(),
-		ScanProcessesInterval: time.Duration(spCfg.GetInt(sysconfig.FullKeyPath(GPUNS, "process_scan_interval_seconds"))) * time.Second,
-		InitialProcessSync:    spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "initial_process_sync")),
-		NVMLLibraryPath:       spCfg.GetString(sysconfig.FullKeyPath(GPUNS, "nvml_lib_path")),
-		Enabled:               spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enabled")),
-		ConfigureCgroupPerms:  spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "configure_cgroup_perms")),
-		EnableFatbinParsing:   spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enable_fatbin_parsing")),
+		Config:                       *ebpf.NewConfig(),
+		ScanProcessesInterval:        time.Duration(spCfg.GetInt(sysconfig.FullKeyPath(GPUNS, "process_scan_interval_seconds"))) * time.Second,
+		InitialProcessSync:           spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "initial_process_sync")),
+		NVMLLibraryPath:              spCfg.GetString(sysconfig.FullKeyPath(GPUNS, "nvml_lib_path")),
+		Enabled:                      spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enabled")),
+		ConfigureCgroupPerms:         spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "configure_cgroup_perms")),
+		EnableFatbinParsing:          spCfg.GetBool(sysconfig.FullKeyPath(GPUNS, "enable_fatbin_parsing")),
+		RingBufferSizePagesPerDevice: spCfg.GetInt(sysconfig.FullKeyPath(GPUNS, "ring_buffer_pages_per_device")),
 	}
 }

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -50,11 +50,6 @@ const (
 	defaultEventTTL            = defaultMapCleanerInterval
 )
 
-var (
-	// defaultRingBufferSize controls the amount of memory in bytes used for buffering perf event data
-	defaultRingBufferSize = 2 * os.Getpagesize()
-)
-
 // bpfMapName stores the name of the BPF maps storing statistics and other info
 type bpfMapName = string
 
@@ -330,7 +325,15 @@ func (p *Probe) setupSharedBuffer(o *manager.Options) {
 		},
 	}
 
-	ringBufferSize := toPowerOf2(defaultRingBufferSize)
+	devCount, _ := p.deps.NvmlLib.DeviceGetCount()
+	if devCount <= 0 {
+		devCount = 1 // Don't let the buffer size be 0
+	}
+
+	// The activity of eBPF events will scale with the number of devices, unlike in other
+	// eBPF modules where the activity is bound to the number of CPUs.
+	numPages := p.cfg.RingBufferSizePagesPerDevice * devCount
+	ringBufferSize := toPowerOf2(numPages * os.Getpagesize())
 
 	o.MapSpecEditors[cudaEventsRingbuf] = manager.MapSpecEditor{
 		Type:       ebpf.RingBuf,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Increases the ringbuffer size for the GPU monitoring probe, to reduce event losses. Also adds a configuration option to allow changing it.

### Motivation

Reduce event loss and increase accuracy of the monitoring.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passing. Validated in load-testing too that there's a reduction of event loss.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->