### PR TITLE
[BARX-916] Trigger e2e tests when release.json is changed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -741,6 +741,7 @@ workflow:
         - test/new-e2e/pkg/**/*
         - test/new-e2e/go.mod
         - flakes.yaml
+        - release.json
       compare_to: $COMPARE_TO_BRANCH
 
 .on_e2e_or_windows_installer_changes:


### PR DESCRIPTION
### What does this PR do?

This PR adds `release.json` to the list of files that changed trigger the e2e tests.

### Motivation

One of the post-mortem actions after incident#36348. See [notebook](https://app.datadoghq.com/notebook/11905646/postmortem-ir-36348-broken-python-integrations-on-the-windows-agent-7-64-0#action-items).