### PR TITLE
[Backport 7.66.x] Resolve PythonHome in the initialization call outside of init hook

### DIFF
--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -233,8 +233,6 @@ func init() {
 	expvarPyInit = expvar.NewMap("pythonInit")
 	expvarPyInit.Set("Errors", expvar.Func(expvarPythonInitErrors))
 
-	resolvePythonHome()
-
 	// Setting environment variables must happen as early as possible in the process lifetime to avoid data race with
 	// `getenv`. Ideally before we start any goroutines that call native code or open network connections.
 	initFIPS()
@@ -330,6 +328,7 @@ func resolvePythonHome() {
 }
 
 func resolvePythonExecPath(ignoreErrors bool) (string, error) {
+	resolvePythonHome()
 	// For Windows, the binary should be in our path already and have a
 	// consistent name
 	if runtime.GOOS == "windows" {
@@ -510,6 +509,7 @@ func initFIPS() {
 		log.Warnf("could not check FIPS mode: %v", err)
 		return
 	}
+	resolvePythonHome()
 	if PythonHome == "" {
 		log.Warnf("Python home is empty. FIPS mode could not be enabled.")
 		return

--- a/releasenotes/notes/bugfix-python-home-init-hook-3bce41cc40f4b91d.yaml
+++ b/releasenotes/notes/bugfix-python-home-init-hook-3bce41cc40f4b91d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a race condition introduced in PR #33521 around the PythonHome getting
+    set in an init hook.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

see https://github.com/DataDog/datadog-agent/pull/36293 for details

Investigation into incident-37187 of increased query time and metric inflation of the postgres dbm check. Current hypothesis is that the PythonHome resolution was moved [into an init hook](https://github.com/DataDog/datadog-agent/pull/33521/files#diff-443184ab5594b2887f4fd9e68df5c2375d1d8f473818f5e33a5a74385b327d5eR236) which may cause a race condition with the python runtime initialization. This PR addresses this by resolving the PythonHome again during the Initialization(...) call

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->