### PR TITLE
[CSPM] do not import open-policy-agent/opa on windows

### DIFF
--- a/pkg/compliance/evaluator_rego.go
+++ b/pkg/compliance/evaluator_rego.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build unix
+
 package compliance
 
 import (

--- a/pkg/compliance/evaluator_rego_unsupported.go
+++ b/pkg/compliance/evaluator_rego_unsupported.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !unix
+
+package compliance
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// EvaluateRegoRule evaluates the given rule and resolved inputs map against
+// the rule's rego program.
+func EvaluateRegoRule(_ context.Context, _ ResolvedInputs, _ *Benchmark, _ *Rule) []*CheckEvent {
+	log.Errorf("rego evaluator is not supported on this platform")
+	return nil
+}

--- a/pkg/compliance/tests/base_test.go
+++ b/pkg/compliance/tests/base_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux
+
 // Package tests implements the unit tests for pkg/compliance.
 package tests
 

--- a/pkg/compliance/tests/helpers.go
+++ b/pkg/compliance/tests/helpers.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package tests implements the test suite of our compliance package.
 package tests
 
 import (

--- a/pkg/compliance/tests/kubernetes_test.go
+++ b/pkg/compliance/tests/kubernetes_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build kubeapiserver
+//go:build linux && kubeapiserver
 
 package tests
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The CSPM product is not supported on windows. While we could make every file in `pkg/compliance` gated with the linux build tag, this PR does most of it by gating the file importing rego. Allowing to remove most of the weight of this package.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->