### PR TITLE
[netpath] Fix race condition in sack traceroute

### DIFF
--- a/pkg/networkpath/traceroute/sack/traceroute_sack_linux.go
+++ b/pkg/networkpath/traceroute/sack/traceroute_sack_linux.go
@@ -87,7 +87,7 @@ func runSackTraceroute(ctx context.Context, p Params) (*sackResult, error) {
 	defer driver.Close()
 
 	log.Debugf("sack traceroute dialing %s", p.Target)
-	// now that the sackDgiriver is listening, dial the target. this is necessary
+	// now that the sackDriver is listening, dial the target. this is necessary
 	// because sackDriver needs to watch the SYNACK to see if SACK is supported
 	conn, err := dialSackTCP(ctx, p)
 	if err != nil {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes a race condition in SACK. If a TCP packet and ICMP packet came back at the exact same moment, it was possible for overlapping use of the read buffer/frame parser.

Instead of using the same parser/buffer for both, they are now wrapped into the `handle` type which contains a conn, parser, and buffer. There are two handles, one for TCP, one for ICMP.

### Motivation
Races are bad

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
```
go build -race github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/sack/portable_sack
LOG_LEVEL=trace sudo -E ./portable_sack 205.251.242.103:443
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->