### PR TITLE
[AGTMETRICS-167]Fix key refresh when additional endpoints and main endpoint shares domain

### DIFF
--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -83,7 +83,7 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 
 		if strings.Contains(setting, "additional_endpoints") {
 			// Updating additional endpoints don't give us the exact key that has been updated so we reload the whole config section.
-			updateAdditionalEndpoints(config, setting, resolver, log)
+			updateAdditionalEndpoints(resolver, setting, config, log)
 			return
 		}
 
@@ -115,7 +115,7 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 // Since additional_endpoints are in the config as a map of domain to api key array, when the api key updates the updater
 // will not know exactly which api key has been updated so we reload the whole list from the config and insert this
 // into our list before deduping.
-func updateAdditionalEndpoints(config config.Component, setting string, resolver DomainResolver, log log.Component) {
+func updateAdditionalEndpoints(resolver DomainResolver, setting string, config config.Component, log log.Component) {
 	additionalEndpoints := utils.MakeEndpoints(config.GetStringMapStringSlice(setting), setting)
 	endpoints, ok := additionalEndpoints[resolver.GetBaseDomain()]
 	if !ok {

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -137,7 +137,7 @@ func updateAdditionalEndpoints(config config.Component, setting string, resolver
 		log.Infof("rotating API key for '%s': %s -> %s", setting, strings.Join(removed, ","), strings.Join(added, ","))
 	} else if len(removed) > 0 {
 		log.Infof("removing API key for '%s': %s", setting, strings.Join(removed, ","))
-	} else {
+	} else if len(added) > 0 {
 		log.Infof("adding API key for '%s': %s", setting, strings.Join(added, ","))
 	}
 }

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -42,10 +42,8 @@ type DomainResolver interface {
 	GetAPIKeysInfo() []utils.APIKeys
 	// GetAPIKeys returns the list of API Keys associated with this `DomainResolver`
 	GetAPIKeys() []string
-	// SetAPIKeys updates the deduped list of API keys associated with this `DomainResolver`
-	// Returns the list of keys that have changed - the returned keys are scrubbed as these will be used to log
-	// which keys have been changed.
-	SetAPIKeys(keys []string) ([]string, []string)
+	// UpdateAPIKeys updates the api keys at the given config path and sets the deduped keys to the new list.
+	UpdateAPIKeys(configPath string, newKeys []utils.APIKeys)
 	// GetBaseDomain returns the base domain for this `DomainResolver`
 	GetBaseDomain() string
 	// GetAlternateDomains returns all the domains that can be returned by `Resolve()` minus the base domain
@@ -85,22 +83,7 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 
 		if strings.Contains(setting, "additional_endpoints") {
 			// Updating additional endpoints don't give us the exact key that has been updated so we reload the whole config section.
-			additionalEndpoints := utils.MakeEndpoints(config.GetStringMapStringSlice(setting), setting)
-			endpoints, ok := additionalEndpoints[resolver.GetBaseDomain()]
-			if !ok {
-				log.Errorf("error: the domain in additional_endpoints changed at runtime for '%s', discarding update.", resolver.GetBaseDomain())
-				return
-			}
-			keys := utils.DedupAPIKeys(endpoints)
-			removed, added := resolver.SetAPIKeys(keys)
-
-			// Not all calls here will involve changes to the api keys since we are just reloading every time something with
-			// `additional_endpoints` contains a key that changes, there are potentially multiple resolvers for different
-			// `additional_endpoints` configurations (eg, `process_config.additional_endpoints` and `additional_endpoints`)
-			if len(removed) > 0 && len(added) > 0 {
-				log.Infof("rotating API key for '%s': %s -> %s", setting, strings.Join(removed, ","), strings.Join(added, ","))
-			}
-
+			updateAdditionalEndpoints(config, setting, resolver, log)
 			return
 		}
 
@@ -126,6 +109,37 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 			log.Errorf("new and old API key for '%s' is invalid (not a string) ignoring new value", setting)
 		}
 	})
+}
+
+// updateAdditionalEndpoints handles updating an API key that is a part of additional endpoints.
+// Since additional_endpoints are in the config as a map of domain to api key array, when the api key updates the updater
+// will not know exactly which api key has been updated so we reload the whole list from the config and insert this
+// into our list before deduping.
+func updateAdditionalEndpoints(config config.Component, setting string, resolver DomainResolver, log log.Component) {
+	additionalEndpoints := utils.MakeEndpoints(config.GetStringMapStringSlice(setting), setting)
+	endpoints, ok := additionalEndpoints[resolver.GetBaseDomain()]
+	if !ok {
+		log.Errorf("error: the domain in additional_endpoints changed at runtime for '%s', discarding update.", resolver.GetBaseDomain())
+		return
+	}
+
+	oldKeys := resolver.GetAPIKeys()
+	resolver.UpdateAPIKeys(setting, endpoints)
+	newKeys := resolver.GetAPIKeys()
+
+	removed := missing(oldKeys, newKeys)
+	added := missing(newKeys, oldKeys)
+
+	// Not all calls here will involve changes to the api keys since we are just reloading every time something with
+	// `additional_endpoints` contains a key that changes, there are potentially multiple resolvers for different
+	// `additional_endpoints` configurations (eg, `process_config.additional_endpoints` and `additional_endpoints`)
+	if len(removed) > 0 && len(added) > 0 {
+		log.Infof("rotating API key for '%s': %s -> %s", setting, strings.Join(removed, ","), strings.Join(added, ","))
+	} else if len(removed) > 0 {
+		log.Infof("removing API key for '%s': %s", setting, strings.Join(removed, ","))
+	} else {
+		log.Infof("adding API key for '%s': %s", setting, strings.Join(added, ","))
+	}
 }
 
 // NewSingleDomainResolver creates a SingleDomainResolver with its destination domain & API keys
@@ -183,19 +197,6 @@ func missing(a []string, b []string) []string {
 	return missing
 }
 
-// SetAPIKeys updates the deduped list of API keys associated with this `DomainResolver`
-func (r *SingleDomainResolver) SetAPIKeys(keys []string) ([]string, []string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	removed := missing(r.dedupedAPIKeys, keys)
-	added := missing(keys, r.dedupedAPIKeys)
-
-	r.dedupedAPIKeys = keys
-
-	return removed, added
-}
-
 // GetAPIKeysInfo returns the list of APIKeys and config paths associated with this `DomainResolver`
 func (r *SingleDomainResolver) GetAPIKeysInfo() []utils.APIKeys {
 	r.mu.Lock()
@@ -211,6 +212,21 @@ func (r *SingleDomainResolver) SetBaseDomain(domain string) {
 // GetAlternateDomains always returns an empty slice for SingleDomainResolver
 func (r *SingleDomainResolver) GetAlternateDomains() []string {
 	return []string{}
+}
+
+// UpdateAPIKeys updates the api keys at the given config path and sets the deduped keys to the new list.
+func (r *SingleDomainResolver) UpdateAPIKeys(configPath string, newKeys []utils.APIKeys) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	newAPIKeys := make([]utils.APIKeys, 0)
+	for idx := range r.apiKeys {
+		if r.apiKeys[idx].ConfigSettingPath != configPath {
+			newAPIKeys = append(newAPIKeys, r.apiKeys[idx])
+		}
+	}
+
+	r.apiKeys = append(newAPIKeys, newKeys...)
+	r.dedupedAPIKeys = utils.DedupAPIKeys(r.apiKeys)
 }
 
 // UpdateAPIKey replaces instances of the oldKey with the newKey
@@ -277,17 +293,19 @@ func (r *MultiDomainResolver) GetAPIKeys() []string {
 	return r.dedupedAPIKeys
 }
 
-// SetAPIKeys updates the deduped list of API keys associated with this `DomainResolver`
-func (r *MultiDomainResolver) SetAPIKeys(keys []string) ([]string, []string) {
+// UpdateAPIKeys updates the api keys at the given config path and sets the deduped keys to the new list.
+func (r *MultiDomainResolver) UpdateAPIKeys(configPath string, newKeys []utils.APIKeys) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	newAPIKeys := make([]utils.APIKeys, 0)
+	for idx := range r.apiKeys {
+		if r.apiKeys[idx].ConfigSettingPath != configPath {
+			newAPIKeys = append(newAPIKeys, r.apiKeys[idx])
+		}
+	}
 
-	removed := missing(r.dedupedAPIKeys, keys)
-	added := missing(keys, r.dedupedAPIKeys)
-
-	r.dedupedAPIKeys = keys
-
-	return removed, added
+	r.apiKeys = append(newAPIKeys, newKeys...)
+	r.dedupedAPIKeys = utils.DedupAPIKeys(r.apiKeys)
 }
 
 // GetAPIKeysInfo returns the list of endpoints associated with this `DomainResolver`
@@ -402,11 +420,6 @@ func (r *LocalDomainResolver) GetAPIKeys() []string {
 	return []string{}
 }
 
-// SetAPIKeys is not implemented for LocalDomainResolver
-func (r *LocalDomainResolver) SetAPIKeys(_keys []string) ([]string, []string) {
-	return []string{}, []string{}
-}
-
 // GetAPIKeysInfo returns the list of endpoints associated with this `DomainResolver`
 func (r *LocalDomainResolver) GetAPIKeysInfo() []utils.APIKeys {
 	return []utils.APIKeys{}
@@ -420,6 +433,10 @@ func (r *LocalDomainResolver) SetBaseDomain(domain string) {
 // GetAlternateDomains is not implemented for LocalDomainResolver
 func (r *LocalDomainResolver) GetAlternateDomains() []string {
 	return []string{}
+}
+
+// UpdateAPIKeys is not implemented for LocalDomainResolver
+func (r *LocalDomainResolver) UpdateAPIKeys(_ string, _ []utils.APIKeys) {
 }
 
 // UpdateAPIKey is not implemented for LocalDomainResolver

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
@@ -56,7 +56,7 @@ func TestSingleDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 		"example.com": {"key4", "key2", "key3"},
 	}
 	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
-	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
+	updateAdditionalEndpoints(resolver, "additional_endpoints", mockConfig, log)
 
 	// The new key4 key is in the list and the main endpoint key1 is still there
 	assert.Equal(t, []string{"key1", "key4", "key2", "key3"}, resolver.GetAPIKeys())
@@ -66,7 +66,7 @@ func TestSingleDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 		"example.com": {"key4", "key1", "key3"},
 	}
 	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
-	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
+	updateAdditionalEndpoints(resolver, "additional_endpoints", mockConfig, log)
 
 	assert.Equal(t, []string{"key1", "key4", "key3"}, resolver.GetAPIKeys())
 }
@@ -87,7 +87,7 @@ func TestMultiDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 		"example.com": {"key4", "key2", "key3"},
 	}
 	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
-	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
+	updateAdditionalEndpoints(resolver, "additional_endpoints", mockConfig, log)
 
 	// The new key4 key is in the list and the main endpoint key1 is still there
 	assert.Equal(t, []string{"key1", "key4", "key2", "key3"}, resolver.GetAPIKeys())
@@ -97,7 +97,7 @@ func TestMultiDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 		"example.com": {"key4", "key1", "key3"},
 	}
 	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
-	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
+	updateAdditionalEndpoints(resolver, "additional_endpoints", mockConfig, log)
 
 	assert.Equal(t, []string{"key1", "key4", "key3"}, resolver.GetAPIKeys())
 }

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver_test.go
@@ -6,18 +6,13 @@
 package resolver
 
 import (
-	"strings"
 	"testing"
 
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
 	"github.com/stretchr/testify/assert"
 )
-
-// Makes a key exactly 32 chars long
-func makeKey(suffix string) string {
-	return strings.Repeat("0", 32-len(suffix)) + suffix
-}
 
 func TestSingleDomainResolverDedupedKey(t *testing.T) {
 	// Note key2 exists twice in the list.
@@ -32,36 +27,77 @@ func TestSingleDomainResolverDedupedKey(t *testing.T) {
 		[]string{"key1", "key2"})
 }
 
-func TestSingleDomainResolverSetApiKeysSimple(t *testing.T) {
+func TestSingleDomainUpdateAPIKeys(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("additional_endpoints", makeKey("key1"), makeKey("key2")),
-		utils.NewAPIKeys("multi_region_failover.api_key", makeKey("key2")),
+		utils.NewAPIKeys("api_key", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "key1", "key2", "key3"),
 	}
 
 	resolver := NewSingleDomainResolver("example.com", apiKeys)
 
-	removed, added := resolver.SetAPIKeys([]string{makeKey("key1"), makeKey("key3")})
+	resolver.UpdateAPIKeys("additional_endpoints", []utils.APIKeys{utils.NewAPIKeys("additional_endpoints", "key4", "key2", "key3")})
 
-	assert.Equal(t, []string{scrubber.HideKeyExceptLastFiveChars(makeKey("key2"))}, removed)
-	assert.Equal(t, []string{scrubber.HideKeyExceptLastFiveChars(makeKey("key3"))}, added)
+	assert.Equal(t, []string{"key1", "key4", "key2", "key3"}, resolver.GetAPIKeys())
 }
 
-func TestSingleDomainResolverSetApiKeysMany(t *testing.T) {
+func TestSingleDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
 	apiKeys := []utils.APIKeys{
-		utils.NewAPIKeys("additional_endpoints", makeKey("key1"), makeKey("key2"), makeKey("key3"), makeKey("key4"), makeKey("key5"), makeKey("key6")),
+		utils.NewAPIKeys("api_key", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "key1", "key2", "key3"),
 	}
-
 	resolver := NewSingleDomainResolver("example.com", apiKeys)
 
-	removed, added := resolver.SetAPIKeys([]string{makeKey("key3"), makeKey("lock2"), makeKey("key1"), makeKey("lock4"), makeKey("key5"), makeKey("key6")})
+	// The duplicate key between the main endpoint and additional_endpoints is removed
+	assert.Equal(t, []string{"key1", "key2", "key3"}, resolver.GetAPIKeys())
 
-	assert.Equal(t, []string{
-		scrubber.HideKeyExceptLastFiveChars(makeKey("key2")),
-		scrubber.HideKeyExceptLastFiveChars(makeKey("key4")),
-	}, removed)
+	log := logmock.New(t)
+	mockConfig := configmock.New(t)
+	endpoints := map[string][]string{
+		"example.com": {"key4", "key2", "key3"},
+	}
+	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
+	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
 
-	assert.Equal(t, []string{
-		scrubber.HideKeyExceptLastFiveChars(makeKey("lock2")),
-		scrubber.HideKeyExceptLastFiveChars(makeKey("lock4")),
-	}, added)
+	// The new key4 key is in the list and the main endpoint key1 is still there
+	assert.Equal(t, []string{"key1", "key4", "key2", "key3"}, resolver.GetAPIKeys())
+
+	// The config is updated so the duplicate key is there again
+	endpoints = map[string][]string{
+		"example.com": {"key4", "key1", "key3"},
+	}
+	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
+	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
+
+	assert.Equal(t, []string{"key1", "key4", "key3"}, resolver.GetAPIKeys())
+}
+
+func TestMultiDomainResolverUpdateAdditionalEndpointsNewKey(t *testing.T) {
+	apiKeys := []utils.APIKeys{
+		utils.NewAPIKeys("api_key", "key1"),
+		utils.NewAPIKeys("additional_endpoints", "key1", "key2", "key3"),
+	}
+	resolver := NewMultiDomainResolver("example.com", apiKeys)
+
+	// The duplicate key between the main endpoint and additional_endpoints is removed
+	assert.Equal(t, []string{"key1", "key2", "key3"}, resolver.GetAPIKeys())
+
+	log := logmock.New(t)
+	mockConfig := configmock.New(t)
+	endpoints := map[string][]string{
+		"example.com": {"key4", "key2", "key3"},
+	}
+	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
+	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
+
+	// The new key4 key is in the list and the main endpoint key1 is still there
+	assert.Equal(t, []string{"key1", "key4", "key2", "key3"}, resolver.GetAPIKeys())
+
+	// The config is updated so the duplicate key is there again
+	endpoints = map[string][]string{
+		"example.com": {"key4", "key1", "key3"},
+	}
+	mockConfig.SetWithoutSource("additional_endpoints", endpoints)
+	updateAdditionalEndpoints(mockConfig, "additional_endpoints", resolver, log)
+
+	assert.Equal(t, []string{"key1", "key4", "key3"}, resolver.GetAPIKeys())
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes a bug from #36160 when the main endpoint domain is the same as the additional endpoint. When an api key was updated in the additional endpoint, this was dropping the main endpoints api key.

This PR ensures that only the additional endpoints api keys are updated in this situation.

### Motivation

### Describe how you validated your changes

Have updated the tests to test additional_endpoint key updates.

Tested manually with this config:

```yaml
dd_url: http://localhost:8080
api_key: ENC[mainkee]

secret_backend_command: /home/stephenwakely/src/secret-resolver.py

additional_endpoints:
  "http://localhost:8080":
  - ENC[kee1]
```


<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->