### PR TITLE
[OTAGENT-368] fix otel-agent converter

### DIFF
--- a/comp/otelcol/converter/impl/testdata/receivers/multi-dd-partial-prom/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/receivers/multi-dd-partial-prom/config-result.yaml
@@ -46,7 +46,15 @@ processors:
 service:
   telemetry:
     metrics:
-      address: "localhost:1234"
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "localhost"
+                port: 1234
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
   pipelines:
       traces:

--- a/comp/otelcol/converter/impl/testdata/receivers/multi-dd-partial-prom/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/receivers/multi-dd-partial-prom/config.yaml
@@ -35,7 +35,15 @@ processors:
 service:
   telemetry:
     metrics:
-      address: "localhost:1234"
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "localhost"
+                port: 1234
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
   pipelines:
       traces:

--- a/comp/otelcol/converter/impl/testdata/receivers/no-prom-not-default-addr/config-result.yaml
+++ b/comp/otelcol/converter/impl/testdata/receivers/no-prom-not-default-addr/config-result.yaml
@@ -30,7 +30,15 @@ processors:
 service:
   telemetry:
     metrics:
-      address: "localhost:1234"
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "localhost"
+                port: 1234
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
   pipelines:
       traces:

--- a/comp/otelcol/converter/impl/testdata/receivers/no-prom-not-default-addr/config.yaml
+++ b/comp/otelcol/converter/impl/testdata/receivers/no-prom-not-default-addr/config.yaml
@@ -19,7 +19,15 @@ processors:
 service:
   telemetry:
     metrics:
-      address: "localhost:1234"
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "localhost"
+                port: 1234
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true
   extensions: [pprof/user-defined, zpages/user-defined, health_check/user-defined, ddflare/user-defined]
   pipelines:
       traces:


### PR DESCRIPTION
### What does this PR do?
Fix otel-agent converter to use the new otel conventions.

### Motivation
The converter currently gets the internal prometheus address from service::telemetry::metrics::address. This config is deprecated and no longer in effect in otel collector v0.123.0+. See https://github.com/open-telemetry/opentelemetry-collector/pull/12756

The new config looks like
```
service:
  telemetry:
    metrics:
      readers:
        - pull:
            exporter:
              prometheus:
                host: "localhost"
                port: 1234
```

### Describe how you validated your changes
modified tests