### PR TITLE
[CWS] Use system-probe CLI in Windows e2e tests

### DIFF
--- a/test/new-e2e/tests/cws/windows_test.go
+++ b/test/new-e2e/tests/cws/windows_test.go
@@ -38,8 +38,8 @@ const (
 	// windowsHostnamePrefix is the prefix of the hostname of the agent
 	windowsHostnamePrefix = "cws-e2e-windows"
 
-	// securityAgentPathWindows is the path of the security-agent binary
-	securityAgentPathWindows = "C:/Program Files/Datadog/Datadog Agent/bin/agent/security-agent.exe"
+	// systemProbePathWindows is the path of the system-probe binary
+	systemProbePathWindows = "C:/Program Files/Datadog/Datadog Agent/bin/agent/system-probe.exe"
 
 	// policiesPathWindows is the path of the default runtime security policies
 	policiesPathWindows = "C:/ProgramData/Datadog/runtime-security.d/test.policy"
@@ -176,7 +176,7 @@ func (a *agentSuiteWindows) Test03CreateFileSignal() {
 
 	var policies string
 	require.EventuallyWithT(a.T(), func(c *assert.CollectT) {
-		policies = a.Env().RemoteHost.MustExecute(fmt.Sprintf("$env:DD_APP_KEY='%s'; $env:DD_API_KEY='%s'; & '%s' runtime policy download | Out-File temp.txt; Get-Content temp.txt", appKey, apiKey, securityAgentPathWindows))
+		policies = a.Env().RemoteHost.MustExecute(fmt.Sprintf("$env:DD_APP_KEY='%s'; $env:DD_API_KEY='%s'; & '%s' runtime policy download | Out-File temp.txt; Get-Content temp.txt", appKey, apiKey, systemProbePathWindows))
 		assert.NotEmpty(c, policies, "should not be empty")
 	}, 1*time.Minute, 1*time.Second)
 
@@ -189,7 +189,7 @@ func (a *agentSuiteWindows) Test03CreateFileSignal() {
 	require.Contains(a.T(), policiesFile, desc, "The policies file should contain the created rule")
 
 	// Reload policies
-	a.Env().RemoteHost.MustExecute(fmt.Sprintf("& '%s' runtime policy reload", securityAgentPathWindows))
+	a.Env().RemoteHost.MustExecute(fmt.Sprintf("& '%s' runtime policy reload", systemProbePathWindows))
 
 	// Check if the policy is loaded
 	policyName := path.Base(policiesPathWindows)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Similarly to https://github.com/DataDog/datadog-agent/pull/35517, use the system-probe CLI in Windows e2e tests now that we removed the security-agent one.

### Motivation

Fix CWS Windows e2e tests.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->