### PR TITLE
wmeta: reuse deviceCache fields in nvml collector

### DIFF
--- a/pkg/gpu/nvml/devices.go
+++ b/pkg/gpu/nvml/devices.go
@@ -27,6 +27,7 @@ type Device struct {
 
 	SMVersion uint32
 	UUID      string
+	Name      string
 	CoreCount int
 	Index     int
 	Memory    uint64
@@ -43,6 +44,11 @@ func NewDevice(dev nvml.Device) (*Device, error) {
 	uuid, ret := dev.GetUUID()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting UUID: %s", nvml.ErrorString(ret))
+	}
+
+	name, ret := dev.GetName()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("error getting name: %s", nvml.ErrorString(ret))
 	}
 
 	cores, ret := dev.GetNumGpuCores()
@@ -64,6 +70,7 @@ func NewDevice(dev nvml.Device) (*Device, error) {
 		NVMLDevice: dev,
 		SMVersion:  smVersion,
 		UUID:       uuid,
+		Name:       name,
 		CoreCount:  cores,
 		Index:      index,
 		Memory:     memInfo.Total,


### PR DESCRIPTION
### What does this PR do?

use ddnvml.Device struct instead of nvml.Device interface inside wmeta nvml collector when possible

### Motivation

re-use deviceCache logic and simplify code (especially around error handling)

### Describe how you validated your changes

all existing UTs should still pass

### Possible Drawbacks / Trade-offs

### Additional Notes
mig API is not supported in deviceCache yet, hence left unchanged with a direct usage of the nvml.Device interface