### PR TITLE
[SVLS] Improve serverless-init log tailing in sidecar mode

### DIFF
--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -67,6 +67,11 @@ func SetupLogAgent(conf *Config, tags map[string]string, tagger tagger.Component
 
 func addFileTailing(logsAgent logsAgent.ServerlessLogsAgent, source string, tags []string) {
 	if filePath, set := os.LookupEnv(envVarTailFilePath); set {
+
+		// The Azure App Service log volume is shared across all instances. This leads to every instance tailing the same files.
+		// To avoid this, we want to add the azure instance ID to the filepath so each instance tails their respective log files.
+		filePath = os.ExpandEnv(filePath)
+
 		src := sources.NewLogSource("serverless-file-tail", &logConfig.LogsConfig{
 			Type:    logConfig.FileType,
 			Path:    filePath,

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/sources"
 	serverlessLogs "github.com/DataDog/datadog-agent/pkg/serverless/logs"
 	serverlessTag "github.com/DataDog/datadog-agent/pkg/serverless/tags"
+	log "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -89,6 +90,7 @@ func addFileTailing(logsAgent logsAgent.ServerlessLogsAgent, source string, tags
 		for i, filePath := range paths {
 			// Skip the default log path if instance tailing is already enabled
 			if appServiceDefaultLoggingEnabled && filePath == "/home/LogFiles/*.log" {
+				log.Debugf("Skipping default log path for AAS instance tailing")
 				continue
 			}
 			name := fmt.Sprintf("serverless-file-tail-%d", i)

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -112,6 +112,6 @@ func isEnabled(envValue string) bool {
 
 // enabled by default
 func isInstanceTailingEnabled() bool {
-	val := os.Getenv(aasInstanceTailing)
+	val := strings.ToLower(os.Getenv(aasInstanceTailing))
 	return val == "" || val == "true"
 }

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -9,7 +9,6 @@
 package log
 
 import (
-	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -83,8 +82,7 @@ func addFileTailing(logsAgent logsAgent.ServerlessLogsAgent, source string, tags
 		logsAgent.GetSources().AddSource(src)
 		// If we are not in Azure or the aas instance env var is not set, we fall back to the previous behavior
 	} else if filePath, set := os.LookupEnv(envVarTailFilePath); set {
-		name := fmt.Sprintf("serverless-file-tail")
-		src := sources.NewLogSource(name, &logConfig.LogsConfig{
+		src := sources.NewLogSource("serverless-file-tail", &logConfig.LogsConfig{
 			Type:    logConfig.FileType,
 			Path:    filePath,
 			Service: os.Getenv("DD_SERVICE"),

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -71,6 +71,7 @@ func addFileTailing(logsAgent logsAgent.ServerlessLogsAgent, source string, tags
 	appServiceDefaultLoggingEnabled := origin == "appservice" && isInstanceTailingEnabled()
 	// The Azure App Service log volume is shared across all instances. This leads to every instance tailing the same files.
 	// To avoid this, we want to add the azure instance ID to the filepath so each instance tails their respective system log files.
+	// Users can also add $COMPUTERNAME to the custom files to achieve the same result.
 	if appServiceDefaultLoggingEnabled {
 		src := sources.NewLogSource("aas-instance-file-tail", &logConfig.LogsConfig{
 			Type:    logConfig.FileType,
@@ -97,7 +98,6 @@ func isEnabled(envValue string) bool {
 	return strings.ToLower(envValue) == "true"
 }
 
-// enabled by default
 func isInstanceTailingEnabled() bool {
 	val := strings.ToLower(os.Getenv(aasInstanceTailing))
 	return val == "true" || val == "1"

--- a/cmd/serverless-init/log/log.go
+++ b/cmd/serverless-init/log/log.go
@@ -71,7 +71,7 @@ func addFileTailing(logsAgent logsAgent.ServerlessLogsAgent, source string, tags
 	appServiceDefaultLoggingEnabled := origin == "appservice" && isInstanceTailingEnabled()
 	// The Azure App Service log volume is shared across all instances. This leads to every instance tailing the same files.
 	// To avoid this, we want to add the azure instance ID to the filepath so each instance tails their respective system log files.
-	// Users can also add $COMPUTERNAME to the custom files to achieve the same result.
+	// Users can also add $COMPUTERNAME to their custom files to achieve the same result.
 	if appServiceDefaultLoggingEnabled {
 		src := sources.NewLogSource("aas-instance-file-tail", &logConfig.LogsConfig{
 			Type:    logConfig.FileType,

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -43,6 +43,8 @@ func TestIsInstanceTailingEnabled(t *testing.T) {
 	assert.False(t, isInstanceTailingEnabled())
 	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "True")
 	assert.True(t, isInstanceTailingEnabled())
-	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "")
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "1")
 	assert.True(t, isInstanceTailingEnabled())
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "")
+	assert.False(t, isInstanceTailingEnabled())
 }

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -37,3 +37,12 @@ func TestIsEnabledFalse(t *testing.T) {
 	assert.False(t, isEnabled("1"))
 	assert.False(t, isEnabled("FALSE"))
 }
+
+func TestIsInstanceTailingEnabled(t *testing.T) {
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "false")
+	assert.False(t, isInstanceTailingEnabled())
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "True")
+	assert.True(t, isInstanceTailingEnabled())
+	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "")
+	assert.True(t, isInstanceTailingEnabled())
+}

--- a/cmd/serverless-init/log/log_test.go
+++ b/cmd/serverless-init/log/log_test.go
@@ -39,6 +39,7 @@ func TestIsEnabledFalse(t *testing.T) {
 }
 
 func TestIsInstanceTailingEnabled(t *testing.T) {
+	assert.False(t, isInstanceTailingEnabled())
 	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "false")
 	assert.False(t, isInstanceTailingEnabled())
 	t.Setenv("DD_AAS_INSTANCE_LOGGING_ENABLED", "True")

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -142,7 +142,7 @@ func setup(_ mode.Conf, tagger tagger.Component, compression logscompression.Com
 	if err != nil {
 		log.Debugf("Error loading config: %v\n", err)
 	}
-	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tags, tagger, compression)
+	logsAgent := serverlessInitLog.SetupLogAgent(agentLogConfig, tags, tagger, compression, origin)
 
 	traceAgent := setupTraceAgent(tags, tagger)
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Our current implementation did not take into account the fact that AAS shares a log volume with all of the instances running serverless-init. This resulted in sending duplicate logs from every running sidecar. This update adds an option to enable logging based on the `$COMPUTERNAME` or  instanceID of the container running serverless-init. Enabling the per instance logging is possible by setting `DD_AAS_INSTANCE_LOGGING_ENABLED=true`.
![image](https://github.com/user-attachments/assets/31d24147-ec54-40a0-bf6e-3d3d2bd1aa0f)

### Motivation
[SLES-2168](https://datadoghq.atlassian.net/browse/SLES-2168)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Unit tests
Application testing in AAS and GCP

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Additional comments from PR review in https://github.com/DataDog/datadog-agent/pull/36156

[SLES-2168]: https://datadoghq.atlassian.net/browse/SLES-2168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ