### PR TITLE
[APMTI-2933] Add a header to know if the payload is from the primary endpoint

### DIFF
--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -56,7 +56,7 @@ func newSenders(cfg *config.AgentConfig, r eventRecorder, path string, climit, q
 			userAgent:         fmt.Sprintf("Datadog Trace Agent/%s/%s", cfg.AgentVersion, cfg.GitCommit),
 			isMRF:             endpoint.IsMRF,
 			isMRFEnabled:      cfg.IsMRFEnabled,
-			isPrimaryEndpoint: i == 0,
+			isPrimaryEndpoint: i == 0, // the first endpoint is the primary one
 		}, statsd)
 	}
 	return senders
@@ -394,15 +394,16 @@ type retriableError struct{ err error }
 func (e retriableError) Error() string { return e.err.Error() }
 
 const (
-	headerAPIKey    = "DD-Api-Key"
-	headerUserAgent = "User-Agent"
+	headerAPIKey          = "DD-Api-Key"
+	headerUserAgent       = "User-Agent"
+	headerPrimaryEndpoint = "DD-Primary-Endpoint"
 )
 
 func (s *sender) do(req *http.Request) error {
 	req.Header.Set(headerAPIKey, s.cfg.apiKey)
 	req.Header.Set(headerUserAgent, s.cfg.userAgent)
 	if s.isPrimarySender() {
-		req.Header.Set("DD-Primary-Endpoint", "true")
+		req.Header.Set(headerPrimaryEndpoint, "true")
 	}
 
 	resp, err := s.cfg.client.Do(req)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a new header (`DD-Primary-Endpoint`, name debatable) to the payload sent by the primary sender.

As agents can send payloads to multiple endpoints, it would be useful to differentiate traffic specifically destined to a datacenter versus traffic dual shipped from another datacenter.

### Motivation

This allow us to be able to create projects targeting specifically a datacenter without taking into account traffic coming from other datacenter.  

The `datacenter` tag is not enough in some cases as we don't always have this info in the spans.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

I added a new unit test to ensure that this header is only added by the primary sender. 

### Possible Drawbacks / Trade-offs

This introduce a differentiation between the sender for the primary endpoint and other senders. It complexifies a bit the logic. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->