### PR TITLE
[autodiscovery/configresolver] Add option to disable env var resolution

### DIFF
--- a/comp/core/autodiscovery/configresolver/configresolver.go
+++ b/comp/core/autodiscovery/configresolver/configresolver.go
@@ -643,6 +643,10 @@ func getEnvvar(_ context.Context, envVar string, svc listeners.Service) (string,
 }
 
 func allowEnvVar(envVar string) bool {
+	if pkgconfigsetup.Datadog().GetBool("ad_disable_env_var_resolution") {
+		return false
+	}
+
 	allowedEnvs := pkgconfigsetup.Datadog().GetStringSlice("ad_allowed_env_vars")
 
 	// If the option is not set or is empty, the default behavior applies: all

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2849,10 +2849,17 @@ api_key:
 ## configurations.
 ## If the list is not set or is empty, the default behavior applies: all envs
 ## are allowed.
+## This list only applies when `ad_disable_env_var_resolution` is set to false.
 #
 # ad_allowed_env_vars:
 #   - <ENV_VAR_1>
 #   - <ENV_VAR_2>
+
+## @param ad_disable_env_var_resolution - boolean - optional - default: false
+## @env DD_AD_DISABLE_ENV_VAR_RESOLUTION - boolean - optional - default: false
+## Disable environment variable resolution in check configurations.
+#
+# ad_disable_env_var_resolution: false
 
 ## @param cloud_foundry_garden - custom object - optional
 ## Settings for Cloudfoundry application container autodiscovery.

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1241,6 +1241,7 @@ func autoconfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("container_exclude_stopped_age", DefaultAuditorTTL-1) // in hours
 	config.BindEnvAndSetDefault("ad_config_poll_interval", int64(10))                 // in seconds
 	config.BindEnvAndSetDefault("ad_allowed_env_vars", []string{})
+	config.BindEnvAndSetDefault("ad_disable_env_var_resolution", false)
 	config.BindEnvAndSetDefault("extra_listeners", []string{})
 	config.BindEnvAndSetDefault("extra_config_providers", []string{})
 	config.BindEnvAndSetDefault("ignore_autoconf", []string{})

--- a/releasenotes/notes/ad-option-to-disable-env-resolution-547a17dd7067d04e.yaml
+++ b/releasenotes/notes/ad-option-to-disable-env-resolution-547a17dd7067d04e.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added a new configuration option, ``ad_disable_env_var_resolution``, which
+    lets users disable environment variable resolution in Autodiscovery check
+    configurations.


### PR DESCRIPTION
### What does this PR do?

This PR adds a new configuration option, `ad_disable_env_var_resolution`, which lets users disable environment variable resolution in Autodiscovery check configurations.

This PR is related to https://github.com/DataDog/datadog-agent/pull/36467


### Describe how you validated your changes

I added unit tests. I also checked the following cases in a local cluster:
- Env var resolution disabled
- Env var resolution enabled
- Env var resolution disabled with an allow-list of envs, confirming the list is ignored
