### PR TITLE
Go DI e2e test improvements

### DIFF
--- a/pkg/dynamicinstrumentation/testutil/e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/e2e_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 	"text/template"
@@ -53,6 +54,17 @@ func TestGoDI(t *testing.T) {
 		t.Skip("ringbuffers not supported on this kernel")
 	}
 
+	for function, expectedCaptureTuples := range expectedCaptures {
+		for _, expectedCaptureValue := range expectedCaptureTuples {
+			justFunctionName := string(function[strings.LastIndex(function, ".")+1:])
+			t.Run(justFunctionName, func(t *testing.T) {
+				runTestCase(t, function, expectedCaptureValue)
+			})
+		}
+	}
+}
+
+func runTestCase(t *testing.T, function string, expectedCaptureValue CapturedValueMapWithOptions) {
 	serviceName := "go-di-sample-service-" + randomLabel()
 	sampleServicePath := BuildSampleService(t)
 	cmd := exec.Command(sampleServicePath)
@@ -79,7 +91,7 @@ func TestGoDI(t *testing.T) {
 
 	require.NoError(t, cmd.Start())
 	t.Cleanup(func() {
-		t.Log(cmd.Process.Kill())
+		cmd.Process.Kill()
 	})
 
 	eventOutputWriter := &eventOutputTestWriter{
@@ -115,47 +127,44 @@ func TestGoDI(t *testing.T) {
 	b := []byte{}
 	var buf *bytes.Buffer
 	doCapture = false
-	for function, expectedCaptureTuples := range expectedCaptures {
-		for _, expectedCaptureValue := range expectedCaptureTuples {
-			// Generate config for this function
-			buf = bytes.NewBuffer(b)
-			functionWithoutPackagePrefix, _ := strings.CutPrefix(function, "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.")
-			t.Log("Instrumenting ", functionWithoutPackagePrefix)
-			results[function] = &testResult{
-				testName:          functionWithoutPackagePrefix,
-				expectation:       expectedCaptureValue.CapturedValueMap,
-				matches:           []bool{},
-				unexpectedResults: []ditypes.CapturedValueMap{},
-			}
-			err = cfgTemplate.Execute(buf, configDataType{
-				ServiceName:  serviceName,
-				FunctionName: functionWithoutPackagePrefix,
-				CaptureDepth: expectedCaptureValue.Options.CaptureDepth,
-			})
-			require.NoError(t, err)
-			eventOutputWriter.expectedResult = expectedCaptureValue.CapturedValueMap
 
-			// Read the configuration via the config manager
-			_, err := cm.ConfigWriter.Write(buf.Bytes())
-			time.Sleep(time.Second * 2)
-			doCapture = true
-			if err != nil {
-				t.Errorf("could not read new configuration: %s", err)
-			}
-			time.Sleep(time.Second * 2)
-			doCapture = false
-		}
+	// Generate config for this function
+	buf = bytes.NewBuffer(b)
+	functionWithoutPackagePrefix, _ := strings.CutPrefix(function, "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.")
+	t.Log("Instrumenting ", functionWithoutPackagePrefix)
+	result := &testResult{
+		testName:          function,
+		expectation:       expectedCaptureValue.CapturedValueMap,
+		matches:           []bool{},
+		unexpectedResults: []ditypes.CapturedValueMap{},
 	}
+	results[function] = result
+	err = cfgTemplate.Execute(buf, configDataType{
+		ServiceName:  serviceName,
+		FunctionName: functionWithoutPackagePrefix,
+		CaptureDepth: expectedCaptureValue.Options.CaptureDepth,
+	})
+	require.NoError(t, err)
+	eventOutputWriter.expectedResult = expectedCaptureValue.CapturedValueMap
 
-	for i := range results {
-		for _, ok := range results[i].matches {
-			if !ok {
-				t.Errorf("Failed test for: %s\nReceived event: %v\nExpected: %v",
-					results[i].testName,
-					pretty.Sprint(results[i].unexpectedResults),
-					pretty.Sprint(results[i].expectation))
-				break
-			}
+	// Read the configuration via the config manager
+	_, err = cm.ConfigWriter.Write(buf.Bytes())
+	time.Sleep(time.Second * 2)
+	doCapture = true
+	if err != nil {
+		t.Errorf("could not read new configuration: %s", err)
+	}
+	time.Sleep(time.Second * 2)
+	doCapture = false
+
+	// Check results
+	for _, ok := range result.matches {
+		if !ok {
+			t.Errorf("Failed test for: %s\nReceived event: %v\nExpected: %v",
+				result.testName,
+				pretty.Sprint(result.unexpectedResults),
+				pretty.Sprint(result.expectation))
+			break
 		}
 	}
 }
@@ -166,6 +175,64 @@ type eventOutputTestWriter struct {
 }
 
 var doCapture bool
+
+// compareCapturedValues compares two CapturedValueMap objects in a deterministic way.
+// This function is needed because the test results are stored in maps, which don't guarantee
+// a consistent iteration order.
+//
+// The function ensures consistent comparison by:
+// 1. Comparing map lengths first
+// 2. Sorting keys before comparison
+// 3. Recursively comparing nested fields
+// 4. Comparing all relevant fields (Type, NotCapturedReason, Value) in a deterministic order
+func compareCapturedValues(expected, actual ditypes.CapturedValueMap) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+
+	expectedKeys := make([]string, 0, len(expected))
+	for k := range expected {
+		expectedKeys = append(expectedKeys, k)
+	}
+	sort.Strings(expectedKeys)
+
+	actualKeys := make([]string, 0, len(actual))
+	for k := range actual {
+		actualKeys = append(actualKeys, k)
+	}
+	sort.Strings(actualKeys)
+
+	if !reflect.DeepEqual(expectedKeys, actualKeys) {
+		return false
+	}
+
+	for _, k := range expectedKeys {
+		expectedVal := expected[k]
+		actualVal := actual[k]
+
+		if expectedVal.Type != actualVal.Type {
+			return false
+		}
+
+		if expectedVal.NotCapturedReason != actualVal.NotCapturedReason {
+			return false
+		}
+
+		if expectedVal.Value != nil && actualVal.Value != nil {
+			if *expectedVal.Value != *actualVal.Value {
+				return false
+			}
+		} else if expectedVal.Value != nil || actualVal.Value != nil {
+			return false
+		}
+
+		if !compareCapturedValues(expectedVal.Fields, actualVal.Fields) {
+			return false
+		}
+	}
+
+	return true
+}
 
 func (e *eventOutputTestWriter) Write(p []byte) (n int, err error) {
 	if !doCapture {
@@ -184,7 +251,7 @@ func (e *eventOutputTestWriter) Write(p []byte) (n int, err error) {
 		e.t.Errorf("received event from unexpected probe: %s", funcName)
 		return
 	}
-	if !reflect.DeepEqual(e.expectedResult, actual) {
+	if !compareCapturedValues(e.expectedResult, actual) {
 		b.matches = append(b.matches, false)
 		b.unexpectedResults = append(b.unexpectedResults, actual)
 		e.t.Error("received unexpected value")

--- a/pkg/dynamicinstrumentation/testutil/e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/e2e_test.go
@@ -125,10 +125,9 @@ func runTestCase(t *testing.T, function string, expectedCaptureValue CapturedVal
 	require.NoError(t, err)
 
 	b := []byte{}
-	var buf *bytes.Buffer
+	buf := bytes.NewBuffer(b)
 
 	// Generate config for this function
-	buf = bytes.NewBuffer(b)
 	functionWithoutPackagePrefix, _ := strings.CutPrefix(function, "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.")
 	t.Log("Instrumenting ", functionWithoutPackagePrefix)
 	result := &testResult{

--- a/pkg/dynamicinstrumentation/testutil/e2e_test.go
+++ b/pkg/dynamicinstrumentation/testutil/e2e_test.go
@@ -126,7 +126,6 @@ func runTestCase(t *testing.T, function string, expectedCaptureValue CapturedVal
 
 	b := []byte{}
 	var buf *bytes.Buffer
-	doCapture = false
 
 	// Generate config for this function
 	buf = bytes.NewBuffer(b)

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -148,68 +148,80 @@ var stringCaptures = fixtures{
 var arrayCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_byte_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Fields: fieldMap{
-				"arg_0": capturedValue("uint8", "1"),
-				"arg_1": capturedValue("uint8", "1"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "uint8", Value: strPtr("1")},
+				{Type: "uint8", Value: strPtr("1")},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_rune_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Fields: fieldMap{
-				"arg_0": capturedValue("int32", "1"),
-				"arg_1": capturedValue("int32", "2"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "int32", Value: strPtr("1")},
+				{Type: "int32", Value: strPtr("2")},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Fields: fieldMap{
-				"arg_0": capturedValue("string", "one"),
-				"arg_1": capturedValue("string", "two"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "string", Value: strPtr("one")},
+				{Type: "string", Value: strPtr("two")},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_int_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Fields: fieldMap{
-				"arg_0": capturedValue("int", "1"),
-				"arg_1": capturedValue("int", "2"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "[2]int", Elements: []ditypes.CapturedValue{
+				{Type: "int", Value: strPtr("1")},
+				{Type: "int", Value: strPtr("2")},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_int8_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Fields: fieldMap{
-				"arg_0": capturedValue("int8", "1"),
-				"arg_1": capturedValue("int8", "2"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "int8", Value: strPtr("1")},
+				{Type: "int8", Value: strPtr("2")},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_uint_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Fields: fieldMap{
-				"arg_0": capturedValue("uint", "1"),
-				"arg_1": capturedValue("uint", "2"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "uint", Value: strPtr("1")},
+				{Type: "uint", Value: strPtr("2")},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_array_of_arrays": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"arg_0": {Type: "array", Fields: fieldMap{
-				"arg_0": {Type: "array", Fields: fieldMap{
-					"arg_0": capturedValue("int", "1"),
-					"arg_1": capturedValue("int", "2"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"arg_0": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "array", Elements: []ditypes.CapturedValue{
+					{Type: "array", Elements: []ditypes.CapturedValue{
+						{Type: "int", Value: strPtr("1")},
+						{Type: "int", Value: strPtr("2")},
+					}},
+					{Type: "array", Elements: []ditypes.CapturedValue{
+						{Type: "int", Value: strPtr("3")},
+						{Type: "int", Value: strPtr("4")},
+					}},
 				}},
-				"arg_1": {Type: "array", Fields: fieldMap{
-					"arg_0": capturedValue("int", "3"),
-					"arg_1": capturedValue("int", "4"),
+				{Type: "array", Elements: []ditypes.CapturedValue{
+					{Type: "array", Elements: []ditypes.CapturedValue{
+						{Type: "int", Value: strPtr("5")},
+						{Type: "int", Value: strPtr("6")},
+					}},
+					{Type: "array", Elements: []ditypes.CapturedValue{
+						{Type: "int", Value: strPtr("7")},
+						{Type: "int", Value: strPtr("8")},
+					}},
 				}},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
@@ -217,14 +229,14 @@ var arrayCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_array_of_structs": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"a": {Type: "array", Fields: fieldMap{
-				"[2]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct[0]": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct", Fields: fieldMap{
-					"anotherInt":    capturedValue("int", "42"),
-					"anotherString": capturedValue("string", "foo"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"a": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct", Elements: []ditypes.CapturedValue{
+					{Type: "int", Value: strPtr("42")},
+					{Type: "string", Value: strPtr("foo")},
 				}},
-				"[2]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct[1]": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct", Fields: fieldMap{
-					"anotherInt":    capturedValue("int", "24"),
-					"anotherString": capturedValue("string", "bar"),
+				{Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct", Elements: []ditypes.CapturedValue{
+					{Type: "int", Value: strPtr("24")},
+					{Type: "string", Value: strPtr("bar")},
 				}},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
@@ -232,25 +244,27 @@ var arrayCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_array_of_arrays_of_arrays": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"b": {Type: "array", Fields: fieldMap{
-				"[2][2][2]int[0]": {Type: "array", Fields: fieldMap{
-					"[2][2]int[0]": {Type: "array", Fields: fieldMap{
-						"[2]int[0]": capturedValue("int", "1"),
-						"[2]int[1]": capturedValue("int", "2"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"b": {Type: "array", Elements: []ditypes.CapturedValue{
+				{Type: "array", Elements: []ditypes.CapturedValue{
+					{Type: "array", Elements: []ditypes.CapturedValue{
+						{Type: "array", Elements: []ditypes.CapturedValue{
+							{Type: "int", Value: strPtr("1")},
+							{Type: "int", Value: strPtr("2")},
+						}},
+						{Type: "array", Elements: []ditypes.CapturedValue{
+							{Type: "int", Value: strPtr("3")},
+							{Type: "int", Value: strPtr("4")},
+						}},
 					}},
-					"[2][2]int[1]": {Type: "array", Fields: fieldMap{
-						"[2]int[0]": capturedValue("int", "3"),
-						"[2]int[1]": capturedValue("int", "4"),
-					}},
-				}},
-				"[2][2][2]int[1]": {Type: "array", Fields: fieldMap{
-					"[2][2]int[0]": {Type: "array", Fields: fieldMap{
-						"[2]int[0]": capturedValue("int", "5"),
-						"[2]int[1]": capturedValue("int", "6"),
-					}},
-					"[2][2]int[1]": {Type: "array", Fields: fieldMap{
-						"[2]int[0]": capturedValue("int", "7"),
-						"[2]int[1]": capturedValue("int", "8"),
+					{Type: "array", Elements: []ditypes.CapturedValue{
+						{Type: "array", Elements: []ditypes.CapturedValue{
+							{Type: "int", Value: strPtr("5")},
+							{Type: "int", Value: strPtr("6")},
+						}},
+						{Type: "array", Elements: []ditypes.CapturedValue{
+							{Type: "int", Value: strPtr("7")},
+							{Type: "int", Value: strPtr("8")},
+						}},
 					}},
 				}},
 			}}},
@@ -262,10 +276,10 @@ var arrayCaptures = fixtures{
 var sliceCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_uint_slice": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"u": {Type: "[]uint", Fields: fieldMap{
-				"[0]uint": capturedValue("uint", "1"),
-				"[1]uint": capturedValue("uint", "2"),
-				"[2]uint": capturedValue("uint", "3"),
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"u": {Type: "[]uint", Elements: []ditypes.CapturedValue{
+				{Type: "uint", Value: strPtr("1")},
+				{Type: "uint", Value: strPtr("2")},
+				{Type: "uint", Value: strPtr("3")},
 			}}},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
@@ -276,15 +290,15 @@ var sliceCaptures = fixtures{
 				"a": capturedValue("int", "3"),
 				"xs": {
 					Type: "[]struct",
-					Fields: fieldMap{
-						"[0]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings": &ditypes.CapturedValue{
+					Elements: []ditypes.CapturedValue{
+						{
 							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings",
 							Fields: fieldMap{
 								"aUint8": capturedValue("uint8", "42"),
 								"aBool":  capturedValue("bool", "true"),
 							},
 						},
-						"[1]github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings": &ditypes.CapturedValue{
+						{
 							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings",
 							Fields: fieldMap{
 								"aUint8": capturedValue("uint8", "24"),
@@ -337,32 +351,248 @@ var sliceCaptures = fixtures{
 }
 
 var structCaptures = fixtures{
-	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_struct": []CapturedValueMapWithOptions{
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_with_unsupported_fields": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"t": {
-					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.threestrings", Fields: fieldMap{
-						"a": capturedValue("string", "a"),
-						"b": capturedValue("string", "bb"),
-						"c": capturedValue("string", "ccc"),
+				"a": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.hasUnsupportedFields",
+					Fields: fieldMap{
+						"a": capturedValue("int", "1"),
+						"b": capturedValue("float32", ""),
+						"c": {
+							Type: "[]uint8",
+							Elements: []ditypes.CapturedValue{
+								*capturedValue("uint8", "3"),
+								*capturedValue("uint8", "4"),
+								*capturedValue("uint8", "5"),
+							},
+						},
 					},
 				},
 			},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
-	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.receiver.test_method_receiver": []CapturedValueMapWithOptions{
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_pointer_method_receiver": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"r": {
-					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.receiver", Fields: fieldMap{
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.receiver",
+					Fields: fieldMap{
+						"arg_0": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.receiver",
+							Fields: fieldMap{
+								"u": capturedValue("uint", "3"),
+							},
+						},
+					},
+				},
+				"a": capturedValue("int", "4"),
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_method_receiver": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"r": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.receiver",
+					Fields: fieldMap{
 						"u": capturedValue("uint", "1"),
-					}},
+					},
+				},
 				"a": capturedValue("int", "2"),
 			},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_with_array": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithAnArray",
+					Fields: fieldMap{
+						"arr": {
+							Type: "[5]uint8",
+							Elements: []ditypes.CapturedValue{
+								*capturedValue("uint8", "1"),
+								*capturedValue("uint8", "2"),
+								*capturedValue("uint8", "3"),
+								*capturedValue("uint8", "4"),
+								*capturedValue("uint8", "5"),
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_with_a_slice": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"s": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithASlice",
+					Fields: fieldMap{
+						"x": capturedValue("int", "1"),
+						"slice": {
+							Type: "[]uint8",
+							Elements: []ditypes.CapturedValue{
+								*capturedValue("uint8", "2"),
+								*capturedValue("uint8", "3"),
+								*capturedValue("uint8", "4"),
+							},
+						},
+						"z": capturedValue("int", "5"),
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_with_an_empty_slice": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"s": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithASlice",
+					Fields: fieldMap{
+						"x": capturedValue("int", "9"),
+						"slice": {
+							Type:     "[]int",
+							Elements: []ditypes.CapturedValue{},
+						},
+						"z": capturedValue("int", "5"),
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_with_a_nil_slice": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"s": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithASlice",
+					Fields: fieldMap{
+						"x":     capturedValue("int", "9"),
+						"slice": {Type: "[]uint8"},
+						"z":     capturedValue("uint64", "5"),
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_pointer_to_struct_with_a_slice": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"s": {
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithASlice",
+					Fields: fieldMap{
+						"arg_0": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithASlice",
+							Fields: fieldMap{
+								"x": capturedValue("int", "5"),
+								"slice": {
+									Type: "[]int",
+									Elements: []ditypes.CapturedValue{
+										*capturedValue("int", "2"),
+										*capturedValue("int", "3"),
+										*capturedValue("int", "4"),
+									},
+								},
+								"z": capturedValue("int", "5"),
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_pointer_to_struct_with_a_string": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"s": {
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithAString",
+					Fields: fieldMap{
+						"arg_0": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithAString",
+							Fields: fieldMap{
+								"x": capturedValue("int", "5"),
+								"s": capturedValue("string", "abcdef"),
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.aStruct",
+					Fields: fieldMap{
+						"aBool":   capturedValue("bool", "true"),
+						"aString": capturedValue("string", "one"),
+						"aNumber": capturedValue("int", "2"),
+						"nested": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct",
+							Fields: fieldMap{
+								"anotherInt":    capturedValue("int", "3"),
+								"anotherString": capturedValue("string", "four"),
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_with_arrays": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"s": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithTwoArrays",
+					Fields: fieldMap{
+						"a": {
+							Type: "[3]uint64",
+							Elements: []ditypes.CapturedValue{
+								*capturedValue("uint64", "1"),
+								*capturedValue("uint64", "2"),
+								*capturedValue("uint64", "3"),
+							},
+						},
+						"b": capturedValue("int", "4"),
+						"c": {
+							Type: "[5]int64",
+							Elements: []ditypes.CapturedValue{
+								*capturedValue("int64", "6"),
+								*capturedValue("int64", "7"),
+								*capturedValue("int64", "8"),
+								*capturedValue("int64", "9"),
+								*capturedValue("int64", "10"),
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nonembedded_struct": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
@@ -372,26 +602,13 @@ var structCaptures = fixtures{
 						"aBool":  capturedValue("bool", "true"),
 						"aInt":   capturedValue("int", "1"),
 						"aInt16": capturedValue("int16", "2"),
-					}}},
+					},
+				},
+			},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
-	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_pointer": []CapturedValueMapWithOptions{
-		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"x": {
-					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct",
-					Fields: fieldMap{
-						"arg_0": {
-							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nStruct", Fields: fieldMap{
-								"aBool":  capturedValue("bool", "true"),
-								"aInt":   capturedValue("int", "1"),
-								"aInt16": capturedValue("int16", "2"),
-							}},
-					}}},
-			Options: TestInstrumentationOptions{CaptureDepth: 10},
-		},
-	},
+
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_multiple_embedded_struct": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
@@ -400,18 +617,248 @@ var structCaptures = fixtures{
 					Fields: fieldMap{
 						"aInt16": capturedValue("int16", "42"),
 						"nested": {
-							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.aStruct", Fields: fieldMap{
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.aStruct",
+							Fields: fieldMap{
 								"aBool":   capturedValue("bool", "true"),
 								"aString": capturedValue("string", "one"),
 								"aNumber": capturedValue("int", "2"),
-								"nested": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct", Fields: fieldMap{
-									"anotherInt":    capturedValue("int", "3"),
-									"anotherString": capturedValue("string", "four"),
-								}},
-							}},
+								"nested": {
+									Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct",
+									Fields: fieldMap{
+										"anotherInt":    capturedValue("int", "3"),
+										"anotherString": capturedValue("string", "four"),
+									},
+								},
+							},
+						},
 						"aBool":  capturedValue("bool", "true"),
 						"aInt32": capturedValue("int32", "31"),
-					}}},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_no_string_struct": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"c": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.cStruct",
+					Fields: fieldMap{
+						"aInt32": capturedValue("int32", "4"),
+						"aUint":  capturedValue("uint", "1"),
+						"nested": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.structWithNoStrings",
+							Fields: fieldMap{
+								"aUint8": capturedValue("uint8", "9"),
+								"aBool":  capturedValue("bool", "true"),
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_struct_and_byte": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"w": capturedValue("uint8", "97"),
+				"x": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.aStruct",
+					Fields: fieldMap{
+						"aBool":   capturedValue("bool", "true"),
+						"aString": capturedValue("string", "one"),
+						"aNumber": capturedValue("int", "2"),
+						"nested": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct",
+							Fields: fieldMap{
+								"anotherInt":    capturedValue("int", "3"),
+								"anotherString": capturedValue("string", "four"),
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_nested_pointer": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": {
+					Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.anotherStruct",
+					Fields: fieldMap{
+						"arg_0": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.anotherStruct",
+							Fields: fieldMap{
+								"nested": {
+									Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct",
+									Fields: fieldMap{
+										"anotherInt":    capturedValue("int", "42"),
+										"anotherString": capturedValue("string", "xyz"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_ten_strings": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"x": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.tenStrings",
+					Fields: fieldMap{
+						"first":   capturedValue("string", "one"),
+						"second":  capturedValue("string", "two"),
+						"third":   capturedValue("string", "three"),
+						"fourth":  capturedValue("string", "four"),
+						"fifth":   capturedValue("string", "five"),
+						"sixth":   capturedValue("string", "six"),
+						"seventh": capturedValue("string", "seven"),
+						"eighth":  capturedValue("string", "eight"),
+						"ninth":   capturedValue("string", "nine"),
+						"tenth":   capturedValue("string", "ten"),
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_struct": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"t": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.threestrings",
+					Fields: fieldMap{
+						"a": capturedValue("string", "a"),
+						"b": capturedValue("string", "bb"),
+						"c": capturedValue("string", "ccc"),
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_deep_struct": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"t": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.deepStruct1",
+					Fields: fieldMap{
+						"a": capturedValue("int", "1"),
+						"b": {
+							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.deepStruct2",
+							Fields: fieldMap{
+								"c": capturedValue("int", "2"),
+								"d": {
+									Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.deepStruct3",
+									Fields: fieldMap{
+										"e": capturedValue("int", "3"),
+										"f": {
+											Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.deepStruct4",
+											Fields: fieldMap{
+												"g": capturedValue("int", "4"),
+												"h": {
+													Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.deepStruct5",
+													Fields: fieldMap{
+														"i": capturedValue("int", "5"),
+														"j": {
+															Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.deepStruct6",
+															Fields: fieldMap{
+																"k": capturedValue("int", "6"),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_empty_struct": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"e": {
+					Type:   "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.emptyStruct",
+					Fields: fieldMap{},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_lots_of_fields": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"l": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.lotsOfFields",
+					Fields: fieldMap{
+						"a": capturedValue("uint8", "1"),
+						"b": capturedValue("uint8", "2"),
+						"c": capturedValue("uint8", "3"),
+						"d": capturedValue("uint8", "4"),
+						"e": capturedValue("uint8", "5"),
+						"f": capturedValue("uint8", "6"),
+						"g": capturedValue("uint8", "7"),
+						"h": capturedValue("uint8", "8"),
+						"i": capturedValue("uint8", "9"),
+						"j": capturedValue("uint8", "10"),
+						"k": capturedValue("uint8", "11"),
+						"l": capturedValue("uint8", "12"),
+						"m": capturedValue("uint8", "13"),
+						"n": capturedValue("uint8", "14"),
+						"o": capturedValue("uint8", "15"),
+						"p": capturedValue("uint8", "16"),
+						"q": capturedValue("uint8", "17"),
+						"r": capturedValue("uint8", "18"),
+						"s": capturedValue("uint8", "19"),
+						"t": capturedValue("uint8", "20"),
+						"u": &ditypes.CapturedValue{
+							Type:              "uint8",
+							NotCapturedReason: "fieldCount",
+						},
+						"v": &ditypes.CapturedValue{
+							Type:              "uint8",
+							NotCapturedReason: "fieldCount",
+						},
+						"w": &ditypes.CapturedValue{
+							Type:              "uint8",
+							NotCapturedReason: "fieldCount",
+						},
+						"x": &ditypes.CapturedValue{
+							Type:              "uint8",
+							NotCapturedReason: "fieldCount",
+						},
+						"y": &ditypes.CapturedValue{
+							Type:              "uint8",
+							NotCapturedReason: "fieldCount",
+						},
+						"z": &ditypes.CapturedValue{
+							Type:              "uint8",
+							NotCapturedReason: "fieldCount",
+						},
+					},
+				},
+			},
 			Options: TestInstrumentationOptions{CaptureDepth: 10},
 		},
 	},
@@ -520,10 +967,10 @@ var pointerCaptures = fixtures{
 								"x": capturedValue("int", "5"),
 								"slice": &ditypes.CapturedValue{
 									Type: "[]uint8",
-									Fields: fieldMap{
-										"[0]uint8": capturedValue("uint8", "2"),
-										"[1]uint8": capturedValue("uint8", "3"),
-										"[2]uint8": capturedValue("uint8", "4"),
+									Elements: []ditypes.CapturedValue{
+										{Type: "uint8", Value: strPtr("2")},
+										{Type: "uint8", Value: strPtr("3")},
+										{Type: "uint8", Value: strPtr("4")},
 									},
 								},
 								"z": capturedValue("uint64", "5"),
@@ -622,7 +1069,4 @@ var expectedCaptures = mergeMaps(
 	sliceCaptures,
 	pointerCaptures,
 	captureDepthCaptures,
-	// mapCaptures,
-	// genericCaptures,
-	// multiParamCaptures,
 )

--- a/pkg/dynamicinstrumentation/testutil/sample/structs.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/structs.go
@@ -10,9 +10,9 @@ type receiver struct {
 }
 
 type hasUnsupportedFields struct {
-	a int
-	b float32
-	c []uint8
+	b int
+	c float32
+	d []uint8
 }
 
 //nolint:all
@@ -175,9 +175,9 @@ func ExecuteStructFuncs() {
 	test_struct_with_arrays(sta)
 
 	test_struct_with_unsupported_fields(hasUnsupportedFields{
-		a: 1,
-		b: 2.0,
-		c: []uint8{3, 4, 5},
+		b: 1,
+		c: 2.0,
+		d: []uint8{3, 4, 5},
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

- Each e2e test fixture is run as a subtest, giving us the ability to run each test individually which is useful for development.
- Fixes the format/naming of many fixtures/test-cases
- Adds more fixtures/test-cases

### Motivation

Need to improve e2e testing to avoid regressions like in #35839

### Describe how you validated your changes

Ran the e2e tests.

### Possible Drawbacks / Trade-offs

### Additional Notes

There's a lot more improvements to be made. A lot more cases, the ability to run multiple samples at once. There's also still some flakiness that needs to be fixed so that these tests are run in CI reliably. 