### PR TITLE
Add another image destination for `dev_nightly-a7-full`

### DIFF
--- a/.gitlab/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/dev_container_deploy/docker_linux.yml
@@ -205,7 +205,7 @@ dev_nightly-a7-full:
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-full-arm64
-    IMG_DESTINATIONS: agent-dev:nightly-full-${CI_COMMIT_REF_SLUG}-jmx
+    IMG_DESTINATIONS: agent-dev:nightly-full-${CI_COMMIT_REF_SLUG}-${CI_COMMIT_SHORT_SHA}-jmx,agent-dev:nightly-full-${CI_COMMIT_REF_SLUG}-jmx
 
 # deploys nightlies to agent-dev
 dev_nightly-dogstatsd:


### PR DESCRIPTION
### What does this PR do?

Adds another image destination for dev_nightly-a7-full that includes the `CI_COMMIT_SHORT_SHA`

### Motivation

To be used in SMP nightly quality gates. We want to be able to easily associate nightly runs with the commit they were built off of

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes