### PR TITLE
fix(installer): Always write the generated disclaimer on Fleet config

### DIFF
--- a/pkg/fleet/installer/setup/common/config.go
+++ b/pkg/fleet/installer/setup/common/config.go
@@ -6,6 +6,7 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"maps"
 	"os"
@@ -91,7 +92,7 @@ func writeConfig(path string, config any, perms os.FileMode, merge bool) error {
 	if err != nil {
 		return fmt.Errorf("could not serialize merged config: %w", err)
 	}
-	if len(existingConfig) == 0 {
+	if !bytes.HasPrefix(serializedMerged, []byte(disclaimerGenerated+"\n\n")) {
 		serializedMerged = []byte(disclaimerGenerated + "\n\n" + string(serializedMerged))
 	}
 	err = os.WriteFile(path, serializedMerged, perms)

--- a/pkg/fleet/installer/setup/common/config_test.go
+++ b/pkg/fleet/installer/setup/common/config_test.go
@@ -10,6 +10,7 @@ package common
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -165,4 +166,23 @@ func TestIntegrationConfigInstanceSpark(t *testing.T) {
 			},
 		},
 	}, spark)
+}
+
+func TestDoubleWriteConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	config := Config{}
+	config.DatadogYAML.APIKey = "1234567890" // Required field
+	config.DatadogYAML.Hostname = "new_hostname"
+	config.DatadogYAML.LogsEnabled = true
+
+	err := writeConfigs(config, tempDir)
+	assert.NoError(t, err)
+
+	err = writeConfigs(config, tempDir)
+	assert.NoError(t, err)
+
+	// Check datadog.yaml
+	datadogYAML, err := os.ReadFile(filepath.Join(tempDir, datadogConfFile))
+	assert.NoError(t, err)
+	assert.True(t, strings.HasPrefix(string(datadogYAML), disclaimerGenerated+"\n\n"))
 }


### PR DESCRIPTION
### What does this PR do?
Ensures the generated disclaimer on Fleet config is always there

### Motivation

### Describe how you validated your changes
Unit tests

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->