### PR TITLE
[tagger/telemetry] Extract common options

### DIFF
--- a/comp/core/tagger/telemetry/telemetry.go
+++ b/comp/core/tagger/telemetry/telemetry.go
@@ -23,6 +23,8 @@ const (
 	querySuccess = "success"
 )
 
+var commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
+
 // CardinalityTelemetry contains the telemetry for a specific cardinality level.
 type CardinalityTelemetry struct {
 	EmptyEntityID telemetry.SimpleCounter
@@ -81,66 +83,66 @@ func NewStore(telemetryComp telemetry.Component) *Store {
 		// queries tracks the number of queries made against the tagger.
 		queries := telemetryComp.NewCounterWithOpts(subsystem, "queries",
 			[]string{"cardinality", "status"}, "Queries made against the tagger.",
-			telemetry.Options{NoDoubleUnderscoreSep: true})
+			commonOpts)
 
 		store = &Store{
 			StoredEntities: telemetryComp.NewGaugeWithOpts(subsystem, "stored_entities",
 				[]string{"source", "prefix"}, "Number of entities in the store.",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// UpdatedEntities tracks the number of updates to tagger entities.
 			// Remote
 			UpdatedEntities: telemetryComp.NewCounterWithOpts(subsystem, "updated_entities",
 				[]string{}, "Number of updates made to entities.",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// PrunedEntities tracks the number of pruned tagger entities.
 			// Remote
 			PrunedEntities: telemetryComp.NewGaugeWithOpts(subsystem, "pruned_entities",
 				[]string{}, "Number of pruned tagger entities.",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// ServerStreamErrors tracks how many errors happened when streaming
 			// out tagger events.
 			ServerStreamErrors: telemetryComp.NewCounterWithOpts(subsystem, "server_stream_errors",
 				[]string{}, "Errors when streaming out tagger events",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// ClientStreamErrors tracks how many errors were received when streaming
 			// tagger events.
 			// Remote
 			ClientStreamErrors: telemetryComp.NewCounterWithOpts(subsystem, "client_stream_errors",
 				[]string{}, "Errors received when streaming tagger events",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// Subscribers tracks how many subscribers the tagger has.
 			Subscribers: telemetryComp.NewGaugeWithOpts(subsystem, "subscribers",
 				[]string{}, "Number of channels subscribing to tagger events",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// Events tracks the number of tagger events being sent out.
 			Events: telemetryComp.NewCounterWithOpts(subsystem, "events",
 				[]string{"cardinality"}, "Number of tagger events being sent out",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// Sends tracks the number of times the tagger has sent a
 			// notification with a group of events.
 			Sends: telemetryComp.NewCounterWithOpts(subsystem, "sends",
 				[]string{}, "Number of of times the tagger has sent a notification with a group of events",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// Receives tracks the number of times the tagger has received a
 			// notification with a group of events.
 			// Remote
 			Receives: telemetryComp.NewCounterWithOpts(subsystem, "receives",
 				[]string{}, "Number of of times the tagger has received a notification with a group of events",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			// OriginInfoRequests tracks the number of requests to the tagger
 			// to generate a container ID from origin info.
 			OriginInfoRequests: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_requests",
 				[]string{"status"}, "Number of requests to the tagger to generate a container ID from origin info.",
-				telemetry.Options{NoDoubleUnderscoreSep: true}),
+				commonOpts),
 
 			LowCardinalityQueries:          newCardinalityTelemetry(queries, types.LowCardinalityString),
 			OrchestratorCardinalityQueries: newCardinalityTelemetry(queries, types.OrchestratorCardinalityString),


### PR DESCRIPTION
### What does this PR do?

This PR is a small cleanup I noticed while working on related code.
It moves the common tagger telemetry options into a variable so they can be reused.

### Describe how you validated your changes
CI