### PR TITLE
Patch: provide a list of distribution metrics where the host tag should be skipped

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -221,6 +221,13 @@ api_key:
 # histogram_percentiles:
 #   - "0.95"
 
+## @param host_tag_disallow_list - list of strings - optional - default: []string{}
+## @env DD_HOST_TAG_DISALLOW_LIST - space separated list of strings - optional - default:[]string{}
+## Configure which metrics will receive a default datadog host, rather than auto-assigning it. It must be a list of strings.
+#
+# host_tag_disallow_list:
+#   - "request.dist.time"
+
 ## @param histogram_copy_to_distribution - boolean - optional - default: false
 ## @env DD_HISTOGRAM_COPY_TO_DISTRIBUTION - boolean - optional - default: false
 ## Copy histogram values to distributions for true global distributions (in beta)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1504,6 +1504,7 @@ func dogstatsd(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("histogram_copy_to_distribution_prefix", "")
 	config.BindEnvAndSetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
 	config.BindEnvAndSetDefault("histogram_percentiles", []string{"0.95"})
+	config.BindEnvAndSetDefault("host_tag_disallow_list", []string{})
 }
 
 func logsagent(config pkgconfigmodel.Setup) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

See below.

### Motivation

Datadog charges for metrics based on tag cardinality, which affects both tag ingestion and indexing costs.

Currently, the host tag is automatically attached to all our metrics. As a result, each deployment increases our cardinality by a certain amount as we cycle through hosts. For some of our higher-volume metrics, this can account for up to 75% of the total cost. 

Scaling up our `host` count would further increase cardinality, potentially leading to unsustainable costs.

To mitigate this, we’re taking steps to remove the `host` tag where it’s unnecessary. While the `host` tag is important for correctly aggregating non-distribution metrics, the biggest driver of cost growth at GitHub is from distribution metrics. That’s why this change is focused specifically on distribution metrics.

In this PR we’re reading a list of distribution metrics (`host_tag_disallow_list`) from the Datadog Agent config. We then assign a default host tag value to these metrics, helping us avoid the additional cardinality and therefore the ingestion costs associated with it.

### Describe how you validated your changes

1. We've written a test to validate that we can read a list from the datadog agent config successfully, and set the `host` to a default value for the provided list of metrics. 
2. We've build the agent via `dda inv omnibus.build` and deployed it to a host, where we've tested that the `host` tag is set to a default value. 

### Additional Notes

Followed the CONTRIBUTING.md guide:

- [X] Have a proper commit history (we advise you to rebase if needed) with clear commit messages.
- [X] Write tests for the code you wrote.
- [X] Preferably make sure that all tests pass locally.
- [X] Summarize your PR with an explanatory title and a message describing your changes, cross-referencing any related bugs/PRs.
- [ ] Use [Reno](#reno) to create a release note.
- [X] Open your PR against the `main` branch.
- [X] Provide adequate QA/testing plan information.