### PR TITLE
[incident-37521] Fix gitlab runners python setup (7.66)

### DIFF
--- a/.gitlab/common/macos.yml
+++ b/.gitlab/common/macos.yml
@@ -19,19 +19,38 @@
 
 .select_python_env_commands:
   # Select the virtualenv using the current Python version. Create it if it doesn't exist.
-  - PYTHON_VERSION=$(python3 --version | awk '{print $2}')
+  - |
+    export PATH="$(pyenv root)/shims:$PATH"
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
+  - PYTHON_VERSION=3.12.6
   - VENV_NAME="datadog-agent-python-$PYTHON_VERSION"
   - VENV_PATH="$(pyenv root)/versions/$VENV_NAME"
   - echo "Using Python $PYTHON_VERSION..."
   - |
     # Check if the virtual environment directory exists
     if [ ! -d "$VENV_PATH" ]; then
+      # Install target python if necessary
+      if [ ! -d "$(pyenv root)/versions/$PYTHON_VERSION" ]; then
+        echo "Installing Python $PYTHON_VERSION..."
+        pyenv install "$PYTHON_VERSION"
+      fi
+
       echo "Creating virtual environment '$VENV_NAME'..."
       pyenv virtualenv "$PYTHON_VERSION" "$VENV_NAME"
     else
       echo "Virtual environment '$VENV_NAME' already exists. Skipping creation."
     fi
   - pyenv activate $VENV_NAME
+
+.install_python_dependencies:
+  # Python 3.12 changes default behavior how packages are installed.
+  # In particular, --break-system-packages command line option is
+  # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
+  - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
+  - pyenv rehash
+  - python3 -m dda self dep sync -f legacy-tasks
+  - pyenv rehash
 
 .vault_login:
   # Point the CLI to our internal vault
@@ -51,16 +70,10 @@
       export GOPATH=$GOROOT
     # Selecting the current Python version
     - !reference [.select_python_env_commands]
+    - !reference [.install_python_dependencies]
     # List Python and Go existing environments and their disk space
     - !reference [.list_go_versions_commands]
     - !reference [.list_python_versions_commands]
-    # Installing the job dependencies
-    # Python 3.12 changes default behavior how packages are installed.
-    # In particular, --break-system-packages command line option is
-    # required to use the old behavior or use a virtual env. https://github.com/actions/runner-images/issues/8615
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)" --break-system-packages
-    - python3 -m dda self dep sync -f legacy-tasks
-    - pyenv rehash
     - dda inv -- -e rtloader.make
     - dda inv -- -e rtloader.install
     - dda inv -- -e install-tools

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -25,9 +25,3 @@ lint_macos_gitlab_arm64:
     - !reference [.on_main]
     - !reference [.manual]
   tags: ["macos:ventura-arm64", "specific:true"]
-
-celian:
-  extends: .lint_macos_gitlab
-  allow_failure: true
-  tags: ["macos:ventura-arm64", "specific:true"]
-  needs: []

--- a/.gitlab/lint/macos.yml
+++ b/.gitlab/lint/macos.yml
@@ -25,3 +25,9 @@ lint_macos_gitlab_arm64:
     - !reference [.on_main]
     - !reference [.manual]
   tags: ["macos:ventura-arm64", "specific:true"]
+
+celian:
+  extends: .lint_macos_gitlab
+  allow_failure: true
+  tags: ["macos:ventura-arm64", "specific:true"]
+  needs: []


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[incident-37521]

This is a combination of https://github.com/DataDog/datadog-agent/pull/36272 and https://github.com/DataDog/datadog-agent/pull/36363, macos jobs (lint / test) are failing due to python install possibly missing.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

See this [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/906590457)

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->