### PR TITLE
[BARX-661] remove leftover release_version

### DIFF
--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -95,18 +95,17 @@ rm -rf "$OMNIBUS_DIR" && mkdir -p "$OMNIBUS_DIR"
 if [ "$SIGN" = "true" ]; then
     # Unlock the keychain to get access to the signing certificates
     security unlock-keychain -p "$KEYCHAIN_PWD" "$KEYCHAIN_NAME"
-    dda inv -- -e omnibus.build --hardened-runtime --release-version "$RELEASE_VERSION" --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
+    dda inv -- -e omnibus.build --hardened-runtime --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
     # Lock the keychain once we're done
     security lock-keychain "$KEYCHAIN_NAME"
 else
-    dda inv -- -e omnibus.build --skip-sign --release-version "$RELEASE_VERSION" --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
+    dda inv -- -e omnibus.build --skip-sign --config-directory "$CONFIG_DIR" --install-directory "$INSTALL_DIR" --base-dir "$OMNIBUS_DIR" || exit 1
 fi
 echo Built packages using omnibus
 
 # --- Notarization ---
 if [ "$SIGN" = true ]; then
     echo -e "\e[0Ksection_start:`date +%s`:notarization\r\e[0KDoing notarization"
-    export RELEASE_VERSION=${RELEASE_VERSION:-$VERSION}
     unset LATEST_DMG
 
     # Find latest .dmg file in $GOPATH/src/github.com/Datadog/datadog-agent/omnibus/pkg

--- a/tasks/libs/releasing/json.py
+++ b/tasks/libs/releasing/json.py
@@ -178,7 +178,7 @@ def _update_release_json_entry(
 ##
 
 
-def _update_release_json(release_json, release_entry, new_version: Version, max_version: Version):
+def _update_release_json(release_json, new_version: Version, max_version: Version):
     """
     Updates the provided release.json object by fetching compatible versions for all dependencies
     of the provided Agent version, constructing the new entry, adding it to the release.json object
@@ -269,11 +269,10 @@ def update_release_json(new_version: Version, max_version: Version):
     """
     release_json = load_release_json()
 
-    release_entry = "release"
-    print(f"Updating {release_entry} for {new_version}")
+    print(f"Updating release json for {new_version}")
 
     # Update release.json object with the entry for the new version
-    release_json = _update_release_json(release_json, release_entry, new_version, max_version)
+    release_json = _update_release_json(release_json, new_version, max_version)
 
     _save_release_json(release_json)
 
@@ -298,7 +297,7 @@ def set_new_release_branch(branch):
     rj["base_branch"] = branch
 
     for field in RELEASE_JSON_FIELDS_TO_UPDATE:
-        rj["nightly"][field] = f"{branch}"
+        rj[RELEASE_JSON_DEPENDENCIES][field] = f"{branch}"
 
     _save_release_json(rj)
 
@@ -323,7 +322,7 @@ def generate_repo_data(ctx, warning_mode, next_version, release_branch):
         repos = ["datadog-agent"]
     else:
         repos = ALL_REPOS
-    previous_tags = find_previous_tags("release", repos, RELEASE_JSON_FIELDS_TO_UPDATE)
+    previous_tags = find_previous_tags(RELEASE_JSON_DEPENDENCIES, repos, RELEASE_JSON_FIELDS_TO_UPDATE)
     data = {}
     for repo in repos:
         branch = release_branch

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -183,7 +183,6 @@ def build(
     skip_deps=False,
     skip_sign=False,
     major_version='7',
-    release_version="nightly",
     hardened_runtime=False,
     system_probe_bin=None,
     go_mod_cache=None,
@@ -197,9 +196,6 @@ def build(
     """
     Build the Agent packages with Omnibus Installer.
     """
-
-    if release_version:
-        print("The release_version argument is deprecated and will be removed soon.")
 
     flavor = AgentFlavor[flavor]
     fips_mode = flavor.is_fips()

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -293,7 +293,7 @@ def tag_devel(ctx, release_branch, commit="HEAD", push=True, force=False):
 
 @task
 def finish(ctx, release_branch, upstream="origin"):
-    """Updates the release entry in the release.json file for the new version.
+    """Updates the release.json file for the new version.
 
     Updates internal module dependencies with the new version.
     """
@@ -773,7 +773,7 @@ def create_release_branches(
 
     That includes:
         - creates a release branch in datadog-agent, datadog-agent-macos, and omnibus-ruby repositories,
-        - updates release.json on new datadog-agent branch to point to newly created release branches in nightly section
+        - updates release.json on new datadog-agent branch to point to newly created release branches
         - updates entries in .gitlab-ci.yml and .gitlab/notify/notify.yml which depend on local branch name
 
     Args:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
remove the `release_version` left in omnibus build now that the [macos build changes](https://github.com/DataDog/datadog-agent-macos-build/pull/256) have been merged
clean up leftover `nightly`/`release_entry` that were missed in the initial PR

### Motivation
follow up to https://github.com/DataDog/datadog-agent/pull/36143

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->