### PR TITLE
Experimental: enable nodetreemodel by default for the config

### DIFF
--- a/pkg/config/create/new.go
+++ b/pkg/config/create/new.go
@@ -27,7 +27,7 @@ func NewConfig(name string) model.Config {
 	// - "unmarshal": Use viper for the config but the reflection based version of UnmarshalKey which used some of
 	//                nodetreemodel internals
 	// - other:       Use viper for the config
-	if envvar == "enable" {
+	if envvar == "enable" || envvar == "" {
 		return nodetreemodel.NewNodeTreeConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 	} else if envvar == "tee" {
 		viperImpl := viperconfig.NewViperConfig(name, "DD", strings.NewReplacer(".", "_"))         // nolint: forbidigo // legit use case

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -259,6 +259,7 @@ func init() {
 	initConfig()
 
 	datadog.BuildSchema()
+	systemProbe.BuildSchema()
 }
 
 // initCommonWithServerless initializes configs that are common to all agents, in particular serverless.

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -85,7 +85,7 @@ var legacyConvertArrayToMap = func(c *mapstructure.DecoderConfig) {
 // Else the viper/legacy version is used.
 func UnmarshalKey(cfg model.Reader, key string, target interface{}, opts ...UnmarshalKeyOption) error {
 	nodetreemodel := os.Getenv("DD_CONF_NODETREEMODEL")
-	if nodetreemodel == "enable" || nodetreemodel == "unmarshal" {
+	if nodetreemodel == "enable" || nodetreemodel == "unmarshal" || nodetreemodel == "" {
 		return unmarshalKeyReflection(cfg, key, target, opts...)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Experimental only: not to be merged.

Enable nodetreemodel by default for the config.

### Motivation

Run the regression detector against this change

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes
