### PR TITLE
[EBPF-702] wmeta: fix support for MIG devices

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -65,6 +65,8 @@ func (c *collector) getGPUDeviceInfo(device ddnvml.Device) (*workloadmeta.GPU, e
 		gpuDeviceInfo.DeviceType = workloadmeta.GPUDeviceTypePhysical
 	case *ddnvml.MIGDevice:
 		gpuDeviceInfo.DeviceType = workloadmeta.GPUDeviceTypeMIG
+	default:
+		gpuDeviceInfo.DeviceType = workloadmeta.GPUDeviceTypeUnknown
 	}
 
 	c.fillNVMLAttributes(&gpuDeviceInfo, device)

--- a/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
+++ b/comp/core/workloadmeta/collectors/internal/nvml/nvml.go
@@ -37,14 +37,6 @@ type collector struct {
 	store   workloadmeta.Component
 }
 
-// getMigProfileName() returns the canonical name of the MIG device
-func getMigProfileName(attr nvml.DeviceAttributes) (string, error) {
-	g := attr.GpuInstanceSliceCount
-	gb := (attr.MemorySizeMB + 1024 - 1) / 1024
-	r := fmt.Sprintf("%dg.%dgb", g, gb)
-	return r, nil
-}
-
 func (c *collector) getGPUDeviceInfo(device ddnvml.Device) (*workloadmeta.GPU, error) {
 	devInfo := device.GetDeviceInfo()
 	gpuDeviceInfo := workloadmeta.GPU{

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1372,10 +1372,13 @@ const (
 	GPUCOUNT
 )
 
+// GPUDeviceType is an enum to identify the type of the GPU device.
 type GPUDeviceType int
 
 const (
+	// GPUDeviceTypePhysical represents a physical GPU device.
 	GPUDeviceTypePhysical GPUDeviceType = iota
+	// GPUDeviceTypeMIG represents a MIG device.
 	GPUDeviceTypeMIG
 )
 

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1380,6 +1380,8 @@ const (
 	GPUDeviceTypePhysical GPUDeviceType = iota
 	// GPUDeviceTypeMIG represents a MIG device.
 	GPUDeviceTypeMIG
+	// GPUDeviceTypeUnknown represents an unknown device type.
+	GPUDeviceTypeUnknown
 )
 
 // GPU represents a GPU resource.

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1372,6 +1372,13 @@ const (
 	GPUCOUNT
 )
 
+type GPUDeviceType int
+
+const (
+	GPUDeviceTypePhysical GPUDeviceType = iota
+	GPUDeviceTypeMIG
+)
+
 // GPU represents a GPU resource.
 type GPU struct {
 	EntityID
@@ -1417,29 +1424,8 @@ type GPU struct {
 	// MemoryBusWidth is the width of the memory bus in bits.
 	MemoryBusWidth uint32
 
-	// MigEnabled is true if the GPU supports MIG (Multi-Instance GPU) and it is enabled.
-	MigEnabled bool
-	// MigDevices is a list of MIG devices that are part of the GPU.
-	MigDevices []*MigDevice
-}
-
-// MigDevice contains information about a MIG device, including the GPU instance ID, device info, attributes, and profile. Nvidia MIG allows a single physical GPU to be partitioned into multiple isolated GPU instances so that multiple workloads can run on the same GPU.
-type MigDevice struct {
-	// GPUInstanceID is the ID of the GPU instance. This is a unique identifier inside the parent GPU device.
-	GPUInstanceID int
-	// UUID is the device id retrieved from nvml in the format "MIG-XXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXX"
-	UUID string
-	Name string
-	// GPUInstanceSliceCount and MemorySizeInGb are retrieved from the profile
-	// mig 1g.10gb profile will have GPUInstanceSliceCount = 1 and MemorySizeMB = 10000
-	GPUInstanceSliceCount uint32
-	MemorySizeMB          uint64
-	// ResourceName is the resource of the profile used, e.g. "1g.10gb", "2g.20gb", etc.
-	ResourceName string
-}
-
-func (m *MigDevice) String() string {
-	return fmt.Sprintf("GPU Instance ID: %d, UUID: %s, Resource: %s", m.GPUInstanceID, m.UUID, m.ResourceName)
+	// DeviceType identifies if this is a physical or virtual device (e.g. MIG)
+	DeviceType GPUDeviceType
 }
 
 var _ Entity = &GPU{}
@@ -1492,12 +1478,10 @@ func (g GPU) String(verbose bool) string {
 	_, _ = fmt.Fprintln(&sb, "Memory Bus Width:", g.MemoryBusWidth)
 	_, _ = fmt.Fprintln(&sb, "Max SM Clock Rate:", g.MaxClockRates[GPUSM])
 	_, _ = fmt.Fprintln(&sb, "Max Memory Clock Rate:", g.MaxClockRates[GPUMemory])
-	if g.MigEnabled {
-		_, _ = fmt.Fprintln(&sb, "----------- MIG Device -----------")
-		_, _ = fmt.Fprintln(&sb, "MIG Enabled: true")
-		for _, migDevice := range g.MigDevices {
-			_, _ = fmt.Fprintln(&sb, migDevice.String())
-		}
+
+	// Do not show "physical" device type as it's the default and redundant information
+	if g.DeviceType == GPUDeviceTypeMIG {
+		_, _ = fmt.Fprintln(&sb, "Device Type: MIG")
 	}
 
 	return sb.String()


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR changes the NVML collector in workloadmeta to use the device cache for MIG devices too, which was added in #36377.

It also removes the `MIGDevice` type, as it was not being used directly. That way, we ensure that the workloadmeta entities only have essential data used for tagging (main use of workloadmeta now). 

### Motivation

https://datadoghq.atlassian.net/browse/EBPF-702

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Tested manually in an instance with MIG devices. Existing unit tests should pass.

Example output from running `agent workload-list`:

``` 
=== Entity gpu sources(merged):[runtime] id: GPU-f03868d6-89fc-e704-51e6-f6a81ea3408f ===
----------- Entity ID -----------
Kind: gpu ID: GPU-f03868d6-89fc-e704-51e6-f6a81ea3408f

----------- Entity Meta -----------
Name: NVIDIA A100-SXM4-40GB
Namespace:

Vendor: nvidia
Driver Version: 550.127.05
Device: NVIDIA A100-SXM4-40GB
Active PIDs: []
Index: 1
Architecture: ampere
Compute Capability: 8.0
Total Number of Cores: 98
Device Total Memory (in bytes): 41473277952
Memory Bus Width: 0
Max SM Clock Rate: 1410
Max Memory Clock Rate: 1215
===
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->