### PR TITLE
Update ADP to version 0.1.5.

### DIFF
--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -20,7 +20,7 @@ docker_trigger_internal:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx
     TMPL_SRC_REPO: ci/datadog-agent/agent
-    TMPL_ADP_VERSION: 0.1.4
+    TMPL_ADP_VERSION: 0.1.5
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
@@ -114,7 +114,7 @@ docker_trigger_internal-ot:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-ot-beta-jmx
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx
     TMPL_SRC_REPO: ci/datadog-agent/agent
-    TMPL_ADP_VERSION: 0.1.4
+    TMPL_ADP_VERSION: 0.1.5
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
@@ -256,7 +256,7 @@ docker_trigger_internal-full:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-full
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full
     TMPL_SRC_REPO: ci/datadog-agent/agent
-    TMPL_ADP_VERSION: 0.1.4
+    TMPL_ADP_VERSION: 0.1.5
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN


### PR DESCRIPTION
### What does this PR do?

Bumps the bundled ADP in internal Agent images to version `0.1.5`.

### Motivation

This pulls in a fix (https://github.com/DataDog/saluki/pull/595) for how ADP caches contexts, which was leading to unintended memory usage/growth when workloads with a high number of pre-aggregated metrics were present.

### Describe how you validated your changes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes

N/A