### PR TITLE
Implement a repackaging based faster local package build

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -107,8 +107,7 @@ end
 do_build = false
 do_package = false
 
-if ENV["OMNIBUS_PACKAGE_ARTIFACT_DIR"]
-  dependency "package-artifact"
+if ENV["OMNIBUS_PACKAGE_ARTIFACT_DIR"] or do_repackage?
   do_package = true
   skip_healthcheck true
 else
@@ -258,7 +257,12 @@ if do_build
     dependency "init-scripts-agent"
   end
 elsif do_package
-  dependency "package-artifact"
+  if do_repackage?
+    dependency "existing-agent-package"
+    dependency "datadog-agent"
+  else
+    dependency "package-artifact"
+  end
   dependency "init-scripts-agent"
 end
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -9,20 +9,27 @@ require 'pathname'
 
 name 'datadog-agent'
 
-# creates required build directories
-dependency 'datadog-agent-prepare'
+# We don't want to build any dependencies in "repackaging mode" so all usual dependencies
+# need to go under this guard.
+unless do_repackage?
+  # creates required build directories
+  dependency 'datadog-agent-prepare'
 
-dependency "python3"
+  dependency "python3"
 
-dependency "openscap" if linux_target? and !arm7l_target? and !heroku_target? # Security-agent dependency, not needed for Heroku
+  dependency "openscap" if linux_target? and !arm7l_target? and !heroku_target? # Security-agent dependency, not needed for Heroku
 
-# Alternative memory allocator which has better support for memory allocated by cgo calls,
-# especially at higher thread counts.
-dependency "libjemalloc" if linux_target?
+  # Alternative memory allocator which has better support for memory allocated by cgo calls,
+  # especially at higher thread counts.
+  dependency "libjemalloc" if linux_target?
 
-dependency 'datadog-agent-dependencies'
+  dependency 'datadog-agent-dependencies'
+end
 
-source path: '..'
+source path: '..',
+       options: {
+         exclude: ["**/testdata/**/*"],
+       }
 relative_path 'src/github.com/DataDog/datadog-agent'
 
 always_build true

--- a/omnibus/config/software/existing-agent-package.rb
+++ b/omnibus/config/software/existing-agent-package.rb
@@ -4,10 +4,10 @@ description 'A previously built artifact, unpacked'
 
 always_build true
 
-# TODO: Configurable URL, version, and arch
-target_package = "datadog-agent_7.64.0-1_arm64.deb"
-source url: "https://apt.datadoghq.com/pool/d/da/#{target_package}",
-       sha256: "c3d8b4c879530967876ccd315876fc40b8c77e945e44297ff6cb854713bb3dd4",
+source_url = ENV['OMNIBUS_REPACKAGE_SOURCE_URL']
+target_package = File.basename(source_url)
+source url: source_url,
+       sha256: ENV['OMNIBUS_REPACKAGE_SOURCE_SHA256'],
        target_filename: target_package
 
 build do

--- a/omnibus/config/software/existing-agent-package.rb
+++ b/omnibus/config/software/existing-agent-package.rb
@@ -1,0 +1,15 @@
+name 'existing-agent-package'
+
+description 'A previously built artifact, unpacked'
+
+always_build true
+
+# TODO: Configurable URL, version, and arch
+target_package = "datadog-agent_7.64.0-1_arm64.deb"
+source url: "https://apt.datadoghq.com/pool/d/da/#{target_package}",
+       sha256: "c3d8b4c879530967876ccd315876fc40b8c77e945e44297ff6cb854713bb3dd4",
+       target_filename: target_package
+
+build do
+  command "dpkg --unpack #{target_package}"
+end

--- a/omnibus/config/software/package-artifact.rb
+++ b/omnibus/config/software/package-artifact.rb
@@ -1,4 +1,4 @@
-name 'package-artifacts'
+name 'package-artifact'
 
 description "Helper to package an XZ build artifact to deb/rpm/..."
 
@@ -54,8 +54,8 @@ build do
     end
     # Omnibus hardcodes the template rendering to be in config/templates/<software-name>
     # so we need to move the input to its expected location
-    FileUtils.mkdir_p "#{Omnibus::Config.project_root()}/config/templates/package-artifacts"
-    FileUtils.move "#{Omnibus::Config.project_root()}/config/templates/installer/README.md.erb", "#{Omnibus::Config.project_root()}/config/templates/package-artifacts/README.md.erb"
+    FileUtils.mkdir_p "#{Omnibus::Config.project_root()}/config/templates/package-artifact"
+    FileUtils.move "#{Omnibus::Config.project_root()}/config/templates/installer/README.md.erb", "#{Omnibus::Config.project_root()}/config/templates/package-artifact/README.md.erb"
     erb source: "README.md.erb",
        dest: "#{install_dir}/README.md",
        mode: 0644,

--- a/omnibus/lib/project_helpers.rb
+++ b/omnibus/lib/project_helpers.rb
@@ -17,5 +17,5 @@ end
 # Determines whether we're under "repackaging" mode for the Agent, which means that we'll try to
 # use an existing package and just build the datadog-agent definition without any dependencies
 def do_repackage?
-  return !ENV.fetch('OMNIBUS_REPACKAGE', '').empty?
+  return !ENV.fetch('OMNIBUS_REPACKAGE_SOURCE_URL', '').empty?
 end

--- a/omnibus/lib/project_helpers.rb
+++ b/omnibus/lib/project_helpers.rb
@@ -13,3 +13,9 @@ end
 def windows_signing_enabled?()
   return ENV['SIGN_WINDOWS_DD_WCS']
 end
+
+# Determines whether we're under "repackaging" mode for the Agent, which means that we'll try to
+# use an existing package and just build the datadog-agent definition without any dependencies
+def do_repackage?
+  return !ENV.fetch('OMNIBUS_REPACKAGE', '').empty?
+end

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -433,19 +433,7 @@ def build_repackaged_agent(ctx, log_level="info"):
 
     env['OMNIBUS_REPACKAGE_SOURCE_URL'] = f"https://apt.datad0g.com/{latest_package.filename}"
     env['OMNIBUS_REPACKAGE_SOURCE_SHA256'] = latest_package.sha256
-
     print("Using the following package as a base:", env['OMNIBUS_REPACKAGE_SOURCE_URL'])
-
-    # Instruct omnibus to use the toolchain targetting the right glibc
-    if sys.platform == "linux":
-        env["PATH"] = f"/opt/toolchains/x86_64/bin:{os.environ.get('PATH', '')}"
-        env.update(
-            {
-                "DD_CC": "x86_64-unknown-linux-gnu-gcc",
-                "DD_CXX": "x86_64-unknown-linux-gnu-g++",
-                "DD_CMAKE_TOOLCHAIN": "/opt/cmake/x86_64-unknown-linux-gnu.toolchain.cmake",
-            }
-        )
 
     bundle_install_omnibus(ctx, None, env)
 

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -395,12 +395,12 @@ def manifest(
     )
 
 
-@task
+@task()
 def build_repackaged_agent(ctx, log_level="info"):
     """
     Create an Agent package by using an existing Agent package as a base and rebuilding the Agent binaries with the local checkout.
 
-    Currently only works for debian packages.
+    Currently only expected to work for debian packages, and requires the `dpkg` command to be available.
     """
     # Make sure we let the user know that we're going to overwrite the existing Agent installation if present
     agent_path = "/opt/datadog-agent"
@@ -416,10 +416,12 @@ def build_repackaged_agent(ctx, log_level="info"):
 
         shutil.rmtree("/opt/datadog-agent")
 
+    architecture = ctx.run("dpkg --print-architecture", hide=True).stdout.strip()
+
     # Fetch the Packages file from the nightly repository and get the datadog-agent package with the highest pipeline ID
     # The assumption here is that only nightlies from master are pushed to the nightly repository
     # and that simply picking up the highest pipeline ID will give us what we want without having to query Gitlab.
-    packages_url = "https://apt.datad0g.com/dists/nightly/7/binary-amd64/Packages"
+    packages_url = f"https://apt.datad0g.com/dists/nightly/7/binary-{architecture}/Packages"
     with requests.get(packages_url, stream=True) as response:
         response.raise_for_status()
         lines = response.iter_lines(decode_unicode=True)

--- a/tasks/unit_tests/omnibus_tests.py
+++ b/tasks/unit_tests/omnibus_tests.py
@@ -285,3 +285,75 @@ class TestRpathEdit(unittest.TestCase):
         )
         # We can't assert regex based temporary name in calls, hence we're checking that we get the correct total number of calls
         assert len(call_list) == 8
+
+
+class TestBuildRepackagedAgent(unittest.TestCase):
+    def test_package_parsing(self):
+        # Sample Packages file content
+        packages_content = """
+Package: datadog-agent
+Version: 1:7.67.0~devel.git.113.2750233.pipeline.63430585-1
+Architecture: amd64
+Filename: pool/d/da/datadog-agent_7.67.0~devel.git.113.2750233.pipeline.63430585-1_amd64.deb
+SHA256: abc123def456
+Description: Datadog Monitoring Agent
+ The Datadog Monitoring Agent is a lightweight process that monitors system
+ processes and services, and sends information back to your Datadog account.
+
+Package: datadog-iot-agent
+Version: 1:7.67.0~devel.git.113.2750233.pipeline.63430585-1
+Architecture: amd64
+Filename: pool/o/ot/other-package_1.0.0_amd64.deb
+SHA256: 789ghi
+Description: Datadog IoT Agent
+ The Datadog IoT Agent is a lightweight process that monitors system
+ processes and services, and sends information back to your Datadog account.
+
+Package: datadog-agent
+Version: 1:7.67.0~devel.git.113.2750233.pipeline.63448947-1
+Architecture: amd64
+Filename: pool/d/da/datadog-agent_7.67.0~devel.git.113.2750233.pipeline.63448947-1_amd64.deb
+SHA256: def456abc789
+Description: Datadog Monitoring Agent
+ This is the datadog-agent package with the highest pipeline ID
+
+Package: datadog-agent
+Version: 1:7.0.0~alpha.1-1
+Architecture: amd64
+Filename: pool/d/da/datadog-agent_7.0.0~alpha.1-1_amd64.deb
+SHA256: f8eb7c99c10c0362490f32c3bf3815193f5cf0778c2b074a208c838d09ef3181
+Description: Datadog Monitoring Agent
+ This package doesn't have a pipeline ID
+"""
+        mock_ctx = MockContextRaising(run={})
+        # Set up some broadly catching patterns for commands that are known to run
+        patterns = [
+            (r'bundle .*', Result()),
+            (r'git describe --tags .*', Result('7.67.0-beta.0-1-g4f19118')),
+            (r'git .*', Result()),
+            (r'aws s3 .*', Result()),
+        ]
+        for pattern, result in patterns:
+            mock_ctx.set_result_for('run', re.compile(pattern), result)
+
+        with (
+            mock.patch('os.path.exists', return_value=False),
+            mock.patch('tasks.omnibus.omnibus_run_task') as mock_run_task,
+            mock.patch('requests.get') as mock_get,
+        ):
+            # Set up the mock response to return the packages content
+            mock_response = mock.MagicMock()
+            mock_response.__enter__.return_value.iter_lines.return_value = packages_content.splitlines()
+            mock_get.return_value = mock_response
+
+            omnibus.build_repackaged_agent(mock_ctx)
+
+            # Verify omnibus_run_task was called with the correct environment variables
+            mock_run_task.assert_called_once()
+            _, kwargs = mock_run_task.call_args
+            env = kwargs['env']
+            self.assertEqual(
+                env['OMNIBUS_REPACKAGE_SOURCE_URL'],
+                'https://apt.datad0g.com/pool/d/da/datadog-agent_7.67.0~devel.git.113.2750233.pipeline.63448947-1_amd64.deb',
+            )
+            self.assertEqual(env['OMNIBUS_REPACKAGE_SOURCE_SHA256'], 'def456abc789')


### PR DESCRIPTION
### What does this PR do?

This PR adds an invoke task that allows developers to build an Agent package by reusing an existing package and just rebuilding the Agent binaries, such that it can be used for e2e testing via the `--local-package` flag.

This is currently limited to debian packages, and the package used as a "base" for the repackaging is taken as the latest successful nightly build.

### Motivation

[BARX-953](https://datadoghq.atlassian.net/browse/BARX-953)

We mainly want to provide a short-term improvement for the feedback loop for using E2E tests.

### Describe how you validated your changes

Unit tests + running the command multiple times on an amd64 devenv, and then running E2E tests successfully like so:

``` bash
dda inv -- new-e2e-tests.run -r TestLinuxRunSuite --local-package $(pwd)/'omnibus/pkg/${package_name}.deb' --targets ./tests/agent-subcommands/run
```

The build also completes successfully for arm64, but the tests run on amd64 environments currently, and I could therefore not do much more with it.

### Possible Drawbacks / Trade-offs

- This assumes that only nightly builds are ever put in the apt repository we're querying, and that thus we can just pick up the one with the highest pipeline number. As far as I know this should always hold, and simplifies the implementation by avoiding having to query Gitlab to confirm.
- This can only be run from a Linux environment, and preferably from a dev-env (I used `dda env dev` subcommands when testing this myself). And due to how e2e tests currently expect amd64 throughout, an amd64 environment is required to build packages that are usable for this purpose. This implies emulation on e.g. arm macOS, which makes the build slower than without emulation; supporting arm64 environments on e2e tests has been a solution that has been discussed and which may happen.
- Also, the build, since it runs on Omnibus, is expected to always overwrite `/opt/datadog-agent` (and the assumption is made currently that that's where it will be built and installed). There might be ways to use a different folder which we would look into if this proves to be a significant annoyance.

The implementation is based on reusing a concept similar to how we split the build and packaging steps of Linux packages within Omnibus. This significantly reduces the overall complexity for the solution, increases fidelity (to the actual build) and reduces maintenance burden. The drawbacks are that it intermingles the logic in Omnibus with the definitions that are used to do the "regular" builds, and that it might reduce the amount of customization that we're able to introduce.

### Additional Notes

To build binaries that are glibc-compatible with all environments we support, setting [these variables](https://github.com/DataDog/datadog-agent-buildimages/blob/5400b7335ca1889861cbaa4e0e781f06f9e5fae7/linux-glibc-2.17-x64/Dockerfile#L47-L49) is necessary (as they're set in our regular builds). https://github.com/DataDog/datadog-agent-buildimages/pull/838 should make our dev-env images already have that properly set up.

Further enhancements are possible but this is already usable in its current state; we can do those in follow-up PR's.

[BARX-953]: https://datadoghq.atlassian.net/browse/BARX-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ