### PR TITLE
remove show-error traceback

### DIFF
--- a/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
+++ b/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1
@@ -74,11 +74,11 @@ function Send-Telemetry($payload) {
 }
 
 function Show-Error($errorMessage, $errorCode) {
-   Write-Error -ErrorAction Continue @"
-    Datadog Install script failed:
+   Write-Host -ForegroundColor Red @"
+Datadog Install script failed:
 
-    Error message: $($errorMessage)
-    Error code: $($errorCode)
+Error message: $($errorMessage)
+Error code: $($errorCode)
 
 "@
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Replace `Write-Error` with `Write-Host` so we don't display a PowerShell traceback of the Show-Error call.
The traceback is always the same, just the `Show-Error` call, so it doesn't give any useful info but is verbose and distracts from the actual error output.


### Motivation
https://datadoghq.atlassian.net/browse/WINA-1364


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

With an error from bootstrap executable
Before
![image](https://github.com/user-attachments/assets/69d48e73-c799-4182-b3ff-628794aa3b9e)
After
![image](https://github.com/user-attachments/assets/1e2b0843-2e8f-434b-9f3d-c6ffdbf56b30)

with a testing `throw "banana phone"` line, which shows we don't get the real traceback now anyway
Before
![image](https://github.com/user-attachments/assets/67102243-142e-470d-8832-7724d805e869)
After
![image](https://github.com/user-attachments/assets/591f475a-3ace-416d-9d1d-90022ed782e1)
