### PR TITLE
[EBPF] gpu: rename stream ended marker

### DIFF
--- a/pkg/gpu/stats_test.go
+++ b/pkg/gpu/stats_test.go
@@ -89,7 +89,7 @@ func TestGetStatsWithOnlyCurrentStreamData(t *testing.T) {
 	pidTgid := uint64(pid)<<32 + uint64(pid)
 	shmemSize := uint64(10)
 	stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
-	stream.processEnded = false
+	stream.ended = false
 	stream.kernelLaunches = []enrichedKernelLaunch{
 		{
 			CudaKernelLaunch: gpuebpf.CudaKernelLaunch{
@@ -105,7 +105,7 @@ func TestGetStatsWithOnlyCurrentStreamData(t *testing.T) {
 
 	allocSize := uint64(10)
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
-	stream.processEnded = false
+	stream.ended = false
 	stream.memAllocEvents.Add(0, gpuebpf.CudaMemEvent{
 		Header: gpuebpf.CudaEventHeader{Ktime_ns: uint64(startKtime), Pid_tgid: pidTgid, Stream_id: streamID},
 		Addr:   0,
@@ -140,7 +140,7 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 	streamID := uint64(120)
 	numThreads := uint64(5)
 	stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
-	stream.processEnded = false
+	stream.ended = false
 	stream.kernelSpans = []*kernelSpan{
 		{
 			startKtime:     uint64(startKtime),
@@ -152,7 +152,7 @@ func TestGetStatsWithOnlyPastStreamData(t *testing.T) {
 
 	allocSize := uint64(10)
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
-	stream.processEnded = false
+	stream.ended = false
 	stream.allocations = []*memoryAllocation{
 		{
 			startKtime: uint64(startKtime),
@@ -192,7 +192,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 	numThreads := uint64(5)
 	shmemSize := uint64(10)
 	stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
-	stream.processEnded = false
+	stream.ended = false
 	stream.kernelLaunches = []enrichedKernelLaunch{
 		{
 			CudaKernelLaunch: gpuebpf.CudaKernelLaunch{
@@ -217,7 +217,7 @@ func TestGetStatsWithPastAndCurrentData(t *testing.T) {
 
 	allocSize := uint64(10)
 	stream = addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
-	stream.processEnded = false
+	stream.ended = false
 	stream.allocations = []*memoryAllocation{
 		{
 			startKtime: uint64(startKtime),
@@ -267,7 +267,7 @@ func TestGetStatsMultiGPU(t *testing.T) {
 	for i, uuid := range testutil.GPUUUIDs {
 		streamID := uint64(i)
 		stream := addStream(t, streamHandlers, pid, streamID, uuid, "")
-		stream.processEnded = false
+		stream.ended = false
 		stream.kernelSpans = []*kernelSpan{
 			{
 				startKtime:     uint64(startKtime),
@@ -355,7 +355,7 @@ func TestGetStatsNormalization(t *testing.T) {
 	for _, pid := range []uint32{pid1, pid2} {
 		streamID := uint64(pid)
 		stream := addStream(t, streamHandlers, pid, streamID, testutil.DefaultGpuUUID, "")
-		stream.processEnded = false
+		stream.ended = false
 		stream.kernelSpans = []*kernelSpan{
 			{
 				startKtime:     uint64(startKtime),
@@ -367,7 +367,7 @@ func TestGetStatsNormalization(t *testing.T) {
 
 		// Add memory allocations
 		globalStream := addGlobalStream(t, streamHandlers, pid, testutil.DefaultGpuUUID, "")
-		globalStream.processEnded = false
+		globalStream.ended = false
 		globalStream.allocations = []*memoryAllocation{
 			{
 				startKtime: uint64(startKtime),

--- a/pkg/gpu/stream.go
+++ b/pkg/gpu/stream.go
@@ -40,7 +40,7 @@ type StreamHandler struct {
 	memAllocEvents   *lru.LRU[uint64, gpuebpf.CudaMemEvent] // holds the memory allocations for the stream, will evict the oldest allocation if the cache is full
 	kernelSpans      []*kernelSpan
 	allocations      []*memoryAllocation
-	processEnded     bool // A marker to indicate that the process has ended, and this handler should be flushed
+	ended            bool // A marker to indicate that the stream has ended, and this handler should be flushed
 	sysCtx           *systemContext
 	limits           streamLimits
 	telemetry        *streamTelemetry // shared telemetry objects for stream-specific telemetry
@@ -380,7 +380,7 @@ func (sh *StreamHandler) markEnd() error {
 		return err
 	}
 
-	sh.processEnded = true
+	sh.ended = true
 	sh.markSynchronization(uint64(nowTs))
 
 	// Close all allocations. Treat them as leaks, as they weren't freed properly

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -250,8 +250,8 @@ func cleanHandlerMap[K comparable](sc *streamCollection, handlerMap map[K]*Strea
 	for key, handler := range handlerMap {
 		deleteReason := ""
 
-		if handler.processEnded {
-			deleteReason = "process_ended"
+		if handler.ended {
+			deleteReason = "ended"
 		} else if handler.isInactive(nowKtime, sc.maxStreamInactivity) {
 			deleteReason = "inactive"
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Rename the `processEnded` variable in the stream to a more appropriate `ended`, as the variable refers to whether the stream and not the entire process is finalized.

### Motivation

Appropriate naming.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

No functional changes, build passing is enough.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->