### PR TITLE
fix(autoinstrumentation): DD_SERVICE in some init containers was inconsistent

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -26,7 +26,6 @@ import (
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -430,29 +429,6 @@ func initContainerResourceRequirements(pod *corev1.Pod, conf initResourceRequire
 		decision.message = insufficientResourcesMessage
 	}
 	return requirements, decision
-}
-
-// Returns the name of Kubernetes resource that owns the pod
-func getServiceNameFromPod(pod *corev1.Pod) (string, error) {
-	ownerReferences := pod.ObjectMeta.OwnerReferences
-	if len(ownerReferences) != 1 {
-		return "", fmt.Errorf("pod should be owned by one resource; current owners: %v+", ownerReferences)
-	}
-
-	switch owner := ownerReferences[0]; owner.Kind {
-	case "StatefulSet":
-		fallthrough
-	case "Job":
-		fallthrough
-	case "CronJob":
-		fallthrough
-	case "DaemonSet":
-		return owner.Name, nil
-	case "ReplicaSet":
-		return kubernetes.ParseDeploymentForReplicaSet(owner.Name), nil
-	}
-
-	return "", nil
 }
 
 func containsInitContainer(pod *corev1.Pod, initContainerName string) bool {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1746,6 +1746,7 @@ func TestInjectLibInitContainer(t *testing.T) {
 			if tt.wantSkipInjection {
 				return
 			}
+
 			c.Mutators = mutator.core.newInitContainerMutators(requirements)
 			initalInitContainerCount := len(tt.pod.Spec.InitContainers)
 			err = c.mutatePod(tt.pod)
@@ -2965,6 +2966,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					Value: "test-app",
 				},
 				corev1.EnvVar{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-app",
+				},
+				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
 					Value: installTime,
 				},
@@ -3002,6 +3007,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					Value: "test-app",
 				},
 				corev1.EnvVar{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-app",
+				},
+				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
 					Value: installTime,
 				},
@@ -3037,6 +3046,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				corev1.EnvVar{
 					Name:  "DD_SERVICE",
 					Value: "test-app",
+				},
+				corev1.EnvVar{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-app",
 				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",
@@ -3412,7 +3425,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					}
 				}
 				if !found {
-					require.Failf(t, "Unexpected env var injected in container", contEnv.Name)
+					require.Failf(t, "Unexpected env var injected in container", "env=%+v", contEnv)
 				}
 			}
 

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -1893,7 +1893,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 		setupConfig               funcs
 	}{
 		{
-			name: "inject all with dotnet-profiler",
+			name: "inject all with dotnet-profiler no service name when SSI disabled",
 			pod: common.FakePodSpec{
 				Annotations: map[string]string{
 					"admission.datadoghq.com/all-lib.version":   "latest",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -2517,10 +2517,15 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				ParentKind: "replicaset",
 				ParentName: "test-deployment-123",
 			}.Create(),
-			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...), corev1.EnvVar{
-				Name:  "DD_SERVICE",
-				Value: "test-deployment",
-			},
+			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...),
+				corev1.EnvVar{
+					Name:  "DD_SERVICE",
+					Value: "test-deployment",
+				},
+				corev1.EnvVar{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-deployment",
+				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_single_step",
@@ -2546,10 +2551,15 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				ParentKind: "statefulset",
 				ParentName: "test-statefulset-123",
 			}.Create(),
-			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...), corev1.EnvVar{
-				Name:  "DD_SERVICE",
-				Value: "test-statefulset-123",
-			},
+			expectedEnvs: append(append(injectAllEnvs(), expBasicConfig()...),
+				corev1.EnvVar{
+					Name:  "DD_SERVICE",
+					Value: "test-statefulset-123",
+				},
+				corev1.EnvVar{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-statefulset-123",
+				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
 					Value: "k8s_single_step",
@@ -2611,6 +2621,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				corev1.EnvVar{
 					Name:  "DD_SERVICE",
 					Value: "test-app",
+				},
+				corev1.EnvVar{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-app",
 				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TYPE",
@@ -2795,6 +2809,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					Value: "test-app",
 				},
 				{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-app",
+				},
+				{
 					Name:  "DD_RUNTIME_METRICS_ENABLED",
 					Value: "true",
 				},
@@ -2863,6 +2881,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					Value: "test-app",
 				},
 				{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-app",
+				},
+				{
 					Name:  "DD_RUNTIME_METRICS_ENABLED",
 					Value: "true",
 				},
@@ -2927,6 +2949,10 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 				corev1.EnvVar{
 					Name:  "DD_SERVICE",
 					Value: "test-app",
+				},
+				corev1.EnvVar{
+					Name:  "DD_SERVICE_K8S_ENV_SOURCE",
+					Value: "owner=test-app",
 				},
 				corev1.EnvVar{
 					Name:  "DD_INSTRUMENTATION_INSTALL_TIME",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/lib_config.go
@@ -32,10 +32,6 @@ type basicLibConfigInjector struct{}
 
 func (basicLibConfigInjector) mutatePod(pod *corev1.Pod) error {
 	libConfig := basicConfig()
-	if name, err := getServiceNameFromPod(pod); err == nil {
-		// Set service name if it can be derived from a pod
-		libConfig.ServiceName = &name
-	}
 	for _, env := range libConfig.ToEnvs() {
 		_ = mutatecommon.InjectEnv(pod, env)
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -151,28 +151,7 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 		injectionType  = config.source.injectionType()
 		autoDetected   = config.source.isFromLanguageDetection()
 
-		// N.B.
-		//
-		// This is kind of gross, and would ideally not happen more than in
-		// one place but we made a decision to infer DD_SERVICE in the auto-instrumentation
-		// webhook a while ago and customers might be relying on this behavior.
-		//
-		// We have another webhook that does something really similar: tagsFromLabels and
-		// it this is where the responsibility should generally.
-		//
-		// The big difference between the two is that tagsFromLabels looks at the label
-		// metadata and we might override it and this one will look for the _name_ of the
-		// owner resource.
-		//
-		// The intention is to have this always run last so that we fallback to the owner
-		// name in cases of missing labels coming from the resource or its owner.
-		//
-		// mutatecommon.InjectEnv will _only_ change an env var if it is present so this code
-		// will add `DD_SERVICE` to all containers on the pod if it wasn't already set.
-		//
-		// We want to get rid of the behavior when we are triggering the fallback _and_
-		// it applies: https://datadoghq.atlassian.net/browse/INPLAT-458
-		serviceNameMutator = newServiceNameMutator(pod)
+		serviceNameMutator = m.serviceNameMutator(pod)
 
 		// initContainerMutators are resource and security constraints
 		// to all the init containers the init containers that we create.
@@ -238,6 +217,33 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 	}
 
 	return lastError
+}
+
+// serviceNameMutator will attempt to find a service name to
+// inject into the pods containers if SSI is enabled.
+//
+// This is kind of gross, and would ideally not happen more than in
+// one place but we made a decision to infer DD_SERVICE in the auto-instrumentation
+// webhook a while ago and customers might be relying on this behavior.
+//
+// We have another webhook that does something really similar: tagsFromLabels and
+// it this is where the responsibility should generally.
+//
+// The big difference between the two is that tagsFromLabels looks at the label
+// metadata and we might override it and this one will look for the _name_ of the
+// owner resource.
+//
+// The intention is to have this always run last so that we fallback to the owner
+// name in cases of missing labels coming from the resource or its owner.
+//
+// We want to get rid of the behavior when we are triggering the fallback _and_
+// it applies: https://datadoghq.atlassian.net/browse/INPLAT-458
+func (m *mutatorCore) serviceNameMutator(pod *corev1.Pod) containerMutator {
+	if !m.filter.IsNamespaceEligible(pod.Namespace) {
+		return &serviceNameMutator{noop: true}
+	}
+
+	return newServiceNameMutator(pod)
 }
 
 // newInitContainerMutators constructs container mutators for behavior

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -151,10 +151,36 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 		injectionType  = config.source.injectionType()
 		autoDetected   = config.source.isFromLanguageDetection()
 
+		// N.B.
+		//
+		// This is kind of gross, and would ideally not happen more than in
+		// one place but we made a decision to infer DD_SERVICE in the auto-instrumentation
+		// webhook a while ago and customers might be relying on this behavior.
+		//
+		// We have another webhook that does something really similar: tagsFromLabels and
+		// it this is where the responsibility should generally.
+		//
+		// The big difference between the two is that tagsFromLabels looks at the label
+		// metadata and we might override it and this one will look for the _name_ of the
+		// owner resource.
+		//
+		// The intention is to have this always run last so that we fallback to the owner
+		// name in cases of missing labels coming from the resource or its owner.
+		//
+		// mutatecommon.InjectEnv will _only_ change an env var if it is present so this code
+		// will add `DD_SERVICE` to all containers on the pod if it wasn't already set.
+		//
+		// We want to get rid of the behavior when we are triggering the fallback _and_
+		// it applies: https://datadoghq.atlassian.net/browse/INPLAT-458
+		serviceNameMutator = newServiceNameMutator(pod)
+
 		// initContainerMutators are resource and security constraints
 		// to all the init containers the init containers that we create.
-		initContainerMutators = m.newInitContainerMutators(requirements)
-		injectorOptions       = libRequirementOptions{
+		initContainerMutators = append(
+			m.newInitContainerMutators(requirements),
+			serviceNameMutator,
+		)
+		injectorOptions = libRequirementOptions{
 			containerFilter:       m.config.containerFilter,
 			initContainerMutators: initContainerMutators,
 		}
@@ -162,6 +188,7 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 		injector          = m.newInjector(pod, startTime, injectorOptions)
 		containerMutators = containerMutators{
 			config.languageDetection.containerMutator(m.config.version),
+			serviceNameMutator,
 		}
 	)
 
@@ -208,32 +235,6 @@ func (m *mutatorCore) injectTracers(pod *corev1.Pod, config extractedPodLibInfo)
 
 	if m.filter.IsNamespaceEligible(pod.Namespace) {
 		_ = basicLibConfigInjector{}.mutatePod(pod)
-
-		// N.B.
-		//
-		// This is kind of gross, and would ideally not happen more than in
-		// one place but we made a decision to infer DD_SERVICE in the auto-instrumentation
-		// webhook a while ago and customers might be relying on this behavior.
-		//
-		// We have another webhook that does something really similar: tagsFromLabels and
-		// it this is where the responsibility should generally.
-		//
-		// The big difference between the two is that tagsFromLabels looks at the label
-		// metadata and we might override it and this one will look for the _name_ of the
-		// owner resource.
-		//
-		// The intention is to have this always run last so that we fallback to the owner
-		// name in cases of missing labels coming from the resource or its owner.
-		//
-		// mutatecommon.InjectEnv will _only_ change an env var if it is present so this code
-		// will add `DD_SERVICE` to all containers on the pod if it wasn't already set.
-		//
-		// We want to get rid of the behavior when we are triggering the fallback _and_
-		// it applies: https://datadoghq.atlassian.net/browse/INPLAT-458
-		serviceNameEnv, found := findServiceNameInPod(pod)
-		if found {
-			_ = mutatecommon.InjectEnv(pod, serviceNameEnv)
-		}
 	}
 
 	return lastError

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func encodeEnvVar(e corev1.EnvVar) string {
+	out, _ := json.Marshal(e)
+	return string(out)
+}
+
+func findServiceNameEnvVarsInPod(pod *corev1.Pod) []corev1.EnvVar {
+	// grouped by env var for DD_SERVICE,
+	// all of the env var definitions and each container.
+	//
+	// we hold onto all of these because we should at least log
+	// a warning for when they are incompatible.
+	found := []corev1.EnvVar{}
+	keys := map[string]int{}
+
+	iterContainer := func(c *corev1.Container) {
+		for _, e := range c.Env {
+			if e.Name == kubernetes.ServiceTagEnvVar {
+				key := encodeEnvVar(e)
+				_, ok := keys[key]
+				if !ok {
+					var env corev1.EnvVar
+					e.DeepCopyInto(&env)
+					found = append(found, env)
+					idx := len(found) - 1
+					keys[key] = idx
+				}
+				return
+			}
+		}
+	}
+
+	for _, c := range pod.Spec.Containers {
+		iterContainer(&c)
+	}
+
+	return found
+}
+
+func findServiceNameInPod(pod *corev1.Pod) (corev1.EnvVar, bool) {
+	found := findServiceNameEnvVarsInPod(pod)
+
+	var ok bool
+	var env corev1.EnvVar
+	if len(found) > 0 {
+		env = found[0]
+		ok = true
+		if len(found) > 1 {
+			log.Debug("more than one unique definition of service name found, choosing the first one")
+		}
+	}
+
+	if !ok {
+		log.Debug("no service env vars found in pod, checking owner name")
+		name, err := getServiceNameFromPodOwnerName(pod)
+		if err != nil {
+			log.Debugf("could not get service name from fallback: %v", err)
+		} else if name == "" {
+			log.Debugf("fallback provided no error but empty service name")
+		} else {
+			env.Name = kubernetes.ServiceTagEnvVar
+			env.Value = name
+			ok = true
+		}
+	}
+
+	return env, ok
+}
+
+// Returns the name of Kubernetes resource that owns the pod
+func getServiceNameFromPodOwnerName(pod *corev1.Pod) (string, error) {
+	ownerReferences := pod.ObjectMeta.OwnerReferences
+	if len(ownerReferences) != 1 {
+		return "", fmt.Errorf("pod should be owned by one resource; current owners: %v+", ownerReferences)
+	}
+
+	switch owner := ownerReferences[0]; owner.Kind {
+	case "StatefulSet":
+		fallthrough
+	case "Job":
+		fallthrough
+	case "CronJob":
+		fallthrough
+	case "DaemonSet":
+		return owner.Name, nil
+	case "ReplicaSet":
+		return kubernetes.ParseDeploymentForReplicaSet(owner.Name), nil
+	}
+
+	return "", nil
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
@@ -17,17 +17,82 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+type serviceNameSource string
+
+const (
+	serviceNameSourceExistingEnv serviceNameSource = "existing"
+	serviceNameSourceOwnerName                     = "owner"
+)
+
+type serviceNameMutator struct {
+	noop   bool
+	envVar corev1.EnvVar
+	source serviceNameSource
+}
+
+func (s *serviceNameMutator) mutateContainer(c *corev1.Container) error {
+	if s.noop {
+		return nil
+	}
+
+	for _, e := range c.Env {
+		if e.Name == kubernetes.ServiceTagEnvVar {
+			return nil
+		}
+	}
+
+	var envs []corev1.EnvVar
+	envs = append(envs, s.envVar)
+
+	if s.source != "" {
+		envs = append(envs, corev1.EnvVar{
+			Name:  "DD_UST_K8S_ENV_SOURCE",
+			Value: fmt.Sprintf("%s:%s", kubernetes.ServiceTagEnvVar, s.source),
+		})
+	}
+
+	c.Env = append(envs, c.Env...)
+	return nil
+}
+
+func newServiceNameMutator(pod *corev1.Pod) *serviceNameMutator {
+	vars := findServiceNameEnvVarsInPod(pod)
+	if len(vars) > 1 {
+		log.Debug("more than one unique definition of service name found for the pod")
+	}
+
+	if len(vars) > 0 {
+		return &serviceNameMutator{
+			envVar: vars[0],
+			source: serviceNameSourceExistingEnv,
+		}
+	}
+
+	name, err := getServiceNameFromPodOwnerName(pod)
+	if err != nil {
+		log.Debugf("error getting owner name for pod: %v", err)
+		return &serviceNameMutator{noop: true}
+	}
+
+	if name == "" {
+		return &serviceNameMutator{noop: true}
+	}
+
+	return &serviceNameMutator{
+		envVar: corev1.EnvVar{
+			Name:  kubernetes.ServiceTagEnvVar,
+			Value: name,
+		},
+		source: serviceNameSourceOwnerName,
+	}
+}
+
 func encodeEnvVar(e corev1.EnvVar) string {
 	out, _ := json.Marshal(e)
 	return string(out)
 }
 
 func findServiceNameEnvVarsInPod(pod *corev1.Pod) []corev1.EnvVar {
-	// grouped by env var for DD_SERVICE,
-	// all of the env var definitions and each container.
-	//
-	// we hold onto all of these because we should at least log
-	// a warning for when they are incompatible.
 	found := []corev1.EnvVar{}
 	keys := map[string]int{}
 
@@ -48,6 +113,8 @@ func findServiceNameEnvVarsInPod(pod *corev1.Pod) []corev1.EnvVar {
 		}
 	}
 
+	// we only look for the service name in the container (and not)
+	// init containers.
 	for _, c := range pod.Spec.Containers {
 		iterContainer(&c)
 	}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name_test.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoinstrumentation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestFindServiceNameInPod(t *testing.T) {
+	envVar := func(k, v string) corev1.EnvVar {
+		return corev1.EnvVar{Name: k, Value: v}
+	}
+
+	envValueFrom := func(k, fieldPath string) corev1.EnvVar {
+		return corev1.EnvVar{
+			Name: k,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: fieldPath,
+				},
+			},
+		}
+	}
+
+	containerWithEnv := func(name string, env ...corev1.EnvVar) corev1.Container {
+		return corev1.Container{Name: name, Env: env}
+	}
+
+	makePod := func(cs ...corev1.Container) *corev1.Pod {
+		return &corev1.Pod{
+			Spec: corev1.PodSpec{
+				Containers: cs,
+			},
+		}
+	}
+
+	testData := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected []corev1.EnvVar
+	}{
+		{
+			name:     "one container, no env",
+			pod:      makePod(containerWithEnv("c-1")),
+			expected: []corev1.EnvVar{},
+		},
+		{
+			name: "one container one env",
+			pod: makePod(
+				containerWithEnv("c-1", envVar("DD_SERVICE", "banana")),
+			),
+			expected: []corev1.EnvVar{
+				{Name: "DD_SERVICE", Value: "banana"},
+			},
+		},
+		{
+			name: "two containers one env",
+			pod: makePod(
+				containerWithEnv("c-1", envVar("DD_SERVICE", "banana")),
+				containerWithEnv("c-2", envVar("DD_SERVICE", "banana")),
+			),
+			expected: []corev1.EnvVar{
+				{Name: "DD_SERVICE", Value: "banana"},
+			},
+		},
+		{
+			name: "env from",
+			pod: makePod(
+				containerWithEnv("c-1", envValueFrom("DD_SERVICE", "some-field")),
+				containerWithEnv("c-2", envValueFrom("DD_SERVICE", "some-field")),
+			),
+			expected: []corev1.EnvVar{
+				envValueFrom("DD_SERVICE", "some-field"),
+			},
+		},
+		{
+			name: "multiple different sources",
+			pod: makePod(
+				containerWithEnv("c-1", envValueFrom("DD_SERVICE", "some-field")),
+				containerWithEnv("c-2", envVar("DD_SERVICE", "some-name")),
+			),
+			expected: []corev1.EnvVar{
+				envValueFrom("DD_SERVICE", "some-field"),
+				envVar("DD_SERVICE", "some-name"),
+			},
+		},
+	}
+
+	for _, tt := range testData {
+		t.Run(tt.name, func(t *testing.T) {
+			out := findServiceNameEnvVarsInPod(tt.pod)
+			require.ElementsMatch(t, tt.expected, out)
+		})
+	}
+}

--- a/releasenotes-dca/notes/auto-instru-fix-inconsistent-service-name-9db8e04a3b2e3fac.yaml
+++ b/releasenotes-dca/notes/auto-instru-fix-inconsistent-service-name-9db8e04a3b2e3fac.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue with autoinstrumentation where sometimes a ``DD_SERVICE`` is
+    not consistent between containers and init containers.


### PR DESCRIPTION







### What does this PR do?

Addresses: https://datadoghq.atlassian.net/browse/INPLAT-550

### Motivation

This isn't a complete fix since we would also want to remove the code that sets the environment variable based on the "owner name" at some point (the source of this confusion).

This makes it so that the likelyhood of inconsistent env-vars when this is called is minimized and it's more obvious what the behavior does (by not tying it to lib-config).

Changes:

1. Moves the implicit service naming out of `libConfig` so this behavior is less hidden and more obvious that it's happening.

2. Adds behavior to find an already set `corev1.EnvVar` for `DD_SERVICE` and use that if it is found before setting one based on the owner name.

Behavior changes:

- For users where `DD_SERVICE` was set by `tagsFromLabels` this would make the init containers injected consistent with the application container. `tagsFromLabels` can use the labels on the pod OR the labels on the owner, and if thats set they would propagate as strings.

- For users where it was not set, this would find the owner name and then propagate it.

### Describe how you validated your changes

Added unit tests for this behavior, will do some more manual QA and add steps to reproduce.

### Possible Drawbacks / Trade-offs

??

### Additional Notes

There is a related issue https://datadoghq.atlassian.net/browse/INPLAT-458 where service name can be overridden for some customers that are providing it the `DD_SERVICE` environment variable in their containers and we _always_ set it to the deployment name. We are investigating ways of deprecating this behavior (and the function `getServiceNameFromPodOwnerName` entirely).