### PR TITLE
discovery: send Service Discovery telemetry

### DIFF
--- a/comp/core/agenttelemetry/impl/agenttelemetry_test.go
+++ b/comp/core/agenttelemetry/impl/agenttelemetry_test.go
@@ -478,7 +478,7 @@ func TestRun(t *testing.T) {
 	profile0Len := len(r.(*runnerMock).jobs[0].profiles)
 	profile1Len := len(r.(*runnerMock).jobs[1].profiles)
 	t.Logf("%+v", r.(*runnerMock).jobs)
-	assert.True(t, (profile0Len == 1 && profile1Len == 4) || (profile0Len == 4 && profile1Len == 1))
+	assert.True(t, (profile0Len == 1 && profile1Len == 5) || (profile0Len == 5 && profile1Len == 1))
 }
 
 func TestReportMetricBasic(t *testing.T) {

--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -283,6 +283,14 @@ var defaultProfiles = `
           aggregate_tags:
             - kind
             - template_name
+  - name: service-discovery
+    metric:
+      metrics:
+        - name: service_discovery.discovered_services
+    schedule:
+      start_after: 30
+      iterations: 0
+      period: 900
 `
 
 func compileMetricsExclude(p *Profile) error {

--- a/pkg/collector/corechecks/servicediscovery/servicediscovery.go
+++ b/pkg/collector/corechecks/servicediscovery/servicediscovery.go
@@ -94,7 +94,7 @@ func (c *Check) Configure(senderManager sender.SenderManager, _ uint64, instance
 		"discovered_services",
 		[]string{},
 		"Number of discovered alive services.",
-		telemetry.Options{NoDoubleUnderscoreSep: true},
+		telemetry.DefaultOptions,
 	)
 
 	return nil

--- a/releasenotes/notes/service-discovery-telemetry-2d18d23177699523.yaml
+++ b/releasenotes/notes/service-discovery-telemetry-2d18d23177699523.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Adds Agent telemetry for Service Discovery.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds the `service_discovery.discovered_services` metric to X-org Agent Telemetry.

### Motivation

Measure how customers are using Service Discovery, how effective we are at detecting services and see if there is a discrepancy between what our backend received and how many services were detected.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->