### PR TITLE
service discovery: Handle [ready] in gunicorn names

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/python.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/python.go
@@ -41,8 +41,17 @@ func (p pythonDetector) detect(args []string) (ServiceMetadata, bool) {
 	// looking like the example below, so redirect to the Gunicorn detector for
 	// this case:
 	//  /usr/bin/python3 /usr/bin/gunicorn foo:app()
-	if len(args) > 0 && filepath.Base(args[0]) == "gunicorn" {
-		return p.gunicorn.detect(args[1:])
+	//
+	// Another case where we want to redirect to the Gunicorn detector is when
+	// gunicorn replaces its command line with something like the below. Because
+	// of the [ready], we end up here first instead of going directly to the
+	// Gunicorn detector.
+	//  [ready] gunicorn: worker [airflow-webserver]
+	if len(args) > 0 {
+		base := filepath.Base(args[0])
+		if base == "gunicorn" || base == "gunicorn:" {
+			return p.gunicorn.detect(args[1:])
+		}
 	}
 
 	var (

--- a/pkg/collector/corechecks/servicediscovery/usm/service_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service_test.go
@@ -815,6 +815,18 @@ func TestExtractServiceMetadata(t *testing.T) {
 			expectedGeneratedName:       "mcservice",
 			expectedGeneratedNameSource: CommandLine,
 		},
+		{
+			name: "gunicorn with replaced cmdline and [ready]",
+			cmdline: []string{
+				"[ready]",
+				"gunicorn:",
+				"worker",
+				"[airflow-webserver]",
+			},
+			lang:                        language.Python,
+			expectedGeneratedName:       "airflow-webserver",
+			expectedGeneratedNameSource: CommandLine,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Improve name generation for the case when [ready] is present in the
command line replaced by gunicorn.  Currently, "ready" ends up being
used as the generated name.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-65

### Describe how you validated your changes

Unit test added.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
