### PR TITLE
[OTAGENT-375] otel-agent exits with 0 when disabled

### DIFF
--- a/cmd/otel-agent/main_test.go
+++ b/cmd/otel-agent/main_test.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build otlp
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExitCode_Disabled(t *testing.T) {
+	t.Setenv("DD_OTELCOLLECTOR_ENABLED", "false")
+	cmd := exec.Command("go", "run", "-tags", "otlp", "main.go", "--config", "test_config.yaml")
+	err := cmd.Run()
+	require.NoError(t, err)
+}

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -10,6 +10,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"os"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/spf13/cobra"
@@ -101,6 +102,9 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 	acfg, err := agentConfig.NewConfigComponent(context.Background(), params.CoreConfPath, params.ConfPaths)
 	if err != nil && err != agentConfig.ErrNoDDExporter {
 		return err
+	}
+	if !acfg.GetBool("otelcollector.enabled") {
+		os.Exit(0)
 	}
 	uris := append(params.ConfPaths, params.Sets...)
 	if err == agentConfig.ErrNoDDExporter {

--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -10,7 +10,6 @@ package run
 import (
 	"context"
 	"fmt"
-	"os"
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 	"github.com/spf13/cobra"
@@ -104,7 +103,8 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 		return err
 	}
 	if !acfg.GetBool("otelcollector.enabled") {
-		os.Exit(0)
+		fmt.Println("*** OpenTelemetry Collector is not enabled, exiting application ***. Set the config option `otelcollector.enabled` or the environment variable `DD_OTELCOLLECTOR_ENABLED` at true to enable it.")
+		return nil
 	}
 	uris := append(params.ConfPaths, params.Sets...)
 	if err == agentConfig.ErrNoDDExporter {

--- a/cmd/otel-agent/subcommands/run/command_test.go
+++ b/cmd/otel-agent/subcommands/run/command_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestFxRun_WithDatadogExporter(t *testing.T) {
+	t.Setenv("DD_OTELCOLLECTOR_ENABLED", "true")
 	fxutil.TestRun(t, func() error {
 		ctx := context.Background()
 		params := &subcommands.GlobalParams{
@@ -26,6 +27,7 @@ func TestFxRun_WithDatadogExporter(t *testing.T) {
 }
 
 func TestFxRun_NoDatadogExporter(t *testing.T) {
+	t.Setenv("DD_OTELCOLLECTOR_ENABLED", "true")
 	fxutil.TestRun(t, func() error {
 		ctx := context.Background()
 		params := &subcommands.GlobalParams{

--- a/cmd/otel-agent/test_config.yaml
+++ b/cmd/otel-agent/test_config.yaml
@@ -1,0 +1,29 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: "localhost:4318"
+      grpc:
+        endpoint: "localhost:4317"
+
+exporters:
+  datadog:
+    api:
+      key: "abc"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [datadog]
+  telemetry:
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: "localhost"
+                port: 8888
+                without_scope_info: true
+                without_type_suffix: true
+                without_units: true


### PR DESCRIPTION
### What does this PR do?
otel-agent properly exits with code 0 when otelcollector.enabled is false

### Motivation
https://datadoghq.atlassian.net/browse/OTAGENT-375
prevents an infinite retry loop in Docker when otel-agent is disabled in the full image

### Describe how you validated your changes
unit test + built otel-agent and tested locally + tested the full image from CI
```
...
2025-04-25 21:36:43 starting otel-agent
...
2025-04-25 21:36:43 setting log level to: info
2025-04-25 21:36:43 *** OpenTelemetry Collector is not enabled, exiting application ***. Set the config option `otelcollector.enabled` or the environment variable `DD_OTELCOLLECTOR_ENABLED` at true to enable it.
2025-04-25 21:36:43 otel-agent exited with code 0, disabling
```