### PR TITLE
[gitlab] remove deprecated `ot-beta` images 

### DIFF
--- a/.gitlab/dev_container_deploy/e2e.yml
+++ b/.gitlab/dev_container_deploy/e2e.yml
@@ -66,20 +66,6 @@ qa_agent_fips_jmx:
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-fips-jmx-winltsc2022-servercore-amd64
     IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-fips-jmx
 
-qa_agent_ot:
-  extends: .docker_publish_job_definition
-  stage: dev_container_deploy
-  rules:
-    - !reference [.on_otel_or_e2e_changes]
-    - !reference [.manual]
-  needs:
-    - docker_build_ot_agent7
-    - docker_build_ot_agent7_arm64
-  variables:
-    IMG_REGISTRIES: agent-qa
-    IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-arm64
-    IMG_DESTINATIONS: agent:${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta
-
 qa_agent_full:
   extends: .docker_publish_job_definition
   stage: dev_container_deploy

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -750,7 +750,7 @@ new-e2e-otel-eks:
     - !reference [.needs_new_e2e_template]
     - qa_dca
     - qa_agent
-    - qa_agent_ot
+    - qa_agent_full
     - new-e2e-otel-eks-init
   variables:
     TARGETS: ./tests/otel
@@ -767,7 +767,7 @@ new-e2e-otel:
     - !reference [.needs_new_e2e_template]
     - qa_dca
     - qa_agent
-    - qa_agent_ot
+    - qa_agent_full
   variables:
     TARGETS: ./tests/otel
     EXTRA_PARAMS: --skip "TestOTelAgentIA(EKS|USTEKS)"
@@ -864,7 +864,7 @@ generate-flakes-finder-pipeline:
     - qa_dca
     - qa_dogstatsd
     - qa_agent
-    - qa_agent_ot
+    - qa_agent_full
     - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:
@@ -920,7 +920,7 @@ generate-fips-e2e-pipeline:
     - qa_dca
     - qa_dogstatsd
     - qa_agent
-    - qa_agent_ot
+    - qa_agent_full
     - tests_windows_sysprobe_x64
   tags: ["arch:amd64"]
   script:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR removes `ot-beta` images from the build pipeline as it is now deprecated and no longer required. It also makes sure the `full` image which supersedes the old one is not used everywhere.

### Motivation

`ot-beta` image has been deprecated.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->