### PR TITLE
fix-tests-clean-kafka-procmap

### DIFF
--- a/pkg/network/usm/tests/utils.go
+++ b/pkg/network/usm/tests/utils.go
@@ -21,13 +21,15 @@ import (
 
 // cleanProtocolMapByProtocol cleans up the protocol map for a given protocol
 func cleanProtocolMapByProtocol(t *testing.T, tr *tracer.Tracer, protocol protocols.ProtocolType) {
-	cleanProtocolMapBySelector(t, tr, func(_ netebpf.ConnTuple, wrapper netebpf.ProtocolStackWrapper) bool {
+	selector := func(_ netebpf.ConnTuple, wrapper netebpf.ProtocolStackWrapper) bool {
 		return wrapper.Stack.Application == uint8(protocol) || wrapper.Stack.Api == uint8(protocol) || wrapper.Stack.Encryption == uint8(protocol)
-	})
+	}
+	cleanProtocolMapBySelector(t, tr, selector)
+	cleanConnMapBySelector(t, tr, selector)
 }
 
 // cleanProtocolMapBySelector cleans up the protocol map for a given selector
-func cleanProtocolMapBySelector(t *testing.T, tr *tracer.Tracer, selector func(tuple netebpf.ConnTuple, wrapper netebpf.ProtocolStackWrapper) bool) {
+func cleanProtocolMapBySelector(t *testing.T, tr *tracer.Tracer, selector func(netebpf.ConnTuple, netebpf.ProtocolStackWrapper) bool) {
 	protocolMap, err := tr.GetMap(probes.ConnectionProtocolMap)
 	require.NoError(t, err)
 
@@ -45,5 +47,27 @@ func cleanProtocolMapBySelector(t *testing.T, tr *tracer.Tracer, selector func(t
 	for _, key := range keysToDelete {
 		// best effort deletion
 		_ = protocolMap.Delete(unsafe.Pointer(&key))
+	}
+}
+
+// cleanConnMapBySelector cleans up the protocol map for a given selector
+func cleanConnMapBySelector(t *testing.T, tr *tracer.Tracer, selector func(netebpf.ConnTuple, netebpf.ProtocolStackWrapper) bool) {
+	connMap, err := tr.GetMap(probes.ConnMap)
+	require.NoError(t, err)
+
+	keysToDelete := make([]netebpf.ConnTuple, 0)
+
+	var key netebpf.ConnTuple
+	var value netebpf.ConnStats
+	iter := connMap.Iterate()
+	for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
+		if selector(key, netebpf.ProtocolStackWrapper{Stack: value.Protocol_stack}) {
+			keysToDelete = append(keysToDelete, key)
+		}
+	}
+
+	for _, key := range keysToDelete {
+		// best effort deletion
+		_ = connMap.Delete(unsafe.Pointer(&key))
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes the `cleanProtocolMapByProtocol` used in tests to clean past detected connections.

### Motivation
- Fixed critical connection leak in tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->