### PR TITLE
[CONTP-744] DCA Leader election watch in clusterchecks by notification

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -8,6 +8,7 @@
 package clusterchecks
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -56,8 +57,16 @@ func (m *mockedPluggableAutoConfig) RemoveScheduler(name string) {
 
 type fakeLeaderEngine struct {
 	sync.Mutex
-	ip  string
-	err error
+	ip         string
+	err        error
+	subscriber chan struct{}
+}
+
+func newFakeLeaderEngine() *fakeLeaderEngine {
+	return &fakeLeaderEngine{
+		subscriber: make(chan struct{}),
+		err:        errors.New("failing"),
+	}
 }
 
 func (e *fakeLeaderEngine) get() (string, error) {
@@ -68,7 +77,19 @@ func (e *fakeLeaderEngine) get() (string, error) {
 
 func (e *fakeLeaderEngine) set(ip string, err error) {
 	e.Lock()
-	defer e.Unlock()
 	e.ip = ip
 	e.err = err
+	e.Unlock()
+	if e.subscriber != nil {
+		e.notify()
+	}
+}
+
+func (e *fakeLeaderEngine) notify() {
+	e.subscriber <- struct{}{}
+}
+
+func (e *fakeLeaderEngine) subscribe() (leadershipChangeNotif <-chan struct{}) {
+	leadershipChangeNotif = e.subscriber
+	return
 }

--- a/pkg/clusteragent/clusterchecks/handler.go
+++ b/pkg/clusteragent/clusterchecks/handler.go
@@ -45,17 +45,17 @@ type pluggableAutoConfig interface {
 
 // Handler is the glue holding all components for cluster-checks management
 type Handler struct {
-	autoconfig           pluggableAutoConfig
-	dispatcher           *dispatcher
-	leaderStatusFreq     time.Duration
-	warmupDuration       time.Duration
-	leaderStatusCallback types.LeaderIPCallback
-	leadershipChan       chan state
-	leaderForwarder      *api.LeaderForwarder
-	m                    sync.RWMutex // Below fields protected by the mutex
-	state                state
-	leaderIP             string
-	errCount             int
+	autoconfig               pluggableAutoConfig
+	dispatcher               *dispatcher
+	warmupDuration           time.Duration
+	leaderStatusCallback     types.LeaderIPCallback
+	leadershipStateNotifChan <-chan struct{} //from subscribing leader election engine (external)
+	leadershipChan           chan state      // for internal notification in handler class
+	leaderForwarder          *api.LeaderForwarder
+	m                        sync.RWMutex // Below fields protected by the mutex
+	state                    state
+	leaderIP                 string
+	errCount                 int
 }
 
 // NewHandler returns a populated Handler
@@ -65,11 +65,10 @@ func NewHandler(ac pluggableAutoConfig, tagger tagger.Component) (*Handler, erro
 		return nil, errors.New("empty autoconfig object")
 	}
 	h := &Handler{
-		autoconfig:       ac,
-		leaderStatusFreq: 1 * time.Second,
-		warmupDuration:   pkgconfigsetup.Datadog().GetDuration("cluster_checks.warmup_duration") * time.Second,
-		leadershipChan:   make(chan state, 1),
-		dispatcher:       newDispatcher(tagger),
+		autoconfig:     ac,
+		warmupDuration: pkgconfigsetup.Datadog().GetDuration("cluster_checks.warmup_duration") * time.Second,
+		leadershipChan: make(chan state, 1),
+		dispatcher:     newDispatcher(tagger),
 	}
 
 	if pkgconfigsetup.Datadog().GetBool("leader_election") {
@@ -79,6 +78,10 @@ func NewHandler(ac pluggableAutoConfig, tagger tagger.Component) (*Handler, erro
 			return nil, err
 		}
 		h.leaderStatusCallback = callback
+		h.leadershipStateNotifChan, err = getLeadershipStateNotifiChan()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Cache a pointer to the handler for the agent status command
@@ -174,14 +177,11 @@ func (h *Handler) leaderWatch(ctx context.Context) {
 	healthProbe := health.RegisterLiveness("clusterchecks-leadership")
 	defer health.Deregister(healthProbe) //nolint:errcheck
 
-	watchTicker := time.NewTicker(h.leaderStatusFreq)
-	defer watchTicker.Stop()
-
 	for {
 		select {
 		case <-healthProbe.C:
 			// This goroutine might hang if the leader election engine blocks
-		case <-watchTicker.C:
+		case <-h.leadershipStateNotifChan: // notification from leader election engine
 			err := h.updateLeaderIP()
 			h.m.Lock()
 			if err != nil {
@@ -195,6 +195,8 @@ func (h *Handler) leaderWatch(ctx context.Context) {
 				if h.errCount > 0 {
 					log.Infof("Found leadership status after %d tries", h.errCount)
 					h.errCount = 0
+				} else {
+					log.Infof("Found leadership status change from leader election engine without errors")
 				}
 			}
 			h.m.Unlock()

--- a/pkg/clusteragent/clusterchecks/handler_test.go
+++ b/pkg/clusteragent/clusterchecks/handler_test.go
@@ -105,6 +105,8 @@ func TestUpdateLeaderIP(t *testing.T) {
 	h = &Handler{
 		leadershipChan:       make(chan state, 1),
 		leaderStatusCallback: le.get,
+
+		leadershipStateNotifChan: le.subscribe(),
 	}
 	le.set("1.2.3.4", nil)
 	err = h.updateLeaderIP()
@@ -117,6 +119,8 @@ func TestUpdateLeaderIP(t *testing.T) {
 	h = &Handler{
 		leadershipChan:       make(chan state, 1),
 		leaderStatusCallback: le.get,
+
+		leadershipStateNotifChan: le.subscribe(),
 	}
 	le.set("", errors.New("failing"))
 	for i := 0; i < 4; i++ {
@@ -141,9 +145,7 @@ func TestHandlerRun(t *testing.T) {
 	ac := &mockedPluggableAutoConfig{}
 	fakeTagger := taggerfxmock.SetupFakeTagger(t)
 	ac.Test(t)
-	le := &fakeLeaderEngine{
-		err: errors.New("failing"),
-	}
+	le := newFakeLeaderEngine()
 
 	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "I'm a teapot", 418)
@@ -153,12 +155,13 @@ func TestHandlerRun(t *testing.T) {
 
 	h := &Handler{
 		autoconfig:           ac,
-		leaderStatusFreq:     100 * time.Millisecond,
 		warmupDuration:       250 * time.Millisecond,
 		leadershipChan:       make(chan state, 1),
 		dispatcher:           newDispatcher(fakeTagger),
 		leaderStatusCallback: le.get,
 		leaderForwarder:      api.NewLeaderForwarder(testPort, 10),
+
+		leadershipStateNotifChan: le.subscribe(),
 	}
 
 	//

--- a/pkg/clusteragent/clusterchecks/leadership_kube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_kube.go
@@ -22,3 +22,13 @@ func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 
 	return engine.GetLeaderIP, nil
 }
+
+func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
+	engine, err := leaderelection.GetLeaderEngine()
+	if err != nil {
+		return nil, err
+	}
+
+	engine.StartLeaderElectionRun()
+	return engine.UpdateLeaderInClusterChecks, nil
+}

--- a/pkg/clusteragent/clusterchecks/leadership_nokube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_nokube.go
@@ -16,3 +16,7 @@ import (
 func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 	return nil, errors.New("No leader election engine compiled in")
 }
+
+func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
+	return nil, errors.New("No leader election engine compiled in")
+}

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -54,17 +54,18 @@ type LeaderEngine struct {
 	m       sync.Mutex
 	once    sync.Once
 
-	subscribers         []chan struct{}
-	HolderIdentity      string
-	LeaseDuration       time.Duration
-	LeaseName           string
-	LeaderNamespace     string
-	coreClient          corev1.CoreV1Interface
-	coordClient         coordinationv1.CoordinationV1Interface
-	ServiceName         string
-	leaderIdentityMutex sync.RWMutex
-	leaderElector       *leaderelection.LeaderElector
-	lockType            string
+	subscribers                 []chan struct{}
+	UpdateLeaderInClusterChecks chan struct{}
+	HolderIdentity              string
+	LeaseDuration               time.Duration
+	LeaseName                   string
+	LeaderNamespace             string
+	coreClient                  corev1.CoreV1Interface
+	coordClient                 coordinationv1.CoordinationV1Interface
+	ServiceName                 string
+	leaderIdentityMutex         sync.RWMutex
+	leaderElector               *leaderelection.LeaderElector
+	lockType                    string
 
 	// leaderIdentity is the HolderIdentity of the current leader.
 	leaderIdentity string
@@ -75,13 +76,14 @@ type LeaderEngine struct {
 
 func newLeaderEngine(ctx context.Context) *LeaderEngine {
 	return &LeaderEngine{
-		ctx:             ctx,
-		LeaseName:       pkgconfigsetup.Datadog().GetString("leader_lease_name"),
-		LeaderNamespace: common.GetResourcesNamespace(),
-		ServiceName:     pkgconfigsetup.Datadog().GetString("cluster_agent.kubernetes_service_name"),
-		leaderMetric:    metrics.NewLeaderMetric(),
-		subscribers:     []chan struct{}{},
-		LeaseDuration:   defaultLeaderLeaseDuration,
+		ctx:                         ctx,
+		LeaseName:                   pkgconfigsetup.Datadog().GetString("leader_lease_name"),
+		LeaderNamespace:             common.GetResourcesNamespace(),
+		ServiceName:                 pkgconfigsetup.Datadog().GetString("cluster_agent.kubernetes_service_name"),
+		leaderMetric:                metrics.NewLeaderMetric(),
+		subscribers:                 []chan struct{}{},
+		UpdateLeaderInClusterChecks: make(chan struct{}),
+		LeaseDuration:               defaultLeaderLeaseDuration,
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -149,6 +149,7 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 		OnNewLeader: func(identity string) {
 			le.updateLeaderIdentity(identity)
 			le.reportLeaderMetric(identity == le.HolderIdentity)
+			le.notifyClusterChecks() // notify cluster checks of the new leader
 			log.Infof("New leader %q", identity)
 		},
 		OnStartedLeading: func(context.Context) {
@@ -234,4 +235,9 @@ func (le *LeaderEngine) notify() {
 
 		s <- struct{}{}
 	}
+}
+
+// notifyClusterChecks sends a notification to clusterchecks when the leader changes in any process.
+func (le *LeaderEngine) notifyClusterChecks() {
+	le.UpdateLeaderInClusterChecks <- struct{}{}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
When leaderelection finds a new leader, clusterchecks will be notified and updated instead of depending on periodic check. 

This PR reverts ["Revert "change to channel for leader watch"]( https://github.com/DataDog/datadog-agent/pull/36074).
The previous bug in leader election watching is fixed in this PR. 

Workflow
1. leaderCallbacks with `OnNewLeader` signal
2. notifyClusterChecks (this fixes the bug of using old notify/subscribe. `notify` is only called when current process has a change in leadership, but it is not triggered if the current process remains as follower but has a new leader)
3. clusterchecks updateLeaderIP

### Motivation
Last PR https://github.com/DataDog/datadog-agent/pull/36074 uses `OnStartedLeading` and `OnStoppedLeading` which causes failure in leader watch if replicas = 3 because one process of the 3 doesn't have leadership change

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Local cluster test: enable dca with 3 replicas
```
clusterAgent:
  enabled: true
  replicas: 3
```
You have 3 dca pods in k8s cluster: leaderA,   followerB, followerC 
1. Delete leaderA, now you have:      leaderAA, followerB, new follower CC
4. print log of all three pods and check the timestamp of these logs
```
leader AA (promoted from old follower C)
2025-04-16 18:53:49 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:159 in func2) | Started leading as "datadog-agent-linux-cluster-agent-cd6cdf7bb-r8vl4"...
2025-04-16 18:53:49 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:199 in leaderWatch) | Found leadership status change from leader election engine without errors
2025-04-16 18:53:49 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:120 in Run) | Becoming leader, waiting 30s for node-agents to report

followerB
2025-04-16 18:53:50 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:153 in func1) | New leader "datadog-agent-linux-cluster-agent-cd6cdf7bb-r8vl4"
2025-04-16 18:53:50 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:199 in leaderWatch) | Found leadership status change from leader election engine without errors

follower CC (new created)
2025-04-16 18:53:56 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:153 in func1) | New leader "datadog-agent-linux-cluster-agent-cd6cdf7bb-r8vl4"
2025-04-16 18:53:56 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:196 in leaderWatch) | Found leadership status after 1 tries
```

Compared to 7.64.1
```
leader AA (promoted from old follower C)
2025-04-16 19:03:42 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:152 in func1) | New leader "datadog-agent-linux-cluster-agent-65bbdc8bf8-hmwgq"
2025-04-16 19:03:42 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:158 in func2) | Started leading as "datadog-agent-linux-cluster-agent-65bbdc8bf8-hmwgq"...
2025-04-16 19:03:42 UTC | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:106 in enqueueOnLeaderNotif) | Got a leader notification, enqueuing a reconciliation for datadog-agent-helm/webhook-certificate
2025-04-16 19:03:45 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:117 in Run) | Becoming leader, waiting 30s for node-agents to report

followerB
No log if there is no error

follower CC (new created)
2025-04-16 19:03:47 UTC | CLUSTER | INFO | (pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go:152 in func1) | New leader "datadog-agent-linux-cluster-agent-65bbdc8bf8-hmwgq"
2025-04-16 19:03:49 UTC | CLUSTER | INFO | (pkg/clusteragent/clusterchecks/handler.go:196 in leaderWatch) | Found leadership status after 3 tries
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->