### PR TITLE
[GPU] collecting nvlink active/inactive/total per gpu device

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -20,10 +20,9 @@ import (
 
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 )
 
 // errUnsupportedDevice is returned when the device does not support the given collector
@@ -38,6 +37,7 @@ const (
 	device       CollectorName = "device"
 	remappedRows CollectorName = "remapped_rows"
 	samples      CollectorName = "samples"
+	nvlink       CollectorName = "nvlink"
 )
 
 // Metric represents a single metric collected from the NVML library.
@@ -71,6 +71,7 @@ var factory = map[CollectorName]subsystemBuilder{
 	remappedRows: newRemappedRowsCollector,
 	clock:        newClocksCollector,
 	samples:      newSamplesCollector,
+	nvlink:       newNvlinkCollector,
 }
 
 // CollectorDependencies holds the dependencies needed to create a set of collectors.

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -71,7 +71,7 @@ var factory = map[CollectorName]subsystemBuilder{
 	remappedRows: newRemappedRowsCollector,
 	clock:        newClocksCollector,
 	samples:      newSamplesCollector,
-	nvlink:       newNvlinkCollector,
+	nvlink:       newNVLinkCollector,
 }
 
 // CollectorDependencies holds the dependencies needed to create a set of collectors.

--- a/pkg/collector/corechecks/gpu/nvidia/convert.go
+++ b/pkg/collector/corechecks/gpu/nvidia/convert.go
@@ -28,27 +28,27 @@ type number interface {
 	constraints.Integer | constraints.Float
 }
 
-func readDoubleFromBuffer[T number](reader io.Reader) (float64, error) {
+func readNumberFromBuffer[T number](reader io.Reader) (T, error) {
 	var value T
 	err := binary.Read(reader, binary.LittleEndian, &value)
-	return float64(value), err
+	return value, err
 }
 
-func metricValueToDouble(valueType nvml.ValueType, value [8]byte) (float64, error) {
+func fieldValueToNumber[T number](valueType nvml.ValueType, value [8]byte) (T, error) {
 	reader := bytes.NewReader(value[:])
 
-	switch nvml.ValueType(valueType) {
+	switch valueType {
 	case nvml.VALUE_TYPE_DOUBLE:
-		return readDoubleFromBuffer[float64](reader)
+		return readNumberFromBuffer[T](reader)
 	case nvml.VALUE_TYPE_UNSIGNED_INT:
-		return readDoubleFromBuffer[uint32](reader)
+		return readNumberFromBuffer[T](reader)
 	case nvml.VALUE_TYPE_UNSIGNED_LONG:
 	case nvml.VALUE_TYPE_UNSIGNED_LONG_LONG:
-		return readDoubleFromBuffer[uint64](reader)
+		return readNumberFromBuffer[T](reader)
 	case nvml.VALUE_TYPE_SIGNED_LONG_LONG: // No typo, there's no SIGNED_LONG in the NVML API
-		return readDoubleFromBuffer[int64](reader)
+		return readNumberFromBuffer[T](reader)
 	case nvml.VALUE_TYPE_SIGNED_INT:
-		return readDoubleFromBuffer[int32](reader)
+		return readNumberFromBuffer[T](reader)
 	}
 
 	return 0, fmt.Errorf("unsupported value type %d", valueType)

--- a/pkg/collector/corechecks/gpu/nvidia/convert.go
+++ b/pkg/collector/corechecks/gpu/nvidia/convert.go
@@ -28,28 +28,28 @@ type number interface {
 	constraints.Integer | constraints.Float
 }
 
-func readNumberFromBuffer[T number](reader io.Reader) (T, error) {
+func readNumberFromBuffer[T number, V number](reader io.Reader) (V, error) {
 	var value T
 	err := binary.Read(reader, binary.LittleEndian, &value)
-	return value, err
+	return V(value), err
 }
 
-func fieldValueToNumber[T number](valueType nvml.ValueType, value [8]byte) (T, error) {
+func fieldValueToNumber[V number](valueType nvml.ValueType, value [8]byte) (V, error) {
 	reader := bytes.NewReader(value[:])
 
 	switch valueType {
 	case nvml.VALUE_TYPE_DOUBLE:
-		return readNumberFromBuffer[T](reader)
+		return readNumberFromBuffer[float64, V](reader)
 	case nvml.VALUE_TYPE_UNSIGNED_INT:
-		return readNumberFromBuffer[T](reader)
-	case nvml.VALUE_TYPE_UNSIGNED_LONG:
-	case nvml.VALUE_TYPE_UNSIGNED_LONG_LONG:
-		return readNumberFromBuffer[T](reader)
+		return readNumberFromBuffer[uint32, V](reader)
+	case nvml.VALUE_TYPE_UNSIGNED_LONG, nvml.VALUE_TYPE_UNSIGNED_LONG_LONG:
+		return readNumberFromBuffer[uint64, V](reader)
 	case nvml.VALUE_TYPE_SIGNED_LONG_LONG: // No typo, there's no SIGNED_LONG in the NVML API
-		return readNumberFromBuffer[T](reader)
+		return readNumberFromBuffer[int64, V](reader)
 	case nvml.VALUE_TYPE_SIGNED_INT:
-		return readNumberFromBuffer[T](reader)
-	}
+		return readNumberFromBuffer[int32, V](reader)
 
-	return 0, fmt.Errorf("unsupported value type %d", valueType)
+	default:
+		return 0, fmt.Errorf("unsupported value type %d", valueType)
+	}
 }

--- a/pkg/collector/corechecks/gpu/nvidia/fields.go
+++ b/pkg/collector/corechecks/gpu/nvidia/fields.go
@@ -94,7 +94,7 @@ func (c *fieldsCollector) Collect() ([]Metric, error) {
 			continue
 		}
 
-		value, convErr := metricValueToDouble(nvml.ValueType(val.ValueType), val.Value)
+		value, convErr := fieldValueToNumber[float64](nvml.ValueType(val.ValueType), val.Value)
 		if convErr != nil {
 			err = multierror.Append(err, fmt.Errorf("failed to convert field value %s: %w", name, convErr))
 		}

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package nvidia
+
+import (
+	"fmt"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+type nvlinkCollector struct {
+	device       nvml.Device
+	totalNVLinks int
+}
+
+func newNvlinkCollector(device nvml.Device) (Collector, error) {
+	// Check if device supports NVLink by trying to get state of first link
+	linkCountField := nvml.FieldValue{
+		FieldId: nvml.FI_DEV_NVLINK_LINK_COUNT,
+		ScopeId: 0,
+	}
+	err := device.GetFieldValues([]nvml.FieldValue{linkCountField})
+	if err == nvml.ERROR_NOT_SUPPORTED {
+		return nil, errUnsupportedDevice
+	} else if err != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get total number of nvlinks: %s", nvml.ErrorString(err))
+	}
+
+	linksCount, convErr := fieldValueToNumber[int](nvml.ValueType(linkCountField.ValueType), linkCountField.Value)
+	if convErr != nil {
+		return nil, fmt.Errorf("failed to convert number of nvlinks to integer: %s", nvml.ErrorString(err))
+	}
+
+	return &nvlinkCollector{
+		device:       device,
+		totalNVLinks: linksCount,
+	}, nil
+}
+
+func (c *nvlinkCollector) DeviceUUID() string {
+	uuid, _ := c.device.GetUUID()
+	return uuid
+}
+
+func (c *nvlinkCollector) Name() CollectorName {
+	return nvlink
+}
+
+func (c *nvlinkCollector) Collect() ([]Metric, error) {
+	var err error
+
+	active, inactive := 0, 0
+
+	// iterate over all existing nvlinks for the device
+	for i := 0; i < c.totalNVLinks; i++ {
+		state, ret := c.device.GetNvLinkState(i)
+		if ret != nvml.SUCCESS {
+			err = multierror.Append(err, fmt.Errorf("failed to get NVLink state for link %d: %s", i, nvml.ErrorString(ret)))
+			continue
+		}
+
+		// Count active and inactive links
+		if state == nvml.FEATURE_ENABLED {
+			active++
+		} else if state == nvml.FEATURE_DISABLED {
+			inactive++
+		}
+	}
+	//TODO: Once we start supporting metrics per nvlink, we should change the metrics to the following format:
+	// "nvlink.[link_index].* where link_index is the index of the nvlink
+	// and * represents all different metrics that will be gathered under the relevant nvlink
+	// (e.g: capability, state, bandwidth mode, version, error counters, throughput, speed, etc...)
+	allMetrics := [3]Metric{
+		{
+			Name:  "nvlink.count.total",
+			Value: float64(c.totalNVLinks),
+			Type:  metrics.GaugeType,
+		},
+		{
+			Name:  "nvlink.count.active",
+			Value: float64(c.totalNVLinks),
+			Type:  metrics.GaugeType,
+		},
+		{
+			Name:  "nvlink.count.inactive",
+			Value: float64(c.totalNVLinks),
+			Type:  metrics.GaugeType,
+		},
+	}
+
+	return allMetrics[:], err
+}

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_test.go
@@ -1,0 +1,183 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build linux && nvml
+
+package nvidia
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	nvmlmock "github.com/NVIDIA/go-nvml/pkg/nvml/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewNVLinkCollector(t *testing.T) {
+	tests := []struct {
+		name      string
+		mockSetup func() *nvmlmock.Device
+		wantError bool
+		wantLinks int
+	}{
+		{
+			name: "Unsupported device",
+			mockSetup: func() *nvmlmock.Device {
+				return &nvmlmock.Device{
+					GetFieldValuesFunc: func(values []nvml.FieldValue) nvml.Return {
+						return nvml.ERROR_NOT_SUPPORTED
+					},
+				}
+			},
+			wantError: true,
+		},
+		{
+			name: "Unknown error",
+			mockSetup: func() *nvmlmock.Device {
+				return &nvmlmock.Device{
+					GetFieldValuesFunc: func(values []nvml.FieldValue) nvml.Return {
+						return nvml.ERROR_UNKNOWN
+					},
+				}
+			},
+			wantError: true,
+		},
+		{
+			name: "Success with 4 links",
+			mockSetup: func() *nvmlmock.Device {
+				return &nvmlmock.Device{
+					GetFieldValuesFunc: func(values []nvml.FieldValue) nvml.Return {
+						require.Len(t, values, 1, "Expected one field value for total number of links, got %d", len(values))
+						require.Equal(t, values[0].FieldId, uint32(nvml.FI_DEV_NVLINK_LINK_COUNT), "Expected field ID to be FI_DEV_NVLINK_LINK_COUNT, got %d", values[0].FieldId)
+						require.Equal(t, values[0].ScopeId, uint32(0), "Expected scope ID to be 0, got %d", values[0].ScopeId)
+						values[0].ValueType = uint32(nvml.VALUE_TYPE_SIGNED_INT)
+						values[0].Value = [8]byte{4, 0, 0, 0, 0, 0, 0, 0} // 4 links
+						return nvml.SUCCESS
+					},
+					GetUUIDFunc: func() (string, nvml.Return) {
+						return "GPU-123", nvml.SUCCESS
+					},
+				}
+			},
+			wantError: false,
+			wantLinks: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDevice := tt.mockSetup()
+			c, err := newNVLinkCollector(mockDevice)
+
+			if tt.wantError {
+				require.Error(t, err)
+				require.Nil(t, c)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, c)
+
+			typedC, ok := c.(*nvlinkCollector)
+			require.True(t, ok)
+			require.Equal(t, tt.wantLinks, typedC.totalNVLinks)
+		})
+	}
+}
+
+func TestNVLinkCollector_Collect(t *testing.T) {
+	tests := []struct {
+		name             string
+		nvlinkStates     []nvml.EnableState
+		nvlinkErrors     []nvml.Return
+		expectedActive   int
+		expectedInactive int
+		expectError      bool
+	}{
+		{
+			name: "All links active",
+			nvlinkStates: []nvml.EnableState{
+				nvml.FEATURE_ENABLED,
+				nvml.FEATURE_ENABLED,
+				nvml.FEATURE_ENABLED,
+			},
+			nvlinkErrors:     []nvml.Return{nvml.SUCCESS, nvml.SUCCESS, nvml.SUCCESS},
+			expectedActive:   3,
+			expectedInactive: 0,
+			expectError:      false,
+		},
+		{
+			name: "Mixed active and inactive links",
+			nvlinkStates: []nvml.EnableState{
+				nvml.FEATURE_ENABLED,
+				nvml.FEATURE_DISABLED,
+				nvml.FEATURE_ENABLED,
+			},
+			nvlinkErrors:     []nvml.Return{nvml.SUCCESS, nvml.SUCCESS, nvml.SUCCESS},
+			expectedActive:   2,
+			expectedInactive: 1,
+			expectError:      false,
+		},
+		{
+			name: "Error getting link state",
+			nvlinkStates: []nvml.EnableState{
+				nvml.FEATURE_ENABLED,
+				nvml.FEATURE_ENABLED,
+			},
+			nvlinkErrors:     []nvml.Return{nvml.SUCCESS, nvml.ERROR_UNKNOWN},
+			expectedActive:   1,
+			expectedInactive: 0,
+			expectError:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock device
+			mockDevice := &nvmlmock.Device{
+				GetFieldValuesFunc: func(values []nvml.FieldValue) nvml.Return {
+					values[0].ValueType = uint32(nvml.VALUE_TYPE_UNSIGNED_INT)
+					values[0].Value = [8]byte{byte(len(tt.nvlinkStates)), 0, 0, 0, 0, 0, 0, 0}
+					return nvml.SUCCESS
+				},
+				GetNvLinkStateFunc: func(link int) (nvml.EnableState, nvml.Return) {
+					return tt.nvlinkStates[link], tt.nvlinkErrors[link]
+				},
+				GetUUIDFunc: func() (string, nvml.Return) {
+					return "GPU-123", nvml.SUCCESS
+				},
+			}
+
+			// Create collector
+			collector, err := newNVLinkCollector(mockDevice)
+			require.NoError(t, err)
+
+			// Collect metrics
+			allMetrics, err := collector.Collect()
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Verify metrics, as we still expect to have all 3 metrics even if some errors were returned
+			require.Len(t, allMetrics, 3)
+
+			// Check total links metric
+			require.Equal(t, float64(len(tt.nvlinkStates)), allMetrics[0].Value)
+			require.Equal(t, metrics.GaugeType, allMetrics[0].Type)
+
+			// Check active links metric
+			require.Equal(t, float64(tt.expectedActive), allMetrics[1].Value)
+			require.Equal(t, metrics.GaugeType, allMetrics[1].Type)
+
+			// Check inactive links metric
+			require.Equal(t, float64(tt.expectedInactive), allMetrics[2].Value)
+			require.Equal(t, metrics.GaugeType, allMetrics[2].Type)
+		})
+	}
+}

--- a/pkg/collector/corechecks/gpu/nvidia/nvlink_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/nvlink_test.go
@@ -27,7 +27,7 @@ func TestNewNVLinkCollector(t *testing.T) {
 			name: "Unsupported device",
 			mockSetup: func() *nvmlmock.Device {
 				return &nvmlmock.Device{
-					GetFieldValuesFunc: func(values []nvml.FieldValue) nvml.Return {
+					GetFieldValuesFunc: func(_ []nvml.FieldValue) nvml.Return {
 						return nvml.ERROR_NOT_SUPPORTED
 					},
 				}
@@ -38,7 +38,7 @@ func TestNewNVLinkCollector(t *testing.T) {
 			name: "Unknown error",
 			mockSetup: func() *nvmlmock.Device {
 				return &nvmlmock.Device{
-					GetFieldValuesFunc: func(values []nvml.FieldValue) nvml.Return {
+					GetFieldValuesFunc: func(_ []nvml.FieldValue) nvml.Return {
 						return nvml.ERROR_UNKNOWN
 					},
 				}

--- a/pkg/collector/corechecks/gpu/nvidia/samples.go
+++ b/pkg/collector/corechecks/gpu/nvidia/samples.go
@@ -122,7 +122,8 @@ func (c *samplesCollector) Collect() ([]Metric, error) {
 
 			sampleInterval := sample.TimeStamp - lastTimestamp
 
-			value, err := fieldValueToNumber[float64](valueType, sample.SampleValue)
+			var value float64
+			value, err = fieldValueToNumber[float64](valueType, sample.SampleValue)
 			if err != nil {
 				err = multierror.Append(err, fmt.Errorf("failed to convert sample value %s from %v with type %v: %w", metric.name, sample.SampleValue, valueType, err))
 				continue

--- a/pkg/collector/corechecks/gpu/nvidia/samples.go
+++ b/pkg/collector/corechecks/gpu/nvidia/samples.go
@@ -122,8 +122,7 @@ func (c *samplesCollector) Collect() ([]Metric, error) {
 
 			sampleInterval := sample.TimeStamp - lastTimestamp
 
-			var value float64
-			value, err = metricValueToDouble(valueType, sample.SampleValue)
+			value, err := fieldValueToNumber[float64](valueType, sample.SampleValue)
 			if err != nil {
 				err = multierror.Append(err, fmt.Errorf("failed to convert sample value %s from %v with type %v: %w", metric.name, sample.SampleValue, valueType, err))
 				continue


### PR DESCRIPTION
### What does this PR do?

 captures nvlink.count.[total/active/inactive] metrics to report nvlinks state for each gpu device

### Motivation

Jira [Ticket](https://datadoghq.atlassian.net/browse/EBPF-691)

### Describe how you validated your changes

existing tests should pass
added explicit tests to test nvlink

### Possible Drawbacks / Trade-offs

### Additional Notes
more granular support (metrics per nvlink) will be added in the future in separate PRs 
(left TODO in the code)