### PR TITLE
[Backport 7.64.x] autodiscovery: only detect NVML library if a feature flag is enabled

### DIFF
--- a/pkg/config/env/environment_containers.go
+++ b/pkg/config/env/environment_containers.go
@@ -74,7 +74,7 @@ func detectContainerFeatures(features FeatureMap, cfg model.Reader) {
 	detectCloudFoundry(features, cfg)
 	detectPodman(features, cfg)
 	detectPodResources(features, cfg)
-	detectNVML(features)
+	detectNVML(features, cfg)
 }
 
 func detectKubernetes(features FeatureMap, cfg model.Reader) {
@@ -248,7 +248,11 @@ func detectPodResources(features FeatureMap, cfg model.Reader) {
 	}
 }
 
-func detectNVML(features FeatureMap) {
+func detectNVML(features FeatureMap, cfg model.Reader) {
+	if !cfg.GetBool("enable_nvml_detection") {
+		return
+	}
+
 	// Use dlopen to search for the library to avoid importing the go-nvml package here,
 	// which is 1MB in size and would increase the agent binary size, when we don't really
 	// need it for anything else.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -605,6 +605,9 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("gce_send_project_id_tag", false)
 	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds
 
+	// GPU
+	config.BindEnvAndSetDefault("enable_nvml_detection", false)
+
 	// Cloud Foundry BBS
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.url", "https://bbs.service.cf.internal:8889")
 	config.BindEnvAndSetDefault("cloud_foundry_bbs.poll_interval", 15)

--- a/releasenotes/notes/disable-nvml-default-223ab621937bf159.yaml
+++ b/releasenotes/notes/disable-nvml-default-223ab621937bf159.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add a configuration option, `enable_nvml_detection`, disabled by default, to stop
+    the agent from trying to find the NVML library on startup.

--- a/releasenotes/notes/disable-nvml-default-223ab621937bf159.yaml
+++ b/releasenotes/notes/disable-nvml-default-223ab621937bf159.yaml
@@ -9,4 +9,4 @@
 fixes:
   - |
     Add a configuration option, `enable_nvml_detection`, disabled by default, to stop
-    the agent from trying to find the NVML library on startup.
+    the Agent from trying to find the NVML library on startup.

--- a/test/new-e2e/tests/gpu/provisioner.go
+++ b/test/new-e2e/tests/gpu/provisioner.go
@@ -72,6 +72,7 @@ func getDefaultProvisionerParams() *provisionerParams {
 	return &provisionerParams{
 		agentOptions: []agentparams.Option{
 			agentparams.WithSystemProbeConfig(defaultSysprobeConfig),
+			agentparams.WithAgentConfig("enable_nvml_detection: true"),
 		},
 		ami:          gpuEnabledAMI,
 		amiOS:        os.Ubuntu2204,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR changes the NVML feature detection to have a feature flag gate, so that for now all GPU monitoring features are gated and only enabled explicitly by the customer.

### Motivation

Avoid enabling by default preview features. Backported to reduce risk for customers. #incident-37075

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manually validated that the agent does not try to load the NVML library by default.

Manually corrupted the `libnvidia-ml.so.1` library, checked that it crashes the agent with the feature flag enabled and doesn't crash it with it disabled.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->