### PR TITLE
[tagger] Refactor to delete GetTaggerTelemetryStore from interface

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
+++ b/cmd/cluster-agent-cloudfoundry/subcommands/run/command.go
@@ -45,6 +45,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	localTaggerfx "github.com/DataDog/datadog-agent/comp/core/tagger/fx"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	wmcatalog "github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/catalog"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafx "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx"
@@ -166,6 +167,7 @@ func run(
 	authToken authtoken.Component,
 	diagonseComp diagnose.Component,
 	dcametadataComp dcametadata.Component,
+	telemetry telemetry.Component,
 ) error {
 	mainCtx, mainCtxCancel := context.WithCancel(context.Background())
 	defer mainCtxCancel() // Calling cancel twice is safe
@@ -208,7 +210,7 @@ func run(
 	// start the autoconfig, this will immediately run any configured check
 	ac.LoadAndRun(mainCtx)
 
-	if err = api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagonseComp, dcametadataComp); err != nil {
+	if err = api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagonseComp, dcametadataComp, telemetry); err != nil {
 		return log.Errorf("Error while starting agent API, exiting: %v", err)
 	}
 

--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -40,6 +40,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/status"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerserver "github.com/DataDog/datadog-agent/comp/core/tagger/server"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	dcametadata "github.com/DataDog/datadog-agent/comp/metadata/clusteragent/def"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
@@ -57,7 +58,7 @@ var (
 )
 
 // StartServer creates the router and starts the HTTP server
-func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component, authToken authtoken.Component, diagnoseComponent diagnose.Component, dcametadataComp dcametadata.Component) error {
+func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagger.Component, ac autodiscovery.Component, statusComponent status.Component, settings settings.Component, cfg config.Component, authToken authtoken.Component, diagnoseComponent diagnose.Component, dcametadataComp dcametadata.Component, telemetry telemetry.Component) error {
 	// create the root HTTP router
 	router = mux.NewRouter()
 	apiRouter = router.PathPrefix("/api/v1").Subrouter()
@@ -121,7 +122,7 @@ func StartServer(ctx context.Context, w workloadmeta.Component, taggerComp tagge
 	// event size should be small enough to fit within the grpc max message size
 	maxEventSize := maxMessageSize / 2
 	pb.RegisterAgentSecureServer(grpcSrv, &serverSecure{
-		taggerServer: taggerserver.NewServer(taggerComp, maxEventSize, cfg.GetInt("remote_tagger.max_concurrent_sync")),
+		taggerServer: taggerserver.NewServer(taggerComp, telemetry, maxEventSize, cfg.GetInt("remote_tagger.max_concurrent_sync")),
 	})
 
 	timeout := pkgconfigsetup.Datadog().GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second

--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -317,7 +317,7 @@ func start(log log.Component,
 	})
 
 	// Starting server early to ease investigations
-	if err := api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagnoseComp, dcametadataComp); err != nil {
+	if err := api.StartServer(mainCtx, wmeta, taggerComp, ac, statusComponent, settings, config, authToken, diagnoseComp, dcametadataComp, telemetry); err != nil {
 		return fmt.Errorf("Error while starting agent API, exiting: %v", err)
 	}
 

--- a/comp/core/tagger/def/component.go
+++ b/comp/core/tagger/def/component.go
@@ -8,7 +8,6 @@ package tagger
 
 import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	taggertypes "github.com/DataDog/datadog-agent/pkg/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
@@ -18,7 +17,6 @@ import (
 
 // Component is the component type.
 type Component interface {
-	GetTaggerTelemetryStore() *telemetry.Store
 	Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error)
 	GenerateContainerIDFromOriginInfo(originInfo origindetection.OriginInfo) (string, error)
 	AccumulateTagsFor(entityID types.EntityID, cardinality types.TagCardinality, tb tagset.TagsAccumulator) error

--- a/comp/core/tagger/def/go.mod
+++ b/comp/core/tagger/def/go.mod
@@ -7,7 +7,6 @@ toolchain go1.23.6
 require (
 	github.com/DataDog/datadog-agent/comp/core/config v0.64.0-devel
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.62.0-rc.7
-	github.com/DataDog/datadog-agent/comp/core/tagger/telemetry v0.0.0-20250129172314-517df3f51a84
 	github.com/DataDog/datadog-agent/comp/core/tagger/types v0.60.0
 	github.com/DataDog/datadog-agent/pkg/tagger/types v0.60.0
 	github.com/DataDog/datadog-agent/pkg/tagset v0.60.0
@@ -18,7 +17,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/flare/types v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.60.0 // indirect
-	github.com/DataDog/datadog-agent/comp/core/telemetry v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/config/create v0.0.0-00010101000000-000000000000 // indirect
@@ -46,8 +44,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.64.1 // indirect
 	github.com/DataDog/viper v1.14.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/ebitengine/purego v0.8.2 // indirect
@@ -62,14 +58,9 @@ require (
 	github.com/magiconair/properties v1.8.9 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.21.1 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.62.0 // indirect
-	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/shirou/gopsutil/v4 v4.25.2 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
@@ -90,7 +81,6 @@ require (
 	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/text v0.24.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
-	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/comp/core/tagger/def/go.sum
+++ b/comp/core/tagger/def/go.sum
@@ -18,6 +18,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -108,8 +109,6 @@ github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALr
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
-github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/comp/core/tagger/impl-noop/tagger.go
+++ b/comp/core/tagger/impl-noop/tagger.go
@@ -16,17 +16,12 @@ package noopimpl
 import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	taggertypes "github.com/DataDog/datadog-agent/pkg/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
 type noopTagger struct{}
-
-func (n *noopTagger) GetTaggerTelemetryStore() *telemetry.Store {
-	return nil
-}
 
 func (n *noopTagger) Tag(types.EntityID, types.TagCardinality) ([]string, error) {
 	return nil, nil

--- a/comp/core/tagger/impl-remote/remote.go
+++ b/comp/core/tagger/impl-remote/remote.go
@@ -258,11 +258,6 @@ func stop(remoteTagger *remoteTagger) error {
 	return nil
 }
 
-// GetTaggerTelemetryStore returns tagger telemetry store
-func (t *remoteTagger) GetTaggerTelemetryStore() *telemetry.Store {
-	return t.telemetryStore
-}
-
 // Tag returns tags for a given entity at the desired cardinality.
 func (t *remoteTagger) Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error) {
 	if cardinality == types.ChecksConfigCardinality {

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -309,11 +309,6 @@ func (t *localTagger) Subscribe(subscriptionID string, filter *types.Filter) (ty
 	return t.tagStore.Subscribe(subscriptionID, filter)
 }
 
-// GetTaggerTelemetryStore returns tagger telemetry tagStore
-func (t *localTagger) GetTaggerTelemetryStore() *telemetry.Store {
-	return t.telemetryStore
-}
-
 // GetEntityHash returns the hash for the tags associated with the given entity.
 // Returns an empty string if the tags lookup fails.
 func (t *localTagger) GetEntityHash(entityID types.EntityID, cardinality types.TagCardinality) string {

--- a/comp/core/tagger/impl/tagger_mock.go
+++ b/comp/core/tagger/impl/tagger_mock.go
@@ -14,7 +14,6 @@ import (
 	taggermock "github.com/DataDog/datadog-agent/comp/core/tagger/mock"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/tagstore"
-	"github.com/DataDog/datadog-agent/comp/core/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	coretelemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -104,11 +103,6 @@ func (f *fakeTagger) GetTagStore() *tagstore.TagStore {
 }
 
 // Tagger methods
-
-// GetTaggerTelemetryStore calls tagger.GetTaggerTelemetryStore().
-func (f *fakeTagger) GetTaggerTelemetryStore() *telemetry.Store {
-	return f.tagger.GetTaggerTelemetryStore()
-}
 
 // Tag calls tagger.Tag().
 func (f *fakeTagger) Tag(entityID types.EntityID, cardinality types.TagCardinality) ([]string, error) {

--- a/comp/core/tagger/server/server.go
+++ b/comp/core/tagger/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/tagger/origindetection"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/proto"
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -33,14 +34,16 @@ const (
 // Server is a grpc server that streams tagger entities
 type Server struct {
 	taggerComponent tagger.Component
+	telemetry       *telemetryStore
 	maxEventSize    int
 	throttler       Throttler
 }
 
 // NewServer returns a new Server
-func NewServer(t tagger.Component, maxEventSize int, maxParallelSync int) *Server {
+func NewServer(t tagger.Component, telemetry telemetry.Component, maxEventSize int, maxParallelSync int) *Server {
 	return &Server{
 		taggerComponent: t,
+		telemetry:       newTelemetryStore(telemetry),
 		maxEventSize:    maxEventSize,
 		throttler:       NewSyncThrottler(uint32(maxParallelSync)),
 	}
@@ -83,7 +86,7 @@ func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecu
 
 				if err != nil {
 					log.Warnf("error sending tagger keep-alive: %s", err)
-					s.taggerComponent.GetTaggerTelemetryStore().ServerStreamErrors.Inc()
+					s.telemetry.ServerStreamErrors.Inc()
 					timeoutRefreshError <- err
 					return
 				}
@@ -152,7 +155,7 @@ func (s *Server) TaggerStreamEntities(in *pb.StreamTagsRequest, out pb.AgentSecu
 
 			if err := processChunksInPlace(responseEvents, s.maxEventSize, computeTagsEventInBytes, sendFunc); err != nil {
 				log.Warnf("error sending tagger event: %s", err)
-				s.taggerComponent.GetTaggerTelemetryStore().ServerStreamErrors.Inc()
+				s.telemetry.ServerStreamErrors.Inc()
 				return err
 			}
 

--- a/comp/core/tagger/server/telemetry.go
+++ b/comp/core/tagger/server/telemetry.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package server
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+)
+
+const subsystem = "tagger"
+
+type telemetryStore struct {
+	// ServerStreamErrors tracks how many errors happened when streaming out
+	// tagger events.
+	ServerStreamErrors telemetry.Counter
+}
+
+func newTelemetryStore(telemetryComp telemetry.Component) *telemetryStore {
+	return &telemetryStore{
+		ServerStreamErrors: telemetryComp.NewCounterWithOpts(
+			subsystem,
+			"server_stream_errors",
+			[]string{},
+			"Errors when streaming out tagger events",
+			telemetry.Options{NoDoubleUnderscoreSep: true},
+		),
+	}
+}

--- a/comp/core/tagger/telemetry/telemetry.go
+++ b/comp/core/tagger/telemetry/telemetry.go
@@ -46,10 +46,6 @@ type Store struct {
 	// tagger events.
 	ClientStreamErrors telemetry.Counter
 
-	// ServerStreamErrors tracks how many errors happened when streaming
-	// out tagger events.
-	ServerStreamErrors telemetry.Counter
-
 	// Subscribers tracks how many subscribers the tagger has.
 	Subscribers telemetry.Gauge
 	// Events tracks the number of tagger events being sent out.
@@ -100,12 +96,6 @@ func NewStore(telemetryComp telemetry.Component) *Store {
 			// Remote
 			PrunedEntities: telemetryComp.NewGaugeWithOpts(subsystem, "pruned_entities",
 				[]string{}, "Number of pruned tagger entities.",
-				commonOpts),
-
-			// ServerStreamErrors tracks how many errors happened when streaming
-			// out tagger events.
-			ServerStreamErrors: telemetryComp.NewCounterWithOpts(subsystem, "server_stream_errors",
-				[]string{}, "Errors when streaming out tagger events",
 				commonOpts),
 
 			// ClientStreamErrors tracks how many errors were received when streaming

--- a/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
+++ b/comp/otelcol/otlp/components/connector/datadogconnector/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/DataDog/datadog-agent/comp/core/secrets v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/status v0.63.0 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/origindetection v0.64.1 // indirect
-	github.com/DataDog/datadog-agent/comp/core/tagger/telemetry v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/tagger/utils v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/comp/core/telemetry v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/comp/def v0.64.1 // indirect


### PR DESCRIPTION
### What does this PR do?

This PR refactors the tagger code to remove the `GetTaggerTelemetryStore` function from the interface.

That function exposed an internal detail that callers shouldn’t need to know about. It was only used by the tagger server to update the `server_stream_errors` metric.

Now, that metric has been moved into a new telemetry store owned by the tagger server. This keeps the logic local and lets us remove `GetTaggerTelemetryStore` from the interface.

The first commit adds the new telemetry store, moves the metric, and updates a few functions to pass the telemetry store to the tagger server.
The second commit removes `GetTaggerTelemetryStore` from the interface and from all tagger implementations.

### Describe how you validated your changes

I forced some errors in the tagger server to verify that the metric is increased as before.