### PR TITLE
feat(autoinstrumentation): add flag to control DD_SERVICE from owner name

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -191,6 +191,13 @@ type InstrumentationConfig struct {
 	// used. If no target matches, the auto instrumentation will not be applied. Full config key:
 	// apm_config.instrumentation.targets
 	Targets []Target `mapstructure:"targets" json:"targets"`
+	// UseOwnerNameAsDefaultServiceName controls whether or not we use the pod resource owner's name to set the service
+	// name if it is not already set.
+	//
+	// This is something we want to disable entirely, but need to have a flag to change this behavior to start.
+	//
+	// https://datadoghq.atlassian.net/browse/INPLAT-458
+	UseOwnerNameAsDefaultServiceName bool `mapstructure:"use_owner_name_as_default_service_name" json:"use_owner_name_as_default_service_name"`
 }
 
 // NewInstrumentationConfig creates a new InstrumentationConfig from the datadog config. It returns an error if the

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -35,8 +35,9 @@ func TestNewInstrumentationConfig(t *testing.T) {
 				LibVersions: map[string]string{
 					"python": "default",
 				},
-				Version:          "v2",
-				InjectorImageTag: "foo",
+				Version:                          "v2",
+				InjectorImageTag:                 "foo",
+				UseOwnerNameAsDefaultServiceName: true,
 			},
 		},
 		{
@@ -56,8 +57,9 @@ func TestNewInstrumentationConfig(t *testing.T) {
 				LibVersions: map[string]string{
 					"python": "default",
 				},
-				Version:          "v2",
-				InjectorImageTag: "foo",
+				Version:                          "v2",
+				InjectorImageTag:                 "foo",
+				UseOwnerNameAsDefaultServiceName: true,
 			},
 		},
 		{
@@ -73,6 +75,7 @@ func TestNewInstrumentationConfig(t *testing.T) {
 				DisabledNamespaces: []string{
 					"hacks",
 				},
+				UseOwnerNameAsDefaultServiceName: true,
 				Targets: []Target{
 					{
 						Name: "Billing Service",
@@ -113,11 +116,12 @@ func TestNewInstrumentationConfig(t *testing.T) {
 			configPath: "testdata/targets_namespace_labels.yaml",
 			shouldErr:  false,
 			expected: &InstrumentationConfig{
-				Enabled:           true,
-				EnabledNamespaces: []string{},
-				InjectorImageTag:  "0",
-				LibVersions:       map[string]string{},
-				Version:           "v2",
+				Enabled:                          true,
+				EnabledNamespaces:                []string{},
+				InjectorImageTag:                 "0",
+				LibVersions:                      map[string]string{},
+				Version:                          "v2",
+				UseOwnerNameAsDefaultServiceName: true,
 				DisabledNamespaces: []string{
 					"hacks",
 				},
@@ -169,12 +173,13 @@ func TestNewInstrumentationConfig(t *testing.T) {
 			name:       "can provide DD_SERVICE from arbitrary label",
 			configPath: "testdata/filter_service_env_var_from.yaml",
 			expected: &InstrumentationConfig{
-				Enabled:            true,
-				EnabledNamespaces:  []string{},
-				DisabledNamespaces: []string{},
-				InjectorImageTag:   "0",
-				Version:            "v2",
-				LibVersions:        map[string]string{},
+				Enabled:                          true,
+				EnabledNamespaces:                []string{},
+				DisabledNamespaces:               []string{},
+				InjectorImageTag:                 "0",
+				Version:                          "v2",
+				LibVersions:                      map[string]string{},
+				UseOwnerNameAsDefaultServiceName: true,
 				Targets: []Target{
 					{
 						Name: "name-services",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/namespace_mutator.go
@@ -243,7 +243,10 @@ func (m *mutatorCore) serviceNameMutator(pod *corev1.Pod) containerMutator {
 		return &serviceNameMutator{noop: true}
 	}
 
-	return newServiceNameMutator(pod)
+	return newServiceNameMutator(
+		pod,
+		m.config.Instrumentation.UseOwnerNameAsDefaultServiceName,
+	)
 }
 
 // newInitContainerMutators constructs container mutators for behavior

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/service_name.go
@@ -61,7 +61,7 @@ func (s *serviceNameMutator) mutateContainer(c *corev1.Container) error {
 	return nil
 }
 
-func newServiceNameMutator(pod *corev1.Pod) *serviceNameMutator {
+func newServiceNameMutator(pod *corev1.Pod, useOwnerNameAsDefaultServiceName bool) *serviceNameMutator {
 	vars := findServiceNameEnvVarsInPod(pod)
 	if len(vars) > 1 {
 		log.Debug("more than one unique definition of service name found for the pod")
@@ -72,6 +72,11 @@ func newServiceNameMutator(pod *corev1.Pod) *serviceNameMutator {
 			EnvVar: vars[0],
 			Source: serviceNameSourceExisting,
 		}
+	}
+
+	if !useOwnerNameAsDefaultServiceName {
+		log.Debug("no service env vars found")
+		return &serviceNameMutator{noop: true}
 	}
 
 	log.Debug("no service env vars found in pod, checking owner name")

--- a/pkg/config/setup/apm.go
+++ b/pkg/config/setup/apm.go
@@ -118,6 +118,14 @@ func setupAPM(config pkgconfigmodel.Setup) {
 	// We pin to a major version by default.
 	config.BindEnvAndSetDefault("apm_config.instrumentation.injector_image_tag", "0", "DD_APM_INSTRUMENTATION_INJECTOR_IMAGE_TAG")
 
+	// option to disable the automatic service naming of pods via instrumentation
+	// via the pod owner name.
+	//
+	// https://datadoghq.atlassian.net/browse/INPLAT-458
+	config.BindEnvAndSetDefault("apm_config.instrumentation.use_owner_name_as_default_service_name",
+		true,
+		"DD_APM_INSTRUMENTATION_USE_OWNER_NAME_AS_DEFAULT_SERVICE_NAME")
+
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")
 	config.BindEnv("apm_config.max_payload_size", "DD_APM_MAX_PAYLOAD_SIZE")


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/INPLAT-458

Some customers have their container's `DD_SERVICE` name overwritten by the auto-instrumentation webhook because it sets the env in the pod, which will overwrite something that's set up in a docker container itself.

This PR adds an option for the customer to disable this behavior. We can't change this by default _yet_ because we don't know the impact of changing this default service name.

### Describe how you validated your changes

Unit tests.

