### PR TITLE
[EBPF] attacher: do not log unnecessary errors

### DIFF
--- a/pkg/ebpf/uprobes/attacher.go
+++ b/pkg/ebpf/uprobes/attacher.go
@@ -571,12 +571,26 @@ func (ua *UprobeAttacher) Stop() {
 	ua.wg.Wait()
 }
 
+func (ua *UprobeAttacher) shouldLogRegistryError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Always log all errors if detailed logging is enabled
+	if ua.config.EnableDetailedLogging {
+		return true
+	}
+
+	var unknownErr *utils.UnknownAttachmentError
+	return errors.As(err, &unknownErr)
+}
+
 // handleProcessStart is called when a new process is started, wraps AttachPIDWithOptions but ignoring the error
 // for API compatibility with processMonitor
 func (ua *UprobeAttacher) handleProcessStart(pid uint32) {
 	err := ua.AttachPIDWithOptions(pid, false) // Do not try to attach to libraries on process start, it hasn't loaded them yet
-	if err != nil && !errors.Is(err, utils.ErrPathIsAlreadyRegistered) {
-		log.Errorf("error attaching to process %d: %v", pid, err)
+	if ua.shouldLogRegistryError(err) {
+		log.Warnf("could not attach to process %d: %v", pid, err)
 	}
 }
 
@@ -590,8 +604,8 @@ func (ua *UprobeAttacher) handleLibraryOpen(libpath sharedlibraries.LibPath) {
 	path := sharedlibraries.ToBytes(&libpath)
 
 	err := ua.AttachLibrary(string(path), libpath.Pid)
-	if err != nil && !errors.Is(err, utils.ErrPathIsAlreadyRegistered) {
-		log.Errorf("error attaching to library %s (PID %d): %v", path, libpath.Pid, err)
+	if ua.shouldLogRegistryError(err) {
+		log.Warnf("could not attach to library %s (PID %d): %v", path, libpath.Pid, err)
 	}
 }
 
@@ -686,6 +700,9 @@ func (ua *UprobeAttacher) AttachPIDWithOptions(pid uint32, attachToLibs bool) er
 	if ua.handlesExecutables() || (ua.config.ExcludeTargets&ExcludeInternal) != 0 {
 		binPath, err = procInfo.Exe()
 		if err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return utils.NewUnknownAttachmentError(err)
+			}
 			return err
 		}
 	}
@@ -774,11 +791,13 @@ func (ua *UprobeAttacher) attachToBinary(fpath utils.FilePath, matchingRules []*
 
 	symbolsToRequest, err := ua.computeSymbolsToRequest(matchingRules)
 	if err != nil {
-		return fmt.Errorf("error computing symbols to request for rules %+v: %w", matchingRules, err)
+		return utils.NewUnknownAttachmentError(fmt.Errorf("error computing symbols to request for rules %+v: %w", matchingRules, err))
 	}
 
 	inspectResult, err := ua.inspector.Inspect(fpath, symbolsToRequest)
 	if err != nil {
+		// Not wrapping this one in an UnknownAttachmentError as it can happen if we're trying to
+		// attach to a process that just doesn't have the symbols we're looking for.
 		return fmt.Errorf("error inspecting %s: %w", fpath.HostPath, err)
 	}
 
@@ -788,7 +807,10 @@ func (ua *UprobeAttacher) attachToBinary(fpath utils.FilePath, matchingRules []*
 		for _, selector := range rule.ProbesSelector {
 			err = ua.attachProbeSelector(selector, fpath, uid, rule, inspectResult)
 			if err != nil {
-				return err
+				// At this point we have done enough validation so that the
+				// probe attachment should work, if it doesn't it's an issue we
+				// don't expect and we want to know about it.
+				return utils.NewUnknownAttachmentError(err)
 			}
 		}
 	}
@@ -951,7 +973,7 @@ func (ua *UprobeAttacher) attachToLibrariesOfPID(pid uint32) error {
 	successfulMatches := make([]string, 0)
 	libs, err := ua.getLibrariesFromMapsFile(int(pid))
 	if err != nil {
-		return err
+		return utils.NewUnknownAttachmentError(err)
 	}
 	for _, libpath := range libs {
 		err := ua.AttachLibrary(libpath, pid)
@@ -967,10 +989,10 @@ func (ua *UprobeAttacher) attachToLibrariesOfPID(pid uint32) error {
 		if len(registerErrors) == 0 {
 			return nil // No libraries found to attach
 		}
-		return fmt.Errorf("no rules matched for pid %d, errors: %v", pid, registerErrors)
+		return utils.NewUnknownAttachmentError(fmt.Errorf("no rules matched for pid %d, errors: %v", pid, registerErrors))
 	}
 	if len(registerErrors) > 0 {
-		return fmt.Errorf("partially hooked (%v), errors while attaching pid %d: %v", successfulMatches, pid, registerErrors)
+		return utils.NewUnknownAttachmentError(fmt.Errorf("partially hooked (%v), errors while attaching pid %d: %v", successfulMatches, pid, registerErrors))
 	}
 	return nil
 }

--- a/pkg/gpu/probe.go
+++ b/pkg/gpu/probe.go
@@ -383,7 +383,7 @@ func getAttacherConfig(cfg *config.Config) uprobes.AttacherConfig {
 		SharedLibsLibset:               sharedlibraries.LibsetGPU,
 		ScanProcessesInterval:          cfg.ScanProcessesInterval,
 		EnablePeriodicScanNewProcesses: true,
-		EnableDetailedLogging:          true,
+		EnableDetailedLogging:          false,
 	}
 }
 

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -129,6 +129,26 @@ var (
 	ErrPathIsAlreadyRegistered = errors.New("path is already registered")
 )
 
+// UnknownAttachmentError is an error that is not one of the expected errors, a
+// shorthand to ensure we don't log expected errors (such as
+// ErrPathIsAlreadyRegistered or errPathIsBlocked, which are expected to happen
+// in normal operation)
+type UnknownAttachmentError struct {
+	Err error
+}
+
+func (e *UnknownAttachmentError) Error() string {
+	return fmt.Sprintf("unexpected error: %v", e.Err)
+}
+
+func (e *UnknownAttachmentError) Unwrap() error {
+	return e.Err
+}
+
+func NewUnknownAttachmentError(err error) *UnknownAttachmentError {
+	return &UnknownAttachmentError{Err: err}
+}
+
 // getBlockReason creates a string specifying the reason for the block based on
 // the error received. To reduce memory usage of this debugging feature, for
 // very common errors we store a summary instead of the full error string,
@@ -152,12 +172,12 @@ func getBlockReason(error error) string {
 // the existing registration if and only if `pid` is new;
 func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB, deactivationCB, alreadyRegistered Callback) error {
 	if activationCB == nil || deactivationCB == nil {
-		return errCallbackIsMissing
+		return NewUnknownAttachmentError(errCallbackIsMissing)
 	}
 
 	path, err := NewFilePath(r.procRoot, namespacedPath, pid)
 	if err != nil {
-		return err
+		return NewUnknownAttachmentError(err)
 	}
 
 	pathID := path.ID
@@ -220,6 +240,9 @@ func (r *FileRegistry) Register(namespacedPath string, pid uint32, activationCB,
 			r.blocklistByID.Add(pathID, BlockListEntry{Path: path.HostPath, Reason: getBlockReason(err)})
 		}
 		r.telemetry.fileHookFailed.Add(1)
+
+		// Passing the error as is, without wrapping it in a `UnknownAttachmentError`,
+		// that's the responsibility of the callback.
 		return err
 	}
 

--- a/pkg/network/usm/utils/file_registry.go
+++ b/pkg/network/usm/utils/file_registry.go
@@ -145,6 +145,8 @@ func (e *UnknownAttachmentError) Unwrap() error {
 	return e.Err
 }
 
+// NewUnknownAttachmentError creates a new `UnknownAttachmentError` instance wrapping
+// the given error.
 func NewUnknownAttachmentError(err error) *UnknownAttachmentError {
 	return &UnknownAttachmentError{Err: err}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Change how registry errors are logged by the uprobe attacher, to ensure that we don't report errors that aren't really errors and are instead part of the normal operation of the attacher.

### Motivation

Reduce log noise.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Ran manually with GPU and USM enabled, ensured that log wasn't polluted.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->