### PR TITLE
Windows tests: fix command line too long error

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -835,7 +835,8 @@ def format_packages(ctx: Context, impacted_packages: set[str], build_tags: list[
 
     # We need to make sure the CLI length is not too long
     packages = compute_gotestsum_cli_args(modules_to_test.values())
-    if sys.platform == "win32" and len(packages) > WINDOWS_MAX_CLI_LENGTH:
+    # -1000 because there are ~1000 extra characters in the gotestsum command
+    if sys.platform == "win32" and len(packages) > WINDOWS_MAX_CLI_LENGTH - 1000:
         print("CLI length is too long, skipping fast tests")
         return get_default_modules().values()
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Reduce the command line max size in windows test by 1000 characters to take into account gotestsum flags.

### Motivation
Had the error "The command line is too long" because the full command was above the limit.
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/890058959/raw

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->