### PR TITLE
[clusteragent/autoscaling/workload] Fix failing test local execution

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/config_retriever_settings_test.go
+++ b/pkg/clusteragent/autoscaling/workload/config_retriever_settings_test.go
@@ -532,6 +532,7 @@ func TestConfigRetriverAutoscalingSettingsReconcile(t *testing.T) {
 	// Become leader, should reconcile. Unfortunately, as it's another goroutine running the reconcile,
 	// we need to wait for the reconcile to happen.
 	isLeader = true
+	time.Sleep(10 * time.Millisecond)
 	testClock.Step(settingsReconcileInterval)
 	require.Eventually(t, func() bool {
 		return store.Count() == 1


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Adds a sleep in a test to ensure the variable change is propogated to all goroutines before behavior is asserted.

### Motivation
Test was failing locally when run with other tests.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->