### PR TITLE
[omnibus] Add sysctl-probe-offline-skip patch to OpenSCAP

### DIFF
--- a/omnibus/config/patches/openscap/sysctl-probe-offline-skip.patch
+++ b/omnibus/config/patches/openscap/sysctl-probe-offline-skip.patch
@@ -1,0 +1,16 @@
+--- a/src/OVAL/results/oval_resultTest.c
++++ b/src/OVAL/results/oval_resultTest.c
+@@ -1144,6 +1144,13 @@ oval_result_t oval_result_test_eval(struct oval_result_test *rtest)
+ 	const char *comment = oval_test_get_comment(test);
+ 	dI("Evaluating %s test '%s': %s.", type, test_id, comment);
+ 
++	/* Skip systctl probe in offline mode */
++	if (getenv("OSCAP_PROBE_ROOT") != NULL && oval_test_get_subtype(test) == OVAL_UNIX_SYSCTL) {
++		dI("Skip %s probe in offline mode.", type);
++		rtest->result = OVAL_RESULT_TRUE;
++		return rtest->result;
++	}
++
+ 	if (rtest->result == OVAL_RESULT_NOT_EVALUATED) {
+ 		if (oval_test_get_subtype(oval_result_test_get_test(rtest)) != OVAL_INDEPENDENT_UNKNOWN) {
+ 			struct oval_string_map *tmp_map = oval_string_map_new();

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -41,8 +41,8 @@ build do
   patch source: "rpm-verbosity-err.patch", env: env # decrease rpmlog verbosity level to ERR
   patch source: "session-print-syschar.patch", env: env # add a function to print system characteristics
   patch source: "memusage-cgroup.patch", env: env # consider cgroup when determining memory usage
-
   patch source: "oval_probe_session_reset.patch", env: env # use oval_probe_session_reset instead of oval_probe_session_reinit
+  patch source: "sysctl-probe-offline-skip.patch", env: env # skip sysctl probe in offline mode
 
   patch source: "oscap-io.patch", env: env # add new oscap-io tool
 


### PR DESCRIPTION
### What does this PR do?

This changes adds a sysctl-probe-offline-skip patch to OpenSCAP.

This patch skip tests using the sysctl probe during the OVAL evaluation when OpenSCAP is running in offline mode.

This prevents OpenSCAP from reporting incorrect sysctl values when the Datadog Agent is running in a container.

For example:

```
$ docker exec agent /bin/bash -c 'cat /host/proc/sys/net/ipv6/conf/default/accept_ra'
1
$ cat /proc/sys/net/ipv6/conf/default/accept_ra
0
```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->