### PR TITLE
[ AGNTLOG-56 ] - Shift comp/logs over to the new implementation of the auditor

### DIFF
--- a/comp/README.md
+++ b/comp/README.md
@@ -308,6 +308,10 @@ Package auditor records the log files the agent is tracking. It tracks
 filename, time last updated, offset (how far into the file the agent has
 read), and tailing mode for each log file.
 
+### [comp/logs/health](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/logs/health)
+
+Package health provides a dependency-injectible health object for kubernetes liveness checks
+
 ### [comp/logs/integrations](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/logs/integrations)
 
 Package integrations adds a go interface for integrations to register and

--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -16,7 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
@@ -29,26 +28,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers/windowsevent"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
 // NewAgent returns a new Logs Agent
 func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta option.Option[workloadmeta.Component], integrationsLogs integrations.Component) {
-	health := health.RegisterLiveness("logs-agent")
-
-	// setup the auditor
-	// We pass the health handle to the auditor because it's the end of the pipeline and the most
-	// critical part. Arguably it could also be plugged to the destination.
-	auditorTTL := time.Duration(a.config.GetInt("logs_config.auditor_ttl")) * time.Hour
-	auditor := auditor.New(a.config.GetString("logs_config.run_path"), auditor.DefaultRegistryFilename, auditorTTL, health)
 	destinationsCtx := client.NewDestinationsContext()
 	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(nil, a.hostname)
 
 	// setup the pipeline provider that provides pairs of processor and sender
 	pipelineProvider := pipeline.NewProvider(
 		a.config.GetInt("logs_config.pipelines"),
-		auditor,
+		a.auditor,
 		diagnosticMessageReceiver,
 		processingRules,
 		a.endpoints,
@@ -62,7 +53,7 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 	)
 
 	// setup the launchers
-	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, auditor, a.tracker)
+	lnchrs := launchers.NewLaunchers(a.sources, pipelineProvider, a.auditor, a.tracker)
 
 	fileLimits := a.config.GetInt("logs_config.open_files_limit")
 	fileValidatePodContainer := a.config.GetBool("logs_config.validate_pod_container_id")
@@ -85,13 +76,10 @@ func (a *logAgent) SetupPipeline(processingRules []*config.ProcessingRule, wmeta
 		a.sources, integrationsLogs))
 
 	a.schedulers = schedulers.NewSchedulers(a.sources, a.services)
-	a.auditor = auditor
 	a.destinationsCtx = destinationsCtx
 	a.pipelineProvider = pipelineProvider
 	a.launchers = lnchrs
-	a.health = health
 	a.diagnosticMessageReceiver = diagnosticMessageReceiver
-
 }
 
 // buildEndpoints builds endpoints for the logs agent

--- a/comp/logs/agent/agentimpl/agent_serverless_init.go
+++ b/comp/logs/agent/agentimpl/agent_serverless_init.go
@@ -15,7 +15,6 @@ import (
 	integrations "github.com/DataDog/datadog-agent/comp/logs/integrations/def"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
-	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
@@ -24,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/schedulers"
 	"github.com/DataDog/datadog-agent/pkg/serverless/streamlogs"
-	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
 
@@ -40,12 +38,7 @@ func (a *logAgent) SetupPipeline(
 	wmeta option.Option[workloadmeta.Component],
 	_ integrations.Component,
 ) {
-	health := health.RegisterLiveness("logs-agent")
-
 	diagnosticMessageReceiver := diagnostic.NewBufferedMessageReceiver(streamlogs.Formatter{}, nil)
-
-	// setup the a null auditor, not tracking data in any registry
-	a.auditor = auditor.NewNullAuditor()
 	destinationsCtx := client.NewDestinationsContext()
 
 	// setup the pipeline provider that provides pairs of processor and sender
@@ -82,7 +75,6 @@ func (a *logAgent) SetupPipeline(
 	a.destinationsCtx = destinationsCtx
 	a.pipelineProvider = pipelineProvider
 	a.launchers = lnchrs
-	a.health = health
 	a.diagnosticMessageReceiver = diagnosticMessageReceiver
 }
 

--- a/comp/logs/agent/agentimpl/analyze_logs_init.go
+++ b/comp/logs/agent/agentimpl/analyze_logs_init.go
@@ -13,8 +13,8 @@ import (
 	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/flare"
+	auditornoop "github.com/DataDog/datadog-agent/comp/logs/auditor/impl-none"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
-	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/launchers"
 	filelauncher "github.com/DataDog/datadog-agent/pkg/logs/launchers/file"
@@ -50,7 +50,7 @@ func SetUpLaunchers(conf configComponent.Component, sourceProvider *sources.Conf
 		nil)
 	tracker := tailers.NewTailerTracker()
 
-	a := auditor.NewNullAuditor()
+	a := auditornoop.NewAuditor()
 	pipelineProvider.Start()
 	fileLauncher.Start(sourceProvider, pipelineProvider, a, tracker)
 	lnchrs.AddLauncher(fileLauncher)

--- a/comp/logs/agent/agentimpl/mock.go
+++ b/comp/logs/agent/agentimpl/mock.go
@@ -11,6 +11,8 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
@@ -18,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
-	"go.uber.org/fx"
 )
 
 // MockModule defines the fx options for the mock component.

--- a/comp/logs/agent/agentimpl/serverless.go
+++ b/comp/logs/agent/agentimpl/serverless.go
@@ -14,6 +14,7 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	"github.com/DataDog/datadog-agent/comp/logs/agent"
 	flareController "github.com/DataDog/datadog-agent/comp/logs/agent/flare"
+	auditornoop "github.com/DataDog/datadog-agent/comp/logs/auditor/impl-none"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
@@ -29,6 +30,7 @@ func NewServerlessLogsAgent(tagger tagger.Component, compression logscompression
 		config:  pkgconfigsetup.Datadog(),
 		started: atomic.NewUint32(0),
 
+		auditor:         auditornoop.NewAuditor(),
 		sources:         sources.NewLogSources(),
 		services:        service.NewServices(),
 		tracker:         tailers.NewTailerTracker(),

--- a/comp/logs/auditor/impl/auditor_test.go
+++ b/comp/logs/auditor/impl/auditor_test.go
@@ -17,6 +17,7 @@ import (
 	configmock "github.com/DataDog/datadog-agent/comp/core/config"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	healthmock "github.com/DataDog/datadog-agent/comp/logs/health/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 )
 
@@ -38,12 +39,13 @@ func (suite *AuditorTestSuite) SetupTest() {
 
 	configComponent := configmock.NewMock(suite.T())
 	logComponent := logmock.New(suite.T())
-
+	healthRegistrar := healthmock.NewMockRegistrar()
 	configComponent.SetWithoutSource("logs_config.run_path", suite.testRunPathDir)
 
 	deps := Dependencies{
 		Config: configComponent,
 		Log:    logComponent,
+		Health: healthRegistrar,
 	}
 
 	suite.a = newAuditor(deps)

--- a/comp/logs/auditor/mock/auditor_mock.go
+++ b/comp/logs/auditor/mock/auditor_mock.go
@@ -5,11 +5,10 @@
 
 //go:build test
 
-// Package mock is the mock component for the auditor
+// Package mock provides a mock for the auditor component
 package mock
 
 import (
-	compdef "github.com/DataDog/datadog-agent/comp/def"
 	auditor "github.com/DataDog/datadog-agent/comp/logs/auditor/def"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
@@ -17,8 +16,6 @@ import (
 
 // ProvidesMock is the mock component output
 type ProvidesMock struct {
-	compdef.Out
-
 	Comp auditor.Component
 }
 

--- a/comp/logs/bundle.go
+++ b/comp/logs/bundle.go
@@ -7,6 +7,8 @@ package logs //nolint:revive // TODO(AML) Fix revive linter
 
 import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
+	auditorfx "github.com/DataDog/datadog-agent/comp/logs/auditor/fx"
+	healthfx "github.com/DataDog/datadog-agent/comp/logs/health/fx"
 	streamlogs "github.com/DataDog/datadog-agent/comp/logs/streamlogs/fx"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
@@ -16,7 +18,9 @@ import (
 // Bundle defines the fx options for this bundle.
 func Bundle() fxutil.BundleOptions {
 	return fxutil.Bundle(
+		healthfx.Module(),
 		agentimpl.Module(),
 		streamlogs.Module(),
+		auditorfx.Module(),
 	)
 }

--- a/comp/logs/bundle_mock.go
+++ b/comp/logs/bundle_mock.go
@@ -9,6 +9,7 @@ package logs //nolint:revive // TODO(AML) Fix revive linter
 
 import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/agentimpl"
+	auditormock "github.com/DataDog/datadog-agent/comp/logs/auditor/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -16,5 +17,6 @@ import (
 func MockBundle() fxutil.BundleOptions {
 	return fxutil.Bundle(
 		agentimpl.MockModule(),
+		auditormock.AuditorMockModule(),
 	)
 }

--- a/comp/logs/health/def/component.go
+++ b/comp/logs/health/def/component.go
@@ -1,0 +1,19 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package health provides a dependency-injectible health object for kubernetes liveness checks
+package health
+
+import "github.com/DataDog/datadog-agent/pkg/status/health"
+
+// team: agent-log-pipelines
+
+// Component is a wrapper around the health package to allow for easier registration of health checks
+type Component interface {
+	RegisterReadiness(name string, options ...health.Option) *health.Handle
+	RegisterLiveness(name string, options ...health.Option) *health.Handle
+	RegisterStartup(name string, options ...health.Option) *health.Handle
+	Deregister(handle *health.Handle) error
+}

--- a/comp/logs/health/fx/fx.go
+++ b/comp/logs/health/fx/fx.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package fx provides the fx module for the health component
+package fx
+
+import (
+	registrarimpl "github.com/DataDog/datadog-agent/comp/logs/health/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module returns the fx module for the health component
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			registrarimpl.NewProvides,
+		),
+	)
+}

--- a/comp/logs/health/impl/health.go
+++ b/comp/logs/health/impl/health.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package healthimpl provides a wrapper around the health package to allow for easier registration of health checks
+package healthimpl
+
+import (
+	healthdef "github.com/DataDog/datadog-agent/comp/logs/health/def"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+)
+
+// Provides contains the auditor component
+type Provides struct {
+	Comp healthdef.Component
+}
+
+// RegistrarImpl is an implementation of LogsHealthRegistrar
+type RegistrarImpl struct{}
+
+// NewRegistrar creates a new Registrar
+func newRegistrar() *RegistrarImpl {
+	return &RegistrarImpl{}
+}
+
+// NewProvides provides a new Registrar
+func NewProvides() Provides {
+	return Provides{
+		Comp: newRegistrar(),
+	}
+}
+
+// RegisterReadiness registers a readiness check with the health package
+func (r *RegistrarImpl) RegisterReadiness(name string, options ...health.Option) *health.Handle {
+	return health.RegisterReadiness(name, options...)
+}
+
+// RegisterLiveness registers a liveness check with the health package
+func (r *RegistrarImpl) RegisterLiveness(name string, options ...health.Option) *health.Handle {
+	return health.RegisterLiveness(name, options...)
+}
+
+// RegisterStartup registers a startup check with the health package
+func (r *RegistrarImpl) RegisterStartup(name string, options ...health.Option) *health.Handle {
+	return health.RegisterStartup(name, options...)
+}
+
+// Deregister deregisters a health check with the health package
+func (r *RegistrarImpl) Deregister(handle *health.Handle) error {
+	return health.Deregister(handle)
+}

--- a/comp/logs/health/mock/health_mock.go
+++ b/comp/logs/health/mock/health_mock.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package mock provides a mock implementation of the LogsHealthRegistrar
+package mock
+
+import (
+	"go.uber.org/fx"
+
+	healthdef "github.com/DataDog/datadog-agent/comp/logs/health/def"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+)
+
+// Registrar is a mock implementation of LogsHealthRegistrar
+type Registrar struct {
+	registeredChecks map[string]int
+}
+
+// Provides is the mock component output
+type Provides struct {
+	fx.Out
+
+	Comp healthdef.Component
+}
+
+// NewProvides provides a new MockRegistrar
+func NewProvides() Provides {
+	return Provides{
+		Comp: NewMockRegistrar(),
+	}
+}
+
+// NewMockRegistrar creates a new Registrar
+func NewMockRegistrar() *Registrar {
+	return &Registrar{
+		registeredChecks: make(map[string]int),
+	}
+}
+
+// RegisterReadiness registers a readiness check with the health package
+func (r *Registrar) RegisterReadiness(name string, _ ...health.Option) *health.Handle {
+	r.registeredChecks[name]++
+	return &health.Handle{}
+}
+
+// RegisterLiveness registers a liveness check with the health package
+func (r *Registrar) RegisterLiveness(name string, _ ...health.Option) *health.Handle {
+	r.registeredChecks[name]++
+	return &health.Handle{}
+}
+
+// RegisterStartup registers a startup check with the health package
+func (r *Registrar) RegisterStartup(name string, _ ...health.Option) *health.Handle {
+	r.registeredChecks[name]++
+	return &health.Handle{}
+}
+
+// Deregister deregisters a health check with the health package
+func (r *Registrar) Deregister(_ *health.Handle) error {
+	return nil
+}
+
+// CountRegistered checks how many times a health check has been registered
+func (r *Registrar) CountRegistered(name string) int {
+	return r.registeredChecks[name]
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The goal of this PR is to shift all references to pkg/logs/auditor to comp/logs/auditor within the scope of the comp/logs directory. This includes 
1. Porting code to the comp/logs/auditor equivalents
2. Shifting to injecting the auditor via fx for the logs agent and the serverless agent
3. Creation of a logs-based wrapper for the pkg/status/health functionality, and a refactoring of its usage in the logs agent

### Motivation

The shift to FX will better align the auditor with the internal architecture specifications moving forward, and was the driving force behind the creation of comp/logs/auditor to begin with. 

One reason for the creation of the comp/logs/health wrapper is to facilitate testing and mocking capabilities for the codebase. Additionally, this health component usage is relatively fragile - the comp/logs/auditor component manages its own liveness check registration, meaning that we can remove the liveness check registration from the logs agent/serverless agent creation. The auditor creating and managing a liveness check for the logs agent isn't necessarily intuitive, so including a mandatory dependence on the health component raises awareness of this relationship should a third party team attempt to inject and utilize the auditor logic independently. 
Also of note, the serverless agent does not make use of the auditor (rather it uses a noop variant) and never requires registration of a liveness check. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Changes were largely testing via automation. An additional test case was added specifically to ensure that the liveness checks sourced from pkg/status/health will remain functional moving forward. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Full MR list for auditor migration:
https://github.com/DataDog/datadog-agent/pull/36259
https://github.com/DataDog/datadog-agent/pull/36292
https://github.com/DataDog/datadog-agent/pull/36295
https://github.com/DataDog/datadog-agent/pull/36348