### PR TITLE
Fix gohai filesystem on windows to use the correct variable

### DIFF
--- a/pkg/gohai/filesystem/filesystem_windows.go
+++ b/pkg/gohai/filesystem/filesystem_windows.go
@@ -106,8 +106,8 @@ func getFileSystemInfo() ([]MountInfo, error) {
 	var findClose = mod.NewProc("FindVolumeClose")
 
 	buf := make([]uint16, 512)
-	var sz int32 = 512
-	fh, _, _ := findFirst.Call(uintptr(unsafe.Pointer(&buf[0])), uintptr(sz))
+	var bufsize int32 = 512
+	fh, _, _ := findFirst.Call(uintptr(unsafe.Pointer(&buf[0])), uintptr(bufsize))
 	var findHandle = windows.Handle(fh)
 	var fileSystemInfo []MountInfo
 
@@ -119,7 +119,7 @@ func getFileSystemInfo() ([]MountInfo, error) {
 		for moreData {
 			outstring := convertWindowsString(buf)
 
-			size, _ := getDiskSize(outstring)
+			diskSize, _ := getDiskSize(outstring)
 
 			mountpts := getMountPoints(outstring)
 			var mountName string
@@ -128,13 +128,13 @@ func getFileSystemInfo() ([]MountInfo, error) {
 			}
 			mountInfo := MountInfo{
 				Name:      outstring,
-				SizeKB:    size / 1024,
+				SizeKB:    diskSize / 1024,
 				MountedOn: mountName,
 			}
 			fileSystemInfo = append(fileSystemInfo, mountInfo)
 			status, _, _ := findNext.Call(fh,
 				uintptr(unsafe.Pointer(&buf[0])),
-				uintptr(size))
+				uintptr(bufsize))
 			if 0 == status {
 				moreData = false
 			}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use the correct variable for the buffer size (and rename variables to have clearer names).

### Motivation
Fix the code.

I noticed this randomly, I think no one has this error because we use a 512 bytes buffer, it would only break if the volume name was longer than 512, or its size smaller than 512. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->