### PR TITLE
[ACIX-550] Prepare macos runners

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -37,6 +37,15 @@
     fi
   - pyenv activate $VENV_NAME
 
+.install_python_dependencies:
+  # Python 3.12 changes default behavior how packages are installed.
+  # In particular, --break-system-packages command line option is
+  # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
+  - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
+  - pyenv rehash
+  - python3 -m dda self dep sync -f legacy-tasks
+  - pyenv rehash
+
 .vault_login:
   # Point the CLI to our internal vault
   - export VAULT_ADDR=https://vault.us1.ddbuild.io
@@ -55,16 +64,10 @@
       export GOPATH=$GOROOT
     # Selecting the current Python version
     - !reference [.select_python_env_commands]
+    - !reference [.install_python_dependencies]
     # List Python and Go existing environments and their disk space
     - !reference [.list_go_versions_commands]
     - !reference [.list_python_versions_commands]
-    # Installing the job dependencies
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
-    - pyenv rehash
     - dda inv -- -e rtloader.make
     - dda inv -- -e rtloader.install
     - dda inv -- -e install-tools

--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -19,6 +19,10 @@
 
 .select_python_env_commands:
   # Select the virtualenv using the current Python version. Create it if it doesn't exist.
+  - |
+    export PATH="$(pyenv root)/shims:$PATH"
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
   - PYTHON_VERSION=$(python3 --version | awk '{print $2}')
   - VENV_NAME="datadog-agent-python-$PYTHON_VERSION"
   - VENV_PATH="$(pyenv root)/versions/$VENV_NAME"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This is necessary to update the runners with the new AMI. This change is fully compatible with the current runner version.

Context: We don't do this in the .zshrc anymore to avoid entering pyenv virtual environment by default.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->