### PR TITLE
Fix issue where interfaces would be attempted to be captured in Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/capture_depth.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth.go
@@ -48,6 +48,46 @@ func pruneDoNotCaptureParams(params []*ditypes.Parameter) []*ditypes.Parameter {
 	return result
 }
 
+func dontCaptureInterfaces(params []*ditypes.Parameter) {
+	if len(params) == 0 {
+		return
+	}
+
+	// Create a queue to hold parameters that need to be processed
+	queue := make([]*ditypes.Parameter, 0, len(params))
+
+	// Initialize the queue with the top-level parameters
+	for _, param := range params {
+		if param != nil {
+			queue = append(queue, param)
+		}
+	}
+
+	// Process parameters until the queue is empty
+	for len(queue) > 0 {
+		// Dequeue the next parameter
+		param := queue[0]
+		queue = queue[1:]
+
+		if param == nil {
+			continue
+		}
+
+		// Check if the parameter is an interface type
+		if param.Type == "runtime.iface" {
+			param.DoNotCapture = true
+			param.NotCaptureReason = ditypes.Unsupported
+		}
+
+		// Add nested parameters to the queue
+		for _, childParam := range param.ParameterPieces {
+			if childParam != nil {
+				queue = append(queue, childParam)
+			}
+		}
+	}
+}
+
 func setFieldLimit(params []*ditypes.Parameter, fieldCountLimit int) {
 	if fieldCountLimit <= 0 || len(params) == 0 {
 		return

--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -32,6 +32,7 @@ func GenerateBPFParamsCode(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) 
 		fieldCountLimit := ditypes.MaxFieldCount
 		setDepthLimit(preChange, depthLimit)
 		setFieldLimit(preChange, fieldCountLimit)
+		dontCaptureInterfaces(preChange)
 
 		// We make a copy of the parameter tree to avoid modifying the original
 		// for the sake of event translation when uploading to backend

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -1054,12 +1054,12 @@ var interfaceCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_interface_complexity": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
-				"a": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interface_complexityA", Fields: fieldMap{
+				"a": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interfaceComplexityA", Fields: fieldMap{
 					"b": capturedValue("int", "1"),
-					"c": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interface_complexityB", Fields: fieldMap{
+					"c": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interfaceComplexityB", Fields: fieldMap{
 						"d": capturedValue("int", "2"),
 						"e": {Type: "runtime.iface", Value: nil, NotCapturedReason: "unsupported"},
-						"f": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interface_complexityC", Fields: fieldMap{
+						"f": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interfaceComplexityC", Fields: fieldMap{
 							"g": capturedValue("int", "4"),
 						}},
 					}},

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -148,7 +148,7 @@ var stringCaptures = fixtures{
 var arrayCaptures = fixtures{
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_byte_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "[2]uint8", Elements: []ditypes.CapturedValue{
 				{Type: "uint8", Value: strPtr("1")},
 				{Type: "uint8", Value: strPtr("1")},
 			}}},
@@ -157,7 +157,7 @@ var arrayCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_rune_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "[2]int32", Elements: []ditypes.CapturedValue{
 				{Type: "int32", Value: strPtr("1")},
 				{Type: "int32", Value: strPtr("2")},
 			}}},
@@ -166,7 +166,7 @@ var arrayCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_string_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "[2]string", Elements: []ditypes.CapturedValue{
 				{Type: "string", Value: strPtr("one")},
 				{Type: "string", Value: strPtr("two")},
 			}}},
@@ -184,7 +184,7 @@ var arrayCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_int8_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "[2]int8", Elements: []ditypes.CapturedValue{
 				{Type: "int8", Value: strPtr("1")},
 				{Type: "int8", Value: strPtr("2")},
 			}}},
@@ -193,7 +193,7 @@ var arrayCaptures = fixtures{
 	},
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_uint_array": []CapturedValueMapWithOptions{
 		{
-			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "array", Elements: []ditypes.CapturedValue{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{"x": {Type: "[2]uint", Elements: []ditypes.CapturedValue{
 				{Type: "uint", Value: strPtr("1")},
 				{Type: "uint", Value: strPtr("2")},
 			}}},
@@ -1050,6 +1050,36 @@ var captureDepthCaptures = fixtures{
 	},
 }
 
+var interfaceCaptures = fixtures{
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_interface_complexity": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interface_complexityA", Fields: fieldMap{
+					"b": capturedValue("int", "1"),
+					"c": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interface_complexityB", Fields: fieldMap{
+						"d": capturedValue("int", "2"),
+						"e": {Type: "runtime.iface", Value: nil, NotCapturedReason: "unsupported"},
+						"f": {Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.interface_complexityC", Fields: fieldMap{
+							"g": capturedValue("int", "4"),
+						}},
+					}},
+				}},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_interface_and_int": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": capturedValue("int", "1"),
+				"b": {Type: "runtime.iface", Value: nil, NotCapturedReason: "unsupported"},
+				"c": capturedValue("uint", "3"),
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 10},
+		},
+	},
+}
+
 // mergeMaps combines multiple fixture maps into a single map
 func mergeMaps(maps ...fixtures) fixtures {
 	result := make(fixtures)
@@ -1069,4 +1099,5 @@ var expectedCaptures = mergeMaps(
 	sliceCaptures,
 	pointerCaptures,
 	captureDepthCaptures,
+	interfaceCaptures,
 )

--- a/pkg/dynamicinstrumentation/testutil/sample/complex.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/complex.go
@@ -43,24 +43,24 @@ type inner struct {
 	E string
 }
 
-type interface_complexityA struct {
+type interfaceComplexityA struct {
 	b int
-	c interface_complexityB
+	c interfaceComplexityB
 }
 
-type interface_complexityB struct {
+type interfaceComplexityB struct {
 	d int
 	e error
-	f interface_complexityC
+	f interfaceComplexityC
 }
 
-type interface_complexityC struct {
+type interfaceComplexityC struct {
 	g int
 }
 
 //go:noinline
 //nolint:all
-func test_interface_complexity(a interface_complexityA) {}
+func test_interface_complexity(a interfaceComplexityA) {}
 
 //go:noinline
 //nolint:all
@@ -130,12 +130,12 @@ func ExecuteComplexFuncs() {
 	circ.t = &circ
 	test_circular_type(circ)
 
-	test_interface_complexity(interface_complexityA{
+	test_interface_complexity(interfaceComplexityA{
 		b: 1,
-		c: interface_complexityB{
+		c: interfaceComplexityB{
 			d: 2,
 			e: errors.New("three"),
-			f: interface_complexityC{
+			f: interfaceComplexityC{
 				g: 4,
 			},
 		},

--- a/pkg/dynamicinstrumentation/testutil/sample/complex.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/complex.go
@@ -5,7 +5,10 @@
 
 package sample
 
-import "io"
+import (
+	"errors"
+	"io"
+)
 
 type tierA struct {
 	a int
@@ -40,6 +43,25 @@ type inner struct {
 	E string
 }
 
+type interface_complexityA struct {
+	b int
+	c interface_complexityB
+}
+
+type interface_complexityB struct {
+	d int
+	e error
+	f interface_complexityC
+}
+
+type interface_complexityC struct {
+	g int
+}
+
+//go:noinline
+//nolint:all
+func test_interface_complexity(a interface_complexityA) {}
+
 //go:noinline
 //nolint:all
 func test_multiple_struct_tiers(a tierA) {}
@@ -65,6 +87,10 @@ type circularReferenceType struct {
 //nolint:all
 //go:noinline
 func test_circular_type(x circularReferenceType) {}
+
+//nolint:all
+//go:noinline
+func test_interface_and_int(a int, b error, c uint) {}
 
 //nolint:all
 func ExecuteComplexFuncs() {
@@ -103,4 +129,18 @@ func ExecuteComplexFuncs() {
 	circ := circularReferenceType{}
 	circ.t = &circ
 	test_circular_type(circ)
+
+	test_interface_complexity(interface_complexityA{
+		b: 1,
+		c: interface_complexityB{
+			d: 2,
+			e: errors.New("three"),
+			f: interface_complexityC{
+				g: 4,
+			},
+		},
+	})
+
+	test_interface_and_int(1, errors.New("two"), 3)
+
 }

--- a/pkg/dynamicinstrumentation/testutil/sample/interfaces.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/interfaces.go
@@ -6,6 +6,7 @@
 package sample
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 )
@@ -55,7 +56,12 @@ func test_interface(b behavior) string {
 }
 
 //nolint:all
+//go:noinline
+func test_error(e error) {}
+
+//nolint:all
 func ExecuteInterfaceFuncs() {
 	test_interface(firstBehavior{"foo"})
 	test_interface(secondBehavior{42})
+	test_error(errors.New("blah"))
 }

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -115,8 +115,11 @@ func convertArgs(definitions []*ditypes.Parameter, captures []*ditypes.Param) ma
 	// We keep track of the number of definitions read, and the number of missing captures to do so.
 	for i := range captures {
 	top:
+		if len(definitions) <= definitionCounter {
+			break
+		}
 		definition := definitions[definitionCounter]
-		if definition.Kind != uint(captures[i].Kind) {
+		if definition.Kind != uint(captures[i].Kind) || definition.DoNotCapture {
 			// definition is not present in captures, put it in the map and move on
 			args[definition.Name] = &ditypes.CapturedValue{
 				Type:              definition.Type,
@@ -167,8 +170,10 @@ func convertArgs(definitions []*ditypes.Parameter, captures []*ditypes.Param) ma
 	}
 
 	definitionsCaptureDifference := len(definitions) - len(captures) - missingCounter
+	if (len(definitions) - definitionsCaptureDifference) >= len(definitions) {
+		return args
+	}
 	remainingDefinitions := definitions[len(definitions)-definitionsCaptureDifference:]
-
 	for i := range remainingDefinitions {
 		args[remainingDefinitions[i].Name] = &ditypes.CapturedValue{
 			Type:              remainingDefinitions[i].Type,


### PR DESCRIPTION
### What does this PR do?

Before the changes in this PR, Go DI would attempt to capture interfaces that are fields of other types like structs. This would cause verifier issues because the underlying type of all interfaces (`runtime.iface`) is so massive and complex that we'd run out of bpf instructions to use.

### Motivation

Stability

### Describe how you validated your changes

Added more e2e tests.

### Possible Drawbacks / Trade-offs

### Additional Notes

This was found using exploration testing!