### PR TITLE
Bump ADP version to 0.1.7.

### DIFF
--- a/.gitlab/internal_image_deploy/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy/internal_image_deploy.yml
@@ -20,7 +20,7 @@ docker_trigger_internal:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-jmx
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx
     TMPL_SRC_REPO: ci/datadog-agent/agent
-    TMPL_ADP_VERSION: 0.1.5
+    TMPL_ADP_VERSION: 0.1.7
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
@@ -114,7 +114,7 @@ docker_trigger_internal-ot:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-ot-beta-jmx
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-ot-beta-jmx
     TMPL_SRC_REPO: ci/datadog-agent/agent
-    TMPL_ADP_VERSION: 0.1.5
+    TMPL_ADP_VERSION: 0.1.7
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
@@ -256,7 +256,7 @@ docker_trigger_internal-full:
     BUILD_TAG: ${CI_COMMIT_REF_SLUG}-full
     TMPL_SRC_IMAGE: v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full
     TMPL_SRC_REPO: ci/datadog-agent/agent
-    TMPL_ADP_VERSION: 0.1.5
+    TMPL_ADP_VERSION: 0.1.7
     RELEASE_STAGING: "true"
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN


### PR DESCRIPTION
### What does this PR do?

Bumps the ADP version to 0.1.7.

### Motivation

Pulls in a number of fixes and optimizations we've incorporated as part of our wider staging rollout, which are primarily relevant as they address an issue with dropped metric packets.

### Describe how you validated your changes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Additional Notes

N/A