### PR TITLE
remove system-probe HTTP handlers on shutdown

### DIFF
--- a/cmd/system-probe/modules/modules.go
+++ b/cmd/system-probe/modules/modules.go
@@ -35,6 +35,9 @@ var moduleOrder = []types.ModuleName{
 
 // nolint: deadcode, unused // may be unused with certain build tag combinations
 func registerModule(mod *module.Factory) {
+	if mod.Name == "" {
+		return
+	}
 	all = append(all, mod)
 }
 

--- a/pkg/system-probe/api/module/loader.go
+++ b/pkg/system-probe/api/module/loader.go
@@ -43,10 +43,10 @@ type loader struct {
 	closed  bool
 }
 
-func (l *loader) forEachModule(fn func(name string, mod Module)) {
+func (l *loader) forEachModule(fn func(name sysconfigtypes.ModuleName, mod Module)) {
 	for name, mod := range l.modules {
 		withModule(name, func() {
-			fn(string(name), mod)
+			fn(name, mod)
 		})
 	}
 }
@@ -90,13 +90,7 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []*Fact
 			continue
 		}
 
-		subRouter, err := makeSubrouter(httpMux, string(factory.Name))
-		if err != nil {
-			l.errors[factory.Name] = err
-			log.Errorf("error making router for module %s: %s", factory.Name, err)
-			continue
-		}
-
+		subRouter := NewRouter(string(factory.Name), httpMux)
 		if err = module.Register(subRouter); err != nil {
 			l.errors[factory.Name] = err
 			log.Errorf("error registering HTTP endpoints for module %s: %s", factory.Name, err)
@@ -122,13 +116,6 @@ func Register(cfg *sysconfigtypes.Config, httpMux *mux.Router, factories []*Fact
 	return nil
 }
 
-func makeSubrouter(r *mux.Router, namespace string) (*Router, error) {
-	if namespace == "" {
-		return nil, errors.New("module name not set")
-	}
-	return NewRouter(namespace, r), nil
-}
-
 // GetStats returns the stats from all modules, namespaced by their names
 func GetStats() map[string]interface{} {
 	l.Lock()
@@ -149,10 +136,15 @@ func RestartModule(factory *Factory, deps FactoryDependencies) error {
 	if currentModule == nil {
 		return fmt.Errorf("module %s is not running", factory.Name)
 	}
+	currentRouter, ok := l.routers[factory.Name]
+	if !ok {
+		return fmt.Errorf("module %s does not have an associated router", factory.Name)
+	}
 
 	var newModule Module
 	var err error
 	withModule(factory.Name, func() {
+		currentRouter.Unregister()
 		currentModule.Close()
 		newModule, err = factory.Fn(l.cfg, deps)
 	})
@@ -162,11 +154,6 @@ func RestartModule(factory *Factory, deps FactoryDependencies) error {
 	}
 	delete(l.errors, factory.Name)
 	log.Infof("module %s restarted", factory.Name)
-
-	currentRouter, ok := l.routers[factory.Name]
-	if !ok {
-		return fmt.Errorf("module %s does not have an associated router", factory.Name)
-	}
 
 	err = newModule.Register(currentRouter)
 	if err != nil {
@@ -187,7 +174,11 @@ func Close() {
 	}
 
 	l.closed = true
-	l.forEachModule(func(_ string, mod Module) {
+	l.forEachModule(func(name sysconfigtypes.ModuleName, mod Module) {
+		currentRouter, ok := l.routers[name]
+		if ok {
+			currentRouter.Unregister()
+		}
 		mod.Close()
 	})
 }
@@ -207,8 +198,8 @@ func updateStats() {
 		}
 
 		l.stats = make(map[string]interface{})
-		l.forEachModule(func(name string, mod Module) {
-			l.stats[name] = mod.GetStats()
+		l.forEachModule(func(name sysconfigtypes.ModuleName, mod Module) {
+			l.stats[string(name)] = mod.GetStats()
 		})
 		for name, err := range l.errors {
 			l.stats[string(name)] = map[string]string{"Error": err.Error()}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Removes module-specific handlers on restart/shutdown so they will not be called after `Close`

### Motivation

Errors in logs due to HTTP handlers being called during system-probe shutdown

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->