### PR TITLE
Fix the create_release_branches task

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -799,17 +799,18 @@ def create_release_branches(
 
         set_new_release_branch(release_branch)
 
-        # Step 1.2 - In datadog-agent repo update gitlab-ci.yaml and notify.yml jobs
-        with open(".gitlab-ci.yml", "w") as f:
+        # Step 1.2 - In datadog-agent repo update gitlab-ci.yaml
+        with open(".gitlab-ci.yml") as f:
             content = f.read()
+        with open(".gitlab-ci.yml", "w") as f:
             f.write(
                 content.replace(f'COMPARE_TO_BRANCH: {get_default_branch()}', f'COMPARE_TO_BRANCH: {release_branch}')
             )
 
         # Step 1.3 - Commit new changes
-        ctx.run("git add release.json .gitlab-ci.yml .gitlab/notify/notify.yml")
+        ctx.run("git add release.json .gitlab-ci.yml")
         ok = try_git_command(
-            ctx, f"git commit -m 'Update release.json, .gitlab-ci.yml and notify.yml with {release_branch}'"
+            ctx, f"git commit -m 'Update release.json, .gitlab-ci.yml with {release_branch}'"
         )
         if not ok:
             raise Exit(
@@ -833,7 +834,7 @@ def create_release_branches(
             )
 
         create_release_pr(
-            f"[release] Update release.json and gitlab files for {release_branch} branch",
+            f"[release] Update release.json and .gitlab-ci.yml files for {release_branch} branch",
             release_branch,
             update_branch,
             current,

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -809,9 +809,7 @@ def create_release_branches(
 
         # Step 1.3 - Commit new changes
         ctx.run("git add release.json .gitlab-ci.yml")
-        ok = try_git_command(
-            ctx, f"git commit -m 'Update release.json, .gitlab-ci.yml with {release_branch}'"
-        )
+        ok = try_git_command(ctx, f"git commit -m 'Update release.json, .gitlab-ci.yml with {release_branch}'")
         if not ok:
             raise Exit(
                 color_message(


### PR DESCRIPTION
### What does this PR do?

We recently changed the `create_release_branches` to benefit from the option to use the variables in the `.gitlab-ci.yml` file (see [PR](https://github.com/DataDog/datadog-agent/pull/35693)). However this introduced a problem with the code which edits this file.

In Python running `with open(".gitlab-ci.yml", "w") as f:` opens the file only in the write mode, so the following `content = f.read()` fails. Both `r+` and `w+` also would not work in this case, so I reverted the logic to how it was before.

### Motivation

Improve the Agent release process.