### PR TITLE
[netpath] Improve reliability of traceroutes

### DIFF
--- a/pkg/networkpath/traceroute/tcp/utils_unix.go
+++ b/pkg/networkpath/traceroute/tcp/utils_unix.go
@@ -9,8 +9,10 @@ package tcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"os"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common"
@@ -109,12 +111,10 @@ func handlePackets(ctx context.Context, conn rawConnWrapper, localIP net.IP, loc
 			}
 		}
 		header, packet, _, err := conn.ReadFrom(buf)
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			continue
+		}
 		if err != nil {
-			if nerr, ok := err.(*net.OpError); ok {
-				if nerr.Timeout() {
-					continue
-				}
-			}
 			return packetResponse{
 				Err: err,
 			}

--- a/pkg/networkpath/traceroute/tcp/utils_unix_test.go
+++ b/pkg/networkpath/traceroute/tcp/utils_unix_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -343,6 +344,6 @@ func (me mockTimeoutErr) Error() string {
 	return string(me)
 }
 
-func (me mockTimeoutErr) Timeout() bool {
-	return true
+func (me mockTimeoutErr) Unwrap() error {
+	return os.ErrDeadlineExceeded
 }


### PR DESCRIPTION
(This PR was separated from [\[NPM-4279\] Add socket filter to linux TCP traceroutes](https://github.com/DataDog/datadog-agent/pull/35651) -- the measurements were done on that PR's build but the result should be the same.)
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR fixes the reachability problem we've seen with certain destinations. The `handlePackets(...)` goroutines were continuing after `listenPackets(...)` returned, causing previous calls of `sendAndReceive` to "steal" packets from the current iteration.

### Motivation
We saw issues with destinations like cloudflare that we expect to always be reachable.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Reachability improvement in vaporeon-b:
* Before with 7.65.0-rc.6: TCP traceroutes were 29.4% unreachable ([ddstaging link](https://ddstaging.datadoghq.com/network/path?query=source_cluster_name%3Avaporeon-b%20protocol%3ATCP&dest-group=destination.geoip.as.domain&refresh_mode=paused&source-group=source_cluster_name&from_ts=1743922800000&to_ts=1743923700000&live=false))
* After with this PR: TCP traceroutes were 3.35% unreachable ([ddstaging link](https://ddstaging.datadoghq.com/network/path?query=source_cluster_name%3Avaporeon-b%20protocol%3ATCP&dest-group=destination.geoip.as.domain&refresh_mode=paused&source-group=source_cluster_name&from_ts=1744126021620&to_ts=1744126921620&live=false))

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->