### PR TITLE
service discovery: Use GetCheck

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/impl_linux.go
@@ -8,8 +8,6 @@
 package servicediscovery
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/servicediscovery/model"
@@ -37,27 +35,11 @@ func newLinuxImpl() (osImpl, error) {
 }
 
 func getDiscoveryServices(client *http.Client) (*model.ServicesResponse, error) {
-	url := sysprobeclient.ModuleURL(sysconfig.DiscoveryModule, "/services")
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	resp, err := sysprobeclient.GetCheck[model.ServicesResponse](client, sysconfig.DiscoveryModule)
 	if err != nil {
 		return nil, err
 	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("got non-success status code: url: %s, status_code: %d", req.URL, resp.StatusCode)
-	}
-
-	res := &model.ServicesResponse{}
-	if err := json.NewDecoder(resp.Body).Decode(res); err != nil {
-		return nil, err
-	}
-	return res, nil
+	return &resp, nil
 }
 
 func (li *linuxImpl) DiscoverServices() (*model.ServicesResponse, error) {

--- a/pkg/collector/corechecks/servicediscovery/model/model.go
+++ b/pkg/collector/corechecks/servicediscovery/model/model.go
@@ -35,7 +35,7 @@ type Service struct {
 	TxBps                      float64  `json:"tx_bps"`
 }
 
-// ServicesResponse is the response for the system-probe /discovery/services endpoint.
+// ServicesResponse is the response for the system-probe /discovery/check endpoint.
 type ServicesResponse struct {
 	StartedServices      []Service `json:"started_services"`
 	StoppedServices      []Service `json:"stopped_services"`

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	pathServices = "/services"
+	pathCheck = "/check"
 
 	// Use a low cache validity to ensure that we refresh information every time
 	// the check is run if needed. This is the same as cacheValidityNoRT in
@@ -246,7 +246,7 @@ func (s *discovery) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/status", s.handleStatusEndpoint)
 	httpMux.HandleFunc("/state", s.handleStateEndpoint)
 	httpMux.HandleFunc("/debug", s.handleDebugEndpoint)
-	httpMux.HandleFunc(pathServices, utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, s.handleServices))
+	httpMux.HandleFunc(pathCheck, utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, s.handleCheck))
 	return nil
 }
 
@@ -359,19 +359,19 @@ func (s *discovery) handleDebugEndpoint(w http.ResponseWriter, _ *http.Request) 
 	utils.WriteAsJSON(w, services)
 }
 
-// handleServers is the handler for the /services endpoint.
-// Returns the list of currently running services.
-func (s *discovery) handleServices(w http.ResponseWriter, req *http.Request) {
+// handleCheck is the handler for the /check endpoint.
+// Returns the list of service discovery events.
+func (s *discovery) handleCheck(w http.ResponseWriter, req *http.Request) {
 	params, err := parseParams(req.URL.Query())
 	if err != nil {
-		_ = log.Errorf("invalid params to /discovery%s: %v", pathServices, err)
+		_ = log.Errorf("invalid params to /discovery%s: %v", pathCheck, err)
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
 	services, err := s.getServices(params)
 	if err != nil {
-		_ = log.Errorf("failed to handle /discovery%s: %v", pathServices, err)
+		_ = log.Errorf("failed to handle /discovery%s: %v", pathCheck, err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -136,7 +136,7 @@ func setupDiscoveryModule(t *testing.T) *testDiscoveryModule {
 }
 
 func getServicesWithParams(t require.TestingT, url string, params *params) *model.ServicesResponse {
-	location := url + "/" + string(config.DiscoveryModule) + pathServices
+	location := url + "/" + string(config.DiscoveryModule) + pathCheck
 	req, err := http.NewRequest(http.MethodGet, location, nil)
 	require.NoError(t, err)
 

--- a/test/new-e2e/tests/discovery/docker_test.go
+++ b/test/new-e2e/tests/discovery/docker_test.go
@@ -67,7 +67,7 @@ func (s *dockerDiscoveryTestSuite) TestServiceDiscoveryContainerID() {
 	containerID = strings.TrimSuffix(containerID, "\n")
 	t.Logf("service container ID: %v", containerID)
 
-	services := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName, "curl", "-s", "--unix-socket", "/opt/datadog-agent/run/sysprobe.sock", "http://unix/discovery/services")
+	services := s.Env().Docker.Client.ExecuteCommand(s.Env().Agent.ContainerName, "curl", "-s", "--unix-socket", "/opt/datadog-agent/run/sysprobe.sock", "http://unix/discovery/check")
 	t.Logf("system-probe services: %v", services)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/test/new-e2e/tests/discovery/linux_test.go
+++ b/test/new-e2e/tests/discovery/linux_test.go
@@ -74,7 +74,7 @@ func (s *linuxTestSuite) TestServiceDiscoveryCheck() {
 	// This is very useful for debugging, but we probably don't want to decode
 	// and assert based on this in this E2E test since this is an internal
 	// interface between the agent and system-probe.
-	services := s.Env().RemoteHost.MustExecute("sudo curl -s --unix /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/debug")
+	services := s.Env().RemoteHost.MustExecute("sudo curl -s --unix /opt/datadog-agent/run/sysprobe.sock http://unix/discovery/check")
 	t.Log("system-probe services", services)
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION


<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Use the GetCheck API to remove some open-coding and also gain access to any improvements done in that API.  Note that this requires a rename of the endpoint to /check from /services.

### Motivation

To get general improvements like the one being done for https://datadoghq.atlassian.net/browse/DSCVR-93.

### Describe how you validated your changes

Covered by automated tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->