### PR TITLE
[NPM-4293] Add config to use SACK traceroute in system-probe

### DIFF
--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl/pathteststore"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 )
 
 type collectorConfigs struct {
@@ -27,6 +28,7 @@ type collectorConfigs struct {
 	networkDevicesNamespace      string
 	sourceExcludedConns          map[string][]string
 	destExcludedConns            map[string][]string
+	tcpMethod                    payload.TCPMethod
 }
 
 func newConfig(agentConfig config.Component) *collectorConfigs {
@@ -50,6 +52,7 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		disableIntraVPCCollection: agentConfig.GetBool("network_path.collector.disable_intra_vpc_collection"),
 		sourceExcludedConns:       agentConfig.GetStringMapStringSlice("network_path.collector.source_excludes"),
 		destExcludedConns:         agentConfig.GetStringMapStringSlice("network_path.collector.dest_excludes"),
+		tcpMethod:                 payload.MakeTCPMethod(agentConfig.GetString("network_path.collector.tcp_method")),
 		networkDevicesNamespace:   agentConfig.GetString("network_devices.namespace"),
 	}
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -348,6 +348,7 @@ func (s *npCollectorImpl) runTracerouteForPath(ptest *pathteststore.PathtestCont
 		MaxTTL:       uint8(s.collectorConfigs.maxTTL),
 		Timeout:      s.collectorConfigs.timeout,
 		Protocol:     ptest.Pathtest.Protocol,
+		TCPMethod:    s.collectorConfigs.tcpMethod,
 	}
 
 	path, err := s.runTraceroute(cfg, s.telemetrycomp)

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -40,7 +40,8 @@ type InstanceConfig struct {
 
 	DestPort uint16 `yaml:"port"`
 
-	Protocol string `yaml:"protocol"`
+	Protocol  string `yaml:"protocol"`
+	TCPMethod string `yaml:"tcp_method"`
 
 	SourceService      string `yaml:"source_service"`
 	DestinationService string `yaml:"destination_service"`
@@ -63,6 +64,7 @@ type CheckConfig struct {
 	DestinationService    string
 	MaxTTL                uint8
 	Protocol              payload.Protocol
+	TCPMethod             payload.TCPMethod
 	Timeout               time.Duration
 	MinCollectionInterval time.Duration
 	Tags                  []string
@@ -91,6 +93,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	c.SourceService = instance.SourceService
 	c.DestinationService = instance.DestinationService
 	c.Protocol = payload.Protocol(strings.ToUpper(instance.Protocol))
+	c.TCPMethod = payload.MakeTCPMethod(instance.TCPMethod)
 
 	c.MinCollectionInterval = firstNonZero(
 		time.Duration(instance.MinCollectionInterval)*time.Second,

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -309,6 +309,42 @@ max_ttl: 64
 				MaxTTL:                64,
 			},
 		},
+		{
+			name: "overriding the TCP method",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+protocol: tcp
+tcp_method: sack
+`),
+			rawInitConfig: []byte(``),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(60) * time.Second,
+				Namespace:             "my-namespace",
+				Protocol:              payload.ProtocolTCP,
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TCPMethod:             payload.TCPConfigSACK,
+			},
+		},
+		{
+			name: "TCP method converts to lower case",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+protocol: tcp
+tcp_method: prefer_SACK
+`),
+			rawInitConfig: []byte(``),
+			expectedConfig: &CheckConfig{
+				DestHostname:          "1.2.3.4",
+				MinCollectionInterval: time.Duration(60) * time.Second,
+				Namespace:             "my-namespace",
+				Protocol:              payload.ProtocolTCP,
+				Timeout:               setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                setup.DefaultNetworkPathMaxTTL,
+				TCPMethod:             payload.TCPConfigPreferSACK,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -56,6 +56,7 @@ func (c *Check) Run() error {
 		MaxTTL:       c.config.MaxTTL,
 		Timeout:      c.config.Timeout,
 		Protocol:     c.config.Protocol,
+		TCPMethod:    c.config.TCPMethod,
 	}
 
 	tr, err := traceroute.New(cfg, c.telemetryComp)
@@ -72,7 +73,7 @@ func (c *Check) Run() error {
 	// Add tags to path
 	path.Source.Service = c.config.SourceService
 	path.Destination.Service = c.config.DestinationService
-	path.Tags = c.config.Tags
+	path.Tags = append(path.Tags, c.config.Tags...)
 
 	// Perform reverse DNS lookup
 	path.Destination.ReverseDNSHostname = traceroute.GetHostname(path.Destination.IPAddress)

--- a/pkg/networkpath/payload/pathevent.go
+++ b/pkg/networkpath/payload/pathevent.go
@@ -6,7 +6,11 @@
 // Package payload contains Network Path payload
 package payload
 
-import "github.com/DataDog/datadog-agent/pkg/network/payload"
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/network/payload"
+)
 
 // Protocol defines supported network protocols
 // Please define new protocols based on the Keyword from:
@@ -19,6 +23,26 @@ const (
 	// ProtocolUDP is the UDP protocol.
 	ProtocolUDP Protocol = "UDP"
 )
+
+// TCPMethod is the method used to run a TCP traceroute.
+type TCPMethod string
+
+const (
+	// TCPConfigSYN means to only perform SYN traceroutes
+	TCPConfigSYN TCPMethod = "syn"
+	// TCPConfigSACK means to only perform SACK traceroutes
+	TCPConfigSACK TCPMethod = "sack"
+	// TCPConfigPreferSACK means to try SACK, and fall back to SYN if the remote doesn't support SACK
+	TCPConfigPreferSACK TCPMethod = "prefer_sack"
+)
+
+// TCPDefaultMethod is what method to use when nothing is specified
+const TCPDefaultMethod TCPMethod = TCPConfigSYN
+
+// MakeTCPMethod converts a TCP traceroute method from config into a TCPMethod
+func MakeTCPMethod(method string) TCPMethod {
+	return TCPMethod(strings.ToLower(method))
+}
 
 // PathOrigin origin of the path e.g. network_traffic, network_path_integration
 type PathOrigin string

--- a/pkg/networkpath/traceroute/common/common.go
+++ b/pkg/networkpath/traceroute/common/common.go
@@ -26,6 +26,7 @@ type (
 		Target     net.IP
 		DstPort    uint16
 		Hops       []*Hop
+		Tags       []string
 	}
 
 	// Hop encapsulates information about a single

--- a/pkg/networkpath/traceroute/config/config.go
+++ b/pkg/networkpath/traceroute/config/config.go
@@ -33,4 +33,6 @@ type Config struct {
 	// Protocol is the protocol to use
 	// for traceroute, default is UDP
 	Protocol payload.Protocol
+	// TCPMethod is the method used to run a TCP traceroute.
+	TCPMethod payload.TCPMethod
 }

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -8,9 +8,12 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
+	"net/netip"
+	"slices"
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
@@ -20,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/networkpath/payload"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/config"
+	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/sack"
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/tcp"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
@@ -152,15 +156,78 @@ func (r *Runner) RunTraceroute(ctx context.Context, cfg config.Config) (payload.
 	return pathResult, nil
 }
 
+func makeSackParams(target net.IP, targetPort uint16, maxTTL uint8, timeout time.Duration) (sack.Params, error) {
+	targetAddr, ok := netip.AddrFromSlice(target)
+	if !ok {
+		return sack.Params{}, fmt.Errorf("invalid target IP")
+	}
+	parallelParams := common.TracerouteParallelParams{
+		MinTTL:            DefaultMinTTL,
+		MaxTTL:            maxTTL,
+		TracerouteTimeout: timeout,
+		PollFrequency:     100 * time.Millisecond,
+		SendDelay:         10 * time.Millisecond,
+	}
+	params := sack.Params{
+		Target:           netip.AddrPortFrom(targetAddr, targetPort),
+		HandshakeTimeout: timeout,
+		FinTimeout:       500 * time.Second,
+		ParallelParams:   parallelParams,
+		LoosenICMPSrc:    true,
+	}
+	return params, nil
+}
+
+var sackFallbackLimit = log.NewLogLimit(10, 5*time.Minute)
+
+type tracerouteImpl func() (*common.Results, error)
+
+func performTCPFallback(tcpMethod payload.TCPMethod, doSyn, doSack tracerouteImpl) (*common.Results, error) {
+	if tcpMethod == "" {
+		tcpMethod = payload.TCPDefaultMethod
+	}
+	switch tcpMethod {
+	case payload.TCPConfigSYN:
+		return doSyn()
+	case payload.TCPConfigSACK:
+		return doSack()
+	case payload.TCPConfigPreferSACK:
+		results, err := doSack()
+		var sackNotSupportedErr *sack.NotSupportedError
+		if errors.As(err, &sackNotSupportedErr) {
+			if sackFallbackLimit.ShouldLog() {
+				log.Infof("SACK traceroute not supported, falling back to SYN: %s", err)
+			}
+			return doSyn()
+		}
+		if err != nil {
+			return nil, fmt.Errorf("SACK traceroute failed fatally, not falling back: %w", err)
+		}
+		return results, nil
+	default:
+		return nil, fmt.Errorf("unexpected TCPMethod: %s", tcpMethod)
+	}
+}
+
 func (r *Runner) runTCP(cfg config.Config, hname string, target net.IP, maxTTL uint8, timeout time.Duration) (payload.NetworkPath, error) {
 	destPort := cfg.DestPort
 	if destPort == 0 {
 		destPort = 80 // TODO: is this the default we want?
 	}
 
-	tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout)
+	doSyn := func() (*common.Results, error) {
+		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout)
+		return tr.TracerouteSequential()
+	}
+	doSack := func() (*common.Results, error) {
+		params, err := makeSackParams(target, destPort, maxTTL, timeout)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make sack params: %w", err)
+		}
+		return sack.RunSackTraceroute(context.TODO(), params)
+	}
 
-	results, err := tr.TracerouteSequential()
+	results, err := performTCPFallback(cfg.TCPMethod, doSyn, doSack)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}
@@ -193,6 +260,7 @@ func (r *Runner) processResults(res *common.Results, protocol payload.Protocol, 
 			Port:      res.DstPort,
 			IPAddress: res.Target.String(),
 		},
+		Tags: slices.Clone(res.Tags),
 	}
 
 	// get hardware interface info

--- a/pkg/networkpath/traceroute/sack/traceroute_sack_linux.go
+++ b/pkg/networkpath/traceroute/sack/traceroute_sack_linux.go
@@ -147,6 +147,7 @@ func RunSackTraceroute(ctx context.Context, p Params) (*common.Results, error) {
 		Target:     p.Target.Addr().AsSlice(),
 		DstPort:    p.Target.Port(),
 		Hops:       hops,
+		Tags:       []string{"tcp_method:sack"},
 	}
 
 	return result, nil

--- a/pkg/networkpath/traceroute/sysprobe.go
+++ b/pkg/networkpath/traceroute/sysprobe.go
@@ -19,13 +19,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, maxTTL uint8, timeout time.Duration) ([]byte, error) {
+func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, maxTTL uint8, timeout time.Duration) ([]byte, error) {
 	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
 	log.Tracef("Network Path traceroute HTTP request timeout: %s", httpTimeout)
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
-	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s", host, clientID, port, maxTTL, timeout, protocol))
+	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s", host, clientID, port, maxTTL, timeout, protocol, tcpMethod))
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -118,6 +118,7 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 		Target:     t.Target,
 		DstPort:    t.DestPort,
 		Hops:       hops,
+		Tags:       []string{"tcp_method:syn"},
 	}, nil
 }
 

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
@@ -62,6 +62,7 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 		Target:     t.Target,
 		DstPort:    t.DestPort,
 		Hops:       hops,
+		Tags:       []string{"tcp_method:syn"},
 	}, nil
 }
 

--- a/pkg/networkpath/traceroute/traceroute_linux.go
+++ b/pkg/networkpath/traceroute/traceroute_linux.go
@@ -42,7 +42,7 @@ func New(cfg config.Config, _ telemetry.Component) (*LinuxTraceroute, error) {
 
 // Run executes a traceroute
 func (l *LinuxTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.MaxTTL, l.cfg.Timeout)
+	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.MaxTTL, l.cfg.Timeout)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}

--- a/pkg/networkpath/traceroute/traceroute_windows.go
+++ b/pkg/networkpath/traceroute/traceroute_windows.go
@@ -44,7 +44,7 @@ func New(cfg config.Config, _ telemetry.Component) (*WindowsTraceroute, error) {
 
 // Run executes a traceroute
 func (w *WindowsTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.MaxTTL, w.cfg.Timeout)
+	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.MaxTTL, w.cfg.Timeout)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR allows customers to add `tcp_method: prefer_sack` into their configuration to first try SACK traceroutes. They can also use `tcp_method: sack` to use sack exclusively (same for `syn`).

### Motivation
SACK traceroutes can give higher quality results

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I added this config to static path:
```
instances:
  - hostname: www.example.com # endpoint hostname or IP
    protocol: TCP
    tcp_method: prefer_sack
    port: 443
    tags:
      - "tag_key:foobar"
      - "tag_key2:tag_value2"
```
You can see in the logs it will traceroute in 1.5 seconds instead of 30 seconds, and the result will be tagged as sack in datadog:
<img width="498" alt="Screenshot 2025-04-03 at 7 37 58 PM" src="https://github.com/user-attachments/assets/0fee0f48-6884-4211-aa22-b696dd456339" />


### Possible Drawbacks / Trade-offs
Right now, it only falls back to SYN on expected errors (failing to dial, and not receiving SACK-permitted). It simply gives up when SACK has an unexpected error. Maybe we should have it fall back anyway but I don't know.
### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->