### PR TITLE
[ebpfless] Fix handling of retransmits in TIME_WAIT state

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1238,6 +1238,7 @@ core,github.com/hashicorp/go-version,MPL-2.0,"Copyright © 2014-2018 HashiCorp, 
 core,github.com/hashicorp/golang-lru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
+core,github.com/hashicorp/golang-lru/v2/expirable,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2/internal,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/golang-lru/v2/simplelru,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"
 core,github.com/hashicorp/hcl,MPL-2.0,"Copyright © 2014-2018 HashiCorp, Inc"

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/google/gopacket/layers"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -77,11 +78,18 @@ type TCPProcessor struct {
 	pendingConns map[PCAPTuple]*connectionState
 	// establishedConns contains connections with tcpState == connStatEstablished
 	establishedConns map[PCAPTuple]*connectionState
+	// recentlyClosed is analogous to the TIME_WAIT state after a connection closes. we use this to
+	// suppress "pre-existing connection" logic on retransmits after a connection closes
+	recentlyClosed *expirable.LRU[PCAPTuple, struct{}]
 }
 
 // TODO make this into a config value
 const maxPendingConns = 4096
 const pendingConnTimeoutNs = uint64(5 * time.Second)
+
+// In practice, linux remembers connections for 1 minute after close (see TCP_TIMEWAIT_LEN).
+// I don't think the exact value matters though, since we use an LRU cache regardless
+const recentlyClosedTimeout = 1 * time.Minute
 
 // NewTCPProcessor constructs an empty TCPProcessor
 func NewTCPProcessor(cfg *config.Config) *TCPProcessor {
@@ -89,6 +97,7 @@ func NewTCPProcessor(cfg *config.Config) *TCPProcessor {
 		cfg:              cfg,
 		pendingConns:     make(map[PCAPTuple]*connectionState, maxPendingConns),
 		establishedConns: make(map[PCAPTuple]*connectionState, cfg.MaxTrackedConnections),
+		recentlyClosed:   expirable.NewLRU[PCAPTuple, struct{}](int(cfg.MaxTrackedConnections), nil, recentlyClosedTimeout),
 	}
 }
 
@@ -297,6 +306,15 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, timestampNs uint64
 	}
 	origState := st.tcpState
 
+	if tcp.SYN {
+		// for some reason they're trying to re-use a recently-closed port
+		t.removeRecentlyClosed(tuple)
+	} else if t.isRecentlyClosed(tuple) {
+		// if it's recently closed, we don't want to run TCP state tracking on the retransmits.
+		// this avoids turning retransmits on recently closed connections into "partial connections"
+		return ProcessResultNone, nil
+	}
+
 	t.updateSynFlag(conn, st, pktType, tcp, payloadLen)
 	t.updateTCPStats(conn, st, pktType, tcp, payloadLen, timestampNs)
 	t.updateFinFlag(conn, st, pktType, tcp, payloadLen)
@@ -317,6 +335,7 @@ func (t *TCPProcessor) Process(conn *network.ConnectionStats, timestampNs uint64
 	}
 	// if the connection just closed, store it in the tracer's closeCallback
 	if st.tcpState == connStatClosed && stateChanged {
+		t.markRecentlyClosed(tuple)
 		return ProcessResultCloseConn, nil
 	}
 	return ProcessResultNone, nil
@@ -338,6 +357,9 @@ func (t *TCPProcessor) RemoveConn(tuple PCAPTuple) {
 	delete(t.establishedConns, tuple)
 }
 
+var pendingConnFullLimiter = log.NewLogLimit(20, 10*time.Minute)
+var establishedConnFullLimiter = log.NewLogLimit(20, 10*time.Minute)
+
 // moveConn moves a connection to the correct map based on its tcpState.
 // If it had to drop the connection because the target map was full, it returns false.
 func (t *TCPProcessor) moveConn(tuple PCAPTuple, st *connectionState) bool {
@@ -351,6 +373,9 @@ func (t *TCPProcessor) moveConn(tuple PCAPTuple, st *connectionState) bool {
 		ok := WriteMapWithSizeLimit(t.pendingConns, tuple, st, maxPendingConns)
 		if !ok {
 			statsTelemetry.droppedPendingConns.Inc()
+			if pendingConnFullLimiter.ShouldLog() {
+				log.Warnf("pending connections buffer filled to %d, connection droped", maxPendingConns)
+			}
 		}
 		return ok
 	case connStatEstablished:
@@ -358,6 +383,9 @@ func (t *TCPProcessor) moveConn(tuple PCAPTuple, st *connectionState) bool {
 		ok := WriteMapWithSizeLimit(t.establishedConns, tuple, st, maxTrackedConns)
 		if !ok {
 			statsTelemetry.droppedEstablishedConns.Inc()
+			if establishedConnFullLimiter.ShouldLog() {
+				log.Warnf("established connections buffer filled to %d, connection droped", maxTrackedConns)
+			}
 		}
 		return ok
 	}
@@ -404,4 +432,16 @@ func (t *TCPProcessor) GetConnDirection(tuple PCAPTuple) (network.ConnectionDire
 		return network.UNKNOWN, false
 	}
 	return conn.connDirection, true
+}
+
+func (t *TCPProcessor) markRecentlyClosed(tuple PCAPTuple) bool {
+	return t.recentlyClosed.Add(tuple, struct{}{})
+}
+
+func (t *TCPProcessor) removeRecentlyClosed(tuple PCAPTuple) bool {
+	return t.recentlyClosed.Remove(tuple)
+}
+
+func (t *TCPProcessor) isRecentlyClosed(tuple PCAPTuple) bool {
+	return t.recentlyClosed.Contains(tuple)
 }

--- a/pkg/network/tracer/connection/ebpfless/tcp_processor.go
+++ b/pkg/network/tracer/connection/ebpfless/tcp_processor.go
@@ -443,5 +443,6 @@ func (t *TCPProcessor) removeRecentlyClosed(tuple PCAPTuple) bool {
 }
 
 func (t *TCPProcessor) isRecentlyClosed(tuple PCAPTuple) bool {
-	return t.recentlyClosed.Contains(tuple)
+	_, ok := t.recentlyClosed.Peek(tuple)
+	return ok
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds a `recentlyClosed` LRU map which keeps track of recently closed connection tuples. Previously, if a retransmit occurred _after_ a connection closed, it would get re-opened as a preexisting connection. This PR makes TCPProcessor consider such connections to remain closed.

### Motivation
There have been reports of a spurious error in ebpfless, which I couldn't reproduce myself, but I fixed in [\[NPM-4334\] Silence misleading error in ebpfless](https://github.com/DataDog/datadog-agent/pull/35419). However, I found the reason I never saw the error myself was because it only occurred if a TCP connection expired via timeout (_not_ via normal connection closing). This got me suspicious that I was missing an edge case with TCP. It turns out there is one such edge case -- I wasn't handling retransmits after connection close properly.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
New test for this case, `TestIncomingRetransmitAfterClose` should pass in the TCP processor suite:
```
go test -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/network/tracer/connection/ebpfless
```

Ebpfless test suite should still pass:
```
sudo -E go test -race -tags=linux,linux_bpf,npm,process,test ./pkg/network/tracer -v --run TestTracerSuite/eBPFless
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
I also added a couple log warnings that I also want to get backported into 7.66.