### PR TITLE
APM: Resolve flaky test TestAggregationProcessTags

### DIFF
--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -707,9 +707,10 @@ func TestAggregationProcessTags(t *testing.T) {
 	assertAggCountsPayload(t, aggCounts)
 
 	assert.Len(aggCounts.Stats, 2)
-	res := []string{aggCounts.Stats[0].ProcessTags, aggCounts.Stats[1].ProcessTags}
-	assert.Equal(aggCounts.Stats[0].ProcessTagsHash, uint64(0x619223a2efed999d))
-	assert.ElementsMatch([]string{"a:1,b:2,c:3", "b:33"}, res)
+	resProcessTags := []string{aggCounts.Stats[0].ProcessTags, aggCounts.Stats[1].ProcessTags}
+	resProcessTagsHash := []uint64{aggCounts.Stats[0].ProcessTagsHash, aggCounts.Stats[1].ProcessTagsHash}
+	assert.ElementsMatch([]string{"a:1,b:2,c:3", "b:33"}, resProcessTags)
+	assert.ElementsMatch([]uint64{7030721150995765661, 6360281807028847755}, resProcessTagsHash)
 	assert.Len(a.buckets, 0)
 }
 


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Unflake the test `TestAggregationProcessTags` - The ordering of stats buckets is not guaranteed (as they're aggregated via a map). This PR checks that the elements match, ensuring we got the appropriate data and ignoring the ordering.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Test previously flaked with count=10 but now doesn't flake at count=100. The test here is sufficient coverage

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->