### PR TITLE
Remove orchestrator config as it is no longer used in the process/runner

### DIFF
--- a/pkg/process/runner/runner.go
+++ b/pkg/process/runner/runner.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
-	oconfig "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/status"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api"
@@ -69,8 +68,6 @@ type CheckRunner struct {
 	groupID *atomic.Int32
 
 	rtIntervalCh chan time.Duration
-
-	orchestrator *oconfig.OrchestratorConfig
 
 	// counters for each type of check
 	runCounters sync.Map
@@ -126,11 +123,6 @@ func NewRunnerWithChecks(
 	runRealTime bool,
 	rtNotifierChan <-chan types.RTResponse,
 ) (*CheckRunner, error) {
-	orchestrator := oconfig.NewDefaultOrchestratorConfig()
-	if err := orchestrator.Load(); err != nil {
-		return nil, err
-	}
-
 	return &CheckRunner{
 		hostInfo:    hostInfo,
 		config:      config,
@@ -140,7 +132,6 @@ func NewRunnerWithChecks(
 		stop: make(chan struct{}),
 
 		rtIntervalCh:  make(chan time.Duration),
-		orchestrator:  orchestrator,
 		groupID:       atomic.NewInt32(rand.Int31()),
 		enabledChecks: checks,
 


### PR DESCRIPTION
### What does this PR do?
Clean up orchestrator config from the process/runner as the checks have migrated to the core checks in https://github.com/DataDog/datadog-agent/pull/22782

### Motivation
🧹 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->