### PR TITLE
Minor improvements to Wi-Fi check

### DIFF
--- a/pkg/aggregator/mocksender/asserts.go
+++ b/pkg/aggregator/mocksender/asserts.go
@@ -78,6 +78,11 @@ func (m *MockSender) AssertMetricWithTimestamp(t *testing.T, method string, metr
 	return m.Mock.AssertCalled(t, method, metric, value, hostname, MatchTagsContains(tags), ts)
 }
 
+// AssertMetricMissing assert the expected metric  was never emitted
+func (m *MockSender) AssertMetricMissing(t *testing.T, method string, metric string) bool {
+	return m.Mock.AssertNotCalled(t, method, metric, mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+}
+
 // AssertEvent assert the expectedEvent was emitted with the following values:
 // AggregationKey, Priority, SourceTypeName, EventType, Host and a Ts range weighted with the parameter allowedDelta
 func (m *MockSender) AssertEvent(t *testing.T, expectedEvent event.Event, allowedDelta time.Duration) bool {

--- a/pkg/collector/corechecks/net/wlan/wlan.go
+++ b/pkg/collector/corechecks/net/wlan/wlan.go
@@ -23,7 +23,7 @@ const (
 
 var getWiFiInfo = GetWiFiInfo
 
-// WiFiInfo contains information about the WiFi connection (defined in Mac wlan_darwin.h and Windows wlan.h)
+// wifiInfo contains information about the WiFi connection (defined in Mac wlan_darwin.h and Windows wlan.h)
 type wifiInfo struct {
 	rssi             int
 	ssid             string

--- a/pkg/collector/corechecks/net/wlan/wlan_darwin.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_darwin.go
@@ -52,7 +52,7 @@ func (phy phyMode) String() string {
 	}
 }
 
-func GetWiFiInfo() (WiFiInfo, error) {
+func GetWiFiInfo() (wifiInfo, error) {
 	info := C.GetWiFiInformation()
 
 	ssid := C.GoString(info.ssid)

--- a/pkg/collector/corechecks/net/wlan/wlan_darwin.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_darwin.go
@@ -74,15 +74,16 @@ func GetWiFiInfo() (WiFiInfo, error) {
 		C.free(unsafe.Pointer(info.errorMessage))
 	}
 
-	wifiInfo := WiFiInfo{
-		Rssi:         int(info.rssi),
-		Ssid:         ssid,
-		Bssid:        bssid,
-		Channel:      int(info.channel),
-		Noise:        int(info.noise),
-		TransmitRate: float64(info.transmitRate), // in Mbps
-		MacAddress:   hardwareAddress,
-		PHYMode:      phyMode(info.activePHYMode).String(),
+	wifiInfo := wifiInfo{
+		rssi:         int(info.rssi),
+		ssid:         ssid,
+		bssid:        bssid,
+		channel:      int(info.channel),
+		noise:        int(info.noise),
+		noiseValid:   true,
+		transmitRate: float64(info.transmitRate), // in Mbps
+		macAddress:   hardwareAddress,
+		phyMode:      phyMode(info.activePHYMode).String(),
 	}
 
 	var err error

--- a/pkg/collector/corechecks/net/wlan/wlan_nix.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_nix.go
@@ -10,6 +10,6 @@ package wlan
 
 import "fmt"
 
-func GetWiFiInfo() (WiFiInfo, error) {
-	return WiFiInfo{}, fmt.Errorf("wifi info only supported on macOS and Windows")
+func GetWiFiInfo() (wifiInfo, error) {
+	return wifiInfo{}, fmt.Errorf("wifi info only supported on macOS and Windows")
 }

--- a/pkg/collector/corechecks/net/wlan/wlan_test.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_test.go
@@ -431,7 +431,7 @@ func TestWLANRoamingEvents(t *testing.T) {
 
 	expectedTags = []string{"ssid:ssid", "bssid:test-bssid-1", "mac_address:hardware-address"}
 
-	// 3rd run: changing the bssid-2 back to bssid-1
+	// 3rd run: changing the test-bssid-2 back to test-bssid-1
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.roaming_events", 1.0, "", expectedTags)
 	// despite channel change, and due to roaming event the channel swap event is not changed

--- a/pkg/collector/corechecks/net/wlan/wlan_test.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_test.go
@@ -19,16 +19,17 @@ import (
 
 func TestWLANOK(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -55,8 +56,8 @@ func TestWLANOK(t *testing.T) {
 
 func TestWLANGetInfoError(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{}, errors.New("some error message")
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{}, errors.New("some error message")
 	}
 
 	defer func() {
@@ -78,8 +79,8 @@ func TestWLANGetInfoError(t *testing.T) {
 
 func TestWLANErrorStoppedSender(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{}, nil
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{}, nil
 	}
 
 	defer func() {
@@ -102,16 +103,17 @@ func TestWLANErrorStoppedSender(t *testing.T) {
 
 func TestWLANEmptySSIDisUnknown(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -138,16 +140,17 @@ func TestWLANEmptySSIDisUnknown(t *testing.T) {
 
 func TestWLANEmptyBSSIDisUnknown(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -174,16 +177,17 @@ func TestWLANEmptyBSSIDisUnknown(t *testing.T) {
 
 func TestWLANEmptyHardwareAddress(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -210,16 +214,17 @@ func TestWLANEmptyHardwareAddress(t *testing.T) {
 
 func TestWLANChannelSwapEvents(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -242,16 +247,17 @@ func TestWLANChannelSwapEvents(t *testing.T) {
 	mockSender.AssertMetric(t, "Count", "wlan.channel_swap_events", 0.0, "", expectedTags)
 
 	// change channel number from 1 to 2
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      2,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      2,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -259,16 +265,17 @@ func TestWLANChannelSwapEvents(t *testing.T) {
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.channel_swap_events", 1.0, "", expectedTags)
 
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -283,16 +290,17 @@ func TestWLANChannelSwapEvents(t *testing.T) {
 
 func TestWLANChannelSwapEventsChannelZero(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      0,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      0,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -314,16 +322,17 @@ func TestWLANChannelSwapEventsChannelZero(t *testing.T) {
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.channel_swap_events", 0.0, "", expectedTags)
 
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      0,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      0,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -331,16 +340,17 @@ func TestWLANChannelSwapEventsChannelZero(t *testing.T) {
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.channel_swap_events", 0.0, "", expectedTags)
 
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "test-ssid",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -351,16 +361,17 @@ func TestWLANChannelSwapEventsChannelZero(t *testing.T) {
 
 func TestWLANRoamingEvents(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "ssid-1",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "ssid",
+			bssid:        "test-bssid-1",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
@@ -368,7 +379,7 @@ func TestWLANRoamingEvents(t *testing.T) {
 		getWiFiInfo = GetWiFiInfo
 	}()
 
-	expectedTags := []string{"ssid:ssid-1", "bssid:test-bssid", "mac_address:hardware-address"}
+	expectedTags := []string{"ssid:ssid", "bssid:test-bssid-1", "mac_address:hardware-address"}
 
 	wlanCheck := new(WLANCheck)
 
@@ -378,65 +389,73 @@ func TestWLANRoamingEvents(t *testing.T) {
 	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
 	mockSender.SetupAcceptAll()
 
-	// 1st run: initial ssid set to ssid-1
+	// 1st run: initial bssid set to bssid-1
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.roaming_events", 0.0, "", expectedTags)
 
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "ssid-2",
-			Bssid:        "test-bssid",
-			Channel:      2,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "ssid",
+			bssid:        "test-bssid-2",
+			channel:      2,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
-	expectedTags = []string{"ssid:ssid-2", "bssid:test-bssid", "mac_address:hardware-address"}
+	expectedTags = []string{"ssid:ssid", "bssid:test-bssid-2", "mac_address:hardware-address"}
 
-	// 2nd run: changing the ssid to ssid-2
+	// 2nd run: changing the test-bssid-1 to test-bssid-2
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.roaming_events", 1.0, "", expectedTags)
+	// despite channel change, and due to roaming event the channel swap event is not changed
+	mockSender.AssertMetric(t, "Count", "wlan.channel_swap_events", 0.0, "", expectedTags)
 
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "ssid-1",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "802.11ac",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "ssid",
+			bssid:        "test-bssid-1",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
 		}, nil
 	}
 
-	expectedTags = []string{"ssid:ssid-1", "bssid:test-bssid", "mac_address:hardware-address"}
+	expectedTags = []string{"ssid:ssid", "bssid:test-bssid-1", "mac_address:hardware-address"}
 
-	// 3rd run: changing the ssid back to ssid-1
+	// 3rd run: changing the bssid-2 back to bssid-1
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.roaming_events", 1.0, "", expectedTags)
+	// despite channel change, and due to roaming event the channel swap event is not changed
+	mockSender.AssertMetric(t, "Count", "wlan.channel_swap_events", 0.0, "", expectedTags)
 
 	// 4th run: keeping the same ssid
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.roaming_events", 0.0, "", expectedTags)
+	mockSender.AssertMetric(t, "Count", "wlan.channel_swap_events", 0.0, "", expectedTags)
 }
 
 func TestWLANNoMetricsWhenWiFiInterfaceInactive(t *testing.T) {
 	// setup mocks
-	getWiFiInfo = func() (WiFiInfo, error) {
-		return WiFiInfo{
-			Rssi:         10,
-			Ssid:         "ssid-1",
-			Bssid:        "test-bssid",
-			Channel:      1,
-			Noise:        20,
-			TransmitRate: 4.0,
-			MacAddress:   "hardware-address",
-			PHYMode:      "None",
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "ssid-1",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "None",
 		}, nil
 	}
 
@@ -455,4 +474,108 @@ func TestWLANNoMetricsWhenWiFiInterfaceInactive(t *testing.T) {
 
 	mockSender.AssertNumberOfCalls(t, "Gauge", 0)
 	mockSender.AssertNumberOfCalls(t, "Count", 0)
+}
+
+func TestWLANNoiseValid(t *testing.T) {
+	// setup mocks
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   false,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
+		}, nil
+	}
+
+	defer func() {
+		getWiFiInfo = GetWiFiInfo
+	}()
+
+	expectedTags := []string{"ssid:test-ssid", "bssid:test-bssid", "mac_address:hardware-address"}
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	wlanCheck.Run()
+	mockSender.AssertMetricMissing(t, "Gauge", "wlan.noise")
+
+	// setup mocks
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:         10,
+			ssid:         "test-ssid",
+			bssid:        "test-bssid",
+			channel:      1,
+			noise:        20,
+			noiseValid:   true,
+			transmitRate: 4.0,
+			macAddress:   "hardware-address",
+			phyMode:      "802.11ac",
+		}, nil
+	}
+	wlanCheck.Run()
+	mockSender.AssertMetric(t, "Gauge", "wlan.noise", 20.0, "", expectedTags)
+}
+
+func TestWLANReceiveRateValid(t *testing.T) {
+	// setup mocks
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:             10,
+			ssid:             "test-ssid",
+			bssid:            "test-bssid",
+			channel:          1,
+			noise:            20,
+			noiseValid:       false,
+			transmitRate:     4.0,
+			receiveRate:      5.0,
+			receiveRateValid: false,
+			macAddress:       "hardware-address",
+			phyMode:          "802.11ac",
+		}, nil
+	}
+
+	defer func() {
+		getWiFiInfo = GetWiFiInfo
+	}()
+
+	expectedTags := []string{"ssid:test-ssid", "bssid:test-bssid", "mac_address:hardware-address"}
+
+	wlanCheck := new(WLANCheck)
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	wlanCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
+
+	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
+	mockSender.SetupAcceptAll()
+
+	wlanCheck.Run()
+	mockSender.AssertMetricMissing(t, "Gauge", "wlan.receive_rate")
+
+	// setup mocks
+	getWiFiInfo = func() (wifiInfo, error) {
+		return wifiInfo{
+			rssi:             10,
+			ssid:             "test-ssid",
+			bssid:            "test-bssid",
+			channel:          1,
+			noise:            20,
+			noiseValid:       true,
+			transmitRate:     4.0,
+			receiveRate:      5.0,
+			receiveRateValid: true,
+			macAddress:       "hardware-address",
+			phyMode:          "802.11ac",
+		}, nil
+	}
+	wlanCheck.Run()
+	mockSender.AssertMetric(t, "Gauge", "wlan.receive_rate", 5.0, "", expectedTags)
 }

--- a/pkg/collector/corechecks/net/wlan/wlan_test.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_test.go
@@ -389,7 +389,7 @@ func TestWLANRoamingEvents(t *testing.T) {
 	mockSender := mocksender.NewMockSenderWithSenderManager(wlanCheck.ID(), senderManager)
 	mockSender.SetupAcceptAll()
 
-	// 1st run: initial bssid set to bssid-1
+	// 1st run: initial bssid set to test-bssid-1
 	wlanCheck.Run()
 	mockSender.AssertMetric(t, "Count", "wlan.roaming_events", 0.0, "", expectedTags)
 

--- a/pkg/collector/corechecks/net/wlan/wlan_windows.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_windows.go
@@ -673,26 +673,27 @@ func getFirstConnectedWlanInfo() (*wlanInfo, error) {
 	return nil, nil
 }
 
-func GetWiFiInfo() (WiFiInfo, error) {
+func GetWiFiInfo() (wifiInfo, error) {
 	wi, err := getFirstConnectedWlanInfo()
 	if err != nil {
-		return WiFiInfo{}, err
+		return wifiInfo{}, err
 	}
 
 	// If no connected WiFi interface found, return empty WiFiInfo
 	if wi == nil {
-		return WiFiInfo{PHYMode: "None"}, nil
+		return wifiInfo{phyMode: "None"}, nil
 	}
 
 	// For majority of cases for connected WiFi interface, return its details
-	return WiFiInfo{
-		Rssi:         int(wi.rssi),
-		Ssid:         wi.ssid,
-		Bssid:        wi.bssid,
-		Channel:      int(wi.channel),
-		Noise:        0, // Noise (aka Interference or SNR) are not available on Windows (not found in API or other methods)
-		TransmitRate: float64(wi.txRate),
-		MacAddress:   wi.adapterMac,
-		PHYMode:      wi.phy,
+	return wifiInfo{
+		rssi:             int(wi.rssi),
+		ssid:             wi.ssid,
+		bssid:            wi.bssid,
+		channel:          int(wi.channel),
+		transmitRate:     float64(wi.txRate),
+		receiveRate:      float64(wi.rxRate),
+		receiveRateValid: true,
+		macAddress:       wi.adapterMac,
+		phyMode:          wi.phy,
 	}, nil
 }

--- a/pkg/collector/corechecks/net/wlan/wlan_windows.go
+++ b/pkg/collector/corechecks/net/wlan/wlan_windows.go
@@ -679,7 +679,7 @@ func GetWiFiInfo() (wifiInfo, error) {
 		return wifiInfo{}, err
 	}
 
-	// If no connected WiFi interface found, return empty WiFiInfo
+	// If no connected WiFi interface found, return empty wifiInfo
 	if wi == nil {
 		return wifiInfo{phyMode: "None"}, nil
 	}


### PR DESCRIPTION
It is internal transitionary PR which 
- Added receive_rate Gauge on Windows
- Fixed obscure bug Roaming events bug
- Stop emitting metric which do not exist on some platform

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->