### PR TITLE
[corecheck/kubelet] Respect timeout in check config

### DIFF
--- a/pkg/collector/corechecks/containers/kubelet/kubelet.go
+++ b/pkg/collector/corechecks/containers/kubelet/kubelet.go
@@ -126,6 +126,12 @@ func (k *KubeletCheck) Configure(senderManager sender.SenderManager, _ uint64, c
 		return err
 	}
 
+	// Set sane defaults
+	if k.instance.Timeout == 0 {
+		// old default was 10 seconds, let's keep it
+		k.instance.Timeout = 10
+	}
+
 	k.instance.Namespace = common.KubeletMetricsPrefix
 	if k.instance.SendHistogramBuckets == nil {
 		sendBuckets := true

--- a/pkg/collector/corechecks/containers/kubelet/provider/node/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/node/provider.go
@@ -12,6 +12,7 @@ package node
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/sender"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/kubelet/common"
@@ -41,7 +42,9 @@ func NewProvider(config *common.KubeletConfig) *Provider {
 // Provide sends the metrics collected from the `/spec` Kubelet endpoint
 func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) error {
 	// Collect raw data
-	nodeSpecRaw, responseCode, err := kc.QueryKubelet(context.TODO(), "/spec/")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(p.config.Timeout)*time.Second)
+	nodeSpecRaw, responseCode, err := kc.QueryKubelet(ctx, "/spec/")
+	cancel()
 	if err != nil || responseCode == 404 {
 		if responseCode == 404 {
 			return nil

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider.go
@@ -63,7 +63,9 @@ func NewProvider(filter *containers.Filter, config *common.KubeletConfig, podUti
 // Provide provides the metrics related to a Kubelet pods
 func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) error {
 	// Collect raw data
-	pods, err := kc.GetLocalPodListWithMetadata(context.TODO())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(p.config.Timeout)*time.Second)
+	pods, err := kc.GetLocalPodListWithMetadata(ctx)
+	cancel()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/pod/provider_test.go
@@ -140,7 +140,8 @@ func (suite *ProviderTestSuite) SetupTest() {
 
 	config := &common.KubeletConfig{
 		OpenmetricsInstance: types.OpenmetricsInstance{
-			Tags: []string{"instance_tag:something"},
+			Tags:    []string{"instance_tag:something"},
+			Timeout: 10,
 		},
 	}
 

--- a/pkg/collector/corechecks/containers/kubelet/provider/prometheus/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/prometheus/provider.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/prometheus/common/model"
 
@@ -163,7 +164,9 @@ func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) e
 		log.Debugf("Skipping collecting metrics as provider is disabled")
 		return nil
 	}
-	data, status, err := kc.QueryKubelet(context.TODO(), p.ScraperConfig.Path)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(p.Config.Timeout)*time.Second)
+	data, status, err := kc.QueryKubelet(ctx, p.ScraperConfig.Path)
+	cancel()
 	if err != nil {
 		log.Debugf("Unable to collect query probes endpoint: %s", err)
 		return err

--- a/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
+++ b/pkg/collector/corechecks/containers/kubelet/provider/summary/provider.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"regexp"
 	"runtime"
+	"time"
 
 	kubeletv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 
@@ -63,7 +64,9 @@ func NewProvider(filter *containers.Filter,
 
 // Provide processes metrics and reports
 func (p *Provider) Provide(kc kubelet.KubeUtilInterface, sender sender.Sender) error {
-	statsSummary, err := kc.GetLocalStatsSummary(context.TODO())
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(p.config.Timeout)*time.Second)
+	statsSummary, err := kc.GetLocalStatsSummary(ctx)
+	cancel()
 	if err != nil || statsSummary == nil {
 		return err
 	}

--- a/releasenotes/notes/kubelet-core-respect-timeout-6c0a118cadaa0595.yaml
+++ b/releasenotes/notes/kubelet-core-respect-timeout-6c0a118cadaa0595.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The kubelet core check now respects the `timeout` parameter of the check configuration file.


### PR DESCRIPTION
### What does this PR do?

This PR updates the kubelet corecheck to respect the `timeout` field which is exposed by the kubelet check config file.

### Motivation

Some users have reported that the agent is unable to start-up sometimes when using the kubelet corecheck, and that switching to the python version allows the agent to become ready. In looking through the two checks, one thing that jumped out is that the corecheck is using the timeout that is configured for the shared kubelet client, which is hardcoded at 30s, while the python check defaulted to 10s. This PR should remove this difference.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->