### PR TITLE
fix remote-tagger stopping race-condition

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -232,7 +232,11 @@ func start(remoteTagger *remoteTagger) error {
 	remoteTagger.log.Info("remote tagger initialized successfully")
 
 	// Start the tagger stream.
-	go remoteTagger.run()
+	remoteTagger.wg.Add(1)
+	go func() {
+		defer remoteTagger.wg.Done()
+		remoteTagger.run()
+	}()
 	return nil
 }
 
@@ -442,8 +446,6 @@ func (t *remoteTagger) Subscribe(string, *types.Filter) (types.Subscription, err
 }
 
 func (t *remoteTagger) run() {
-	t.wg.Add(1)
-	defer t.wg.Done()
 	for {
 		select {
 		case <-t.telemetryTicker.C:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes a race condition in the remote tagger implementation that causes TLS handshake errors during shutdown. The fix ensures proper synchronization between the remote tagger's communication goroutine and the stop lifecycle, preventing abrupt connection termination during TLS handshakes.

### Motivation
When a sub-agent (like the trace-agent) is restarted or stopped shortly after starting, the remote tagger's `run()` goroutine may be in the middle of establishing a connection or performing a TLS handshake when the `stop()` function is called. Since the `stop()` function didn't wait for the goroutine to finish before closing the connection, it would abruptly terminate the connection during the handshake process, resulting in the EOF error on the server side: `Error from the Agent HTTP server 'CMD API Server': http: TLS handshake error from 127.0.0.1:xxxx: EOF`.
This issue affects the reliability of the remote tagger component, particularly during sub-agent restarts, and can lead to connection errors and potential data loss.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manual Testing:
- Started a disabled trace-agent (with `apm_config.enabled: false` config) next to a running agent with and without the change
- Without the change, we observed the error `Error from the Agent HTTP server 'CMD API Server': http: TLS handshake error from 127.0.0.1:XXXX: EOF` in core-agent logs
- With the change, the error disappeared and the trace-agent stopped gracefully
- Used `GRPC_GO_LOG_VERBOSITY_LEVEL=99` and `GRPC_GO_LOG_SEVERITY_LEVEL=info` to get detailed gRPC logs. The gRPC logs showed a significant difference in shutdown behavior:
	- Without the fix: The connection was abruptly terminated during a TLS handshake
	- With the fix: The logs showed proper context cancellation, with the channel transitioning to `SHUTDOWN` state and the subchannel being properly deleted before the channel was deleted