### PR TITLE
Patch `setuptools` to pin `wheel`

### DIFF
--- a/omnibus/config/patches/setuptools3/pin-wheel.patch
+++ b/omnibus/config/patches/setuptools3/pin-wheel.patch
@@ -1,0 +1,11 @@
+--- a/setuptools/build_meta.py
++++ b/setuptools/build_meta.py
+@@ -335,7 +335,7 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
+         exec(code, locals())
+ 
+     def get_requires_for_build_wheel(self, config_settings=None):
+-        return self._get_build_requires(config_settings, requirements=['wheel'])
++        return self._get_build_requires(config_settings, requirements=['wheel==0.45.1'])
+ 
+     def get_requires_for_build_sdist(self, config_settings=None):
+         return self._get_build_requires(config_settings, requirements=[])

--- a/omnibus/config/software/setuptools3.rb
+++ b/omnibus/config/software/setuptools3.rb
@@ -24,6 +24,8 @@ build do
     python = "#{install_dir}/embedded/bin/python3"
   end
 
+  patch source: "pin-wheel.patch"
+
   command "#{python} -m pip install ."
 
   if ohai["platform"] != "windows"


### PR DESCRIPTION
### What does this PR do?

Pins build dependency `wheel` for `setuptools` by applying a patch.

### Motivation

Build was broken after an upstream `wheel` update.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->