### PR TITLE
[tagger/telemetry] Delete unnecessary sync.Once

### DIFF
--- a/comp/core/tagger/telemetry/telemetry.go
+++ b/comp/core/tagger/telemetry/telemetry.go
@@ -7,8 +7,6 @@
 package telemetry
 
 import (
-	"sync"
-
 	"github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 )
@@ -70,79 +68,72 @@ type Store struct {
 	UnknownCardinalityQueries      CardinalityTelemetry
 }
 
-var store *Store
-var initializeOnce sync.Once
-
 // NewStore returns a new Store.
 func NewStore(telemetryComp telemetry.Component) *Store {
-	initializeOnce.Do(func() {
-		// queries tracks the number of queries made against the tagger.
-		queries := telemetryComp.NewCounterWithOpts(subsystem, "queries",
-			[]string{"cardinality", "status"}, "Queries made against the tagger.",
-			commonOpts)
+	// queries tracks the number of queries made against the tagger.
+	queries := telemetryComp.NewCounterWithOpts(subsystem, "queries",
+		[]string{"cardinality", "status"}, "Queries made against the tagger.",
+		commonOpts)
 
-		store = &Store{
-			StoredEntities: telemetryComp.NewGaugeWithOpts(subsystem, "stored_entities",
-				[]string{"source", "prefix"}, "Number of entities in the store.",
-				commonOpts),
+	return &Store{
+		StoredEntities: telemetryComp.NewGaugeWithOpts(subsystem, "stored_entities",
+			[]string{"source", "prefix"}, "Number of entities in the store.",
+			commonOpts),
 
-			// UpdatedEntities tracks the number of updates to tagger entities.
-			// Remote
-			UpdatedEntities: telemetryComp.NewCounterWithOpts(subsystem, "updated_entities",
-				[]string{}, "Number of updates made to entities.",
-				commonOpts),
+		// UpdatedEntities tracks the number of updates to tagger entities.
+		// Remote
+		UpdatedEntities: telemetryComp.NewCounterWithOpts(subsystem, "updated_entities",
+			[]string{}, "Number of updates made to entities.",
+			commonOpts),
 
-			// PrunedEntities tracks the number of pruned tagger entities.
-			// Remote
-			PrunedEntities: telemetryComp.NewGaugeWithOpts(subsystem, "pruned_entities",
-				[]string{}, "Number of pruned tagger entities.",
-				commonOpts),
+		// PrunedEntities tracks the number of pruned tagger entities.
+		// Remote
+		PrunedEntities: telemetryComp.NewGaugeWithOpts(subsystem, "pruned_entities",
+			[]string{}, "Number of pruned tagger entities.",
+			commonOpts),
 
-			// ClientStreamErrors tracks how many errors were received when streaming
-			// tagger events.
-			// Remote
-			ClientStreamErrors: telemetryComp.NewCounterWithOpts(subsystem, "client_stream_errors",
-				[]string{}, "Errors received when streaming tagger events",
-				commonOpts),
+		// ClientStreamErrors tracks how many errors were received when streaming
+		// tagger events.
+		// Remote
+		ClientStreamErrors: telemetryComp.NewCounterWithOpts(subsystem, "client_stream_errors",
+			[]string{}, "Errors received when streaming tagger events",
+			commonOpts),
 
-			// Subscribers tracks how many subscribers the tagger has.
-			Subscribers: telemetryComp.NewGaugeWithOpts(subsystem, "subscribers",
-				[]string{}, "Number of channels subscribing to tagger events",
-				commonOpts),
+		// Subscribers tracks how many subscribers the tagger has.
+		Subscribers: telemetryComp.NewGaugeWithOpts(subsystem, "subscribers",
+			[]string{}, "Number of channels subscribing to tagger events",
+			commonOpts),
 
-			// Events tracks the number of tagger events being sent out.
-			Events: telemetryComp.NewCounterWithOpts(subsystem, "events",
-				[]string{"cardinality"}, "Number of tagger events being sent out",
-				commonOpts),
+		// Events tracks the number of tagger events being sent out.
+		Events: telemetryComp.NewCounterWithOpts(subsystem, "events",
+			[]string{"cardinality"}, "Number of tagger events being sent out",
+			commonOpts),
 
-			// Sends tracks the number of times the tagger has sent a
-			// notification with a group of events.
-			Sends: telemetryComp.NewCounterWithOpts(subsystem, "sends",
-				[]string{}, "Number of of times the tagger has sent a notification with a group of events",
-				commonOpts),
+		// Sends tracks the number of times the tagger has sent a
+		// notification with a group of events.
+		Sends: telemetryComp.NewCounterWithOpts(subsystem, "sends",
+			[]string{}, "Number of of times the tagger has sent a notification with a group of events",
+			commonOpts),
 
-			// Receives tracks the number of times the tagger has received a
-			// notification with a group of events.
-			// Remote
-			Receives: telemetryComp.NewCounterWithOpts(subsystem, "receives",
-				[]string{}, "Number of of times the tagger has received a notification with a group of events",
-				commonOpts),
+		// Receives tracks the number of times the tagger has received a
+		// notification with a group of events.
+		// Remote
+		Receives: telemetryComp.NewCounterWithOpts(subsystem, "receives",
+			[]string{}, "Number of of times the tagger has received a notification with a group of events",
+			commonOpts),
 
-			// OriginInfoRequests tracks the number of requests to the tagger
-			// to generate a container ID from origin info.
-			OriginInfoRequests: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_requests",
-				[]string{"status"}, "Number of requests to the tagger to generate a container ID from origin info.",
-				commonOpts),
+		// OriginInfoRequests tracks the number of requests to the tagger
+		// to generate a container ID from origin info.
+		OriginInfoRequests: telemetryComp.NewCounterWithOpts(subsystem, "origin_info_requests",
+			[]string{"status"}, "Number of requests to the tagger to generate a container ID from origin info.",
+			commonOpts),
 
-			LowCardinalityQueries:          newCardinalityTelemetry(queries, types.LowCardinalityString),
-			OrchestratorCardinalityQueries: newCardinalityTelemetry(queries, types.OrchestratorCardinalityString),
-			HighCardinalityQueries:         newCardinalityTelemetry(queries, types.HighCardinalityString),
-			NoneCardinalityQueries:         newCardinalityTelemetry(queries, types.NoneCardinalityString),
-			UnknownCardinalityQueries:      newCardinalityTelemetry(queries, types.UnknownCardinalityString),
-		}
-	})
-
-	return store
+		LowCardinalityQueries:          newCardinalityTelemetry(queries, types.LowCardinalityString),
+		OrchestratorCardinalityQueries: newCardinalityTelemetry(queries, types.OrchestratorCardinalityString),
+		HighCardinalityQueries:         newCardinalityTelemetry(queries, types.HighCardinalityString),
+		NoneCardinalityQueries:         newCardinalityTelemetry(queries, types.NoneCardinalityString),
+		UnknownCardinalityQueries:      newCardinalityTelemetry(queries, types.UnknownCardinalityString),
+	}
 }
 
 // QueriesByCardinality returns a set of counters for a given cardinality level.


### PR DESCRIPTION
### What does this PR do?

This PR is a small cleanup. it just deletes an unnecessary `sync.Once` in the tagger telemetry. `NewStore` should only be called once.

### Describe how you validated your changes
CI