### PR TITLE
service discovery: Get name from uvicorn command line

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/usm/service_test.go
+++ b/pkg/collector/corechecks/servicediscovery/usm/service_test.go
@@ -827,6 +827,83 @@ func TestExtractServiceMetadata(t *testing.T) {
 			expectedGeneratedName:       "airflow-webserver",
 			expectedGeneratedNameSource: CommandLine,
 		},
+		{
+			name: "uvicorn with first arg",
+			cmdline: []string{
+				"/usr/local/bin/python",
+				"/usr/local/bin/uvicorn",
+				"myapp.asgi:application",
+				"--host=0.0.0.0",
+				"--port=8000",
+			},
+			lang:                        language.Python,
+			expectedGeneratedName:       "myapp.asgi",
+			expectedGeneratedNameSource: CommandLine,
+		},
+		{
+			name: "uvicorn with middle args",
+			cmdline: []string{
+				"/app/.venv/bin/python3",
+				"/app/.venv/bin/uvicorn",
+				"--factory",
+				"--host=0.0.0.0",
+				"--port=8000",
+				"app:create_app",
+				"--workers=4",
+			},
+			lang:                        language.Python,
+			expectedGeneratedName:       "app",
+			expectedGeneratedNameSource: CommandLine,
+		},
+		{
+			name: "uvicorn with header",
+			cmdline: []string{
+				"/usr/local/bin/python3",
+				"/usr/local/bin/uvicorn",
+				"--header=X-Foo:Bar",
+				"api.v1.app:app",
+			},
+			lang:                        language.Python,
+			expectedGeneratedName:       "api.v1.app",
+			expectedGeneratedNameSource: CommandLine,
+		},
+		{
+			name: "uvicorn with header separate",
+			cmdline: []string{
+				"/usr/local/bin/python3",
+				"/usr/local/bin/uvicorn",
+				"--header",
+				"X-Foo:Bar",
+				"api.v1.app:app",
+			},
+			lang:                        language.Python,
+			expectedGeneratedName:       "api.v1.app",
+			expectedGeneratedNameSource: CommandLine,
+		},
+		{
+			name: "uvicorn with header separate last",
+			cmdline: []string{
+				"/usr/local/bin/python3",
+				"/usr/local/bin/uvicorn",
+				"api.v1.app:app",
+				"--header",
+				"X-Foo:Bar",
+			},
+			lang:                        language.Python,
+			expectedGeneratedName:       "api.v1.app",
+			expectedGeneratedNameSource: CommandLine,
+		},
+		{
+			name: "uvicorn unknown",
+			cmdline: []string{
+				"/usr/local/bin/python3",
+				"/usr/local/bin/uvicorn",
+				"foo",
+			},
+			lang:                        language.Python,
+			expectedGeneratedName:       "uvicorn",
+			expectedGeneratedNameSource: CommandLine,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Parse out the name from uvicorn similar to gunicorn. Since python is
always on the uvicorn command line we don't need a separate detector but
add the support to the Python one.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-66

### Describe how you validated your changes

Unit tests added.

Also dumped all rows with names currently generated as "uvicorn" from staging
and ran their command lines through the new code.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
