### PR TITLE
[CXP-2073] Add e2e tests for process_config.additional_endpoints

### DIFF
--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -70,6 +70,10 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 	config.OnUpdate(func(setting string, oldValue, newValue any) {
 		found := false
 
+		if setting == "process_config.additional_endpoints" {
+			log.Infof("process_config.additional_endpoints refresh oldValue: %v, newValue: %v", scrubber.HideKeyExceptLastFiveChars(oldValue.(string)), scrubber.HideKeyExceptLastFiveChars(newValue.(string)))
+		}
+
 		for _, endpoint := range resolver.GetAPIKeysInfo() {
 			if endpoint.ConfigSettingPath == setting {
 				found = true

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -70,10 +70,6 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 	config.OnUpdate(func(setting string, oldValue, newValue any) {
 		found := false
 
-		if setting == "process_config.additional_endpoints" {
-			log.Infof("process_config.additional_endpoints refresh oldValue: %v, newValue: %v", scrubber.HideKeyExceptLastFiveChars(oldValue.(string)), scrubber.HideKeyExceptLastFiveChars(newValue.(string)))
-		}
-
 		for _, endpoint := range resolver.GetAPIKeysInfo() {
 			if endpoint.ConfigSettingPath == setting {
 				found = true

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -733,7 +733,7 @@ func (c *Client) GetAllProcessPayloadAPIKeys() (map[string]struct{}, error) {
 		return nil, err
 	}
 
-	keys := make(map[string]struct{}, 0)
+	keys := make(map[string]struct{})
 	for _, payload := range payloads {
 		keys[payload.APIKey] = struct{}{}
 	}

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -727,15 +727,19 @@ func (c *Client) GetLastProcessPayloadAPIKey() (string, error) {
 
 // GetAllProcessPayloadAPIKeys fetches fakeintake on `/api/v1/collector` endpoint and returns
 // a list of unique API keys of the received process payloads
-func (c *Client) GetAllProcessPayloadAPIKeys() (map[string]struct{}, error) {
+func (c *Client) GetAllProcessPayloadAPIKeys() ([]string, error) {
 	payloads, err := c.getFakePayloads(processesEndpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	keys := make(map[string]struct{})
+	keysFound := make(map[string]struct{})
+	keys := make([]string, 0)
 	for _, payload := range payloads {
-		keys[payload.APIKey] = struct{}{}
+		if _, ok := keysFound[payload.APIKey]; !ok {
+			keysFound[payload.APIKey] = struct{}{}
+			keys = append(keys, payload.APIKey)
+		}
 	}
 
 	return keys, nil

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -725,7 +725,7 @@ func (c *Client) GetLastProcessPayloadAPIKey() (string, error) {
 	return payloads[len(payloads)-1].APIKey, nil
 }
 
-// GetAllProcessPayloadAPIKey fetches fakeintake on `/api/v1/collector` endpoint and returns
+// GetAllProcessPayloadAPIKeys fetches fakeintake on `/api/v1/collector` endpoint and returns
 // a list of unique API keys of the received process payloads
 func (c *Client) GetAllProcessPayloadAPIKeys() (map[string]struct{}, error) {
 	payloads, err := c.getFakePayloads(processesEndpoint)

--- a/test/fakeintake/client/client.go
+++ b/test/fakeintake/client/client.go
@@ -725,6 +725,22 @@ func (c *Client) GetLastProcessPayloadAPIKey() (string, error) {
 	return payloads[len(payloads)-1].APIKey, nil
 }
 
+// GetAllProcessPayloadAPIKey fetches fakeintake on `/api/v1/collector` endpoint and returns
+// a list of unique API keys of the received process payloads
+func (c *Client) GetAllProcessPayloadAPIKeys() (map[string]struct{}, error) {
+	payloads, err := c.getFakePayloads(processesEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	keys := make(map[string]struct{}, 0)
+	for _, payload := range payloads {
+		keys[payload.APIKey] = struct{}{}
+	}
+
+	return keys, nil
+}
+
 // GetContainers fetches fakeintake on `/api/v1/container` endpoint and returns
 // all received container payloads
 func (c *Client) GetContainers() ([]*aggregator.ContainerPayload, error) {

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -6,6 +6,7 @@
 package process
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -66,7 +67,8 @@ func (s *linuxTestSuite) TestAPIKeyRefresh() {
 	)
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertAPIKey(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().Agent.Client, s.Env().FakeIntake.Client(), false)
+		assertAPIKeyStatus(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().Agent.Client, false)
+		assertLastPayloadAPIKey(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().FakeIntake.Client())
 	}, 2*time.Minute, 10*time.Second)
 
 	// API key refresh
@@ -75,7 +77,8 @@ func (s *linuxTestSuite) TestAPIKeyRefresh() {
 	require.Contains(t, secretRefreshOutput, "api_key")
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertAPIKey(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().Agent.Client, s.Env().FakeIntake.Client(), false)
+		assertAPIKeyStatus(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().Agent.Client, false)
+		assertLastPayloadAPIKey(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().FakeIntake.Client())
 	}, 2*time.Minute, 10*time.Second)
 }
 
@@ -96,7 +99,8 @@ func (s *linuxTestSuite) TestAPIKeyRefreshCoreAgent() {
 	)
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertAPIKey(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().Agent.Client, s.Env().FakeIntake.Client(), true)
+		assertAPIKeyStatus(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().Agent.Client, true)
+		assertLastPayloadAPIKey(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().FakeIntake.Client())
 	}, 2*time.Minute, 10*time.Second)
 
 	// API key refresh
@@ -105,7 +109,65 @@ func (s *linuxTestSuite) TestAPIKeyRefreshCoreAgent() {
 	require.Contains(t, secretRefreshOutput, "api_key")
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertAPIKey(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().Agent.Client, s.Env().FakeIntake.Client(), true)
+		assertAPIKeyStatus(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().Agent.Client, true)
+		assertLastPayloadAPIKey(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().FakeIntake.Client())
+	}, 2*time.Minute, 10*time.Second)
+}
+
+func (s *linuxTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
+	t := s.T()
+
+	fakeIntakeURL := s.Env().FakeIntake.Client().URL()
+
+	additionalEndpoint := fmt.Sprintf(`  additional_endpoints:
+    %s:
+      - ENC[api_key_additional]`, fakeIntakeURL)
+	config := coreAgentRefreshStr + additionalEndpoint
+
+	secretClient := secretsutils.NewClient(t, s.Env().RemoteHost, "/tmp/test-secret")
+	apiKey := "apikeyabcde"
+	apiKeyAdditional := "apikey12345"
+	secretClient.SetSecret("api_key", apiKey)
+	secretClient.SetSecret("api_key_additional", apiKeyAdditional)
+
+	s.UpdateEnv(
+		awshost.Provisioner(
+			awshost.WithAgentOptions(
+				agentparams.WithAgentConfig(config),
+				secretsutils.WithUnixSetupScript("/tmp/test-secret/secret-resolver.py", false),
+				agentparams.WithSkipAPIKeyInConfig(),
+			),
+		),
+	)
+
+	fakeIntakeClient := s.Env().FakeIntake.Client()
+	agentClient := s.Env().Agent.Client
+
+	fakeIntakeClient.FlushServerAndResetAggregators()
+
+	// Assert that the status and payloads have the correct API key
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertAPIKeyStatus(collect, apiKey, agentClient, true)
+		assertAPIKeyStatus(collect, apiKeyAdditional, agentClient, true)
+		assertAllPayloadsAPIKeys(collect, []string{apiKey, apiKeyAdditional}, fakeIntakeClient)
+	}, 2*time.Minute, 10*time.Second)
+
+	// Refresh secrets in the agent
+	apiKey = "apikeyfghijk"
+	apiKeyAdditional = "apikey67890"
+	secretClient.SetSecret("api_key", apiKey)
+	secretClient.SetSecret("api_key_additional", apiKeyAdditional)
+	secretRefreshOutput := s.Env().Agent.Client.Secret(agentclient.WithArgs([]string{"refresh"}))
+	require.Contains(t, secretRefreshOutput, "api_key")
+	require.Contains(t, secretRefreshOutput, "api_key_additional")
+
+	fakeIntakeClient.FlushServerAndResetAggregators()
+
+	// Assert that the status and payloads have the correct API key
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertAPIKeyStatus(collect, apiKey, agentClient, true)
+		assertAPIKeyStatus(collect, apiKeyAdditional, agentClient, true)
+		assertAllPayloadsAPIKeys(collect, []string{apiKey, apiKeyAdditional}, fakeIntakeClient)
 	}, 2*time.Minute, 10*time.Second)
 }
 

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -160,7 +160,6 @@ func (s *linuxTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
 	secretRefreshOutput := s.Env().Agent.Client.Secret(agentclient.WithArgs([]string{"refresh"}))
 	require.Contains(t, secretRefreshOutput, "api_key")
 	require.Contains(t, secretRefreshOutput, "api_key_additional")
-	t.Logf("secretRefreshOutput: %s", secretRefreshOutput)
 
 	fakeIntakeClient.FlushServerAndResetAggregators()
 
@@ -168,13 +167,7 @@ func (s *linuxTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertAPIKeyStatus(collect, apiKey, agentClient, true)
 		assertAPIKeyStatus(collect, apiKeyAdditional, agentClient, true)
-		// Assert that all received payloads have the expected API keys
-		payloadKeys, err := fakeIntakeClient.GetAllProcessPayloadAPIKeys()
-		require.NoError(collect, err)
-		t.Logf("payloadKeys: %+v", payloadKeys)
-		for _, expectedAPIKey := range []string{apiKey, apiKeyAdditional} {
-			assert.Contains(collect, payloadKeys, expectedAPIKey)
-		}
+		assertAllPayloadsAPIKeys(collect, []string{apiKey, apiKeyAdditional}, fakeIntakeClient)
 	}, 2*time.Minute, 10*time.Second)
 }
 

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -120,7 +120,7 @@ func (s *linuxTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
 	fakeIntakeURL := s.Env().FakeIntake.Client().URL()
 
 	additionalEndpoint := fmt.Sprintf(`  additional_endpoints:
-    %s:
+    "%s":
       - ENC[api_key_additional]`, fakeIntakeURL)
 	config := coreAgentRefreshStr + additionalEndpoint
 
@@ -160,6 +160,7 @@ func (s *linuxTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
 	secretRefreshOutput := s.Env().Agent.Client.Secret(agentclient.WithArgs([]string{"refresh"}))
 	require.Contains(t, secretRefreshOutput, "api_key")
 	require.Contains(t, secretRefreshOutput, "api_key_additional")
+	t.Logf("secretRefreshOutput: %s", secretRefreshOutput)
 
 	fakeIntakeClient.FlushServerAndResetAggregators()
 

--- a/test/new-e2e/tests/process/linux_test.go
+++ b/test/new-e2e/tests/process/linux_test.go
@@ -168,7 +168,13 @@ func (s *linuxTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertAPIKeyStatus(collect, apiKey, agentClient, true)
 		assertAPIKeyStatus(collect, apiKeyAdditional, agentClient, true)
-		assertAllPayloadsAPIKeys(collect, []string{apiKey, apiKeyAdditional}, fakeIntakeClient)
+		// Assert that all received payloads have the expected API keys
+		payloadKeys, err := fakeIntakeClient.GetAllProcessPayloadAPIKeys()
+		require.NoError(collect, err)
+		t.Logf("payloadKeys: %+v", payloadKeys)
+		for _, expectedAPIKey := range []string{apiKey, apiKeyAdditional} {
+			assert.Contains(collect, payloadKeys, expectedAPIKey)
+		}
 	}, 2*time.Minute, 10*time.Second)
 }
 

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -381,20 +381,38 @@ func assertManualProcessDiscoveryCheck(t *testing.T, check string, process strin
 	assert.True(t, populated, "no %s process had all data populated", process)
 }
 
-func assertAPIKey(collect *assert.CollectT, apiKey string, agentClient agentclient.Agent, fakeIntakeClient *fakeintakeclient.Client, coreAgent bool) {
+func assertAPIKeyStatus(collect *assert.CollectT, apiKey string, agentClient agentclient.Agent, coreAgent bool) {
 	// Assert that the status has the correct API key
 	statusMap := getAgentStatus(collect, agentClient)
 	endpoints := statusMap.ProcessAgentStatus.Expvars.Map.Endpoints
 	if coreAgent {
 		endpoints = statusMap.ProcessComponentStatus.Expvars.Map.Endpoints
 	}
-	for _, key := range endpoints {
-		// Original key is obfuscated to the last 5 characters
-		assert.Equal(collect, key[0], apiKey[len(apiKey)-5:])
+	found := false
+	for _, epKeys := range endpoints {
+		for _, key := range epKeys {
+			// Original key is obfuscated to the last 5 characters
+			if key == apiKey[len(apiKey)-5:] {
+				found = true
+				break
+			}
+		}
 	}
+	require.True(collect, found, "API key %s not found in endpoints %+v", apiKey, endpoints)
+}
 
+func assertLastPayloadAPIKey(collect *assert.CollectT, expectedAPIKey string, fakeIntakeClient *fakeintakeclient.Client) {
 	// Assert that the last received payload has the correct API key
 	lastAPIKey, err := fakeIntakeClient.GetLastProcessPayloadAPIKey()
 	require.NoError(collect, err)
-	assert.Equal(collect, apiKey, lastAPIKey)
+	assert.Equal(collect, expectedAPIKey, lastAPIKey)
+}
+
+func assertAllPayloadsAPIKeys(collect *assert.CollectT, expectedAPIKeys []string, fakeIntakeClient *fakeintakeclient.Client) {
+	// Assert that all received payloads have the expected API keys
+	payloadKeys, err := fakeIntakeClient.GetAllProcessPayloadAPIKeys()
+	require.NoError(collect, err)
+	for _, expectedAPIKey := range expectedAPIKeys {
+		assert.Contains(collect, payloadKeys, expectedAPIKey)
+	}
 }

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -83,7 +83,8 @@ func (s *windowsTestSuite) TestAPIKeyRefresh() {
 	)
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertAPIKey(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().Agent.Client, s.Env().FakeIntake.Client(), false)
+		assertAPIKeyStatus(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().Agent.Client, false)
+		assertLastPayloadAPIKey(collect, "abcdefghijklmnopqrstuvwxyz123456", s.Env().FakeIntake.Client())
 	}, 2*time.Minute, 10*time.Second)
 
 	// API key refresh
@@ -92,7 +93,8 @@ func (s *windowsTestSuite) TestAPIKeyRefresh() {
 	require.Contains(t, secretRefreshOutput, "api_key")
 
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		assertAPIKey(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().Agent.Client, s.Env().FakeIntake.Client(), false)
+		assertAPIKeyStatus(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().Agent.Client, false)
+		assertLastPayloadAPIKey(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().FakeIntake.Client())
 	}, 2*time.Minute, 10*time.Second)
 }
 

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -6,6 +6,7 @@
 package process
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -95,6 +96,68 @@ func (s *windowsTestSuite) TestAPIKeyRefresh() {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertAPIKeyStatus(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().Agent.Client, false)
 		assertLastPayloadAPIKey(collect, "123456abcdefghijklmnopqrstuvwxyz", s.Env().FakeIntake.Client())
+	}, 2*time.Minute, 10*time.Second)
+}
+
+func (s *windowsTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
+	t := s.T()
+
+	fakeIntakeURL := s.Env().FakeIntake.Client().URL()
+
+	additionalEndpoint := fmt.Sprintf(`  additional_endpoints:
+    "%s":
+      - ENC[api_key_additional]`, fakeIntakeURL)
+	config := processAgentWinRefreshStr + additionalEndpoint
+
+	secretClient := secretsutils.NewClient(t, s.Env().RemoteHost, `C:\TestFolder`)
+	apiKey := "apikeyabcde"
+	apiKeyAdditional := "apikey12345"
+	secretClient.SetSecret("api_key", apiKey)
+	secretClient.SetSecret("api_key_additional", apiKeyAdditional)
+
+	agentParams := []func(*agentparams.Params) error{
+		agentparams.WithSkipAPIKeyInConfig(),
+		agentparams.WithAgentConfig(config),
+	}
+	agentParams = append(agentParams, secretsutils.WithWindowsSetupScript("C:/TestFolder/wrapper.bat", true)...)
+
+	s.UpdateEnv(
+		awshost.Provisioner(
+			awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
+			awshost.WithAgentOptions(
+				agentParams...,
+			),
+		),
+	)
+
+	fakeIntakeClient := s.Env().FakeIntake.Client()
+	agentClient := s.Env().Agent.Client
+
+	fakeIntakeClient.FlushServerAndResetAggregators()
+
+	// Assert that the status and payloads have the correct API key
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertAPIKeyStatus(collect, apiKey, agentClient, false)
+		assertAPIKeyStatus(collect, apiKeyAdditional, agentClient, false)
+		assertAllPayloadsAPIKeys(collect, []string{apiKey, apiKeyAdditional}, fakeIntakeClient)
+	}, 2*time.Minute, 10*time.Second)
+
+	// Refresh secrets in the agent
+	apiKey = "apikeyfghijk"
+	apiKeyAdditional = "apikey67890"
+	secretClient.SetSecret("api_key", apiKey)
+	secretClient.SetSecret("api_key_additional", apiKeyAdditional)
+	secretRefreshOutput := s.Env().Agent.Client.Secret(agentclient.WithArgs([]string{"refresh"}))
+	require.Contains(t, secretRefreshOutput, "api_key")
+	require.Contains(t, secretRefreshOutput, "api_key_additional")
+
+	fakeIntakeClient.FlushServerAndResetAggregators()
+
+	// Assert that the status and payloads have the correct API key
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertAPIKeyStatus(collect, apiKey, agentClient, false)
+		assertAPIKeyStatus(collect, apiKeyAdditional, agentClient, false)
+		assertAllPayloadsAPIKeys(collect, []string{apiKey, apiKeyAdditional}, fakeIntakeClient)
 	}, 2*time.Minute, 10*time.Second)
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds Linux and Windows E2E tests for secret refreshing of `process_config.additional_endpoints` introduced in https://github.com/DataDog/datadog-agent/pull/36160. 

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Ran the tests and they passed


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->