### PR TITLE
[OTAGENT-328] Add default queue setting for DDOT logs exporter

### DIFF
--- a/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/factory.go
@@ -262,8 +262,9 @@ func (f *factory) consumeStatsPayload(ctx context.Context, wg *sync.WaitGroup, s
 func (f *factory) createLogsExporter(
 	ctx context.Context,
 	set exporter.Settings,
-	_ component.Config,
+	c component.Config,
 ) (exporter.Logs, error) {
+	cfg := checkAndCastConfig(c, set.Logger)
 	var logch chan *message.Message
 	if provider := f.logsAgent.GetPipelineProvider(); provider != nil {
 		logch = provider.NextPipelineChan()
@@ -272,6 +273,7 @@ func (f *factory) createLogsExporter(
 	lc := &logsagentexporter.Config{
 		OtelSource:    "otel_agent",
 		LogSourceName: logsagentexporter.LogSourceName,
+		QueueSettings: cfg.QueueSettings,
 	}
 	return lf.CreateLogs(ctx, set, lc)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Sets `QueueSettings` for the DDOT logs exporter, which wasn't set properly before. We added queue settings in this previous PR https://github.com/DataDog/datadog-agent/pull/33900, but were missing it in the `logsagentexporter.Config`.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Tested locally and validated that `otelcol_exporter_queue_size` and `otelcol_exporter_queue_capacity` now show for logs.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->