### PR TITLE
CAP-2292 add e2e test for api key refresh

### DIFF
--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -841,9 +841,9 @@ func (c *Client) GetOrchestratorResources(filter *PayloadFilter) ([]*aggregator.
 	return orchs, nil
 }
 
-// GetLastOrchestratorResourcesPayloadAPIKeys fetches fakeintake on `/api/v2/orch` endpoint and returns
-// the API key of the last received orchestrator payload
-func (c *Client) GetLastOrchestratorResourcesPayloadAPIKeys() ([]string, error) {
+// GetOrchestratorResourcesPayloadAPIKeys fetches fakeintake on `/api/v2/orch` endpoint and returns
+// the API keys of the received orchestrator payloads
+func (c *Client) GetOrchestratorResourcesPayloadAPIKeys() ([]string, error) {
 	payloads, err := c.getFakePayloads(orchestratorEndpoint)
 	if err != nil {
 		return nil, err

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -841,6 +841,25 @@ func (c *Client) GetOrchestratorResources(filter *PayloadFilter) ([]*aggregator.
 	return orchs, nil
 }
 
+// GetLastOrchestratorResourcesPayloadAPIKeys fetches fakeintake on `/api/v2/orch` endpoint and returns
+// the API key of the last received orchestrator payload
+func (c *Client) GetLastOrchestratorResourcesPayloadAPIKeys() ([]string, error) {
+	payloads, err := c.getFakePayloads(orchestratorEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(payloads))
+	uniqueKeys := make(map[string]struct{}, len(payloads))
+	for _, payload := range payloads {
+		if _, ok := uniqueKeys[payload.APIKey]; !ok {
+			keys = append(keys, payload.APIKey)
+			uniqueKeys[payload.APIKey] = struct{}{}
+		}
+	}
+	return keys, nil
+}
+
 // GetOrchestratorManifests fetches fakeintake on `/api/v2/orchmanif` endpoint and returns
 // all received process payloads
 func (c *Client) GetOrchestratorManifests() ([]*aggregator.OrchestratorManifestPayload, error) {

--- a/test/new-e2e/tests/orchestrator/agent_api_key_values.yaml
+++ b/test/new-e2e/tests/orchestrator/agent_api_key_values.yaml
@@ -1,0 +1,26 @@
+fullnameOverride: dda-linux-apikeyrefresh
+datadog:
+  kubelet:
+    tlsVerify: false
+
+agents:
+  useHostNetwork: true
+
+clusterAgent:
+  enabled: true
+  env:
+    - name: DD_SECRET_REFRESH_INTERVAL
+      value: "5"
+    - name: DD_SECRET_BACKEND_COMMAND
+      value: /readsecret_multiple_providers.sh
+    - name: DD_API_KEY
+      value: "ENC[file@/etc/secret-volume/apikey]"
+    - name: DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL
+      value: "%s"
+  volumes:
+    - name: secret-volume
+      secret:
+        secretName: apikeyrefresh
+  volumeMounts:
+    - name: secret-volume
+      mountPath: /etc/secret-volume

--- a/test/new-e2e/tests/orchestrator/k8s_api_key_test.go
+++ b/test/new-e2e/tests/orchestrator/k8s_api_key_test.go
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
+// Copyright 2025-present Datadog, Inc.
 
 package orchestrator
 
@@ -23,9 +23,9 @@ import (
 //go:embed agent_api_key_values.yaml
 var agentAPIKeyRefreshValuesFmt string
 
-// TestZZZClusterAgentAPIKeyRefresh tests the agent's ability to refresh the API key
+// TestZzzClusterAgentAPIKeyRefresh tests the agent's ability to refresh the API key
 // ZZZ is used to ensure this test runs last in the suite as it requires redeploying the agent
-func (suite *k8sSuite) TestZZZClusterAgentAPIKeyRefresh() {
+func (suite *k8sSuite) TestZzzClusterAgentAPIKeyRefresh() {
 	namespace := "datadog"
 	secretName := "apikeyrefresh"
 	apiKeyOld := "abcdefghijklmnopqrstuvwxyz123456"
@@ -90,7 +90,7 @@ func (suite *k8sSuite) applySecret(namespace, name string, secretData map[string
 // eventuallyHasExpectedAPIKey checks if the API key is present in the orchestrator resources payloads.
 func (suite *k8sSuite) eventuallyHasExpectedAPIKey(apiKey string) {
 	hasKey := func() bool {
-		keys, err := suite.Env().FakeIntake.Client().GetLastOrchestratorResourcesPayloadAPIKeys()
+		keys, err := suite.Env().FakeIntake.Client().GetOrchestratorResourcesPayloadAPIKeys()
 		if err != nil {
 			return false
 		}

--- a/test/new-e2e/tests/orchestrator/k8s_api_key_test.go
+++ b/test/new-e2e/tests/orchestrator/k8s_api_key_test.go
@@ -24,7 +24,7 @@ import (
 var agentAPIKeyRefreshValuesFmt string
 
 // TestZzzClusterAgentAPIKeyRefresh tests the agent's ability to refresh the API key
-// ZZZ is used to ensure this test runs last in the suite as it requires redeploying the agent
+// Zzz is used to ensure this test runs last in the suite as it requires redeploying the agent
 func (suite *k8sSuite) TestZzzClusterAgentAPIKeyRefresh() {
 	namespace := "datadog"
 	secretName := "apikeyrefresh"

--- a/test/new-e2e/tests/orchestrator/k8s_api_key_test.go
+++ b/test/new-e2e/tests/orchestrator/k8s_api_key_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package orchestrator
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	awskubernetes "github.com/DataDog/datadog-agent/test/new-e2e/pkg/provisioners/aws/kubernetes"
+	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
+)
+
+//go:embed agent_api_key_values.yaml
+var agentAPIKeyRefreshValuesFmt string
+
+// TestZZZClusterAgentAPIKeyRefresh tests the agent's ability to refresh the API key
+// ZZZ is used to ensure this test runs last in the suite as it requires redeploying the agent
+func (suite *k8sSuite) TestZZZClusterAgentAPIKeyRefresh() {
+	namespace := "datadog"
+	secretName := "apikeyrefresh"
+	apiKeyOld := "abcdefghijklmnopqrstuvwxyz123456"
+
+	// apply secret containing the old API key which is used by the agent
+	suite.applySecret(namespace, secretName, map[string][]byte{"apikey": []byte(apiKeyOld)})
+
+	// install the agent with old API key
+	suite.UpdateEnv(
+		awskubernetes.KindProvisioner(
+			awskubernetes.WithAgentOptions(
+				kubernetesagentparams.WithNamespace(namespace),
+				kubernetesagentparams.WithHelmValues(fmt.Sprintf(agentAPIKeyRefreshValuesFmt, suite.Env().FakeIntake.URL)),
+			),
+		),
+	)
+
+	// verify that the old API key exists in the orchestrator resources payloads
+	suite.eventuallyHasExpectedAPIKey(apiKeyOld)
+
+	// update the secret with a new API key and agent will refresh it
+	apiKeyNew := "123456abcdefghijklmnopqrstuvwxyz"
+	suite.applySecret(namespace, secretName, map[string][]byte{"apikey": []byte(apiKeyNew)})
+
+	// verify that the new API key exists in the orchestrator resources payloads
+	suite.eventuallyHasExpectedAPIKey(apiKeyNew)
+}
+
+// applySecret creates or updates a secret in the given namespace with the provided data.
+func (suite *k8sSuite) applySecret(namespace, name string, secretData map[string][]byte) {
+	client := suite.Env().KubernetesCluster.KubernetesClient.K8sClient
+
+	// Check if the namespace exists, create it if not
+	if _, err := client.CoreV1().Namespaces().Get(context.Background(), namespace, v1.GetOptions{}); err != nil {
+		_, err = client.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Name: namespace,
+			},
+		}, v1.CreateOptions{})
+		require.NoError(suite.T(), err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: secretData,
+	}
+
+	// Check if the secret already exists, update it if it does
+	var err error
+	if _, err = client.CoreV1().Secrets(namespace).Get(context.Background(), name, v1.GetOptions{}); err != nil {
+		_, err = client.CoreV1().Secrets(namespace).Create(context.Background(), secret, v1.CreateOptions{})
+	} else {
+		_, err = client.CoreV1().Secrets(namespace).Update(context.Background(), secret, v1.UpdateOptions{})
+	}
+	require.NoError(suite.T(), err)
+}
+
+// eventuallyHasExpectedAPIKey checks if the API key is present in the orchestrator resources payloads.
+func (suite *k8sSuite) eventuallyHasExpectedAPIKey(apiKey string) {
+	hasKey := func() bool {
+		keys, err := suite.Env().FakeIntake.Client().GetLastOrchestratorResourcesPayloadAPIKeys()
+		if err != nil {
+			return false
+		}
+
+		for _, key := range keys {
+			if key == apiKey {
+				return true
+			}
+		}
+		return false
+	}
+
+	assert.Eventually(suite.T(), hasKey, 10*time.Minute, 10*time.Second)
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add a test to verify api key refresh on orchestrator endpoint.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->