### PR TITLE
Stringify outputs more low-level state from the config

### DIFF
--- a/pkg/config/model/stringify.go
+++ b/pkg/config/model/stringify.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package model
+
+// StringifyConfig defines configuration options for the Stringify method
+type StringifyConfig struct {
+	DedupPointerAddr bool
+	OmitPointerAddr  bool
+	SettingFilters   []string
+}
+
+// StringifyOption sets an option on the StringifyConfig
+type StringifyOption func(*StringifyConfig)
+
+// DedupPointerAddr deduplicates pointers in the Stringify output
+func DedupPointerAddr(strcfg *StringifyConfig) {
+	strcfg.DedupPointerAddr = true
+}
+
+// OmitPointerAddr omits pointer's raw addresses in the Stringify output, useful for testing
+func OmitPointerAddr(strcfg *StringifyConfig) {
+	strcfg.OmitPointerAddr = true
+}
+
+// FilterSettings will filter the output of Stringify to only show the given settings
+func FilterSettings(filters []string) StringifyOption {
+	return func(strcfg *StringifyConfig) {
+		strcfg.SettingFilters = filters
+	}
+}

--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -198,8 +198,8 @@ type Reader interface {
 	// by a call to the 'Set' method. The configuration will sequentially call each receiver.
 	OnUpdate(callback NotificationReceiver)
 
-	// Stringify stringifies the config
-	Stringify(source Source) string
+	// Stringify stringifies the config, only available if "test" build tag is enabled
+	Stringify(source Source, opts ...StringifyOption) string
 }
 
 // Writer is a subset of Config that only allows writing the configuration

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -71,6 +71,9 @@ type ntmConfig struct {
 	// - unknown keys can be assigned and retrieved
 	allowDynamicSchema *atomic.Bool
 
+	// tree debugger is used by the Stringify method, useful for debugging and test assertions
+	td *treeDebugger
+
 	// defaults contains the settings with a default value
 	defaults InnerNode
 	// unknown contains the settings set at runtime from unknown source. This should only evey be used by tests.
@@ -473,11 +476,11 @@ func (c *ntmConfig) buildSchema() {
 }
 
 // Stringify stringifies the config, but only with the test build tag
-func (c *ntmConfig) Stringify(source model.Source) string {
+func (c *ntmConfig) Stringify(source model.Source, opts ...model.StringifyOption) string {
 	c.Lock()
 	defer c.Unlock()
 	// only does anything if the build tag "test" is enabled
-	text, err := c.toDebugString(source)
+	text, err := c.toDebugString(source, opts...)
 	if err != nil {
 		return fmt.Sprintf("Stringify error: %s", err)
 	}

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -400,7 +400,7 @@ func TestAllKeysLowercased(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, keys)
 }
 
-func TestStringify(t *testing.T) {
+func TestStringifyLayers(t *testing.T) {
 	configData := `network_path:
   collector:
     workers: 6
@@ -421,60 +421,202 @@ secret_backend_command: ./my_secret_fetcher.sh
 	err := cfg.ReadConfig(strings.NewReader(configData))
 	require.NoError(t, err)
 
-	txt := cfg.(*ntmConfig).Stringify("none")
+	txt := cfg.(*ntmConfig).Stringify("none", model.OmitPointerAddr)
 	expect := "Stringify error: invalid source: none"
 	assert.Equal(t, expect, txt)
 
-	txt = cfg.(*ntmConfig).Stringify(model.SourceDefault)
-	expect = `network_path
-  collector
-    input_chan_size
-      val:100000, source:default
-    processing_chan_size
-      val:100000, source:default
-    workers
-      val:4, source:default
-secret_backend_command
-  val:, source:default
-secret_backend_timeout
-  val:0, source:default
-server_timeout
-  val:30, source:default`
+	txt = cfg.(*ntmConfig).Stringify(model.SourceDefault, model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=default
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000003>), val:100000, source:default
+    > processing_chan_size
+        leaf(#ptr<000004>), val:100000, source:default
+    > workers
+        leaf(#ptr<000005>), val:4, source:default
+> secret_backend_command
+    leaf(#ptr<000006>), val:"", source:default
+> secret_backend_timeout
+    leaf(#ptr<000007>), val:0, source:default
+> server_timeout
+    leaf(#ptr<000008>), val:30, source:default`
 	assert.Equal(t, expect, txt)
 
-	txt = cfg.(*ntmConfig).Stringify(model.SourceFile)
-	expect = `network_path
-  collector
-    workers
-      val:6, source:file
-secret_backend_command
-  val:./my_secret_fetcher.sh, source:file`
+	txt = cfg.(*ntmConfig).Stringify(model.SourceFile, model.OmitPointerAddr)
+	expect = `tree(#ptr<000009>) source=file
+> network_path
+  inner(#ptr<000010>)
+  > collector
+    inner(#ptr<000011>)
+    > workers
+        leaf(#ptr<000012>), val:6, source:file
+> secret_backend_command
+    leaf(#ptr<000013>), val:"./my_secret_fetcher.sh", source:file`
 	assert.Equal(t, expect, txt)
 
-	txt = cfg.(*ntmConfig).Stringify(model.SourceEnvVar)
-	expect = `network_path
-  collector
-    input_chan_size
-      val:23456, source:environment-variable
-secret_backend_timeout
-  val:60, source:environment-variable`
+	txt = cfg.(*ntmConfig).Stringify(model.SourceEnvVar, model.OmitPointerAddr)
+	expect = `tree(#ptr<000014>) source=environment-variable
+> network_path
+  inner(#ptr<000015>)
+  > collector
+    inner(#ptr<000016>)
+    > input_chan_size
+        leaf(#ptr<000017>), val:"23456", source:environment-variable
+> secret_backend_timeout
+    leaf(#ptr<000018>), val:"60", source:environment-variable`
 	assert.Equal(t, expect, txt)
 
-	txt = cfg.(*ntmConfig).Stringify("root")
-	expect = `network_path
-  collector
-    input_chan_size
-      val:23456, source:environment-variable
-    processing_chan_size
-      val:100000, source:default
-    workers
-      val:6, source:file
-secret_backend_command
-  val:./my_secret_fetcher.sh, source:file
-secret_backend_timeout
-  val:60, source:environment-variable
-server_timeout
-  val:30, source:default`
+	txt = cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect = `tree(#ptr<000019>) source=root
+> network_path
+  inner(#ptr<000020>)
+  > collector
+    inner(#ptr<000021>)
+    > input_chan_size
+        leaf(#ptr<000022>), val:"23456", source:environment-variable
+    > processing_chan_size
+        leaf(#ptr<000023>), val:100000, source:default
+    > workers
+        leaf(#ptr<000024>), val:6, source:file
+> secret_backend_command
+    leaf(#ptr<000025>), val:"./my_secret_fetcher.sh", source:file
+> secret_backend_timeout
+    leaf(#ptr<000026>), val:"60", source:environment-variable
+> server_timeout
+    leaf(#ptr<000027>), val:30, source:default`
+	assert.Equal(t, expect, txt)
+}
+
+func TestStringifyAll(t *testing.T) {
+	configData := `network_path:
+  collector:
+    workers: 6
+`
+	os.Setenv("TEST_NETWORK_PATH_COLLECTOR_INPUT_CHAN_SIZE", "23456")
+
+	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault("network_path.collector.input_chan_size", 100000)
+	cfg.BindEnvAndSetDefault("network_path.collector.workers", 4)
+	cfg.BindEnvAndSetDefault("secret_backend_command", "")
+
+	cfg.BuildSchema()
+	err := cfg.ReadConfig(strings.NewReader(configData))
+	require.NoError(t, err)
+
+	txt := cfg.(*ntmConfig).Stringify("all", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000003>), val:"23456", source:environment-variable
+    > workers
+        leaf(#ptr<000004>), val:6, source:file
+> secret_backend_command
+    leaf(#ptr<000005>), val:"", source:default
+tree(#ptr<000006>) source=default
+> network_path
+  inner(#ptr<000007>)
+  > collector
+    inner(#ptr<000008>)
+    > input_chan_size
+        leaf(#ptr<000009>), val:100000, source:default
+    > workers
+        leaf(#ptr<000010>), val:4, source:default
+> secret_backend_command
+    leaf(#ptr<000011>), val:"", source:default
+tree(#ptr<000012>) source=environment-variable
+> network_path
+  inner(#ptr<000013>)
+  > collector
+    inner(#ptr<000014>)
+    > input_chan_size
+        leaf(#ptr<000015>), val:"23456", source:environment-variable
+tree(#ptr<000016>) source=file
+> network_path
+  inner(#ptr<000017>)
+  > collector
+    inner(#ptr<000018>)
+    > workers
+        leaf(#ptr<000019>), val:6, source:file`
+	assert.Equal(t, expect, txt)
+}
+
+func TestStringifyFilterSettings(t *testing.T) {
+	configData := `logs_config:
+  container_collect_all: true
+process_config:
+  process_discovery:
+    interval: 4
+`
+	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault("logs_config.container_collect_all", false)
+	cfg.BindEnvAndSetDefault("process_config.cmd_port", 6162)
+	cfg.BindEnvAndSetDefault("process_config.process_collection.enabled", true)
+	cfg.BindEnvAndSetDefault("process_config.process_discovery.interval", 0)
+
+	cfg.BuildSchema()
+	err := cfg.ReadConfig(strings.NewReader(configData))
+	require.NoError(t, err)
+
+	txt := cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> logs_config
+  inner(#ptr<000001>)
+  > container_collect_all
+      leaf(#ptr<000002>), val:true, source:file
+> process_config
+  inner(#ptr<000003>)
+  > cmd_port
+      leaf(#ptr<000004>), val:6162, source:default
+  > process_collection
+    inner(#ptr<000005>)
+    > enabled
+        leaf(#ptr<000006>), val:true, source:default
+  > process_discovery
+    inner(#ptr<000007>)
+    > interval
+        leaf(#ptr<000008>), val:4, source:file`
+	assert.Equal(t, expect, txt)
+
+	txt = cfg.(*ntmConfig).Stringify("root", model.FilterSettings([]string{"process_config"}), model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> process_config
+  inner(#ptr<000003>)
+  > cmd_port
+      leaf(#ptr<000004>), val:6162, source:default
+  > process_collection
+    inner(#ptr<000005>)
+    > enabled
+        leaf(#ptr<000006>), val:true, source:default
+  > process_discovery
+    inner(#ptr<000007>)
+    > interval
+        leaf(#ptr<000008>), val:4, source:file`
+	assert.Equal(t, expect, txt)
+
+	txt = cfg.(*ntmConfig).Stringify("root", model.FilterSettings([]string{"process_config.process_collection"}), model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> process_config
+  inner(#ptr<000003>)
+  > process_collection
+    inner(#ptr<000005>)
+    > enabled
+        leaf(#ptr<000006>), val:true, source:default`
+	assert.Equal(t, expect, txt)
+
+	txt = cfg.(*ntmConfig).Stringify("root", model.FilterSettings([]string{"process_config.process_discovery"}), model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> process_config
+  inner(#ptr<000003>)
+  > process_discovery
+    inner(#ptr<000007>)
+    > interval
+        leaf(#ptr<000008>), val:4, source:file`
 	assert.Equal(t, expect, txt)
 }
 
@@ -501,17 +643,20 @@ func TestUnsetForSource(t *testing.T) {
 	require.NoError(t, err)
 
 	// The merged config
-	txt := cfg.(*ntmConfig).Stringify("root")
-	expect := `network_path
-  collector
-    input_chan_size
-      val:23456, source:environment-variable
-    pathtest_contexts_limit
-      val:654321, source:environment-variable
-    processing_chan_size
-      val:78900, source:environment-variable
-    workers
-      val:6, source:file`
+	txt := cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000003>), val:"23456", source:environment-variable
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:"654321", source:environment-variable
+    > processing_chan_size
+        leaf(#ptr<000005>), val:"78900", source:environment-variable
+    > workers
+        leaf(#ptr<000006>), val:6, source:file`
 	assert.Equal(t, expect, txt)
 
 	// No change if source doesn't match
@@ -528,70 +673,85 @@ func TestUnsetForSource(t *testing.T) {
 
 	// Remove a setting from the env source, nothing in the file source, it goes to default
 	cfg.UnsetForSource("network_path.collector.input_chan_size", model.SourceEnvVar)
-	txt = cfg.(*ntmConfig).Stringify("root")
-	expect = `network_path
-  collector
-    input_chan_size
-      val:100000, source:default
-    pathtest_contexts_limit
-      val:654321, source:environment-variable
-    processing_chan_size
-      val:78900, source:environment-variable
-    workers
-      val:6, source:file`
+	txt = cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000007>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:"654321", source:environment-variable
+    > processing_chan_size
+        leaf(#ptr<000005>), val:"78900", source:environment-variable
+    > workers
+        leaf(#ptr<000006>), val:6, source:file`
 	assert.Equal(t, expect, txt)
 
 	// Remove a setting from the file source, it goes to default
 	cfg.UnsetForSource("network_path.collector.workers", model.SourceFile)
-	txt = cfg.(*ntmConfig).Stringify("root")
-	expect = `network_path
-  collector
-    input_chan_size
-      val:100000, source:default
-    pathtest_contexts_limit
-      val:654321, source:environment-variable
-    processing_chan_size
-      val:78900, source:environment-variable
-    workers
-      val:4, source:default`
+	txt = cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000007>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:"654321", source:environment-variable
+    > processing_chan_size
+        leaf(#ptr<000005>), val:"78900", source:environment-variable
+    > workers
+        leaf(#ptr<000008>), val:4, source:default`
 	assert.Equal(t, expect, txt)
 
 	// Removing a setting from the env source, it goes to file source
 	cfg.UnsetForSource("network_path.collector.processing_chan_size", model.SourceEnvVar)
-	txt = cfg.(*ntmConfig).Stringify("root")
-	expect = `network_path
-  collector
-    input_chan_size
-      val:100000, source:default
-    pathtest_contexts_limit
-      val:654321, source:environment-variable
-    processing_chan_size
-      val:45678, source:file
-    workers
-      val:4, source:default`
+	txt = cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000007>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:"654321", source:environment-variable
+    > processing_chan_size
+        leaf(#ptr<000009>), val:45678, source:file
+    > workers
+        leaf(#ptr<000008>), val:4, source:default`
 	assert.Equal(t, expect, txt)
 
 	// Then remove it from the file source as well, leaving the default source
 	cfg.UnsetForSource("network_path.collector.processing_chan_size", model.SourceFile)
-	txt = cfg.(*ntmConfig).Stringify("root")
-	expect = `network_path
-  collector
-    input_chan_size
-      val:100000, source:default
-    pathtest_contexts_limit
-      val:654321, source:environment-variable
-    processing_chan_size
-      val:100000, source:default
-    workers
-      val:4, source:default`
+	txt = cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000007>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000004>), val:"654321", source:environment-variable
+    > processing_chan_size
+        leaf(#ptr<000010>), val:100000, source:default
+    > workers
+        leaf(#ptr<000008>), val:4, source:default`
 	assert.Equal(t, expect, txt)
 
 	// Check the file layer in isolation
-	fileTxt := cfg.(*ntmConfig).Stringify(model.SourceFile)
-	fileExpect := `network_path
-  collector
-    pathtest_contexts_limit
-      val:43210, source:file`
+	fileTxt := cfg.(*ntmConfig).Stringify(model.SourceFile, model.OmitPointerAddr)
+	fileExpect := `tree(#ptr<000011>) source=file
+> network_path
+  inner(#ptr<000012>)
+  > collector
+    inner(#ptr<000013>)
+    > pathtest_contexts_limit
+        leaf(#ptr<000014>), val:43210, source:file`
 	assert.Equal(t, fileExpect, fileTxt)
 
 	// Removing from the file source first does not change the merged value, because it uses env layer
@@ -599,24 +759,30 @@ func TestUnsetForSource(t *testing.T) {
 	assert.Equal(t, expect, txt)
 
 	// But the file layer itself has been modified
-	fileTxt = cfg.(*ntmConfig).Stringify(model.SourceFile)
-	fileExpect = `network_path
-  collector`
+	fileTxt = cfg.(*ntmConfig).Stringify(model.SourceFile, model.OmitPointerAddr)
+	fileExpect = `tree(#ptr<000011>) source=file
+> network_path
+  inner(#ptr<000012>)
+  > collector
+    inner(#ptr<000013>)`
 	assert.Equal(t, fileExpect, fileTxt)
 
 	// Finally, remove it from the env layer
 	cfg.UnsetForSource("network_path.collector.pathtest_contexts_limit", model.SourceEnvVar)
-	txt = cfg.(*ntmConfig).Stringify("root")
-	expect = `network_path
-  collector
-    input_chan_size
-      val:100000, source:default
-    pathtest_contexts_limit
-      val:100000, source:default
-    processing_chan_size
-      val:100000, source:default
-    workers
-      val:4, source:default`
+	txt = cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect = `tree(#ptr<000000>) source=root
+> network_path
+  inner(#ptr<000001>)
+  > collector
+    inner(#ptr<000002>)
+    > input_chan_size
+        leaf(#ptr<000007>), val:100000, source:default
+    > pathtest_contexts_limit
+        leaf(#ptr<000015>), val:100000, source:default
+    > processing_chan_size
+        leaf(#ptr<000010>), val:100000, source:default
+    > workers
+        leaf(#ptr<000008>), val:4, source:default`
 	assert.Equal(t, expect, txt)
 }
 

--- a/pkg/config/nodetreemodel/debug_string.go
+++ b/pkg/config/nodetreemodel/debug_string.go
@@ -10,7 +10,9 @@ package nodetreemodel
 
 import "github.com/DataDog/datadog-agent/pkg/config/model"
 
-func (c *ntmConfig) toDebugString(_ model.Source) (string, error) {
+type treeDebugger struct {}
+
+func (c *ntmConfig) toDebugString(_ model.Source, _ ...model.StringifyOption) (string, error) {
 	// don't show any data outside of tests, that way we don't have to worry about scrubbing
-	return "nodeTreeModelConfig{...}", nil
+	return "nodeTreeModelConfig{...no-test-tag...}", nil
 }

--- a/pkg/config/nodetreemodel/debug_string_testonly.go
+++ b/pkg/config/nodetreemodel/debug_string_testonly.go
@@ -15,51 +15,196 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
-func (c *ntmConfig) toDebugString(source model.Source) (string, error) {
-	var node Node
-	switch source {
-	case "root":
-		node = c.root
-	case model.SourceEnvVar:
-		node = c.envs
-	case model.SourceDefault:
-		node = c.defaults
-	case model.SourceFile:
-		node = c.file
-	default:
-		return "", fmt.Errorf("invalid source: %s", source)
+func (c *ntmConfig) toDebugString(source model.Source, opts ...model.StringifyOption) (string, error) {
+	strcfg := model.StringifyConfig{}
+	for _, opt := range opts {
+		opt(&strcfg)
 	}
-	lines, err := debugTree(node, 0)
+
+	// Collect the filters for settings
+	var filterSet map[string]struct{}
+	var traverseSet map[string]struct{}
+	if strcfg.SettingFilters != nil {
+		filterSet = make(map[string]struct{}, len(strcfg.SettingFilters))
+		traverseSet = make(map[string]struct{})
+		for _, setting := range strcfg.SettingFilters {
+			filterSet[setting] = struct{}{}
+			parts := strings.Split(setting, ".")
+			for i := 0; i < len(parts)-1; i += 1 {
+				partial := strings.Join(parts[:i+1], ".")
+				traverseSet[partial] = struct{}{}
+			}
+		}
+	}
+
+	if c.td == nil {
+		c.td = &treeDebugger{seenPtrs: make(map[string]*ptrCount)}
+	}
+	c.td.cfg = strcfg
+	c.td.filterSet = filterSet
+	c.td.traverseSet = traverseSet
+
+	if source == "all" {
+		lines := []string{}
+		for _, src := range []model.Source{"root", model.SourceDefault, model.SourceEnvVar, model.SourceFile} {
+			single, err := c.td.stringifySourceTree(c.selectTree(src), src)
+			if err != nil {
+				return "", err
+			}
+			lines = append(lines, single...)
+		}
+		lines = c.td.appendExtraDetails(lines)
+		return strings.Join(lines, "\n"), nil
+	}
+
+	lines, err := c.td.stringifySourceTree(c.selectTree(source), source)
 	if err != nil {
 		return "", err
 	}
+	lines = c.td.appendExtraDetails(lines)
 	return strings.Join(lines, "\n"), nil
 }
 
-func debugTree(n Node, depth int) ([]string, error) {
+func (c *ntmConfig) selectTree(src model.Source) Node {
+	switch src {
+	case "root":
+		return c.root
+	case model.SourceEnvVar:
+		return c.envs
+	case model.SourceDefault:
+		return c.defaults
+	case model.SourceFile:
+		return c.file
+	default:
+		return nil
+	}
+}
+
+type ptrCount struct {
+	key int
+	num int
+}
+
+type treeDebugger struct {
+	cfg          model.StringifyConfig
+	filterSet    map[string]struct{}
+	traverseSet  map[string]struct{}
+	seenPtrOrder []string
+	seenPtrs     map[string]*ptrCount
+}
+
+func (d *treeDebugger) appendExtraDetails(lines []string) []string {
+	if !d.cfg.DedupPointerAddr {
+		return lines
+	}
+
+	res := []string{}
+	for _, addr := range d.seenPtrOrder {
+		pc := d.seenPtrs[addr]
+		res = append(res, fmt.Sprintf("#ptr<%06d> (%d) => %s", pc.key, pc.num, addr))
+	}
+	return append(lines, res...)
+}
+
+func (d *treeDebugger) stringifySourceTree(tree Node, src model.Source) ([]string, error) {
+	if tree == nil {
+		return nil, fmt.Errorf("invalid source: %s", src)
+	}
+	res, err := d.nodeToString(tree, 0, "")
+	if err != nil {
+		return res, err
+	}
+	ptr := d.makePointer(tree)
+	res = append([]string{fmt.Sprintf("tree(%s) source=%s", ptr, src)}, res...)
+	return res, nil
+}
+
+func (d *treeDebugger) branchCheckFilter(path string) (bool, bool) {
+	if path == "" {
+		return true, true
+	}
+	if d.filterSet == nil {
+		return true, true
+	}
+	parts := strings.Split(path, ".")
+	for i, _ := range parts {
+		part := strings.Join(parts[:i+1], ".")
+		if _, found := d.filterSet[part]; found {
+			return true, true
+		}
+	}
+	if _, found := d.traverseSet[path]; found {
+		return true, false
+	}
+	return false, false
+}
+
+func (d *treeDebugger) nodeToString(n Node, depth int, path string) ([]string, error) {
+	isAllowBranch, isPrefixSetting := d.branchCheckFilter(path)
+	if !isAllowBranch {
+		return []string{}, nil
+	}
+
 	padding := strings.Repeat("  ", depth)
 	if n == nil {
-		return []string{fmt.Sprintf("%s%v", padding, "<nil>")}, nil
+		return []string{fmt.Sprintf("%s  %v", padding, "<nil>")}, nil
 	}
 	if leaf, ok := n.(LeafNode); ok {
+		if !isPrefixSetting {
+			return []string{}, nil
+		}
 		val := leaf.Get()
 		source := leaf.Source()
-		return []string{fmt.Sprintf("%sval:%v, source:%s", padding, val, source)}, nil
+		ptr := d.makePointer(n)
+		showval := fmt.Sprintf("%v", val)
+		if strval, ok := val.(string); ok {
+			showval = fmt.Sprintf("%q", strval)
+		}
+		return []string{fmt.Sprintf("%s  leaf(%s), val:%v, source:%s", padding, ptr, showval, source)}, nil
 	}
 	inner, ok := n.(InnerNode)
 	if !ok {
 		return nil, fmt.Errorf("unknown node type: %T", n)
 	}
 	keys := inner.ChildrenKeys()
+	ptr := d.makePointer(n)
 	result := []string{}
+	if depth > 0 && (isAllowBranch || isPrefixSetting) {
+		result = append(result, fmt.Sprintf("%sinner(%s)", padding, ptr))
+	}
 	for _, key := range keys {
-		msg := fmt.Sprintf("%s%s", padding, key)
+		nextPath := path + "." + key
+		if path == "" {
+			nextPath = key
+		}
+		msg := fmt.Sprintf("%s> %s", padding, key)
 		child, _ := n.GetChild(key)
-		rest, err := debugTree(child, depth+1)
+		rest, err := d.nodeToString(child, depth+1, nextPath)
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, append([]string{msg}, rest...)...)
+		isAllowBranch, isPrefixSetting := d.branchCheckFilter(nextPath)
+		if isAllowBranch || isPrefixSetting {
+			rest = append([]string{msg}, rest...)
+		}
+		result = append(result, rest...)
 	}
 	return result, nil
+}
+
+func (d *treeDebugger) makePointer(object interface{}) string {
+	ptr := fmt.Sprintf("%p", object)
+	if d.cfg.DedupPointerAddr || d.cfg.OmitPointerAddr {
+		if _, found := d.seenPtrs[ptr]; !found {
+			d.seenPtrs[ptr] = &ptrCount{
+				key: len(d.seenPtrs),
+				num: 0,
+			}
+			d.seenPtrOrder = append(d.seenPtrOrder, ptr)
+		}
+		pc := d.seenPtrs[ptr]
+		pc.num += 1
+		return fmt.Sprintf("#ptr<%06d>", pc.key)
+	}
+	return ptr
 }

--- a/pkg/config/nodetreemodel/debug_string_testonly.go
+++ b/pkg/config/nodetreemodel/debug_string_testonly.go
@@ -30,7 +30,7 @@ func (c *ntmConfig) toDebugString(source model.Source, opts ...model.StringifyOp
 		for _, setting := range strcfg.SettingFilters {
 			filterSet[setting] = struct{}{}
 			parts := strings.Split(setting, ".")
-			for i := 0; i < len(parts)-1; i += 1 {
+			for i := 0; i < len(parts)-1; i++ {
 				partial := strings.Join(parts[:i+1], ".")
 				traverseSet[partial] = struct{}{}
 			}
@@ -127,7 +127,7 @@ func (d *treeDebugger) branchCheckFilter(path string) (bool, bool) {
 		return true, true
 	}
 	parts := strings.Split(path, ".")
-	for i, _ := range parts {
+	for i := range parts {
 		part := strings.Join(parts[:i+1], ".")
 		if _, found := d.filterSet[part]; found {
 			return true, true
@@ -203,7 +203,7 @@ func (d *treeDebugger) makePointer(object interface{}) string {
 			d.seenPtrOrder = append(d.seenPtrOrder, ptr)
 		}
 		pc := d.seenPtrs[ptr]
-		pc.num += 1
+		pc.num++
 		return fmt.Sprintf("#ptr<%06d>", pc.key)
 	}
 	return ptr

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -506,8 +506,8 @@ func (t *teeConfig) Object() model.Reader {
 }
 
 // Stringify stringifies the config
-func (t *teeConfig) Stringify(source model.Source) string {
-	return t.baseline.Stringify(source)
+func (t *teeConfig) Stringify(source model.Source, opts ...model.StringifyOption) string {
+	return t.baseline.Stringify(source, opts...)
 }
 
 func (t *teeConfig) GetProxies() *model.Proxy {

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -811,7 +811,7 @@ func NewViperConfig(name string, envPrefix string, envKeyReplacer *strings.Repla
 }
 
 // Stringify stringifies the config, but only for nodetremodel with the test build tag
-func (c *safeConfig) Stringify(_ model.Source) string {
+func (c *safeConfig) Stringify(_ model.Source, _ ...model.StringifyOption) string {
 	return "safeConfig{...}"
 }
 


### PR DESCRIPTION
### What does this PR do?

Improve the Stringify method, such that it outputs more low-level state from the config

### Motivation

`Stringify` can be used for debugging the config by outputting more details from its tree representation. In particular, it always quotes string values to differentiate them from ints, and includes the pointer address of nodes in the config, making it easier to determine what exact values are stored in the config's state. Options like `OmitPointerAddr` make tests deterministic by replacing raw pointer addresses with stable identifiers, which are maintained across separate calls to `Stringify`.

### Describe how you validated your changes

Unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
