### PR TITLE
[clusteragent/autoscaling/workload] Ensure lock is released in config retriever

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_values.go
@@ -79,17 +79,18 @@ func (p *autoscalingValuesProcessor) processValues(values *kubeAutoscaling.Workl
 		return nil
 	}
 
-	// Ignore values if the PodAutoscaler has a custom recommender configuration
-	if podAutoscaler.CustomRecommenderConfiguration() != nil {
-		return nil
-	}
-
 	// Update PodAutoscaler values with received values
 	// Even on error, the PodAutoscaler can be partially updated, always setting it
 	defer func() {
 		p.processed[id] = struct{}{}
 		p.store.UnlockSet(id, podAutoscaler, configRetrieverStoreID)
 	}()
+
+	// Ignore values if the PodAutoscaler has a custom recommender configuration
+	if podAutoscaler.CustomRecommenderConfiguration() != nil {
+		return nil
+	}
+
 	scalingValues, err := parseAutoscalingValues(timestamp, values)
 	if err != nil {
 		return fmt.Errorf("failed to parse scaling values for PodAutoscaler %s: %w", id, err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Ensure lock is released even if we want to discard 

### Motivation
Deadlock issue as lock was never released, causing no pods to be scaled/values to be updated.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Checked this behavior locally running:
- DPA relying on product recommendations
- DPA relying on external recommendations
and verifying that there was no longer a deadlock

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->