### PR TITLE
[OTAGENT-355] Improve config in serializer exporter

### DIFF
--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -255,7 +255,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v1.27.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/httpprovider v1.27.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.27.0 // indirect
-	go.opentelemetry.io/collector/confmap/xconfmap v0.122.0 // indirect
+	go.opentelemetry.io/collector/confmap/xconfmap v0.122.1 // indirect
 	go.opentelemetry.io/collector/connector/xconnector v0.121.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.122.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror/xconsumererror v0.121.0 // indirect

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.sum
@@ -479,8 +479,8 @@ go.opentelemetry.io/collector/confmap/provider/httpprovider v1.27.0 h1:u144bOgB+
 go.opentelemetry.io/collector/confmap/provider/httpprovider v1.27.0/go.mod h1:dO/PLYcLJJmF2upHutaLRuW9Jf0ImqdIMHxr5aGiXro=
 go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.27.0 h1:X7fohJKfGCS1cwY6/wmcjNmT/KGgcJfkyzBNnyNYiPQ=
 go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.27.0/go.mod h1:/vvb4mYN+J4IA2hRlkqAiBdxyOJFamW60ChxqDi8o1Y=
-go.opentelemetry.io/collector/confmap/xconfmap v0.122.0 h1:uRwR2/DEhLCwsdQyD5rTG/cAPUm5ixZb96y3rUaUo/g=
-go.opentelemetry.io/collector/confmap/xconfmap v0.122.0/go.mod h1:76K9ypccfRyorlYYit8O82mX4hseQP8VJ/TYqCKI4fA=
+go.opentelemetry.io/collector/confmap/xconfmap v0.122.1 h1:E8sdJens/sq+evv/VHzbDP3B28uZIAPkKjtB4mVVTso=
+go.opentelemetry.io/collector/confmap/xconfmap v0.122.1/go.mod h1:33HDN5uVKRihgLiShZZDzxN0qiTA1+t8hK41rrf1jls=
 go.opentelemetry.io/collector/connector v0.121.0 h1:Bhre1CU8+nvXhOO74ZjCQth6JIwuRgGmUVFU5I6fDhY=
 go.opentelemetry.io/collector/connector v0.121.0/go.mod h1:njtHMkFOuZ5W5Ax2BnsqC8EThgTU7tF1k7OBpRs0+uQ=
 go.opentelemetry.io/collector/connector/connectortest v0.121.0 h1:3MhdOd5Sbd4kE/gjY8WDc0lb5Y2V1IEeYfRss8P5tnU=

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/go.sum
@@ -418,8 +418,8 @@ go.opentelemetry.io/collector/config/configtls v1.28.1 h1:UTnB30vfXbnkm94754sd8a
 go.opentelemetry.io/collector/config/configtls v1.28.1/go.mod h1:aXztDbmrn/MGbvCNPEYu9KcX8lXFKHyh4x6OsvOfl2c=
 go.opentelemetry.io/collector/confmap v1.28.1 h1:/zUmvpnERhFXrxVCVgubjJRgeOwdPbhTfUILZPUBfyw=
 go.opentelemetry.io/collector/confmap v1.28.1/go.mod h1:2aJggo/KQl7uynFyMNNMbl7jvKkSD7CniOVEpCbjRng=
-go.opentelemetry.io/collector/confmap/xconfmap v0.122.0 h1:uRwR2/DEhLCwsdQyD5rTG/cAPUm5ixZb96y3rUaUo/g=
-go.opentelemetry.io/collector/confmap/xconfmap v0.122.0/go.mod h1:76K9ypccfRyorlYYit8O82mX4hseQP8VJ/TYqCKI4fA=
+go.opentelemetry.io/collector/confmap/xconfmap v0.122.1 h1:E8sdJens/sq+evv/VHzbDP3B28uZIAPkKjtB4mVVTso=
+go.opentelemetry.io/collector/confmap/xconfmap v0.122.1/go.mod h1:33HDN5uVKRihgLiShZZDzxN0qiTA1+t8hK41rrf1jls=
 go.opentelemetry.io/collector/consumer v1.28.1 h1:3lHW2e0i7kEkbDqK1vErA8illqPpwDxMzgc5OUDsJ0Y=
 go.opentelemetry.io/collector/consumer v1.28.1/go.mod h1:g0T16JPMYFN6T2noh+1YBxJSt5i5Zp+Y0Y6pvkMqsDQ=
 go.opentelemetry.io/collector/consumer/consumererror v0.122.1 h1:/eL7rtfnKUMgjtiD+NXm6hd3QQ+tjD1oGc+ImPxFdIg=

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/config.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/config.go
@@ -23,7 +23,8 @@ import (
 type ExporterConfig struct {
 	// squash ensures fields are correctly decoded in embedded struct
 	exporterhelper.TimeoutConfig `mapstructure:",squash"`
-	exporterhelper.QueueConfig   `mapstructure:",squash"`
+
+	exporterhelper.QueueConfig `mapstructure:"sending_queue"`
 
 	Metrics MetricsConfig `mapstructure:"metrics"`
 	// API defines the Datadog API configuration.

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/config.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/config.go
@@ -6,9 +6,17 @@
 package serializerexporter
 
 import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configopaque"
+	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.uber.org/zap"
 )
 
 // ExporterConfig defines configuration for the serializer exporter.
@@ -33,9 +41,76 @@ type ExporterConfig struct {
 
 	// HostMetadataConfig defines the host metadata related configuration.
 	HostMetadata datadogconfig.HostMetadataConfig `mapstructure:"host_metadata"`
+
+	// Non-fatal warnings found during configuration loading.
+	warnings []error
+}
+
+// Validate the configuration for errors. This is required by component.Config.
+func (c *ExporterConfig) Validate() error {
+	key := string(c.API.Key)
+	if key != "" { // there is no api key in the config when serializer exporter is used in OTLP ingest
+		if err := datadogconfig.StaticAPIKeyCheck(key); err != nil {
+			return err
+		}
+	}
+
+	histCfg := c.Metrics.Metrics.HistConfig
+	if histCfg.Mode == datadogconfig.HistogramModeNoBuckets && !histCfg.SendAggregations {
+		return fmt.Errorf("'nobuckets' mode and `send_aggregation_metrics` set to false will send no histogram metrics")
+	}
+
+	if c.HostMetadata.Enabled && c.HostMetadata.ReporterPeriod < 5*time.Minute {
+		return errors.New("reporter_period must be 5 minutes or higher")
+	}
+
+	return nil
+}
+
+// LogWarnings logs warning messages that were generated on unmarshaling.
+func (c *ExporterConfig) LogWarnings(logger *zap.Logger) {
+	for _, err := range c.warnings {
+		logger.Warn(fmt.Sprintf("%v", err))
+	}
+}
+
+// Unmarshal a configuration map into the configuration struct.
+func (c *ExporterConfig) Unmarshal(configMap *confmap.Conf) error {
+	err := configMap.Unmarshal(c)
+	if err != nil {
+		return err
+	}
+
+	if c.HostMetadata.HostnameSource == datadogconfig.HostnameSourceFirstResource {
+		c.warnings = append(c.warnings, errors.New("first_resource is deprecated, opt in to https://docs.datadoghq.com/opentelemetry/mapping/host_metadata/ instead"))
+	}
+
+	c.API.Key = configopaque.String(strings.TrimSpace(string(c.API.Key)))
+
+	// If an endpoint is not explicitly set, override it based on the site.
+	if !configMap.IsSet("metrics::endpoint") {
+		c.Metrics.Metrics.Endpoint = fmt.Sprintf("https://api.%s", c.API.Site)
+	}
+
+	// Return an error if an endpoint is explicitly set to ""
+	if c.Metrics.Metrics.Endpoint == "" {
+		return datadogconfig.ErrEmptyEndpoint
+	}
+
+	const (
+		initialValueSetting = "metrics::sums::initial_cumulative_monotonic_value"
+		cumulMonoMode       = "metrics::sums::cumulative_monotonic_mode"
+	)
+	if configMap.IsSet(initialValueSetting) && c.Metrics.Metrics.SumConfig.CumulativeMonotonicMode != datadogconfig.CumulativeMonotonicSumModeToDelta {
+		return fmt.Errorf("%q can only be configured when %q is set to %q",
+			initialValueSetting, cumulMonoMode, datadogconfig.CumulativeMonotonicSumModeToDelta)
+	}
+
+	return nil
 }
 
 var _ component.Config = (*ExporterConfig)(nil)
+var _ confmap.Unmarshaler = (*ExporterConfig)(nil)
 
 // MetricsConfig defines the metrics exporter specific configuration options
 type MetricsConfig struct {

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/config_test.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/config_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/confmap/xconfmap"
 )
 
 func TestUnmarshalDefaultConfig(t *testing.T) {
@@ -30,9 +32,13 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 func TestUnmarshalConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
+	sub, err := cm.Sub(component.MustNewID(TypeStr).String())
+	require.NoError(t, err)
 	factory := newFactory()
 	got := factory.CreateDefaultConfig()
-	require.NoError(t, cm.Unmarshal(&got))
+	require.NoError(t, sub.Unmarshal(&got))
+	assert.NoError(t, xconfmap.Validate(got))
+
 	want := factory.CreateDefaultConfig().(*ExporterConfig)
 	want.TimeoutConfig.Timeout = 10 * time.Second
 	want.QueueConfig.QueueSize = 100
@@ -47,9 +53,10 @@ func TestUnmarshalConfig(t *testing.T) {
 	want.Metrics.Metrics.HistConfig.SendAggregations = true
 	want.Metrics.Metrics.SumConfig.CumulativeMonotonicMode = datadogconfig.CumulativeMonotonicSumModeRawValue
 	want.Metrics.Metrics.SummaryConfig.Mode = datadogconfig.SummaryModeNoQuantiles
-	want.API.Key = "abc"
+	want.API.Key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	want.API.Site = "localhost"
 	want.API.FailOnInvalidKey = true
 	want.HostMetadata.Enabled = true
+
 	assert.Equal(t, want, got)
 }

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
@@ -156,10 +156,21 @@ func (f *factory) Reporter(params exp.Settings, forwarder defaultforwarder.Forwa
 	return f.reporter, reporterErr
 }
 
+// checkAndCastConfig checks the configuration type and its warnings, and casts it to
+// the Datadog Config struct.
+func checkAndCastConfig(c component.Config, logger *zap.Logger) *ExporterConfig {
+	cfg, ok := c.(*ExporterConfig)
+	if !ok {
+		panic("programming error: config structure is not of type *ExporterConfig")
+	}
+	cfg.LogWarnings(logger)
+	return cfg
+}
+
 // createMetricsExporter creates a new metrics exporter.
 func (f *factory) createMetricExporter(ctx context.Context, params exp.Settings, c component.Config) (exp.Metrics, error) {
 	var err error
-	cfg := c.(*ExporterConfig)
+	cfg := checkAndCastConfig(c, params.Logger)
 	var forwarder *defaultforwarder.DefaultForwarder
 	if f.s == nil {
 		f.s, forwarder, err = initSerializer(params.Logger, cfg, f.hostProvider)

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/collector/component v1.28.1
 	go.opentelemetry.io/collector/config/confignet v1.28.1 // indirect
 	go.opentelemetry.io/collector/confmap v1.28.1
+	go.opentelemetry.io/collector/confmap/xconfmap v0.122.1
 	go.opentelemetry.io/collector/consumer v1.28.1
 	go.opentelemetry.io/collector/exporter v0.122.1
 	go.opentelemetry.io/collector/extension v1.28.1 // indirect
@@ -166,6 +167,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.122.0
 	go.opentelemetry.io/collector/component/componenttest v0.122.1
+	go.opentelemetry.io/collector/config/configopaque v1.28.1
 	go.opentelemetry.io/collector/exporter/exportertest v0.122.1
 )
 
@@ -203,7 +205,6 @@ require (
 	go.opentelemetry.io/collector/config/configauth v0.122.1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.28.1 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.122.1 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.28.1 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.28.1 // indirect
 	go.opentelemetry.io/collector/consumer/consumererror v0.122.1 // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.122.1 // indirect

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/go.sum
@@ -362,8 +362,8 @@ go.opentelemetry.io/collector/config/configtls v1.28.1 h1:UTnB30vfXbnkm94754sd8a
 go.opentelemetry.io/collector/config/configtls v1.28.1/go.mod h1:aXztDbmrn/MGbvCNPEYu9KcX8lXFKHyh4x6OsvOfl2c=
 go.opentelemetry.io/collector/confmap v1.28.1 h1:/zUmvpnERhFXrxVCVgubjJRgeOwdPbhTfUILZPUBfyw=
 go.opentelemetry.io/collector/confmap v1.28.1/go.mod h1:2aJggo/KQl7uynFyMNNMbl7jvKkSD7CniOVEpCbjRng=
-go.opentelemetry.io/collector/confmap/xconfmap v0.122.0 h1:uRwR2/DEhLCwsdQyD5rTG/cAPUm5ixZb96y3rUaUo/g=
-go.opentelemetry.io/collector/confmap/xconfmap v0.122.0/go.mod h1:76K9ypccfRyorlYYit8O82mX4hseQP8VJ/TYqCKI4fA=
+go.opentelemetry.io/collector/confmap/xconfmap v0.122.1 h1:E8sdJens/sq+evv/VHzbDP3B28uZIAPkKjtB4mVVTso=
+go.opentelemetry.io/collector/confmap/xconfmap v0.122.1/go.mod h1:33HDN5uVKRihgLiShZZDzxN0qiTA1+t8hK41rrf1jls=
 go.opentelemetry.io/collector/consumer v1.28.1 h1:3lHW2e0i7kEkbDqK1vErA8illqPpwDxMzgc5OUDsJ0Y=
 go.opentelemetry.io/collector/consumer v1.28.1/go.mod h1:g0T16JPMYFN6T2noh+1YBxJSt5i5Zp+Y0Y6pvkMqsDQ=
 go.opentelemetry.io/collector/consumer/consumererror v0.122.1 h1:/eL7rtfnKUMgjtiD+NXm6hd3QQ+tjD1oGc+ImPxFdIg=

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/testdata/config.yaml
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/testdata/config.yaml
@@ -1,6 +1,7 @@
 serializer:
   timeout: 10s
-  queue_size: 100
+  sending_queue:
+    queue_size: 100
   metrics:
     tag_cardinality: high
     apm_stats_receiver_addr: localhost:1234

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/testdata/config.yaml
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/testdata/config.yaml
@@ -1,23 +1,24 @@
-timeout: 10s
-queue_size: 100
-metrics:
-  tag_cardinality: high
-  apm_stats_receiver_addr: localhost:1234
-  tags: "tag"
-  delta_ttl: 200
-  endpoint: localhost:5678
-  resource_attributes_as_tags: true
-  instrumentation_scope_metadata_as_tags: true
-  histograms:
-    mode: counters
-    send_aggregation_metrics: true
-  sums:
-    cumulative_monotonic_mode: raw_value
-  summaries:
-    mode: noquantiles
-api:
-  key: abc
-  site: localhost
-  fail_on_invalid_key: true
-host_metadata:
-  enabled: true
+serializer:
+  timeout: 10s
+  queue_size: 100
+  metrics:
+    tag_cardinality: high
+    apm_stats_receiver_addr: localhost:1234
+    tags: "tag"
+    delta_ttl: 200
+    endpoint: localhost:5678
+    resource_attributes_as_tags: true
+    instrumentation_scope_metadata_as_tags: true
+    histograms:
+      mode: counters
+      send_aggregation_metrics: true
+    sums:
+      cumulative_monotonic_mode: raw_value
+    summaries:
+      mode: noquantiles
+  api:
+    key: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    site: localhost
+    fail_on_invalid_key: true
+  host_metadata:
+    enabled: true


### PR DESCRIPTION
### What does this PR do?
1. Add static validations on configs, copied from https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/datadog/config
2. Move queue configs to a dedicated sub-section `sending_queue`. In the new versions queue configs can no longer be top-level exporter configs. 

### Motivation
related to http://github.com/open-telemetry/opentelemetry-collector/issues/12709#issuecomment-2790524593

### Describe how you validated your changes
unit tests