### PR TITLE
Ignore empty env vars when building the configuration

### DIFF
--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -497,7 +497,7 @@ func (c *ntmConfig) buildEnvVars() {
 
 	for configKey, listEnvVars := range c.configEnvVars {
 		for _, envVar := range listEnvVars {
-			if value, ok := os.LookupEnv(envVar); ok {
+			if value, ok := os.LookupEnv(envVar); ok && value != "" {
 				if err := c.insertNodeFromString(root, configKey, value); err != nil {
 					envWarnings = append(envWarnings, err)
 				} else {

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -387,6 +387,21 @@ func TestEnvVarMultipleSettings(t *testing.T) {
 	assert.Equal(t, 0, cfg.GetInt("c"))
 }
 
+func TestEmptyEnvVarSettings(t *testing.T) {
+	cfg := NewNodeTreeConfig("test", "TEST", nil)
+	cfg.SetDefault("a", -1)
+	cfg.BindEnv("a")
+
+	// This empty string is ignored, so the default value of -1 will be returned by GetInt
+	t.Setenv("TEST_A", "")
+
+	cfg.BuildSchema()
+	assert.Equal(t, -1, cfg.GetInt("a"))
+
+	cfg.Set("a", 123, model.SourceFile)
+	assert.Equal(t, 123, cfg.GetInt("a"))
+}
+
 func TestAllKeysLowercased(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", nil)
 	cfg.SetDefault("a", 0)


### PR DESCRIPTION
### What does this PR do?

Ignore empty env vars when building the configuration.

### Motivation

This mirror the behavior from viper in nodetreemodel.

### Describe how you validated your changes

Running the CI tests is enough