### PR TITLE
[CWS] Fix rule override reporting in ruleset_loaded events 

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -353,12 +353,9 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb fu
 			Origin:        a.probe.Origin(),
 			KernelVersion: a.kernelVersion,
 			Distribution:  a.distribution,
+			PolicyName:    rule.Policy.Name,
+			PolicyVersion: rule.Policy.Version,
 		},
-	}
-
-	if policy := rule.Policy; policy != nil {
-		backendEvent.AgentContext.PolicyName = policy.Name
-		backendEvent.AgentContext.PolicyVersion = policy.Def.Version
 	}
 
 	seclog.Tracef("Prepare event message for rule `%s`", rule.ID)

--- a/pkg/security/probe/process_killer_test.go
+++ b/pkg/security/probe/process_killer_test.go
@@ -13,13 +13,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/containerutils"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"github.com/stretchr/testify/assert"
 )
 
 type FakeProcessKillerOS struct{}
@@ -129,7 +130,7 @@ func craftKillRule(id, scope string) *rules.Rule {
 					},
 				},
 			},
-			Policy: &rules.Policy{
+			Policy: rules.PolicyInfo{
 				Source: "test",
 			},
 			Actions: []*rules.Action{

--- a/pkg/security/probe/selftests/tester.go
+++ b/pkg/security/probe/selftests/tester.go
@@ -190,11 +190,17 @@ func (t *SelfTester) LoadPolicies(_ []rules.MacroFilter, _ []rules.RuleFilter) (
 		policyDef.Rules[i] = selfTest.GetRuleDefinition()
 	}
 
-	policy, err := rules.LoadPolicyFromDefinition(policyName, policySource, rules.SelftestPolicy, policyDef, nil, nil)
+	pInfo := &rules.PolicyInfo{
+		Name:       policyName,
+		Source:     policySource,
+		Type:       rules.SelftestPolicy,
+		IsInternal: true,
+	}
+
+	policy, err := rules.LoadPolicyFromDefinition(pInfo, policyDef, nil, nil)
 	if err != nil {
 		return nil, multierror.Append(nil, err)
 	}
-	policy.IsInternal = true
 
 	return []*rules.Policy{policy}, nil
 }

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -135,12 +135,13 @@ func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawC
 	r.debouncer.Call()
 }
 
-func normalize(policy *rules.Policy) {
+func normalizePolicyName(name string) string {
 	// remove the version
-	_, normalized, found := strings.Cut(policy.Info.Name, ".")
+	_, normalized, found := strings.Cut(name, ".")
 	if found {
-		policy.Info.Name = normalized
+		return normalized
 	}
+	return name
 }
 
 func writePolicy(name string, data []byte) (string, error) {
@@ -173,13 +174,12 @@ func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFi
 		}
 
 		pInfo := &rules.PolicyInfo{
-			Name:   id,
+			Name:   normalizePolicyName(id),
 			Source: rules.PolicyProviderTypeRC,
 			Type:   policyType,
 		}
 		reader := bytes.NewReader(cfg)
 		policy, err := rules.LoadPolicy(pInfo, reader, macroFilters, ruleFilters)
-		normalize(policy)
 		policies = append(policies, policy)
 		return err
 	}

--- a/pkg/security/rconfig/policies.go
+++ b/pkg/security/rconfig/policies.go
@@ -137,9 +137,9 @@ func (r *RCPolicyProvider) rcCustomsUpdateCallback(configs map[string]state.RawC
 
 func normalize(policy *rules.Policy) {
 	// remove the version
-	_, normalized, found := strings.Cut(policy.Name, ".")
+	_, normalized, found := strings.Cut(policy.Info.Name, ".")
 	if found {
-		policy.Name = normalized
+		policy.Info.Name = normalized
 	}
 }
 
@@ -172,8 +172,13 @@ func (r *RCPolicyProvider) LoadPolicies(macroFilters []rules.MacroFilter, ruleFi
 			}
 		}
 
+		pInfo := &rules.PolicyInfo{
+			Name:   id,
+			Source: rules.PolicyProviderTypeRC,
+			Type:   policyType,
+		}
 		reader := bytes.NewReader(cfg)
-		policy, err := rules.LoadPolicy(id, rules.PolicyProviderTypeRC, policyType, reader, macroFilters, ruleFilters)
+		policy, err := rules.LoadPolicy(pInfo, reader, macroFilters, ruleFilters)
 		normalize(policy)
 		policies = append(policies, policy)
 		return err

--- a/pkg/security/rules/bundled/bundled_policy_provider.go
+++ b/pkg/security/rules/bundled/bundled_policy_provider.go
@@ -33,11 +33,17 @@ func (p *PolicyProvider) LoadPolicies([]rules.MacroFilter, []rules.RuleFilter) (
 		Rules:   newBundledPolicyRules(p.cfg),
 	}
 
-	policy, err := rules.LoadPolicyFromDefinition("bundled_policy", "bundled", rules.InternalPolicyType, policyDef, nil, nil)
+	pInfo := &rules.PolicyInfo{
+		Name:       "bundled_policy",
+		Source:     "bundled",
+		Type:       rules.InternalPolicyType,
+		IsInternal: true,
+	}
+
+	policy, err := rules.LoadPolicyFromDefinition(pInfo, policyDef, nil, nil)
 	if err != nil {
 		return nil, multierror.Append(nil, err)
 	}
-	policy.IsInternal = true
 	policy.SetInternalCallbackAction(RefreshUserCacheRuleID, RefreshSBOMRuleID)
 
 	return []*rules.Policy{policy}, nil

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -490,7 +490,7 @@ func (e *RuleEngine) RuleMatch(ctx *eval.Context, rule *rules.Rule, event eval.E
 
 	// add matched rules before any auto suppression check to ensure that this information is available in activity dumps
 	if ev.ContainerContext.ContainerID != "" && (e.config.ActivityDumpTagRulesEnabled || e.config.AnomalyDetectionTagRulesEnabled) {
-		ev.Rules = append(ev.Rules, model.NewMatchedRule(rule.Def.ID, rule.Def.Version, rule.Def.Tags, rule.Policy.Name, rule.Policy.Def.Version))
+		ev.Rules = append(ev.Rules, model.NewMatchedRule(rule.Def.ID, rule.Def.Version, rule.Def.Tags, rule.Policy.Name, rule.Policy.Version))
 	}
 
 	if e.AutoSuppression.Suppresses(rule, ev) {
@@ -660,14 +660,16 @@ func getPoliciesVersions(rs *rules.RuleSet, includeInternalPolicies bool) []stri
 
 	cache := make(map[string]bool)
 	for _, rule := range rs.GetRules() {
-		if rule.Policy.IsInternal && !includeInternalPolicies {
-			continue
-		}
-		version := rule.Policy.Def.Version
-		if _, exists := cache[version]; !exists {
-			cache[version] = true
+		for _, pInfo := range rule.UsedBy {
+			if rule.Policy.IsInternal && !includeInternalPolicies {
+				continue
+			}
 
-			versions = append(versions, version)
+			version := pInfo.Version
+			if _, exists := cache[version]; !exists {
+				cache[version] = true
+				versions = append(versions, version)
+			}
 		}
 	}
 

--- a/pkg/security/rules/monitor/policy_monitor.go
+++ b/pkg/security/rules/monitor/policy_monitor.go
@@ -362,19 +362,18 @@ func NewPoliciesState(rs *rules.RuleSet, err *multierror.Error, includeInternalP
 	if err != nil && err.Errors != nil {
 		for _, err := range err.Errors {
 			if rerr, ok := err.(*rules.ErrRuleLoad); ok {
-				for _, pInfo := range rerr.Rule.UsedBy {
-					if pInfo.IsInternal && !includeInternalPolicies {
-						continue
-					}
-
-					if _, exists := mp[pInfo.Name]; !exists {
-						policyState = PolicyStateFromPolicyInfo(&pInfo)
-						mp[pInfo.Name] = policyState
-					} else {
-						policyState = mp[pInfo.Name]
-					}
-					policyState.Rules = append(policyState.Rules, RuleStateFromRule(rerr.Rule, &pInfo, string(rerr.Type()), rerr.Err.Error()))
+				if rerr.Rule.Policy.IsInternal && !includeInternalPolicies {
+					continue
 				}
+				policyName := rerr.Rule.Policy.Name
+
+				if _, exists := mp[policyName]; !exists {
+					policyState = PolicyStateFromPolicyInfo(&rerr.Rule.Policy)
+					mp[policyName] = policyState
+				} else {
+					policyState = mp[policyName]
+				}
+				policyState.Rules = append(policyState.Rules, RuleStateFromRule(rerr.Rule, &rerr.Rule.Policy, string(rerr.Type()), rerr.Err.Error()))
 			}
 		}
 	}

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -167,6 +167,11 @@ type PolicyInfo struct {
 	IsInternal bool
 }
 
+// Equals compares two PolicyInfo objects and returns true if they are equal
+func (pi *PolicyInfo) Equals(other *PolicyInfo) bool {
+	return reflect.DeepEqual(pi, other)
+}
+
 // Policy represents a policy which is composed of a list of rules, macros and on-demand hook points
 type Policy struct {
 	// Def is the policy definition

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -50,9 +50,9 @@ type PolicyRule struct {
 	Actions    []*Action
 	Accepted   bool
 	Error      error
-	Policy     *Policy
-	ModifiedBy []*PolicyRule
-	UsedBy     []*Policy
+	Policy     PolicyInfo
+	ModifiedBy []PolicyInfo
+	UsedBy     []PolicyInfo
 }
 
 func (r *PolicyRule) isAccepted() bool {
@@ -134,7 +134,7 @@ func (r *PolicyRule) MergeWith(r2 *PolicyRule) error {
 		}
 	}
 
-	r.ModifiedBy = append(r.ModifiedBy, r2)
+	r.ModifiedBy = append(r.ModifiedBy, r2.Policy)
 
 	return nil
 }
@@ -153,13 +153,26 @@ const (
 	SelftestPolicy PolicyType = "selftest"
 )
 
+// PolicyInfo contains information about a policy that aren't part of the policy definition
+type PolicyInfo struct {
+	// Name is the name of the policy
+	Name string
+	// Source is the source of the policy
+	Source string
+	// Type is the type of the policy
+	Type PolicyType
+	// Version is the version of the policy, this field is copied from the policy definition
+	Version string
+	// IsInternal is true if the policy is internal
+	IsInternal bool
+}
+
 // Policy represents a policy which is composed of a list of rules, macros and on-demand hook points
 type Policy struct {
-	Def        *PolicyDef
-	Name       string
-	Source     string
-	Type       PolicyType
-	IsInternal bool
+	// Def is the policy definition
+	Def *PolicyDef
+	// Info contains the policy information such as its name, source and type
+	Info PolicyInfo
 	// multiple macros can have the same ID but different filters (e.g. agent version)
 	macros map[MacroID][]*PolicyMacro
 	// multiple rules can have the same ID but different filters (e.g. agent version)
@@ -248,7 +261,7 @@ RULES:
 		rule := &PolicyRule{
 			Def:      ruleDef,
 			Accepted: true,
-			Policy:   p,
+			Policy:   p.Info, // copy the policy information as it can be modified on a per-rule basis when merging rules from different policies
 		}
 		p.rules[ruleDef.ID] = append(p.rules[ruleDef.ID], rule)
 		for _, filter := range ruleFilters {
@@ -292,12 +305,14 @@ RULES:
 }
 
 // LoadPolicyFromDefinition load a policy from a definition
-func LoadPolicyFromDefinition(name string, source string, policyType PolicyType, def *PolicyDef, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
+func LoadPolicyFromDefinition(info *PolicyInfo, def *PolicyDef, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
+	if def != nil && def.Version != "" {
+		info.Version = def.Version
+	}
+
 	p := &Policy{
 		Def:    def,
-		Name:   name,
-		Source: source,
-		Type:   policyType,
+		Info:   *info,
 		macros: make(map[MacroID][]*PolicyMacro, len(def.Macros)),
 		rules:  make(map[RuleID][]*PolicyRule, len(def.Rules)),
 	}
@@ -306,12 +321,12 @@ func LoadPolicyFromDefinition(name string, source string, policyType PolicyType,
 }
 
 // LoadPolicy load a policy
-func LoadPolicy(name string, source string, policyType PolicyType, reader io.Reader, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
+func LoadPolicy(info *PolicyInfo, reader io.Reader, macroFilters []MacroFilter, ruleFilters []RuleFilter) (*Policy, error) {
 	def := PolicyDef{}
 	decoder := yaml.NewDecoder(reader)
 	if err := decoder.Decode(&def); err != nil {
-		return nil, &ErrPolicyLoad{Name: name, Err: err}
+		return nil, &ErrPolicyLoad{Name: info.Name, Err: err}
 	}
 
-	return LoadPolicyFromDefinition(name, source, policyType, &def, macroFilters, ruleFilters)
+	return LoadPolicyFromDefinition(info, &def, macroFilters, ruleFilters)
 }

--- a/pkg/security/secl/rules/policy_dir.go
+++ b/pkg/security/secl/rules/policy_dir.go
@@ -47,7 +47,13 @@ func (p *PoliciesDirProvider) loadPolicy(filename string, macroFilters []MacroFi
 		policyType = CustomPolicyType
 	}
 
-	return LoadPolicy(name, PolicyProviderTypeDir, policyType, f, macroFilters, ruleFilters)
+	pInfo := &PolicyInfo{
+		Name:   name,
+		Source: PolicyProviderTypeDir,
+		Type:   policyType,
+	}
+
+	return LoadPolicy(pInfo, f, macroFilters, ruleFilters)
 }
 
 func (p *PoliciesDirProvider) getPolicyFiles() ([]string, error) {

--- a/pkg/security/secl/rules/policy_loader.go
+++ b/pkg/security/secl/rules/policy_loader.go
@@ -66,7 +66,7 @@ func (p *PolicyLoader) LoadPolicies(opts PolicyLoaderOpts) ([]*Policy, *multierr
 		}
 
 		for _, policy := range policies {
-			if policy.Name == DefaultPolicyName {
+			if policy.Info.Name == DefaultPolicyName {
 				if defaultPolicy == nil {
 					defaultPolicy = policy // only load the first seen default policy
 				}

--- a/pkg/security/secl/rules/policy_loader_test.go
+++ b/pkg/security/secl/rules/policy_loader_test.go
@@ -127,11 +127,13 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				},
 			},
 			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
+				expectedLoadedPolicies := []*Policy{
 					{
-						Name:   DefaultPolicyName,
-						Source: PolicyProviderTypeRC,
-						Type:   DefaultPolicyType,
+						Info: PolicyInfo{
+							Name:   DefaultPolicyName,
+							Source: PolicyProviderTypeRC,
+							Type:   DefaultPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -139,6 +141,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/rc-default/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   DefaultPolicyName,
+										Source: PolicyProviderTypeRC,
+										Type:   DefaultPolicyType,
 									},
 									Accepted: true,
 								},
@@ -149,15 +156,22 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "bravo",
 										Expression: "open.file.path == \"/etc/rc-default/bravo\"",
 									},
+									Policy: PolicyInfo{
+										Name:   DefaultPolicyName,
+										Source: PolicyProviderTypeRC,
+										Type:   DefaultPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
 					{
-						Name:   "myRC.policy",
-						Source: PolicyProviderTypeRC,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myRC.policy",
+							Source: PolicyProviderTypeRC,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -165,6 +179,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   "myRC.policy",
+										Source: PolicyProviderTypeRC,
+										Type:   CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -175,15 +194,22 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "alpha",
 										Expression: "open.file.path == \"/etc/rc-custom/alpha\"",
 									},
+									Policy: PolicyInfo{
+										Name:   "myRC.policy",
+										Source: PolicyProviderTypeRC,
+										Type:   CustomPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
 					{
-						Name:   "myLocal.policy",
-						Source: PolicyProviderTypeDir,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myLocal.policy",
+							Source: PolicyProviderTypeDir,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -191,6 +217,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -201,17 +232,22 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "bar",
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
-				})
+				}
 
 				defaultPolicyCount, lastSeenDefaultPolicyIdx := numAndLastIdxOfDefaultPolicies(expectedLoadedPolicies)
 
 				assert.Equalf(t, 1, defaultPolicyCount, "There are more than 1 default policies")
-				assert.Equalf(t, PolicyProviderTypeRC, got[lastSeenDefaultPolicyIdx].Source, "The default policy is not from RC")
+				assert.Equalf(t, PolicyProviderTypeRC, got[lastSeenDefaultPolicyIdx].Info.Source, "The default policy is not from RC")
 
 				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
 					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
@@ -277,11 +313,13 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				},
 			},
 			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
+				expectedLoadedPolicies := []*Policy{
 					{
-						Name:   "myRC.policy",
-						Source: PolicyProviderTypeRC,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myRC.policy",
+							Source: PolicyProviderTypeRC,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -289,6 +327,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/rc-custom/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   "myRC.policy",
+										Source: PolicyProviderTypeRC,
+										Type:   CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -299,15 +342,22 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "bar3",
 										Expression: "open.file.path == \"/etc/rc-custom/bar\"",
 									},
+									Policy: PolicyInfo{
+										Name:   "myRC.policy",
+										Source: PolicyProviderTypeRC,
+										Type:   CustomPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
 					{
-						Name:   "myLocal.policy",
-						Source: PolicyProviderTypeDir,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myLocal.policy",
+							Source: PolicyProviderTypeDir,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -315,6 +365,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -325,12 +380,17 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "bar",
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
-				})
+				}
 
 				defaultPolicyCount, _ := numAndLastIdxOfDefaultPolicies(expectedLoadedPolicies)
 				assert.Equalf(t, 0, defaultPolicyCount, "The count of default policies do not match")
@@ -385,11 +445,13 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				},
 			},
 			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
+				expectedLoadedPolicies := []*Policy{
 					{
-						Name:   "myLocal.policy",
-						Source: PolicyProviderTypeDir,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myLocal.policy",
+							Source: PolicyProviderTypeDir,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -397,6 +459,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -407,12 +474,17 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "bar",
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
-				})
+				}
 
 				defaultPolicyCount, _ := numAndLastIdxOfDefaultPolicies(expectedLoadedPolicies)
 				assert.Equalf(t, 0, defaultPolicyCount, "The count of default policies do not match")
@@ -469,11 +541,13 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				},
 			},
 			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
+				expectedLoadedPolicies := []*Policy{
 					{
-						Name:   "myLocal.policy",
-						Source: PolicyProviderTypeDir,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myLocal.policy",
+							Source: PolicyProviderTypeDir,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -481,6 +555,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -491,12 +570,17 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "bar",
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
-				})
+				}
 
 				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
 					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
@@ -558,18 +642,22 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 				},
 			},
 			want: func(t assert.TestingT, got []*Policy, _ ...interface{}) bool {
-				expectedLoadedPolicies := fixupPoliciesRulesPolicy([]*Policy{
+				expectedLoadedPolicies := []*Policy{
 					{
-						Name:   "myRC.policy",
-						Source: PolicyProviderTypeRC,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myRC.policy",
+							Source: PolicyProviderTypeRC,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules:  map[string][]*PolicyRule{},
 					},
 					{
-						Name:   "myLocal.policy",
-						Source: PolicyProviderTypeDir,
-						Type:   CustomPolicyType,
+						Info: PolicyInfo{
+							Name:   "myLocal.policy",
+							Source: PolicyProviderTypeDir,
+							Type:   CustomPolicyType,
+						},
 						macros: map[string][]*PolicyMacro{},
 						rules: map[string][]*PolicyRule{
 							"foo": {
@@ -577,6 +665,11 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									Def: &RuleDefinition{
 										ID:         "foo",
 										Expression: "open.file.path == \"/etc/local-custom/foo\"",
+									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
 									},
 									Accepted: true,
 								},
@@ -587,12 +680,17 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 										ID:         "bar",
 										Expression: "open.file.path == \"/etc/local-custom/bar\"",
 									},
+									Policy: PolicyInfo{
+										Name:   "myLocal.policy",
+										Source: PolicyProviderTypeDir,
+										Type:   CustomPolicyType,
+									},
 									Accepted: true,
 								},
 							},
 						},
 					},
-				})
+				}
 
 				if !cmp.Equal(expectedLoadedPolicies, got, policyCmpOpts...) {
 					t.Errorf("The loaded policies do not match the expected\nDiff:\n%s", cmp.Diff(expectedLoadedPolicies, got, policyCmpOpts...))
@@ -658,7 +756,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   DefaultPolicyName,
 								Source: PolicyProviderTypeRC,
 								Type:   DefaultPolicyType,
@@ -713,7 +811,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   DefaultPolicyName,
 								Source: PolicyProviderTypeRC,
 								Type:   DefaultPolicyType,
@@ -769,7 +867,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   DefaultPolicyType,
@@ -998,7 +1096,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1053,7 +1151,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   DefaultPolicyName,
 								Source: PolicyProviderTypeRC,
 								Type:   DefaultPolicyType,
@@ -1109,7 +1207,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P0.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1165,7 +1263,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1220,7 +1318,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 					"rule_1": {
 						PolicyRule: &PolicyRule{
 							Def: &RuleDefinition{ID: "rule_1", Expression: "exec.file.path == \"/etc/custom/foo\""},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P0.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1340,8 +1438,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									},
 								},
 							},
-
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   DefaultPolicyType,
@@ -1436,7 +1533,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									},
 								},
 							},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1518,7 +1615,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									},
 								},
 							},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1600,7 +1697,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									},
 								},
 							},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P0.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1679,7 +1776,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 							Def: &RuleDefinition{
 								ID: "rule_1", Expression: "exec.file.path == \"/etc/default/foo\"",
 							},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1787,7 +1884,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 								},
 								Combine: OverridePolicy,
 							},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1881,7 +1978,7 @@ func TestPolicyLoader_LoadPolicies(t *testing.T) {
 									},
 								},
 							},
-							Policy: &Policy{
+							Policy: PolicyInfo{
 								Name:   "P1.policy",
 								Source: PolicyProviderTypeRC,
 								Type:   CustomPolicyType,
@@ -1925,7 +2022,7 @@ func numAndLastIdxOfDefaultPolicies(policies []*Policy) (int, int) {
 	var defaultPolicyCount int
 	var lastSeenDefaultPolicyIdx int
 	for idx, policy := range policies {
-		if policy.Name == DefaultPolicyName {
+		if policy.Info.Name == DefaultPolicyName {
 			defaultPolicyCount++
 			lastSeenDefaultPolicyIdx = idx
 		}
@@ -1982,7 +2079,12 @@ type testPolicyDef struct {
 }
 
 func testPolicyToPolicy(testPolicy *testPolicyDef) (*Policy, *multierror.Error) {
-	policy, err := LoadPolicyFromDefinition(testPolicy.name, testPolicy.source, testPolicy.policyType, &testPolicy.def, nil, nil)
+	info := &PolicyInfo{
+		Name:   testPolicy.name,
+		Source: testPolicy.source,
+		Type:   testPolicy.policyType,
+	}
+	policy, err := LoadPolicyFromDefinition(info, &testPolicy.def, nil, nil)
 	if err != nil {
 		return nil, multierror.Append(nil, err)
 	}
@@ -2004,22 +2106,6 @@ func testPoliciesToPolicies(testPolicies []*testPolicyDef) ([]*Policy, *multierr
 	}
 
 	return policies, errs
-}
-
-func fixupRulesPolicy(policy *Policy) *Policy {
-	for _, rules := range policy.rules {
-		for _, rule := range rules {
-			rule.Policy = policy
-		}
-	}
-	return policy
-}
-
-func fixupPoliciesRulesPolicy(policies []*Policy) []*Policy {
-	for _, policy := range policies {
-		fixupRulesPolicy(policy)
-	}
-	return policies
 }
 
 func checkOverrideResult(t assert.TestingT, expected map[eval.RuleID]*Rule, got map[eval.RuleID]*Rule) bool {

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -1425,9 +1425,11 @@ rules:
 				ruleFilters:  nil,
 			},
 			want: &Policy{
-				Name:   "myLocal.policy",
-				Source: PolicyProviderTypeRC,
-				Type:   CustomPolicyType,
+				Info: PolicyInfo{
+					Name:   "myLocal.policy",
+					Source: PolicyProviderTypeRC,
+					Type:   CustomPolicyType,
+				},
 				rules:  map[string][]*PolicyRule{},
 				macros: map[string][]*PolicyMacro{},
 			},
@@ -1463,10 +1465,12 @@ broken
 				macroFilters: nil,
 				ruleFilters:  nil,
 			},
-			want: fixupRulesPolicy(&Policy{
-				Name:   "myLocal.policy",
-				Source: PolicyProviderTypeRC,
-				Type:   CustomPolicyType,
+			want: &Policy{
+				Info: PolicyInfo{
+					Name:   "myLocal.policy",
+					Source: PolicyProviderTypeRC,
+					Type:   CustomPolicyType,
+				},
 				rules: map[string][]*PolicyRule{
 					"rule_test": {
 						{
@@ -1475,12 +1479,17 @@ broken
 								Expression: "",
 								Disabled:   true,
 							},
+							Policy: PolicyInfo{
+								Name:   "myLocal.policy",
+								Source: PolicyProviderTypeRC,
+								Type:   CustomPolicyType,
+							},
 							Accepted: true,
 						},
 					},
 				},
 				macros: map[string][]*PolicyMacro{},
-			}),
+			},
 			wantErr: assert.NoError,
 		},
 		{
@@ -1497,10 +1506,12 @@ broken
 				macroFilters: nil,
 				ruleFilters:  nil,
 			},
-			want: fixupRulesPolicy(&Policy{
-				Name:   "myLocal.policy",
-				Source: PolicyProviderTypeRC,
-				Type:   CustomPolicyType,
+			want: &Policy{
+				Info: PolicyInfo{
+					Name:   "myLocal.policy",
+					Source: PolicyProviderTypeRC,
+					Type:   CustomPolicyType,
+				},
 				rules: map[string][]*PolicyRule{
 					"rule_test": {
 						{
@@ -1509,12 +1520,17 @@ broken
 								Expression: "open.file.path == \"/etc/gshadow\"",
 								Combine:    OverridePolicy,
 							},
+							Policy: PolicyInfo{
+								Name:   "myLocal.policy",
+								Source: PolicyProviderTypeRC,
+								Type:   CustomPolicyType,
+							},
 							Accepted: true,
 						},
 					},
 				},
 				macros: map[string][]*PolicyMacro{},
-			}),
+			},
 			wantErr: assert.NoError,
 		},
 	}
@@ -1522,7 +1538,13 @@ broken
 		t.Run(tt.name, func(t *testing.T) {
 			r := strings.NewReader(tt.args.fileContent)
 
-			got, err := LoadPolicy(tt.args.name, tt.args.source, tt.args.policyType, r, tt.args.macroFilters, tt.args.ruleFilters)
+			info := &PolicyInfo{
+				Name:   tt.args.name,
+				Source: tt.args.source,
+				Type:   tt.args.policyType,
+			}
+
+			got, err := LoadPolicy(info, r, tt.args.macroFilters, tt.args.ruleFilters)
 
 			if !tt.wantErr(t, err, fmt.Sprintf("LoadPolicy(%v, %v, %v, %v, %v)", tt.args.name, tt.args.source, r, tt.args.macroFilters, tt.args.ruleFilters)) {
 				return

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -349,7 +349,6 @@ func (rs *RuleSet) AddRule(parsingContext *ast.ParsingContext, pRule *PolicyRule
 	if _, exists := rs.rules[pRule.Def.ID]; exists {
 		return "", nil
 	}
-	pRule.UsedBy = append(pRule.UsedBy, pRule.Policy)
 
 	var tags []string
 	for k, v := range pRule.Def.Tags {
@@ -882,11 +881,11 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *mu
 		for _, rule := range policy.GetAcceptedRules() {
 			if existingRule := rulesIndex[rule.Def.ID]; existingRule != nil {
 				existingRule.UsedBy = append(existingRule.UsedBy, rule.Policy)
-
 				if err := existingRule.MergeWith(rule); err != nil {
 					errs = multierror.Append(errs, err)
 				}
 			} else {
+				rule.UsedBy = append(rule.UsedBy, rule.Policy)
 				rulesIndex[rule.Def.ID] = rule
 				allRules = append(allRules, rule)
 			}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

- Add a new PolicyInfo type that is used to store policy information, each rule now gets a copy of this information so that it can safely be modified based on rule overrides/disabling without any side effect for other rules/policies.
- Fix rule overrides causing rule to be reported twice in the same policy instead of once per policy
- Avoid reporting the modified_by field on override rules

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->