### PR TITLE
[ACIX-551] Migrate macos build job to new runners

### DIFF
--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -40,6 +40,7 @@ agent_dmg-x64-a7:
     NOTARIZATION_TIMEOUT: 30m
     NOTARIZATION_ATTEMPTS: 3
     NOTARIZATION_WAIT_TIME: 15s
+  timeout: 2h
   cache:
     - !reference [.cache_omnibus_ruby_deps, cache]
   before_script:

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -49,8 +49,7 @@ agent_dmg-x64-a7:
 
 new-agent_dmg-x64-a7:
   stage: package_build
-  # TODO(celian): Don't use the test image
-  tags: ["macos:ventura-amd64-test", "specific:true"]
+  tags: ["macos:ventura-amd64"]
   needs: ["go_mod_tidy_check"]
   allow_failure: true
 

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -49,7 +49,7 @@ agent_dmg-x64-a7:
 
 new-agent_dmg-x64-a7:
   stage: package_build
-  tags: ["macos:ventura-amd64"]
+  tags: ["macos:ventura-amd64", "specific:true"]
   needs: ["go_mod_tidy_check"]
   allow_failure: true
 

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -1,36 +1,4 @@
 ---
-.agent_build_common_dmg:
-  script:
-    # remove artifacts from previous pipelines that may come from the cache
-    - rm -rf $OMNIBUS_PACKAGE_DIR/*
-    - mkdir -p $OMNIBUS_PACKAGE_DIR
-    - !reference [.setup_macos_github_app]
-    - $S3_CP_CMD $S3_ARTIFACTS_URI/agent-version.cache .
-    - export VERSION_CACHE_CONTENT=$(cat agent-version.cache | base64 -)
-    - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
-    - python3 -m dda self dep sync -f legacy-tasks
-    - dda inv -- -e github.trigger-macos --workflow-type "build" --datadog-agent-ref "$CI_COMMIT_SHA" --destination "$OMNIBUS_PACKAGE_DIR" --version-cache "$VERSION_CACHE_CONTENT" --integrations-core-ref "$INTEGRATIONS_CORE_VERSION"
-    - !reference [.upload_sbom_artifacts]
-  timeout: 3h # MacOS builds can take 1h~2h, increase the timeout to avoid timeout flakes
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - $OMNIBUS_PACKAGE_DIR
-
-agent_dmg-x64-a7:
-  extends: .agent_build_common_dmg
-  rules:
-    - !reference [.on_macos_gui_change]
-    - !reference [.on_packaging_change]
-    - !reference [.on_main_or_release_branch]
-    - !reference [.on_all_builds]
-    - !reference [.manual]
-  stage: package_build
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["arch:amd64"]
-  needs: ["go_mod_tidy_check"]
-  timeout: 6h
-
 .macos_setup_python:
   # Selecting the current Python version
   - !reference [.select_python_env_commands]
@@ -47,27 +15,16 @@ agent_dmg-x64-a7:
     export GOMODCACHE=~/gomodcache
     mkdir -p $GOMODCACHE
 
-new-agent_dmg-x64-a7:
+agent_dmg-x64-a7:
   stage: package_build
   tags: ["macos:ventura-amd64", "specific:true"]
   needs: ["go_mod_tidy_check"]
-  allow_failure: true
-
-  # TODO(celian): Temporary rules.
   rules:
-    # This is used to avoid conflicts with the current build job on main / release branches with s3. This will run on dev branches
-    - !reference  [.except_mergequeue]
-    - !reference [.on_main_or_release_branch_or_deploy_manual]
-    - when: on_success
-
-  # TODO(celian): Replace by the following after testing new builds.
-  # rules:
-  #    - !reference [.on_macos_gui_change]
-  #    - !reference [.on_packaging_change]
-  #    - !reference [.on_main_or_release_branch]
-  #    - !reference [.on_all_builds]
-  #    - !reference [.manual]
-  # allow_failure: false  # (remove)
+     - !reference [.on_macos_gui_change]
+     - !reference [.on_packaging_change]
+     - !reference [.on_main_or_release_branch]
+     - !reference [.on_all_builds]
+     - !reference [.manual]
   artifacts:
     expire_in: 2 weeks
     paths:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Completes migration for the new agent dmg build job.

👉 [Job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/915008647).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

- XCode has been updated from 14.2 to 14.3.1

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

# **QA: Please read**

> [!IMPORTANT]
> This PR changes how the agent is built. To be sure that the agent is still working fine on amd64 macos, please QA the main features your team own using the dmg artifact from `agent_dmg-x64`.