### PR TITLE
Revert "change to channel for leader watch"

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -8,7 +8,6 @@
 package clusterchecks
 
 import (
-	"errors"
 	"sync"
 	"testing"
 
@@ -57,16 +56,8 @@ func (m *mockedPluggableAutoConfig) RemoveScheduler(name string) {
 
 type fakeLeaderEngine struct {
 	sync.Mutex
-	ip         string
-	err        error
-	subscriber chan struct{}
-}
-
-func newFakeLeaderEngine() *fakeLeaderEngine {
-	return &fakeLeaderEngine{
-		subscriber: make(chan struct{}),
-		err:        errors.New("failing"),
-	}
+	ip  string
+	err error
 }
 
 func (e *fakeLeaderEngine) get() (string, error) {
@@ -77,19 +68,7 @@ func (e *fakeLeaderEngine) get() (string, error) {
 
 func (e *fakeLeaderEngine) set(ip string, err error) {
 	e.Lock()
+	defer e.Unlock()
 	e.ip = ip
 	e.err = err
-	e.Unlock()
-	if e.subscriber != nil {
-		e.notify()
-	}
-}
-
-func (e *fakeLeaderEngine) notify() {
-	e.subscriber <- struct{}{}
-}
-
-func (e *fakeLeaderEngine) subscribe() (leadershipChangeNotif <-chan struct{}) {
-	leadershipChangeNotif = e.subscriber
-	return
 }

--- a/pkg/clusteragent/clusterchecks/leadership_kube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_kube.go
@@ -22,15 +22,3 @@ func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 
 	return engine.GetLeaderIP, nil
 }
-
-func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
-	engine, err := leaderelection.GetLeaderEngine()
-	if err != nil {
-		return nil, err
-	}
-
-	engine.StartLeaderElectionRun()
-
-	leadershipChangeNotif, _ := engine.Subscribe()
-	return leadershipChangeNotif, nil
-}

--- a/pkg/clusteragent/clusterchecks/leadership_nokube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_nokube.go
@@ -16,7 +16,3 @@ import (
 func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 	return nil, errors.New("No leader election engine compiled in")
 }
-
-func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
-	return nil, errors.New("No leader election engine compiled in")
-}


### PR DESCRIPTION
This reverts commit 164484aa91efa40b110e823ac817a4c97000380d.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
We transitioned leader election from periodic polling to channel-based notifications in latest [PR](https://github.com/DataDog/datadog-agent/pull/34924). However, a recently discovered bug causes the follower node to fail to refresh the leader IP as expected after receiving the notification and calling updateLeaderIP. The issue appears to lie within the callback function and requires further investigation. In the meantime, we are rolling back the problematic PR.

### Motivation
log on Pod name: datadog-cluster-agent-dcc75dcf-qzdz5:
old leader name: datadog-cluster-agent-dcc75dcf-nzm6v
new leader name: datadog-cluster-agent-dcc75dcf-n2fv6
```
2025-04-11 06:29:52 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go:219 in EnsureLeaderElectionRuns) | Leader election running, current leader is "datadog-cluster-agent-dcc75dcf-nzm6v"
2025-04-11 06:29:51 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:152 in func1) | New leader "datadog-cluster-agent-dcc75dcf-nzm6v"
2025-04-11 06:29:51 UTC | CLUSTER | INFO | (client-go@v0.31.2/tools/leaderelection/leaderelection.go:212 in Run) | attempting to acquire leader lease datadog-agent/datadog-agent-leader-election...
2025-04-11 06:29:51 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go:236 in runLeaderElection) | Starting leader election process for "datadog-cluster-agent-dcc75dcf-qzdz5"
```
After refreshing the leader name was still datadog-cluster-agent-dcc75dcf-nzm6v which caused the unscheduled cluster checks. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
reverting

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->