### PR TITLE
Static quality gates reports for relative size

### DIFF
--- a/.gitlab/functional_test/static_quality_gate.yml
+++ b/.gitlab/functional_test/static_quality_gate.yml
@@ -61,9 +61,20 @@ static_quality_gates:
     - dda inv -- quality-gates.parse-and-trigger-gates || exit $?
   retry:
     max: 2
-    exit_codes: 42
+    exit_codes:
+      - 42
+      - 101 # Failed to extract dependencies
+    when:
+      - runner_system_failure
+      - stuck_or_timeout_failure
+      - unknown_failure
+      - api_failure
+      - scheduler_failure
+      - stale_schedule
+      - data_integrity_failure
   artifacts:
     when: always
     paths:
       - extract_rpm_package_report
+      - static_gate_report.json
     expire_in: 1 week

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -160,6 +160,8 @@ def parse_and_trigger_gates(ctx, config_path="test/static/static_quality_gates.y
 
     metric_handler.send_metrics_to_datadog()
 
+    metric_handler.generate_metric_reports(ctx, branch=branch)
+
     github = GithubAPI()
     if github.get_pr_for_branch(branch).totalCount > 0:
         display_pr_comment(ctx, final_state == "success", gate_states, metric_handler)

--- a/tasks/static_quality_gates/lib/gates_lib.py
+++ b/tasks/static_quality_gates/lib/gates_lib.py
@@ -1,4 +1,5 @@
 import glob
+import json
 import math
 import os
 import types
@@ -93,11 +94,15 @@ class GateMetricHandler:
         "datadog.agent.static_quality_gate.max_allowed_on_disk_size": "max_on_disk_size",
     }
 
-    def __init__(self, git_ref, bucket_branch):
+    def __init__(self, git_ref, bucket_branch, filename=None):
         self.metrics = {}
         self.metadata = {}
         self.git_ref = git_ref
         self.bucket_branch = bucket_branch
+        self.series_is_complete = True
+
+        if filename is not None:
+            self._load_metrics_report(filename)
 
     def get_formatted_metric(self, gate_name, metric_name):
         return byte_to_string(self.metrics[gate_name][metric_name])
@@ -114,6 +119,10 @@ class GateMetricHandler:
 
         for key in kwargs:
             self.metadata[gate][key] = kwargs[key]
+
+    def _load_metrics_report(self, filename):
+        with open(filename) as f:
+            self.metrics = json.load(f)
 
     def _add_gauge(self, timestamp, common_tags, gate, metric_name, metric_key):
         if self.metrics[gate].get(metric_key):
@@ -157,6 +166,7 @@ class GateMetricHandler:
                             "orange",
                         )
                     )
+                    self.series_is_complete = False
         return series
 
     def send_metrics_to_datadog(self):
@@ -165,3 +175,22 @@ class GateMetricHandler:
         if series:
             send_metrics(series=series)
         print(color_message("Metric sending finished !", "blue"))
+
+    def generate_metric_reports(self, ctx, filename="static_gate_report.json", branch=None):
+        if not self.series_is_complete:
+            print(
+                color_message(
+                    "[WARN] Some static quality gates are missing some metrics, the generated report might not be trustworthy.",
+                    "orange",
+                )
+            )
+
+        with open(filename, "w") as f:
+            json.dump(self.metrics, f)
+
+        CI_COMMIT_SHA = os.environ.get("CI_COMMIT_SHA")
+        if branch == "main" and CI_COMMIT_SHA:
+            ctx.run(
+                f"aws s3 cp --only-show-errors --region us-east-1 --sse AES256 {filename} s3://dd-ci-artefacts-build-stable/datadog-agent/static_quality_gates/{CI_COMMIT_SHA}/{filename}",
+                hide="stdout",
+            )


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Generate a `static_gate_report.json` file that is uploaded to s3 and also as an artifact. This report will allow to compare current gates with previous ancestor runs to get the relative size increase of each gate.
This PR contains element of #35836 which can only function after this PR is merged on main.

### Motivation

Static quality gates relative size

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
