### PR TITLE
Optimize allocations in cgroup parsing

### DIFF
--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -112,6 +112,7 @@ single-machine-performance-regression_detector:
       --baseline-sha ${BASELINE_SHA} \
       --comparison-sha ${CI_COMMIT_SHA} \
       --target-config-dir test/regression/ \
+      --replicas 250 \
       --submission-metadata submission_metadata \
       --tags ${SMP_TAGS} || {
         exit_code=$?

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -112,7 +112,7 @@ single-machine-performance-regression_detector:
       --baseline-sha ${BASELINE_SHA} \
       --comparison-sha ${CI_COMMIT_SHA} \
       --target-config-dir test/regression/ \
-      --replicas 250 \
+      --replicas 100 \
       --submission-metadata submission_metadata \
       --tags ${SMP_TAGS} || {
         exit_code=$?

--- a/.gitlab/functional_test/regression_detector.yml
+++ b/.gitlab/functional_test/regression_detector.yml
@@ -112,7 +112,7 @@ single-machine-performance-regression_detector:
       --baseline-sha ${BASELINE_SHA} \
       --comparison-sha ${CI_COMMIT_SHA} \
       --target-config-dir test/regression/ \
-      --replicas 100 \
+      --replicas 50 \
       --submission-metadata submission_metadata \
       --tags ${SMP_TAGS} || {
         exit_code=$?

--- a/pkg/util/cgroups/cgroupv2.go
+++ b/pkg/util/cgroups/cgroupv2.go
@@ -12,13 +12,19 @@ import (
 )
 
 type cgroupV2 struct {
+	// 8-byte aligned fields first
+	controllers map[string]struct{}
+	pidMapper   pidMapper
+	fr          fileReader
+	inode       uint64
+
+	// string fields (16 bytes each on 64-bit systems)
 	identifier   string
 	cgroupRoot   string
 	relativePath string
-	controllers  map[string]struct{}
-	fr           fileReader
-	pidMapper    pidMapper
-	inode        uint64
+
+	// bool field last
+	markedForDeletion bool
 }
 
 func newCgroupV2(identifier, cgroupRoot, relativePath string, controllers map[string]struct{}, pidMapper pidMapper) *cgroupV2 {

--- a/pkg/util/cgroups/go.mod
+++ b/pkg/util/cgroups/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/cgroups/v3 v3.0.5
 	github.com/google/go-cmp v0.7.0
 	github.com/stretchr/testify v1.10.0
+	golang.org/x/sys v0.32.0
 )
 
 require (
@@ -22,7 +23,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.2.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/pkg/util/cgroups/reader.go
+++ b/pkg/util/cgroups/reader.go
@@ -43,7 +43,7 @@ type Reader struct {
 }
 
 type readerImpl interface {
-	parseCgroups() (map[string]Cgroup, error)
+	parseCgroups(res map[string]Cgroup) (map[string]Cgroup, error)
 }
 
 // ReaderFilter allows to filter cgroups based on their path + folder name
@@ -146,6 +146,10 @@ func (r *Reader) init() error {
 		r.readerFilter = DefaultFilter
 	}
 
+	// Initialize maps
+	r.cgroups = make(map[string]Cgroup)
+	r.cgroupByInode = make(map[uint64]Cgroup)
+
 	if isCgroup1(cgroupMounts) {
 		r.cgroupVersion = 1
 
@@ -211,7 +215,7 @@ func (r *Reader) RefreshCgroups(cacheValidity time.Duration) error {
 		return nil
 	}
 
-	newCgroups, err := r.impl.parseCgroups()
+	newCgroups, err := r.impl.parseCgroups(r.cgroups)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/cgroups/readerv1.go
+++ b/pkg/util/cgroups/readerv1.go
@@ -43,8 +43,11 @@ func newReaderV1(procPath string, mountPoints map[string]string, baseController 
 	return nil, &InvalidInputError{Desc: fmt.Sprintf("cannot create cgroup readerv1: %s controller not found", baseController)}
 }
 
-func (r *readerV1) parseCgroups() (map[string]Cgroup, error) {
-	res := make(map[string]Cgroup)
+func (r *readerV1) parseCgroups(res map[string]Cgroup) (map[string]Cgroup, error) {
+	// Clear the map while preserving capacity
+	for k := range res {
+		delete(res, k)
+	}
 
 	err := filepath.WalkDir(r.cgroupRoot, func(fullPath string, de fs.DirEntry, err error) error {
 		if err != nil {
@@ -60,7 +63,6 @@ func (r *readerV1) parseCgroups() (map[string]Cgroup, error) {
 			if err != nil {
 				return err
 			}
-
 			res[id] = newCgroupV1(id, relPath, r.baseController, r.mountPoints, r.pidMapper)
 		}
 		return err

--- a/pkg/util/cgroups/readerv1_test.go
+++ b/pkg/util/cgroups/readerv1_test.go
@@ -46,7 +46,8 @@ func TestReaderV1(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 
-	cgroups, err := r.parseCgroups()
+	cgroups := make(map[string]Cgroup)
+	cgroups, err = r.parseCgroups(cgroups)
 	assert.NoError(t, err)
 
 	expected := map[string]Cgroup{

--- a/pkg/util/cgroups/readerv2.go
+++ b/pkg/util/cgroups/readerv2.go
@@ -8,8 +8,9 @@
 package cgroups
 
 import (
+	"errors"
 	"fmt"
-	"io/fs"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -40,30 +41,95 @@ func newReaderV2(procPath, cgroupRoot string, filter ReaderFilter, pidMapperID s
 	}, nil
 }
 
-// parseCgroups parses the cgroups from the cgroupRoot and returns a map of cgroup id to cgroup.
-func (r *readerV2) parseCgroups() (map[string]Cgroup, error) {
-	res := make(map[string]Cgroup)
+// parseCgroups parses the cgroups from the cgroupRoot and returns a map of
+// cgroup id to cgroup. The provided map will only be populated with discovered
+// cgroups, nothing stale.
+func (r *readerV2) parseCgroups(res map[string]Cgroup) (map[string]Cgroup, error) {
+	// Mark all existing cgroups for deletion. Those that are found in the DFS
+	// will be retained ultimately in this map, the rest will be removed. This
+	// allows us to elide expensive calls to newCgroupV2 -- one obligatory
+	// syscall per call, string allocation per -- for cgroups we have already
+	// seen.
+	for id := range res {
+		if cg, ok := res[id].(*cgroupV2); ok {
+			cg.markedForDeletion = true
+		}
+	}
 
-	err := filepath.WalkDir(r.cgroupRoot, func(fullPath string, de fs.DirEntry, err error) error {
+	// Avoid the use of filepath.WalkDir which is allocation hungry, at least as
+	// of Go 1.23.8. Instead we perform our own depth-first search.
+	stack := []string{r.cgroupRoot}
+
+	for len(stack) > 0 {
+		// Pop the directory to search from the stack, alter said stack.
+		dir := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		id, err := r.filter(dir, filepath.Base(dir))
 		if err != nil {
-			return err
-		}
-		if !de.IsDir() {
-			return nil
-		}
-
-		id, err := r.filter(fullPath, de.Name())
-		if id != "" {
-			relPath, err := filepath.Rel(r.cgroupRoot, fullPath)
-			if err != nil {
-				return err
+			// If SkipDir is returned, record the cgroup if valid, then skip
+			// pushing subdirectories.
+			if errors.Is(err, filepath.SkipDir) {
+				if id != "" {
+					relPath, err := filepath.Rel(r.cgroupRoot, dir)
+					if err != nil {
+						return nil, err
+					}
+					// Reuse existing cgroup if available
+					if existing, ok := res[id]; ok {
+						if cg, ok := existing.(*cgroupV2); ok {
+							cg.relativePath = relPath
+							cg.markedForDeletion = false
+						}
+					} else {
+						res[id] = newCgroupV2(id, r.cgroupRoot, relPath, r.cgroupControllers, r.pidMapper)
+					}
+				}
+				continue
 			}
-			res[id] = newCgroupV2(id, r.cgroupRoot, relPath, r.cgroupControllers, r.pidMapper)
+			return nil, err
+		}
+		if id != "" {
+			relPath, err := filepath.Rel(r.cgroupRoot, dir)
+			if err != nil {
+				return nil, err
+			}
+			// Reuse existing cgroup if available
+			if existing, ok := res[id]; ok {
+				if cg, ok := existing.(*cgroupV2); ok {
+					cg.relativePath = relPath
+					cg.markedForDeletion = false
+				}
+			} else {
+				res[id] = newCgroupV2(id, r.cgroupRoot, relPath, r.cgroupControllers, r.pidMapper)
+			}
 		}
 
-		return err
-	})
-	return res, err
+		// Now read all entries and push only directories onto the stack. Note
+		// this is allocation hungry itself. A direct call to unix.Open is
+		// feasible but would require us to handle C-style strings.
+		//
+		// Might be worthwhile eventually.
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				subPath := filepath.Join(dir, entry.Name())
+				stack = append(stack, subPath)
+			}
+		}
+	}
+
+	// Remove cgroups that are still marked for deletion
+	for id, cg := range res {
+		if cgv2, ok := cg.(*cgroupV2); ok && cgv2.markedForDeletion {
+			delete(res, id)
+		}
+	}
+
+	return res, nil
 }
 
 func readCgroupControllers(cgroupRoot string) (map[string]struct{}, error) {

--- a/pkg/util/cgroups/readerv2_test.go
+++ b/pkg/util/cgroups/readerv2_test.go
@@ -8,9 +8,13 @@
 package cgroups
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/pprof"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +50,8 @@ func TestReaderV2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 
-	cgroups, err := r.parseCgroups()
+	cgroups := make(map[string]Cgroup)
+	cgroups, err = r.parseCgroups(cgroups)
 	assert.NoError(t, err)
 
 	expected := map[string]Cgroup{
@@ -68,4 +73,179 @@ func TestReaderV2(t *testing.T) {
 	}
 
 	assert.Empty(t, cmp.Diff(expected, cgroups, cmp.AllowUnexported(cgroupV2{})))
+}
+
+func BenchmarkParseCgroups_Small(b *testing.B) {
+	benchmarkParseCgroups(b, 5)
+}
+
+func BenchmarkParseCgroups_Medium(b *testing.B) {
+	benchmarkParseCgroups(b, 50)
+}
+
+func BenchmarkParseCgroups_Large(b *testing.B) {
+	// Create memory profile in /tmp with random name
+	memProfile := filepath.Join(os.TempDir(), fmt.Sprintf("parse-cgroups-large-memprofile-%d.out", time.Now().UnixNano()))
+	f, err := os.Create(memProfile)
+	if err != nil {
+		b.Fatalf("Failed to create memory profile: %v", err)
+	}
+	defer f.Close()
+	b.Logf("Memory profile will be saved to: %s", memProfile)
+
+	// Set memory profile rate to capture all allocations
+	runtime.MemProfileRate = 1
+
+	// Run the benchmark
+	benchmarkParseCgroups(b, 500)
+
+	// Write the final memory profile
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		b.Fatalf("Failed to write memory profile: %v", err)
+	}
+}
+
+func benchmarkParseCgroups(b *testing.B, numCgroups int) {
+	// Create a temporary directory structure that mimics cgroup v2
+	tmpDir := b.TempDir()
+
+	// Create root cgroup.controllers file
+	if err := os.WriteFile(filepath.Join(tmpDir, "cgroup.controllers"), []byte("cpu memory io pids\n"), 0644); err != nil {
+		b.Fatal(err)
+	}
+
+	// Create a mock cgroup hierarchy
+	createMockCgroups(tmpDir, numCgroups)
+
+	// Create a readerV2 instance
+	reader, err := newReaderV2("/proc", tmpDir, DefaultFilter, "")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Enable allocation reporting
+	b.ReportAllocs()
+
+	// Reset timer before actual benchmark
+	b.ResetTimer()
+
+	// Run the benchmark
+	b.Run("parseCgroups", func(b *testing.B) {
+		cgroups := make(map[string]Cgroup)
+		for i := 0; i < b.N; i++ {
+			_, err := reader.parseCgroups(cgroups)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func createMockCgroups(root string, numCgroups int) {
+	// Create a typical cgroup hierarchy with varying depths and patterns
+	dirs := make([]string, 0, numCgroups)
+
+	// System slice hierarchy with various services
+	systemServices := []string{
+		"docker", "kubelet", "containerd", "systemd-journald", "sshd",
+		"cron", "dbus", "networkd", "logind", "polkitd",
+	}
+	for _, service := range systemServices {
+		dirs = append(dirs, fmt.Sprintf("system.slice/%s.service", service))
+		dirs = append(dirs, fmt.Sprintf("system.slice/%s.service/%s-1234.scope", service, service))
+	}
+
+	// User slice hierarchy with multiple users and sessions
+	users := []string{"1000", "1001", "1002", "1003", "1004"}
+	for _, user := range users {
+		dirs = append(dirs, fmt.Sprintf("user.slice/user-%s.slice", user))
+		for session := 1; session <= 3; session++ {
+			dirs = append(dirs, fmt.Sprintf("user.slice/user-%s.slice/session-%d.scope", user, session))
+		}
+	}
+
+	// Container hierarchies with different runtimes
+	containerRuntimes := []string{"docker", "containerd", "crio"}
+	for _, runtime := range containerRuntimes {
+		for i := 0; i < 5; i++ {
+			containerID := fmt.Sprintf("%s-%x", runtime, i)
+			dirs = append(dirs, fmt.Sprintf("kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod%s.slice/%s.scope",
+				containerID, containerID))
+		}
+	}
+
+	// Add more cgroups to reach desired size with varying patterns
+	for i := len(dirs); i < numCgroups; i++ {
+		// Create unique paths with varying patterns
+		pattern := i % 4
+		var path string
+		switch pattern {
+		case 0:
+			// Simple nested structure
+			depth := (i % 3) + 1
+			path = fmt.Sprintf("custom.slice/group-%d", i)
+			for j := 1; j < depth; j++ {
+				path = fmt.Sprintf("%s/subgroup-%d", path, j)
+			}
+		case 1:
+			// Container-like structure
+			path = fmt.Sprintf("containers.slice/container-%x/container-%x.scope", i, i)
+		case 2:
+			// Service-like structure
+			path = fmt.Sprintf("services.slice/service-%d.service/service-%d.scope", i, i)
+		case 3:
+			// User-like structure
+			path = fmt.Sprintf("users.slice/user-%d.slice/session-%d.scope", i, i%10)
+		}
+		dirs = append(dirs, path)
+	}
+
+	// Create directories and files
+	for _, dir := range dirs {
+		path := filepath.Join(root, dir)
+		if err := os.MkdirAll(path, 0755); err != nil {
+			panic(err)
+		}
+
+		// Create typical cgroup files with varying content
+		files := []string{
+			"cgroup.procs",
+			"cgroup.controllers",
+			"cpu.stat",
+			"memory.current",
+			"memory.stat",
+			"io.stat",
+			"pids.current",
+		}
+
+		for _, file := range files {
+			// Generate some realistic-looking content
+			content := generateCgroupFileContent(file)
+			if err := os.WriteFile(filepath.Join(path, file), []byte(content), 0644); err != nil {
+				panic(err)
+			}
+		}
+	}
+}
+
+func generateCgroupFileContent(filename string) string {
+	switch filename {
+	case "cgroup.procs":
+		return "1234\n5678\n"
+	case "cgroup.controllers":
+		return "cpu memory io pids\n"
+	case "cpu.stat":
+		return "usage_usec 1234567\nuser_usec 1000000\nsystem_usec 234567\n"
+	case "memory.current":
+		return "123456789\n"
+	case "memory.stat":
+		return "anon 1000000\nfile 2000000\nkernel_stack 50000\nslab 100000\n"
+	case "io.stat":
+		return "8:0 rbytes=123456 wbytes=789012 rios=100 wios=200\n"
+	case "pids.current":
+		return "10\n"
+	default:
+		return "0\n"
+	}
 }

--- a/pkg/util/cgroups/utils.go
+++ b/pkg/util/cgroups/utils.go
@@ -10,9 +10,9 @@ package cgroups
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"os"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -32,14 +32,15 @@ func randToken(n int) (string, error) {
 }
 
 func inodeForPath(path string) uint64 {
-	stat, err := os.Stat(path)
-	if err != nil {
+	var stat unix.Stat_t
+
+	// os.Stat calls eventually fstatat so we skip the middle.
+	if err := unix.Fstatat(unix.AT_FDCWD, path, &stat, 0); err != nil {
 		log.Debugf("unable to retrieve the inode for path %s: %v", path, err)
 		return unknownInode
 	}
-	inode := stat.Sys().(*syscall.Stat_t).Ino
-	if inode > 2 {
-		return inode
+	if stat.Ino > 2 {
+		return stat.Ino
 	}
 	return unknownInode
 }


### PR DESCRIPTION
### What does this PR do?

This commit is an attempt to improve cgroup parsing -- especially concerned with v2 -- with reference to incident-37244. I have introduced new benchmarks and especially a "large" one that is also rigged up to do memory profiling. Baseline results prior to any code changes, other than introduction of the benchmark:

```
      768B    32.12MB (flat, cum) 93.77% of Total
         .          .     44:func (r *readerV2) parseCgroups() (map[string]Cgroup, error) {
      768B       768B     45:   res := make(map[string]Cgroup)
         .          .     46:
         .    32.12MB     47:   err := filepath.WalkDir(r.cgroupRoot, func(fullPath string, de fs.DirEntry, err error) error {
         .          .     48:           if err != nil {
         .          .     49:                   return err
         .          .     50:           }
         .          .     51:           if !de.IsDir() {
         .          .     52:                   return nil
         .          .     53:           }
         .          .     54:
         .          .     55:           id, err := r.filter(fullPath, de.Name())
         .          .     56:           if id != "" {
         .          .     57:                   relPath, err := filepath.Rel(r.cgroupRoot, fullPath)
         .          .     58:                   if err != nil {
         .          .     59:                           return err
         .          .     60:                   }
    2.54MB     9.57MB     61:                   res[id] = newCgroupV2(id, r.cgroupRoot, relPath, r.cgroupControllers, r.pidMapper)
         .          .     62:           }
         .          .     63:
         .          .     64:           return err
         .          .     65:   })
         .          .     66:   return res, err
```

and after:

```
  435.55kB    20.55MB (flat, cum) 91.79% of Total
         .          .     47:func (r *readerV2) parseCgroups(res map[string]Cgroup) (map[string]Cgroup, error) {
         .          .     48:   // Mark all existing cgroups for deletion. Those that are found in the DFS
         .          .     49:   // will be retained ultimately in this map, the rest will be removed. This
         .          .     50:   // allows us to elide expensive calls to newCgroupV2 -- one obligatory
         .          .     51:   // syscall per call, string allocation per -- for cgroups we have already
         .          .     52:   // seen.
         .          .     53:   for id := range res {
         .          .     54:           if cg, ok := res[id].(*cgroupV2); ok {
         .          .     55:                   cg.markedForDeletion = true
         .          .     56:           }
         .          .     57:   }
         .          .     58:
         .          .     59:   // Avoid the use of filepath.WalkDir which is allocation hungry, at least as
         .          .     60:   // of Go 1.23.8. Instead we perform our own depth-first search.
         .          .     61:   stack := []string{r.cgroupRoot}
         .          .     62:
         .          .     63:   for len(stack) > 0 {
         .          .     64:           // Pop the directory to search from the stack, alter said stack.
         .          .     65:           dir := stack[len(stack)-1]
         .          .     66:           stack = stack[:len(stack)-1]
         .          .     67:
         .          .     68:           id, err := r.filter(dir, filepath.Base(dir))
         .          .     69:           if err != nil {
         .          .     70:                   // If SkipDir is returned, record the cgroup if valid, then skip
         .          .     71:                   // pushing subdirectories.
         .          .     72:                   if errors.Is(err, filepath.SkipDir) {
         .          .     73:                           if id != "" {
         .          .     74:                                   relPath, err := filepath.Rel(r.cgroupRoot, dir)
         .          .     75:                                   if err != nil {
         .          .     76:                                           return nil, err
         .          .     77:                                   }
         .          .     78:                                   // Reuse existing cgroup if available
         .          .     79:                                   if existing, ok := res[id]; ok {
         .          .     80:                                           if cg, ok := existing.(*cgroupV2); ok {
         .          .     81:                                                   cg.relativePath = relPath
         .          .     82:                                                   cg.markedForDeletion = false
         .          .     83:                                           }
         .          .     84:                                   } else {
         .          .     85:                                           res[id] = newCgroupV2(id, r.cgroupRoot, relPath, r.cgroupControllers, r.pidMapper)
         .          .     86:                                   }
         .          .     87:                           }
         .          .     88:                           continue
         .          .     89:                   }
         .          .     90:                   return nil, err
         .          .     91:           }
         .          .     92:           if id != "" {
         .          .     93:                   relPath, err := filepath.Rel(r.cgroupRoot, dir)
         .          .     94:                   if err != nil {
         .          .     95:                           return nil, err
         .          .     96:                   }
         .          .     97:                   // Reuse existing cgroup if available
         .          .     98:                   if existing, ok := res[id]; ok {
         .          .     99:                           if cg, ok := existing.(*cgroupV2); ok {
         .          .    100:                                   cg.relativePath = relPath
         .          .    101:                                   cg.markedForDeletion = false
         .          .    102:                           }
         .          .    103:                   } else {
  326.95kB   892.86kB    104:                           res[id] = newCgroupV2(id, r.cgroupRoot, relPath, r.cgroupControllers, r.pidMapper)
         .          .    105:                   }
         .          .    106:           }
         .          .    107:
         .          .    108:           // Now read all entries and push only directories onto the stack. Note
         .          .    109:           // this is allocation hungry itself. A direct call to unix.Open is
         .          .    110:           // feasible but would require us to handle C-style strings.
         .          .    111:           //
         .          .    112:           // Might be worthwhile eventually.
         .    17.43MB    113:           entries, err := os.ReadDir(dir)
         .          .    114:           if err != nil {
         .          .    115:                   return nil, err
         .          .    116:           }
         .          .    117:           for _, entry := range entries {
         .          .    118:                   if entry.IsDir() {
         .     2.14MB    119:                           subPath := filepath.Join(dir, entry.Name())
  108.59kB   108.59kB    120:                           stack = append(stack, subPath)
         .          .    121:                   }
         .          .    122:           }
         .          .    123:   }
         .          .    124:
```

Flat costs are up but cummulative costs are down by 12Mb. In particular I have:

* changed the field ordering of the cgroupv2 struct so it is more compact in memory,
* updated the parseCgroup interface to reuse the passed `res` map,
* added a mark/sweep mechanism to the gathered v2 cgroups to avoid calling newCgroupV2 for already discovered cgroups, eliding allocation and syscall expense and
* removed a call in `inodeForPath` to `os.Stat` in favor of `unix.Fstatat` which elides some allocation overhead in `os.Stat`.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->


### Describe how you validated your changes

I have relied on existing unit tests, in addition to introducing new micro-benchmarks. My goal is to see the improvement in the Regression Detector results, not in micro.

### Possible Drawbacks / Trade-offs

The implementation is now more complicated and distinctly relies on this code being only built for Linux.

### Additional Notes

The current allocation hot-spot in the v2 parseCgroup is in `os.ReadDir` as the above demonstrates. I left notes to the effect that `unix.Open` might be profitable to explore next.