### PR TITLE
Change structure of remote-tagger timeout to cancel when receiving Done signal

### DIFF
--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -568,7 +568,7 @@ func (t *remoteTagger) startTaggerStream(maxElapsed time.Duration) error {
 	for {
 		select {
 		case <-t.ctx.Done():
-			return &backoff.PermanentError{Err: errTaggerStreamNotStarted}
+			return errTaggerStreamNotStarted
 		case <-timer.C:
 			// Check the auth token
 			if t.token == "" {

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -561,48 +561,55 @@ func (t *remoteTagger) startTaggerStream(maxElapsed time.Duration) error {
 	expBackoff.MaxInterval = 5 * time.Minute
 	expBackoff.MaxElapsedTime = maxElapsed
 
-	return backoff.Retry(func() error {
+	var err error
+	timer := time.NewTimer(0) // immediate first attempt
+	defer timer.Stop()
+
+	for {
 		select {
 		case <-t.ctx.Done():
 			return &backoff.PermanentError{Err: errTaggerStreamNotStarted}
-		default:
+		case <-timer.C:
+			// Check the auth token
+			if t.token == "" {
+				return errors.New("RemoteTagger initialization failed: auth token is unset")
+			}
+
+			// Cancel any existing stream context before creating a new one
+			if t.streamCancel != nil {
+				t.streamCancel()
+			}
+
+			t.streamCtx, t.streamCancel = context.WithCancel(
+				metadata.NewOutgoingContext(t.ctx, metadata.MD{
+					"authorization": []string{fmt.Sprintf("Bearer %s", t.token)},
+				}),
+			)
+
+			prefixes := make([]string, 0)
+			for prefix := range t.filter.GetPrefixes() {
+				prefixes = append(prefixes, string(prefix))
+			}
+
+			t.stream, err = t.client.TaggerStreamEntities(t.streamCtx, &pb.StreamTagsRequest{
+				Cardinality: pb.TagCardinality(t.filter.GetCardinality()),
+				StreamingID: uuid.New().String(),
+				Prefixes:    prefixes,
+			})
+
+			if err != nil {
+				t.log.Debugf("unable to establish stream, will retry: %s", err)
+				nextBackoff := expBackoff.NextBackOff()
+				if nextBackoff == backoff.Stop {
+					return err
+				}
+				timer.Reset(nextBackoff)
+				continue
+			}
+
+			return nil
 		}
-
-		var err error
-
-		// Check the auth token
-		if t.token == "" {
-			return errors.New("RemoteTagger initialization failed: auth token is unset")
-		}
-
-		// Cancel any existing stream context before creating a new one
-		if t.streamCancel != nil {
-			t.streamCancel()
-		}
-
-		t.streamCtx, t.streamCancel = context.WithCancel(
-			metadata.NewOutgoingContext(t.ctx, metadata.MD{
-				"authorization": []string{fmt.Sprintf("Bearer %s", t.token)},
-			}),
-		)
-
-		prefixes := make([]string, 0)
-		for prefix := range t.filter.GetPrefixes() {
-			prefixes = append(prefixes, string(prefix))
-		}
-
-		t.stream, err = t.client.TaggerStreamEntities(t.streamCtx, &pb.StreamTagsRequest{
-			Cardinality: pb.TagCardinality(t.filter.GetCardinality()),
-			StreamingID: uuid.New().String(),
-			Prefixes:    prefixes,
-		})
-		if err != nil {
-			t.log.Debug("unable to establish stream, will possibly retry: %s", err)
-			return err
-		}
-
-		return nil
-	}, expBackoff)
+	}
 }
 
 func (t *remoteTagger) writeList(w http.ResponseWriter, _ *http.Request) {

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -572,7 +572,13 @@ func (t *remoteTagger) startTaggerStream(maxElapsed time.Duration) error {
 		case <-timer.C:
 			// Check the auth token
 			if t.token == "" {
-				return errors.New("RemoteTagger initialization failed: auth token is unset")
+				t.log.Debug("RemoteTagger initialization failed: auth token is unset")
+				nextBackoff := expBackoff.NextBackOff()
+				if nextBackoff == backoff.Stop {
+					return err
+				}
+				timer.Reset(nextBackoff)
+				continue
 			}
 
 			// Cancel any existing stream context before creating a new one


### PR DESCRIPTION
### What does this PR do?

This PR changes the structure of closing the remote tagger to recognize the write to the done channel immediately by using the backoff via timer instead of using the imported backoff library's structure.

### Motivation

After #35818 merged I started observing that the system-probe was very slow to shutdown during local development when I interrupted the process. I've concluded that the new wait group blocks the process from exiting until the remote tagger properly closes. While that PR  makes sense, it exposes a very slow implementation of exponential backoff where it can take up to 5 minutes for the process to close even after the tagger has been closed.

### Describe how you validated your changes

When locally developing the dynamicinstrumentation system-probe module the remote tagger was failing to initialize (as expected as i'm not connecting to platform). Hitting control-c would show a delay in killing the process that only gets longer as the system-probe runs for longer. After this change it does not occur. 

### Possible Drawbacks / Trade-offs

### Additional Notes

@misteriaud please verify that this doesn't affect the bug/race you fixed in your PR.