### PR TITLE
[OTAGENT-331] Stop DDOT if otelCollector.enabled is false

### DIFF
--- a/comp/otelcol/collector/impl/collector.go
+++ b/comp/otelcol/collector/impl/collector.go
@@ -58,7 +58,8 @@ type collectorImpl struct {
 type Requires struct {
 	// Lc specifies the compdef lifecycle settings, used for appending startup
 	// and shutdown hooks.
-	Lc compdef.Lifecycle
+	Lc         compdef.Lifecycle
+	Shutdowner compdef.Shutdowner
 
 	CollectorContrib collectorcontrib.Component
 	URIs             []string
@@ -145,6 +146,13 @@ var buildInfo = component.BuildInfo{
 
 // NewComponent returns a new instance of the collector component with full Agent functionalities.
 func NewComponent(reqs Requires) (Provides, error) {
+	if !reqs.Config.GetBool("otelcollector.enabled") {
+		reqs.Log.Info("OpenTelemetry Collector is not enabled, exiting application")
+		// Required to signal that the whole app must stop.
+		_ = reqs.Shutdowner.Shutdown()
+		return Provides{}, nil
+	}
+
 	factories, err := reqs.CollectorContrib.OTelComponentFactories()
 	if err != nil {
 		return Provides{}, err

--- a/comp/otelcol/otlp/integrationtest/integration_test.go
+++ b/comp/otelcol/otlp/integrationtest/integration_test.go
@@ -70,6 +70,7 @@ import (
 	gzipfx "github.com/DataDog/datadog-agent/comp/trace/compression/fx-gzip"
 	traceconfig "github.com/DataDog/datadog-agent/comp/trace/config"
 	pkgconfigenv "github.com/DataDog/datadog-agent/pkg/config/env"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
@@ -102,6 +103,7 @@ func runTestOTelAgent(ctx context.Context, params *subcommands.GlobalParams) err
 			if err != nil {
 				return nil, err
 			}
+			c.Set("otelcollector.enabled", true, pkgconfigmodel.SourceFile)
 			pkgconfigenv.DetectFeatures(c)
 			return c, nil
 		}),

--- a/test/new-e2e/tests/otel/otel-agent/complete_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/complete_test.go
@@ -26,7 +26,7 @@ type completeTestSuite struct {
 var completeConfig string
 
 func TestOTelAgentComplete(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
@@ -39,7 +39,7 @@ agents:
           value: 'false'
         - name: DD_APM_FEATURES
           value: 'disable_receive_resource_spans_v2'
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &completeTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(completeConfig)))))
 }

--- a/test/new-e2e/tests/otel/otel-agent/config.go
+++ b/test/new-e2e/tests/otel/otel-agent/config.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package otelagent contains e2e otel agent tests
+package otelagent
+
+import (
+	"gopkg.in/yaml.v3"
+)
+
+// ensureMapKey ensures a map key exists with a map value and returns the nested map
+func ensureMapKey(m map[string]interface{}, key string) map[string]interface{} {
+	if _, ok := m[key]; !ok {
+		m[key] = make(map[string]interface{})
+	}
+	return m[key].(map[string]interface{})
+}
+
+func enableOTELAgentonfig(valueYaml string) string {
+	var config map[string]interface{}
+	if valueYaml == "" {
+		config = make(map[string]interface{})
+	} else {
+		if err := yaml.Unmarshal([]byte(valueYaml), &config); err != nil {
+			return valueYaml
+		}
+	}
+
+	// Initialize the agents.containers.otelAgent structure if it doesn't exist
+	agents := ensureMapKey(config, "agents")
+	containers := ensureMapKey(agents, "containers")
+	otelAgent := ensureMapKey(containers, "otelAgent")
+
+	// Init env if needed and set DD_OTELCOLLECTOR_ENABLED
+	if _, ok := otelAgent["env"]; !ok {
+		otelAgent["env"] = []interface{}{}
+	}
+
+	env := otelAgent["env"].([]interface{})
+	found := false
+	for _, e := range env {
+		if envMap, ok := e.(map[string]interface{}); ok && envMap["name"] == "DD_OTELCOLLECTOR_ENABLED" {
+			envMap["value"] = "true"
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		otelAgent["env"] = append(env, map[string]interface{}{
+			"name": "DD_OTELCOLLECTOR_ENABLED", "value": "true",
+		})
+	}
+
+	// Return updated YAML
+	modifiedYaml, err := yaml.Marshal(config)
+	if err != nil {
+		return valueYaml
+	}
+	return string(modifiedYaml)
+}

--- a/test/new-e2e/tests/otel/otel-agent/host_metrics_receiver_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/host_metrics_receiver_test.go
@@ -26,12 +26,12 @@ type hostmetricsreceiverTestSuite struct {
 var hostmetricsreceiverConfig string
 
 func TestOTelAgentHostmetricsReceiver(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &hostmetricsreceiverTestSuite{},
 		e2e.WithProvisioner(

--- a/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/infraattributes_eks_test.go
@@ -25,12 +25,12 @@ type iaEKSTestSuite struct {
 }
 
 func TestOTelAgentIAEKS(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &iaEKSTestSuite{}, e2e.WithProvisioner(awskubernetes.EKSProvisioner(awskubernetes.WithEKSOptions(eks.WithLinuxNodeGroup()), awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(iaConfig)))))
 }
@@ -71,12 +71,12 @@ type iaUSTEKSTestSuite struct {
 }
 
 func TestOTelAgentIAUSTEKS(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &iaUSTEKSTestSuite{}, e2e.WithProvisioner(awskubernetes.EKSProvisioner(awskubernetes.WithEKSOptions(eks.WithLinuxNodeGroup()), awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(iaConfig)))))
 }

--- a/test/new-e2e/tests/otel/otel-agent/infraattributes_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/infraattributes_test.go
@@ -27,12 +27,12 @@ type iaTestSuite struct {
 var iaConfig string
 
 func TestOTelAgentIA(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &iaTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(iaConfig)))))
 }

--- a/test/new-e2e/tests/otel/otel-agent/loadbalancing_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/loadbalancing_test.go
@@ -26,12 +26,12 @@ type loadBalancingTestSuite struct {
 var loadBalancingConfig string
 
 func TestOTelAgentLoadBalancing(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &loadBalancingTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(loadBalancingConfig)))))
 }

--- a/test/new-e2e/tests/otel/otel-agent/minimal_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/minimal_test.go
@@ -36,12 +36,12 @@ var minimalFullConfig string
 var sources string
 
 func TestOTelAgentMinimal(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &minimalTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(minimalConfig)))))
 }

--- a/test/new-e2e/tests/otel/otel-agent/no_dd_exporter_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/no_dd_exporter_test.go
@@ -32,12 +32,12 @@ var noDDExporterProvidedConfig string
 var noDDExporterFullConfig string
 
 func TestOTelAgentWithNoDDExporter(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
     containerCollectUsingFiles: false
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &noDDExporterTestSuite{},
 		e2e.WithProvisioner(

--- a/test/new-e2e/tests/otel/otel-agent/receive_resource_spans_v2_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/receive_resource_spans_v2_test.go
@@ -21,7 +21,7 @@ type otelAgentSpanReceiverV2TestSuite struct {
 }
 
 func TestOTelAgentSpanReceiverV2(t *testing.T) {
-	values := `
+	values := enableOTELAgentonfig(`
 datadog:
   logs:
     containerCollectAll: false
@@ -32,7 +32,7 @@ agents:
       env:
         - name: DD_OTLP_CONFIG_TRACES_SPAN_NAME_AS_RESOURCE_NAME
           value: 'false'
-`
+`)
 	t.Parallel()
 	e2e.Run(t, &otelAgentSpanReceiverV2TestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithHelmValues(values), kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(minimalConfig)))))
 }

--- a/test/new-e2e/tests/otel/otel-agent/sampling_test.go
+++ b/test/new-e2e/tests/otel/otel-agent/sampling_test.go
@@ -27,7 +27,10 @@ var samplingConfig string
 
 func TestOTelAgentSampling(t *testing.T) {
 	t.Parallel()
-	e2e.Run(t, &samplingTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(kubernetesagentparams.WithOTelAgent(), kubernetesagentparams.WithOTelConfig(samplingConfig)))))
+	e2e.Run(t, &samplingTestSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(awskubernetes.WithAgentOptions(
+		kubernetesagentparams.WithHelmValues(enableOTELAgentonfig("")),
+		kubernetesagentparams.WithOTelAgent(),
+		kubernetesagentparams.WithOTelConfig(samplingConfig)))))
 }
 
 func (s *samplingTestSuite) SetupSuite() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Backport of https://github.com/DataDog/datadog-agent/pull/35641.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Set `otelCollector.enabled` at false and make sure DDOT is not run in the full image.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->