### PR TITLE
trace-agent: collect process tags from first span

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -710,21 +710,21 @@ func droppedTracesFromHeader(h http.Header, ts *info.TagStats) int64 {
 
 // todo:raphael cleanup unused methods of extraction once implementation
 // in all tracers is completed
+// order of priority:
+// 1. tags in the v06 payload
+// 2. tags in the first span of the first chunk
+// 3. tags in the header
 func getProcessTags(h http.Header, p *pb.TracerPayload) string {
-	// Check if the process tags are not already set in the payload
 	if p.Tags != nil {
 		if ptags, ok := p.Tags[tagProcessTags]; ok {
 			return ptags
 		}
 	}
-	// Check if the process tags are set in the first span
-	span, ok := getFirstSpan(p)
-	if ok {
+	if span, ok := getFirstSpan(p); ok {
 		if ptags, ok := span.Meta[tagProcessTags]; ok {
 			return ptags
 		}
 	}
-	// Check if the process tags are set in the HTTP header
 	return h.Get(header.ProcessTags)
 }
 

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -711,7 +711,7 @@ func droppedTracesFromHeader(h http.Header, ts *info.TagStats) int64 {
 // todo:raphael cleanup unused methods of extraction once implementation
 // in all tracers is completed
 // order of priority:
-// 1. tags in the v06 payload
+// 1. tags in the v07 payload
 // 2. tags in the first span of the first chunk
 // 3. tags in the header
 func getProcessTags(h http.Header, p *pb.TracerPayload) string {

--- a/test/new-e2e/tests/apm/tracegen.go
+++ b/test/new-e2e/tests/apm/tracegen.go
@@ -77,7 +77,7 @@ func tracegenTCPCommands(service string, peerTags string, enableClientSideStats 
 	return run, rm
 }
 
-func traceWithProcessTags(h *components.RemoteHost, processTags, service string) {
+func traceWithProcessTagsWithHeader(h *components.RemoteHost, processTags, service string) {
 	// TODO: once go tracer support process tags, use tracegen instead!
 	h.MustExecute(fmt.Sprintf(`curl -X POST http://localhost:8126/v0.4/traces \
 -H 'X-Datadog-Process-Tags: %s' \
@@ -87,5 +87,17 @@ func traceWithProcessTags(h *components.RemoteHost, processTags, service string)
 -H 'Datadog-Meta-Lang: go' \
 --data-binary @- <<EOF
 [[{"trace_id":1234567890123456789,"span_id":9876543210987654321,"parent_id":0,"name":"http.request","resource":"GET /api/users","service":"%s","type":"web","start":0,"duration":200000000,"meta":{"http.method":"GET","http.url":"/api/users","http.status_code":"200","env":"dev","version":"1.0.0"},"metrics":{"_sampling_priority_v1":1}}]]
+EOF`, processTags, service))
+}
+
+func traceWithProcessTags(h *components.RemoteHost, processTags, service string) {
+	// TODO: once go tracer support process tags, use tracegen instead!
+	h.MustExecute(fmt.Sprintf(`curl -X POST http://localhost:8126/v0.4/traces \
+-H 'X-Datadog-Trace-Count: 1' \
+-H 'Content-Type: application/json' \
+-H 'User-Agent: Go-http-client/1.1' \
+-H 'Datadog-Meta-Lang: go' \
+--data-binary @- <<EOF
+[[{"trace_id":1234567890123456789,"span_id":9876543210987654321,"parent_id":0,"name":"http.request","resource":"GET /api/users","service":"%s","type":"web","start":0,"duration":200000000,"meta":{"_dd.tags.process":%s,"http.method":"GET","http.url":"/api/users","http.status_code":"200","env":"dev","version":"1.0.0"},"metrics":{"_sampling_priority_v1":1}}]]
 EOF`, processTags, service))
 }

--- a/test/new-e2e/tests/apm/tracegen.go
+++ b/test/new-e2e/tests/apm/tracegen.go
@@ -98,6 +98,6 @@ func traceWithProcessTags(h *components.RemoteHost, processTags, service string)
 -H 'User-Agent: Go-http-client/1.1' \
 -H 'Datadog-Meta-Lang: go' \
 --data-binary @- <<EOF
-[[{"trace_id":1234567890123456789,"span_id":9876543210987654321,"parent_id":0,"name":"http.request","resource":"GET /api/users","service":"%s","type":"web","start":0,"duration":200000000,"meta":{"_dd.tags.process":%s,"http.method":"GET","http.url":"/api/users","http.status_code":"200","env":"dev","version":"1.0.0"},"metrics":{"_sampling_priority_v1":1}}]]
-EOF`, processTags, service))
+[[{"trace_id":1234567890123456789,"span_id":9876543210987654321,"parent_id":0,"name":"http.request","resource":"GET /api/users","service":"%s","type":"web","start":0,"duration":200000000,"meta":{"_dd.tags.process":"%s","http.method":"GET","http.url":"/api/users","http.status_code":"200","env":"dev","version":"1.0.0"},"metrics":{"_sampling_priority_v1":1}}]]
+EOF`, service, processTags))
 }

--- a/test/new-e2e/tests/apm/vm_test.go
+++ b/test/new-e2e/tests/apm/vm_test.go
@@ -305,6 +305,30 @@ func (s *VMFakeintakeSuite) TestBasicTrace() {
 	}, 3*time.Minute, 10*time.Second, "Failed to find traces with basic properties")
 }
 
+func (s *VMFakeintakeSuite) TestProcessTagsHeaderTrace() {
+	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	s.Require().NoError(err)
+
+	// Wait for agent to be live
+	s.T().Log("Waiting for Trace Agent to be live.")
+	s.Require().NoError(waitRemotePort(s, 8126))
+
+	traceWithProcessTagsWithHeader(s.Env().RemoteHost, "binary:generator", "test-service")
+
+	s.T().Log("Waiting for traces.")
+	s.EventuallyWithTf(func(c *assert.CollectT) {
+		s.logStatus()
+		testProcessTraces(c, s.Env().FakeIntake, "binary:generator")
+		s.logJournal(false)
+	}, 3*time.Minute, 10*time.Second, "Failed to find traces with process tags")
+
+	s.EventuallyWithTf(func(c *assert.CollectT) {
+		s.logStatus()
+		testStatsHaveProcessTags(c, s.Env().FakeIntake, "binary:generator")
+		s.logJournal(false)
+	}, 3*time.Minute, 10*time.Second, "Failed to find traces with process tags")
+}
+
 func (s *VMFakeintakeSuite) TestProcessTagsTrace() {
 	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
 	s.Require().NoError(err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Support extracting process tags not only from headers but also from the first span. We're still discussing the favoured vector of transmission and the first span is a likely one.
Making sure that this agent transmits process tags, will cleanup unused method after implementation on tracer side

Added dedicated e2e test

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->