### PR TITLE
[DSCVR-99] Add support for C++ in Service Discovery language detection

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/language/language_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/language/language_linux.go
@@ -27,6 +27,7 @@ var languageNameToLanguageMap = map[languagemodels.LanguageName]Language{
 	languagemodels.Python: Python,
 	languagemodels.Java:   Java,
 	languagemodels.Ruby:   Ruby,
+	languagemodels.CPP:    CPlusPlus,
 }
 
 // ProcessInfo holds information about a process.

--- a/pkg/collector/corechecks/servicediscovery/language/language_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/language/language_linux.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-// languageNameToLanguageMap translates the constants rom the
+// languageNameToLanguageMap translates the constants from the
 // languagedetection package to the constants used in this file. The latter
 // are shared with the backend, and at least java/jvm differs in the name
 // from the languagedetection package.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add entry to const translation map to properly support C++ in Service Discovery language detection

### Motivation

Without this change SD won't report C++ detection correctly

### Describe how you validated your changes
Trivial change and existing unit tests pass

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->