### PR TITLE
feat(gha): Use signed commits for otel collector dependencies

### DIFF
--- a/.github/workflows/collector-generate-and-update.yml
+++ b/.github/workflows/collector-generate-and-update.yml
@@ -26,11 +26,22 @@ jobs:
           features: legacy-tasks
 
       - name: Run Collector Update Script
+        id: collector-update
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           dda inv -- -e install-tools
           dda inv -- -e collector.update
+          echo "OCB_VERSION=$OCB_VERSION" >> $GITHUB_OUTPUT
           dda inv -- -e collector.generate
           dda inv -- -e generate-licenses
-          dda inv -- -e collector.pull-request
+
+      - uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        name: Create pull request
+        with:
+          commit-message: Update OTel Collector dependencies to ${{ steps.collector-update.outputs.OCB_VERSION}} and generate OTel Agent
+          branch: update-otel-collector-dependencies-${{ steps.collector-update.outputs.OCB_VERSION}}
+          sign-commits: true
+          title: Update OTel Collector dependencies to v${{ steps.collector-update.outputs.OCB_VERSION}}
+          body: This PR updates the dependencies of the OTel Collector to v{OCB_VERSION} and generates the OTel Agent code.
+          draft: true

--- a/tasks/collector.py
+++ b/tasks/collector.py
@@ -14,16 +14,6 @@ from invoke.tasks import task
 from tasks.go import tidy
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.common.color import Color, color_message
-from tasks.libs.common.constants import (
-    GITHUB_REPO_NAME,
-)
-from tasks.libs.common.git import (
-    check_clean_branch_state,
-    check_uncommitted_changes,
-    get_git_config,
-    revert_git_config,
-    set_git_config,
-)
 
 LICENSE_HEADER = """// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
@@ -509,6 +499,7 @@ class CollectorVersionUpdater:
             for file in testfiles:
                 files.append(os.path.join(root, file))
         collector_version = self.core_collector.get_version()[1:]
+        os.environ["OCB_VERSION"] = collector_version
         for file in files:
             update_file(file, self.core_collector.get_old_version(), collector_version)
 
@@ -524,45 +515,3 @@ def update(_):
     updater = CollectorVersionUpdater()
     updater.update()
     print("Update complete.")
-
-
-@task()
-def pull_request(ctx):
-    # Save current Git configuration
-    original_config = {'user.name': get_git_config(ctx, 'user.name'), 'user.email': get_git_config(ctx, 'user.email')}
-
-    try:
-        # Set new Git configuration
-        set_git_config(ctx, 'user.name', 'github-actions[bot]')
-        set_git_config(ctx, 'user.email', 'github-actions[bot]@users.noreply.github.com')
-
-        # Perform Git operations
-        ctx.run('git add .')
-        if check_uncommitted_changes(ctx):
-            branch_name = f"update-otel-collector-dependencies-{OCB_VERSION}"
-            gh = GithubAPI(repository=GITHUB_REPO_NAME)
-            ctx.run(f'git switch -c {branch_name}')
-            ctx.run(
-                f'git commit -m "Update OTel Collector dependencies to {OCB_VERSION} and generate OTel Agent" --no-verify'
-            )
-            try:
-                # don't check if local branch exists; we just created it
-                check_clean_branch_state(ctx, gh, branch_name)
-            except Exit as e:
-                # local branch already exists, so skip error if this is thrown
-                if "already exists locally" not in str(e):
-                    print(e)
-                    return
-            ctx.run(f'git push -u origin {branch_name} --no-verify')  # skip pre-commit hook if installed locally
-            gh.create_pr(
-                pr_title=f"Update OTel Collector dependencies to v{OCB_VERSION}",
-                pr_body=f"This PR updates the dependencies of the OTel Collector to v{OCB_VERSION} and generates the OTel Agent code.",
-                target_branch=branch_name,
-                base_branch="main",
-                draft=True,
-            )
-        else:
-            print("No changes detected, skipping PR creation.")
-    finally:
-        # Revert to original Git configuration
-        revert_git_config(ctx, original_config)

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -313,21 +313,5 @@ def get_last_release_tag(ctx, repo, pattern):
     return last_tag_commit, last_tag_name
 
 
-def get_git_config(ctx, key):
-    try:
-        result = ctx.run(f'git config --get {key}')
-    except Exit:
-        return None
-    return result.stdout.strip() if result.return_code == 0 else None
-
-
 def set_git_config(ctx, key, value):
     ctx.run(f'git config {key} {value}')
-
-
-def revert_git_config(ctx, original_config):
-    for key, value in original_config.items():
-        if value is None:
-            ctx.run(f'git config --unset {key}', hide=True)
-        else:
-            ctx.run(f'git config {key} {value}', hide=True)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use signed commits for otel collector dependecies workflow:
- Save the new OCB_VERSION as env variable and push it in GITHUB_OUTPUT
- Reuse this variable in the `peter-evans/create-pull-request` action
- Remove the no more used python code

### Motivation
https://datadoghq.atlassian.net/browse/ACIX-515

### Describe how you validated your changes
Ran the workflow on a personal fork TBD
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->