### PR TITLE
feat(gha): Signed commits in go mod tidy

### DIFF
--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types:
       - labeled
+      - synchronize # As the commit is ignored by dependabot we need to recreate it if we rebase.
 
 permissions: {}
 jobs:

--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -4,16 +4,18 @@ on:
     types:
       - labeled
 
+permissions: {}
 jobs:
   mod_tidy_and_generate_licenses:
     if: ${{ github.repository == 'DataDog/datadog-agent' && github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-go') }}
-    runs-on: ubuntu-latest
     permissions:
       contents: write
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
       - name: Install go
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
@@ -37,12 +39,15 @@ jobs:
       - name: Update mocks
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
         run: dda inv -- -e security-agent.gen-mocks # generate both security agent and process mocks
-      - uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5.1.0
-        id: autocommit
-        with:
-          commit_message: Auto-generate go.sum and LICENSE-3rdparty.csv changes
-      - name: changes
-        env:
-          CHANGES: ${{ steps.autocommit.outputs.changes_detected }}
+      - name: Create commit
         run: |
-          echo "Changes detected: $CHANGES"
+          git config --global user.name "Login will be determined by the Github API based on the creator of the token"
+          git config --global user.email ""
+          git commit -am "[dependabot skip] Auto-generate go.sum and LICENSE-3rdparty.csv changes"
+      - name: "Push signed commits"
+        uses: asana/push-signed-commits@d615ca88d8e1a946734c24970d1e7a6c56f34897 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          local_branch_name: ${{ github.head_ref }}
+          remote_name: "origin"
+          remote_branch_name: ${{ github.head_ref }}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Move from `stefanzweifel/git-auto-commit-action` to `asana/push-signed-commits` to have signed commits on the mod_tidy generation for `dependabot` PR
- Use `[dependabot skip]` in the commit message ([source](https://github.com/dependabot/dependabot-core/issues/2798#issuecomment-737779277)) to try to fool dependabot, and allow it to auto-close PRs

### Motivation
Enabler to force signed commits in our branch protection rule
https://datadoghq.atlassian.net/browse/ACIX-515

### Describe how you validated your changes
Tested on a personal repo on [this PR](https://github.com/petit-suisse/datadog-agent/pull/63):
- the `@dependabot rebase` works even if we have an additional commit. It flushes the `go_mod_tidy` workflow, but we can force it by re-applying the `dependencies-go` label
- we have a [signed commit](https://github.com/petit-suisse/datadog-agent/pull/23/commits/6002432a5e6388d8ddf3230a5f69f6ff10d660cf)
- A [go-dep PR with an additional commit](https://github.com/petit-suisse/datadog-agent/pull/23) is auto-closed if the dependency is [updated](https://github.com/petit-suisse/datadog-agent/pull/93)
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->