### PR TITLE
dont fail on StartPending service state

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -226,6 +226,8 @@ func startWatchdog(_ context.Context, timeout time.Time) error {
 	defer dataDogService.Close()
 
 	// main watchdog loop
+	// Watch the Installer and Agent services and ensure they stay running
+	// The Agent MSI starts them initially.
 	for time.Now().Before(timeout) {
 		// check the Installer service
 		status, err := instService.Query()

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -232,11 +232,11 @@ func startWatchdog(_ context.Context, timeout time.Time) error {
 		if err != nil {
 			return fmt.Errorf("could not query service: %w", err)
 		}
-		if status.State != svc.Running {
+		if status.State != svc.Running && status.State != svc.StartPending {
 			// the service has died
 			// we need to restore the stable Agent
 			// return an error to signal the caller to restore the stable Agent
-			return fmt.Errorf("Datadog Agent is not running")
+			return fmt.Errorf("Datadog Installer is not running")
 		}
 
 		// check the Agent service
@@ -244,7 +244,7 @@ func startWatchdog(_ context.Context, timeout time.Time) error {
 		if err != nil {
 			return fmt.Errorf("could not query service: %w", err)
 		}
-		if status.State != svc.Running {
+		if status.State != svc.Running && status.State != svc.StartPending {
 			// the service has died
 			// we need to restore the stable Agent
 			// return an error to signal the caller to restore the stable Agent

--- a/releasenotes/notes/win-fleet-startpending-service-state-bbe28a47e853db5f.yaml
+++ b/releasenotes/notes/win-fleet-startpending-service-state-bbe28a47e853db5f.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Do not fail remote upgrade on Windows when the Agent service takes more than 3 minutes to start


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
don't fail when the service state is `START_PENDING` during the watchdog phase of remote upgrade experiment on Windows

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1460
It's possible for the service to still be in `START_PENDING` at this time, but the [MSI waits 3 minutes](https://github.com/DataDog/datadog-agent/blob/16e8e82d5038e66d4e83294807fc5f8da4ba55fa/tools/windows/DatadogAgentInstaller/CustomActions/ServiceCustomAction.cs#L367) for the service to transition from `START_PENDING` to `RUNNING` so this is unlikely.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
