### PR TITLE
[CWS] add timeout context to selftest command

### DIFF
--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -262,7 +262,7 @@ func (c *CWSConsumer) RunSelfTest(gRPC bool) (bool, error) {
 		return false, nil
 	}
 
-	if err := c.selfTester.RunSelfTest(selftests.DefaultTimeout); err != nil {
+	if err := c.selfTester.RunSelfTest(c.ctx, selftests.DefaultTimeout); err != nil {
 		return true, err
 	}
 

--- a/pkg/security/probe/selftests/chmod.go
+++ b/pkg/security/probe/selftests/chmod.go
@@ -9,6 +9,7 @@
 package selftests
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 
@@ -36,12 +37,12 @@ func (o *ChmodSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 }
 
 // GenerateEvent generate an event
-func (o *ChmodSelfTest) GenerateEvent() error {
+func (o *ChmodSelfTest) GenerateEvent(ctx context.Context) error {
 	o.isSuccess = false
 
 	// we need to use chmod (or any other external program) as our PID is discarded by probes
 	// so the events would not be generated
-	cmd := exec.Command("chmod", "777", o.filename)
+	cmd := exec.CommandContext(ctx, "chmod", "777", o.filename)
 	if err := cmd.Run(); err != nil {
 		log.Debugf("error running chmod: %v", err)
 		return err

--- a/pkg/security/probe/selftests/chown.go
+++ b/pkg/security/probe/selftests/chown.go
@@ -9,6 +9,7 @@
 package selftests
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"os/user"
@@ -37,7 +38,7 @@ func (o *ChownSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 }
 
 // GenerateEvent generate an event
-func (o *ChownSelfTest) GenerateEvent() error {
+func (o *ChownSelfTest) GenerateEvent(ctx context.Context) error {
 	o.isSuccess = false
 
 	// we need to use chown (or any other external program) as our PID is discarded by probes
@@ -48,7 +49,7 @@ func (o *ChownSelfTest) GenerateEvent() error {
 		return err
 	}
 
-	cmd := exec.Command("chown", currentUser.Uid, o.filename)
+	cmd := exec.CommandContext(ctx, "chown", currentUser.Uid, o.filename)
 	if err := cmd.Run(); err != nil {
 		log.Debugf("error running chown: %v", err)
 		return err

--- a/pkg/security/probe/selftests/create_file_windows.go
+++ b/pkg/security/probe/selftests/create_file_windows.go
@@ -7,6 +7,7 @@
 package selftests
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -44,10 +45,10 @@ func (o *WindowsCreateFileSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 }
 
 // GenerateEvent generate an event
-func (o *WindowsCreateFileSelfTest) GenerateEvent() error {
+func (o *WindowsCreateFileSelfTest) GenerateEvent(ctx context.Context) error {
 	o.isSuccess = false
 
-	cmd := exec.Command(
+	cmd := exec.CommandContext(ctx,
 		"powershell",
 		"-c",
 		"New-Item",

--- a/pkg/security/probe/selftests/ebpfless.go
+++ b/pkg/security/probe/selftests/ebpfless.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"golang.org/x/net/context"
 )
 
 // EBPFLessSelfTest defines an ebpf less self test
@@ -38,7 +39,7 @@ func (o *EBPFLessSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 }
 
 // GenerateEvent generate an event
-func (o *EBPFLessSelfTest) GenerateEvent() error {
+func (o *EBPFLessSelfTest) GenerateEvent(_ context.Context) error {
 	return nil
 }
 

--- a/pkg/security/probe/selftests/open.go
+++ b/pkg/security/probe/selftests/open.go
@@ -9,6 +9,7 @@
 package selftests
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 
@@ -36,12 +37,12 @@ func (o *OpenSelfTest) GetRuleDefinition() *rules.RuleDefinition {
 }
 
 // GenerateEvent generate an event
-func (o *OpenSelfTest) GenerateEvent() error {
+func (o *OpenSelfTest) GenerateEvent(ctx context.Context) error {
 	o.isSuccess = false
 
 	// we need to use touch (or any other external program) as our PID is discarded by probes
 	// so the events would not be generated
-	cmd := exec.Command("touch", o.filename)
+	cmd := exec.CommandContext(ctx, "touch", o.filename)
 	if err := cmd.Run(); err != nil {
 		log.Debugf("error running touch: %v", err)
 		return err

--- a/pkg/security/probe/selftests/open_registry_key_windows.go
+++ b/pkg/security/probe/selftests/open_registry_key_windows.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/net/context"
 )
 
 // WindowsOpenRegistryKeyTest defines a windows open registry key self test
@@ -37,12 +38,12 @@ func (o *WindowsOpenRegistryKeyTest) GetRuleDefinition() *rules.RuleDefinition {
 }
 
 // GenerateEvent generate an event
-func (o *WindowsOpenRegistryKeyTest) GenerateEvent() error {
+func (o *WindowsOpenRegistryKeyTest) GenerateEvent(ctx context.Context) error {
 	o.isSuccess = false
 
 	path := fmt.Sprintf("Registry::HKEY_LOCAL_MACHINE:\\%s", o.keyPath)
 
-	cmd := exec.Command(
+	cmd := exec.CommandContext(ctx,
 		"powershell",
 		"-c",
 		"Get-ItemProperty",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add context timeout to self test commands.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->