### PR TITLE
[Backport 7.65.x] handle API versions of DO-intake API

### DIFF
--- a/comp/trace/config/setup.go
+++ b/comp/trace/config/setup.go
@@ -650,6 +650,9 @@ func applyDatadogConfig(c *config.AgentConfig, core corecompcfg.Component) error
 	if k := "ol_proxy_config.additional_endpoints"; core.IsSet(k) {
 		c.OpenLineageProxy.AdditionalEndpoints = core.GetStringMapStringSlice(k)
 	}
+	if k := "ol_proxy_config.api_version"; core.IsSet(k) {
+		c.OpenLineageProxy.APIVersion = core.GetInt(k)
+	}
 	c.DebugServerPort = core.GetInt("apm_config.debug.port")
 	return nil
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1004,6 +1004,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnv("ol_proxy_config.dd_url")
 	config.BindEnv("ol_proxy_config.api_key")
 	config.BindEnv("ol_proxy_config.additional_endpoints")
+	config.BindEnvAndSetDefault("ol_proxy_config.api_version", 2)
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/trace/api/openlineage.go
+++ b/pkg/trace/api/openlineage.go
@@ -46,7 +46,7 @@ func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []s
 		// Fallback to the main agent site
 		host = fmt.Sprintf(openlineageURLTemplate, cfg.Site)
 	}
-	log.Debug("[openlineage] OpenLineage Host: %s", host)
+	log.Debugf("[openlineage] OpenLineage Host: %s", host)
 	u, err := url.Parse(host)
 	if err != nil {
 		// if the main intake URL is invalid we don't use additional endpoints
@@ -82,7 +82,7 @@ func addOpenLineageAPIVersion(u *url.URL, version int) {
 	query := u.Query()
 	query.Set("api-version", strconv.Itoa(version))
 	u.RawQuery = query.Encode()
-	log.Debug("[openlineage] OpenLineage API version added, URL: %s", u.String())
+	log.Debugf("[openlineage] OpenLineage API version added, URL: %s", u.String())
 }
 
 func openLineageErrorHandler(message string) http.Handler {
@@ -164,7 +164,7 @@ func (m *openLineageTransport) RoundTrip(req *http.Request) (rresp *http.Respons
 		if rerr != nil {
 			log.Errorf("[openlineage] RoundTrip failed: %v", rerr)
 		} else {
-			log.Debugf("[openlineage] Returned status: %s, from host: %s, path: %s", rresp.Status, m.urls[0].Host, m.urls[0].Path)
+			log.Debugf("[openlineage] Returned status: %s, from host: %s, path: %s, query %s", rresp.Status, m.urls[0].Host, m.urls[0].Path, m.urls[0].Query())
 		}
 
 		return rresp, rerr
@@ -184,7 +184,7 @@ func (m *openLineageTransport) RoundTrip(req *http.Request) (rresp *http.Respons
 			if rerr != nil {
 				log.Errorf("[openlineage] RoundTrip failed: %v", rerr)
 			} else {
-				log.Debugf("[openlineage] Returned status: %s, from host: %s, path: %s", rresp.Status, m.urls[0].Host, m.urls[0].Path)
+				log.Debugf("[openlineage] Returned status: %s, from host: %s, path: %s, query: %s", rresp.Status, u.Host, u.Path, u.Query())
 			}
 			continue
 		}

--- a/pkg/trace/api/openlineage.go
+++ b/pkg/trace/api/openlineage.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,6 +52,11 @@ func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []s
 		// if the main intake URL is invalid we don't use additional endpoints
 		return nil, nil, fmt.Errorf("[openlineage] error parsing intake URL %s: %v", host, err)
 	}
+
+	if cfg.OpenLineageProxy.APIVersion >= 2 {
+		addOpenLineageAPIVersion(u, cfg.OpenLineageProxy.APIVersion)
+	}
+
 	urls = append(urls, u)
 	apiKeys = append(apiKeys, apiKey)
 
@@ -62,11 +68,21 @@ func openLineageEndpoints(cfg *config.AgentConfig) (urls []*url.URL, apiKeys []s
 				log.Errorf("[openlineage] error parsing additional intake URL %s: %v", urlStr, err)
 				continue
 			}
+			if cfg.OpenLineageProxy.APIVersion >= 2 {
+				addOpenLineageAPIVersion(u, cfg.OpenLineageProxy.APIVersion)
+			}
 			urls = append(urls, u)
 			apiKeys = append(apiKeys, key)
 		}
 	}
 	return urls, apiKeys, nil
+}
+
+func addOpenLineageAPIVersion(u *url.URL, version int) {
+	query := u.Query()
+	query.Set("api-version", strconv.Itoa(version))
+	u.RawQuery = query.Encode()
+	log.Debug("[openlineage] OpenLineage API version added, URL: %s", u.String())
 }
 
 func openLineageErrorHandler(message string) http.Handler {

--- a/pkg/trace/api/openlineage_test.go
+++ b/pkg/trace/api/openlineage_test.go
@@ -91,8 +91,8 @@ func TestOpenLineageEndpoint(t *testing.T) {
 
 		urls, keys, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, len(urls), 5)
-		assert.Equal(t, len(keys), 5)
+		assert.Equal(t, 5, len(urls))
+		assert.Equal(t, 5, len(keys))
 
 		for _, url := range urls {
 			urlStr := url.String()
@@ -150,8 +150,8 @@ func TestOpenLineageEndpoint(t *testing.T) {
 
 		urls, keys, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, len(urls), 5)
-		assert.Equal(t, len(keys), 5)
+		assert.Equal(t, 5, len(urls))
+		assert.Equal(t, 5, len(keys))
 
 		for _, url := range urls {
 			urlStr := url.String()
@@ -187,8 +187,8 @@ func TestOpenLineageEndpoint(t *testing.T) {
 
 		urls, keys, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.eu/api/v1/lineage")
-		assert.Equal(t, keys, []string{"test_api_key"})
+		assert.Equal(t, "https://data-obs-intake.datadoghq.eu/api/v1/lineage", urls[0].String())
+		assert.Equal(t, []string{"test_api_key"}, keys)
 	})
 
 	t.Run("dd-site-fallback", func(t *testing.T) {
@@ -198,8 +198,8 @@ func TestOpenLineageEndpoint(t *testing.T) {
 
 		urls, keys, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.eu/api/v1/lineage")
-		assert.Equal(t, keys, []string{"test_api_key"})
+		assert.Equal(t, "https://data-obs-intake.datadoghq.eu/api/v1/lineage", urls[0].String())
+		assert.Equal(t, []string{"test_api_key"}, keys)
 	})
 
 	t.Run("datadoghq.com", func(t *testing.T) {
@@ -211,8 +211,8 @@ func TestOpenLineageEndpoint(t *testing.T) {
 
 		urls, keys, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.com/api/v1/lineage?api-version=17")
-		assert.Equal(t, keys, []string{"test_api_key"})
+		assert.Equal(t, "https://data-obs-intake.datadoghq.com/api/v1/lineage?api-version=17", urls[0].String())
+		assert.Equal(t, []string{"test_api_key"}, keys)
 
 	})
 
@@ -223,7 +223,7 @@ func TestOpenLineageEndpoint(t *testing.T) {
 		cfg.OpenLineageProxy.APIKey = "test_api_key"
 		urls, _, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.com/api/v1/lineage")
+		assert.Equal(t, "https://data-obs-intake.datadoghq.com/api/v1/lineage", urls[0].String())
 	})
 
 	t.Run("different-api", func(t *testing.T) {
@@ -233,7 +233,7 @@ func TestOpenLineageEndpoint(t *testing.T) {
 		cfg.OpenLineageProxy.APIKey = "test_api_key"
 		urls, _, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, urls[0].String(), "https://intake.testing.com/different-api")
+		assert.Equal(t, "https://intake.testing.com/different-api", urls[0].String())
 	})
 }
 

--- a/pkg/trace/api/openlineage_test.go
+++ b/pkg/trace/api/openlineage_test.go
@@ -120,6 +120,77 @@ func TestOpenLineageEndpoint(t *testing.T) {
 		}
 	})
 
+	t.Run("adds-v2-api-version", func(t *testing.T) {
+		var cfg config.AgentConfig
+		cfg.OpenLineageProxy.DDURL = "us3.datadoghq.com"
+		cfg.OpenLineageProxy.APIKey = "test_api_key"
+		cfg.OpenLineageProxy.AdditionalEndpoints = map[string][]string{
+			"us5.datadoghq.com":       {"test_api_key_2"},
+			"datadoghq.eu":            {"test_api_key_3"},
+			"datad0g.com":             {"test_api_key_4"},
+			"ddstaging.datadoghq.com": {"test_api_key_5"},
+		}
+		cfg.OpenLineageProxy.APIVersion = 2
+
+		expectedURLs := map[string]bool{
+			"https://data-obs-intake.us3.datadoghq.com/api/v1/lineage?api-version=2":       false,
+			"https://data-obs-intake.us5.datadoghq.com/api/v1/lineage?api-version=2":       false,
+			"https://data-obs-intake.datadoghq.eu/api/v1/lineage?api-version=2":            false,
+			"https://data-obs-intake.datad0g.com/api/v1/lineage?api-version=2":             false,
+			"https://data-obs-intake.ddstaging.datadoghq.com/api/v1/lineage?api-version=2": false,
+		}
+
+		expectedKeys := map[string]bool{
+			"test_api_key":   false,
+			"test_api_key_2": false,
+			"test_api_key_3": false,
+			"test_api_key_4": false,
+			"test_api_key_5": false,
+		}
+
+		urls, keys, err := openLineageEndpoints(&cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, len(urls), 5)
+		assert.Equal(t, len(keys), 5)
+
+		for _, url := range urls {
+			urlStr := url.String()
+			if _, exists := expectedURLs[urlStr]; exists {
+				expectedURLs[urlStr] = true
+			} else {
+				t.Errorf("Unexpected URL found: %s", urlStr)
+			}
+		}
+
+		for _, key := range keys {
+			if _, exists := expectedKeys[key]; exists {
+				expectedKeys[key] = true
+			} else {
+				t.Errorf("Unexpected key found: %s", key)
+			}
+		}
+
+		for url, found := range expectedURLs {
+			assert.True(t, found, "Expected URL not found: %s", url)
+		}
+
+		for key, found := range expectedKeys {
+			assert.True(t, found, "Expected key not found: %s", key)
+		}
+	})
+
+	t.Run("does-not-add-v1-version", func(t *testing.T) {
+		var cfg config.AgentConfig
+		cfg.Site = "datadoghq.eu"
+		cfg.OpenLineageProxy.APIKey = "test_api_key"
+		cfg.OpenLineageProxy.APIVersion = 1
+
+		urls, keys, err := openLineageEndpoints(&cfg)
+		assert.NoError(t, err)
+		assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.eu/api/v1/lineage")
+		assert.Equal(t, keys, []string{"test_api_key"})
+	})
+
 	t.Run("dd-site-fallback", func(t *testing.T) {
 		var cfg config.AgentConfig
 		cfg.Site = "datadoghq.eu"
@@ -135,11 +206,12 @@ func TestOpenLineageEndpoint(t *testing.T) {
 		var cfg config.AgentConfig
 		cfg.OpenLineageProxy.DDURL = "datadoghq.com"
 		cfg.OpenLineageProxy.APIKey = "test_api_key"
+		cfg.OpenLineageProxy.APIVersion = 17
 		cfg.OpenLineageProxy.AdditionalEndpoints = map[string][]string{}
 
 		urls, keys, err := openLineageEndpoints(&cfg)
 		assert.NoError(t, err)
-		assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.com/api/v1/lineage")
+		assert.Equal(t, urls[0].String(), "https://data-obs-intake.datadoghq.com/api/v1/lineage?api-version=17")
 		assert.Equal(t, keys, []string{"test_api_key"})
 
 	})

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -272,6 +272,8 @@ type OpenLineageProxy struct {
 	APIKey string `json:"-"` // Never marshal this field
 	// AdditionalEndpoints is a map of additional Datadog sites to API keys.
 	AdditionalEndpoints map[string][]string
+	// APIVersion indicates what version the OpenLineageProxy uses for the DO-intake API.
+	APIVersion int
 }
 
 // InstallSignatureConfig contains the information on how the agent was installed
@@ -605,7 +607,8 @@ func New() *AgentConfig {
 			MaxPayloadSize: 5 * 1024 * 1024,
 		},
 		OpenLineageProxy: OpenLineageProxy{
-			Enabled: true,
+			Enabled:    true,
+			APIVersion: 2,
 		},
 
 		Features:               make(map[string]struct{}),


### PR DESCRIPTION
This is a backport of #35969 to 7.65.x

### What does this PR do?
Adds an option to choose api-version for DO-intake.

### Motivation
We are writing new code path for OpenLineage events, which for now is distinguished by `api-version=2` in query.
We want to route new traffic (mostly from Spark Tracer for now) to this path.

### Describe how you validated your changes
Tests, running locally with Java tracer