### PR TITLE
Avoid caching python version in status header

### DIFF
--- a/comp/core/status/statusimpl/common_header_provider.go
+++ b/comp/core/status/statusimpl/common_header_provider.go
@@ -35,6 +35,7 @@ type headerProvider struct {
 	textTemplatesFunctions textTemplate.FuncMap
 	htmlTemplatesFunctions htmlTemplate.FuncMap
 	config                 config.Component
+	params                 status.Params
 }
 
 func (h *headerProvider) Index() int {
@@ -74,6 +75,8 @@ func (h *headerProvider) data() map[string]interface{} {
 	data["time_nano"] = nowFunc().UnixNano()
 	data["config"] = populateConfig(h.config)
 	data["fips_status"] = populateFIPSStatus(h.config)
+	pythonVersion := h.params.PythonVersionGetFunc()
+	data["python_version"] = strings.Split(pythonVersion, " ")[0]
 	return data
 }
 
@@ -87,8 +90,6 @@ func newCommonHeaderProvider(params status.Params, config config.Component) stat
 	data["pid"] = os.Getpid()
 	data["go_version"] = runtime.Version()
 	data["agent_start_nano"] = startTimeProvider.UnixNano()
-	pythonVersion := params.PythonVersionGetFunc()
-	data["python_version"] = strings.Split(pythonVersion, " ")[0]
 	data["build_arch"] = runtime.GOARCH
 
 	return &headerProvider{
@@ -97,6 +98,7 @@ func newCommonHeaderProvider(params status.Params, config config.Component) stat
 		textTemplatesFunctions: status.TextFmap(),
 		htmlTemplatesFunctions: status.HTMLFmap(),
 		config:                 config,
+		params:                 params,
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Now that RTLoader is lazy loaded, if the python version is retrieved only at startup it remains `n/a` all the time.
Without that PR the `datadog-agent status` command always return `python_version: n/a`

Likely broken since: https://github.com/DataDog/datadog-agent/pull/32611

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->