### PR TITLE
[api/security] Fix DCA auth token error msg

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -194,7 +194,7 @@ func getClusterAgentAuthToken(ctx context.Context, config configModel.Reader, to
 
 func validateAuthToken(authToken string) error {
 	if len(authToken) < authTokenMinimalLen {
-		return fmt.Errorf("cluster agent authentication token length must be greater than %d, curently: %d", authTokenMinimalLen, len(authToken))
+		return fmt.Errorf("cluster agent authentication token must be at least %d characters long, currently: %d", authTokenMinimalLen, len(authToken))
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Fixes an error message about the DCA auth token. This is just a detail that I noticed this while writing some tests.

The message said the length should be greater than the minimum, but it should say greater than or equal to the minimum.


### Describe how you validated your changes
Checked the error manually.
