### PR TITLE
fix(windows): Push installer MSI/PS1 artefacts on agent deploy

### DIFF
--- a/.gitlab/deploy_packages/windows.yml
+++ b/.gitlab/deploy_packages/windows.yml
@@ -53,7 +53,8 @@ deploy_staging_windows_tags-7:
 # Datadog Installer
 deploy_installer_packages_windows-x64:
   rules:
-    !reference [.on_deploy_installer]
+    - !reference [.on_deploy_installer]
+    - !reference [.on_deploy]
   stage: deploy_packages
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
   tags: ["arch:amd64"]


### PR DESCRIPTION
### What does this PR do?
In the near future we'll want to release some Windows installer artefacts with the agent (namely the windows installer install script & the bootstrapper). This PR makes sure pieces are published to our artifacts bucket during an agent release pipeline

### Motivation

### Describe how you validated your changes
CI is green

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->