### PR TITLE
[CWS] Add a new kernel compilation flag

### DIFF
--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -142,6 +142,7 @@ var (
 		// various kernel behavior
 		"CONFIG_KEXEC",
 		"CONFIG_KEXEC_SIG",
+		"CONFIG_KEXEC_SIG_FORCE",
 		"CONFIG_HIBERNATION",
 		"CONFIG_BINFMT_MISC",
 		"CONFIG_LEGACY_PTYS",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a new kernel compilation flags to the list of flags tracked by CWS.

### Motivation

This flag is missing to get a full picture of the KEXEC configuration.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Start the agent, wait for a bit (depending on how you've configured your `runtime_security_config.sysctl.snapshot.period`), you should eventually see an event in the backend. If your host had a value for `CONFIG_KEXEC_SIG_FORCE` in `/boo/config-${uname -r}`, you should see it in the event.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->