### PR TITLE
[CWS] Report error for failing kill actions

### DIFF
--- a/pkg/security/probe/actions.go
+++ b/pkg/security/probe/actions.go
@@ -22,6 +22,8 @@ import (
 type KillActionStatus string
 
 const (
+	// KillActionStatusError indicates the kill action failed
+	KillActionStatusError KillActionStatus = "error"
 	// KillActionStatusPerformed indicates the kill action was performed
 	KillActionStatusPerformed KillActionStatus = "performed"
 	// KillActionStatusRuleDisarmed indicates the kill action was skipped because the rule was disarmed

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -245,7 +245,7 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 	var processesKilled int64
 	var killedAt time.Time
 	killActionStatus := KillActionStatusError
-	now := time.Now()
+	now := time.Now() // get the current time now to make sure it precedes the any process exit time
 	for _, pid := range pids {
 		log.Debugf("requesting signal %s to be sent to %d", kill.Signal, pid)
 

--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -243,7 +243,9 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 	sig := model.SignalConstants[kill.Signal]
 
 	var processesKilled int64
-	killedAt := time.Now()
+	var killedAt time.Time
+	killActionStatus := KillActionStatusError
+	now := time.Now()
 	for _, pid := range pids {
 		log.Debugf("requesting signal %s to be sent to %d", kill.Signal, pid)
 
@@ -251,6 +253,8 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 			seclog.Debugf("failed to kill process %d: %s", pid, err)
 		} else {
 			processesKilled++
+			killedAt = now
+			killActionStatus = KillActionStatusPerformed
 		}
 	}
 
@@ -269,7 +273,7 @@ func (p *ProcessKiller) KillAndReport(kill *rules.KillDefinition, rule *rules.Ru
 	report := &KillActionReport{
 		Scope:      scope,
 		Signal:     kill.Signal,
-		Status:     KillActionStatusPerformed,
+		Status:     killActionStatus,
 		CreatedAt:  ev.ProcessContext.ExecTime,
 		DetectedAt: ev.ResolveEventTime(),
 		KilledAt:   killedAt,

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -95,7 +95,7 @@ func TestActionKill(t *testing.T) {
 				"set-signal-handler", ";",
 				"open", testFile, ";",
 				"sleep", "1", ";",
-				"open", testFile, ";",
+				"open", syscallTester, ";",
 				"wait-signal", ";",
 				"signal", "sigusr1", strconv.Itoa(int(os.Getpid())), ";",
 				"sleep", "1",
@@ -151,7 +151,7 @@ func TestActionKill(t *testing.T) {
 				timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 
-				cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";", "open", testFile, ";", "sleep", "5")
+				cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";", "open", syscallTester, ";", "sleep", "5")
 				_ = cmd.Run()
 
 				ch <- true
@@ -303,7 +303,7 @@ func TestActionKillRuleSpecific(t *testing.T) {
 			timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
-			cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";", "open", testFile, ";", "sleep", "5")
+			cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";", "open", syscallTester, ";", "sleep", "5")
 			_ = cmd.Run()
 
 			ch <- true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR makes it so:
- A kill action is reported as `performed` only if the kill attempt was successful, otherwise the `error` status is reported
- A kill action has a `killed_at` time field reported only if the kill attempt was successful, otherwise this field is omitted

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->