### PR TITLE
fix: ensure extra_dbname contains engine default

### DIFF
--- a/releasenotes/notes/aurora-discovery-dbname-fallback-747a09692db20fbf.yaml
+++ b/releasenotes/notes/aurora-discovery-dbname-fallback-747a09692db20fbf.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes an issue where usage of the extra_dbname variable in the Aurora
+    Discovery template would be an empty string if the database name
+    was not specified in the database cluster resource, instead preferring to fallback
+    to the default database name for the engine.

--- a/releasenotes/notes/aurora-discovery-dbname-fallback-747a09692db20fbf.yaml
+++ b/releasenotes/notes/aurora-discovery-dbname-fallback-747a09692db20fbf.yaml
@@ -8,7 +8,6 @@
 ---
 fixes:
   - |
-    Fixes an issue where usage of the extra_dbname variable in the Aurora
-    Discovery template would be an empty string if the database name
-    was not specified in the database cluster resource, instead preferring to fallback
-    to the default database name for the engine.
+    Fixes an issue where the `extra_dbname` variable in the Aurora
+    Discovery template would default to an empty string if no database name
+    was specified in the cluster resource. It now correctly falls back to the engine's default database name.


### PR DESCRIPTION
NB: This is an internal copy of #36194 by @wparr-circle 

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fixes https://github.com/DataDog/datadog-agent/issues/36148

This change introduces a fallback mechanism where _if_ the database does not set DbName - the value of %%extra_dbname%% will be populated instead based on the Engine (a required field in the AWS API) type.

### Motivation
Following the introduction of [support for %%extra_dbname%% in the templates for the aurora autodiscovery feature](https://github.com/DataDog/datadog-agent/pull/31138), we ran into issues where we have mixed usage of DBName being set vs. unset where the %%extra_dbname%% substituion would render `""`.
This unfortunately prevents us from being able to utilise discovery feature for both RDS clusters where DBName is set or unset.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Included some new unit test cases to provide coverage around this fallback mechanism, and error paths.

It may be tested standing up a few aurora clusters (postgres, mysql) without any DBName specified. Setting up a template including the following, should be able to successfully discovery and generate checks which complete without error.

```yaml
dbname: %%extra_dbname%%
```

### Possible Drawbacks / Trade-offs
N/A

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

N/A