### PR TITLE
system-probe: Use longer timeouts for check clients

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1126,6 +1126,7 @@ func agent(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("check_runners", int64(4))
 	config.BindEnvAndSetDefault("check_cancel_timeout", 500*time.Millisecond)
 	config.BindEnvAndSetDefault("check_system_probe_startup_time", 5*time.Minute)
+	config.BindEnvAndSetDefault("check_system_probe_timeout", 60*time.Second)
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	// used to override the path where the IPC cert/key files are stored/retrieved
 	config.BindEnvAndSetDefault("ipc_cert_file_path", "")

--- a/pkg/system-probe/api/client/client_test.go
+++ b/pkg/system-probe/api/client/client_test.go
@@ -67,7 +67,7 @@ func TestGetCheck(t *testing.T) {
 	httpClient := &http.Client{Transport: &http.Transport{DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 		return net.Dial("tcp", server.Listener.Addr().String())
 	}}}
-	client := &CheckClient{client: httpClient}
+	client := &CheckClient{client: httpClient, startupClient: httpClient}
 
 	//test happy flow
 	resp, err := GetCheck[testData](client, "test")
@@ -117,6 +117,7 @@ func TestGetCheckStartup(t *testing.T) {
 
 	client := &CheckClient{
 		client:         httpClient,
+		startupClient:  httpClient,
 		startTime:      time.Now(),
 		startupTimeout: 5 * time.Minute,
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently, the timeout in the system-probe API is only 5 seconds.  While
this makes sense for clients which need to access system-probe as part
of some other work (e.g. for flare generation), it may be too small for
core agent checks which rely on system-probe to do most of the work.
Spuriously timing out early in this case is not helpful since the check
does not perform its main function, and system-probe actually continues
to compute whatever it had to compute in the background (since the http
handler will run to completion), except that the result is not returned
to whoever asked for it.

Increase the timeout to handle this.  During startup, to prevent waiting
for unnecessarily long time if system-probe has issues starting up, use
the shorter timeout since the stats endpoint should return quickly.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-94

### Describe how you validated your changes

The existing code being touched is covered by automated tests.

The increased timeouts were [tested](https://ddstaging.datadoghq.com/dashboard/cc9-qxb-fsx/agent-discovery?fromUser=true&refresh_mode=paused&tpl_var_kube_cluster_name%5B0%5D=oddish-c&from_ts=1744624944571&to_ts=1744645238000&live=false) on one cluster in staging.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
