### PR TITLE
Fix various string/array bugs in Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -78,7 +78,7 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 		}
 	}
 
-	fieldIDs := make([]bininspect.FieldIdentifier, 0)
+	fieldIDs := []bininspect.FieldIdentifier{}
 	for _, funcParams := range typeMap.Functions {
 		for _, param := range funcParams {
 			fieldIDs = append(fieldIDs,

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -273,6 +273,12 @@ func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[st
 		typeHeader.ID = randomLabel()
 	}
 
+	for k := range seenTypes {
+		if seenTypes[k].count > 0 {
+			seenTypes[k].count--
+		}
+	}
+
 	return &typeHeader, nil
 }
 

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -28,10 +28,10 @@ const ConfigBPFProbeID = "config" // ConfigBPFProbeID is the ID used for the con
 var (
 	CaptureParameters       = true  // CaptureParameters is the default value for if probes should capture parameter values
 	ArgumentsMaxSize        = 10000 // ArgumentsMaxSize is the default size in bytes of the output buffer used for param values
-	StringMaxSize           = 512   // StringMaxSize is the length limit
+	StringMaxSize           = 60    // StringMaxSize is the length limit
 	MaxReferenceDepth uint8 = 4     // MaxReferenceDepth is the default depth that DI will traverse datatypes for capturing values
 	MaxFieldCount           = 20    // MaxFieldCount is the default limit for how many fields DI will capture in a single data type
-	SliceMaxLength          = 10    // SliceMaxLength is the default limit in number of elements of a slice
+	SliceMaxLength          = 5     // SliceMaxLength is the default limit in number of elements of a slice
 )
 
 // ProbeID is the unique identifier for probes

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -463,10 +463,10 @@ var structCaptures = fixtures{
 					Fields: fieldMap{
 						"x": capturedValue("int", "9"),
 						"slice": {
-							Type:     "[]int",
+							Type:     "[]uint8",
 							Elements: []ditypes.CapturedValue{},
 						},
-						"z": capturedValue("int", "5"),
+						"z": capturedValue("uint64", "5"),
 					},
 				},
 			},
@@ -696,10 +696,15 @@ var structCaptures = fixtures{
 							Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.anotherStruct",
 							Fields: fieldMap{
 								"nested": {
-									Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct",
+									Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct",
 									Fields: fieldMap{
-										"anotherInt":    capturedValue("int", "42"),
-										"anotherString": capturedValue("string", "xyz"),
+										"arg_0": {
+											Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.nestedStruct",
+											Fields: fieldMap{
+												"anotherInt":    capturedValue("int", "42"),
+												"anotherString": capturedValue("string", "xyz"),
+											},
+										},
 									},
 								},
 							},

--- a/pkg/dynamicinstrumentation/testutil/sample/strings.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/strings.go
@@ -13,8 +13,33 @@ func test_single_string(x string) {}
 //go:noinline
 func test_three_strings(x, y, z string) {}
 
+type threeStringStruct struct {
+	a string
+	b string
+	c string
+}
+
+type oneStringStruct struct {
+	a string
+}
+
+//nolint:all
+//go:noinline
+func test_three_strings_in_struct(a threeStringStruct) {}
+
+//nolint:all
+//go:noinline
+func test_three_strings_in_struct_pointer(a *threeStringStruct) {}
+
+//nolint:all
+//go:noinline
+func test_one_string_in_struct_pointer(a *oneStringStruct) {}
+
 //nolint:all
 func ExecuteStringFuncs() {
 	test_single_string("abc")
 	test_three_strings("abc", "def", "ghi")
+	test_three_strings_in_struct(threeStringStruct{a: "abc", b: "def", c: "ghi"})
+	test_three_strings_in_struct_pointer(&threeStringStruct{a: "abc", b: "def", c: "ghi"})
+	test_one_string_in_struct_pointer(&oneStringStruct{a: "omg"})
 }

--- a/pkg/dynamicinstrumentation/uploader/di_log_converter.go
+++ b/pkg/dynamicinstrumentation/uploader/di_log_converter.go
@@ -119,6 +119,9 @@ func convertArgs(definitions []*ditypes.Parameter, captures []*ditypes.Param) ma
 			break
 		}
 		definition := definitions[definitionCounter]
+		if definition == nil || captures[i] == nil {
+			continue
+		}
 		if definition.Kind != uint(captures[i].Kind) || definition.DoNotCapture {
 			// definition is not present in captures, put it in the map and move on
 			args[definition.Name] = &ditypes.CapturedValue{


### PR DESCRIPTION
### What does this PR do?

Handles a few bugs in Go DI:

- There were issues where in some test cases strings would cause a verifier issue that's resolved by having an extra register assignment for string addresses.
- Fixes an issue where we weren't subtracting from the `seenTypes` map counters when returning up from depth first traversal of types, causing false positives of recursive types. For example, structs with 5+ strings would have issues.
- Various index/nil checks 

Also adds more e2e test fixtures

### Motivation

Bug fixes that I observed.

### Describe how you validated your changes

More e2e tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->