### PR TITLE
Add purpose tag to obfuscation sql cache metrics

### DIFF
--- a/comp/otelcol/otlp/components/connector/datadogconnector/connector.go
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/connector.go
@@ -6,11 +6,12 @@ package datadogconnector // import "github.com/DataDog/datadog-agent/comp/otelco
 import (
 	"context"
 	"fmt"
+	"time"
+
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 	datadogconfig "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog/config"
-	"time"
 
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor"
 	"github.com/DataDog/datadog-agent/pkg/obfuscate"
@@ -124,6 +125,7 @@ func newTraceToMetricConnector(set component.TelemetrySettings, cfg component.Co
 	oconf := tcfg.Obfuscation.Export(tcfg)
 	oconf.Statsd = metricsClient
 	oconf.Redis.Enabled = true
+	oconf.Cache.Purpose = "datadogconnector"
 
 	// TODO(IbraheemA): When creating datadogconnector in otel-agent, use components (e.g. concentrator) from trace-agent instead of creating new ones
 	return &traceToMetricConnector{

--- a/pkg/collector/corechecks/oracle/obfuscate.go
+++ b/pkg/collector/corechecks/oracle/obfuscate.go
@@ -33,7 +33,7 @@ func (c *Check) LazyInitObfuscator() *obfuscate.Obfuscator {
 			obfuscaterConfig = obfuscate.Config{}
 		}
 		obfuscaterConfig.SQL = c.config.ObfuscatorOptions
-
+		obfuscaterConfig.Cache.Purpose = "oracle"
 		c.obfuscator = obfuscate.NewObfuscator(obfuscaterConfig)
 	}
 

--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -269,6 +269,7 @@ func lazyInitObfuscator() *obfuscate.Obfuscator {
 		if len(obfuscaterConfig.Mongo.ObfuscateSQLValues) == 0 {
 			obfuscaterConfig.Mongo.ObfuscateSQLValues = defaultMongoObfuscateSettings.ObfuscateSQLValues
 		}
+		obfuscaterConfig.Cache.Purpose = "python"
 		obfuscator = obfuscate.NewObfuscator(obfuscaterConfig)
 	})
 	return obfuscator

--- a/pkg/obfuscate/obfuscate.go
+++ b/pkg/obfuscate/obfuscate.go
@@ -14,6 +14,7 @@ package obfuscate
 
 import (
 	"bytes"
+	"fmt"
 
 	"go.uber.org/atomic"
 
@@ -297,6 +298,9 @@ type CacheConfig struct {
 
 	// MaxSize is the maximum size of the cache in bytes.
 	MaxSize int64 `mapstructure:"max_size"`
+
+	// Purpose is the purpose of the cache.
+	Purpose string `mapstructure:"-"`
 }
 
 // NewObfuscator creates a new obfuscator
@@ -305,8 +309,12 @@ func NewObfuscator(cfg Config) *Obfuscator {
 		cfg.Logger = noopLogger{}
 	}
 	o := Obfuscator{
-		opts:              &cfg,
-		queryCache:        newMeasuredCache(cacheOptions{On: cfg.Cache.Enabled, Statsd: cfg.Statsd, MaxSize: cfg.Cache.MaxSize}),
+		opts: &cfg,
+		queryCache: newMeasuredCache(cacheOptions{
+			On:      cfg.Cache.Enabled,
+			Statsd:  cfg.Statsd,
+			MaxSize: cfg.Cache.MaxSize,
+			Tags:    []string{fmt.Sprintf("purpose:%s", cfg.Cache.Purpose)}}),
 		sqlLiteralEscapes: atomic.NewBool(false),
 		log:               cfg.Logger,
 	}

--- a/pkg/trace/agent/obfuscate.go
+++ b/pkg/trace/agent/obfuscate.go
@@ -184,6 +184,7 @@ func (a *Agent) lazyInitObfuscator() *obfuscate.Obfuscator {
 
 	if a.obfuscator == nil {
 		if a.obfuscatorConf != nil {
+			a.obfuscatorConf.Cache.Purpose = "trace-agent"
 			a.obfuscator = obfuscate.NewObfuscator(*a.obfuscatorConf)
 		} else {
 			a.obfuscator = obfuscate.NewObfuscator(obfuscate.Config{})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add `purpose` tag to

- `datadog.trace_agent.obfuscation.sql_cache.hits`
- `datadog.trace_agent.obfuscation.sql_cache.misses`

### Motivation

The SQL obfuscation feature could be used for different purposes.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

I think we should rename metrics as well, but renaming is a breaking change.