### PR TITLE
[CWS] Fix `proc_cache_t` marshalling

### DIFF
--- a/pkg/security/secl/model/marshallers_linux.go
+++ b/pkg/security/secl/model/marshallers_linux.go
@@ -83,15 +83,14 @@ func (e *Process) MarshalProcCache(data []byte, bootTime time.Time) (int, error)
 	written := ContainerIDLen + 8
 
 	// process without cgroup should be mainly pid 1
-	if !e.CGroup.CGroupFile.IsNull() {
-		toAdd, err := e.CGroup.CGroupFile.MarshalBinary()
-		if err != nil {
-			return 0, err
-		}
-
-		copy(data[written:written+len(toAdd)], toAdd)
-		written += len(toAdd)
+	// TODO: fix empty cgroup path key for not-pid-1 processes
+	toAdd, err := e.CGroup.CGroupFile.MarshalBinaryAllowEmpty()
+	if err != nil {
+		return 0, err
 	}
+
+	copy(data[written:written+len(toAdd)], toAdd)
+	written += len(toAdd)
 
 	added, err := MarshalBinary(data[written:], &e.FileEvent)
 	if err != nil {
@@ -210,5 +209,12 @@ func (p *PathKey) MarshalBinary() ([]byte, error) {
 	buff := make([]byte, 16)
 	p.Write(buff)
 
+	return buff, nil
+}
+
+// MarshalBinaryAllowEmpty returns the binary representation of a path key with could be empty
+func (p *PathKey) MarshalBinaryAllowEmpty() ([]byte, error) {
+	buff := make([]byte, 16)
+	p.Write(buff)
 	return buff, nil
 }

--- a/pkg/security/secl/model/marshallers_linux.go
+++ b/pkg/security/secl/model/marshallers_linux.go
@@ -84,13 +84,8 @@ func (e *Process) MarshalProcCache(data []byte, bootTime time.Time) (int, error)
 
 	// process without cgroup should be mainly pid 1
 	// TODO: fix empty cgroup path key for not-pid-1 processes
-	toAdd, err := e.CGroup.CGroupFile.MarshalBinaryAllowEmpty()
-	if err != nil {
-		return 0, err
-	}
-
-	copy(data[written:written+len(toAdd)], toAdd)
-	written += len(toAdd)
+	e.CGroup.CGroupFile.Write(data[written:])
+	written += PathKeySize
 
 	added, err := MarshalBinary(data[written:], &e.FileEvent)
 	if err != nil {
@@ -206,15 +201,8 @@ func (p *PathKey) MarshalBinary() ([]byte, error) {
 		return nil, &ErrInvalidKeyPath{Inode: p.Inode, MountID: p.MountID}
 	}
 
-	buff := make([]byte, 16)
+	buff := make([]byte, PathKeySize)
 	p.Write(buff)
 
-	return buff, nil
-}
-
-// MarshalBinaryAllowEmpty returns the binary representation of a path key with could be empty
-func (p *PathKey) MarshalBinaryAllowEmpty() ([]byte, error) {
-	buff := make([]byte, 16)
-	p.Write(buff)
 	return buff, nil
 }

--- a/pkg/security/secl/model/marshallers_test.go
+++ b/pkg/security/secl/model/marshallers_test.go
@@ -1,0 +1,275 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+// Package model holds model related files
+package model
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
+)
+
+type testIntegerType interface {
+	uint64 | uint32 | uint16
+}
+
+type testInteger[T testIntegerType] struct {
+	value   T
+	binData []byte
+}
+
+func newTestInteger[T testIntegerType](value T) *testInteger[T] {
+	var buffer []byte
+	switch value := any(value).(type) {
+	case uint64:
+		buffer = make([]byte, 8)
+		binary.NativeEndian.PutUint64(buffer, value)
+	case uint32:
+		buffer = make([]byte, 4)
+		binary.NativeEndian.PutUint32(buffer, value)
+	case uint16:
+		buffer = make([]byte, 2)
+		binary.NativeEndian.PutUint16(buffer, value)
+	default:
+		panic("unsupported type")
+	}
+
+	return &testInteger[T]{
+		value:   value,
+		binData: buffer,
+	}
+}
+
+func TestMarshalProcCache(t *testing.T) {
+	const procCacheSize = 248
+
+	testCgroupFlags := newTestInteger(uint64(1))
+	testCGroupFileInode := newTestInteger(uint64(123456789))
+	testCGroupFileMountID := newTestInteger(uint32(24))
+	testCGroupFilePathID := newTestInteger(uint32(808))
+	testFileInode := newTestInteger(uint64(987654321))
+	testFileMountID := newTestInteger(uint32(42))
+	testFilePathID := newTestInteger(uint32(404))
+	testFileFlags := newTestInteger(uint32(3))
+	testFileUID := newTestInteger(uint32(1000))
+	testFileGID := newTestInteger(uint32(1000))
+	testFileNLink := newTestInteger(uint32(2))
+	testFileMode := newTestInteger(uint16(0755))
+	testFileCTime := newTestInteger(uint64(622547800))
+	testFileMTime := newTestInteger(uint64(622547800))
+
+	testBootTime := time.Unix(159, 0)
+	testExecTime := time.Unix(951, 0)
+	testExecEpochTime := newTestInteger(uint64(testExecTime.Sub(testBootTime)))
+
+	testCases := []struct {
+		name               string
+		process            Process
+		bootTime           time.Time
+		expectedDataChunks [][]byte
+	}{
+		{
+			name:     "empty process",
+			process:  Process{},
+			bootTime: time.Time{},
+			expectedDataChunks: [][]byte{
+				make([]byte, procCacheSize),
+			},
+		},
+		{
+			name: "process with comm",
+			process: Process{
+				Comm: "test-process",
+			},
+			bootTime: time.Time{},
+			expectedDataChunks: [][]byte{
+				make([]byte, procCacheSize-16),
+				{
+					't', 'e', 's', 't', '-', 'p', 'r', 'o',
+					'c', 'e', 's', 's', 0x00, 0x00, 0x00, 0x00,
+				},
+			},
+		},
+		{
+			name: "process-with-cgroup-key",
+			process: Process{
+				ContainerID: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				CGroup: CGroupContext{
+					CGroupFlags: containerutils.CGroupFlags(testCgroupFlags.value),
+					CGroupFile: PathKey{
+						Inode:   testCGroupFileInode.value,
+						MountID: testCGroupFileMountID.value,
+						PathID:  testCGroupFilePathID.value,
+					},
+				},
+				FileEvent: FileEvent{
+					FileFields: FileFields{
+						PathKey: PathKey{
+							Inode:   testFileInode.value,
+							MountID: testFileMountID.value,
+							PathID:  testFilePathID.value,
+						},
+						Flags: int32(testFileFlags.value),
+						UID:   testFileUID.value,
+						GID:   testFileGID.value,
+						NLink: testFileNLink.value,
+						Mode:  testFileMode.value,
+						CTime: testFileCTime.value,
+						MTime: testFileMTime.value,
+					},
+				},
+				ExecTime: testExecTime,
+				TTYName:  "tty1",
+				Comm:     "test-process",
+			},
+			bootTime: testBootTime,
+			expectedDataChunks: [][]byte{
+				{
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+				},
+				testCgroupFlags.binData,
+				testCGroupFileInode.binData,
+				testCGroupFileMountID.binData,
+				testCGroupFilePathID.binData,
+				testFileInode.binData,
+				testFileMountID.binData,
+				testFilePathID.binData,
+				testFileFlags.binData,
+				make([]byte, 4), // padding
+				testFileUID.binData,
+				testFileGID.binData,
+				testFileNLink.binData,
+				testFileMode.binData,
+				make([]byte, 2), // padding
+				make([]byte, 8), // ctime sec
+				testFileCTime.binData,
+				make([]byte, 8), // mtime sec
+				testFileMTime.binData,
+				testExecEpochTime.binData,
+				{
+					't', 't', 'y', '1', 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				},
+				{
+					't', 'e', 's', 't', '-', 'p', 'r', 'o',
+					'c', 'e', 's', 's', 0x00, 0x00, 0x00, 0x00,
+				},
+			},
+		},
+		{
+			name: "process-without-cgroup-key",
+			process: Process{
+				ContainerID: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				CGroup: CGroupContext{
+					CGroupFlags: containerutils.CGroupFlags(testCgroupFlags.value),
+				},
+				FileEvent: FileEvent{
+					FileFields: FileFields{
+						PathKey: PathKey{
+							Inode:   testFileInode.value,
+							MountID: testFileMountID.value,
+							PathID:  testFilePathID.value,
+						},
+						Flags: int32(testFileFlags.value),
+						UID:   testFileUID.value,
+						GID:   testFileGID.value,
+						NLink: testFileNLink.value,
+						Mode:  testFileMode.value,
+						CTime: testFileCTime.value,
+						MTime: testFileMTime.value,
+					},
+				},
+				ExecTime: testExecTime,
+				TTYName:  "tty1",
+				Comm:     "test-process",
+			},
+			bootTime: testBootTime,
+			expectedDataChunks: [][]byte{
+				{
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+					'0', '1', '2', '3', '4', '5', '6', '7',
+					'8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+				},
+				testCgroupFlags.binData,
+				make([]byte, 8), // cgroup file inode
+				make([]byte, 4), // cgroup file mount id
+				make([]byte, 4), // cgroup file path id
+				testFileInode.binData,
+				testFileMountID.binData,
+				testFilePathID.binData,
+				testFileFlags.binData,
+				make([]byte, 4), // padding
+				testFileUID.binData,
+				testFileGID.binData,
+				testFileNLink.binData,
+				testFileMode.binData,
+				make([]byte, 2), // padding
+				make([]byte, 8), // ctime sec
+				testFileCTime.binData,
+				make([]byte, 8), // mtime sec
+				testFileMTime.binData,
+				testExecEpochTime.binData,
+				{
+					't', 't', 'y', '1', 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				},
+				{
+					't', 'e', 's', 't', '-', 'p', 'r', 'o',
+					'c', 'e', 's', 's', 0x00, 0x00, 0x00, 0x00,
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			var expectedData []byte
+			for _, chunk := range testCase.expectedDataChunks {
+				expectedData = append(expectedData, chunk...)
+			}
+
+			data := make([]byte, procCacheSize)
+			n, err := testCase.process.MarshalProcCache(data, testCase.bootTime)
+			if err != nil {
+				t.Fatalf("failed to marshal process: %v", err)
+			}
+
+			assert.Equal(t, len(expectedData), n)
+			assert.Equal(t, len(expectedData), len(data))
+			assert.Equal(t, expectedData, data)
+		})
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fix `proc_cache_t` marshalling that was corrupted for processes with an empty cgroup path key due to an incorrect write offset.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->