### PR TITLE
[CWS] make sure cilium/ebpf is not imported by the cluster agent

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -12,16 +12,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 
 	"github.com/acobaugh/osrelease"
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
-	"github.com/cilium/ebpf/btf"
-	"github.com/cilium/ebpf/features"
-	"github.com/cilium/ebpf/link"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
@@ -319,107 +313,16 @@ func (k *Version) IsInRangeCloseOpen(begin kernel.Version, end kernel.Version) b
 	return k.Code != 0 && begin <= k.Code && k.Code < end
 }
 
-// HaveMmapableMaps returns whether the kernel supports mmapable maps.
-func (k *Version) HaveMmapableMaps() bool {
-	return features.HaveMapFlag(features.BPF_F_MMAPABLE) == nil
-}
-
-// HaveRingBuffers returns whether the kernel supports ring buffer.
-// https://github.com/torvalds/linux/commit/457f44363a8894135c85b7a9afd2bd8196db24ab
-func (k *Version) HaveRingBuffers() bool {
-	return features.HaveMapType(ebpf.RingBuf) == nil
-}
-
 // HasNoPreallocMapsInPerfEvent returns true if the kernel supports using non-preallocated maps in perf_event programs
 // See https://github.com/torvalds/linux/commit/274052a2b0ab9f380ce22b19ff80a99b99ecb198
 func (k *Version) HasNoPreallocMapsInPerfEvent() bool {
 	return k.Code >= Kernel6_1
 }
 
-// HasCgroupSysctlSupportWithRingbuf returns true if cgroup/sysctl programs are available with access to ringbuffer
-func (k *Version) HasCgroupSysctlSupportWithRingbuf() bool {
-	if features.HaveProgramType(ebpf.CGroupSysctl) != nil {
-		return false
-	}
-
-	// features.HaveProgramHelper doesn't implement feature testing for cgroup/sysctl yet, keep the kernel version
-	// fall back for now.
-	if features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnRingbufOutput) == nil &&
-		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetSmpProcessorId) == nil &&
-		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnKtimeGetNs) == nil {
-		return true
-	}
-
-	return k.Code >= Kernel5_8
-}
-
-// HasTracingHelpersInCgroupSysctlPrograms returns true if basic tracing helpers are available in cgroup/sysctl programs
-// Namely, the helpers we care about are: bpf_probe_read_*, bpf_get_current_pid_tgid, bpf_get_current_task, etc
-func (k *Version) HasTracingHelpersInCgroupSysctlPrograms() bool {
-	if !k.HasCgroupSysctlSupportWithRingbuf() {
-		return false
-	}
-
-	// features.HaveProgramHelper doesn't implement feature testing for cgroup/sysctl yet, keep the kernel version
-	// fall back for now.
-	if features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetCurrentTask) == nil &&
-		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetCurrentComm) == nil &&
-		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnProbeReadKernel) == nil &&
-		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetCurrentPidTgid) == nil {
-		return true
-	}
-
-	return k.Code >= Kernel6_1
-}
-
-// HasSKStorage returns true if the kernel supports SK_STORAGE maps
-// See https://github.com/torvalds/linux/commit/6ac99e8f23d4b10258406ca0dd7bffca5f31da9d
-func (k *Version) HasSKStorage() bool {
-	if features.HaveMapType(ebpf.SkStorage) == nil {
-		return true
-	}
-
-	return k.Code != 0 && k.Code >= Kernel5_2
-}
-
-// HasSKStorageInTracingPrograms returns true if the kernel supports SK_STORAGE maps in tracing programs
-// See https://github.com/torvalds/linux/commit/8e4597c627fb48f361e2a5b012202cb1b6cbcd5e
-func (k *Version) HasSKStorageInTracingPrograms() bool {
-	if !k.HasSKStorage() {
-		return false
-	}
-
-	if !k.HaveFentrySupport() {
-		return false
-	}
-
-	// features.HaveProgramHelper doesn't implement feature testing for ebpf.Tracing yet, keep the kernel version
-	// fall back for now.
-	if features.HaveProgramHelper(ebpf.Tracing, asm.FnSkStorageGet) == nil {
-		return true
-	}
-	return k.Code != 0 && k.Code >= Kernel5_11
-}
-
 // IsMapValuesToMapHelpersAllowed returns true if the kernel supports passing map values to map helpers
 // See https://github.com/torvalds/linux/commit/d71962f3e627b5941804036755c844fabfb65ff5
 func (k *Version) IsMapValuesToMapHelpersAllowed() bool {
 	return k.Code != 0 && k.Code >= Kernel4_18
-}
-
-// HasBPFForEachMapElemHelper returns true if the kernel support the bpf_for_each_map_elem helper
-// See https://github.com/torvalds/linux/commit/69c087ba6225b574afb6e505b72cb75242a3d844
-func (k *Version) HasBPFForEachMapElemHelper() bool {
-	// because of https://lore.kernel.org/bpf/20211231151018.3781550-1-houtao1@huawei.com/
-	// we need a kernel 5.17 or higher on arm64 to use the bpf_for_each_map_elem helper
-	if runtime.GOARCH == "arm64" && k.Code < Kernel5_17 {
-		return false
-	}
-
-	if features.HaveProgramHelper(ebpf.PerfEvent, asm.FnForEachMapElem) == nil {
-		return true
-	}
-	return k.Code != 0 && k.Code >= Kernel5_13
 }
 
 // HavePIDLinkStruct returns whether the kernel uses the pid_link struct, which was removed in 4.19
@@ -432,69 +335,7 @@ func (k *Version) HaveLegacyPipeInodeInfoStruct() bool {
 	return k.Code != 0 && k.Code < Kernel5_5
 }
 
-func (k *Version) commonFentryCheck(funcName string) bool {
-	if features.HaveProgramType(ebpf.Tracing) != nil {
-		return false
-	}
-
-	spec := &ebpf.ProgramSpec{
-		Type:       ebpf.Tracing,
-		AttachType: ebpf.AttachTraceFEntry,
-		AttachTo:   funcName,
-		Instructions: asm.Instructions{
-			asm.LoadImm(asm.R0, 0, asm.DWord),
-			asm.Return(),
-		},
-	}
-	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
-		LogDisabled: true,
-	})
-	if err != nil {
-		return false
-	}
-	defer prog.Close()
-
-	link, err := link.AttachTracing(link.TracingOptions{
-		Program: prog,
-	})
-	if err != nil {
-		return false
-	}
-	defer link.Close()
-
-	return true
-}
-
-// HaveFentrySupport returns whether the kernel supports fentry probes
-func (k *Version) HaveFentrySupport() bool {
-	return k.commonFentryCheck("vfs_open")
-}
-
-// HaveFentrySupportWithStructArgs returns whether the kernel supports fentry probes with struct arguments
-func (k *Version) HaveFentrySupportWithStructArgs() bool {
-	return k.commonFentryCheck("audit_set_loginuid")
-}
-
-// HaveFentryNoDuplicatedWeakSymbols returns whether the kernel supports fentry probes with struct arguments
-func (k *Version) HaveFentryNoDuplicatedWeakSymbols() bool {
-	var symbol string
-	switch runtime.GOARCH {
-	case "amd64":
-		symbol = "__ia32_sys_setregid16"
-	default:
-		return true
-	}
-
-	return k.commonFentryCheck(symbol)
-}
-
 // SupportBPFSendSignal returns true if the eBPF function bpf_send_signal is available
 func (k *Version) SupportBPFSendSignal() bool {
 	return k.Code != 0 && k.Code >= Kernel5_3
-}
-
-// SupportCORE returns is CORE is supported
-func (k *Version) SupportCORE() bool {
-	_, err := btf.LoadKernelSpec()
-	return err == nil
 }

--- a/pkg/security/ebpf/kernel/kernel_bpf.go
+++ b/pkg/security/ebpf/kernel/kernel_bpf.go
@@ -1,0 +1,172 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && linux_bpf
+
+// Package kernel holds kernel related files
+package kernel
+
+import (
+	"runtime"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
+	"github.com/cilium/ebpf/features"
+	"github.com/cilium/ebpf/link"
+)
+
+// HaveMmapableMaps returns whether the kernel supports mmapable maps.
+func (k *Version) HaveMmapableMaps() bool {
+	return features.HaveMapFlag(features.BPF_F_MMAPABLE) == nil
+}
+
+// HaveRingBuffers returns whether the kernel supports ring buffer.
+// https://github.com/torvalds/linux/commit/457f44363a8894135c85b7a9afd2bd8196db24ab
+func (k *Version) HaveRingBuffers() bool {
+	return features.HaveMapType(ebpf.RingBuf) == nil
+}
+
+// HasCgroupSysctlSupportWithRingbuf returns true if cgroup/sysctl programs are available with access to ringbuffer
+func (k *Version) HasCgroupSysctlSupportWithRingbuf() bool {
+	if features.HaveProgramType(ebpf.CGroupSysctl) != nil {
+		return false
+	}
+
+	// features.HaveProgramHelper doesn't implement feature testing for cgroup/sysctl yet, keep the kernel version
+	// fall back for now.
+	if features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnRingbufOutput) == nil &&
+		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetSmpProcessorId) == nil &&
+		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnKtimeGetNs) == nil {
+		return true
+	}
+
+	return k.Code >= Kernel5_8
+}
+
+// HasTracingHelpersInCgroupSysctlPrograms returns true if basic tracing helpers are available in cgroup/sysctl programs
+// Namely, the helpers we care about are: bpf_probe_read_*, bpf_get_current_pid_tgid, bpf_get_current_task, etc
+func (k *Version) HasTracingHelpersInCgroupSysctlPrograms() bool {
+	if !k.HasCgroupSysctlSupportWithRingbuf() {
+		return false
+	}
+
+	// features.HaveProgramHelper doesn't implement feature testing for cgroup/sysctl yet, keep the kernel version
+	// fall back for now.
+	if features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetCurrentTask) == nil &&
+		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetCurrentComm) == nil &&
+		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnProbeReadKernel) == nil &&
+		features.HaveProgramHelper(ebpf.CGroupSysctl, asm.FnGetCurrentPidTgid) == nil {
+		return true
+	}
+
+	return k.Code >= Kernel6_1
+}
+
+// HasSKStorage returns true if the kernel supports SK_STORAGE maps
+// See https://github.com/torvalds/linux/commit/6ac99e8f23d4b10258406ca0dd7bffca5f31da9d
+func (k *Version) HasSKStorage() bool {
+	if features.HaveMapType(ebpf.SkStorage) == nil {
+		return true
+	}
+
+	return k.Code != 0 && k.Code >= Kernel5_2
+}
+
+// HasSKStorageInTracingPrograms returns true if the kernel supports SK_STORAGE maps in tracing programs
+// See https://github.com/torvalds/linux/commit/8e4597c627fb48f361e2a5b012202cb1b6cbcd5e
+func (k *Version) HasSKStorageInTracingPrograms() bool {
+	if !k.HasSKStorage() {
+		return false
+	}
+
+	if !k.HaveFentrySupport() {
+		return false
+	}
+
+	// features.HaveProgramHelper doesn't implement feature testing for ebpf.Tracing yet, keep the kernel version
+	// fall back for now.
+	if features.HaveProgramHelper(ebpf.Tracing, asm.FnSkStorageGet) == nil {
+		return true
+	}
+	return k.Code != 0 && k.Code >= Kernel5_11
+}
+
+// HasBPFForEachMapElemHelper returns true if the kernel support the bpf_for_each_map_elem helper
+// See https://github.com/torvalds/linux/commit/69c087ba6225b574afb6e505b72cb75242a3d844
+func (k *Version) HasBPFForEachMapElemHelper() bool {
+	// because of https://lore.kernel.org/bpf/20211231151018.3781550-1-houtao1@huawei.com/
+	// we need a kernel 5.17 or higher on arm64 to use the bpf_for_each_map_elem helper
+	if runtime.GOARCH == "arm64" && k.Code < Kernel5_17 {
+		return false
+	}
+
+	if features.HaveProgramHelper(ebpf.PerfEvent, asm.FnForEachMapElem) == nil {
+		return true
+	}
+	return k.Code != 0 && k.Code >= Kernel5_13
+}
+
+func (k *Version) commonFentryCheck(funcName string) bool {
+	if features.HaveProgramType(ebpf.Tracing) != nil {
+		return false
+	}
+
+	spec := &ebpf.ProgramSpec{
+		Type:       ebpf.Tracing,
+		AttachType: ebpf.AttachTraceFEntry,
+		AttachTo:   funcName,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+	}
+	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err != nil {
+		return false
+	}
+	defer prog.Close()
+
+	link, err := link.AttachTracing(link.TracingOptions{
+		Program: prog,
+	})
+	if err != nil {
+		return false
+	}
+	defer link.Close()
+
+	return true
+}
+
+// HaveFentrySupport returns whether the kernel supports fentry probes
+func (k *Version) HaveFentrySupport() bool {
+	return k.commonFentryCheck("vfs_open")
+}
+
+// HaveFentrySupportWithStructArgs returns whether the kernel supports fentry probes with struct arguments
+func (k *Version) HaveFentrySupportWithStructArgs() bool {
+	return k.commonFentryCheck("audit_set_loginuid")
+}
+
+// HaveFentryNoDuplicatedWeakSymbols returns whether the kernel supports fentry probes with struct arguments
+func (k *Version) HaveFentryNoDuplicatedWeakSymbols() bool {
+	var symbol string
+	switch runtime.GOARCH {
+	case "amd64":
+		symbol = "__ia32_sys_setregid16"
+	default:
+		return true
+	}
+
+	return k.commonFentryCheck(symbol)
+}
+
+// SupportCORE returns is CORE is supported
+func (k *Version) SupportCORE() bool {
+	_, err := btf.LoadKernelSpec()
+	return err == nil
+}

--- a/pkg/security/ebpf/kernel/kernel_nobpf.go
+++ b/pkg/security/ebpf/kernel/kernel_nobpf.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !linux_bpf
+
+// Package kernel holds kernel related files
+package kernel
+
+// SupportCORE returns is CORE is supported (here it's not, since we are built without eBPF support)
+func (k *Version) SupportCORE() bool {
+	return false
+}

--- a/pkg/security/ebpf/kernel/kernel_nobpf.go
+++ b/pkg/security/ebpf/kernel/kernel_nobpf.go
@@ -8,7 +8,14 @@
 // Package kernel holds kernel related files
 package kernel
 
-// SupportCORE returns is CORE is supported (here it's not, since we are built without eBPF support)
+// SupportCORE returns is CORE is supported
+// here it's not, since we are built without eBPF support
 func (k *Version) SupportCORE() bool {
+	return false
+}
+
+// HasSKStorage returns true if the kernel supports SK_STORAGE maps
+// here it's not, since we are built without eBPF support
+func (k *Version) HasSKStorage() bool {
 	return false
 }

--- a/pkg/security/ebpf/kernel/kernel_nobpf.go
+++ b/pkg/security/ebpf/kernel/kernel_nobpf.go
@@ -19,3 +19,57 @@ func (k *Version) SupportCORE() bool {
 func (k *Version) HasSKStorage() bool {
 	return false
 }
+
+// HaveRingBuffers returns whether the kernel supports ring buffer.
+// here it's not, since we are built without eBPF support
+func (k *Version) HaveRingBuffers() bool {
+	return false
+}
+
+// HaveFentrySupport returns whether the kernel supports fentry probes
+// here it's not, since we are built without eBPF support
+func (k *Version) HaveFentrySupport() bool {
+	return false
+}
+
+// HaveFentrySupportWithStructArgs returns whether the kernel supports fentry probes with struct arguments
+// here it's not, since we are built without eBPF support
+func (k *Version) HaveFentrySupportWithStructArgs() bool {
+	return false
+}
+
+// HaveFentryNoDuplicatedWeakSymbols returns whether the kernel supports fentry probes with struct arguments
+// here it's not, since we are built without eBPF support
+func (k *Version) HaveFentryNoDuplicatedWeakSymbols() bool {
+	return false
+}
+
+// HasBPFForEachMapElemHelper returns true if the kernel support the bpf_for_each_map_elem helper
+// here it's not, since we are built without eBPF support
+func (k *Version) HasBPFForEachMapElemHelper() bool {
+	return false
+}
+
+// HaveMmapableMaps returns whether the kernel supports mmapable maps.
+// here it's not, since we are built without eBPF support
+func (k *Version) HaveMmapableMaps() bool {
+	return false
+}
+
+// HasCgroupSysctlSupportWithRingbuf returns true if cgroup/sysctl programs are available with access to ringbuffer
+// here it's not, since we are built without eBPF support
+func (k *Version) HasCgroupSysctlSupportWithRingbuf() bool {
+	return false
+}
+
+// HasSKStorageInTracingPrograms returns true if the kernel supports SK_STORAGE maps in tracing programs
+// here it's not, since we are built without eBPF support
+func (k *Version) HasSKStorageInTracingPrograms() bool {
+	return false
+}
+
+// HasTracingHelpersInCgroupSysctlPrograms returns true if basic tracing helpers are available in cgroup/sysctl programs
+// here it's not, since we are built without eBPF support
+func (k *Version) HasTracingHelpersInCgroupSysctlPrograms() bool {
+	return false
+}

--- a/pkg/security/rules/filtermodel/rule_filters_model_linux.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model_linux.go
@@ -18,13 +18,13 @@ import (
 
 // RuleFilterEvent defines a rule filter event
 type RuleFilterEvent struct {
-	*kernel.Version
+	kv  *kernel.Version
 	cfg RuleFilterEventConfig
 }
 
 // RuleFilterModel defines a filter model
 type RuleFilterModel struct {
-	*kernel.Version
+	kv  *kernel.Version
 	cfg RuleFilterEventConfig
 }
 
@@ -35,16 +35,16 @@ func NewRuleFilterModel(cfg RuleFilterEventConfig) (*RuleFilterModel, error) {
 		return nil, err
 	}
 	return &RuleFilterModel{
-		Version: kv,
-		cfg:     cfg,
+		kv:  kv,
+		cfg: cfg,
 	}, nil
 }
 
 // NewEvent returns a new event
 func (m *RuleFilterModel) NewEvent() eval.Event {
 	return &RuleFilterEvent{
-		Version: m.Version,
-		cfg:     m.cfg,
+		kv:  m.kv,
+		cfg: m.cfg,
 	}
 }
 
@@ -54,7 +54,7 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 	case "kernel.version.major":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
-				kv := ctx.Event.(*RuleFilterEvent)
+				kv := ctx.Event.(*RuleFilterEvent).kv
 				if ubuntuKernelVersion := kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 					return int(ubuntuKernelVersion.Major)
 				}
@@ -65,7 +65,7 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 	case "kernel.version.minor":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
-				kv := ctx.Event.(*RuleFilterEvent)
+				kv := ctx.Event.(*RuleFilterEvent).kv
 				if ubuntuKernelVersion := kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 					return int(ubuntuKernelVersion.Minor)
 				}
@@ -76,7 +76,7 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 	case "kernel.version.patch":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
-				kv := ctx.Event.(*RuleFilterEvent)
+				kv := ctx.Event.(*RuleFilterEvent).kv
 				if ubuntuKernelVersion := kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 					return int(ubuntuKernelVersion.Patch)
 				}
@@ -87,7 +87,7 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 	case "kernel.version.abi":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
-				kv := ctx.Event.(*RuleFilterEvent)
+				kv := ctx.Event.(*RuleFilterEvent).kv
 				if ubuntuKernelVersion := kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 					return int(ubuntuKernelVersion.Abi)
 				}
@@ -98,7 +98,7 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 	case "kernel.version.flavor":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
-				kv := ctx.Event.(*RuleFilterEvent)
+				kv := ctx.Event.(*RuleFilterEvent).kv
 				if ubuntuKernelVersion := kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 					return ubuntuKernelVersion.Flavor
 				}
@@ -113,70 +113,70 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 		}, nil
 	case "os.id":
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return ctx.Event.(*RuleFilterEvent).OsRelease["ID"] },
+			EvalFnc: func(ctx *eval.Context) string { return ctx.Event.(*RuleFilterEvent).kv.OsRelease["ID"] },
 			Field:   field,
 		}, nil
 	case "os.platform_id":
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return ctx.Event.(*RuleFilterEvent).OsRelease["PLATFORM_ID"] },
+			EvalFnc: func(ctx *eval.Context) string { return ctx.Event.(*RuleFilterEvent).kv.OsRelease["PLATFORM_ID"] },
 			Field:   field,
 		}, nil
 	case "os.version_id":
 		return &eval.StringEvaluator{
-			EvalFnc: func(ctx *eval.Context) string { return ctx.Event.(*RuleFilterEvent).OsRelease["VERSION_ID"] },
+			EvalFnc: func(ctx *eval.Context) string { return ctx.Event.(*RuleFilterEvent).kv.OsRelease["VERSION_ID"] },
 			Field:   field,
 		}, nil
 
 	case "os.is_amazon_linux":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsAmazonLinuxKernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsAmazonLinuxKernel() },
 			Field:   field,
 		}, nil
 	case "os.is_cos":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsCOSKernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsCOSKernel() },
 			Field:   field,
 		}, nil
 	case "os.is_debian":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsDebianKernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsDebianKernel() },
 			Field:   field,
 		}, nil
 	case "os.is_oracle":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsOracleUEKKernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsOracleUEKKernel() },
 			Field:   field,
 		}, nil
 	case "os.is_rhel":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
-				return ctx.Event.(*RuleFilterEvent).IsRH7Kernel() || ctx.Event.(*RuleFilterEvent).IsRH8Kernel()
+				return ctx.Event.(*RuleFilterEvent).kv.IsRH7Kernel() || ctx.Event.(*RuleFilterEvent).kv.IsRH8Kernel()
 			},
 			Field: field,
 		}, nil
 	case "os.is_rhel7":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsRH7Kernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsRH7Kernel() },
 			Field:   field,
 		}, nil
 	case "os.is_rhel8":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsRH8Kernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsRH8Kernel() },
 			Field:   field,
 		}, nil
 	case "os.is_sles":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsSLESKernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsSLESKernel() },
 			Field:   field,
 		}, nil
 	case "os.is_sles12":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsSuse12Kernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsSuse12Kernel() },
 			Field:   field,
 		}, nil
 	case "os.is_sles15":
 		return &eval.BoolEvaluator{
-			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).IsSuse15Kernel() },
+			EvalFnc: func(ctx *eval.Context) bool { return ctx.Event.(*RuleFilterEvent).kv.IsSuse15Kernel() },
 			Field:   field,
 		}, nil
 	case "envs":
@@ -198,7 +198,7 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 				revt := ctx.Event.(*RuleFilterEvent)
-				return revt.cfg.COREEnabled && revt.SupportCORE()
+				return revt.cfg.COREEnabled && revt.kv.SupportCORE()
 			},
 			Field: field,
 		}, nil
@@ -211,27 +211,27 @@ func (m *RuleFilterModel) GetEvaluator(field eval.Field, _ eval.RegisterID) (eva
 func (e *RuleFilterEvent) GetFieldValue(field eval.Field) (interface{}, error) {
 	switch field {
 	case "kernel.version.major":
-		if ubuntuKernelVersion := e.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
+		if ubuntuKernelVersion := e.kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 			return int(ubuntuKernelVersion.Major), nil
 		}
-		return int(e.Code.Major()), nil
+		return int(e.kv.Code.Major()), nil
 	case "kernel.version.minor":
-		if ubuntuKernelVersion := e.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
+		if ubuntuKernelVersion := e.kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 			return int(ubuntuKernelVersion.Minor), nil
 		}
-		return int(e.Code.Minor()), nil
+		return int(e.kv.Code.Minor()), nil
 	case "kernel.version.patch":
-		if ubuntuKernelVersion := e.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
+		if ubuntuKernelVersion := e.kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 			return int(ubuntuKernelVersion.Patch), nil
 		}
-		return int(e.Code.Patch()), nil
+		return int(e.kv.Code.Patch()), nil
 	case "kernel.version.abi":
-		if ubuntuKernelVersion := e.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
+		if ubuntuKernelVersion := e.kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 			return int(ubuntuKernelVersion.Abi), nil
 		}
 		return 0, nil
 	case "kernel.version.flavor":
-		if ubuntuKernelVersion := e.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
+		if ubuntuKernelVersion := e.kv.UbuntuKernelVersion(); ubuntuKernelVersion != nil {
 			return ubuntuKernelVersion.Flavor, nil
 		}
 		return "", nil
@@ -239,32 +239,32 @@ func (e *RuleFilterEvent) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "os":
 		return runtime.GOOS, nil
 	case "os.id":
-		return e.OsRelease["ID"], nil
+		return e.kv.OsRelease["ID"], nil
 	case "os.platform_id":
-		return e.OsRelease["PLATFORM_ID"], nil
+		return e.kv.OsRelease["PLATFORM_ID"], nil
 	case "os.version_id":
-		return e.OsRelease["VERSION_ID"], nil
+		return e.kv.OsRelease["VERSION_ID"], nil
 
 	case "os.is_amazon_linux":
-		return e.IsAmazonLinuxKernel(), nil
+		return e.kv.IsAmazonLinuxKernel(), nil
 	case "os.is_cos":
-		return e.IsCOSKernel(), nil
+		return e.kv.IsCOSKernel(), nil
 	case "os.is_debian":
-		return e.IsDebianKernel(), nil
+		return e.kv.IsDebianKernel(), nil
 	case "os.is_oracle":
-		return e.IsOracleUEKKernel(), nil
+		return e.kv.IsOracleUEKKernel(), nil
 	case "os.is_rhel":
-		return e.IsRH7Kernel() || e.IsRH8Kernel(), nil
+		return e.kv.IsRH7Kernel() || e.kv.IsRH8Kernel(), nil
 	case "os.is_rhel7":
-		return e.IsRH7Kernel(), nil
+		return e.kv.IsRH7Kernel(), nil
 	case "os.is_rhel8":
-		return e.IsRH8Kernel(), nil
+		return e.kv.IsRH8Kernel(), nil
 	case "os.is_sles":
-		return e.IsSLESKernel(), nil
+		return e.kv.IsSLESKernel(), nil
 	case "os.is_sles12":
-		return e.IsSuse12Kernel(), nil
+		return e.kv.IsSuse12Kernel(), nil
 	case "os.is_sles15":
-		return e.IsSuse15Kernel(), nil
+		return e.kv.IsSuse15Kernel(), nil
 	case "envs":
 		return os.Environ(), nil
 	case "origin":
@@ -272,7 +272,7 @@ func (e *RuleFilterEvent) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "hostname":
 		return getHostname(), nil
 	case "kernel.core.enabled":
-		return e.cfg.COREEnabled && e.SupportCORE(), nil
+		return e.cfg.COREEnabled && e.kv.SupportCORE(), nil
 	}
 
 	return nil, &eval.ErrFieldNotFound{Field: field}

--- a/pkg/security/rules/filtermodel/rule_filters_model_linux.go
+++ b/pkg/security/rules/filtermodel/rule_filters_model_linux.go
@@ -40,6 +40,14 @@ func NewRuleFilterModel(cfg RuleFilterEventConfig) (*RuleFilterModel, error) {
 	}, nil
 }
 
+// NewRuleFilterModelWithKernelVersion returns a new rule filter model
+func NewRuleFilterModelWithKernelVersion(cfg RuleFilterEventConfig, kv *kernel.Version) *RuleFilterModel {
+	return &RuleFilterModel{
+		kv:  kv,
+		cfg: cfg,
+	}
+}
+
 // NewEvent returns a new event
 func (m *RuleFilterModel) NewEvent() eval.Event {
 	return &RuleFilterEvent{

--- a/pkg/security/tests/rule_filters_test.go
+++ b/pkg/security/tests/rule_filters_test.go
@@ -29,9 +29,7 @@ func TestSECLRuleFilter(t *testing.T) {
 		Code:         kernel.Kernel5_9,
 	}
 
-	m, err := filtermodel.NewRuleFilterModel(filtermodel.RuleFilterEventConfig{})
-	assert.NoError(t, err)
-	m.Version = kv
+	m := filtermodel.NewRuleFilterModelWithKernelVersion(filtermodel.RuleFilterEventConfig{}, kv)
 	seclRuleFilter := rules.NewSECLRuleFilter(m)
 
 	t.Run("true", func(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR allows the cluster-agent/security-agent compliance part to use a `*kernel.Version` from pkg/security/ebpf without importing the whole cilium/ebpf library and feature detection.

The main idea is to gate the feature detection part under `linux_bpf` (a system-probe specific tag), and to provide fallback for other binaries or tool (like go generate stuff)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->