### PR TITLE
SBOM: increase default input chan size for container sboms

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -205,7 +205,11 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		defaultBatchMaxConcurrentSend: 10,
 		defaultBatchMaxContentSize:    pkgconfigsetup.DefaultBatchMaxContentSize,
 		defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
-		defaultInputChanSize:          pkgconfigsetup.DefaultInputChanSize,
+
+		// on every periodic refresh, we re-send all the SBOMs for all the
+		// container images in the workloadmeta store. This can be a lot of
+		// payloads at once, so we need a large input channel size to avoid dropping
+		defaultInputChanSize: 1000,
 	},
 	{
 		eventType:                     eventplatform.EventTypeServiceDiscovery,


### PR DESCRIPTION
### What does this PR do?

Every hour (by default), all the SBOMs for all the images stored in the workloadmeta stored are sent again to the backend to refresh it. This creates a big spike of payloads in the queue that default size of 100 may not be enough to handle. This PR bumps it to 1000 by default.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->