### PR TITLE
Fix iglendd exclusion from the releasing team

### DIFF
--- a/tasks/libs/releasing/documentation.py
+++ b/tasks/libs/releasing/documentation.py
@@ -20,7 +20,7 @@ NON_RELEASING_TEAMS = {
     'agent-release-management',
     'container-ecosystems',
     'apm-trace-storage',
-    'iglendd',  # Not a team but he's in the codeowners file
+    '@iglendd',  # Not a team but he's in the codeowners file
     'sdlc-security',
     'data-jobs-monitoring',
     'serverless-aws',


### PR DESCRIPTION
### What does this PR do?

This PR fixes the exclusion of `iglendd` from the list of releasing teams. The name that we pull from `CODEOWNERS` had `@` at the beginning.

### Motivation

Release process cleanup.
