### PR TITLE
[CWS] do not count order error in case of ringbuf

### DIFF
--- a/pkg/security/probe/eventstream/monitor.go
+++ b/pkg/security/probe/eventstream/monitor.go
@@ -428,12 +428,18 @@ func (pbm *Monitor) CountLostEvent(count uint64, mapName string, cpu int) {
 }
 
 // CountEvent adds `count` to the counter of received events of the specified type
-func (pbm *Monitor) CountEvent(eventType model.EventType, timestamp uint64, count uint64, size uint64, mapName string, cpu int) {
-	// check event order
-	if timestamp < pbm.lastTimestamp && pbm.lastTimestamp != 0 {
-		pbm.sortingErrorStats[mapName][eventType].Inc()
-	} else {
-		pbm.lastTimestamp = timestamp
+func (pbm *Monitor) CountEvent(eventType model.EventType, event *model.Event, size uint64, cpu int, checkOrder bool) {
+	const mapName = EventStreamMap
+
+	if checkOrder {
+		timestamp := event.TimestampRaw
+
+		// check event order
+		if timestamp < pbm.lastTimestamp && pbm.lastTimestamp != 0 {
+			pbm.sortingErrorStats[mapName][eventType].Inc()
+		} else {
+			pbm.lastTimestamp = timestamp
+		}
 	}
 
 	// sanity check
@@ -441,7 +447,7 @@ func (pbm *Monitor) CountEvent(eventType model.EventType, timestamp uint64, coun
 		return
 	}
 
-	pbm.stats[mapName][cpu][eventType].Count.Add(count)
+	pbm.stats[mapName][cpu][eventType].Count.Add(1)
 	pbm.stats[mapName][cpu][eventType].Bytes.Add(size)
 }
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -920,7 +920,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 		return
 	}
 
-	p.monitors.eventStreamMonitor.CountEvent(eventType, event.TimestampRaw, 1, dataLen, eventstream.EventStreamMap, CPU)
+	p.monitors.eventStreamMonitor.CountEvent(eventType, event, dataLen, CPU, !p.useRingBuffers)
 
 	// no need to dispatch events
 	switch eventType {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

It doesn't make sense to check event order in case of ringbuf thus skip the check and don't report the metric.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->