### PR TITLE
[FA] Expose set_instance method

### DIFF
--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -190,6 +190,16 @@ DATADOG_AGENT_RTLOADER_API int get_check_deprecated(rtloader_t *rtloader, rtload
 */
 DATADOG_AGENT_RTLOADER_API char *run_check(rtloader_t *, rtloader_pyobject_t *check);
 
+/*! \fn int set_instance(rtloader_t *rtloader, rtloader_pyobject_t *check, const char *instance_str)
+    \brief Sets the instance for a check.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param check A rtloader_pyobject_t * pointer to the check instance.
+    \param instance_str A const C-string with the instance string.
+    \return An integer with the success of the operation. Zero for success, non-zero for failure.
+    \sa rtloader_pyobject_t, rtloader_t
+*/
+DATADOG_AGENT_RTLOADER_API int set_instance(rtloader_t *, rtloader_pyobject_t *check, const char *instance_str);
+
 /*! \fn char *cancel_check(rtloader_t *, rtloader_pyobject_t *check)
     \brief Cancels a check instance. This allow check to be notified when
     they're unscheduled and can free any remaining resources.

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -118,6 +118,14 @@ public:
     */
     virtual char *runCheck(RtLoaderPyObject *check) = 0;
 
+    //! Pure virtual setInstance member.
+    /*!
+      \param check The python object pointer to the check we wish to set the instance for.
+      \param instance_str A C-string containing the instance config for the check instance.
+      \return A boolean indicating the success or not of the operation.
+    */
+    virtual bool setInstance(RtLoaderPyObject *check, const char *instance_str) = 0;
+
     //! Pure virtual cancelCheck member.
     /*!
       \param check The python object pointer to the check we wish to cancel.

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -272,6 +272,11 @@ char *run_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
     return AS_TYPE(RtLoader, rtloader)->runCheck(AS_TYPE(RtLoaderPyObject, check));
 }
 
+int set_instance(rtloader_t *rtloader, rtloader_pyobject_t *check, const char *instance_str)
+{
+    return AS_TYPE(RtLoader, rtloader)->setInstance(AS_TYPE(RtLoaderPyObject, check), instance_str) ? 1 : 0;
+}
+
 void cancel_check(rtloader_t *rtloader, rtloader_pyobject_t *check)
 {
     AS_TYPE(RtLoader, rtloader)->cancelCheck(AS_TYPE(RtLoaderPyObject, check));

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -63,6 +63,7 @@ public:
                   RtLoaderPyObject *&check);
 
     char *runCheck(RtLoaderPyObject *check);
+    bool setInstance(RtLoaderPyObject *check, const char *instance_str);
     void cancelCheck(RtLoaderPyObject *check);
     char **getCheckWarnings(RtLoaderPyObject *check);
     char *getCheckDiagnoses(RtLoaderPyObject *check);


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

* Move the instance initialization in a separate method
* Expose the `set_instance` method so we can update the instance at runtime without modifying the full check
* Make sure it can be used for the following PR https://github.com/DataDog/datadog-agent/pull/35862

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Making sure the integrations are scheduled, running as usual in the e2e tests.

QA steps with a new RC:
* Start an agent with the latest RC
* Check it does not crash, and that default integrations are running without errors (check `agent status` command for `disk` integration for instance)
* Create a non-default integration configuration file (like Redis under `conf.d/redisdb.d/conf.yaml`) 
* Restart the agent
* Check it does not crash, and that the Redis integration can be started without errors from the agent side (errors from the python check side is fine)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->