### PR TITLE
Remote config configurable org status polling

### DIFF
--- a/comp/remote-config/rcservice/rcserviceimpl/rcservice.go
+++ b/comp/remote-config/rcservice/rcserviceimpl/rcservice.go
@@ -85,6 +85,9 @@ func newRemoteConfigService(deps dependencies) (rcservice.Component, error) {
 	if deps.Cfg.IsSet("remote_configuration.refresh_interval") {
 		options = append(options, remoteconfig.WithRefreshInterval(deps.Cfg.GetDuration("remote_configuration.refresh_interval"), "remote_configuration.refresh_interval"))
 	}
+	if deps.Cfg.IsSet("remote_configuration.org_status_refresh_interval") {
+		options = append(options, remoteconfig.WithOrgStatusRefreshInterval(deps.Cfg.GetDuration("remote_configuration.org_status_refresh_interval"), "remote_configuration.org_status_refresh_interval"))
+	}
 	if deps.Cfg.IsSet("remote_configuration.max_backoff_interval") {
 		options = append(options, remoteconfig.WithMaxBackoffInterval(deps.Cfg.GetDuration("remote_configuration.max_backoff_interval"), "remote_configuration.max_backoff_interval"))
 	}

--- a/comp/remote-config/rcservicemrf/rcservicemrfimpl/rcservicemrf.go
+++ b/comp/remote-config/rcservicemrf/rcservicemrfimpl/rcservicemrf.go
@@ -81,6 +81,9 @@ func newMrfRemoteConfigService(deps dependencies) (rcservicemrf.Component, error
 	if deps.Cfg.IsSet("multi_region_failover.remote_configuration.refresh_interval") {
 		options = append(options, remoteconfig.WithRefreshInterval(deps.Cfg.GetDuration("multi_region_failover.remote_configuration.refresh_interval"), "multi_region_failover.remote_configuration.refresh_interval"))
 	}
+	if deps.Cfg.IsSet("multi_region_failover.remote_configuration.org_status_refresh_interval") {
+		options = append(options, remoteconfig.WithOrgStatusRefreshInterval(deps.Cfg.GetDuration("multi_region_failover.remote_configuration.org_status_refresh_interval"), "multi_region_failover.remote_configuration.org_status_refresh_interval"))
+	}
 	if deps.Cfg.IsSet("multi_region_failover.remote_configuration.max_backoff_interval") {
 		options = append(options, remoteconfig.WithMaxBackoffInterval(deps.Cfg.GetDuration("multi_region_failover.remote_configuration.max_backoff_interval"), "remote_configuration.max_backoff_time"))
 	}

--- a/pkg/config/remote/service/service_test.go
+++ b/pkg/config/remote/service/service_test.go
@@ -1505,3 +1505,36 @@ func listsEqual(mustMatch []string) func(candidate []string) bool {
 		return true
 	}
 }
+
+func TestWithOrgStatusPollingIntervalNoConfigPassed(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetWithoutSource("run_path", "/tmp")
+
+	baseRawURL := "https://localhost"
+	mockTelemetryReporter := newMockRcTelemetryReporter()
+	options := []Option{
+		WithAPIKey("abc"),
+	}
+	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", getHostTags, mockTelemetryReporter, agentVersion, options...)
+	assert.NoError(t, err)
+	assert.Equal(t, service.orgStatusRefreshInterval, defaultRefreshInterval)
+	assert.NotNil(t, service)
+	service.Stop()
+}
+
+func TestWithOrgStatusPollingIntervalConfigPassed(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.SetWithoutSource("run_path", "/tmp")
+
+	baseRawURL := "https://localhost"
+	mockTelemetryReporter := newMockRcTelemetryReporter()
+	options := []Option{
+		WithAPIKey("abc"),
+		WithOrgStatusRefreshInterval(54*time.Second, "test.org_status_refresh_interval"),
+	}
+	service, err := NewService(cfg, "Remote Config", baseRawURL, "localhost", getHostTags, mockTelemetryReporter, agentVersion, options...)
+	assert.NoError(t, err)
+	assert.Equal(t, service.orgStatusRefreshInterval, 54*time.Second)
+	assert.NotNil(t, service)
+	service.Stop()
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1199,6 +1199,7 @@ func remoteconfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("remote_configuration.config_root", "")
 	config.BindEnvAndSetDefault("remote_configuration.director_root", "")
 	config.BindEnv("remote_configuration.refresh_interval")
+	config.BindEnv("remote_configuration.org_status_refresh_interval")
 	config.BindEnvAndSetDefault("remote_configuration.max_backoff_interval", 5*time.Minute)
 	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30*time.Second)
 	config.BindEnvAndSetDefault("remote_configuration.clients.cache_bypass_limit", 5)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1199,7 +1199,7 @@ func remoteconfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("remote_configuration.config_root", "")
 	config.BindEnvAndSetDefault("remote_configuration.director_root", "")
 	config.BindEnv("remote_configuration.refresh_interval")
-	config.BindEnv("remote_configuration.org_status_refresh_interval")
+	config.BindEnvAndSetDefault("remote_configuration.org_status_refresh_interval", 1*time.Minute)
 	config.BindEnvAndSetDefault("remote_configuration.max_backoff_interval", 5*time.Minute)
 	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30*time.Second)
 	config.BindEnvAndSetDefault("remote_configuration.clients.cache_bypass_limit", 5)

--- a/pkg/config/setup/multi_region_failover.go
+++ b/pkg/config/setup/multi_region_failover.go
@@ -22,6 +22,7 @@ func setupMultiRegionFailover(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("multi_region_failover.failover_apm", false)
 
 	config.BindEnv("multi_region_failover.remote_configuration.refresh_interval")
+	config.BindEnv("multi_region_failover.remote_configuration.org_status_refresh_interval")
 	config.BindEnv("multi_region_failover.remote_configuration.max_backoff_time")
 	config.BindEnvAndSetDefault("multi_region_failover.remote_configuration.max_backoff_interval", 5*time.Minute)
 	config.BindEnv("multi_region_failover.remote_configuration.config_root")

--- a/pkg/config/setup/multi_region_failover.go
+++ b/pkg/config/setup/multi_region_failover.go
@@ -21,7 +21,7 @@ func setupMultiRegionFailover(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("multi_region_failover.failover_logs", false)
 	config.BindEnvAndSetDefault("multi_region_failover.failover_apm", false)
 
-	config.BindEnv("multi_region_failover.remote_configuration.refresh_interval")
+	config.BindEnvAndSetDefault("multi_region_failover.remote_configuration.refresh_interval", 1*time.Minute)
 	config.BindEnv("multi_region_failover.remote_configuration.org_status_refresh_interval")
 	config.BindEnv("multi_region_failover.remote_configuration.max_backoff_time")
 	config.BindEnvAndSetDefault("multi_region_failover.remote_configuration.max_backoff_interval", 5*time.Minute)

--- a/pkg/config/setup/multi_region_failover.go
+++ b/pkg/config/setup/multi_region_failover.go
@@ -21,8 +21,8 @@ func setupMultiRegionFailover(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("multi_region_failover.failover_logs", false)
 	config.BindEnvAndSetDefault("multi_region_failover.failover_apm", false)
 
-	config.BindEnvAndSetDefault("multi_region_failover.remote_configuration.refresh_interval", 1*time.Minute)
-	config.BindEnv("multi_region_failover.remote_configuration.org_status_refresh_interval")
+	config.BindEnv("multi_region_failover.remote_configuration.refresh_interval")
+	config.BindEnvAndSetDefault("multi_region_failover.remote_configuration.org_status_refresh_interval", 1*time.Minute)
 	config.BindEnv("multi_region_failover.remote_configuration.max_backoff_time")
 	config.BindEnvAndSetDefault("multi_region_failover.remote_configuration.max_backoff_interval", 5*time.Minute)
 	config.BindEnv("multi_region_failover.remote_configuration.config_root")

--- a/pkg/serverless/remoteconfig/remoteconfig.go
+++ b/pkg/serverless/remoteconfig/remoteconfig.go
@@ -43,7 +43,7 @@ func StartRCService(functionARN string) *remoteconfig.CoreAgentService {
 		if config.IsSet("remote_configuration.refresh_interval") {
 			options = append(options, remoteconfig.WithRefreshInterval(config.GetDuration("remote_configuration.refresh_interval"), "remote_configuration.refresh_interval"))
 		}
-		if config.IsSet("remote_configuration.org_status_refresh_interval") {
+		if config.IsConfigured("remote_configuration.org_status_refresh_interval") {
 			options = append(options, remoteconfig.WithOrgStatusRefreshInterval(config.GetDuration("remote_configuration.org_status_refresh_interval"), "remote_configuration.org_status_refresh_interval"))
 		}
 		if config.IsSet("remote_configuration.max_backoff_interval") {

--- a/pkg/serverless/remoteconfig/remoteconfig.go
+++ b/pkg/serverless/remoteconfig/remoteconfig.go
@@ -43,6 +43,9 @@ func StartRCService(functionARN string) *remoteconfig.CoreAgentService {
 		if config.IsSet("remote_configuration.refresh_interval") {
 			options = append(options, remoteconfig.WithRefreshInterval(config.GetDuration("remote_configuration.refresh_interval"), "remote_configuration.refresh_interval"))
 		}
+		if config.IsSet("remote_configuration.org_status_refresh_interval") {
+			options = append(options, remoteconfig.WithOrgStatusRefreshInterval(config.GetDuration("remote_configuration.org_status_refresh_interval"), "remote_configuration.org_status_refresh_interval"))
+		}
 		if config.IsSet("remote_configuration.max_backoff_interval") {
 			options = append(options, remoteconfig.WithMaxBackoffInterval(config.GetDuration("remote_configuration.max_backoff_interval"), "remote_configuration.max_backoff_interval"))
 		}


### PR DESCRIPTION
### What does this PR do?

This PR allows users to make the remote config org status polling interval that is defined [here](https://github.com/DataDog/datadog-agent/blob/e0c94ee83df20740e1289b7bb757fe5a247a1e9a/pkg/config/remote/service/service.go#L508-L533) to be configurable. A user can pass a `remote_configuration.org_status_refresh_interval` config to configure the value as they wish, with a default of 1m if they do not provide this value 

### Motivation

Customers have asked for this option to be configurable 

### Describe how you validated your changes

1. Added new unit tests to test this functionality (i.e. `TestWithOrgStatusPollingIntervalNoConfigPassed` and `TestWithOrgStatusPollingIntervalConfigPassed`)
2. End-to-end tested that we see the correct polling interval when set

When an option is not provided, we see the following (note: log was added for debugging, removed for PR), which is using the default of `1m0s`. 

```
2025-04-14 16:39:50 EDT | CORE | INFO | (pkg/config/remote/service/service.go:532 in func1) | starting RC org status polling with interval 1m0s
...
2025-04-14 16:55:51 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
2025-04-14 16:56:52 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
2025-04-14 16:57:52 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
2025-04-14 16:58:52 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
2025-04-14 16:59:52 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
```

When the value is passed (in this case set to 10s), we see the polling interval updated

Set value as 
```
remote_configuration:
   org_status_refresh_interval: 10s

```

Associated logs 
```
2025-04-14 17:04:20 EDT | CORE | INFO | (pkg/config/remote/service/service.go:532 in func1) | starting RC org status polling with interval 10s
...
2025-04-14 17:05:41 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
2025-04-14 17:05:51 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
2025-04-14 17:06:01 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
2025-04-14 17:06:11 EDT | CORE | INFO | (pkg/config/remote/service/service.go:635 in pollOrgStatus) | [Remote Config] Polling remote configuration org status
```

### Possible Drawbacks / Trade-offs

Customer has more control over the org status polling, which may cause them to set this interval incorrectly. 

### Additional Notes

Note: This is a revision for the following PR https://github.com/DataDog/datadog-agent/pull/36030, closed the previous due to rebased commits being included in the commit log. 