### PR TITLE
[EBPF]: migrated gpu probe to use safenvml

### DIFF
--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -13,13 +13,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
-
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/cuda"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )

--- a/pkg/gpu/consumer_test.go
+++ b/pkg/gpu/consumer_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/cuda"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
-	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/safenvml/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/cuda"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/util/ktime"
 )
 

--- a/pkg/gpu/context_test.go
+++ b/pkg/gpu/context_test.go
@@ -16,8 +16,8 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )

--- a/pkg/gpu/context_test.go
+++ b/pkg/gpu/context_test.go
@@ -16,8 +16,8 @@ import (
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/uprobes"
-	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/safenvml/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 )
 
 const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"

--- a/pkg/gpu/cuda/env_test.go
+++ b/pkg/gpu/cuda/env_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 )
 
 func TestGetVisibleDevices(t *testing.T) {

--- a/pkg/gpu/e2e_events_test.go
+++ b/pkg/gpu/e2e_events_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
-	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/safenvml/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )

--- a/pkg/gpu/e2e_events_test.go
+++ b/pkg/gpu/e2e_events_test.go
@@ -16,10 +16,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
-
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )

--- a/pkg/gpu/nvml/testutil/nvml.go
+++ b/pkg/gpu/nvml/testutil/nvml.go
@@ -15,7 +15,7 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 

--- a/pkg/gpu/nvml/testutil/nvml.go
+++ b/pkg/gpu/nvml/testutil/nvml.go
@@ -15,7 +15,7 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 

--- a/pkg/gpu/probe_test.go
+++ b/pkg/gpu/probe_test.go
@@ -21,7 +21,7 @@ import (
 	consumerstestutil "github.com/DataDog/datadog-agent/pkg/eventmonitor/consumers/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 

--- a/pkg/gpu/safenvml/testutil/nvml.go
+++ b/pkg/gpu/safenvml/testutil/nvml.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux_bpf && test && nvml
+
+// Package testutil provides utilities for testing the NVML package.
+package testutil
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/require"
+
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
+)
+
+// ToDDNVMLDevices converts a slice of nvml.Device to a slice of ddnvml.Device
+func ToDDNVMLDevices(t testing.TB, devices []nvml.Device) []*ddnvml.Device {
+	ddnvmlDevices := make([]*ddnvml.Device, len(devices))
+	for i, dev := range devices {
+		dev, err := ddnvml.NewDevice(dev)
+		require.NoError(t, err, "error converting nvml.Device %d to ddnvml.Device", i)
+		ddnvmlDevices[i] = dev
+	}
+	return ddnvmlDevices
+}
+
+// GetDDNVMLMocksWithIndexes returns a slice of ddnvml.Device mocks with the given indexes
+func GetDDNVMLMocksWithIndexes(t testing.TB, indexes ...int) []*ddnvml.Device {
+	devices := make([]*ddnvml.Device, len(indexes))
+	for i, idx := range indexes {
+		devices[i] = GetDDNVMLMockWithIndex(t, idx)
+	}
+	return devices
+}
+
+// GetDDNVMLMockWithIndex returns a ddnvml.Device mock with the given index, based on the data
+// present in mocks.go
+func GetDDNVMLMockWithIndex(t testing.TB, index int) *ddnvml.Device {
+	dev := testutil.GetDeviceMock(index)
+	dddev, err := ddnvml.NewDevice(dev)
+	require.NoError(t, err, "error converting nvml.Device to ddnvml.Device")
+	return dddev
+}
+
+// RequireDevicesEqual checks that the two devices are equal by comparing their UUIDs, which gives a better
+// output than using require.Equal on the devices themselves
+func RequireDevicesEqual(t *testing.T, expected, actual *ddnvml.Device, msgAndArgs ...interface{}) {
+	extraFmt := ""
+	if len(msgAndArgs) > 0 {
+		extraFmt = fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...) + ": "
+	}
+
+	require.Equal(t, expected.UUID, actual.UUID, "%sUUIDs do not match", extraFmt)
+}
+
+// RequireDeviceListsEqual checks that the two device lists are equal by comparing their UUIDs, which gives a better
+// output than using require.ElementsMatch on the lists themselves
+func RequireDeviceListsEqual(t *testing.T, expected, actual []*ddnvml.Device, msgAndArgs ...interface{}) {
+	extraFmt := ""
+	if len(msgAndArgs) > 0 {
+		extraFmt = fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...) + ": "
+	}
+
+	require.Len(t, actual, len(expected), "%sdevice lists have different lengths", extraFmt)
+
+	for i := range expected {
+		require.Equal(t, expected[i].UUID, actual[i].UUID, "%sUUIDs do not match for element %d", extraFmt, i)
+	}
+}

--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -17,7 +17,7 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/config/consts"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/gpu/stream_collection_test.go
+++ b/pkg/gpu/stream_collection_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
-	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
+	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/safenvml/testutil"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 

--- a/pkg/gpu/stream_collection_test.go
+++ b/pkg/gpu/stream_collection_test.go
@@ -12,11 +12,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
-
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
 	nvmltestutil "github.com/DataDog/datadog-agent/pkg/gpu/nvml/testutil"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
 

--- a/pkg/gpu/stream_test.go
+++ b/pkg/gpu/stream_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/gpu/config"
 	"github.com/DataDog/datadog-agent/pkg/gpu/cuda"
 	gpuebpf "github.com/DataDog/datadog-agent/pkg/gpu/ebpf"
-	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/nvml"
+	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )


### PR DESCRIPTION
### What does this PR do?

[Jira ticket](https://datadoghq.atlassian.net/browse/EBPF-698)

converted gpu probe to use the safenvml pkg

### Motivation

see base [PR](https://github.com/DataDog/datadog-agent/pull/36138)

### Describe how you validated your changes

all existing tests should pass

### Possible Drawbacks / Trade-offs

### Additional Notes
