### PR TITLE
[fentry] Make config to enable CNM fentry

### DIFF
--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -309,6 +309,8 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_ebpfless"), false, "DD_ENABLE_EBPFLESS", "DD_NETWORK_CONFIG_ENABLE_EBPFLESS")
 
+	cfg.BindEnvAndSetDefault(join(netNS, "enable_fentry"), false)
+
 	// windows config
 	cfg.BindEnvAndSetDefault(join(spNS, "windows.enable_monotonic_count"), false)
 

--- a/pkg/ebpf/ebpftest/buildmode.go
+++ b/pkg/ebpf/ebpftest/buildmode.go
@@ -41,7 +41,7 @@ func (p prebuiltMode) String() string {
 
 func (p prebuiltMode) Env() map[string]string {
 	return map[string]string{
-		"NETWORK_TRACER_FENTRY_TESTS":        "false",
+		"DD_NETWORK_CONFIG_ENABLE_FENTRY":    "false",
 		"DD_ENABLE_RUNTIME_COMPILER":         "false",
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
@@ -58,7 +58,7 @@ func (r runtimeCompiled) String() string {
 
 func (r runtimeCompiled) Env() map[string]string {
 	return map[string]string{
-		"NETWORK_TRACER_FENTRY_TESTS":        "false",
+		"DD_NETWORK_CONFIG_ENABLE_FENTRY":    "false",
 		"DD_ENABLE_RUNTIME_COMPILER":         "true",
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
@@ -75,7 +75,7 @@ func (c core) String() string {
 
 func (c core) Env() map[string]string {
 	return map[string]string{
-		"NETWORK_TRACER_FENTRY_TESTS":        "false",
+		"DD_NETWORK_CONFIG_ENABLE_FENTRY":    "false",
 		"DD_ENABLE_RUNTIME_COMPILER":         "false",
 		"DD_ENABLE_CO_RE":                    "true",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
@@ -92,7 +92,7 @@ func (f fentry) String() string {
 
 func (f fentry) Env() map[string]string {
 	return map[string]string{
-		"NETWORK_TRACER_FENTRY_TESTS":        "true",
+		"DD_NETWORK_CONFIG_ENABLE_FENTRY":    "true",
 		"DD_ENABLE_RUNTIME_COMPILER":         "false",
 		"DD_ENABLE_CO_RE":                    "true",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",
@@ -109,7 +109,7 @@ func (e ebpfless) String() string {
 
 func (e ebpfless) Env() map[string]string {
 	return map[string]string{
-		"NETWORK_TRACER_FENTRY_TESTS":        "false",
+		"DD_NETWORK_CONFIG_ENABLE_FENTRY":    "false",
 		"DD_ENABLE_RUNTIME_COMPILER":         "false",
 		"DD_ENABLE_CO_RE":                    "false",
 		"DD_ALLOW_RUNTIME_COMPILED_FALLBACK": "false",

--- a/pkg/ebpf/ebpftest/buildmode_test.go
+++ b/pkg/ebpf/ebpftest/buildmode_test.go
@@ -23,7 +23,8 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.EnableCORE)
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
-		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_FENTRY"))
 		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, Prebuilt, GetBuildMode())
@@ -34,7 +35,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.EnableCORE)
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
-		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_FENTRY"))
 		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, RuntimeCompiled, GetBuildMode())
@@ -45,7 +46,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.True(t, cfg.EnableCORE)
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
-		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_FENTRY"))
 		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, CORE, GetBuildMode())
@@ -56,7 +57,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.True(t, cfg.EnableCORE)
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
-		assert.Equal(t, "true", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "true", os.Getenv("DD_NETWORK_CONFIG_ENABLE_FENTRY"))
 		assert.Equal(t, "false", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, Fentry, GetBuildMode())
@@ -67,7 +68,7 @@ func TestBuildModeConstants(t *testing.T) {
 		assert.False(t, cfg.EnableCORE)
 		assert.False(t, cfg.AllowPrebuiltFallback)
 		assert.False(t, cfg.AllowRuntimeCompiledFallback)
-		assert.Equal(t, "false", os.Getenv("NETWORK_TRACER_FENTRY_TESTS"))
+		assert.Equal(t, "false", os.Getenv("DD_NETWORK_CONFIG_ENABLE_FENTRY"))
 		assert.Equal(t, "true", os.Getenv("DD_ENABLE_EBPFLESS"))
 
 		assert.Equal(t, Ebpfless, GetBuildMode())

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -283,7 +283,11 @@ type Config struct {
 	// buffers (>=5.8) will result in forcing the use of Perf Maps instead.
 	EnableUSMRingBuffers bool
 
+	// EnableEbpfless enables the use of network tracing without eBPF using packet capture.
 	EnableEbpfless bool
+
+	// EnableFentry enables the experimental fentry tracer (disabled by default)
+	EnableFentry bool
 
 	// EnableUSMEventStream enables USM to use the event stream instead
 	// of netlink for receiving process events.
@@ -395,6 +399,7 @@ func New() *Config {
 		EnableNPMConnectionRollup: cfg.GetBool(sysconfig.FullKeyPath(netNS, "enable_connection_rollup")),
 
 		EnableEbpfless: cfg.GetBool(sysconfig.FullKeyPath(netNS, "enable_ebpfless")),
+		EnableFentry:   cfg.GetBool(sysconfig.FullKeyPath(netNS, "enable_fentry")),
 
 		// Service Monitoring
 		EnableGoTLSSupport:        cfg.GetBool(sysconfig.FullKeyPath(smNS, "tls", "go", "enabled")),

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -217,7 +217,7 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 	var tracerType = TracerTypeFentry
 	var closeTracerFn func()
 	m, closeTracerFn, err = fentry.LoadTracer(config, mgrOptions, connCloseEventHandler)
-	if err != nil && !errors.Is(err, fentry.ErrorNotSupported) {
+	if err != nil && !errors.Is(err, fentry.ErrorDisabled) {
 		// failed to load fentry tracer
 		return nil, err
 	}

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -31,8 +31,7 @@ var ErrorDisabled = errors.New("fentry tracer is disabled")
 // LoadTracer loads a new tracer
 func LoadTracer(config *config.Config, mgrOpts manager.Options, connCloseEventHandler *perf.EventHandler) (*ddebpf.Manager, func(), error) {
 	if !config.EnableFentry {
-		panic("bruh")
-		//return nil, nil, ErrorDisabled
+		return nil, nil, ErrorDisabled
 	}
 
 	m := ddebpf.NewManagerWithDefault(&manager.Manager{}, "network", &ebpftelemetry.ErrorsTelemetryModifier{}, connCloseEventHandler)

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -21,18 +21,18 @@ import (
 	ebpftelemetry "github.com/DataDog/datadog-agent/pkg/ebpf/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 )
 
 const probeUID = "net"
 
-// ErrorNotSupported is the error when entry tracer is not supported on an environment
-var ErrorNotSupported = errors.New("fentry tracer is only supported on Fargate")
+// ErrorDisabled is the error that occurs when enable_fentry is false
+var ErrorDisabled = errors.New("fentry tracer is disabled")
 
 // LoadTracer loads a new tracer
 func LoadTracer(config *config.Config, mgrOpts manager.Options, connCloseEventHandler *perf.EventHandler) (*ddebpf.Manager, func(), error) {
-	if !fargate.IsFargateInstance() {
-		return nil, nil, ErrorNotSupported
+	if !config.EnableFentry {
+		panic("bruh")
+		//return nil, nil, ErrorDisabled
 	}
 
 	m := ddebpf.NewManagerWithDefault(&manager.Manager{}, "network", &ebpftelemetry.ErrorsTelemetryModifier{}, connCloseEventHandler)

--- a/pkg/network/tracer/connection/fentry/tracer.go
+++ b/pkg/network/tracer/connection/fentry/tracer.go
@@ -34,8 +34,16 @@ func LoadTracer(config *config.Config, mgrOpts manager.Options, connCloseEventHa
 		return nil, nil, ErrorDisabled
 	}
 
+	hasPotentialFentryDeadlock, err := ddebpf.HasTasksRCUExitLockSymbol()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to check HasTasksRCUExitLockSymbol: %w", err)
+	}
+	if hasPotentialFentryDeadlock {
+		return nil, nil, fmt.Errorf("unable to load fentry because this kernel version has a potential deadlock (fixed in kernel v6.9+)")
+	}
+
 	m := ddebpf.NewManagerWithDefault(&manager.Manager{}, "network", &ebpftelemetry.ErrorsTelemetryModifier{}, connCloseEventHandler)
-	err := ddebpf.LoadCOREAsset(netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
+	err = ddebpf.LoadCOREAsset(netebpf.ModuleFileName("tracer-fentry", config.BPFDebug), func(ar bytecode.AssetReader, o manager.Options) error {
 		o.RemoveRlimit = mgrOpts.RemoveRlimit
 		o.MapSpecEditors = mgrOpts.MapSpecEditors
 		o.ConstantEditors = mgrOpts.ConstantEditors

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -1966,7 +1966,7 @@ func (s *TracerSuite) TestKprobeAttachWithKprobeEvents() {
 	tr := setupTracer(t, cfg)
 
 	if tr.ebpfTracer.Type() == connection.TracerTypeFentry {
-		t.Skip("skipped on Fargate")
+		t.Skip("skipped on fentry")
 	}
 
 	cmd := []string{"curl", "-k", "-o/dev/null", "example.com"}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a `network_config.enable_fentry` option to make the tracer try to use fentry.

### Motivation
We are evaluating making another push towards fentry to fix some performance issues.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
```
TEST_FENTRY_OVERRIDE=true sudo -E go test -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run  TestTracerSuite/fentry -count 1
```

### Possible Drawbacks / Trade-offs
This doesn't fall back to kprobes when fentry fails to load, but at least for now that's what I want to happen.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->