### PR TITLE
chore: use registry.ddbuild.io for devcontainer

### DIFF
--- a/.run/docker/Run development container.run.xml
+++ b/.run/docker/Run development container.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Run development container" type="docker-deploy" factoryName="docker-image" server-name="Docker">
     <deployment type="docker-image">
       <settings>
-        <option name="imageTag" value="486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-devenv:1-arm64" />
+        <option name="imageTag" value="registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64" />
         <option name="command" value="sleep infinity" />
         <option name="containerName" value="datadog-agent-devenv" />
         <option name="commandLineOptions" value="-w /home/datadog/go/src/github.com/DataDog/datadog-agent" />


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Replace the `486234852809.dkr.ecr.us-east-1.amazonaws.com` devcontainer image with the newer `registry.ddbuild.io` one in Jetbrains run configuration.

### Motivation

This is needed to ensure using the latest devcontainer image in the Jetbrains run configuration.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Devcontainer running
```
CONTAINER ID   IMAGE                                                 COMMAND                  CREATED         STATUS         PORTS                                                                                                                                  NAMES
11977e8d722d   registry.ddbuild.io/ci/datadog-agent-devenv:1-arm64   "sleep infinity"         8 minutes ago   Up 8 minutes                                                                                                                                          datadog-agent-devenv
```

Building the Datadog Agent
```
➜ docker exec -it datadog-agent-devenv bash -c "inv agent.hacky-dev-image-build --trace-agent --target-image=wdhifdatadog/agent --push"
/usr/lib/python3/dist-packages/blinker/base.py:93: SyntaxWarning: invalid escape sequence '\*'
  """Connect *receiver* to signal events sent by *sender*.
/usr/lib/python3/dist-packages/blinker/base.py:161: SyntaxWarning: invalid escape sequence '\*'
  """Connect the decorated function as a receiver for *sender*.
/usr/lib/python3/dist-packages/blinker/base.py:242: SyntaxWarning: invalid escape sequence '\*'
  """Emit this signal on behalf of *sender*, passing on \*\*kwargs.
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
-- Found Python3: /tmp/tmpeutizlaz/opt/datadog-agent/embedded/bin/python3.12 (found version "3.12.9") found components: Interpreter Development Development.Module Development.Embed
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/datadog/go/src/github.com/DataDog/datadog-agent/rtloader/build
[...]
latest: digest: sha256:fb9b00809089c3d3ceaef8b5e1cb04ca8b0c9f9060ccb0694d157f62f1cea57a size: 3257

What's next:
    Try Docker Debug for seamless, persistent debugging tools in any container or image → docker debug datadog-agent-devenv
    Learn more at https://docs.docker.com/go/debug-cli/
```

Running said agent
```
➜ kubectl get pods
NAME                                             READY   STATUS    RESTARTS   AGE
datadog-agent-zvhbt                              5/5     Running   0          2m5s
datadog-cluster-agent-5d5744cb66-b8cwg           1/1     Running   0          3m39s
datadog-cluster-checks-runner-78b96df6c5-jf6fz   1/1     Running   0          3m39s
datadog-operator-5f875f6cc8-p8n42                1/1     Running   0          8m35s
```

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A