### PR TITLE
OTLP: Use "instrumentation scope" rather than "library" for tags in serializer exporter

### DIFF
--- a/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/exporter.go
@@ -122,7 +122,7 @@ func translatorFromConfig(
 	}
 
 	if cfg.ExporterConfig.InstrumentationScopeMetadataAsTags {
-		options = append(options, metrics.WithInstrumentationLibraryMetadataAsTags())
+		options = append(options, metrics.WithInstrumentationScopeMetadataAsTags())
 	}
 
 	var numberMode metrics.NumberMode

--- a/releasenotes/notes/apm-otlp-instrumentation-scope-tags-e12d3069fb7602a4.yaml
+++ b/releasenotes/notes/apm-otlp-instrumentation-scope-tags-e12d3069fb7602a4.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    When using OTLP ingest with metrics, the instrumentation_scope_metadata_as_tags option now
+    outputs the `instrumentation_scope` tag instead of the deprecated `instrumentation_library` tag.


### PR DESCRIPTION
### What does this PR do?

Modifies the serializerexporter to use the `WithInstrumentationScopeMetadataAsTags` option the metrics translator when the `instrumentation_scope_metadata_as_tags` option is set, instead of the `WithInstrumentationLibraryMetadataAsTags`.

The implication is that when `instrumentation_scope_metadata_as_tags` is set, metrics received through OTLP ingest will have a `instrumentation_scope` tag instead of a `instrumentation_library` tag. Considering the bug was introduced 3 years ago (when we transitioned from `instrumentation_library` to `instrumentation_scope`), this might be a breaking change for some users.

### Motivation

The primary goal is to enable the use of the new scope attribute translation once the mapping-go dependency gets updated (see [this PR](https://github.com/DataDog/opentelemetry-mapping-go/pull/598)).

This is also to be consistent with the old metrics exporter from contrib, which uses [this function](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/dda6bf922502281344a0a122c636e8ec1b374d88/pkg/datadog/config/metrics.go#L212) to convert from the config to translator options.

