### PR TITLE
trivy: fix nil created in containerd image inspector

### DIFF
--- a/pkg/util/trivy/containerd.go
+++ b/pkg/util/trivy/containerd.go
@@ -144,9 +144,14 @@ func inspect(ctx context.Context, imgMeta *workloadmeta.ContainerImageMetadata, 
 
 	var history []v1.History
 	for _, h := range imgConfig.History {
+		var created time.Time
+		if h.Created != nil {
+			created = *h.Created
+		}
+
 		history = append(history, v1.History{
 			Author:     h.Author,
-			Created:    v1.Time{Time: *h.Created},
+			Created:    v1.Time{Time: created},
 			CreatedBy:  h.CreatedBy,
 			Comment:    h.Comment,
 			EmptyLayer: h.EmptyLayer,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

According [to the spec](https://github.com/opencontainers/image-spec/blob/main/config.md#:~:text=the%20following%20fields%3A-,created%20string%2C%20OPTIONAL,-A%20combined%20date) the created field is optional (represented by a pointer here) and can be nil. This PR makes sure we handle this case correctly.

### Motivation

We hit a nil-ptr panic on staging because of this issue.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->