### PR TITLE
fix(installer): Publish installer scripts on agent deploy

### DIFF
--- a/.gitlab/deploy_packages/deploy_common.yml
+++ b/.gitlab/deploy_packages/deploy_common.yml
@@ -114,7 +114,8 @@
 
 deploy_installer_install_scripts:
   rules:
-    !reference [.on_deploy_installer]
+    - !reference [.on_deploy_installer]
+    - !reference [.on_deploy]
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   stage: deploy_packages
   needs: ["installer-install-scripts"]


### PR DESCRIPTION
### What does this PR do?
We now deploy one of the installer scripts with the agent, so we need the agent deploy pipeline to push the installer scripts to our artifacts bucket

### Motivation

### Describe how you validated your changes
[Manual pipeline triggered](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/62350292) -- verified that the `deploy_installer_install_scripts` was present

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->