### PR TITLE
fix(installer-script): Use agent package for default script

### DIFF
--- a/.gitlab/package_build/installer.yml
+++ b/.gitlab/package_build/installer.yml
@@ -101,7 +101,7 @@ installer-install-scripts:
     - mkdir -p $OMNIBUS_PACKAGE_DIR
     - tar -xJOf $OMNIBUS_PACKAGE_DIR/datadog-installer-7*amd64.tar.xz --wildcards "opt/datadog-packages/datadog-installer/*/bin/installer/installer" > installer-amd64
     - tar -xJOf $OMNIBUS_PACKAGE_DIR/datadog-installer-7*arm64.tar.xz --wildcards "opt/datadog-packages/datadog-installer/*/bin/installer/installer" > installer-arm64
-    - dda inv -- -e installer.build-linux-script "default" "$VERSION" "installer-amd64" "installer-arm64" "install.sh"
+    - dda inv -- -e installer.build-linux-script "default" "$VERSION" "installer-amd64" "installer-arm64" "install.sh" --package="agent-package"
     - dda inv -- -e installer.build-linux-script "databricks" "$VERSION" "installer-amd64" "installer-arm64" "install-databricks.sh"
     - dda inv -- -e installer.build-linux-script "emr" "$VERSION" "installer-amd64" "installer-arm64" "install-emr.sh"
     - dda inv -- -e installer.build-linux-script "dataproc" "$VERSION" "installer-amd64" "installer-arm64" "install-dataproc.sh"

--- a/pkg/fleet/installer/setup/install.sh
+++ b/pkg/fleet/installer/setup/install.sh
@@ -29,7 +29,7 @@ aarch64)
   ;;
 esac
 installer_domain=${DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE:-$([[ "$DD_SITE" == "datad0g.com" ]] && echo "install.datad0g.com" || echo "install.datadoghq.com")}
-installer_url="https://${installer_domain}/v2/installer-package/blobs/sha256:${installer_sha256}"
+installer_url="https://${installer_domain}/v2/PACKAGE_NAME/blobs/sha256:${installer_sha256}"
 
 tmp_dir="/opt/datadog-packages/tmp"
 tmp_bin="${tmp_dir}/installer"

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -71,7 +71,7 @@ def build(
 
 
 @task
-def build_linux_script(ctx, flavor, version, bin_amd64, bin_arm64, output):
+def build_linux_script(ctx, flavor, version, bin_amd64, bin_arm64, output, package="installer-package"):
     '''
     Builds the script that is used to install datadog on linux.
     '''
@@ -88,6 +88,7 @@ def build_linux_script(ctx, flavor, version, bin_amd64, bin_arm64, output):
     bin_arm64_sha256 = hashlib.sha256(open(bin_arm64, 'rb').read()).hexdigest()
     install_script = install_script.replace('INSTALLER_AMD64_SHA256', bin_amd64_sha256)
     install_script = install_script.replace('INSTALLER_ARM64_SHA256', bin_arm64_sha256)
+    install_script = install_script.replace('PACKAGE_NAME', package)
 
     makedirs(DIR_BIN, exist_ok=True)
     with open(path.join(DIR_BIN, output), 'w') as f:


### PR DESCRIPTION
### What does this PR do?
The default script needs to fetch the installer layer from the pinned agent package and not from the installer package

### Motivation

### Describe how you validated your changes
Manual QA

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->