### PR TITLE
compute client stats hash in agent

### DIFF
--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -140,6 +140,7 @@ func (a *ClientStatsAggregator) getAggregationBucketTime(now, bs time.Time) time
 func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
 	// populate container tags data on the payload
 	a.setVersionDataFromContainerTags(p)
+	p.ProcessTagsHash = processTagsHash(p.ProcessTags)
 	// compute the PayloadAggregationKey, common for all buckets within the payload
 	payloadAggKey := newPayloadAggregationKey(p.Env, p.Hostname, p.Version, p.ContainerID, p.GitCommitSha, p.ImageTag, p.ProcessTagsHash)
 

--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -693,10 +693,8 @@ func TestAggregationProcessTags(t *testing.T) {
 	bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
 	c1 := payloadWithCounts(testTime, bak, "", "test-version", "abc", "abc123", 11, 7, 100)
 	c1.ProcessTags = "a:1,b:2,c:3"
-	c1.ProcessTagsHash = 33
 	c2 := payloadWithCounts(testTime, bak, "", "test-version", "abc", "abc123", 11, 7, 100)
 	c2.ProcessTags = "b:33"
-	c1.ProcessTagsHash = 59
 
 	assert.Len(msw.payloads, 0)
 	a.add(testTime, deepCopy(c1))
@@ -710,6 +708,7 @@ func TestAggregationProcessTags(t *testing.T) {
 
 	assert.Len(aggCounts.Stats, 2)
 	res := []string{aggCounts.Stats[0].ProcessTags, aggCounts.Stats[1].ProcessTags}
+	assert.Equal(aggCounts.Stats[0].ProcessTagsHash, uint64(0x619223a2efed999d))
 	assert.ElementsMatch([]string{"a:1,b:2,c:3", "b:33"}, res)
 	assert.Len(a.buckets, 0)
 }


### PR DESCRIPTION
### What does this PR do?

Compute the client stats hash in the agent as it's used only here for aggregation. This will avoid consistency issues on the tracer implementation side.

[matching PR](https://github.com/DataDog/dd-trace-java/pull/8704)
