### PR TITLE
[OTAGENT-320] Use ddprofilingextension  for internal profiling of the otel agent

### DIFF
--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -221,9 +221,10 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 		fx.Supply(traceconfig.Params{FailIfAPIKeyMissing: false}),
 
 		fx.Supply(&traceagentcomp.Params{
-			CPUProfile:  "",
-			MemProfile:  "",
-			PIDFilePath: "",
+			CPUProfile:               "",
+			MemProfile:               "",
+			PIDFilePath:              "",
+			DisableInternalProfiling: true,
 		}),
 		traceagentfx.Module(),
 	)

--- a/comp/trace/agent/impl/agent.go
+++ b/comp/trace/agent/impl/agent.go
@@ -253,7 +253,7 @@ func stop(ag component) error {
 	if err := ag.Statsd.Flush(); err != nil {
 		log.Error("Could not flush statsd: ", err)
 	}
-	stopAgentSidekicks(ag.config, ag.Statsd)
+	stopAgentSidekicks(ag.config, ag.Statsd, ag.params.DisableInternalProfiling)
 	if ag.params.CPUProfile != "" {
 		pprof.StopCPUProfile()
 	}

--- a/comp/trace/agent/impl/params.go
+++ b/comp/trace/agent/impl/params.go
@@ -16,4 +16,6 @@ type Params struct {
 	CPUProfile string
 	// MemProfile contains the value for the --mem-profile flag.
 	MemProfile string
+	// DisableInternalProfiling is used to disable internal profiling.
+	DisableInternalProfiling bool
 }

--- a/comp/trace/agent/impl/run_test.go
+++ b/comp/trace/agent/impl/run_test.go
@@ -25,7 +25,7 @@ func TestProfilingConfig(t *testing.T) {
 	cconfig.SetWithoutSource("internal_profiling.mutex_profile_fraction", 7)
 	cconfig.SetWithoutSource("internal_profiling.block_profile_rate", 10)
 	cconfig.SetWithoutSource("internal_profiling.enable_goroutine_stacktraces", true)
-	settings := profilingConfig(tconfig)
+	settings := profilingConfig(tconfig, false)
 	assert.NotNil(t, settings)
 	assert.Equal(t, settings.ProfilingURL, "https://intake.profile.datadoghq.com/v1/input")
 	assert.Equal(t, settings.Tags[0:2], []string{"k1:v1", "k2:v2"})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR disables the internal profiling for the trace component when using DDOT. Internal profiling for DDOT should be done using ddprofilingextension.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Enable [ddprofilingextension](https://github.com/DataDog/datadog-agent/tree/main/comp/otelcol/ddprofilingextension) and run DDOT with `DD_APM_INTERNAL_PROFILING_ENABLED`. You must not have the warning `Profiler Stopped`
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->