### PR TITLE
[process-agent] Switch to remote workloadmeta

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -34,7 +34,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	dualTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-dual"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
+	wmcatalogremote "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	compstatsd "github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
@@ -165,19 +165,11 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		autoexitimpl.Module(),
 
 		// Provide the corresponding workloadmeta Params to configure the catalog
-		wmcatalog.GetCatalog(),
+		wmcatalogremote.GetCatalog(),
 
 		// Provide workloadmeta module
-		workloadmetafx.ModuleWithProvider(func(c config.Component) workloadmeta.Params {
-			var catalog workloadmeta.AgentType
-
-			if c.GetBool("process_config.remote_workloadmeta") {
-				catalog = workloadmeta.Remote
-			} else {
-				catalog = workloadmeta.ProcessAgent
-			}
-
-			return workloadmeta.Params{AgentType: catalog}
+		workloadmetafx.Module(workloadmeta.Params{
+			AgentType: workloadmeta.Remote,
 		}),
 
 		dualTaggerfx.Module(tagger.DualParams{

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -29,7 +29,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	dualTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx-dual"
 	taggerTypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
-	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
+	wmcatalogremote "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog-remote"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/eventplatformimpl"
@@ -136,17 +136,9 @@ func MakeCommand(globalParamsGetter func() *command.GlobalParams, name string, a
 				// Provide npcollector module
 				npcollectorimpl.Module(),
 				// Provide the corresponding workloadmeta Params to configure the catalog
-				wmcatalog.GetCatalog(),
-				workloadmetafx.ModuleWithProvider(func(config config.Component) workloadmeta.Params {
-
-					var catalog workloadmeta.AgentType
-					if config.GetBool("process_config.remote_workloadmeta") {
-						catalog = workloadmeta.Remote
-					} else {
-						catalog = workloadmeta.ProcessAgent
-					}
-
-					return workloadmeta.Params{AgentType: catalog}
+				wmcatalogremote.GetCatalog(),
+				workloadmetafx.Module(workloadmeta.Params{
+					AgentType: workloadmeta.Remote,
 				}),
 
 				// Tagger must be initialized after agent config has been setup

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -178,7 +178,6 @@ func setupProcesses(config pkgconfigmodel.Setup) {
 	procBindEnvAndSetDefault(config, "process_config.internal_profiling.enabled", false)
 	procBindEnvAndSetDefault(config, "process_config.grpc_connection_timeout_secs", DefaultGRPCConnectionTimeoutSecs)
 	procBindEnvAndSetDefault(config, "process_config.remote_tagger", false)
-	procBindEnvAndSetDefault(config, "process_config.remote_workloadmeta", false) // This flag might change. It's still being tested.
 	procBindEnvAndSetDefault(config, "process_config.disable_realtime_checks", false)
 	procBindEnvAndSetDefault(config, "process_config.ignore_zombie_processes", false)
 

--- a/pkg/config/setup/process_test.go
+++ b/pkg/config/setup/process_test.go
@@ -47,10 +47,6 @@ func TestProcessDefaultConfig(t *testing.T) {
 			defaultValue: false,
 		},
 		{
-			key:          "process_config.remote_workloadmeta",
-			defaultValue: false,
-		},
-		{
 			key:          "process_config.process_discovery.enabled",
 			defaultValue: true,
 		},


### PR DESCRIPTION
### What does this PR do?

This PR makes the process-agent always use the remote workloadmeta.

There used to be a config option to choose between remote and local, but now we want to use remote only. This is already how it works in the security-agent and system-probe.

The benefits are the same as for the other agents: the process-agent binary is smaller, and now only one agent will fetch data from sources like container runtime sockets.

### Describe how you validated your changes

@DataDog/container-intake how should we test this?

I did a basic test on a local cluster. I set up the process-agent to run the process checks instead of the core agent. Everything looks fine, but I’m not sure what else we should check to make sure this change is safe.
