### PR TITLE
fix(installer): Put the task DB outside of the versioned agent path

### DIFF
--- a/cmd/installer/subcommands/daemon/run_windows_test.go
+++ b/cmd/installer/subcommands/daemon/run_windows_test.go
@@ -101,4 +101,6 @@ func createConfigDir(t *testing.T) {
 	require.NoError(t, err)
 	err = paths.IsInstallerDataDirSecure()
 	require.NoError(t, err)
+	err = os.MkdirAll(paths.RunPath, 0755)
+	require.NoError(t, err)
 }

--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	installerErrors "github.com/DataDog/datadog-agent/pkg/fleet/installer/errors"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/exec"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	pbgo "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
@@ -108,7 +109,7 @@ func NewDaemon(hostname string, rcFetcher client.ConfigFetcher, config config.Re
 	if err != nil {
 		return nil, fmt.Errorf("could not get resolve installer executable path: %w", err)
 	}
-	dbPath := filepath.Join(config.GetString("run_path"), "installer_tasks.db")
+	dbPath := filepath.Join(paths.RunPath, "installer_tasks.db")
 	taskDB, err := newTaskDB(dbPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not create task DB: %w", err)


### PR DESCRIPTION
### What does this PR do?
`"run_path"` is set to be the agent versioned path, so the task DB is not preserved during agent upgrades. This PR fixes it.

### Motivation

### Describe how you validated your changes
manual qa on a vm

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->