### PR TITLE
[DJMS-55] Fix Spark integration: don't create integration file on workers

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -239,7 +239,7 @@ func setupDatabricksDriver(s *common.Setup) {
 
 func setupDatabricksWorker(s *common.Setup) {
 	setClearHostTag(s, "spark_node", "worker")
-	
+
 	if os.Getenv("WORKER_LOGS_ENABLED") == "true" {
 		var sparkIntegration common.IntegrationConfig
 		s.Config.DatadogYAML.LogsEnabled = true

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -239,14 +239,15 @@ func setupDatabricksDriver(s *common.Setup) {
 
 func setupDatabricksWorker(s *common.Setup) {
 	setClearHostTag(s, "spark_node", "worker")
-
-	var sparkIntegration common.IntegrationConfig
+	
 	if os.Getenv("WORKER_LOGS_ENABLED") == "true" {
+		var sparkIntegration common.IntegrationConfig
 		s.Config.DatadogYAML.LogsEnabled = true
 		sparkIntegration.Logs = workerLogs
 		s.Span.SetTag("host_tag_set.worker_logs_enabled", "true")
+		s.Config.IntegrationConfigs["spark.d/databricks.yaml"] = sparkIntegration
 	}
-	s.Config.IntegrationConfigs["spark.d/databricks.yaml"] = sparkIntegration
+
 }
 
 func addCustomHostTags(s *common.Setup) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Skip Spark integration setup on Databricks workers if logs collection is not enabled

### Motivation

When logs collection is not enabled, there isn't anything to write in the spark integration config file on the Databricks workers. Creating an empty file actually triggers a warning: 
![image](https://github.com/user-attachments/assets/83751efa-5822-4d3d-81f5-0c3274db5ecd)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->