### PR TITLE
Use `strings.ReplaceAll` instead of `Replace` with -1

### DIFF
--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -221,12 +221,12 @@ func getIntegrationName(packageName string) string {
 	case "datadog-go-metro":
 		return "go-metro"
 	default:
-		return strings.TrimSpace(strings.Replace(strings.TrimPrefix(packageName, "datadog-"), "-", "_", -1))
+		return strings.TrimSpace(strings.ReplaceAll(strings.TrimPrefix(packageName, "datadog-"), "-", "_"))
 	}
 }
 
 func normalizePackageName(packageName string) string {
-	return strings.Replace(packageName, "_", "-", -1)
+	return strings.ReplaceAll(packageName, "_", "-")
 }
 
 func semverToPEP440(version *semver.Version) string {

--- a/comp/autoscaling/datadogclient/impl/status_test.go
+++ b/comp/autoscaling/datadogclient/impl/status_test.go
@@ -12,13 +12,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
 	datadogclient "github.com/DataDog/datadog-agent/comp/autoscaling/datadogclient/def"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 )
 
 func TestStatusProvider(t *testing.T) {
@@ -75,8 +76,8 @@ func TestStatusProvider(t *testing.T) {
     Last Success: Never
 `
 			// We replace windows line break by linux so the tests pass on every OS
-			expected := strings.Replace(string(expectedTextOutput), "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expected := strings.ReplaceAll(string(expectedTextOutput), "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			assert.Equal(t, expected, output)
 		}},
 		{"HTML", func(t *testing.T) {

--- a/comp/core/diagnose/impl/diagnose_test.go
+++ b/comp/core/diagnose/impl/diagnose_test.go
@@ -92,8 +92,8 @@ func TestRunSuites(t *testing.T) {
 	assert.Nil(err)
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(runSuitetextresult, "\r\n", "\n", -1)
-	output := strings.Replace(string(result), "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(runSuitetextresult, "\r\n", "\n")
+	output := strings.ReplaceAll(string(result), "\r\n", "\n")
 
 	assert.Equal(expectedResult, output)
 
@@ -101,8 +101,8 @@ func TestRunSuites(t *testing.T) {
 	assert.Nil(err)
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult = strings.Replace(runSuitejsonresult, "\r\n", "\n", -1)
-	output = strings.Replace(string(result), "\r\n", "\n", -1)
+	expectedResult = strings.ReplaceAll(runSuitejsonresult, "\r\n", "\n")
+	output = strings.ReplaceAll(string(result), "\r\n", "\n")
 
 	assert.Equal(expectedResult, output)
 }
@@ -120,8 +120,8 @@ func TestRunSuite(t *testing.T) {
 	assert.Nil(err)
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(runSuitetextresult, "\r\n", "\n", -1)
-	output := strings.Replace(string(result), "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(runSuitetextresult, "\r\n", "\n")
+	output := strings.ReplaceAll(string(result), "\r\n", "\n")
 
 	assert.Equal(expectedResult, output)
 
@@ -129,8 +129,8 @@ func TestRunSuite(t *testing.T) {
 	assert.Nil(err)
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult = strings.Replace(runSuitejsonresult, "\r\n", "\n", -1)
-	output = strings.Replace(string(result), "\r\n", "\n", -1)
+	expectedResult = strings.ReplaceAll(runSuitejsonresult, "\r\n", "\n")
+	output = strings.ReplaceAll(string(result), "\r\n", "\n")
 
 	assert.Equal(expectedResult, output)
 
@@ -167,8 +167,8 @@ func TestAPIDiagnose(t *testing.T) {
 	assert.Nil(err)
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(runSuitejsonresult, "\r\n", "\n", -1)
-	output := strings.Replace(prettyJSON.String(), "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(runSuitejsonresult, "\r\n", "\n")
+	output := strings.ReplaceAll(prettyJSON.String(), "\r\n", "\n")
 
 	assert.Equal(expectedResult, output)
 }
@@ -188,7 +188,7 @@ func TestFlareProvider(t *testing.T) {
 
 	flarecallback(mock)
 
-	expectedResult := strings.Replace(runSuitetextresult, "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(runSuitetextresult, "\r\n", "\n")
 
 	mock.AssertFileContent(strings.TrimSuffix(expectedResult, "\n"), "diagnose.log")
 }

--- a/comp/core/gui/guiimpl/agent.go
+++ b/comp/core/gui/guiimpl/agent.go
@@ -120,7 +120,7 @@ func getLog(w http.ResponseWriter, r *http.Request, config configmodel.Reader) {
 	}
 	escapedLogFileContents := html.EscapeString(string(logFileContents))
 
-	html := strings.Replace(escapedLogFileContents, "\n", "<br>", -1)
+	html := strings.ReplaceAll(escapedLogFileContents, "\n", "<br>")
 
 	if flip {
 		// Reverse the order so that the bottom of the file is read first

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -70,7 +70,7 @@ const expectedBody = `<!DOCTYPE html>
         <i class="fa fa-power-off fa-fw"> </i>&nbsp;
         Restart Agent
       </li>
-      
+
     </ul>
   </div>
   <div class="top_bar">
@@ -86,7 +86,7 @@ const expectedBody = `<!DOCTYPE html>
     <div id="error" class="page">
       <div id="error_content"></div>
       <div id="logged_out">
-        
+
 <h3>Refreshing the Session</h3>
 <p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
 <ul>
@@ -159,8 +159,8 @@ func TestRenderIndexPage(t *testing.T) {
 	assert.Equal(t, "text/html; charset=utf-8", res.Header.Get("Content-Type"))
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(expectedBody, "\r\n", "\n", -1)
-	output := strings.Replace(string(bodyBytes), "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(expectedBody, "\r\n", "\n")
+	output := strings.ReplaceAll(string(bodyBytes), "\r\n", "\n")
 
 	assert.Equal(t, expectedResult, output)
 }

--- a/comp/core/gui/guiimpl/platform_windows_test.go
+++ b/comp/core/gui/guiimpl/platform_windows_test.go
@@ -70,7 +70,7 @@ const expectedBody = `<!DOCTYPE html>
         <i class="fa fa-power-off fa-fw"> </i>&nbsp;
         Restart Agent
       </li>
-
+      
     </ul>
   </div>
   <div class="top_bar">
@@ -86,7 +86,7 @@ const expectedBody = `<!DOCTYPE html>
     <div id="error" class="page">
       <div id="error_content"></div>
       <div id="logged_out">
-
+        
 <h3>Refreshing the Session</h3>
 <p>Please ensure you access the Datadog Agent Manager with one of the following:</p>
 <ul>

--- a/comp/core/status/render_helpers.go
+++ b/comp/core/status/render_helpers.go
@@ -182,7 +182,7 @@ func lastErrorTraceback(value string) string {
 	if err != nil || len(lastErrorArray) == 0 {
 		return "No traceback"
 	}
-	lastErrorArray[0]["traceback"] = strings.Replace(lastErrorArray[0]["traceback"], "\n", "\n      ", -1)
+	lastErrorArray[0]["traceback"] = strings.ReplaceAll(lastErrorArray[0]["traceback"], "\n", "\n      ")
 	lastErrorArray[0]["traceback"] = strings.TrimRight(lastErrorArray[0]["traceback"], "\n\t ")
 	return lastErrorArray[0]["traceback"]
 }
@@ -413,8 +413,8 @@ func getVersion(instances map[string]interface{}) string {
 func pythonLoaderErrorHTML(value string) htemplate.HTML {
 	value = htemplate.HTMLEscapeString(value)
 
-	value = strings.Replace(value, "\n", "<br>", -1)
-	value = strings.Replace(value, "  ", "&nbsp;&nbsp;&nbsp;", -1)
+	value = strings.ReplaceAll(value, "\n", "<br>")
+	value = strings.ReplaceAll(value, "  ", "&nbsp;&nbsp;&nbsp;")
 	return htemplate.HTML(value)
 }
 
@@ -428,8 +428,8 @@ func lastErrorTracebackHTML(value string) htemplate.HTML {
 
 	traceback := htemplate.HTMLEscapeString(lastErrorArray[0]["traceback"])
 
-	traceback = strings.Replace(traceback, "\n", "<br>", -1)
-	traceback = strings.Replace(traceback, "  ", "&nbsp;&nbsp;&nbsp;", -1)
+	traceback = strings.ReplaceAll(traceback, "\n", "<br>")
+	traceback = strings.ReplaceAll(traceback, "  ", "&nbsp;&nbsp;&nbsp;")
 
 	return htemplate.HTML(traceback)
 }

--- a/comp/core/status/statusimpl/common_header_provider_test.go
+++ b/comp/core/status/statusimpl/common_header_provider_test.go
@@ -100,8 +100,8 @@ func TestCommonHeaderProviderText(t *testing.T) {
 `, pid, goVersion, arch, agentFlavor, config.GetString("confd_path"), config.GetString("additional_checksd"))
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
-	output := strings.Replace(buffer.String(), "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
+	output := strings.ReplaceAll(buffer.String(), "\r\n", "\n")
 
 	assert.Equal(t, expectedResult, output)
 }
@@ -206,8 +206,8 @@ func TestCommonHeaderProviderTextWithFipsInformation(t *testing.T) {
 `, pid, goVersion, arch, agentFlavor, config.GetString("confd_path"), config.GetString("additional_checksd"))
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
-	output := strings.Replace(buffer.String(), "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
+	output := strings.ReplaceAll(buffer.String(), "\r\n", "\n")
 
 	assert.Equal(t, expectedResult, output)
 }
@@ -234,7 +234,7 @@ func TestCommonHeaderProviderHTML(t *testing.T) {
 	// We have to do this strings replacement because html/temaplte escapes the `+` sign
 	// https://github.com/golang/go/issues/42506
 	result := buffer.String()
-	unescapedResult := strings.Replace(result, "&#43;", "+", -1)
+	unescapedResult := strings.ReplaceAll(result, "&#43;", "+")
 
 	expectedHTMLOutput := fmt.Sprintf(`<div class="stat">
   <span class="stat_title">Agent Info</span>
@@ -263,8 +263,8 @@ func TestCommonHeaderProviderHTML(t *testing.T) {
 `, version.AgentVersion, agentFlavor, pid, config.GetString("confd_path"), config.GetString("additional_checksd"), goVersion, arch)
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(expectedHTMLOutput, "\r\n", "\n", -1)
-	output := strings.Replace(unescapedResult, "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(expectedHTMLOutput, "\r\n", "\n")
+	output := strings.ReplaceAll(unescapedResult, "\r\n", "\n")
 
 	assert.Equal(t, expectedResult, output)
 }
@@ -298,7 +298,7 @@ func TestCommonHeaderProviderHTMLWithFipsInformation(t *testing.T) {
 	// We have to do this strings replacement because html/temaplte escapes the `+` sign
 	// https://github.com/golang/go/issues/42506
 	result := buffer.String()
-	unescapedResult := strings.Replace(result, "&#43;", "+", -1)
+	unescapedResult := strings.ReplaceAll(result, "&#43;", "+")
 
 	expectedHTMLOutput := fmt.Sprintf(`<div class="stat">
   <span class="stat_title">Agent Info</span>
@@ -335,8 +335,8 @@ func TestCommonHeaderProviderHTMLWithFipsInformation(t *testing.T) {
 `, version.AgentVersion, agentFlavor, pid, config.GetString("confd_path"), config.GetString("additional_checksd"), goVersion, arch)
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(expectedHTMLOutput, "\r\n", "\n", -1)
-	output := strings.Replace(unescapedResult, "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(expectedHTMLOutput, "\r\n", "\n")
+	output := strings.ReplaceAll(unescapedResult, "\r\n", "\n")
 
 	assert.Equal(t, expectedResult, output)
 }

--- a/comp/core/status/statusimpl/status_test.go
+++ b/comp/core/status/statusimpl/status_test.go
@@ -303,8 +303,8 @@ X Section
 
 `, testTextHeader, pid, goVersion, arch, agentFlavor, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"))
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(expectedStatusTextOutput, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedStatusTextOutput, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -351,8 +351,8 @@ X Section
 `, testTextHeader, pid, goVersion, arch, agentFlavor, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"))
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(expectedStatusTextOutput, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedStatusTextOutput, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -364,7 +364,7 @@ X Section
 				// We have to do this strings replacement because html/temaplte escapes the `+` sign
 				// https://github.com/golang/go/issues/42506
 				result := string(bytes)
-				unescapedResult := strings.Replace(result, "&#43;", "+", -1)
+				unescapedResult := strings.ReplaceAll(result, "&#43;", "+")
 
 				expectedStatusHTMLOutput := fmt.Sprintf(`<div class="stat">
   <span class="stat_title">Agent Info</span>
@@ -405,8 +405,8 @@ X Section
 `, agentVersion, agentFlavor, pid, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"), goVersion, arch)
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(expectedStatusHTMLOutput, "\r\n", "\n", -1)
-				output := strings.Replace(unescapedResult, "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedStatusHTMLOutput, "\r\n", "\n")
+				output := strings.ReplaceAll(unescapedResult, "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -419,7 +419,7 @@ X Section
 				// We have to do this strings replacement because html/temaplte escapes the `+` sign
 				// https://github.com/golang/go/issues/42506
 				result := string(bytes)
-				unescapedResult := strings.Replace(result, "&#43;", "+", -1)
+				unescapedResult := strings.ReplaceAll(result, "&#43;", "+")
 
 				expectedStatusHTMLOutput := fmt.Sprintf(`<div class="stat">
   <span class="stat_title">Agent Info</span>
@@ -454,8 +454,8 @@ X Section
 `, agentVersion, agentFlavor, pid, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"), goVersion, arch)
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(expectedStatusHTMLOutput, "\r\n", "\n", -1)
-				output := strings.Replace(unescapedResult, "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedStatusHTMLOutput, "\r\n", "\n")
+				output := strings.ReplaceAll(unescapedResult, "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -533,8 +533,8 @@ Section
 `, testTextHeader, pid, goVersion, arch, agentFlavor, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"))
 
 	// We replace windows line break by linux so the tests pass on every OS
-	expectedResult := strings.Replace(expectedOutput, "\r\n", "\n", -1)
-	output := strings.Replace(string(bytesResult), "\r\n", "\n", -1)
+	expectedResult := strings.ReplaceAll(expectedOutput, "\r\n", "\n")
+	output := strings.ReplaceAll(string(bytesResult), "\r\n", "\n")
 
 	assert.Equal(t, expectedResult, output)
 }
@@ -626,8 +626,8 @@ Status render errors
 `, testTextHeader, pid, goVersion, arch, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"))
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(expectedStatusTextErrorOutput, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedStatusTextErrorOutput, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -753,8 +753,8 @@ X Section
 `
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(result, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(result, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -772,8 +772,8 @@ X Section
 </div>
 `
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(result, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(result, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -791,8 +791,8 @@ X Section
 `
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(result, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(result, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -886,8 +886,8 @@ Status render errors
 `
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(expected, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expected, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},
@@ -935,8 +935,8 @@ Status render errors
 `, testTextHeader, pid, goVersion, arch, deps.Config.GetString("confd_path"), deps.Config.GetString("additional_checksd"))
 
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(expectedStatusTextErrorOutput, "\r\n", "\n", -1)
-				output := strings.Replace(string(bytes), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedStatusTextErrorOutput, "\r\n", "\n")
+				output := strings.ReplaceAll(string(bytes), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			},

--- a/comp/core/tagger/k8s_metadata/k8s_metadata.go
+++ b/comp/core/tagger/k8s_metadata/k8s_metadata.go
@@ -77,10 +77,10 @@ func resolveTag(tmpl, label string) string {
 	tagName := tmpl
 	for _, v := range vars {
 		if _, ok := templateVariables[string(v.Name)]; ok {
-			tagName = strings.Replace(tagName, string(v.Raw), label, -1)
+			tagName = strings.ReplaceAll(tagName, string(v.Raw), label)
 			continue
 		}
-		tagName = strings.Replace(tagName, string(v.Raw), "", -1)
+		tagName = strings.ReplaceAll(tagName, string(v.Raw), "")
 	}
 	return tagName
 }

--- a/comp/dogstatsd/mapper/mapper.go
+++ b/comp/dogstatsd/mapper/mapper.go
@@ -125,8 +125,8 @@ func buildRegex(matchRe string, matchType string) (*regexp.Regexp, error) {
 		if strings.Contains(matchRe, "**") {
 			return nil, fmt.Errorf("invalid wildcard match pattern `%s`, it should not contain consecutive `*`", matchRe)
 		}
-		matchRe = strings.Replace(matchRe, ".", "\\.", -1)
-		matchRe = strings.Replace(matchRe, "*", "([^.]*)", -1)
+		matchRe = strings.ReplaceAll(matchRe, ".", "\\.")
+		matchRe = strings.ReplaceAll(matchRe, "*", "([^.]*)")
 	}
 	regex, err := regexp.Compile("^" + matchRe + "$")
 	if err != nil {

--- a/comp/logs/agent/agentimpl/agent_test.go
+++ b/comp/logs/agent/agentimpl/agent_test.go
@@ -330,8 +330,8 @@ func (suite *AgentTestSuite) TestStatusOut() {
     OSFileLimit: 1048576
 `
 			// We replace windows line break by linux so the tests pass on every OS
-			expectedResult := strings.Replace(result, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(result, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 
 			assert.Equal(t, expectedResult, output)
 		}},
@@ -351,8 +351,8 @@ func (suite *AgentTestSuite) TestStatusOut() {
 </div>
 `
 			// We replace windows line break by linux so the tests pass on every OS
-			expectedResult := strings.Replace(result, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(result, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 
 			assert.Equal(t, expectedResult, output)
 		}},

--- a/comp/netflow/server/status_test.go
+++ b/comp/netflow/server/status_test.go
@@ -12,9 +12,10 @@ import (
 	"strings"
 	"testing"
 
-	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
+
+	nfconfig "github.com/DataDog/datadog-agent/comp/netflow/config"
 )
 
 func TestStatusProvider(t *testing.T) {
@@ -90,8 +91,8 @@ func TestStatusProvider(t *testing.T) {
 `
 
 			// We replace windows line break by linux so the tests pass on every OS
-			expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			assert.Equal(t, expectedResult, output)
 		}},
 		{"HTML", func(t *testing.T) {
@@ -129,8 +130,8 @@ func TestStatusProvider(t *testing.T) {
     </span>
   </div>`
 
-			expectedResult := strings.Replace(expectedHTMLOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedHTMLOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			assert.Equal(t, expectedResult, output)
 		}},
 	}

--- a/comp/process/agent/status_test.go
+++ b/comp/process/agent/status_test.go
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
 )
 
 //go:embed fixtures
@@ -124,8 +125,8 @@ func TestStatusError(t *testing.T) {
 			assert.NoError(t, err)
 
 			// We replace windows line break by linux so the tests pass on every OS
-			expected := strings.Replace(string(errorResponse), "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expected := strings.ReplaceAll(string(errorResponse), "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 
 			assert.Equal(t, expected, output)
 		}},

--- a/comp/process/status/statusimpl/status_test.go
+++ b/comp/process/status/statusimpl/status_test.go
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/comp/core/config"
 )
 
 //go:embed fixtures
@@ -125,8 +126,8 @@ func TestStatusError(t *testing.T) {
 			assert.NoError(t, err)
 
 			// We replace windows line break by linux so the tests pass on every OS
-			expected := strings.Replace(string(errorResponse), "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expected := strings.ReplaceAll(string(errorResponse), "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 
 			assert.Equal(t, expected, output)
 		}},

--- a/comp/snmptraps/status/statusimpl/status_test.go
+++ b/comp/snmptraps/status/statusimpl/status_test.go
@@ -64,8 +64,8 @@ func TestStatusProvider(t *testing.T) {
 `
 
 			// We replace windows line break by linux so the tests pass on every OS
-			expectedResult := strings.Replace(expectedOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 
 			assert.Equal(t, expectedResult, output)
 		}},
@@ -87,8 +87,8 @@ func TestStatusProvider(t *testing.T) {
 `
 
 			// We replace windows line break by linux so the tests pass on every OS
-			expectedResult := strings.Replace(expectedOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 
 			assert.Equal(t, expectedResult, output)
 		}},

--- a/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_windows.go
+++ b/internal/third_party/kubernetes/pkg/kubelet/cri/remote/util/util_windows.go
@@ -82,7 +82,7 @@ func npipeDial(ctx context.Context, addr string) (net.Conn, error) {
 
 func parseEndpoint(endpoint string) (string, string, error) {
 	// url.Parse doesn't recognize \, so replace with / first.
-	endpoint = strings.Replace(endpoint, "\\", "/", -1)
+	endpoint = strings.ReplaceAll(endpoint, "\\", "/")
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return "", "", err

--- a/pkg/cli/subcommands/check/command.go
+++ b/pkg/cli/subcommands/check/command.go
@@ -501,7 +501,7 @@ func run(
 			// Every instance will create its own directory
 			instanceID := strings.SplitN(string(c.ID()), ":", 2)[1]
 			// Colons can't be part of Windows file paths
-			instanceID = strings.Replace(instanceID, ":", "_", -1)
+			instanceID = strings.ReplaceAll(instanceID, ":", "_")
 			profileDataDir := filepath.Join(cliParams.profileMemoryDir, cliParams.checkName, instanceID)
 
 			snapshotDir := filepath.Join(profileDataDir, "snapshots")

--- a/pkg/collector/corechecks/net/wlan/wlan.go
+++ b/pkg/collector/corechecks/net/wlan/wlan.go
@@ -130,7 +130,7 @@ func (c *WLANCheck) Run() error {
 		bssid = "unknown"
 	}
 
-	macAddress := strings.ToLower(strings.Replace(wi.macAddress, " ", "_", -1))
+	macAddress := strings.ToLower(strings.ReplaceAll(wi.macAddress, " ", "_"))
 	if macAddress == "" {
 		macAddress = "unknown"
 	}

--- a/pkg/collector/corechecks/snmp/status/status_test.go
+++ b/pkg/collector/corechecks/snmp/status/status_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
-	// Importing the discovery package to register the expvar
 	"github.com/stretchr/testify/assert"
 
+	// Importing the discovery package to register the expvar
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/discovery"

--- a/pkg/collector/corechecks/snmp/status/status_test.go
+++ b/pkg/collector/corechecks/snmp/status/status_test.go
@@ -13,12 +13,13 @@ import (
 	"testing"
 
 	// Importing the discovery package to register the expvar
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/discovery"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/snmp"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestStatus(t *testing.T) {
@@ -100,8 +101,8 @@ func TestStatusWithProfileError(t *testing.T) {
   foobar: error1
 error2`
 
-			expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			assert.Contains(t, output, expectedResult)
 
 			fmt.Printf("%s", b.String())
@@ -119,8 +120,8 @@ error2
   </span>
 </div>`
 
-			expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			assert.Contains(t, output, expectedResult)
 
 			fmt.Printf("%s", b.String())
@@ -205,8 +206,8 @@ func TestStatusAutodiscoveryMultipleSubnets(t *testing.T) {
   No IPs found in the subnet.
 `
 
-			expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			assert.Contains(t, output, expectedResult)
 
 			fmt.Printf("%s", b.String())
@@ -233,8 +234,8 @@ func TestStatusAutodiscoveryMultipleSubnets(t *testing.T) {
 </span>
 </div>`
 
-			expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			assert.Contains(t, output, expectedResult)
 
 			fmt.Printf("%s", b.String())
@@ -303,9 +304,9 @@ func TestStatusLegacyDiscoveryMultipleSubnets(t *testing.T) {
   No IPs found in the subnet.`,
 			}
 
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			for _, expectedTextOutput := range expectedTextOutputs {
-				expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
 				assert.Contains(t, output, expectedResult)
 			}
 
@@ -326,9 +327,9 @@ func TestStatusLegacyDiscoveryMultipleSubnets(t *testing.T) {
 				`Subnet 127.0.10.1/30 scanned.</br>
     Found no IPs in the subnet.</br>`,
 			}
-			output := strings.Replace(b.String(), "\r\n", "\n", -1)
+			output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 			for _, expectedTextOutput := range expectedTextOutputs {
-				expectedResult := strings.Replace(expectedTextOutput, "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(expectedTextOutput, "\r\n", "\n")
 				assert.Contains(t, output, expectedResult)
 			}
 			fmt.Printf("%s", b.String())

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -462,7 +462,7 @@ func Initialize(paths ...string) error {
 
 	// store the Python version after killing \n chars within the string
 	if pyInfo != nil {
-		PythonVersion = strings.Replace(C.GoString(pyInfo.version), "\n", "", -1)
+		PythonVersion = strings.ReplaceAll(C.GoString(pyInfo.version), "\n", "")
 		// Set python version in the cache
 		cache.Cache.Set(pythonInfoCacheKey, PythonVersion, cache.NoExpiration)
 

--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -389,7 +389,7 @@ func buildHistogramAggregates(agentConfig Config) []string {
 	if configValue == "" {
 		return nil
 	}
-	configValue = strings.Replace(configValue, " ", "", -1)
+	configValue = strings.ReplaceAll(configValue, " ", "")
 	result := strings.Split(configValue, ",")
 
 	for _, res := range result {
@@ -417,7 +417,7 @@ func buildHistogramPercentiles(agentConfig Config) []string {
 	}
 
 	// percentiles are rounded down to 2 digits and (0:1)
-	configList = strings.Replace(configList, " ", "", -1)
+	configList = strings.ReplaceAll(configList, " ", "")
 	result := strings.Split(configList, ",")
 	for _, res := range result {
 		num, err := strconv.ParseFloat(res, 64)

--- a/pkg/config/setup/process.go
+++ b/pkg/config/setup/process.go
@@ -93,7 +93,7 @@ var processesAddOverrideOnce sync.Once
 func procBindEnvAndSetDefault(config pkgconfigmodel.Setup, key string, val interface{}) {
 	// Uppercase, replace "." with "_" and add "DD_" prefix to key so that we follow the same environment
 	// variable convention as the core agent.
-	processConfigKey := "DD_" + strings.Replace(strings.ToUpper(key), ".", "_", -1)
+	processConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
 	processAgentKey := strings.Replace(processConfigKey, "PROCESS_CONFIG", "PROCESS_AGENT", 1)
 
 	envs := []string{processConfigKey, processAgentKey}
@@ -103,7 +103,7 @@ func procBindEnvAndSetDefault(config pkgconfigmodel.Setup, key string, val inter
 // procBindEnv is a helper function that generates both "DD_PROCESS_CONFIG_" and "DD_PROCESS_AGENT_" prefixes from a key, but does not set a default.
 // We need this helper function because the standard BindEnv can only generate one prefix from a key.
 func procBindEnv(config pkgconfigmodel.Setup, key string) {
-	processConfigKey := "DD_" + strings.Replace(strings.ToUpper(key), ".", "_", -1)
+	processConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
 	processAgentKey := strings.Replace(processConfigKey, "PROCESS_CONFIG", "PROCESS_AGENT", 1)
 
 	config.BindEnv(key, processConfigKey, processAgentKey)

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -469,7 +469,7 @@ func suffixHostEtc(suffix string) string {
 func eventMonitorBindEnvAndSetDefault(config pkgconfigmodel.Config, key string, val interface{}) {
 	// Uppercase, replace "." with "_" and add "DD_" prefix to key so that we follow the same environment
 	// variable convention as the core agent.
-	emConfigKey := "DD_" + strings.Replace(strings.ToUpper(key), ".", "_", -1)
+	emConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
 	runtimeSecKey := strings.Replace(emConfigKey, "EVENT_MONITORING_CONFIG", "RUNTIME_SECURITY_CONFIG", 1)
 
 	envs := []string{emConfigKey, runtimeSecKey}
@@ -478,7 +478,7 @@ func eventMonitorBindEnvAndSetDefault(config pkgconfigmodel.Config, key string, 
 
 // eventMonitorBindEnv is the same as eventMonitorBindEnvAndSetDefault, but without setting a default.
 func eventMonitorBindEnv(config pkgconfigmodel.Config, key string) {
-	emConfigKey := "DD_" + strings.Replace(strings.ToUpper(key), ".", "_", -1)
+	emConfigKey := "DD_" + strings.ReplaceAll(strings.ToUpper(key), ".", "_")
 	runtimeSecKey := strings.Replace(emConfigKey, "EVENT_MONITORING_CONFIG", "RUNTIME_SECURITY_CONFIG", 1)
 
 	config.BindEnv(key, emConfigKey, runtimeSecKey)

--- a/pkg/config/utils/clusteragent.go
+++ b/pkg/config/utils/clusteragent.go
@@ -56,7 +56,7 @@ func GetClusterAgentEndpoint() (string, error) {
 	}
 
 	dcaSvc = strings.ToUpper(dcaSvc)
-	dcaSvc = strings.Replace(dcaSvc, "-", "_", -1) // Kubernetes replaces "-" with "_" in the service names injected in the env var.
+	dcaSvc = strings.ReplaceAll(dcaSvc, "-", "_") // Kubernetes replaces "-" with "_" in the service names injected in the env var.
 
 	// host
 	dcaSvcHostEnv := fmt.Sprintf("%s_SERVICE_HOST", dcaSvc)

--- a/pkg/flare/config_check_test.go
+++ b/pkg/flare/config_check_test.go
@@ -151,8 +151,8 @@ Log Config:
 				assert.Contains(t, b.String(), "\x1b[31m")
 			} else {
 				// We replace windows line break by linux so the tests pass on every OS
-				expectedResult := strings.Replace(test.expected, "\r\n", "\n", -1)
-				output := strings.Replace(b.String(), "\r\n", "\n", -1)
+				expectedResult := strings.ReplaceAll(test.expected, "\r\n", "\n")
+				output := strings.ReplaceAll(b.String(), "\r\n", "\n")
 
 				assert.Equal(t, expectedResult, output)
 			}

--- a/pkg/logs/client/http/test_utils.go
+++ b/pkg/logs/client/http/test_utils.go
@@ -76,7 +76,7 @@ func NewTestServerWithOptions(statusCode int, concurrentSends int, retryDestinat
 	destCtx := client.NewDestinationsContext()
 	destCtx.Start()
 
-	endpoint := config.NewEndpoint("test", "", strings.Replace(url[1], "/", "", -1), port, false)
+	endpoint := config.NewEndpoint("test", "", strings.ReplaceAll(url[1], "/", ""), port, false)
 	endpoint.BackoffFactor = 1
 	endpoint.BackoffBase = 0.01
 	endpoint.BackoffMax = 10

--- a/pkg/obfuscate/http.go
+++ b/pkg/obfuscate/http.go
@@ -56,5 +56,5 @@ func (o *Obfuscator) ObfuscateURLString(val string) string {
 			u.Path = strings.Join(segs, "/")
 		}
 	}
-	return strings.Replace(u.String(), "/REDACTED/", "?", -1)
+	return strings.ReplaceAll(u.String(), "/REDACTED/", "?")
 }

--- a/pkg/obfuscate/sql.go
+++ b/pkg/obfuscate/sql.go
@@ -41,7 +41,7 @@ type metadataFinderFilter struct {
 func (f *metadataFinderFilter) Filter(token, lastToken TokenKind, buffer []byte) (TokenKind, []byte, error) {
 	if f.collectComments && token == Comment {
 		// A comment with line-breaks will be brought to a single line.
-		comment := strings.TrimSpace(strings.Replace(string(buffer), "\n", " ", -1))
+		comment := strings.TrimSpace(strings.ReplaceAll(string(buffer), "\n", " "))
 		f.size += int64(len(comment))
 		f.comments = append(f.comments, comment)
 	}

--- a/pkg/process/checks/format_test.go
+++ b/pkg/process/checks/format_test.go
@@ -695,5 +695,5 @@ Process Lifecyle Events
 // assertEqualAnyLineBreak is an assertion helper to compare strings ignoring the \r character
 func assertEqualAnyLineBreak(t *testing.T, expected, actual string) {
 	t.Helper()
-	assert.Equal(t, expected, strings.Replace(actual, "\r\n", "\n", -1))
+	assert.Equal(t, expected, strings.ReplaceAll(actual, "\r\n", "\n"))
 }

--- a/pkg/security/generators/accessors/accessors.go
+++ b/pkg/security/generators/accessors/accessors.go
@@ -1020,7 +1020,7 @@ func getSetHandler(allFields map[string]*common.StructField, field *common.Struc
 			if !field.IsOrigTypePtr {
 				ptr = "&"
 			}
-			return fmt.Sprintf(`%s(%sev.%s, "%s", value)`, field.SetHandler, ptr, field.Name, strings.Replace(fqn, field.Alias+".", "", -1))
+			return fmt.Sprintf(`%s(%sev.%s, "%s", value)`, field.SetHandler, ptr, field.Name, strings.ReplaceAll(fqn, field.Alias+".", ""))
 		}
 
 		idx := strings.LastIndex(name, ".")

--- a/pkg/security/secl/rules/fim_unix.go
+++ b/pkg/security/secl/rules/fim_unix.go
@@ -30,7 +30,7 @@ func expandFim(baseID, groupID, baseExpr string) []expandedRule {
 
 	var expandedRules []expandedRule
 	for _, eventType := range []string{"open", "chmod", "chown", "link", "rename", "unlink", "utimes"} {
-		expr := strings.Replace(baseExpr, "fim.write.file.", fmt.Sprintf("%s.file.", eventType), -1)
+		expr := strings.ReplaceAll(baseExpr, "fim.write.file.", fmt.Sprintf("%s.file.", eventType))
 		if eventType == "open" {
 			expr = fmt.Sprintf("(%s) && open.flags & (O_CREAT|O_TRUNC|O_APPEND|O_RDWR|O_WRONLY) > 0", expr)
 		}
@@ -42,7 +42,7 @@ func expandFim(baseID, groupID, baseExpr string) []expandedRule {
 		})
 
 		if eventType == "rename" {
-			expr := strings.Replace(baseExpr, "fim.write.file.", "rename.file.destination.", -1)
+			expr := strings.ReplaceAll(baseExpr, "fim.write.file.", "rename.file.destination.")
 			id := fmt.Sprintf("__fim_expanded_%s_%s_%s", "rename_destination", groupID, baseID)
 			expandedRules = append(expandedRules, expandedRule{
 				id:   id,

--- a/pkg/security/security_profile/rules.go
+++ b/pkg/security/security_profile/rules.go
@@ -140,7 +140,7 @@ func addRule(expression string, groupID string, opts SECLRuleOpts) *rules.RuleDe
 	ruleDef := &rules.RuleDefinition{
 		Expression: expression,
 		GroupID:    groupID,
-		ID:         strings.Replace(uuid.New().String(), "-", "_", -1),
+		ID:         strings.ReplaceAll(uuid.New().String(), "-", "_"),
 	}
 	applyContext(ruleDef, opts)
 	if opts.EnableKill {
@@ -183,7 +183,7 @@ func getGroupID(opts SECLRuleOpts) string {
 	if len(opts.ImageName) != 0 {
 		groupID = fmt.Sprintf("%s%s", groupID, opts.ImageName)
 	} else {
-		groupID = fmt.Sprintf("%s%s", groupID, strings.Replace(uuid.New().String(), "-", "_", -1)) // It should be unique so that we can target it at least, but ImageName should be always set
+		groupID = fmt.Sprintf("%s%s", groupID, strings.ReplaceAll(uuid.New().String(), "-", "_")) // It should be unique so that we can target it at least, but ImageName should be always set
 	}
 	if len(opts.ImageTag) != 0 {
 		groupID = fmt.Sprintf("%s_%s", groupID, opts.ImageTag)

--- a/pkg/security/tests/statsdclient/statsd_client.go
+++ b/pkg/security/tests/statsdclient/statsd_client.go
@@ -45,7 +45,7 @@ func (s *StatsdClient) GetByPrefix(prefix string) map[string]int64 {
 
 	for key, value := range s.counts {
 		if strings.HasPrefix(key, prefix) {
-			k := strings.Replace(key, prefix, "", -1)
+			k := strings.ReplaceAll(key, prefix, "")
 			result[k] = value
 		}
 	}

--- a/pkg/status/collector/status_test.go
+++ b/pkg/status/collector/status_test.go
@@ -52,8 +52,8 @@ func TestRender(t *testing.T) {
 			require.NoError(t, err)
 
 			// We replace windows line break by linux so the tests pass on every OS
-			result := strings.Replace(string(expectedOutput), "\r\n", "\n", -1)
-			stringOutput := strings.Replace(output.String(), "\r\n", "\n", -1)
+			result := strings.ReplaceAll(string(expectedOutput), "\r\n", "\n")
+			stringOutput := strings.ReplaceAll(output.String(), "\r\n", "\n")
 
 			require.Equal(t, result, stringOutput, "HTML rendering is not as expected")
 		})

--- a/pkg/util/scrubber/yaml_scrubber_test.go
+++ b/pkg/util/scrubber/yaml_scrubber_test.go
@@ -106,8 +106,8 @@ func TestConfigScrubbedValidYaml(t *testing.T) {
 	assert.NoError(t, err, "Could not load YAML configuration after being scrubbed")
 
 	// We replace windows line break by linux so the tests pass on every OS
-	trimmedOutput := strings.TrimSpace(strings.Replace(string(outputConfData), "\r\n", "\n", -1))
-	trimmedCleaned := strings.TrimSpace(strings.Replace(string(cleaned), "\r\n", "\n", -1))
+	trimmedOutput := strings.TrimSpace(strings.ReplaceAll(string(outputConfData), "\r\n", "\n"))
+	trimmedCleaned := strings.TrimSpace(strings.ReplaceAll(string(cleaned), "\r\n", "\n"))
 
 	assert.Equal(t, trimmedOutput, trimmedCleaned)
 }
@@ -132,8 +132,8 @@ func TestConfigScrubbedYaml(t *testing.T) {
 	assert.NoError(t, err, "Could not load YAML configuration after being scrubbed")
 
 	// We replace windows line break by linux so the tests pass on every OS
-	trimmedOutput := strings.TrimSpace(strings.Replace(string(outputConfData), "\r\n", "\n", -1))
-	trimmedCleaned := strings.TrimSpace(strings.Replace(string(cleaned), "\r\n", "\n", -1))
+	trimmedOutput := strings.TrimSpace(strings.ReplaceAll(string(outputConfData), "\r\n", "\n"))
+	trimmedCleaned := strings.TrimSpace(strings.ReplaceAll(string(cleaned), "\r\n", "\n"))
 
 	assert.Equal(t, trimmedOutput, trimmedCleaned)
 }

--- a/pkg/util/winutil/scmmonitor_test.go
+++ b/pkg/util/winutil/scmmonitor_test.go
@@ -63,7 +63,7 @@ func TestServices(t *testing.T) {
 
 		entries := strings.Split(line, ",")
 		for i, s := range entries {
-			entries[i] = strings.Replace(s, "\"", "", -1)
+			entries[i] = strings.ReplaceAll(s, "\"", "")
 		}
 		pid, _ := strconv.ParseInt(entries[1], 10, 64)
 		if pid == 0 {

--- a/test/integration/util/leaderelection/leaderelection_test.go
+++ b/test/integration/util/leaderelection/leaderelection_test.go
@@ -58,7 +58,7 @@ func generateApiserverCompose(version string) error {
 		return err
 	}
 
-	newComposeFile := strings.Replace(string(apiserverCompose), "APIVERSION_PLACEHOLDER", version, -1)
+	newComposeFile := strings.ReplaceAll(string(apiserverCompose), "APIVERSION_PLACEHOLDER", version)
 
 	err = os.WriteFile(getApiserverComposePath(version), []byte(newComposeFile), os.ModePerm)
 	if err != nil {

--- a/test/new-e2e/tests/agent-configuration/gui/gui_common.go
+++ b/test/new-e2e/tests/agent-configuration/gui/gui_common.go
@@ -146,13 +146,13 @@ func checkStaticFiles(t *testing.T, client *http.Client, host *components.Remote
 
 		body, err := io.ReadAll(resp.Body)
 		// We replace windows line break by linux so the tests pass on every OS
-		bodyContent := strings.Replace(string(body), "\r\n", "\n", -1)
+		bodyContent := strings.ReplaceAll(string(body), "\r\n", "\n")
 		assert.NoErrorf(t, err, "failed to read content of GUI asset at address %s", fullLink)
 
 		// retrieving the served file in the Agent insallation director, removing the "view/" prefix
 		expectedBody, err := host.ReadFile(path.Join(installPath, "bin", "agent", "dist", "views", strings.TrimLeft(link, "view/")))
 		// We replace windows line break by linux so the tests pass on every OS
-		expectedBodyContent := strings.Replace(string(expectedBody), "\r\n", "\n", -1)
+		expectedBodyContent := strings.ReplaceAll(string(expectedBody), "\r\n", "\n")
 		assert.NoErrorf(t, err, "unable to retrieve file %v in the expected served files", link)
 
 		assert.Equalf(t, expectedBodyContent, bodyContent, "content of the file %v is not the same as expected", link)

--- a/test/new-e2e/tests/installer/windows/installer.go
+++ b/test/new-e2e/tests/installer/windows/installer.go
@@ -319,7 +319,7 @@ func CreatePackageSourceIfLocal(host *components.RemoteHost, pkg TestPackageConf
 			return pkg, err
 		}
 		// Must replace slashes so that daemon can parse it correctly
-		outPath = strings.Replace(outPath, "\\", "/", -1)
+		outPath = strings.ReplaceAll(outPath, "\\", "/")
 		pkg.urloverride = fmt.Sprintf("file://%s", outPath)
 	}
 	return pkg, nil

--- a/test/new-e2e/tests/windows/iis.go
+++ b/test/new-e2e/tests/windows/iis.go
@@ -87,7 +87,7 @@ func CreateIISSite(host *components.RemoteHost, site []IISSiteDefinition) error 
 		if ((get-iissite -name %s).State -ne "Started") {
 			New-IISSite -ErrorAction SilentlyContinue -Name %s -BindingInformation '%s' -PhysicalPath %s
 		}`
-		wintgtpath := strings.Replace(tgtpath, "/", "\\", -1)
+		wintgtpath := strings.ReplaceAll(tgtpath, "/", "\\")
 		cmd := fmt.Sprintf(script, s.Name, s.Name, s.BindingPort, wintgtpath)
 		output, err := host.Execute(cmd)
 		if err != nil {
@@ -100,7 +100,7 @@ func CreateIISSite(host *components.RemoteHost, site []IISSiteDefinition) error 
 			if ($res -eq $null) {
 				New-WebApplication -Site '%s' -Name '%s' -PhysicalPath '%s'
 			}`
-			physpath := strings.Replace(app.PhysicalPath, "/", "\\", -1)
+			physpath := strings.ReplaceAll(app.PhysicalPath, "/", "\\")
 
 			// make the physical path first since it's required
 			err := host.MkdirAll(physpath)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Replace uses of `strings.Replace(..., -1)` with `strings.ReplaceAll`.

### Motivation
It's cleaner and less error prone.
Also this is one of the warnings from our static analysis tool, so I see those in my IDE, would rather fix them and not see them 😄 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
No functional change expected, CI should be enough.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->