### PR TITLE
Fix pointer cut-off bug in Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/capture_depth.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth.go
@@ -9,7 +9,6 @@
 package codegen
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
@@ -276,7 +275,6 @@ func correctPointersWithoutPieces(params []*ditypes.Parameter) {
 
 		// Check if parameter is a pointer with no parameter pieces
 		if reflect.Kind(param.Kind) == reflect.Pointer && len(param.ParameterPieces) == 0 {
-			fmt.Println("Found a pointer with no parameter pieces!", param.Type)
 			param.ParameterPieces = []*ditypes.Parameter{{}}
 			return
 		}

--- a/pkg/dynamicinstrumentation/codegen/capture_depth.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth.go
@@ -246,29 +246,24 @@ func correctStructSize(param *ditypes.Parameter) {
 	}
 }
 
-// correctPointersWithoutPieces checks recursively if any parameter of kind Pointer in the given slice
-// has no parameter pieces (i.e., empty ParameterPieces) and corrects it accordingly
+// correctPointersWithoutPieces checks recursively if any parameter of kind Pointer in the parameter tree
+// has no parameter pieces and corrects it accordingly. This can occur for various reasons, such as
+// when capture depth is enforced.
 func correctPointersWithoutPieces(params []*ditypes.Parameter) {
 	if len(params) == 0 {
 		return
 	}
 
-	// Create a queue to process parameters breadth-first
 	queue := make([]*ditypes.Parameter, 0, len(params))
-
-	// Initialize queue with top-level parameters
 	for _, param := range params {
 		if param != nil {
 			queue = append(queue, param)
 		}
 	}
 
-	// Process parameters until queue is empty
 	for len(queue) > 0 {
-		// Dequeue the next parameter
 		param := queue[0]
 		queue = queue[1:]
-
 		if param == nil {
 			continue
 		}
@@ -278,14 +273,11 @@ func correctPointersWithoutPieces(params []*ditypes.Parameter) {
 			param.ParameterPieces = []*ditypes.Parameter{{}}
 			return
 		}
-
-		// Add child parameters to the queue for processing
 		for _, childParam := range param.ParameterPieces {
 			if childParam != nil {
 				queue = append(queue, childParam)
 			}
 		}
 	}
-
 	return
 }

--- a/pkg/dynamicinstrumentation/codegen/capture_depth.go
+++ b/pkg/dynamicinstrumentation/codegen/capture_depth.go
@@ -279,5 +279,4 @@ func correctPointersWithoutPieces(params []*ditypes.Parameter) {
 			}
 		}
 	}
-	return
 }

--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -40,6 +40,8 @@ func GenerateBPFParamsCode(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) 
 		copyTree(&params, &preChange)
 
 		params = applyExclusions(params)
+		correctPointersWithoutPieces(params)
+
 		for i := range params {
 			if params[i].DoNotCapture {
 				log.Tracef("Not capturing parameter %d %s: %s", i, params[i].Name, params[i].NotCaptureReason.String())

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -237,7 +237,7 @@ func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[st
 	}
 
 	v, typeParsedAlready := seenTypes[typeHeader.Type]
-	if typeParsedAlready {
+	if typeParsedAlready && typeHeader.Kind != uint(reflect.Pointer) {
 		v.count++
 		if v.count > ditypes.MaxReferenceDepth {
 			return &ditypes.Parameter{}, nil

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -106,6 +106,8 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 				// This is not directly assigned, expect the address for it on the stack
 				if elementParam.Kind == uint(reflect.Pointer) {
 					targetExpressions = append(targetExpressions,
+						ditypes.PrintStatement("%s", "Dereferencing pointer"),
+						ditypes.ApplyOffsetLocationExpression(uint(elementParam.FieldOffset)),
 						ditypes.DereferenceLocationExpression(uint(elementParam.TotalSize)),
 					)
 					_, ok := seenPointers[elementParam.ID]
@@ -117,6 +119,7 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					// Structs don't provide context on location, or have values themselves
 					// Just need to copy the address for each field
 					targetExpressions = append(targetExpressions,
+						ditypes.ApplyOffsetLocationExpression(uint(elementParam.FieldOffset)),
 						ditypes.CopyLocationExpression(),
 					)
 

--- a/pkg/dynamicinstrumentation/eventparser/event_parser.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser.go
@@ -79,7 +79,6 @@ func readParams(indicies []uint64, values []byte) []*ditypes.Param {
 // from the byte buffer. It returns the resulting parameter and an indication of
 // how many bytes were read from the buffer
 func parseParamValue(definition *ditypes.Param, buffer []byte) (*ditypes.Param, int) {
-
 	if definition == nil {
 		return nil, 0
 	}
@@ -143,6 +142,7 @@ func parseParamValue(definition *ditypes.Param, buffer []byte) (*ditypes.Param, 
 			if nextIndex > len(buffer) {
 				break
 			}
+
 			// This is a regular value (no sub-fields).
 			// We parse the value of it from the buffer and push it to the value stack
 			paramDefinition.ValueStr = parseIndividualValue(paramDefinition.Kind, buffer[bufferIndex:nextIndex])
@@ -226,7 +226,7 @@ func parseTypeDefinition(b []byte) *ditypes.Param {
 			Type: parseKindToString(kind),
 		}
 		if newParam.Kind == 0 {
-			break
+			goto stackCheck
 		}
 		i += sizeOfKindAndSize
 		if newParam.Size == 0 {

--- a/pkg/dynamicinstrumentation/eventparser/event_parser.go
+++ b/pkg/dynamicinstrumentation/eventparser/event_parser.go
@@ -276,7 +276,6 @@ func parseTypeDefinition(b []byte) *ditypes.Param {
 			goto stackCheck
 		}
 	}
-	return nil
 }
 
 // countBufferUsedByTypeDefinition is used to determine that amount of bytes

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -1085,6 +1085,96 @@ var interfaceCaptures = fixtures{
 	},
 }
 
+var linkedListCaptures = fixtures{
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_linked_list": []CapturedValueMapWithOptions{
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+					Fields: fieldMap{
+						"val": capturedValue("int", "1"),
+						"b": {
+							Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+							Fields: fieldMap{
+								"arg_0": {
+									Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+									Fields: fieldMap{
+										"val": capturedValue("int", "2"),
+										"b": {
+											Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+											Fields: fieldMap{
+												"arg_0": {
+													Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+													Fields: fieldMap{
+														"val": capturedValue("int", "3"),
+														"b":   {Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 4},
+		},
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+					Fields: fieldMap{
+						"val": capturedValue("int", "1"),
+						"b": {
+							Type: "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+							Fields: fieldMap{
+								"arg_0": {
+									Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+									Fields: fieldMap{
+										"val": capturedValue("int", "2"),
+										"b": {
+											Type:   "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+											Fields: fieldMap{},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 3},
+		},
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": {
+					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+					Fields: fieldMap{
+						"val": capturedValue("int", "1"),
+						"b": {
+							Type:   "*github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+							Fields: fieldMap{},
+						},
+					},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 2},
+		},
+		{
+			CapturedValueMap: map[string]*ditypes.CapturedValue{
+				"a": {
+					Type:              "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.node",
+					NotCapturedReason: "depth",
+					Fields:            fieldMap{},
+				},
+			},
+			Options: TestInstrumentationOptions{CaptureDepth: 1},
+		},
+	},
+}
+
 // mergeMaps combines multiple fixture maps into a single map
 func mergeMaps(maps ...fixtures) fixtures {
 	result := make(fixtures)
@@ -1105,4 +1195,5 @@ var expectedCaptures = mergeMaps(
 	pointerCaptures,
 	captureDepthCaptures,
 	interfaceCaptures,
+	linkedListCaptures,
 )

--- a/pkg/dynamicinstrumentation/testutil/sample/pointers.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/pointers.go
@@ -135,7 +135,7 @@ func ExecutePointerFuncs() {
 	b := node{
 		val: 1,
 		b: &node{
-			val: 5,
+			val: 2,
 			b: &node{
 				val: 3,
 				b:   nil,


### PR DESCRIPTION
### What does this PR do?

This fixes an issue that I observed where when capture depth is applied at the level of a pointer (not the value under it), the generated BPF code was not correctly laying out the output buffer such that event parsing could understand not to look for the underlying type. I've corrected this issue.

### Motivation

Bug fix

### Describe how you validated your changes

New e2e test fixtures.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->