### PR TITLE
system-probe: disable transparent huge pages

### DIFF
--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -171,6 +171,12 @@ func run(log log.Component, _ config.Component, telemetry telemetry.Component, s
 	// prepare go runtime
 	ddruntime.SetMaxProcs()
 
+	if sysprobeconfig.GetBool("system_probe_config.disable_thp") {
+		if err := ddruntime.DisableTransparentHugePages(); err != nil {
+			log.Warnf("cannot disable transparent huge pages, performance may be degraded: %s", err)
+		}
+	}
+
 	// Setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -66,6 +66,7 @@ var (
 func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("ignore_host_etc", false)
 	cfg.BindEnvAndSetDefault("go_core_dump", false)
+	cfg.BindEnvAndSetDefault(join(spNS, "disable_thp"), true)
 
 	// SBOM configuration
 	cfg.BindEnvAndSetDefault("sbom.host.enabled", false)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -66,7 +66,7 @@ var (
 func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("ignore_host_etc", false)
 	cfg.BindEnvAndSetDefault("go_core_dump", false)
-	cfg.BindEnvAndSetDefault(join(spNS, "disable_thp"), true)
+	cfg.BindEnvAndSetDefault(join(spNS, "disable_thp"), false)
 
 	// SBOM configuration
 	cfg.BindEnvAndSetDefault("sbom.host.enabled", false)

--- a/pkg/runtime/thp_linux.go
+++ b/pkg/runtime/thp_linux.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package runtime defines limits for the Go runtime
+package runtime
+
+import "golang.org/x/sys/unix"
+
+// DisableTransparentHugePages disables transparent huge pages (THP) for the current process.
+func DisableTransparentHugePages() error {
+	return unix.Prctl(unix.PR_SET_THP_DISABLE, 1, 0, 0, 0)
+}

--- a/pkg/runtime/thp_unsupported.go
+++ b/pkg/runtime/thp_unsupported.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+
+// Package runtime defines limits for the Go runtime
+package runtime
+
+// DisableTransparentHugePages is not supported on non-linux hosts.
+func DisableTransparentHugePages() error {
+	return nil
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds a new config flag to the system probe config allowing to disable transparent huge pages use for this process. Transparent huge pages can be seen very clearly in SMP graphs ([example](https://app.datadoghq.com/dashboard/vz3-jd5-bdi?fromUser=false&refresh_mode=paused&tpl_var_experiment%5B0%5D=quality_gate_idle_all_features&tpl_var_job_id%5B0%5D=cff5090e-abaa-42d8-b685-2927cdb9ca3b&view=spans&from_ts=1746635346000&to_ts=1746635946000&live=false)) and the associated stair pattern when looking at system-probe memory.
This PR doesn't change anything as is, it simply provides a way to disable THP through a config flag. But the config flag is left disabled by default for now.

This upstream go discussion https://github.com/golang/go/issues/64332 is also interesting with similar behavior and fix.

Something important: this prctl applies to the whole process (this includes cgo), but is also inherited by child processes. This is not an issue for system-probe, but might be for other agent binaries.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->