### PR TITLE
[clusteragent/autoscaling/workload] Ignore pods owned directly by `Deployment`

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -9,7 +9,6 @@ package workload
 
 import (
 	"context"
-	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -142,7 +141,7 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 
 	// Ignore pods owned directly by a deployment
 	if ownerRef.Kind == kubernetes.DeploymentKind {
-		return nil, fmt.Errorf(errDeploymentNotValidOwner)
+		return nil, errDeploymentNotValidOwner
 	}
 
 	if ownerRef.Kind == kubernetes.ReplicaSetKind {

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -9,6 +9,7 @@ package workload
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -138,6 +139,12 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 	}
 
 	ownerRef := pod.OwnerReferences[0]
+
+	// Ignore pods owned directly by a deployment
+	if ownerRef.Kind == kubernetes.DeploymentKind {
+		return nil, fmt.Errorf("deployment is not a valid owner")
+	}
+
 	if ownerRef.Kind == kubernetes.ReplicaSetKind {
 		// Check if it's owned by a Deployment, otherwise ReplicaSet is direct owner
 		deploymentName := kubernetes.ParseDeploymentForReplicaSet(ownerRef.Name)

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher.go
@@ -142,7 +142,7 @@ func (pa podPatcher) findAutoscaler(pod *corev1.Pod) (*model.PodAutoscalerIntern
 
 	// Ignore pods owned directly by a deployment
 	if ownerRef.Kind == kubernetes.DeploymentKind {
-		return nil, fmt.Errorf("deployment is not a valid owner")
+		return nil, fmt.Errorf(errDeploymentNotValidOwner)
 	}
 
 	if ownerRef.Kind == kubernetes.ReplicaSetKind {

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -345,7 +345,7 @@ func TestFindAutoscaler(t *testing.T) {
 				},
 			},
 			expectedAutoscalerID: "",
-			expectedError:        errors.New(errDeploymentNotValidOwner),
+			expectedError:        errDeploymentNotValidOwner,
 		},
 		{
 			name: "Pod with owner but no matching autoscaler should return nil",

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -345,7 +345,7 @@ func TestFindAutoscaler(t *testing.T) {
 				},
 			},
 			expectedAutoscalerID: "",
-			expectedError:        errors.New("deployment is not a valid owner"),
+			expectedError:        errors.New(errDeploymentNotValidOwner),
 		},
 		{
 			name: "Pod with owner but no matching autoscaler should return nil",

--- a/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_patcher_test.go
@@ -330,6 +330,24 @@ func TestFindAutoscaler(t *testing.T) {
 			expectedError:        nil,
 		},
 		{
+			name: "Pod with directly deployment owner should return nil",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns",
+					Name:      "pod1",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "Deployment",
+							Name:       "deployment",
+							APIVersion: "apps/v1",
+						},
+					},
+				},
+			},
+			expectedAutoscalerID: "",
+			expectedError:        errors.New("deployment is not a valid owner"),
+		},
+		{
 			name: "Pod with owner but no matching autoscaler should return nil",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher.go
@@ -19,9 +19,9 @@ import (
 
 const (
 	patcherQueueSize = 100
-
-	errDeploymentNotValidOwner = "deployment is not a valid owner"
 )
+
+var errDeploymentNotValidOwner = fmt.Errorf("deployment is not a valid owner")
 
 // NamespacedPodOwner represents a pod owner in a namespace
 type NamespacedPodOwner struct {
@@ -222,7 +222,7 @@ func (pw *PodWatcherImpl) runPatcher(ctx context.Context) {
 
 func getNamespacedPodOwner(ns string, owner *workloadmeta.KubernetesPodOwner) (NamespacedPodOwner, error) {
 	if owner.Kind == kubernetes.DeploymentKind {
-		return NamespacedPodOwner{}, fmt.Errorf(errDeploymentNotValidOwner)
+		return NamespacedPodOwner{}, errDeploymentNotValidOwner
 	}
 
 	res := NamespacedPodOwner{

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher.go
@@ -19,6 +19,8 @@ import (
 
 const (
 	patcherQueueSize = 100
+
+	errDeploymentNotValidOwner = "deployment is not a valid owner"
 )
 
 // NamespacedPodOwner represents a pod owner in a namespace
@@ -220,7 +222,7 @@ func (pw *PodWatcherImpl) runPatcher(ctx context.Context) {
 
 func getNamespacedPodOwner(ns string, owner *workloadmeta.KubernetesPodOwner) (NamespacedPodOwner, error) {
 	if owner.Kind == kubernetes.DeploymentKind {
-		return NamespacedPodOwner{}, fmt.Errorf("deployment is not a valid owner")
+		return NamespacedPodOwner{}, fmt.Errorf(errDeploymentNotValidOwner)
 	}
 
 	res := NamespacedPodOwner{

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher.go
@@ -9,6 +9,7 @@ package workload
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
@@ -26,6 +27,7 @@ type NamespacedPodOwner struct {
 	Namespace string
 	// Kind is the kind of the pod owner (e.g. Deployment, StatefulSet etc.)
 	// ReplicaSet is replaced by Deployment
+	// Pods with Deployment as direct owner are not included
 	Kind string
 	// Name is the name of the pod owner
 	Name string
@@ -143,7 +145,12 @@ func (pw *PodWatcherImpl) HandleEvent(event workloadmeta.Event) {
 }
 
 func (pw *PodWatcherImpl) handleSetEvent(pod *workloadmeta.KubernetesPod) {
-	podOwner := getNamespacedPodOwner(pod.Namespace, &pod.Owners[0])
+	podOwner, err := getNamespacedPodOwner(pod.Namespace, &pod.Owners[0])
+	if err != nil {
+		log.Debugf("Ignoring pod %s with invalid owner %s", pod.ID, err)
+		return
+	}
+
 	log.Debugf("Adding pod %s to owner %s", pod.ID, podOwner)
 	if _, ok := pw.podsPerPodOwner[podOwner]; !ok {
 		pw.podsPerPodOwner[podOwner] = make(map[string]*workloadmeta.KubernetesPod)
@@ -173,7 +180,12 @@ func (pw *PodWatcherImpl) handleSetEvent(pod *workloadmeta.KubernetesPod) {
 }
 
 func (pw *PodWatcherImpl) handleUnsetEvent(pod *workloadmeta.KubernetesPod) {
-	podOwner := getNamespacedPodOwner(pod.Namespace, &pod.Owners[0])
+	podOwner, err := getNamespacedPodOwner(pod.Namespace, &pod.Owners[0])
+	if err != nil {
+		log.Debugf("Ignoring pod %s with invalid owner %s", pod.ID, err)
+		return
+	}
+
 	if podOwner.Name == "" {
 		log.Debugf("Ignoring pod %s without owner name", pod.Name)
 		return
@@ -206,7 +218,11 @@ func (pw *PodWatcherImpl) runPatcher(ctx context.Context) {
 	}
 }
 
-func getNamespacedPodOwner(ns string, owner *workloadmeta.KubernetesPodOwner) NamespacedPodOwner {
+func getNamespacedPodOwner(ns string, owner *workloadmeta.KubernetesPodOwner) (NamespacedPodOwner, error) {
+	if owner.Kind == kubernetes.DeploymentKind {
+		return NamespacedPodOwner{}, fmt.Errorf("deployment is not a valid owner")
+	}
+
 	res := NamespacedPodOwner{
 		Name:      owner.Name,
 		Kind:      owner.Kind,
@@ -219,5 +235,5 @@ func getNamespacedPodOwner(ns string, owner *workloadmeta.KubernetesPodOwner) Na
 			res.Name = deploymentName
 		}
 	}
-	return res
+	return res, nil
 }

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher_test.go
@@ -9,6 +9,7 @@ package workload
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -156,6 +157,7 @@ func TestGetNamespacedPodOwner(t *testing.T) {
 		ns       string
 		owner    *workloadmeta.KubernetesPodOwner
 		expected NamespacedPodOwner
+		err      error
 	}{
 		{
 			name: "pod owned by deployment",
@@ -196,10 +198,29 @@ func TestGetNamespacedPodOwner(t *testing.T) {
 				Name:      "datadog-agent-linux-cluster-agent",
 			},
 		},
+		{
+			name: "pod owned by deployment directly",
+			ns:   "default",
+			owner: &workloadmeta.KubernetesPodOwner{
+				Kind: kubernetes.DeploymentKind,
+				Name: "datadog-agent-linux-cluster-agent",
+			},
+			expected: NamespacedPodOwner{
+				Namespace: "default",
+				Kind:      kubernetes.ReplicaSetKind,
+				Name:      "datadog-agent-linux-cluster-agent",
+			},
+			err: errors.New("deployment is not a valid owner"),
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			res := getNamespacedPodOwner(tt.ns, tt.owner)
-			assert.Equal(t, tt.expected, res)
+			res, err := getNamespacedPodOwner(tt.ns, tt.owner)
+			if tt.err != nil {
+				assert.Equal(t, tt.err, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, res)
+			}
 		})
 	}
 }

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher_test.go
@@ -210,7 +210,7 @@ func TestGetNamespacedPodOwner(t *testing.T) {
 				Kind:      kubernetes.ReplicaSetKind,
 				Name:      "datadog-agent-linux-cluster-agent",
 			},
-			err: errors.New("deployment is not a valid owner"),
+			err: errors.New(errDeploymentNotValidOwner),
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/workload/pod_watcher_test.go
+++ b/pkg/clusteragent/autoscaling/workload/pod_watcher_test.go
@@ -9,7 +9,6 @@ package workload
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -210,7 +209,7 @@ func TestGetNamespacedPodOwner(t *testing.T) {
 				Kind:      kubernetes.ReplicaSetKind,
 				Name:      "datadog-agent-linux-cluster-agent",
 			},
-			err: errors.New(errDeploymentNotValidOwner),
+			err: errDeploymentNotValidOwner,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
 Ignore pods owned directly by `Deployment` in the pod watcher/patcher

### Motivation
Pods should not be directly owned by `Deployment` but `ReplicaSet`; if we do see a pod with the owner `Deployment`, it should not be autoscaled.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Tested by creating a deployment, then a pod with owner ID set to the deployment UID (so pod was directly owned by deployment). Confirmed that these codepaths were hit.

Changes are also covered by unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->