### PR TITLE
[CONTP-731] Update config webhook to use new csi schema

### DIFF
--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -59,13 +59,13 @@ const (
 	webhookName = "agent_config"
 )
 
-// csiInjectionMode defines the mode of the injected csi volume
-// mode can be either 'socket' or 'local'
-type csiInjectionMode string
+// csiInjectionType defines the type CSI volume to be injected by the CSI driver
+type csiInjectionType string
 
 const (
-	csiModeSocket csiInjectionMode = "socket"
-	csiModeLocal  csiInjectionMode = "local"
+	csiAPMSocket               csiInjectionType = "APMSocket"
+	csiDSDSocket               csiInjectionType = "DSDSocket"
+	csiDatadogSocketsDirectory csiInjectionType = "DatadogSocketsDirectory"
 )
 
 // Webhook is the webhook that injects DD_AGENT_HOST and DD_ENTITY_ID into a pod


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Updates the config webhook to use the new CSI volume schema introduced in [this](https://github.com/DataDog/datadog-csi-driver/pull/23) PR.

### Motivation

Inject and mount CSI volumes using the correct schema

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests are updated. 

E2E tests are already in place to validate the webhook default behaviour in the absence of CSI. 

The following steps can be used to verify the behaviour when csi mode is used:

Use the following to deploy the cluster agent with different configurations:

**ATTENTION: it is expected that pods that get a CSI volume are stuck in ContainerCreating phase because there is no CSI driver to process the volume mount request. This is okay. In this QA we need to verify that the correct mutation is done only. You can force delete the pod using `kubectl delete pod --force <pod-name>`**

```
clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: socket
  envDict:
    DD_CSI_ENABLED: "true"
    DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TYPE_SOCKET_VOLUMES: <true or false, default is false>
```

#### Case 1: Default CSI behaviour

To test this, use:
```
clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: csi
```

Deploy any pod.

Verify the pod got the following volume injected in the pod:
```
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: true
      volumeAttributes:
        type: DatadogSocketsDirectory
    name: datadog
```

It should be mounted like this:
```
- mountPath: /var/run/datadog
  name: datadog
  readOnly: true
```

#### Case 2: CSI with socket volume types

To test this, use:
```
clusterAgent:
  admissionController:
    enabled: true
    mutateUnlabelled: true
    configMode: csi
  envDict:
    DD_CSI_ENABLED: "true"
    DD_ADMISSION_CONTROLLER_INJECT_CONFIG_TYPE_SOCKET_VOLUMES: "true"
```

Deploy any pod.

Verify the pod got the following volumes injected in the pod:
```
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: true
      volumeAttributes:
        type: DSDSocket
    name: datadog-dogstatsd
  - csi:
      driver: k8s.csi.datadoghq.com
      readOnly: true
      volumeAttributes:
        type: APMSocket
    name: datadog-trace-agent
```

They should be mounted as such:

```
- mountPath: /var/run/datadog/dsd.socket
  name: datadog-dogstatsd
  readOnly: true
- mountPath: /var/run/datadog/apm.socket
  name: datadog-trace-agent
  readOnly: true
```

### Possible Drawbacks / Trade-offs

None