### PR TITLE
Stop reporting fake Ready status in WLM based on AD annotation

### DIFF
--- a/comp/core/autodiscovery/listeners/container_test.go
+++ b/comp/core/autodiscovery/listeners/container_test.go
@@ -144,6 +144,7 @@ func TestCreateContainerService(t *testing.T) {
 			Annotations: map[string]string{
 				fmt.Sprintf("ad.datadoghq.com/%s.exclude", kubernetesContainer.Name):         `false`,
 				fmt.Sprintf("ad.datadoghq.com/%s.exclude", kubernetesExcludedContainer.Name): `true`,
+				tolerateUnreadyAnnotation: `true`,
 			},
 		},
 		Containers: []workloadmeta.OrchestratorContainer{
@@ -293,7 +294,7 @@ func TestCreateContainerService(t *testing.T) {
 						},
 						hosts: map[string]string{"pod": pod.IP},
 						ports: []ContainerPort{},
-						ready: pod.Ready,
+						ready: true,
 					},
 				},
 			},

--- a/comp/core/autodiscovery/listeners/kubelet.go
+++ b/comp/core/autodiscovery/listeners/kubelet.go
@@ -160,7 +160,7 @@ func (l *KubeletListener) createContainerService(
 	svc := &service{
 		entity:   container,
 		tagsHash: l.tagger.GetEntityHash(types.NewEntityID(types.ContainerID, container.ID), types.ChecksConfigCardinality),
-		ready:    pod.Ready,
+		ready:    pod.Ready || shouldSkipPodReadiness(pod),
 		ports:    ports,
 		extraConfig: map[string]string{
 			"pod_name":  pod.Name,

--- a/comp/core/autodiscovery/listeners/kubelet_test.go
+++ b/comp/core/autodiscovery/listeners/kubelet_test.go
@@ -141,6 +141,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 
 	podWithMetricsExcludeAnnotation := podWithAnnotations.DeepCopy().(*workloadmeta.KubernetesPod)
 	podWithMetricsExcludeAnnotation.Annotations[fmt.Sprintf("ad.datadoghq.com/%s.metrics_exclude", containerName)] = `true`
+	podWithMetricsExcludeAnnotation.Annotations[tolerateUnreadyAnnotation] = `true`
 
 	podWithLogsExcludeAnnotation := podWithAnnotations.DeepCopy().(*workloadmeta.KubernetesPod)
 	podWithLogsExcludeAnnotation.Annotations[fmt.Sprintf("ad.datadoghq.com/%s.logs_exclude", containerName)] = `true`
@@ -472,6 +473,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 						},
 						metricsExcluded: true,
 						tagger:          taggerComponent,
+						ready:           true,
 					},
 				},
 			},

--- a/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
+++ b/comp/core/workloadmeta/collectors/util/kubernetes_resource_parsers/pod_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build kubeapiserver && test
+//go:build kubeapiserver
 
 package kubernetesresourceparsers
 

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -371,8 +371,9 @@ func (ku *KubeUtil) GetPodForContainerID(ctx context.Context, containerID string
 		return pod, nil
 	}
 
+	// Error is not nil
 	// Retry with cache invalidation
-	if err != nil && errors.IsNotFound(err) {
+	if errors.IsNotFound(err) {
 		log.Debugf("Cannot get container %q: %s, retrying without cache...", containerID, err)
 		pods, err = ku.ForceGetLocalPodList(ctx)
 		if err != nil {
@@ -506,9 +507,6 @@ func IsPodReady(pod *Pod) bool {
 		return false
 	}
 
-	if tolerate, ok := pod.Metadata.Annotations[unreadyAnnotation]; ok && tolerate == "true" {
-		return true
-	}
 	for _, status := range pod.Status.Conditions {
 		if status.Type == "Ready" && status.Status == "True" {
 			return true

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -113,7 +113,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), changes, 2)
 	assert.Equal(suite.T(), "nginx", changes[0].Spec.Containers[0].Name)
-	require.True(suite.T(), IsPodReady(changes[0]))
+	require.False(suite.T(), IsPodReady(changes[0]))
 }
 
 func (suite *PodwatcherTestSuite) TestPodWatcherWithInitContainers() {


### PR DESCRIPTION
### What does this PR do?

Remove AD logic from the PodWatcher as the PodWatcher has not been related to AD for a long time now.
The AD logic is put back in AD so that the `Ready` status in WLM is accurate and will allow `PodWatcher` to detect readiness changes to Pods with `tolerate-unready` in all other WLM subscribers.

### Motivation

Bugfix.

### Describe how you validated your changes

Pick a Pod with `tolerate-unready` and a readiness probe on a container that takes some time (like >10s) to be ready. The reported Container heath in `agent workload-list` for the container will stay `unhealthy` even if the container readiness has changed to `ready`.

### Possible Drawbacks / Trade-offs

### Additional Notes
