### PR TITLE
Add verbose flag to tidy task

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -314,7 +314,7 @@ def tidy_all(ctx):
 
 
 @task
-def tidy(ctx):
+def tidy(ctx, verbose: bool = False):
     check_valid_mods(ctx)
 
     ctx.run("go work sync")
@@ -330,11 +330,12 @@ def tidy(ctx):
             resource.setrlimit(resource.RLIMIT_NOFILE, (1024, current_ulimit[1]))
 
     # Note: It's currently faster to tidy everything than looking for exactly what we should tidy
+    verbosity = "-x" if verbose else ""
     promises = []
     for mod in get_default_modules().values():
         with ctx.cd(mod.full_path()):
             # https://docs.pyinvoke.org/en/stable/api/runners.html#invoke.runners.Runner.run
-            promises.append(ctx.run("go mod tidy", asynchronous=True))
+            promises.append(ctx.run(f"go mod tidy {verbosity}", asynchronous=True))
 
     for promise in promises:
         promise.join()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add a verbose argument to the `tidy` task.

### Motivation
When running it for the first time, the first `go mod tidy` can take a long time. Using the verbose flag will show the commands being run by `go` under the hood.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->