### PR TITLE
Make rc_kubernetes_deploy wait for docker_trigger_internal-full

### DIFF
--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -11,8 +11,11 @@ rc_kubernetes_deploy:
       when: manual
   needs:
     - job: docker_trigger_internal
+      artifacts: false
     - job: docker_trigger_cluster_agent_internal
+      artifacts: false
     - job: docker_trigger_internal-full
+      artifacts: false
     - job: k8s-e2e-main # Currently only require container Argo workflow
       artifacts: false
       optional: true

--- a/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
+++ b/.gitlab/internal_kubernetes_deploy/rc_kubernetes_deploy.yml
@@ -11,9 +11,8 @@ rc_kubernetes_deploy:
       when: manual
   needs:
     - job: docker_trigger_internal
-      artifacts: false
     - job: docker_trigger_cluster_agent_internal
-      artifacts: false
+    - job: docker_trigger_internal-full
     - job: k8s-e2e-main # Currently only require container Argo workflow
       artifacts: false
       optional: true


### PR DESCRIPTION
### What does this PR do?

This PR makes r`c_kubernetes_deploy` job to need `docker_trigger_internal-full` before it starts. As in most cases we deploy the `-full` flavor image now we need to make sure that those images are available before we start the deployment.

### Motivation

Improve the Agent release process.