### PR TITLE
[AGENTRUN-205] remove unused component in API component

### DIFF
--- a/cmd/agent/subcommands/jmx/command.go
+++ b/cmd/agent/subcommands/jmx/command.go
@@ -36,7 +36,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 	"github.com/DataDog/datadog-agent/comp/core/secrets"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	dualTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-dual"
@@ -132,9 +131,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			apiimpl.Module(),
 			grpcNonefx.Module(),
 			authtokenimpl.Module(),
-			// TODO(components): this is a temporary hack as the StartServer() method of the API package was previously called with nil arguments
-			// This highlights the fact that the API Server created by JMX (through ExecJmx... function) should be different from the ones created
-			// in others commands such as run.
 			fx.Supply(option.None[collector.Component]()),
 			fx.Supply(option.None[integrations.Component]()),
 			dualTaggerfx.Module(common.DualTaggerParams()),
@@ -147,7 +143,6 @@ func Commands(globalParams *command.GlobalParams) []*cobra.Command {
 			fx.Invoke(func(wmeta workloadmeta.Component, tagger tagger.Component) {
 				proccontainers.InitSharedContainerProvider(wmeta, tagger)
 			}),
-			fx.Provide(func() remoteagentregistry.Component { return nil }),
 			haagentfx.Module(),
 			logscompression.Module(),
 			metricscompression.Module(),

--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -12,19 +12,12 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/aggregator/diagnosesendermanager"
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	grpc "github.com/DataDog/datadog-agent/comp/api/grpcserver/def"
-	"github.com/DataDog/datadog-agent/comp/collector/collector"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/secrets"
-	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 // Module defines the fx options for this component.
@@ -35,13 +28,7 @@ func Module() fxutil.Module {
 
 type apiServer struct {
 	cfg               config.Component
-	secretResolver    secrets.Component
 	authToken         authtoken.Component
-	taggerComp        tagger.Component
-	autoConfig        autodiscovery.Component
-	wmeta             workloadmeta.Component
-	collector         option.Option[collector.Component]
-	senderManager     diagnosesendermanager.Component
 	cmdListener       net.Listener
 	ipcListener       net.Listener
 	telemetry         telemetry.Component
@@ -52,18 +39,12 @@ type apiServer struct {
 type dependencies struct {
 	fx.In
 
-	Lc                    fx.Lifecycle
-	SecretResolver        secrets.Component
-	AuthToken             authtoken.Component
-	Tagger                tagger.Component
-	Cfg                   config.Component
-	AutoConfig            autodiscovery.Component
-	WorkloadMeta          workloadmeta.Component
-	Collector             option.Option[collector.Component]
-	DiagnoseSenderManager diagnosesendermanager.Component
-	Telemetry             telemetry.Component
-	EndpointProviders     []api.EndpointProvider `group:"agent_endpoint"`
-	GrpcComponent         grpc.Component
+	Lc                fx.Lifecycle
+	AuthToken         authtoken.Component
+	Cfg               config.Component
+	Telemetry         telemetry.Component
+	EndpointProviders []api.EndpointProvider `group:"agent_endpoint"`
+	GrpcComponent     grpc.Component
 }
 
 var _ api.Component = (*apiServer)(nil)
@@ -71,14 +52,8 @@ var _ api.Component = (*apiServer)(nil)
 func newAPIServer(deps dependencies) api.Component {
 
 	server := apiServer{
-		secretResolver:    deps.SecretResolver,
 		authToken:         deps.AuthToken,
-		taggerComp:        deps.Tagger,
 		cfg:               deps.Cfg,
-		autoConfig:        deps.AutoConfig,
-		wmeta:             deps.WorkloadMeta,
-		collector:         deps.Collector,
-		senderManager:     deps.DiagnoseSenderManager,
 		telemetry:         deps.Telemetry,
 		endpointProviders: fxutil.GetAndFilterGroup(deps.EndpointProviders),
 		grpcComponent:     deps.GrpcComponent,

--- a/comp/api/api/apiimpl/api_test.go
+++ b/comp/api/api/apiimpl/api_test.go
@@ -16,35 +16,19 @@ import (
 
 	"golang.org/x/net/http2"
 
-	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/observability"
 	api "github.com/DataDog/datadog-agent/comp/api/api/def"
 	"github.com/DataDog/datadog-agent/comp/api/authtoken"
 	authtokenmock "github.com/DataDog/datadog-agent/comp/api/authtoken/mock"
 	grpc "github.com/DataDog/datadog-agent/comp/api/grpcserver/def"
 	grpcNonefx "github.com/DataDog/datadog-agent/comp/api/grpcserver/fx-none"
-	"github.com/DataDog/datadog-agent/comp/collector/collector"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery"
-	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
-	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
-	"github.com/DataDog/datadog-agent/comp/core/secrets/secretsimpl"
-	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
-	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
-	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
-	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap/pidmapimpl"
 
 	// package dependencies
-
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 
 	// third-party dependencies
 	dto "github.com/prometheus/client_model/go"
@@ -67,22 +51,7 @@ func getAPIServer(t *testing.T, params config.MockParams, fxOptions ...fx.Option
 		t,
 		Module(),
 		fx.Replace(params),
-		hostnameimpl.MockModule(),
-		secretsimpl.MockModule(),
-		demultiplexerimpl.MockModule(),
 		fx.Provide(func(t testing.TB) authtoken.Component { return authtokenmock.New(t) }),
-		fx.Supply(context.Background()),
-		taggerfxmock.MockModule(),
-		fx.Provide(func(mock taggermock.Mock) tagger.Component {
-			return mock
-		}),
-		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: nil}),
-		autodiscoveryimpl.MockModule(),
-		fx.Provide(func(mock autodiscovery.Mock) autodiscovery.Component {
-			return mock
-		}),
-		fx.Supply(option.None[collector.Component]()),
-		pidmapimpl.Module(),
 		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints
 		fx.Provide(func() api.AgentEndpointProvider {
 			return api.AgentEndpointProvider{
@@ -92,8 +61,6 @@ func getAPIServer(t *testing.T, params config.MockParams, fxOptions ...fx.Option
 		telemetryimpl.MockModule(),
 		config.MockModule(),
 		grpcNonefx.Module(),
-		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-		fx.Provide(func(t testing.TB) log.Component { return logmock.New(t) }),
 		fx.Options(fxOptions...),
 	)
 }
@@ -102,19 +69,8 @@ func testAPIServer(params config.MockParams, fxOptions ...fx.Option) (*fx.App, t
 	return fxutil.TestApp[testdeps](
 		Module(),
 		fx.Replace(params),
-		hostnameimpl.MockModule(),
-		secretsimpl.MockModule(),
-		demultiplexerimpl.MockModule(),
 		fx.Provide(func(t *testing.T) authtoken.Component { return authtokenmock.New(t) }),
 		fx.Supply(context.Background()),
-		taggerfxmock.MockModule(),
-		fx.Supply(autodiscoveryimpl.MockParams{Scheduler: nil}),
-		autodiscoveryimpl.MockModule(),
-		fx.Provide(func(mock autodiscovery.Mock) autodiscovery.Component {
-			return mock
-		}),
-		fx.Supply(option.None[collector.Component]()),
-		pidmapimpl.Module(),
 		// Ensure we pass a nil endpoint to test that we always filter out nil endpoints
 		fx.Provide(func() api.AgentEndpointProvider {
 			return api.AgentEndpointProvider{
@@ -124,8 +80,6 @@ func testAPIServer(params config.MockParams, fxOptions ...fx.Option) (*fx.App, t
 		telemetryimpl.MockModule(),
 		config.MockModule(),
 		grpcNonefx.Module(),
-		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-		fx.Provide(func(t testing.TB) log.Component { return logmock.New(t) }),
 		fx.Options(fxOptions...),
 	)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

After merging https://github.com/DataDog/datadog-agent/pull/35083 and https://github.com/DataDog/datadog-agent/pull/35023 we are able to get rid of many component on the API that are no longer directly accessed. 

### Motivation

Remove unused component and simplify the API component 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit test 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->