### PR TITLE
[Draft] Capture live KM dump when driver service in E2E is stuck

### DIFF
--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -830,6 +830,12 @@ func (s *baseStartStopSuite) captureLiveKernelDump(host *components.RemoteHost, 
 		s.T().Logf("Remote execute error: %s\n", err)
 	}
 
+	if exists, _ := host.FileExists(destDumpFile); exists {
+		s.T().Logf("live kernel dump moved to %s\n", destDumpFile)
+	} else {
+		s.T().Logf("live kernel dump not found at %s\n", destDumpFile)
+	}
+
 	// Cleanup the "localhost" subdirectory.
 	host.RemoveAll(sourceDumpDir)
 }

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -784,15 +784,15 @@ func (s *baseStartStopSuite) sendHostMemoryMetrics(host *components.RemoteHost) 
 }
 
 // captureLiveKernelDump sends a commnad to the host to create a live kernel dump.
-func (s *baseStartStopSuite) captureLiveKernelDump(host components.RemoteHost, dumpDir string) {
+func (s *baseStartStopSuite) captureLiveKernelDump(host *components.RemoteHost, dumpDir string) {
 	tempDumpDir := `C:\Windows\Temp`
 	sourceDumpDir := fmt.Sprintf(`%s\localhost`, tempDumpDir)
 
+	// The live kernel dump will be placed under subdirectory named "localhost."
 	// Make sure the subdirectory where the dump will be generated is empty.
 	host.RemoveAll(sourceDumpDir)
 
 	// This Powershell command is originally tailored for storage cluster environments.
-	// The live kernel dump will be placed under subdirectory named "localhost."
 	getSubsystemCmd := `$ss = Get-CimInstance -ClassName MSFT_StorageSubSystem -Namespace Root\Microsoft\Windows\Storage`
 	createLiveDumpCmd := fmt.Sprintf(`Invoke-CimMethod -InputObject $ss -MethodName "GetDiagnosticInfo" -Arguments @{DestinationPath="%s"; IncludeLiveDump=$true}"`, tempDumpDir)
 	dumpCmd := fmt.Sprintf("%s;%s", getSubsystemCmd, createLiveDumpCmd)

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -672,7 +672,8 @@ func (s *baseStartStopSuite) assertServiceState(expected string, serviceName str
 		}
 	}, 1*time.Minute, 1*time.Second, "%s should be in the expected state", serviceName)
 
-	if s.T().Failed() && slices.Contains(s.getInstalledKernelServices(), serviceName) {
+	// if s.T().Failed() && slices.Contains(s.getInstalledKernelServices(), serviceName) {
+	if serviceName == "ddprocmon" {
 		// if a driver service failed to get to the expected state, capture a kernel dump for debugging.
 		s.T().Logf("capturing live kernel dump due to %s not in %s state\n", serviceName, expected)
 		s.captureLiveKernelDump(host, s.dumpFolder)


### PR DESCRIPTION
### What does this PR do?
This PR captures a live KM dump if during the Windows E2E start-stop tests, a driver service has not transitioned to its expected state (e.g. stuck trying to stop).  The live dump is generated under the existing dump folder.  The command used is originally intended for storage clusters and therefore the dump will be under a "localhost" subdirectory.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1331 
This is needed to investigate intermittent E2E test failures, where the driver service does not stop on shutdown.

### Describe how you validated your changes
With a test npm driver that 1) holds a thread with busy spinning, 2) yields to the scheduler, verified that the dump does contain the stuck thread.
-TBD: verify that the dump is accessible.

### Possible Drawbacks / Trade-offs
The live KM dumps can be quite large: 500MB - 1GB, larger depending on the VM memory.
