### PR TITLE
[EBPF-694] gpu: send sync events on cudaMemcpy

### DIFF
--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -25,6 +25,7 @@ BPF_LRU_MAP(cuda_alloc_cache, __u64, cuda_alloc_request_args_t, 1024)
 BPF_LRU_MAP(cuda_sync_cache, __u64, __u64, 1024)
 BPF_LRU_MAP(cuda_set_device_cache, __u64, int, 1024)
 BPF_LRU_MAP(cuda_event_query_cache, __u64, __u64, 1024) // maps PID/TGID -> event
+BPF_LRU_MAP(cuda_memcpy_cache, __u64, __u64, 1024) // maps PID/TGID -> stream
 BPF_HASH_MAP(cuda_event_to_stream, cuda_event_key_t, cuda_event_value_t, 1024) // maps PID + event -> stream id
 
 // cudaLaunchKernel receives the dim3 argument by value, which gets translated as
@@ -323,6 +324,40 @@ int BPF_UPROBE(uprobe__cudaEventDestroy, __u64 event) {
 
     // If this deletion doesn't get triggered, the map cleaner will clean these entries up
     bpf_map_delete_elem(&cuda_event_to_stream, &key);
+
+    return 0;
+}
+
+SEC("uprobe/cudaMemcpy")
+int BPF_UPROBE(uprobe__cudaMemcpy, void *dst, const void *src, size_t count, int kind) {
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+
+    log_debug("cudaMemcpy: pid=%llu, dst=%llx, src=%llx, count=%lu, kind=%d", pid_tgid, (__u64)dst, (__u64)src, count, kind);
+    bpf_map_update_with_telemetry(cuda_memcpy_cache, &pid_tgid, &count, BPF_ANY);
+
+    return 0;
+}
+
+SEC("uretprobe/cudaMemcpy")
+int BPF_URETPROBE(uretprobe__cudaMemcpy) {
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u64 *count = NULL;
+    cuda_sync_t event = { 0 };
+
+    log_debug("cudaMemcpy[ret]: pid=%llx\n", pid_tgid);
+
+    count = bpf_map_lookup_elem(&cuda_memcpy_cache, &pid_tgid);
+    if (!count) {
+        log_debug("cudaMemcpy[ret]: failed to find cudaMemcpy request");
+        return 0;
+    }
+
+    fill_header(&event.header, 0, cuda_sync);
+
+    log_debug("cudaMemcpy[ret]: EMIT cudaSync pid_tgid=%llu", event.header.pid_tgid);
+
+    bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);
+    bpf_map_delete_elem(&cuda_memcpy_cache, &pid_tgid);
 
     return 0;
 }

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -354,6 +354,10 @@ int BPF_URETPROBE(uretprobe__cudaMemcpy) {
 
     fill_header(&event.header, 0, cuda_sync);
 
+    // According to https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#concurrent-execution-between-host-and-device
+    // most memory transfers force a synchronization on the global stream. Note that other streams might or might not sync,
+    // but for now we don't have fine-grained synchronization data for streams.
+
     log_debug("cudaMemcpy[ret]: EMIT cudaSync pid_tgid=%llu", event.header.pid_tgid);
 
     bpf_ringbuf_output_with_telemetry(&cuda_events, &event, sizeof(event), 0);

--- a/pkg/gpu/ebpf/c/runtime/gpu.c
+++ b/pkg/gpu/ebpf/c/runtime/gpu.c
@@ -332,7 +332,7 @@ SEC("uprobe/cudaMemcpy")
 int BPF_UPROBE(uprobe__cudaMemcpy, void *dst, const void *src, size_t count, int kind) {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
 
-    log_debug("cudaMemcpy: pid=%llu, dst=%llx, src=%llx, count=%lu, kind=%d", pid_tgid, (__u64)dst, (__u64)src, count, kind);
+    log_debug("cudaMemcpy: pid_tgid=%llu", pid_tgid);
     bpf_map_update_with_telemetry(cuda_memcpy_cache, &pid_tgid, &count, BPF_ANY);
 
     return 0;
@@ -344,7 +344,7 @@ int BPF_URETPROBE(uretprobe__cudaMemcpy) {
     __u64 *count = NULL;
     cuda_sync_t event = { 0 };
 
-    log_debug("cudaMemcpy[ret]: pid=%llx\n", pid_tgid);
+    log_debug("cudaMemcpy[ret]: pid_tgid=%llu\n", pid_tgid);
 
     count = bpf_map_lookup_elem(&cuda_memcpy_cache, &pid_tgid);
     if (!count) {

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -57,6 +57,7 @@ const (
 	cudaSetDeviceCacheMap  bpfMapName = "cuda_set_device_cache"
 	cudaEventStreamMap     bpfMapName = "cuda_event_to_stream"
 	cudaEventQueryCacheMap bpfMapName = "cuda_event_query_cache"
+	cudaMemcpyCacheMap     bpfMapName = "cuda_memcpy_cache"
 )
 
 // probeFuncName stores the ebpf hook function name
@@ -77,6 +78,8 @@ const (
 	cudaEventSynchronizeProbe    probeFuncName = "uprobe__cudaEventSynchronize"
 	cudaEventSynchronizeRetProbe probeFuncName = "uretprobe__cudaEventSynchronize"
 	cudaEventDestroyProbe        probeFuncName = "uprobe__cudaEventDestroy"
+	cudaMemcpyProbe              probeFuncName = "uprobe__cudaMemcpy"
+	cudaMemcpyRetProbe           probeFuncName = "uretprobe__cudaMemcpy"
 )
 
 // ProbeDependencies holds the dependencies for the probe
@@ -285,6 +288,7 @@ func (p *Probe) setupManager(buf io.ReaderAt, opts manager.Options) error {
 			{Name: cudaSetDeviceCacheMap},
 			{Name: cudaEventStreamMap},
 			{Name: cudaEventQueryCacheMap},
+			{Name: cudaMemcpyCacheMap},
 		}}, "gpu", &ebpftelemetry.ErrorsTelemetryModifier{})
 
 	if opts.MapSpecEditors == nil {
@@ -371,6 +375,8 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventSynchronizeRetProbe}},
 							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaEventDestroyProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMemcpyProbe}},
+							&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: cudaMemcpyRetProbe}},
 						},
 					},
 				},

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -114,7 +114,7 @@ func (s *probeTestSuite) TestCanReceiveEvents() {
 		ebpf.CudaEventTypeKernelLaunch.String(): 1,
 		ebpf.CudaEventTypeSetDevice.String():    1,
 		ebpf.CudaEventTypeMemory.String():       2,
-		ebpf.CudaEventTypeSync.String():         3, // cudaStreamSynchronize, cudaEventQuery and cudaEventSynchronize
+		ebpf.CudaEventTypeSync.String():         4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
 	}
 
 	for evName, value := range expectedEvents {

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -27,6 +27,8 @@ import (
 
 type probeTestSuite struct {
 	suite.Suite
+
+	telemetryMock telemetry.Mock
 }
 
 func TestProbe(t *testing.T) {
@@ -151,8 +153,6 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 	cmd, err := testutil.RunSample(t, testutil.CudaSample)
 	require.NoError(t, err)
 
-	//TODO: change this check to  count telemetry counter of the consumer (once added).
-	// we are expecting 2 different streamhandlers because cudasample generates 3 events in total for 2 different streams (stream 0 and stream 30)
 	require.Eventually(t, func() bool {
 		return probe.streamHandlers.streamCount() == 2
 	}, 3*time.Second, 100*time.Millisecond, "stream handlers count mismatch: expected: 2, got: %d", probe.streamHandlers.streamCount())
@@ -165,6 +165,31 @@ func (s *probeTestSuite) TestCanGenerateStats() {
 	metricKey := model.StatsKey{PID: uint32(cmd.Process.Pid), DeviceUUID: testutil.DefaultGpuUUID}
 	metrics := getMetricsEntry(metricKey, stats)
 	require.NotNil(t, metrics)
+
+	telemetryMock, ok := probe.deps.Telemetry.(telemetry.Mock)
+	require.True(t, ok)
+
+	eventMetrics, err := telemetryMock.GetCountMetric("gpu__consumer", "events")
+	require.NoError(t, err)
+
+	expectedEvents := map[string]int{
+		ebpf.CudaEventTypeKernelLaunch.String(): 1,
+		ebpf.CudaEventTypeSetDevice.String():    1,
+		ebpf.CudaEventTypeMemory.String():       2,
+		ebpf.CudaEventTypeSync.String():         4, // cudaStreamSynchronize, cudaEventQuery, cudaEventSynchronize and cudaMemcpy
+	}
+
+	actualEvents := make(map[string]int)
+	for _, m := range eventMetrics {
+		if evType, ok := m.Tags()["event_type"]; ok {
+			actualEvents[evType] = int(m.Value())
+		}
+	}
+
+	require.ElementsMatch(t, maps.Keys(expectedEvents), maps.Keys(actualEvents))
+	for evName, value := range expectedEvents {
+		require.Equal(t, value, actualEvents[evName], "event %s count mismatch", evName)
+	}
 
 	require.Greater(t, metrics.UsedCores, 0.0) // core usage depends on the time this took to run, so it's not deterministic
 	require.Equal(t, metrics.Memory.MaxBytes, uint64(110))

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -27,8 +27,6 @@ import (
 
 type probeTestSuite struct {
 	suite.Suite
-
-	telemetryMock telemetry.Mock
 }
 
 func TestProbe(t *testing.T) {

--- a/pkg/gpu/testdata/cudasample.c
+++ b/pkg/gpu/testdata/cudasample.c
@@ -53,6 +53,10 @@ cudaError_t cudaEventDestroy(cudaEvent_t event) {
     return 0;
 }
 
+cudaError_t cudaMemcpy(void *dst, const void *src, size_t count, int kind) {
+    return 0;
+}
+
 int main(int argc, char **argv) {
     cudaStream_t stream = 30;
     cudaEvent_t event = 42;
@@ -80,6 +84,8 @@ int main(int argc, char **argv) {
     cudaMalloc(&ptr, 100);
     cudaFree(ptr);
     cudaStreamSynchronize(stream);
+
+    cudaMemcpy((void *)0x1234, (void *)0x5678, 100, 0); // kind 0 is cudaMemcpyHostToDevice
 
     cudaEventRecord(event, stream);
     cudaEventQuery(event);


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a probe for the `cudaMemcpy` CUDA call, sending a synchronization event in that case as the copies force synchronization.

### Motivation

Improve accuracy and reduce missed synchronization events.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Unit tests included ensuring the sync events are sent.

### Possible Drawbacks / Trade-offs

This PR does not take into account logic for blocking/non-blocking streams, and just triggers a sync on the global stream. Once we have support for more fine-grained synchronization management we will take that into account for the memcpy syncs too.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->