### PR TITLE
ci(compare_to): Force pipeline creation to deal with ddci migration

### DIFF
--- a/tasks/unit_tests/pipeline_tests.py
+++ b/tasks/unit_tests/pipeline_tests.py
@@ -28,7 +28,7 @@ class TestCompareToItself(unittest.TestCase):
     @staticmethod
     def side(x):
         if x == "c0mm1t":
-            return MagicMock(author_name=pipeline.BOT_NAME)
+            return MagicMock(author_name=pipeline.BOT_NAME, title="Commit to compare to itself")
         else:
             return MagicMock(author_name="Aimee Jaquet")
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Force pipeline creation during the `compare_to` test to deal with ddci migration

### Motivation
Adapt to the `ddci` migration, as the skipped pipelines are ignored by the test ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/888735980))

### Describe how you validated your changes
- Non regression validated [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/890187667).
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->