### PR TITLE
Apply config overrides to the AgentRuntime layer, not EnvVar

### DIFF
--- a/pkg/config/model/config_overrides.go
+++ b/pkg/config/model/config_overrides.go
@@ -46,7 +46,7 @@ func ApplyOverrideFuncs(config Config) {
 func applyOverrideVars(config Config) {
 	for k, v := range overrideVars {
 		if config.IsKnown(k) {
-			config.Set(k, v, SourceEnvVar)
+			config.Set(k, v, SourceAgentRuntime)
 		}
 	}
 }

--- a/pkg/config/setup/config_test.go
+++ b/pkg/config/setup/config_test.go
@@ -638,6 +638,8 @@ external_config:
 
 	assert.Equal(config.GetString("api_key"), "overrided", "the api key should have been overrided")
 	assert.Equal(config.GetString("dd_url"), "https://app.datadoghq.eu", "this shouldn't be overrided")
+	assert.Equal(config.GetSource("api_key"), pkgconfigmodel.SourceAgentRuntime)
+	assert.Equal(config.GetSource("dd_url"), pkgconfigmodel.SourceFile)
 
 	pkgconfigmodel.AddOverrides(map[string]interface{}{
 		"dd_url": "http://localhost",
@@ -646,6 +648,8 @@ external_config:
 
 	assert.Equal(config.GetString("api_key"), "overrided", "the api key should have been overrided")
 	assert.Equal(config.GetString("dd_url"), "http://localhost", "this dd_url should have been overrided")
+	assert.Equal(config.GetSource("api_key"), pkgconfigmodel.SourceAgentRuntime)
+	assert.Equal(config.GetSource("dd_url"), pkgconfigmodel.SourceAgentRuntime)
 }
 
 func TestGetValidHostAliasesWithConfig(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Apply config overrides to the AgentRuntime layer, not EnvVar

### Motivation

Overrides don't actually come from env vars, so it's incorrect to add them to that layer. When the config is using a dynamic schema (by calling `SetTestOnlyDynamicSchema`) it rebuilds the env layer from vars, which breaks the behavior of overrides if they are being added to the env var layer.

When run with DD_CONF_NODETREEMODEL=enable, this fixes the test TestApplyOverrides in pkg/config/setup/config_test.go

### Describe how you validated your changes

Add new checks for the source of overrides in unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
