### PR TITLE
service discovery: Reduce overhead of readlink calls

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/ignore_proc_test.go
@@ -19,8 +19,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 // TestShouldIgnorePid check cases of ignored and non-ignored services
@@ -77,10 +75,7 @@ func TestShouldIgnorePid(t *testing.T) {
 			}, 3*time.Second, 100*time.Millisecond)
 
 			// now can check the ignored service
-			discoveryCtx := parsingContext{
-				procRoot:  kernel.ProcFSRoot(),
-				netNsInfo: make(map[uint32]*namespaceInfo),
-			}
+			discoveryCtx := newParsingContext()
 			service := discovery.getService(discoveryCtx, int32(cmd.Process.Pid))
 			if test.ignore {
 				require.Empty(t, service)

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux.go
@@ -13,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -383,38 +382,6 @@ func (s *discovery) handleCheck(w http.ResponseWriter, req *http.Request) {
 	}
 
 	utils.WriteAsJSON(w, services, utils.CompactOutput)
-}
-
-const prefix = "socket:["
-
-// getSockets get a list of socket inode numbers opened by a process
-func getSockets(pid int32) ([]uint64, error) {
-	statPath := kernel.HostProc(fmt.Sprintf("%d/fd", pid))
-	d, err := os.Open(statPath)
-	if err != nil {
-		return nil, err
-	}
-	defer d.Close()
-	fnames, err := d.Readdirnames(-1)
-	if err != nil {
-		return nil, err
-	}
-	var sockets []uint64
-	for _, fd := range fnames {
-		fullPath, err := os.Readlink(filepath.Join(statPath, fd))
-		if err != nil {
-			continue
-		}
-		if strings.HasPrefix(fullPath, prefix) {
-			sock, err := strconv.ParseUint(fullPath[len(prefix):len(fullPath)-1], 10, 64)
-			if err != nil {
-				continue
-			}
-			sockets = append(sockets, sock)
-		}
-	}
-
-	return sockets, nil
 }
 
 // socketInfo stores information related to each socket.

--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -22,7 +22,6 @@ import (
 	"regexp"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -1266,91 +1265,6 @@ func TestTagsPriority(t *testing.T) {
 			require.Equalf(t, c.expectedServiceName, name, "got wrong service name from container tags")
 			require.Equalf(t, c.expectedTagName, tagName, "got wrong tag name for service naming")
 		})
-	}
-}
-
-func getSocketsOld(p *process.Process) ([]uint64, error) {
-	FDs, err := p.OpenFiles()
-	if err != nil {
-		return nil, err
-	}
-
-	// sockets have the following pattern "socket:[inode]"
-	var sockets []uint64
-	for _, fd := range FDs {
-		if strings.HasPrefix(fd.Path, prefix) {
-			inodeStr := strings.TrimPrefix(fd.Path[:len(fd.Path)-1], prefix)
-			sock, err := strconv.ParseUint(inodeStr, 10, 64)
-			if err != nil {
-				continue
-			}
-			sockets = append(sockets, sock)
-		}
-	}
-
-	return sockets, nil
-}
-
-const (
-	numberFDs = 100
-)
-
-func createFilesAndSockets(tb testing.TB) {
-	listeningSockets := make([]net.Listener, 0, numberFDs)
-	tb.Cleanup(func() {
-		for _, l := range listeningSockets {
-			l.Close()
-		}
-	})
-	for i := 0; i < numberFDs; i++ {
-		l, err := net.Listen("tcp", "localhost:0")
-		require.NoError(tb, err)
-		listeningSockets = append(listeningSockets, l)
-	}
-	regularFDs := make([]*os.File, 0, numberFDs)
-	tb.Cleanup(func() {
-		for _, f := range regularFDs {
-			f.Close()
-		}
-	})
-	for i := 0; i < numberFDs; i++ {
-		f, err := os.CreateTemp("", "")
-		require.NoError(tb, err)
-		regularFDs = append(regularFDs, f)
-	}
-}
-
-func TestGetSockets(t *testing.T) {
-	createFilesAndSockets(t)
-	p, err := process.NewProcess(int32(os.Getpid()))
-	require.NoError(t, err)
-
-	sockets, err := getSockets(p.Pid)
-	require.NoError(t, err)
-
-	sockets2, err := getSocketsOld(p)
-	require.NoError(t, err)
-
-	require.Equal(t, sockets, sockets2)
-}
-
-func BenchmarkGetSockets(b *testing.B) {
-	createFilesAndSockets(b)
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		getSockets(int32(os.Getpid()))
-	}
-}
-
-func BenchmarkOldGetSockets(b *testing.B) {
-	createFilesAndSockets(b)
-	p, err := process.NewProcess(int32(os.Getpid()))
-	require.NoError(b, err)
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		getSocketsOld(p)
 	}
 }
 

--- a/pkg/collector/corechecks/servicediscovery/module/socket.go
+++ b/pkg/collector/corechecks/servicediscovery/module/socket.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package module
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+)
+
+const prefix = "socket:["
+
+// getSockets get a list of socket inode numbers opened by a process
+func getSockets(pid int32) ([]uint64, error) {
+	statPath := kernel.HostProc(fmt.Sprintf("%d/fd", pid))
+	d, err := os.Open(statPath)
+	if err != nil {
+		return nil, err
+	}
+	defer d.Close()
+	fnames, err := d.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	var sockets []uint64
+	for _, fd := range fnames {
+		fullPath, err := os.Readlink(filepath.Join(statPath, fd))
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(fullPath, prefix) {
+			sock, err := strconv.ParseUint(fullPath[len(prefix):len(fullPath)-1], 10, 64)
+			if err != nil {
+				continue
+			}
+			sockets = append(sockets, sock)
+		}
+	}
+
+	return sockets, nil
+}

--- a/pkg/collector/corechecks/servicediscovery/module/socket.go
+++ b/pkg/collector/corechecks/servicediscovery/module/socket.go
@@ -3,22 +3,52 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build linux
+
 package module
 
 import (
 	"fmt"
+	"io"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"golang.org/x/sys/unix"
 )
 
-const prefix = "socket:["
+const (
+	prefix = "socket:["
+	// readlinkBufferSize is the minimum size needed to read a socket path
+	// which looks like "socket:[165614651]"
+	readlinkBufferSize = 64
+)
+
+func readlinkat(dirfd int, fd string, buf []byte) (int, error) {
+	var n int
+	var err error
+	for {
+		n, err = unix.Readlinkat(dirfd, fd, buf)
+		if err != unix.EAGAIN {
+			break
+		}
+	}
+	if n == len(buf) {
+		// This indicates that the buffers was _possibly_ too small to read the
+		// entire path. Since we do not expect socket paths to be larger than
+		// our buffer size, we just return an error and ignore this file.
+		return n, io.ErrShortBuffer
+	}
+	return n, err
+}
 
 // getSockets get a list of socket inode numbers opened by a process
-func getSockets(pid int32) ([]uint64, error) {
+func getSockets(pid int32, buf []byte) ([]uint64, error) {
+	if len(buf) < readlinkBufferSize {
+		return nil, io.ErrShortBuffer
+	}
+
 	statPath := kernel.HostProc(fmt.Sprintf("%d/fd", pid))
 	d, err := os.Open(statPath)
 	if err != nil {
@@ -29,14 +59,17 @@ func getSockets(pid int32) ([]uint64, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	dirFd := int(d.Fd())
+
 	var sockets []uint64
 	for _, fd := range fnames {
-		fullPath, err := os.Readlink(filepath.Join(statPath, fd))
+		n, err := readlinkat(dirFd, fd, buf)
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(fullPath, prefix) {
-			sock, err := strconv.ParseUint(fullPath[len(prefix):len(fullPath)-1], 10, 64)
+		if strings.HasPrefix(string(buf[:n]), prefix) {
+			sock, err := strconv.ParseUint(string(buf[len(prefix):n-1]), 10, 64)
 			if err != nil {
 				continue
 			}

--- a/pkg/collector/corechecks/servicediscovery/module/socket_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/socket_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-present Datadog, Inc.
 
+//go:build linux
+
 package module
 
 import (

--- a/pkg/collector/corechecks/servicediscovery/module/socket_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/socket_test.go
@@ -6,17 +6,21 @@
 package module
 
 import (
+	"fmt"
+	"io"
 	"net"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/shirou/gopsutil/v4/process"
 	"github.com/stretchr/testify/require"
 )
 
-func getSocketsOld(p *process.Process) ([]uint64, error) {
+func getSocketsOriginal(p *process.Process) ([]uint64, error) {
 	FDs, err := p.OpenFiles()
 	if err != nil {
 		return nil, err
@@ -28,6 +32,35 @@ func getSocketsOld(p *process.Process) ([]uint64, error) {
 		if strings.HasPrefix(fd.Path, prefix) {
 			inodeStr := strings.TrimPrefix(fd.Path[:len(fd.Path)-1], prefix)
 			sock, err := strconv.ParseUint(inodeStr, 10, 64)
+			if err != nil {
+				continue
+			}
+			sockets = append(sockets, sock)
+		}
+	}
+
+	return sockets, nil
+}
+
+func getSocketsOld(pid int32) ([]uint64, error) {
+	statPath := kernel.HostProc(fmt.Sprintf("%d/fd", pid))
+	d, err := os.Open(statPath)
+	if err != nil {
+		return nil, err
+	}
+	defer d.Close()
+	fnames, err := d.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	var sockets []uint64
+	for _, fd := range fnames {
+		fullPath, err := os.Readlink(filepath.Join(statPath, fd))
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(fullPath, prefix) {
+			sock, err := strconv.ParseUint(fullPath[len(prefix):len(fullPath)-1], 10, 64)
 			if err != nil {
 				continue
 			}
@@ -72,31 +105,73 @@ func TestGetSockets(t *testing.T) {
 	p, err := process.NewProcess(int32(os.Getpid()))
 	require.NoError(t, err)
 
-	sockets, err := getSockets(p.Pid)
+	buf := make([]byte, readlinkBufferSize)
+	sockets, err := getSockets(p.Pid, buf)
 	require.NoError(t, err)
 
-	sockets2, err := getSocketsOld(p)
+	socketsOld, err := getSocketsOld(p.Pid)
 	require.NoError(t, err)
 
-	require.Equal(t, sockets, sockets2)
+	socketsOriginal, err := getSocketsOriginal(p)
+	require.NoError(t, err)
+
+	require.Equal(t, sockets, socketsOld)
+	require.Equal(t, sockets, socketsOriginal)
+}
+
+func TestGetSocketsBufferTooSmall(t *testing.T) {
+	p, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+
+	buf := make([]byte, readlinkBufferSize-1)
+	_, err = getSockets(p.Pid, buf)
+	require.ErrorIs(t, err, io.ErrShortBuffer)
+}
+
+func TestReadlinkatBufferFull(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a symlink with a path that is longer than our buffer size
+	target := strings.Repeat("A", readlinkBufferSize+1)
+	symlinkPath := filepath.Join(tmpDir, "testlink")
+	err := os.Symlink(target, symlinkPath)
+	require.NoError(t, err)
+
+	dir, err := os.Open(tmpDir)
+	require.NoError(t, err)
+	defer dir.Close()
+
+	buf := make([]byte, readlinkBufferSize)
+	_, err = readlinkat(int(dir.Fd()), "testlink", buf)
+	require.ErrorIs(t, err, io.ErrShortBuffer)
 }
 
 func BenchmarkGetSockets(b *testing.B) {
 	createFilesAndSockets(b)
+	buf := make([]byte, readlinkBufferSize)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		getSockets(int32(os.Getpid()))
+		getSockets(int32(os.Getpid()), buf)
 	}
 }
 
-func BenchmarkOldGetSockets(b *testing.B) {
+func BenchmarkGetSocketsOld(b *testing.B) {
+	createFilesAndSockets(b)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		getSocketsOld(int32(os.Getpid()))
+	}
+}
+
+func BenchmarkGetSocketsOriginal(b *testing.B) {
 	createFilesAndSockets(b)
 	p, err := process.NewProcess(int32(os.Getpid()))
 	require.NoError(b, err)
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		getSocketsOld(p)
+		getSocketsOriginal(p)
 	}
 }

--- a/pkg/collector/corechecks/servicediscovery/module/socket_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/socket_test.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package module
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/shirou/gopsutil/v4/process"
+	"github.com/stretchr/testify/require"
+)
+
+func getSocketsOld(p *process.Process) ([]uint64, error) {
+	FDs, err := p.OpenFiles()
+	if err != nil {
+		return nil, err
+	}
+
+	// sockets have the following pattern "socket:[inode]"
+	var sockets []uint64
+	for _, fd := range FDs {
+		if strings.HasPrefix(fd.Path, prefix) {
+			inodeStr := strings.TrimPrefix(fd.Path[:len(fd.Path)-1], prefix)
+			sock, err := strconv.ParseUint(inodeStr, 10, 64)
+			if err != nil {
+				continue
+			}
+			sockets = append(sockets, sock)
+		}
+	}
+
+	return sockets, nil
+}
+
+const (
+	numberFDs = 100
+)
+
+func createFilesAndSockets(tb testing.TB) {
+	listeningSockets := make([]net.Listener, 0, numberFDs)
+	tb.Cleanup(func() {
+		for _, l := range listeningSockets {
+			l.Close()
+		}
+	})
+	for i := 0; i < numberFDs; i++ {
+		l, err := net.Listen("tcp", "localhost:0")
+		require.NoError(tb, err)
+		listeningSockets = append(listeningSockets, l)
+	}
+	regularFDs := make([]*os.File, 0, numberFDs)
+	tb.Cleanup(func() {
+		for _, f := range regularFDs {
+			f.Close()
+		}
+	})
+	for i := 0; i < numberFDs; i++ {
+		f, err := os.CreateTemp("", "")
+		require.NoError(tb, err)
+		regularFDs = append(regularFDs, f)
+	}
+}
+
+func TestGetSockets(t *testing.T) {
+	createFilesAndSockets(t)
+	p, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(t, err)
+
+	sockets, err := getSockets(p.Pid)
+	require.NoError(t, err)
+
+	sockets2, err := getSocketsOld(p)
+	require.NoError(t, err)
+
+	require.Equal(t, sockets, sockets2)
+}
+
+func BenchmarkGetSockets(b *testing.B) {
+	createFilesAndSockets(b)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		getSockets(int32(os.Getpid()))
+	}
+}
+
+func BenchmarkOldGetSockets(b *testing.B) {
+	createFilesAndSockets(b)
+	p, err := process.NewProcess(int32(os.Getpid()))
+	require.NoError(b, err)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		getSocketsOld(p)
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

service discovery: Reduce overhead of readlink calls

Reduce the overhead of the readlink usage while getting socket inodes by
fixing some low-hanging fruits:

- The Go standard library readlink tries with a smaller buffer (128
  bytes) and then increases the sizes if it's not enough.  This is
  unnecessary in our case since we currently only need to read socket
  inodes.

- The readlink internally allocates a buffer every time, but we only
  use the buffer for parsing out the inode so we can re-use the same
  buffer every time.

- readlinkat(2) is not used so the path needs to be joined every
  time.

This shows a ~35% shorter execution time and ~75% fewer bytes allocated
in benchmarks:

```
 BenchmarkGetSockets-20                      8744            136404 ns/op 12845 B/op        426 allocs/op
 BenchmarkGetSocketsOld-20                   6088            212760 ns/op 52523 B/op       1044 allocs/op
 BenchmarkGetSocketsOriginal-20              5434            221940 ns/op 67390 B/op       1260 allocs/op
```
### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-92

### Describe how you validated your changes

Unit tests.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
