### PR TITLE
flare: Include system-probe discovery module state

### DIFF
--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -35,6 +35,10 @@ func addSystemProbePlatformSpecificEntries(fb flaretypes.FlareBuilder) {
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "dmesg.log"), priviledged.GetLinuxDmesg)
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "selinux_sestatus.log"), getSystemProbeSelinuxSestatus)
 		_ = fb.AddFileFromFunc(filepath.Join("system-probe", "selinux_semodule_list.log"), getSystemProbeSelinuxSemoduleList)
+
+		if pkgconfigsetup.SystemProbe().GetBool("discovery.enabled") {
+			_ = fb.AddFileFromFunc(filepath.Join("system-probe", "discovery.log"), getSystemProbeDiscoveryState)
+		}
 	}
 }
 
@@ -65,5 +69,11 @@ func getSystemProbeSelinuxSestatus() ([]byte, error) {
 func getSystemProbeSelinuxSemoduleList() ([]byte, error) {
 	sysProbeClient := sysprobeclient.Get(priviledged.GetSystemProbeSocketPath())
 	url := sysprobeclient.DebugURL("/selinux_semodule_list")
+	return priviledged.GetHTTPData(sysProbeClient, url)
+}
+
+func getSystemProbeDiscoveryState() ([]byte, error) {
+	sysProbeClient := sysprobeclient.Get(priviledged.GetSystemProbeSocketPath())
+	url := sysprobeclient.ModuleURL(sysconfig.DiscoveryModule, "/state")
 	return priviledged.GetHTTPData(sysProbeClient, url)
 }


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Include the state of the system-probe discovery module in the flare if it is enabled.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-14

### Describe how you validated your changes

Tested by generating a flare with SD enabled and checking that it included the `system-probe/discovery.log` file.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->