### PR TITLE
[netpath] SACK: Add socket filter for CPU perf

### DIFF
--- a/pkg/networkpath/traceroute/filter/tcp_test.go
+++ b/pkg/networkpath/traceroute/filter/tcp_test.go
@@ -240,7 +240,7 @@ func TestSynackFilter(t *testing.T) {
 		}
 		if parser.TCP.SrcPort != layers.TCPPort(serverAddrPort.Port()) ||
 			parser.TCP.DstPort != layers.TCPPort(clientAddrPort.Port()) {
-			t.Logf("skipping packet becasue of ports")
+			t.Logf("skipping packet because of ports")
 			continue
 		}
 		t.Logf("found synack")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This is a follow up to [\[NPM-4279\] Add socket filter to linux TCP traceroutes](https://github.com/DataDog/datadog-agent/pull/35651), applying the same thing to SACK.

### Motivation
This improves CPU usage of TCP traceroutes because system-probe captures vastly less packets.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
New tests should pass:
```
sudo go test -tags test,linux,linux_bpf github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/filter -count 10
```
SACK traceroute should still work:
```
go build -race github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/sack/portable_sack
LOG_LEVEL=trace sudo -E ./portable_sack 205.251.242.103:443
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->