### PR TITLE
Export function and types to parse check command output and use float64 for points

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -652,6 +652,7 @@
 /test/fakeintake/aggregator/servicediscovery* @DataDog/agent-discovery
 /test/new-e2e/                                @DataDog/agent-e2e-testing @DataDog/agent-devx-loops
 /test/new-e2e/pkg/components/datadog-installer @DataDog/windows-agent
+/test/new-e2e/pkg/testcommon/check            @DataDog/agent-runtimes
 /test/new-e2e/test-infra-definition           @DataDog/agent-devx-loops
 /test/new-e2e/system-probe                    @DataDog/ebpf-platform
 /test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform

--- a/test/new-e2e/pkg/testcommon/check/parse.go
+++ b/test/new-e2e/pkg/testcommon/check/parse.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package check contains the code to parse the check command output
 package check
 
 import (
@@ -34,8 +35,8 @@ type Metric struct {
 	Type           string      `json:"type"`
 }
 
-// ParseCheckOutput parses the check command json output
-func ParseCheckOutput(t *testing.T, check []byte) []Root {
+// ParseJSONOutput parses the check command json output
+func ParseJSONOutput(t *testing.T, check []byte) []Root {
 	// On Windows a warning is printed when running the check command with the wrong user
 	// This warning is not part of the JSON output and needs to be ignored when parsing
 	startIdx := bytes.IndexAny(check, "[{")

--- a/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/environments"
+	checkutils "github.com/DataDog/datadog-agent/test/new-e2e/pkg/testcommon/check"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
 
@@ -50,7 +51,7 @@ func (v *baseCheckSuite) TestCustomCheck() {
 
 func (v *baseCheckSuite) TestCheckRate() {
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-rate", "--json"}))
-	data := ParseCheckOutput(v.T(), []byte(check))
+	data := checkutils.ParseJSONOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 
@@ -65,7 +66,7 @@ func (v *baseCheckSuite) TestCheckTimes() {
 	times := 10
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-times", fmt.Sprint(times), "--json"}))
 
-	data := ParseCheckOutput(v.T(), []byte(check))
+	data := checkutils.ParseJSONOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 

--- a/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
+++ b/test/new-e2e/tests/agent-subcommands/check/check_common_test.go
@@ -50,27 +50,27 @@ func (v *baseCheckSuite) TestCustomCheck() {
 
 func (v *baseCheckSuite) TestCheckRate() {
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-rate", "--json"}))
-	data := parseCheckOutput(v.T(), []byte(check))
+	data := ParseCheckOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 
 	assert.Equal(v.T(), len(metrics), 2)
 	assert.Equal(v.T(), metrics[0].Metric, "hello.world")
-	assert.Equal(v.T(), metrics[0].Points[0][1], 123)
+	assert.EqualValues(v.T(), metrics[0].Points[0][1], 123)
 	assert.Equal(v.T(), metrics[1].Metric, "hello.world")
-	assert.Equal(v.T(), metrics[1].Points[0][1], 133)
+	assert.EqualValues(v.T(), metrics[1].Points[0][1], 133)
 }
 
 func (v *baseCheckSuite) TestCheckTimes() {
 	times := 10
 	check := v.Env().Agent.Client.Check(agentclient.WithArgs([]string{"hello", "--check-times", fmt.Sprint(times), "--json"}))
 
-	data := parseCheckOutput(v.T(), []byte(check))
+	data := ParseCheckOutput(v.T(), []byte(check))
 
 	metrics := data[0].Aggregator.Metrics
 
 	assert.Equal(v.T(), len(metrics), times)
-	for idx := 0; idx < times; idx++ {
-		assert.Equal(v.T(), metrics[idx].Points[0][1], 123+idx*10) // see fixtures/hello.py
+	for idx := range times {
+		assert.EqualValues(v.T(), metrics[idx].Points[0][1], 123+idx*10) // see fixtures/hello.py
 	}
 }

--- a/test/new-e2e/tests/agent-subcommands/check/parse.go
+++ b/test/new-e2e/tests/agent-subcommands/check/parse.go
@@ -13,25 +13,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type root struct {
-	Aggregator aggregator `json:"aggregator"`
+// Root is the root object of the check command output
+type Root struct {
+	Aggregator Aggregator `json:"aggregator"`
 }
 
-type aggregator struct {
-	Metrics []metric `json:"metrics"`
+// Aggregator contains the metrics emitted by a check
+type Aggregator struct {
+	Metrics []Metric `json:"metrics"`
 }
 
-type metric struct {
-	Host           string   `json:"host"`
-	Interval       int      `json:"interval"`
-	Metric         string   `json:"metric"`
-	Points         [][]int  `json:"points"`
-	SourceTypeName string   `json:"source_type_name"`
-	Tags           []string `json:"tags"`
-	Type           string   `json:"type"`
+// Metric represents a metric emitted by a check
+type Metric struct {
+	Host           string      `json:"host"`
+	Interval       int         `json:"interval"`
+	Metric         string      `json:"metric"`
+	Points         [][]float64 `json:"points"`
+	SourceTypeName string      `json:"source_type_name"`
+	Tags           []string    `json:"tags"`
+	Type           string      `json:"type"`
 }
 
-func parseCheckOutput(t *testing.T, check []byte) []root {
+// ParseCheckOutput parses the check command json output
+func ParseCheckOutput(t *testing.T, check []byte) []Root {
 	// On Windows a warning is printed when running the check command with the wrong user
 	// This warning is not part of the JSON output and needs to be ignored when parsing
 	startIdx := bytes.IndexAny(check, "[{")
@@ -39,7 +43,7 @@ func parseCheckOutput(t *testing.T, check []byte) []root {
 
 	check = check[startIdx:]
 
-	var data []root
+	var data []Root
 	err := json.Unmarshal([]byte(check), &data)
 	require.NoErrorf(t, err, "Failed to unmarshal check output: %v", string(check))
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
1. Use float64 as type for metric points
2. Export the function and types used to parse the check subcommand output

### Motivation
Points are really float64 (it happens that the ones in this test are integers, but it's still not the correct type to unmarshal the output).
This will be used by https://github.com/DataDog/datadog-agent/pull/35990, where metrics are really float64.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->