### PR TITLE
(fleet) enable SUSE on APM inject tests

### DIFF
--- a/pkg/fleet/installer/env/env.go
+++ b/pkg/fleet/installer/env/env.go
@@ -86,7 +86,7 @@ var defaultEnv = Env{
 		RuntimeMetricsEnabled:     nil,
 		LogsInjection:             nil,
 		APMTracingEnabled:         nil,
-		ProfilingEnabled:          nil,
+		ProfilingEnabled:          "",
 		DataStreamsEnabled:        nil,
 		AppsecEnabled:             nil,
 		IastEnabled:               nil,
@@ -121,7 +121,7 @@ type InstallScriptEnv struct {
 	RuntimeMetricsEnabled *bool
 	LogsInjection         *bool
 	APMTracingEnabled     *bool
-	ProfilingEnabled      *bool
+	ProfilingEnabled      string
 	DataStreamsEnabled    *bool
 	AppsecEnabled         *bool
 	IastEnabled           *bool
@@ -229,7 +229,7 @@ func FromEnv() *Env {
 			RuntimeMetricsEnabled:     getBoolEnv(envRuntimeMetricsEnabled),
 			LogsInjection:             getBoolEnv(envLogsInjection),
 			APMTracingEnabled:         getBoolEnv(envAPMTracingEnabled),
-			ProfilingEnabled:          getBoolEnv(envProfilingEnabled),
+			ProfilingEnabled:          getEnvOrDefault(envProfilingEnabled, ""),
 			DataStreamsEnabled:        getBoolEnv(envDataStreamsEnabled),
 			AppsecEnabled:             getBoolEnv(envAppsecEnabled),
 			IastEnabled:               getBoolEnv(envIastEnabled),
@@ -272,7 +272,7 @@ func (e *InstallScriptEnv) ToEnv(env []string) []string {
 	env = appendBoolEnv(env, envRuntimeMetricsEnabled, e.RuntimeMetricsEnabled)
 	env = appendBoolEnv(env, envLogsInjection, e.LogsInjection)
 	env = appendBoolEnv(env, envAPMTracingEnabled, e.APMTracingEnabled)
-	env = appendBoolEnv(env, envProfilingEnabled, e.ProfilingEnabled)
+	env = appendStringEnv(env, envProfilingEnabled, e.ProfilingEnabled, "")
 	env = appendBoolEnv(env, envDataStreamsEnabled, e.DataStreamsEnabled)
 	env = appendBoolEnv(env, envAppsecEnabled, e.AppsecEnabled)
 	env = appendBoolEnv(env, envIastEnabled, e.IastEnabled)
@@ -407,8 +407,8 @@ func overridesByNameToEnv[T any](envPrefix string, overridesByPackage map[string
 }
 
 func getEnvOrDefault(env string, defaultValue string) string {
-	value := os.Getenv(env)
-	if value == "" {
+	value, set := os.LookupEnv(env)
+	if !set {
 		return defaultValue
 	}
 	return value

--- a/pkg/fleet/installer/packages/apminject/apm_inject.go
+++ b/pkg/fleet/installer/packages/apminject/apm_inject.go
@@ -403,12 +403,8 @@ func (a *InjectorInstaller) addLocalStableConfig(ctx context.Context) (err error
 					AppsecScaEnabled:      a.Env.InstallScript.AppsecScaEnabled,
 				},
 			}
-			if a.Env.InstallScript.ProfilingEnabled != nil {
-				profEnabled := "false"
-				if *a.Env.InstallScript.ProfilingEnabled {
-					profEnabled = "auto"
-				}
-				cfg.Default.ProfilingEnabled = &profEnabled
+			if a.Env.InstallScript.ProfilingEnabled != "" {
+				cfg.Default.ProfilingEnabled = &a.Env.InstallScript.ProfilingEnabled
 			}
 
 			return yaml.Marshal(cfg)

--- a/pkg/fleet/installer/packages/apminject/docker.go
+++ b/pkg/fleet/installer/packages/apminject/docker.go
@@ -237,6 +237,18 @@ func isDockerInstalled(ctx context.Context) bool {
 
 // isDockerActive checks if docker is started on the system
 func isDockerActive(ctx context.Context) bool {
-	cmd := exec.CommandContext(ctx, "pidof", "dockerd")
-	return cmd.Run() == nil
+	processes, err := process.Processes()
+	if err != nil {
+		return false // Don't pollute with warning logs
+	}
+	for _, process := range processes {
+		name, err := process.NameWithContext(ctx)
+		if err != nil {
+			continue // Don't pollute with warning logs
+		}
+		if name == "dockerd" {
+			return true
+		}
+	}
+	return false
 }

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -115,7 +115,7 @@ func (h *Host) GetDockerRuntimePath(runtime string) string {
 
 	var cmd string
 	switch h.os.Flavor {
-	case e2eos.AmazonLinux:
+	case e2eos.AmazonLinux, e2eos.Suse:
 		cmd = "sudo docker system info --format '{{ (index .Runtimes \"%s\").Path }}'"
 	default:
 		cmd = "sudo docker system info --format '{{ (index .Runtimes \"%s\").Runtime.Path }}'"
@@ -202,7 +202,7 @@ func (h *Host) WaitForFileExists(useSudo bool, filePaths ...string) {
 // This is because of a race condition where the trace agent is not ready to receive traces and we send them
 // meaning that the traces are lost
 func (h *Host) WaitForTraceAgentSocketReady() {
-	_, err := h.remote.Execute("timeout=30; while ! grep -q 'Listening for traces at unix://' <(journalctl _PID=`systemctl show -p MainPID datadog-agent-trace | cut -d\"=\" -f2`); do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]")
+	_, err := h.remote.Execute("timeout=30; while ! grep -q 'Listening for traces at unix://' <(sudo journalctl _PID=`systemctl show -p MainPID datadog-agent-trace | cut -d\"=\" -f2`); do sleep 1; ((timeout--)); done; [ $timeout -ne 0 ]")
 	require.NoError(h.t(), err, "trace agent did not become ready")
 }
 

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -52,7 +52,7 @@ var (
 	packagesTestsWithSkippedFlavors = []packageTestsWithSkippedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
-		{t: testApmInjectAgent, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
+		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault}, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
 		{t: testUpgradeScenario},
 	}
 )

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -169,6 +169,17 @@ func (s *packageBaseSuite) SetupSuite() {
 	s.host = host.New(s.T, s.Env().RemoteHost, s.os, s.arch)
 	s.disableUnattendedUpgrades()
 	s.updateCurlOnUbuntu()
+	s.updatePythonOnSuse()
+}
+
+func (s *packageBaseSuite) updatePythonOnSuse() {
+	// Suse15 comes with Python3.6 by default which is too old for injection
+	if s.os.Flavor != e2eos.Suse {
+		return
+	}
+	s.host.Run("sudo zypper --non-interactive ar http://download.opensuse.org/distribution/leap/15.5/repo/oss/ oss || true")
+	s.host.Run("sudo zypper --non-interactive --gpg-auto-import-keys in python311")
+	s.host.Run("sudo ln -sf /usr/bin/python3.11 /usr/bin/python3")
 }
 
 func (s *packageBaseSuite) disableUnattendedUpgrades() {

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -52,7 +52,7 @@ var (
 	packagesTestsWithSkippedFlavors = []packageTestsWithSkippedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
-		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault, e2eos.Suse15}, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
+		{t: testApmInjectAgent, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
 		{t: testUpgradeScenario},
 	}
 )

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -131,7 +131,7 @@ func (s *packageApmInjectSuite) TestInstrumentHost() {
 }
 
 func (s *packageApmInjectSuite) TestInstrumentProfilingEnabled() {
-	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python", "DD_PROFILING_ENABLED=true", "DD_DATA_STREAMS_ENABLED=true", envForceInstall("datadog-agent"))
+	s.RunInstallScript("DD_APM_INSTRUMENTATION_ENABLED=host", "DD_APM_INSTRUMENTATION_LIBRARIES=python", "DD_PROFILING_ENABLED=auto", "DD_DATA_STREAMS_ENABLED=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 	s.assertStableConfig(map[string]interface{}{
 		"DD_PROFILING_ENABLED":    "auto",
@@ -163,6 +163,10 @@ func (s *packageApmInjectSuite) TestSystemdReload() {
 // TestUpgrade_InjectorDeb_To_InjectorOCI tests the upgrade from the DEB injector to the OCI injector.
 // Library package is OCI.
 func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
+	if s.os.Flavor == e2eos.Suse {
+		s.T().Skip("Can't install APM deb/rpm packages on Suse, they were never released")
+	}
+
 	s.host.InstallDocker()
 
 	// Deb install using today's defaults
@@ -204,6 +208,10 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
 // TestUpgrade_InjectorOCI_To_InjectorDeb tests the upgrade from the OCI injector to the DEB injector.
 // Library package is OCI.
 func (s *packageApmInjectSuite) TestUpgrade_InjectorOCI_To_InjectorDeb() {
+	if s.os.Flavor == e2eos.Suse {
+		s.T().Skip("Can't install APM deb/rpm packages on Suse, they were never released")
+	}
+
 	s.host.InstallDocker()
 
 	// OCI install
@@ -363,6 +371,10 @@ func (s *packageApmInjectSuite) TestUninstrument() {
 }
 
 func (s *packageApmInjectSuite) TestInstrumentScripts() {
+	if s.os.Flavor == e2eos.Suse {
+		s.T().Skip("Can't install APM deb/rpm packages on Suse, they were never released")
+	}
+
 	s.host.InstallDocker()
 
 	// Deb install using today's defaults


### PR DESCRIPTION
This PR enables SUSE on APM inject e2e tests.
