### PR TITLE
usm: tests: Address races in TestVerifySketches

### DIFF
--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -2307,18 +2307,23 @@ func testHTTPLikeSketches(t *testing.T, tr *tracer.Tracer, client *nethttp.Clien
 		}
 
 		for key, stats := range requests {
-			if getRequestStats != nil && postRequestsStats != nil {
-				break
-			}
 			if key.Path.Content.Get() != parsedURL.Path {
 				continue
 			}
 			if key.Method.String() == "GET" {
-				getRequestStats = stats
+				if getRequestStats == nil {
+					getRequestStats = stats
+				} else {
+					getRequestStats.CombineWith(stats)
+				}
 				continue
 			}
 			if key.Method.String() == "POST" {
-				postRequestsStats = stats
+				if postRequestsStats == nil {
+					postRequestsStats = stats
+				} else {
+					postRequestsStats.CombineWith(stats)
+				}
 				continue
 			}
 		}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Handles flakiness with a test

### Motivation

The HTTP post requests (2) can be sent separately to the user mode But we're overriding the postRequestStats variable with the last instance of stats.

With the change, we will merge all stats together

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->