### PR TITLE
[RC] Restore ignoring unauthorized/proxy errors in poll org status

### DIFF
--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -612,8 +612,11 @@ func (s *CoreAgentService) Stop() error {
 func (s *CoreAgentService) pollOrgStatus() {
 	response, err := s.api.FetchOrgStatus(context.Background())
 	if err != nil {
-		// Unauthorized and proxy error are caught by the main loop requesting the latest config,
-		// and it limits the error log.
+		// Unauthorized and proxy error are caught by the main loop requesting the latest config
+		if errors.Is(err, api.ErrUnauthorized) || errors.Is(err, api.ErrProxy) {
+			return
+		}
+
 		if errors.Is(err, api.ErrGatewayTimeout) || errors.Is(err, api.ErrServiceUnavailable) {
 			s.fetchOrgStatus503And504ErrCount++
 		}


### PR DESCRIPTION
### What does this PR do?

We previously dropped logging unauthorized and proxy related issues in the poll org status loop and let the main config refresh loop handle it. This restores that functionality to prevent the poll org status loop from logging invalid API keys or proxy errors every minute without any rate limiting.

### Motivation

Less spammy logs during very specific invalid state conditions

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->