### PR TITLE
Fix metric mapping for Slurm and Kyverno

### DIFF
--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -1011,9 +1011,9 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 	case metrics.MetricSourceKubeflow:
 		return 416
 	case metrics.MetricSourceSlurm:
-		return 417
-	case metrics.MetricSourceKyverno:
 		return 418
+	case metrics.MetricSourceKyverno:
+		return 417
 	case metrics.MetricSourceTibcoEMS:
 		return 419
 	case metrics.MetricSourceMilvus:

--- a/releasenotes/notes/fix-kyverno-and-slurm-metric-origin-ce4d09d9d1fbf6b4.yaml
+++ b/releasenotes/notes/fix-kyverno-and-slurm-metric-origin-ce4d09d9d1fbf6b4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix metrics origins mapping for Kyverno and Slurm.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix metric mapping for Slurm and Kyverno

### Motivation
The integers were swapped. [source](https://github.com/DataDog/dd-source/blob/main/domains/metrics/shared/libs/proto/origin/origin.proto)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->