### PR TITLE
[.github/codeowners] Add container-autoscaling as a codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -405,7 +405,7 @@
 /comp/core/autodiscovery/providers/remote_config*.go  @DataDog/remote-config
 /pkg/cloudfoundry                       @Datadog/agent-integrations
 /pkg/clusteragent/                      @DataDog/container-platform
-/pkg/clusteragent/autoscaling/          @DataDog/container-integrations
+/pkg/clusteragent/autoscaling/          @DataDog/container-autoscaling @DataDog/container-integrations
 /pkg/clusteragent/admission/mutate/autoscaling          @DataDog/container-integrations
 /pkg/clusteragent/admission/mutate/autoinstrumentation/ @DataDog/container-platform @DataDog/injection-platform
 /pkg/clusteragent/admission/mutate/cwsinstrumentation    @Datadog/agent-security

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -6,6 +6,7 @@
 '@datadog/container-integrations': CONTINT
 '@datadog/container-platform': CONTP
 '@datadog/container-ecosystems': CECO
+'@datadog/container-autoscaling': CASCL
 '@datadog/agent-security': CWS
 '@datadog/agent-apm': APMSP
 '@datadog/network-device-monitoring': NDMII

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -25,6 +25,7 @@
 '@datadog/asm-go': '#k9-library-go'
 '@datadog/container-app': '#container-app'
 '@datadog/container-ecosystems': '#agent-onboarding'
+'@datadog/container-autoscaling': '#container-autoscaling'
 '@datadog/container-integrations': '#container-integrations'
 '@datadog/container-intake': '#process-agent-ops'
 '@datadog/container-platform': '#container-platform'

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -124,4 +124,4 @@ class TestJUnitUploadFromTGZ(unittest.TestCase):
             "tasks/unit_tests/testdata/test_output_no_failure.json",
         )
         mock_popen.assert_called()
-        self.assertEqual(mock_popen.call_count, 30)
+        self.assertEqual(mock_popen.call_count, 31)

--- a/tasks/unit_tests/junit_tests.py
+++ b/tasks/unit_tests/junit_tests.py
@@ -55,7 +55,7 @@ class TestSplitJUnitXML(unittest.TestCase):
     def test_with_split(self):
         xml_file = Path("./tasks/unit_tests/testdata/secret.tar.gz/-go-src-datadog-agent-junit-out-base.xml")
         owners = read_owners(".github/CODEOWNERS")
-        self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, {}, {}), 28)
+        self.assertEqual(junit.split_junitxml(xml_file.parent, xml_file, owners, {}, {}), 29)
 
 
 class TestGroupPerTag(unittest.TestCase):


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add @DataDog/container-autoscaling as a codeowner for autoscaling-related files

### Motivation

Keep CODEOWNERS file up-to-date

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->