### PR TITLE
[CWS] extract `evalRule` and `checkPoliciesLocal` to common package

### DIFF
--- a/cmd/security-agent/subcommands/runtime/activity_dump.go
+++ b/cmd/security-agent/subcommands/runtime/activity_dump.go
@@ -920,3 +920,10 @@ func activityDumpToSeccompProfile(_ log.Component, _ config.Component, _ secrets
 
 	return nil
 }
+
+func printStorageRequestMessage(prefix string, storage *api.StorageRequestMessage) {
+	fmt.Printf("%so file: %s\n", prefix, storage.GetFile())
+	fmt.Printf("%s  format: %s\n", prefix, storage.GetFormat())
+	fmt.Printf("%s  storage type: %s\n", prefix, storage.GetType())
+	fmt.Printf("%s  compression: %v\n", prefix, storage.GetCompression())
+}

--- a/cmd/security-agent/subcommands/runtime/command.go
+++ b/cmd/security-agent/subcommands/runtime/command.go
@@ -33,17 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
-	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
-	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
-	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
-	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	winmodel "github.com/DataDog/datadog-agent/pkg/security/seclwin/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/security/clihelpers"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -358,23 +348,6 @@ func dumpNetworkNamespace(_ log.Component, _ config.Component, _ secrets.Compone
 	return nil
 }
 
-//nolint:unused // TODO(SEC) Fix unused linter
-func printStorageRequestMessage(prefix string, storage *api.StorageRequestMessage) {
-	fmt.Printf("%so file: %s\n", prefix, storage.GetFile())
-	fmt.Printf("%s  format: %s\n", prefix, storage.GetFormat())
-	fmt.Printf("%s  storage type: %s\n", prefix, storage.GetType())
-	fmt.Printf("%s  compression: %v\n", prefix, storage.GetCompression())
-}
-
-func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
-	agentVersion, err := utils.GetAgentSemverVersion()
-	if err != nil {
-		return nil, err
-	}
-
-	return rules.NewAgentVersionFilter(agentVersion)
-}
-
 func checkPolicies(_ log.Component, _ config.Component, args *checkPoliciesCliParams) error {
 	if args.evaluateAllPolicySources {
 		if args.windowsModel {
@@ -389,7 +362,11 @@ func checkPolicies(_ log.Component, _ config.Component, args *checkPoliciesCliPa
 
 		return checkPoliciesLoaded(client, os.Stdout)
 	}
-	return checkPoliciesLocal(args, os.Stdout)
+	return clihelpers.CheckPoliciesLocal(clihelpers.CheckPoliciesLocalParams{
+		Dir:                      args.dir,
+		EvaluateAllPolicySources: args.evaluateAllPolicySources,
+		UseWindowsModel:          args.windowsModel,
+	}, os.Stdout)
 }
 
 func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.Writer) error {
@@ -412,264 +389,13 @@ func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.
 	return nil
 }
 
-func newFakeEvent() eval.Event {
-	return model.NewFakeEvent()
-}
-
-func newFakeWindowsEvent() eval.Event {
-	return winmodel.NewFakeEvent()
-}
-
-func newEvalOpts(winModel bool) *eval.Opts {
-	var evalOpts eval.Opts
-
-	if winModel {
-		evalOpts.
-			WithConstants(winmodel.SECLConstants()).
-			WithLegacyFields(winmodel.SECLLegacyFields).
-			WithVariables(model.SECLVariables)
-	} else {
-		evalOpts.
-			WithConstants(model.SECLConstants()).
-			WithLegacyFields(model.SECLLegacyFields).
-			WithVariables(model.SECLVariables)
-	}
-
-	return &evalOpts
-}
-
-func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
-	cfg := &pconfig.Config{
-		EnableKernelFilters: true,
-		EnableApprovers:     true,
-		EnableDiscarders:    true,
-		PIDCacheSize:        1,
-	}
-
-	// enabled all the rules
-	enabled := map[eval.EventType]bool{"*": true}
-
-	ruleOpts := rules.NewRuleOpts(enabled)
-	evalOpts := newEvalOpts(args.windowsModel)
-
-	ruleOpts.WithLogger(seclog.DefaultLogger)
-
-	agentVersionFilter, err := newAgentVersionFilter()
-	if err != nil {
-		return fmt.Errorf("failed to create agent version filter: %w", err)
-	}
-
-	os := runtime.GOOS
-	if args.windowsModel {
-		os = "windows"
-	}
-
-	ruleFilterModel := filtermodel.NewOSOnlyFilterModel(os)
-	seclRuleFilter := rules.NewSECLRuleFilter(ruleFilterModel)
-
-	loaderOpts := rules.PolicyLoaderOpts{
-		MacroFilters: []rules.MacroFilter{
-			agentVersionFilter,
-			seclRuleFilter,
-		},
-		RuleFilters: []rules.RuleFilter{
-			agentVersionFilter,
-			seclRuleFilter,
-		},
-	}
-
-	provider, err := rules.NewPoliciesDirProvider(args.dir)
-	if err != nil {
-		return err
-	}
-
-	loader := rules.NewPolicyLoader(provider)
-
-	var ruleSet *rules.RuleSet
-	if args.windowsModel {
-		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
-		ruleSet.SetFakeEventCtor(newFakeWindowsEvent)
-	} else {
-		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
-		ruleSet.SetFakeEventCtor(newFakeEvent)
-	}
-	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
-		return err
-	}
-
-	report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
-	if err != nil {
-		return err
-	}
-
-	content, _ := json.MarshalIndent(report, "", "\t")
-	_, err = fmt.Fprintf(writer, "%s\n", string(content))
-	if err != nil {
-		return fmt.Errorf("unable to write out report: %w", err)
-	}
-
-	return nil
-}
-
-// EvalReport defines a report of an evaluation
-type EvalReport struct {
-	Succeeded bool
-	Approvers map[string]rules.Approvers
-	Event     eval.Event
-	Error     error `json:",omitempty"`
-}
-
-// EventData defines the structure used to represent an event
-type EventData struct {
-	Type   eval.EventType
-	Values map[string]interface{}
-}
-
-func eventDataFromJSON(file string) (eval.Event, error) {
-	f, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	decoder := json.NewDecoder(f)
-	decoder.UseNumber()
-
-	var eventData EventData
-	if err := decoder.Decode(&eventData); err != nil {
-		return nil, err
-	}
-
-	kind := secconfig.ParseEvalEventType(eventData.Type)
-	if kind == model.UnknownEventType {
-		return nil, errors.New("unknown event type")
-	}
-
-	event := &model.Event{
-		BaseEvent: model.BaseEvent{
-			Type:             uint32(kind),
-			FieldHandlers:    &model.FakeFieldHandlers{},
-			ContainerContext: &model.ContainerContext{},
-		},
-	}
-	event.Init()
-
-	for k, v := range eventData.Values {
-		switch v := v.(type) {
-		case json.Number:
-			value, err := v.Int64()
-			if err != nil {
-				return nil, err
-			}
-			if err := event.SetFieldValue(k, int(value)); err != nil {
-				return nil, err
-			}
-		case []any:
-			if stringSlice, ok := anySliceToStringSlice(v); ok {
-				if err := event.SetFieldValue(k, stringSlice); err != nil {
-					return nil, err
-				}
-			} else {
-				if err := event.SetFieldValue(k, v); err != nil {
-					return nil, err
-				}
-			}
-		default:
-			if err := event.SetFieldValue(k, v); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return event, nil
-}
-
-func anySliceToStringSlice(in []any) ([]string, bool) {
-	out := make([]string, len(in))
-	for i, v := range in {
-		val, ok := v.(string)
-		if !ok {
-			return nil, false
-		}
-		out[i] = val
-	}
-	return out, true
-}
-
 func evalRule(_ log.Component, _ config.Component, _ secrets.Component, evalArgs *evalCliParams) error {
-	policiesDir := evalArgs.dir
-
-	// enabled all the rules
-	enabled := map[eval.EventType]bool{"*": true}
-
-	ruleOpts := rules.NewRuleOpts(enabled)
-	evalOpts := newEvalOpts(evalArgs.windowsModel)
-	ruleOpts.WithLogger(seclog.DefaultLogger)
-
-	agentVersionFilter, err := newAgentVersionFilter()
-	if err != nil {
-		return fmt.Errorf("failed to create agent version filter: %w", err)
-	}
-
-	loaderOpts := rules.PolicyLoaderOpts{
-		MacroFilters: []rules.MacroFilter{
-			agentVersionFilter,
-		},
-		RuleFilters: []rules.RuleFilter{
-			&rules.RuleIDFilter{
-				ID: evalArgs.ruleID,
-			},
-		},
-	}
-
-	provider, err := rules.NewPoliciesDirProvider(policiesDir)
-	if err != nil {
-		return err
-	}
-
-	loader := rules.NewPolicyLoader(provider)
-
-	var ruleSet *rules.RuleSet
-	if evalArgs.windowsModel {
-		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
-	} else {
-		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
-	}
-
-	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
-		return err
-	}
-
-	event, err := eventDataFromJSON(evalArgs.eventFile)
-	if err != nil {
-		return err
-	}
-
-	report := EvalReport{
-		Event: event,
-	}
-
-	if !evalArgs.windowsModel {
-		approvers, err := ruleSet.GetApprovers(kfilters.GetCapababilities())
-		if err != nil {
-			report.Error = err
-		} else {
-			report.Approvers = approvers
-		}
-	}
-
-	report.Succeeded = ruleSet.Evaluate(event)
-	output, err := json.MarshalIndent(report, "", "    ")
-	if err != nil {
-		return err
-	}
-	fmt.Printf("%s\n", string(output))
-
-	if !report.Succeeded {
-		os.Exit(-1)
-	}
-
-	return nil
+	return clihelpers.EvalRule(clihelpers.EvalRuleParams{
+		Dir:             evalArgs.dir,
+		UseWindowsModel: evalArgs.windowsModel,
+		RuleID:          evalArgs.ruleID,
+		EventFile:       evalArgs.eventFile,
+	})
 }
 
 // nolint: deadcode, unused

--- a/cmd/system-probe/subcommands/runtime/activity_dump.go
+++ b/cmd/system-probe/subcommands/runtime/activity_dump.go
@@ -627,3 +627,10 @@ func stopActivityDump(_ log.Component, _ config.Component, _ secrets.Component, 
 	fmt.Println("done!")
 	return nil
 }
+
+func printStorageRequestMessage(prefix string, storage *api.StorageRequestMessage) {
+	fmt.Printf("%so file: %s\n", prefix, storage.GetFile())
+	fmt.Printf("%s  format: %s\n", prefix, storage.GetFormat())
+	fmt.Printf("%s  storage type: %s\n", prefix, storage.GetType())
+	fmt.Printf("%s  compression: %v\n", prefix, storage.GetCompression())
+}

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -326,6 +326,7 @@ func dumpProcessCache(_ log.Component, _ config.Component, _ secrets.Component, 
 	return nil
 }
 
+//nolint:unused // TODO(SEC) Fix unused linter
 func dumpNetworkNamespace(_ log.Component, _ config.Component, _ secrets.Component, dumpNetworkNamespaceArgs *dumpNetworkNamespaceCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -33,15 +33,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
-	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
-	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
-	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/clihelpers"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/security/seclog"
-	winmodel "github.com/DataDog/datadog-agent/pkg/security/seclwin/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
@@ -335,7 +328,6 @@ func dumpProcessCache(_ log.Component, _ config.Component, _ secrets.Component, 
 	return nil
 }
 
-// nolint: deadcode, unused
 func dumpNetworkNamespace(_ log.Component, _ config.Component, _ secrets.Component, dumpNetworkNamespaceArgs *dumpNetworkNamespaceCliParams) error {
 	client, err := secagent.NewRuntimeSecurityClient()
 	if err != nil {
@@ -355,14 +347,6 @@ func dumpNetworkNamespace(_ log.Component, _ config.Component, _ secrets.Compone
 	fmt.Printf("Network namespace dump: %s\n", resp.GetDumpFilename())
 	fmt.Printf("Network namespace dump graph: %s\n", resp.GetGraphFilename())
 	return nil
-}
-
-//nolint:unused // TODO(SEC) Fix unused linter
-func printStorageRequestMessage(prefix string, storage *api.StorageRequestMessage) {
-	fmt.Printf("%so file: %s\n", prefix, storage.GetFile())
-	fmt.Printf("%s  format: %s\n", prefix, storage.GetFormat())
-	fmt.Printf("%s  storage type: %s\n", prefix, storage.GetType())
-	fmt.Printf("%s  compression: %v\n", prefix, storage.GetCompression())
 }
 
 func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
@@ -388,7 +372,11 @@ func checkPolicies(_ log.Component, _ config.Component, args *checkPoliciesCliPa
 
 		return checkPoliciesLoaded(client, os.Stdout)
 	}
-	return checkPoliciesLocal(args, os.Stdout)
+	return clihelpers.CheckPoliciesLocal(clihelpers.CheckPoliciesLocalParams{
+		Dir:                      args.dir,
+		EvaluateAllPolicySources: args.evaluateAllPolicySources,
+		UseWindowsModel:          args.windowsModel,
+	}, os.Stdout)
 }
 
 func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.Writer) error {
@@ -411,232 +399,13 @@ func checkPoliciesLoaded(client secagent.SecurityModuleClientWrapper, writer io.
 	return nil
 }
 
-func newFakeEvent() eval.Event {
-	return model.NewFakeEvent()
-}
-
-func newFakeWindowsEvent() eval.Event {
-	return winmodel.NewFakeEvent()
-}
-
-func newEvalOpts(winModel bool) *eval.Opts {
-	var evalOpts eval.Opts
-
-	if winModel {
-		evalOpts.
-			WithConstants(winmodel.SECLConstants()).
-			WithLegacyFields(winmodel.SECLLegacyFields).
-			WithVariables(model.SECLVariables)
-	} else {
-		evalOpts.
-			WithConstants(model.SECLConstants()).
-			WithLegacyFields(model.SECLLegacyFields).
-			WithVariables(model.SECLVariables)
-	}
-
-	return &evalOpts
-}
-
-func checkPoliciesLocal(args *checkPoliciesCliParams, writer io.Writer) error {
-	cfg := &pconfig.Config{
-		EnableKernelFilters: true,
-		EnableApprovers:     true,
-		EnableDiscarders:    true,
-		PIDCacheSize:        1,
-	}
-
-	// enabled all the rules
-	enabled := map[eval.EventType]bool{"*": true}
-
-	ruleOpts := rules.NewRuleOpts(enabled)
-	evalOpts := newEvalOpts(args.windowsModel)
-
-	ruleOpts.WithLogger(seclog.DefaultLogger)
-
-	agentVersionFilter, err := newAgentVersionFilter()
-	if err != nil {
-		return fmt.Errorf("failed to create agent version filter: %w", err)
-	}
-
-	loaderOpts := rules.PolicyLoaderOpts{
-		MacroFilters: []rules.MacroFilter{
-			agentVersionFilter,
-		},
-		RuleFilters: []rules.RuleFilter{
-			agentVersionFilter,
-		},
-	}
-
-	provider, err := rules.NewPoliciesDirProvider(args.dir)
-	if err != nil {
-		return err
-	}
-
-	loader := rules.NewPolicyLoader(provider)
-
-	var ruleSet *rules.RuleSet
-	if args.windowsModel {
-		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
-		ruleSet.SetFakeEventCtor(newFakeWindowsEvent)
-	} else {
-		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
-		ruleSet.SetFakeEventCtor(newFakeEvent)
-	}
-	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
-		return err
-	}
-
-	report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
-	if err != nil {
-		return err
-	}
-
-	content, _ := json.MarshalIndent(report, "", "\t")
-	_, err = fmt.Fprintf(writer, "%s\n", string(content))
-	if err != nil {
-		return fmt.Errorf("unable to write out report: %w", err)
-	}
-
-	return nil
-}
-
-// EvalReport defines a report of an evaluation
-type EvalReport struct {
-	Succeeded bool
-	Approvers map[string]rules.Approvers
-	Event     eval.Event
-	Error     error `json:",omitempty"`
-}
-
-// EventData defines the structure used to represent an event
-type EventData struct {
-	Type   eval.EventType
-	Values map[string]interface{}
-}
-
-func eventDataFromJSON(file string) (eval.Event, error) {
-	f, err := os.Open(file)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	decoder := json.NewDecoder(f)
-	decoder.UseNumber()
-
-	var eventData EventData
-	if err := decoder.Decode(&eventData); err != nil {
-		return nil, err
-	}
-
-	kind := secconfig.ParseEvalEventType(eventData.Type)
-	if kind == model.UnknownEventType {
-		return nil, errors.New("unknown event type")
-	}
-
-	event := &model.Event{
-		BaseEvent: model.BaseEvent{
-			Type:             uint32(kind),
-			FieldHandlers:    &model.FakeFieldHandlers{},
-			ContainerContext: &model.ContainerContext{},
-		},
-	}
-	event.Init()
-
-	for k, v := range eventData.Values {
-		switch v := v.(type) {
-		case json.Number:
-			value, err := v.Int64()
-			if err != nil {
-				return nil, err
-			}
-			if err := event.SetFieldValue(k, int(value)); err != nil {
-				return nil, err
-			}
-		default:
-			if err := event.SetFieldValue(k, v); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return event, nil
-}
-
 func evalRule(_ log.Component, _ config.Component, _ secrets.Component, evalArgs *evalCliParams) error {
-	policiesDir := evalArgs.dir
-
-	// enabled all the rules
-	enabled := map[eval.EventType]bool{"*": true}
-
-	ruleOpts := rules.NewRuleOpts(enabled)
-	evalOpts := newEvalOpts(evalArgs.windowsModel)
-	ruleOpts.WithLogger(seclog.DefaultLogger)
-
-	agentVersionFilter, err := newAgentVersionFilter()
-	if err != nil {
-		return fmt.Errorf("failed to create agent version filter: %w", err)
-	}
-
-	loaderOpts := rules.PolicyLoaderOpts{
-		MacroFilters: []rules.MacroFilter{
-			agentVersionFilter,
-		},
-		RuleFilters: []rules.RuleFilter{
-			&rules.RuleIDFilter{
-				ID: evalArgs.ruleID,
-			},
-		},
-	}
-
-	provider, err := rules.NewPoliciesDirProvider(policiesDir)
-	if err != nil {
-		return err
-	}
-
-	loader := rules.NewPolicyLoader(provider)
-
-	var ruleSet *rules.RuleSet
-	if evalArgs.windowsModel {
-		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
-	} else {
-		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
-	}
-
-	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
-		return err
-	}
-
-	event, err := eventDataFromJSON(evalArgs.eventFile)
-	if err != nil {
-		return err
-	}
-
-	report := EvalReport{
-		Event: event,
-	}
-
-	if !evalArgs.windowsModel {
-		approvers, err := ruleSet.GetApprovers(kfilters.GetCapababilities())
-		if err != nil {
-			report.Error = err
-		} else {
-			report.Approvers = approvers
-		}
-	}
-
-	report.Succeeded = ruleSet.Evaluate(event)
-	output, err := json.MarshalIndent(report, "", "    ")
-	if err != nil {
-		return err
-	}
-	fmt.Printf("%s\n", string(output))
-
-	if !report.Succeeded {
-		os.Exit(-1)
-	}
-
-	return nil
+	return clihelpers.EvalRule(clihelpers.EvalRuleParams{
+		Dir:             evalArgs.dir,
+		UseWindowsModel: evalArgs.windowsModel,
+		RuleID:          evalArgs.ruleID,
+		EventFile:       evalArgs.eventFile,
+	})
 }
 
 // nolint: deadcode, unused

--- a/cmd/system-probe/subcommands/runtime/command.go
+++ b/cmd/system-probe/subcommands/runtime/command.go
@@ -34,8 +34,6 @@ import (
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/DataDog/datadog-agent/pkg/security/clihelpers"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -347,15 +345,6 @@ func dumpNetworkNamespace(_ log.Component, _ config.Component, _ secrets.Compone
 	fmt.Printf("Network namespace dump: %s\n", resp.GetDumpFilename())
 	fmt.Printf("Network namespace dump graph: %s\n", resp.GetGraphFilename())
 	return nil
-}
-
-func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
-	agentVersion, err := utils.GetAgentSemverVersion()
-	if err != nil {
-		return nil, err
-	}
-
-	return rules.NewAgentVersionFilter(agentVersion)
 }
 
 func checkPolicies(_ log.Component, _ config.Component, args *checkPoliciesCliParams) error {

--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -1,0 +1,310 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux || windows
+
+package clihelpers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+
+	secconfig "github.com/DataDog/datadog-agent/pkg/security/config"
+	pconfig "github.com/DataDog/datadog-agent/pkg/security/probe/config"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
+	"github.com/DataDog/datadog-agent/pkg/security/rules/filtermodel"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	winmodel "github.com/DataDog/datadog-agent/pkg/security/seclwin/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+)
+
+// EvalReport defines a report of an evaluation
+type EvalReport struct {
+	Succeeded bool
+	Approvers map[string]rules.Approvers
+	Event     eval.Event
+	Error     error `json:",omitempty"`
+}
+
+// EventData defines the structure used to represent an event
+type EventData struct {
+	Type   eval.EventType
+	Values map[string]interface{}
+}
+
+type EvalRuleParams struct {
+	Dir             string
+	UseWindowsModel bool
+	RuleID          string
+	EventFile       string
+}
+
+func EvalRule(evalArgs EvalRuleParams) error {
+	policiesDir := evalArgs.Dir
+
+	// enabled all the rules
+	enabled := map[eval.EventType]bool{"*": true}
+
+	ruleOpts := rules.NewRuleOpts(enabled)
+	evalOpts := newEvalOpts(evalArgs.UseWindowsModel)
+	ruleOpts.WithLogger(seclog.DefaultLogger)
+
+	agentVersionFilter, err := newAgentVersionFilter()
+	if err != nil {
+		return fmt.Errorf("failed to create agent version filter: %w", err)
+	}
+
+	loaderOpts := rules.PolicyLoaderOpts{
+		MacroFilters: []rules.MacroFilter{
+			agentVersionFilter,
+		},
+		RuleFilters: []rules.RuleFilter{
+			&rules.RuleIDFilter{
+				ID: evalArgs.RuleID,
+			},
+		},
+	}
+
+	provider, err := rules.NewPoliciesDirProvider(policiesDir)
+	if err != nil {
+		return err
+	}
+
+	loader := rules.NewPolicyLoader(provider)
+
+	var ruleSet *rules.RuleSet
+	if evalArgs.UseWindowsModel {
+		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
+	} else {
+		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+	}
+
+	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
+		return err
+	}
+
+	event, err := eventDataFromJSON(evalArgs.EventFile)
+	if err != nil {
+		return err
+	}
+
+	report := EvalReport{
+		Event: event,
+	}
+
+	if !evalArgs.UseWindowsModel {
+		approvers, err := ruleSet.GetApprovers(kfilters.GetCapababilities())
+		if err != nil {
+			report.Error = err
+		} else {
+			report.Approvers = approvers
+		}
+	}
+
+	report.Succeeded = ruleSet.Evaluate(event)
+	output, err := json.MarshalIndent(report, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s\n", string(output))
+
+	if !report.Succeeded {
+		os.Exit(-1)
+	}
+
+	return nil
+}
+
+func eventDataFromJSON(file string) (eval.Event, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	decoder := json.NewDecoder(f)
+	decoder.UseNumber()
+
+	var eventData EventData
+	if err := decoder.Decode(&eventData); err != nil {
+		return nil, err
+	}
+
+	kind := secconfig.ParseEvalEventType(eventData.Type)
+	if kind == model.UnknownEventType {
+		return nil, errors.New("unknown event type")
+	}
+
+	event := &model.Event{
+		BaseEvent: model.BaseEvent{
+			Type:             uint32(kind),
+			FieldHandlers:    &model.FakeFieldHandlers{},
+			ContainerContext: &model.ContainerContext{},
+		},
+	}
+	event.Init()
+
+	for k, v := range eventData.Values {
+		switch v := v.(type) {
+		case json.Number:
+			value, err := v.Int64()
+			if err != nil {
+				return nil, err
+			}
+			if err := event.SetFieldValue(k, int(value)); err != nil {
+				return nil, err
+			}
+		case []any:
+			if stringSlice, ok := anySliceToStringSlice(v); ok {
+				if err := event.SetFieldValue(k, stringSlice); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := event.SetFieldValue(k, v); err != nil {
+					return nil, err
+				}
+			}
+		default:
+			if err := event.SetFieldValue(k, v); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return event, nil
+}
+
+func anySliceToStringSlice(in []any) ([]string, bool) {
+	out := make([]string, len(in))
+	for i, v := range in {
+		val, ok := v.(string)
+		if !ok {
+			return nil, false
+		}
+		out[i] = val
+	}
+	return out, true
+}
+
+func newFakeEvent() eval.Event {
+	return model.NewFakeEvent()
+}
+
+func newFakeWindowsEvent() eval.Event {
+	return winmodel.NewFakeEvent()
+}
+
+func newEvalOpts(winModel bool) *eval.Opts {
+	var evalOpts eval.Opts
+
+	if winModel {
+		evalOpts.
+			WithConstants(winmodel.SECLConstants()).
+			WithLegacyFields(winmodel.SECLLegacyFields).
+			WithVariables(model.SECLVariables)
+	} else {
+		evalOpts.
+			WithConstants(model.SECLConstants()).
+			WithLegacyFields(model.SECLLegacyFields).
+			WithVariables(model.SECLVariables)
+	}
+
+	return &evalOpts
+}
+
+func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
+	agentVersion, err := utils.GetAgentSemverVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	return rules.NewAgentVersionFilter(agentVersion)
+}
+
+type CheckPoliciesLocalParams struct {
+	Dir                      string
+	EvaluateAllPolicySources bool
+	UseWindowsModel          bool
+}
+
+func CheckPoliciesLocal(args CheckPoliciesLocalParams, writer io.Writer) error {
+	cfg := &pconfig.Config{
+		EnableKernelFilters: true,
+		EnableApprovers:     true,
+		EnableDiscarders:    true,
+		PIDCacheSize:        1,
+	}
+
+	// enabled all the rules
+	enabled := map[eval.EventType]bool{"*": true}
+
+	ruleOpts := rules.NewRuleOpts(enabled)
+	evalOpts := newEvalOpts(args.UseWindowsModel)
+
+	ruleOpts.WithLogger(seclog.DefaultLogger)
+
+	agentVersionFilter, err := newAgentVersionFilter()
+	if err != nil {
+		return fmt.Errorf("failed to create agent version filter: %w", err)
+	}
+
+	os := runtime.GOOS
+	if args.UseWindowsModel {
+		os = "windows"
+	}
+
+	ruleFilterModel := filtermodel.NewOSOnlyFilterModel(os)
+	seclRuleFilter := rules.NewSECLRuleFilter(ruleFilterModel)
+
+	loaderOpts := rules.PolicyLoaderOpts{
+		MacroFilters: []rules.MacroFilter{
+			agentVersionFilter,
+			seclRuleFilter,
+		},
+		RuleFilters: []rules.RuleFilter{
+			agentVersionFilter,
+			seclRuleFilter,
+		},
+	}
+
+	provider, err := rules.NewPoliciesDirProvider(args.Dir)
+	if err != nil {
+		return err
+	}
+
+	loader := rules.NewPolicyLoader(provider)
+
+	var ruleSet *rules.RuleSet
+	if args.UseWindowsModel {
+		ruleSet = rules.NewRuleSet(&winmodel.Model{}, newFakeWindowsEvent, ruleOpts, evalOpts)
+		ruleSet.SetFakeEventCtor(newFakeWindowsEvent)
+	} else {
+		ruleSet = rules.NewRuleSet(&model.Model{}, newFakeEvent, ruleOpts, evalOpts)
+		ruleSet.SetFakeEventCtor(newFakeEvent)
+	}
+	if err := ruleSet.LoadPolicies(loader, loaderOpts); err.ErrorOrNil() != nil {
+		return err
+	}
+
+	report, err := kfilters.NewApplyRuleSetReport(cfg, ruleSet)
+	if err != nil {
+		return err
+	}
+
+	content, _ := json.MarshalIndent(report, "", "\t")
+	_, err = fmt.Fprintf(writer, "%s\n", string(content))
+	if err != nil {
+		return fmt.Errorf("unable to write out report: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/security/clihelpers/eval.go
+++ b/pkg/security/clihelpers/eval.go
@@ -5,6 +5,7 @@
 
 //go:build linux || windows
 
+// Package clihelpers holds common CLI helpers
 package clihelpers
 
 import (
@@ -41,6 +42,7 @@ type EventData struct {
 	Values map[string]interface{}
 }
 
+// EvalRuleParams are parameters to the EvalRule function
 type EvalRuleParams struct {
 	Dir             string
 	UseWindowsModel bool
@@ -48,6 +50,7 @@ type EvalRuleParams struct {
 	EventFile       string
 }
 
+// EvalRule evaluates a rule against an event
 func EvalRule(evalArgs EvalRuleParams) error {
 	policiesDir := evalArgs.Dir
 
@@ -230,12 +233,14 @@ func newAgentVersionFilter() (*rules.AgentVersionFilter, error) {
 	return rules.NewAgentVersionFilter(agentVersion)
 }
 
+// CheckPoliciesLocalParams are parameters to the CheckPoliciesLocal function
 type CheckPoliciesLocalParams struct {
 	Dir                      string
 	EvaluateAllPolicySources bool
 	UseWindowsModel          bool
 }
 
+// CheckPoliciesLocal checks the policies in a directory
 func CheckPoliciesLocal(args CheckPoliciesLocalParams, writer io.Writer) error {
 	cfg := &pconfig.Config{
 		EnableKernelFilters: true,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `evalRule` had diverged between the system-probe and the security-agent CLI. This PR moves this common code to a common package that is imported by both CLI instead. 
 
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->