### PR TITLE
[CWS] Fix for connect event not showing for non-blocking connections

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/connect.h
+++ b/pkg/security/ebpf/c/include/hooks/network/connect.h
@@ -23,7 +23,7 @@ int __attribute__((always_inline)) sys_connect_ret(void *ctx, int retval) {
         return 0;
     }
 
-    if (IS_UNHANDLED_ERROR(retval)) {
+    if (IS_UNHANDLED_ERROR(retval) && retval != -EINPROGRESS) {
         return 0;
     }
 


### PR DESCRIPTION
### What does this PR do?

When a non-blocking socket connection is performed, it returns EINPROGRESS. This return code was being identified as an unhandled error by the eBPF probe, which prevented the event from being sent to userspace.

This PR excludes EINPROGRESS as an error for connect.

### Describe how you validated your changes

Validated locally with a reproducer that created a non-blocking socket

