### PR TITLE
AGNTLOG-151 - add logs_destination.destination_workers to x-org telemetry

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -216,6 +216,7 @@ var defaultProfiles = `
           aggregate_tags:
             - truncated
             - line_type
+        - name: logs_destination.destination_workers
         - name: point.sent
         - name: point.dropped
         - name: transactions.input_count


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds the RTT fairness destination workers metric to x-org telemetry. This will prove exceedingly helpful in identifying the usage of the feature in the fleet, as well as estimating its effectiveness. 

Definition of the metric lives at: https://github.com/DataDog/datadog-agent/blob/main/pkg/logs/metrics/metrics.go#L95

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->