### PR TITLE
[netpath] Do not report random port

### DIFF
--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -232,7 +232,7 @@ func (r *Runner) runTCP(cfg config.Config, hname string, target net.IP, maxTTL u
 		return payload.NetworkPath{}, err
 	}
 
-	pathResult, err := r.processResults(results, payload.ProtocolTCP, hname, cfg.DestHostname)
+	pathResult, err := r.processResults(results, payload.ProtocolTCP, hname, cfg.DestHostname, cfg.DestPort)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}
@@ -241,7 +241,7 @@ func (r *Runner) runTCP(cfg config.Config, hname string, target net.IP, maxTTL u
 	return pathResult, nil
 }
 
-func (r *Runner) processResults(res *common.Results, protocol payload.Protocol, hname string, destinationHost string) (payload.NetworkPath, error) {
+func (r *Runner) processResults(res *common.Results, protocol payload.Protocol, hname string, destinationHost string, destinationPort uint16) (payload.NetworkPath, error) {
 	if res == nil {
 		return payload.NetworkPath{}, nil
 	}
@@ -257,7 +257,7 @@ func (r *Runner) processResults(res *common.Results, protocol payload.Protocol, 
 		},
 		Destination: payload.NetworkPathDestination{
 			Hostname:  destinationHost,
-			Port:      res.DstPort,
+			Port:      destinationPort,
 			IPAddress: res.Target.String(),
 		},
 		Tags: slices.Clone(res.Tags),

--- a/pkg/networkpath/traceroute/runner/runner_test.go
+++ b/pkg/networkpath/traceroute/runner/runner_test.go
@@ -287,7 +287,11 @@ func TestProcessResults(t *testing.T) {
 					},
 				)
 			}
-			actual, err := runner.processResults(test.inputResults, test.protocol, test.hname, test.destinationHost)
+			dstPort := uint16(0)
+			if test.inputResults != nil {
+				dstPort = test.inputResults.DstPort
+			}
+			actual, err := runner.processResults(test.inputResults, test.protocol, test.hname, test.destinationHost, dstPort)
 			if test.errMsg != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), test.errMsg)

--- a/pkg/networkpath/traceroute/runner/runner_unix.go
+++ b/pkg/networkpath/traceroute/runner/runner_unix.go
@@ -44,7 +44,7 @@ func (r *Runner) runUDP(cfg config.Config, hname string, dest net.IP, maxTTL uin
 		return payload.NetworkPath{}, fmt.Errorf("traceroute run failed: %s", err.Error())
 	}
 
-	pathResult, err := r.processDublinResults(results, hname, cfg.DestHostname, destPort, dest)
+	pathResult, err := r.processDublinResults(results, hname, cfg.DestHostname, cfg.DestPort, dest)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}

--- a/pkg/networkpath/traceroute/runner/runner_windows.go
+++ b/pkg/networkpath/traceroute/runner/runner_windows.go
@@ -29,7 +29,7 @@ func (r *Runner) runUDP(cfg config.Config, hname string, target net.IP, maxTTL u
 		return payload.NetworkPath{}, err
 	}
 
-	pathResult, err := r.processResults(results, payload.ProtocolUDP, hname, cfg.DestHostname)
+	pathResult, err := r.processResults(results, payload.ProtocolUDP, hname, cfg.DestHostname, cfg.DestPort)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

[netpath] Do not report random port



### Motivation

There is no value reporting random port and could confuse users.

<img width="194" alt="image" src="https://github.com/user-attachments/assets/600c7328-592d-4862-9d8a-2de24d52537d" />


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->