### PR TITLE
[backport 7.65.x]eBPF: fix tracefs race kernel crashes (#36270)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,8 @@ require (
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	// TODO: pin to an operator released version once there is a release that includes the api module
 	github.com/DataDog/datadog-operator/api v0.0.0-20250218182124-bd4ad0b8d2fd
-	github.com/DataDog/ebpf-manager v0.7.7
+	// https://github.com/DataDog/ebpf-manager/tree/v0.7.7%2Bfixes
+	github.com/DataDog/ebpf-manager v0.7.8-0.20250418192221-da9c1f9926d4
 	github.com/DataDog/gopsutil v1.2.2
 	github.com/DataDog/nikos v1.12.12
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240816154533-f7f9beb53a42/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11 h1:6vwU//TjBIghQKMgIP9UyIRhN/LWS1y8tYzvRnu8JZw=
 github.com/DataDog/dd-trace-go/v2 v2.0.0-beta.11/go.mod h1:woPHoAOfAIM7kl4GauR+qrWui7teNg44Um0verg2rzQ=
-github.com/DataDog/ebpf-manager v0.7.7 h1:4m+hZr0VyvvUxCVLI7g4iIQqUAijTgk6e1WKKtw4znE=
-github.com/DataDog/ebpf-manager v0.7.7/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
+github.com/DataDog/ebpf-manager v0.7.8-0.20250418192221-da9c1f9926d4 h1:x92r4HyUUOzKfxtdZv0zF3fXc2wk+btiwKgO5jy49H8=
+github.com/DataDog/ebpf-manager v0.7.8-0.20250418192221-da9c1f9926d4/go.mod h1:F3ezth0x5IE6hE6p5mhG005TdExhu60fAWiB8cRMsP8=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe h1:RO40ywnX/vZLi4Pb4jRuFGgQQBYGIIoQ6u+P2MIgFOA=
 github.com/DataDog/go-grpc-bidirectional-streaming-example v0.0.0-20221024060302-b9cf785c02fe/go.mod h1:90sqV0j7E8wYCyqIp5d9HmYWLTFQttqPFFtNYDyAybQ=
 github.com/DataDog/go-libddwaf/v3 v3.5.2 h1:BjLzPn0rAhCq2IDuidC/+puTlhpEz8xt5fej9Cq8EpU=

--- a/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
+++ b/pkg/collector/corechecks/ebpf/probe/ebpfcheck/probe.go
@@ -186,9 +186,11 @@ func (k *Probe) attach(collSpec *ebpf.CollectionSpec) (err error) {
 				k.links = append(k.links, l)
 			} else if strings.HasPrefix(spec.SectionName, kretprobePrefix) {
 				attachPoint := spec.SectionName[len(kretprobePrefix):]
+				manager.TraceFSLock.Lock()
 				l, err := link.Kretprobe(attachPoint, prog, &link.KprobeOptions{
 					TraceFSPrefix: "ddebpfc",
 				})
+				manager.TraceFSLock.Unlock()
 				if err != nil {
 					return fmt.Errorf("link kretprobe %s to %s: %s", spec.Name, attachPoint, err)
 				}

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -21,6 +21,7 @@ import (
 	ebpfruntime "github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 )
@@ -142,9 +143,11 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 		return fmt.Errorf("could not find bpf program for symbol %s", probe.FuncName)
 	}
 
+	manager.TraceFSLock.Lock()
 	link, err := executable.Uprobe(probe.FuncName, bpfProgram, &link.UprobeOptions{
 		PID: int(procInfo.PID),
 	})
+	manager.TraceFSLock.Unlock()
 	if err != nil {
 		diagnostics.Diagnostics.SetError(procInfo.ServiceName, procInfo.RuntimeID, probe.ID, "UPROBE_FAILURE", err.Error())
 		return fmt.Errorf("could not attach bpf program via uprobe: %w", err)


### PR DESCRIPTION
(cherry picked from commit e6d7c0e8c1c62027fc2a4307ef31ee644e0b2c13)

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/36270 to 7.65.x

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->