### PR TITLE
bazel: devcontainer: remove the build image's config.toml

### DIFF
--- a/bazel/.devcontainer/Dockerfile
+++ b/bazel/.devcontainer/Dockerfile
@@ -5,6 +5,10 @@ RUN curl -LO https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/ba
     && chmod +x /bazelisk-linux-$(dpkg --print-architecture) \
     && ln -s /bazelisk-linux-$(dpkg --print-architecture) /usr/local/bin/bazel
 
+# Remove the build image cargo's config.toml as bazel will refuse to
+# build if it's present since it would break hermeticity
+RUN rm -f /.cargo/config.toml
+
 # Make Bazel output stuff to a volume we're mounting
 RUN echo "startup --output_user_root=/tmp/bazel/build_output" > /etc/bazel.bazelrc
 


### PR DESCRIPTION
This causes bazel to refuse to build rust code as it would break hermeticity
The drawback is that we won't support older glibc releases until we find a way to fix this through rules_rust

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->