### PR TITLE
Update lading to 0.25.9

### DIFF
--- a/test/regression/cases/file_to_blackhole_0ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/lading/lading.yaml
@@ -4,13 +4,13 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         load_profile:
-          constant: 10MB
+          constant: 10 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/file_to_blackhole_0ms_latency_http1/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency_http1/lading/lading.yaml
@@ -4,13 +4,13 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         load_profile:
-          constant: 10MB
+          constant: 10 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/file_to_blackhole_0ms_latency_http2/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency_http2/lading/lading.yaml
@@ -4,13 +4,13 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         load_profile:
-          constant: 10MB
+          constant: 10 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/lading/lading.yaml
@@ -4,13 +4,13 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         load_profile:
-          constant: 10MB
+          constant: 10 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency_linear_load/lading/lading.yaml
@@ -6,18 +6,18 @@ generator:
         load_profile:
           linear:
             # Over a ten minute experiment this will mean load proceeds from
-            # 10MB to 310MB per second. As a file rotates every 500MB we will
+            # 10 MiB to 310 MiB per second. As a file rotates every 500 MiB we will
             # see files rotating, by the end, every two seconds.
             #
             # Agent is not expected to keep up.
-            initial_bytes_per_second: 10MB
-            rate: 0.5MB
+            initial_bytes_per_second: 10 MiB
+            rate: 0.5 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/file_to_blackhole_100ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/lading/lading.yaml
@@ -4,13 +4,13 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         load_profile:
-          constant: 10MB
+          constant: 10 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/file_to_blackhole_300ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_300ms_latency/lading/lading.yaml
@@ -4,13 +4,13 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         load_profile:
-          constant: 10MB
+          constant: 10 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/file_to_blackhole_500ms_latency/lading/lading.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/lading/lading.yaml
@@ -4,13 +4,13 @@ generator:
         seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
                59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
         load_profile:
-          constant: 10MB
+          constant: 10 MiB
         concurrent_logs: 1
-        maximum_bytes_per_log: 500MB
+        maximum_bytes_per_log: 500 MiB
         total_rotations: 5
         max_depth: 0
         variant: "ascii"
-        maximum_prebuild_cache_size_bytes: 300MB
+        maximum_prebuild_cache_size_bytes: 300 MiB
         mount_point: /smp-shared
 
 blackhole:

--- a/test/regression/cases/otlp_ingest_logs/lading/lading.yaml
+++ b/test/regression/cases/otlp_ingest_logs/lading/lading.yaml
@@ -5,11 +5,11 @@ generator:
       headers:
         content-type: "application/x-protobuf"
       target_uri: "http://127.0.0.1:4318/v1/logs"
-      bytes_per_second: "3 Mb"
+      bytes_per_second: "3 MiB"
       parallel_connections: 5
       method:
         post:
-          maximum_prebuild_cache_size_bytes: "512 Mb"
+          maximum_prebuild_cache_size_bytes: "512 MiB"
           variant: "opentelemetry_logs"
 
 blackhole:

--- a/test/regression/cases/otlp_ingest_metrics/lading/lading.yaml
+++ b/test/regression/cases/otlp_ingest_metrics/lading/lading.yaml
@@ -5,11 +5,11 @@ generator:
       headers:
         content-type: "application/x-protobuf"
       target_uri: "http://127.0.0.1:4318/v1/metrics"
-      bytes_per_second: "6 Mb"
+      bytes_per_second: "6 MiB"
       parallel_connections: 5
       method:
         post:
-          maximum_prebuild_cache_size_bytes: "512 Mb"
+          maximum_prebuild_cache_size_bytes: "512 MiB"
           variant: "opentelemetry_metrics"
 
 blackhole:

--- a/test/regression/cases/otlp_ingest_traces/lading/lading.yaml
+++ b/test/regression/cases/otlp_ingest_traces/lading/lading.yaml
@@ -5,11 +5,11 @@ generator:
       headers:
         content-type: "application/x-protobuf"
       target_uri: "http://127.0.0.1:4318/v1/traces"
-      bytes_per_second: "3 Mb"
+      bytes_per_second: "3 MiB"
       parallel_connections: 5
       method:
         post:
-          maximum_prebuild_cache_size_bytes: "5 Mb"
+          maximum_prebuild_cache_size_bytes: "5 MiB"
           variant: "opentelemetry_traces"
 
 blackhole:

--- a/test/regression/cases/tcp_dd_logs_filter_exclude/lading/lading.yaml
+++ b/test/regression/cases/tcp_dd_logs_filter_exclude/lading/lading.yaml
@@ -4,8 +4,8 @@ generator:
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       addr: "127.0.0.1:10000"
       variant: "datadog_log"
-      bytes_per_second: "50 Mb"
-      maximum_prebuild_cache_size_bytes: "400 Mb"
+      bytes_per_second: "50 MiB"
+      maximum_prebuild_cache_size_bytes: "400 MiB"
 
 blackhole:
   - http:

--- a/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
+++ b/test/regression/cases/tcp_syslog_to_blackhole/lading/lading.yaml
@@ -4,8 +4,8 @@ generator:
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131]
       addr: "127.0.0.1:10000"
       variant: "syslog5424"
-      bytes_per_second: "50 Mb"
-      maximum_prebuild_cache_size_bytes: "256 Mb"
+      bytes_per_second: "50 MiB"
+      maximum_prebuild_cache_size_bytes: "256 MiB"
 
 blackhole:
   - http:

--- a/test/regression/cases/uds_dogstatsd_20mb_12k_contexts_20_senders/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_20mb_12k_contexts_20_senders/lading/lading.yaml
@@ -41,7 +41,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -85,7 +85,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -129,7 +129,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -173,7 +173,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -217,7 +217,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -261,7 +261,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -305,7 +305,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -349,7 +349,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -393,7 +393,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -437,7 +437,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -481,7 +481,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -525,7 +525,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -569,7 +569,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -613,7 +613,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -657,7 +657,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -701,7 +701,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -745,7 +745,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -789,7 +789,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -833,7 +833,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
@@ -877,7 +877,7 @@ generator:
             set: 9
             histogram: 1
       bytes_per_second: "1 MiB"
-      maximum_prebuild_cache_size_bytes: "16 Mb"
+      maximum_prebuild_cache_size_bytes: "16 MiB"
       maximum_block_size: 8192
 
 blackhole:

--- a/test/regression/cases/uds_dogstatsd_20mb_12k_contexts_20_senders/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_20mb_12k_contexts_20_senders/lading/lading.yaml
@@ -42,7 +42,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 132]
@@ -86,7 +86,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 133]
@@ -130,7 +130,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 134]
@@ -174,7 +174,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 135]
@@ -218,7 +218,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 136]
@@ -262,7 +262,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 137]
@@ -306,7 +306,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 138]
@@ -350,7 +350,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 139]
@@ -394,7 +394,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 140]
@@ -438,7 +438,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 141]
@@ -482,7 +482,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 142]
@@ -526,7 +526,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 143]
@@ -570,7 +570,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 144]
@@ -614,7 +614,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 145]
@@ -658,7 +658,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 146]
@@ -702,7 +702,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 147]
@@ -746,7 +746,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 148]
@@ -790,7 +790,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 149]
@@ -834,7 +834,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
   - unix_datagram:
       seed: [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53,
              59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 149]
@@ -878,7 +878,7 @@ generator:
             histogram: 1
       bytes_per_second: "1 MiB"
       maximum_prebuild_cache_size_bytes: "16 MiB"
-      maximum_block_size: 8192
+      maximum_block_size: "8 MiB"
 
 blackhole:
   - http:

--- a/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api/lading/lading.yaml
@@ -38,7 +38,7 @@ generator:
             set: 0
             histogram: 0
       bytes_per_second: "100 MiB"
-      maximum_prebuild_cache_size_bytes: "500 Mb"
+      maximum_prebuild_cache_size_bytes: "500 MiB"
 
 blackhole:
   - http:

--- a/test/regression/cases/uds_dogstatsd_to_api_cpu/lading/lading.yaml
+++ b/test/regression/cases/uds_dogstatsd_to_api_cpu/lading/lading.yaml
@@ -38,7 +38,7 @@ generator:
             set: 0
             histogram: 0
       bytes_per_second: "100 MiB"
-      maximum_prebuild_cache_size_bytes: "500 Mb"
+      maximum_prebuild_cache_size_bytes: "500 MiB"
 
 blackhole:
   - http:

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.25.8
+  version: 0.25.9
 
 target:
 

--- a/test/regression/x-disabled-cases/otel_to_otel_logs/lading/lading.yaml
+++ b/test/regression/x-disabled-cases/otel_to_otel_logs/lading/lading.yaml
@@ -5,11 +5,11 @@ generator:
       headers:
         content-type: "application/x-protobuf"
       target_uri: "http://127.0.0.1:4318/v1/traces"
-      bytes_per_second: "10 Mb"
+      bytes_per_second: "10 MiB"
       parallel_connections: 5
       method:
         post:
-          maximum_prebuild_cache_size_bytes: "512 Mb"
+          maximum_prebuild_cache_size_bytes: "512 MiB"
           variant: "opentelemetry_traces"
 
 blackhole:


### PR DESCRIPTION
### What does this PR do?

This release brings fixes to generator throttle in low-throughput experiments and is more strict about the interpretation of Mb/M/m etc. We normalize all experiments on decimal units.

