### PR TITLE
[ACIX-648] create unique qualification tags for agent 6

### DIFF
--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -360,7 +360,6 @@ def push_tags_in_batches(ctx, tags, force_option="", delete=False):
 
     for idx in range(0, len(tags), TAG_BATCH_SIZE):
         batch_tags = tags[idx : idx + TAG_BATCH_SIZE]
-        print(f"git {command} origin {' '.join(batch_tags)}{force_option}")
-        # ctx.run(f"git {command} origin {' '.join(batch_tags)}{force_option}")
+        ctx.run(f"git {command} origin {' '.join(batch_tags)}{force_option}")
 
     print(f"{'Deleted' if delete else 'Pushed'} tags: {tags_list}")

--- a/tasks/libs/common/git.py
+++ b/tasks/libs/common/git.py
@@ -16,6 +16,8 @@ from tasks.libs.common.user_interactions import yes_no_question
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+TAG_BATCH_SIZE = 3
+
 
 @contextmanager
 def clone(ctx, repo, branch, options=""):
@@ -344,3 +346,21 @@ def create_tree(ctx, base_branch):
         blob["content"] = content
         tree["tree"].append(blob)
     return tree
+
+
+def push_tags_in_batches(ctx, tags, force_option="", delete=False):
+    """
+    Push or delete tags to remote in batches
+    """
+    if not tags:
+        return
+
+    tags_list = ' '.join(tags)
+    command = "push --delete" if delete else "push"
+
+    for idx in range(0, len(tags), TAG_BATCH_SIZE):
+        batch_tags = tags[idx : idx + TAG_BATCH_SIZE]
+        print(f"git {command} origin {' '.join(batch_tags)}{force_option}")
+        # ctx.run(f"git {command} origin {' '.join(batch_tags)}{force_option}")
+
+    print(f"{'Deleted' if delete else 'Pushed'} tags: {tags_list}")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -274,7 +274,7 @@ def tag_version(
                 )
 
         if push:
-            push_tags_in_batches(ctx, tags, force=force_option)
+            push_tags_in_batches(ctx, tags, force_option)
             print(f"Created tags for version {agent_version}")
 
     if skip_agent_context:

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -34,6 +34,7 @@ from tasks.libs.common.git import (
     get_last_commit,
     get_last_release_tag,
     is_agent6,
+    push_tags_in_batches,
     try_git_command,
 )
 from tasks.libs.common.gomodules import get_default_modules
@@ -84,7 +85,6 @@ from tasks.pipeline import edit_schedule, run
 from tasks.release_metrics.metrics import get_prs_metrics, get_release_lead_time
 
 BACKPORT_LABEL_COLOR = "5319e7"
-TAG_BATCH_SIZE = 3
 QUALIFICATION_TAG = "qualification"
 
 
@@ -211,12 +211,8 @@ def tag_modules(
                 tags.extend(new_tags)
 
         if push:
-            tags_list = ' '.join(tags)
             set_gitconfig_in_ci(ctx)
-            for idx in range(0, len(tags), TAG_BATCH_SIZE):
-                batch_tags = tags[idx : idx + TAG_BATCH_SIZE]
-                ctx.run(f"git push origin {' '.join(batch_tags)}{force_option}")
-            print(f"Pushed tag {tags_list}")
+            push_tags_in_batches(ctx, tags, force_option)
         print(f"Created module tags for version {agent_version}")
 
     if skip_agent_context:
@@ -266,21 +262,20 @@ def tag_version(
         tags = __tag_single_module(ctx, get_default_modules()["."], agent_version, commit, force_option, devel)
 
         set_gitconfig_in_ci(ctx)
-        # create or update the qualification tag using the force option (points tag to next RC)
         if is_agent6(ctx) and (start_qual or is_qualification(ctx, "6.53.x")):
+            # remove all the qualification tags if it is the final version
             if FINAL_VERSION_RE.match(agent_version):
-                ctx.run(f"git push --delete origin {QUALIFICATION_TAG}")
+                qualification_tags = get_qualification_tags(ctx, release_branch)
+                push_tags_in_batches(ctx, qualification_tags, delete=True)
+            # create or update the qualification tag on the current commit
             else:
-                force_option = __get_force_option(not start_qual)
                 tags += __tag_single_module(
-                    ctx, get_default_modules()["."], QUALIFICATION_TAG, commit, force_option, False
+                    ctx, get_default_modules()["."], f"{QUALIFICATION_TAG}-{int(time.time())}", commit, "", False
                 )
 
         if push:
-            tags_list = ' '.join(tags)
-            ctx.run(f"git push origin {tags_list}{force_option}")
-            print(f"Pushed tag {tags_list}")
-        print(f"Created tags for version {agent_version}")
+            push_tags_in_batches(ctx, tags, force=force_option)
+            print(f"Created tags for version {agent_version}")
 
     if skip_agent_context:
         _tag_version()
@@ -541,16 +536,42 @@ def create_rc(ctx, release_branch, patch_version=False, upstream="origin"):
 
 @task
 def is_qualification(ctx, release_branch, output=False):
+    if qualification_tag_query(ctx, release_branch):
+        if output:
+            print('true')
+        return True
+    if output:
+        print("false")
+    return False
+
+
+def qualification_tag_query(ctx, release_branch):
     with agent_context(ctx, release_branch):
-        try:
-            ctx.run(f"git tag | grep {QUALIFICATION_TAG}", hide=True)
-            if output:
-                print('true')
-            return True
-        except Failure:
-            if output:
-                print("false")
-            return False
+        res = ctx.run(f"git ls-remote origin --tags --refs {QUALIFICATION_TAG}-*", hide=True)
+        if res.stdout:
+            return res.stdout.splitlines()
+        return None
+
+
+@task
+def get_qualification_tags(ctx, release_branch, latest_tag=False):
+    """Get the qualification tags in remote repository
+
+    Args:
+        latest_tag: if True, only return the latest commit and tag
+    """
+    tags = []
+    latest_ref = (0, None, None)
+    for ref in qualification_tag_query(ctx, release_branch):
+        if ref.endswith("^{}"):
+            commit, tag = ref.replace("^{}", "").split("\t")
+            if latest_tag:
+                _, timestamp = tag.split("-")
+                if int(timestamp) > latest_ref[0]:
+                    latest_ref = (int(timestamp), commit, tag)
+            else:
+                tags.append(tag)
+    return (latest_ref[1], latest_ref[2]) if latest_tag else tags
 
 
 @task
@@ -634,7 +655,8 @@ def get_qualification_rc_tag(ctx, release_branch):
     with agent_context(ctx, release_branch):
         err_msg = "Error: Expected exactly one release candidate tag associated with the qualification tag commit. Tags found:"
         try:
-            res = ctx.run(f"git tag --points-at $(git rev-list -n 1 {QUALIFICATION_TAG}) | grep 6.53")
+            latest_commit, _ = get_qualification_tags(ctx, release_branch, latest_tag=True)
+            res = ctx.run(f"git tag --points-at {latest_commit} | grep 6.53")
         except Failure as err:
             raise Exit(message=f"{err_msg} []", code=1) from err
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR updates the way we manage qualification tags for Agent 6 releases. Instead of reusing the same qualification tag and force-updating it:

- now we create unique timestamped qualification tags in this format: `qualification-<timestamp>`
- these tags will not be moved once created (which will fix the need to force-fetch tags and eliminate clobbering errors)
- this means that `# of RCs = the # of qualification tags` per qualification phase
- we always use `git ls-remote` to get the qualification tags so that we can use the remote as the source of truth
- at the end of the qualification phase we delete all generated qualification tags

This removes the need to force-fetch tags and eliminates clobbering errors.
### Motivation
Previously, we reused a single tag called qualification and force moved it to a new commit for a new rc during the qualification phase. This caused Git errors for developers when pulling or fetching changes since Git doesn't automatically overwrite local tags and it will throw an error since local and remote are out of sync.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

tested by calling functions locally by using them to create qualification tags, delete them, check if it's in qualification phase 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->