### PR TITLE
eBPF: strip the LBB* symbols from eBPF object files

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -134,10 +134,14 @@ def ninja_define_ebpf_compiler(
         command="/opt/datadog-agent/embedded/bin/clang-bpf -MD -MF $out.d $target $ebpfflags $kheaders $flags -c $in -o $out",
         depfile="$out.d",
     )
-    strip = "&& /opt/datadog-agent/embedded/bin/llvm-strip -g $out" if strip_object_files else ""
+
+    strip = "/opt/datadog-agent/embedded/bin/llvm-strip -g $out"
+    strip_lbb = "/opt/datadog-agent/embedded/bin/llvm-strip -w -N \"LBB*\" $out"
+    strip_part = f"&& {strip} && {strip_lbb}" if strip_object_files else ""
+
     nw.rule(
         name="llc",
-        command=f"/opt/datadog-agent/embedded/bin/llc-bpf -march=bpf -filetype=obj -o $out $in {strip}",
+        command=f"/opt/datadog-agent/embedded/bin/llc-bpf -march=bpf -filetype=obj -o $out $in {strip_part}",
     )
 
 


### PR DESCRIPTION
Reverts DataDog/datadog-agent#35867

# What does this PR do?

When building eBPF object files, LLVM will include thousands of LLB* symbols, that are the entrypoint of the LLVM basic blocks. Those symbols are useless as far as eBPF is concerned, and ignored at load time by cilium/ebpf https://github.com/cilium/ebpf/blob/e3234a15a707cc0b79b78acee40773895350d5d7/elf_reader.go#L292.

This PR strips them in addition to regular -g strip, when stripping object files.