### PR TITLE
Add VolumeMount to all containers even if volume already exists

### DIFF
--- a/pkg/clusteragent/admission/mutate/common/common.go
+++ b/pkg/clusteragent/admission/mutate/common/common.go
@@ -133,12 +133,6 @@ func injectDynamicEnvInContainers(containers []corev1.Container, fn BuildEnvVarF
 // InjectVolume injects a volume into a pod template if it doesn't exist
 func InjectVolume(pod *corev1.Pod, volume corev1.Volume, volumeMount corev1.VolumeMount) bool {
 	podStr := PodString(pod)
-	for _, vol := range pod.Spec.Volumes {
-		if vol.Name == volume.Name {
-			log.Debugf("Ignoring pod %q: volume %q already exists", podStr, vol.Name)
-			return false
-		}
-	}
 
 	shouldInject := false
 	for i, container := range pod.Spec.Containers {
@@ -161,6 +155,12 @@ func InjectVolume(pod *corev1.Pod, volume corev1.Volume, volumeMount corev1.Volu
 	}
 
 	if shouldInject {
+		for _, vol := range pod.Spec.Volumes {
+			if vol.Name == volume.Name {
+				log.Debugf("Pod %q: Volume %q already exists. Not adding again", podStr, vol.Name)
+				return
+			}
+		}
 		pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
 	}
 


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Depending on the order of webhooks it can happen that datadog adds the volume in the first step. If another webhook (e.g. istio sidecar injection) adds another container to the pod datadog will inject all env variables but the volume mount will not be added.

This PR fixes this.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->