### PR TITLE
[Backport 7.65.x] [CWS] Fix disabling of multiple rules

### DIFF
--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -107,10 +107,7 @@ func applyOverride(rd1, rd2 *PolicyRule) {
 	}
 
 	if wasOverridden {
-		rd1.Policy.Name = rd2.Policy.Name
-		rd1.Policy.Source = rd2.Policy.Source
-		rd1.Policy.Type = rd2.Policy.Type
-
+		rd1.Policy = rd2.Policy
 	}
 }
 
@@ -129,16 +126,11 @@ func (r *PolicyRule) MergeWith(r2 *PolicyRule) error {
 
 	if r.Def.Disabled {
 		r.Def.Disabled = r2.Def.Disabled
-		r.Policy.Name = r2.Policy.Name
-		r.Policy.Source = r2.Policy.Source
-		r.Policy.Type = r2.Policy.Type
-
+		r.Policy = r2.Policy
 	} else {
 		if r.Policy.Type == DefaultPolicyType && r2.Policy.Type == CustomPolicyType {
 			r.Def.Disabled = r2.Def.Disabled
-			r.Policy.Name = r2.Policy.Name
-			r.Policy.Source = r2.Policy.Source
-			r.Policy.Type = r2.Policy.Type
+			r.Policy = r2.Policy
 		}
 	}
 

--- a/releasenotes/notes/cws-fix-disable-rules-c34db2eedfa31681.yaml
+++ b/releasenotes/notes/cws-fix-disable-rules-c34db2eedfa31681.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    CWS: Fixed a bug preventing more than one runtime security rule
+    from being disabled, and caused incorrect policy information to
+    be reported in ruleset loaded events.

--- a/releasenotes/notes/cws-fix-disable-rules-c34db2eedfa31681.yaml
+++ b/releasenotes/notes/cws-fix-disable-rules-c34db2eedfa31681.yaml
@@ -8,6 +8,6 @@
 ---
 fixes:
   - |
-    CWS: Fixed a bug preventing more than one runtime security rule
+    CWS: Fixed a bug that prevented more than one runtime security rule
     from being disabled, and caused incorrect policy information to
     be reported in ruleset loaded events.


### PR DESCRIPTION
Backport 8a66955d3143820e2d5baa7a40211e3bcf660f6b from #36235.

___

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes:
- a bug where no more than one runtime security rules could be disabled through custom ones.
- a bug where the policy of all default rules was changed to the policy of the first rule that disabled/override a default one, and thus `ruleset_loaded` events reporting wrong policy information.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->