### PR TITLE
[EBPF] kmt: fail fast when running the compiler in a worktree

### DIFF
--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -13,6 +13,7 @@ from invoke.runners import Result
 
 from tasks.kernel_matrix_testing.tool import Exit, info, warn
 from tasks.libs.ciproviders.gitlab_api import ReferenceTag
+from tasks.libs.common.utils import get_repo_root
 from tasks.libs.types.arch import ARCH_AMD64, ARCH_ARM64, Arch
 
 if TYPE_CHECKING:
@@ -99,6 +100,16 @@ class CompilerImage:
             warn(f"[!] Running compiler image {image_used} is different from the expected {self.image}, will restart")
             self.start()
 
+    def ensure_in_git_repo(self):
+        # The compiler requires a .git directory to be present and valid, so if we're running in a git worktree
+        # we'll get failures as it cannot find the root .git directory.
+        repo_root = get_repo_root()
+        git_dir = repo_root / ".git"
+        if not git_dir.exists():
+            raise Exit(f"[-] .git directory not found in {repo_root}, this command needs to be run from a git repository")
+        elif not git_dir.is_dir():
+            raise Exit(f"[-] .git directory is not a directory in {repo_root}, git worktrees are not supported")
+
     def exec(
         self,
         cmd: str,
@@ -112,6 +123,7 @@ class CompilerImage:
             cmd = f"cd {run_dir} && {cmd}"
 
         self.ensure_running()
+        self.ensure_in_git_repo()
         color_env = "-e FORCE_COLOR=1"
         if not force_color:
             color_env = ""
@@ -131,6 +143,8 @@ class CompilerImage:
         if self.is_loaded:
             self.stop()
 
+        self.ensure_in_git_repo()
+
         # Check if the image exists
         res = self.ctx.run(f"docker image inspect {self.image}", hide=True, warn=True)
         if res is None or not res.ok:
@@ -142,7 +156,7 @@ class CompilerImage:
             platform = f"--platform linux/{self.arch.go_arch}"
         res = self.ctx.run(
             f"docker run {platform} -d --restart always --name {self.name} "
-            f"--mount type=bind,source={os.getcwd()},target={CONTAINER_AGENT_PATH} "
+            f"--mount type=bind,source={get_repo_root()},target={CONTAINER_AGENT_PATH} "
             f"{self.image} sleep \"infinity\"",
             warn=True,
         )

--- a/tasks/kernel_matrix_testing/compiler.py
+++ b/tasks/kernel_matrix_testing/compiler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 import tempfile
 from pathlib import Path
@@ -106,7 +105,9 @@ class CompilerImage:
         repo_root = get_repo_root()
         git_dir = repo_root / ".git"
         if not git_dir.exists():
-            raise Exit(f"[-] .git directory not found in {repo_root}, this command needs to be run from a git repository")
+            raise Exit(
+                f"[-] .git directory not found in {repo_root}, this command needs to be run from a git repository"
+            )
         elif not git_dir.is_dir():
             raise Exit(f"[-] .git directory is not a directory in {repo_root}, git worktrees are not supported")
 

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -181,7 +181,9 @@ def get_repo_root():
     """
     Get the root of the repository, where the .git directory is.
     """
-    return Path(__file__).parent.parent.parent.parent
+    import tasks
+
+    return Path(tasks.__file__).parent.parent
 
 
 def get_xcode_version(ctx):

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -5,6 +5,7 @@ Miscellaneous functions, no tasks here
 from __future__ import annotations
 
 import os
+from pathlib import Path
 import platform
 import re
 import shutil
@@ -174,6 +175,13 @@ def get_embedded_path(ctx):
             return test_embedded_path
 
     return None
+
+
+def get_repo_root():
+    """
+    Get the root of the repository, where the .git directory is.
+    """
+    return Path(__file__).parent.parent.parent.parent
 
 
 def get_xcode_version(ctx):

--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -5,7 +5,6 @@ Miscellaneous functions, no tasks here
 from __future__ import annotations
 
 import os
-from pathlib import Path
 import platform
 import re
 import shutil
@@ -18,6 +17,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
+from pathlib import Path
 from subprocess import CalledProcessError, check_output
 from types import SimpleNamespace
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR checks that the compiler image is not being started from a git worktree, and outputs an error message explaining the failure reason.

### Motivation

Running the compiler from a worktree can cause weird error messages, it's better to detect it and show a proper error.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Ran locally from a worktree and from a regular repo.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->