### PR TITLE
[OTAGENT-380] fix and put back CI datadog_otel_components_ocb_build

### DIFF
--- a/.gitlab/integration_test/otel.yml
+++ b/.gitlab/integration_test/otel.yml
@@ -43,4 +43,24 @@ docker_image_build_otel:
     - !reference [.except_mergequeue]
     - when: on_success
 
-# TODO(songy23): restore datadog_otel_components_ocb_build in next version upgrade
+datadog_otel_components_ocb_build:
+  stage: integration_test
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["arch:amd64"]
+  needs: ["go_deps"]
+  artifacts:
+    paths:
+      - ocb-output.log
+      - otelcol-custom.log
+      - flare-info.log
+    when: always
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    - echo "Building custom collector with datadog components"
+    - test/otel/testdata/ocb_build_script.sh
+    - echo "see artifacts for job logs"
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  timeout: 15 minutes

--- a/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
+++ b/comp/otelcol/otlp/components/exporter/serializerexporter/factory.go
@@ -139,6 +139,11 @@ func NewFactoryForOSSExporter(typ component.Type, statsIn chan []byte) exp.Facto
 	)
 }
 
+// NewFactory implements the required func to be used in OCB. This interface does not work with APM stats. Do not change the func signature or OCB will fail.
+func NewFactory() exp.Factory {
+	return NewFactoryForOSSExporter(component.MustNewType(TypeStr), nil)
+}
+
 // Reporter builds and returns an *inframetadata.Reporter.
 func (f *factory) Reporter(params exp.Settings, forwarder defaultforwarder.Forwarder, reporterPeriod time.Duration) (*inframetadata.Reporter, error) {
 	var reporterErr error

--- a/test/otel/testdata/builder-config.yaml
+++ b/test/otel/testdata/builder-config.yaml
@@ -1,93 +1,93 @@
 connectors:
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector
-    v0.122.0
-- gomod: github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/connector/datadogconnector
-    v0.122.0
+    v0.124.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector
+    v0.124.0
 converters:
-- gomod: github.com/DataDog/datadog-agent/comp/otelcol/converter/impl v0.61.0
+- gomod: github.com/DataDog/datadog-agent/comp/otelcol/converter/impl v0.64.3
   path: ./comp/otelcol/converter/impl
 dist:
   description: Basic OTel Collector distribution for Developers
   name: otelcol-custom
   output_path: /tmp/otel-ci/otelcol-custom
 exporters:
-- gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.122.1
-- gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.122.1
-- gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.122.1
-- gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.122.1
+- gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.124.0
+- gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.124.0
+- gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.124.0
+- gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter
-    v0.122.0
+    v0.124.0
 - gomod: github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/serializerexporter
-    v0.61.0
+    v0.64.3
   path: ./comp/otelcol/otlp/components/exporter/serializerexporter
 extensions:
-- gomod: github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl v0.61.0
+- gomod: github.com/DataDog/datadog-agent/comp/otelcol/ddflareextension/impl v0.64.3
   path: ./comp/otelcol/ddflareextension/impl
-- gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.122.1
+- gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/dockerobserver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecsobserver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/ecstaskobserver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/hostobserver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer/k8sobserver
-    v0.122.0
+    v0.124.0
 processors:
 - gomod: github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/processor/infraattributesprocessor
-    v0.61.0
+    v0.64.3
   path: ./comp/otelcol/otlp/components/processor/infraattributesprocessor
-- gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.122.1
-- gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.122.1
+- gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.124.0
+- gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/cumulativetodeltaprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor
-    v0.122.0
+    v0.124.0
 providers:
-- gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.28.1
-- gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.28.1
-- gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.28.1
-- gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.28.1
-- gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.28.1
+- gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.30.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.30.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.30.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.30.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.30.0
 receivers:
-- gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.122.1
-- gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.122.1
+- gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.124.0
+- gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator
-    v0.122.0
+    v0.124.0
 - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver
-    v0.122.0
+    v0.124.0

--- a/test/otel/testdata/ocb_build_script.sh
+++ b/test/otel/testdata/ocb_build_script.sh
@@ -68,24 +68,15 @@ dd_mods=$(find . -type f -name "go.mod" -exec dirname {} \; | sort | sed 's/.//'
 
 
 
-# Use a forked version of the Datadog exporter
-#
-# This change adds a replace directive for the datadog exporter to point to a forked version: GitHub Comparison: https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/main...ogaca-dd:opentelemetry-collector-contrib:olivierg/tmp-fix-ocb
-#
-# Issues Fixed:
-# 	1.	Dependency Mismatch:
-# 	  -	connector/datadogconnector/go.mod does not reference the latest version of exporter/datadogexporter.
-# 	  -	This adjustment is necessary until opentelemetry-collector-contrib v0.122.1 is officially released.
-# 	2.	Compatibility Issue:
-# 	  -	opentelemetry-collector-contrib fails to compile due to recent changes in the Datadog Agent.
-# 	  -	The pkgconfigmodel package was renamed to viperconfig, breaking compatibility with the latest updates.
-echo "- github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter => github.com/ogaca-dd/opentelemetry-collector-contrib/exporter/datadogexporter v0.0.0-20250220150909-786462df4eca" >> /tmp/otel-ci/builder-config.yaml
+# TODO(songy23): remove this once v0.125.0 is brought to Agent
+echo "- github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter => github.com/songy23/opentelemetry-service-contrib/exporter/datadogexporter v0.0.0-20250421165018-f26f9d62977a" >> /tmp/otel-ci/builder-config.yaml
+echo "- github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector => github.com/songy23/opentelemetry-service-contrib/connector/datadogconnector v0.0.0-20250421165018-f26f9d62977a" >> /tmp/otel-ci/builder-config.yaml
 
 
 } >>"$WORK_DIR/builder-config.yaml"
 
 # Install and configure OCB
-OCB_VERSION="0.122.1"
+OCB_VERSION="0.124.0"
 CGO_ENABLED=0 go install -trimpath -ldflags="-s -w" \
 	go.opentelemetry.io/collector/cmd/builder@v${OCB_VERSION}
 mv -v "$(go env GOPATH)/bin/builder" "$WORK_DIR/ocb"


### PR DESCRIPTION
### What does this PR do?
Fix and put back CI datadog_otel_components_ocb_build

### Motivation
This CI was removed in https://github.com/DataDog/datadog-agent/pull/35845/commits/6dc19d0374ee32f1d11a7f1eb08475cde56b32c0 because upstream otel v0.122.x release missed the OCB artifacts (which is necessary for the CI). Now that newer otel versions are released, we can re-enable it. Also fixes a bunch of other issues around it.

### Describe how you validated your changes
ran `test/otel/testdata/ocb_build_script.sh` locally and verified it works