### PR TITLE
[autodiscovery] Delete unnecessary funcs from interface

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -651,20 +651,6 @@ func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
 	ac.deleteMappingsOfCheckIDsWithSecrets(changes.Unschedule)
 }
 
-// MapOverLoadedConfigs calls the given function with the map of all
-// loaded configs (those that would be returned from LoadedConfigs).
-//
-// This is done with the config store locked, so callers should perform minimal
-// work within f.
-func (ac *AutoConfig) MapOverLoadedConfigs(f func(map[string]integration.Config)) {
-	if ac == nil || ac.store == nil {
-		log.Error("AutoConfig store not initialized")
-		f(map[string]integration.Config{})
-		return
-	}
-	ac.cfgMgr.mapOverLoadedConfigs(f)
-}
-
 // LoadedConfigs returns a slice of all loaded configs.  Loaded configs are non-template
 // configs, either as received from a config provider or as resolved from a template and
 // a service.  They do not include service configs.

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -261,7 +261,7 @@ func (ac *AutoConfig) writeConfigCheck(w http.ResponseWriter, r *http.Request) {
 func (ac *AutoConfig) GetConfigCheck() integration.ConfigCheckResponse {
 	var response integration.ConfigCheckResponse
 
-	configSlice := ac.LoadedConfigs()
+	configSlice := ac.GetAllConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})
@@ -305,7 +305,7 @@ func (ac *AutoConfig) GetConfigCheck() integration.ConfigCheckResponse {
 func (ac *AutoConfig) getRawConfigCheck() integration.ConfigCheckResponse {
 	var response integration.ConfigCheckResponse
 
-	configSlice := ac.LoadedConfigs()
+	configSlice := ac.GetAllConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})
@@ -649,23 +649,6 @@ func (ac *AutoConfig) processRemovedConfigs(configs []integration.Config) {
 	changes := ac.cfgMgr.processDelConfigs(configs)
 	ac.applyChanges(changes)
 	ac.deleteMappingsOfCheckIDsWithSecrets(changes.Unschedule)
-}
-
-// LoadedConfigs returns a slice of all loaded configs.  Loaded configs are non-template
-// configs, either as received from a config provider or as resolved from a template and
-// a service.  They do not include service configs.
-//
-// The returned slice is freshly created and will not be modified after return.
-func (ac *AutoConfig) LoadedConfigs() []integration.Config {
-	var configs []integration.Config
-	ac.cfgMgr.mapOverLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
-		configs = make([]integration.Config, 0, len(loadedConfigs))
-		for _, c := range loadedConfigs {
-			configs = append(configs, c)
-		}
-	})
-
-	return configs
 }
 
 // GetUnresolvedTemplates returns all templates in the cache, in their unresolved

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig_test.go
@@ -399,11 +399,10 @@ func TestResolveTemplate(t *testing.T) {
 }
 
 func countLoadedConfigs(ac *AutoConfig) int {
-	count := -1 // -1 would indicate f was not called
-	ac.MapOverLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
-		count = len(loadedConfigs)
-	})
-	return count
+	if ac == nil || ac.store == nil {
+		return 0
+	}
+	return len(ac.GetAllConfigs())
 }
 
 func TestRemoveTemplate(t *testing.T) {

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -29,7 +29,6 @@ type Component interface {
 	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)
 	RemoveScheduler(name string)
-	LoadedConfigs() []integration.Config
 	GetUnresolvedTemplates() map[string][]integration.Config
 	GetIDOfCheckWithEncryptedSecrets(checkID checkid.ID) checkid.ID
 	GetAutodiscoveryErrors() map[string]map[string]providers.ErrorMsgSet

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -29,7 +29,6 @@ type Component interface {
 	AddListeners(listenerConfigs []pkgconfigsetup.Listeners)
 	AddScheduler(name string, s scheduler.Scheduler, replayConfigs bool)
 	RemoveScheduler(name string)
-	MapOverLoadedConfigs(f func(map[string]integration.Config))
 	LoadedConfigs() []integration.Config
 	GetUnresolvedTemplates() map[string][]integration.Config
 	GetIDOfCheckWithEncryptedSecrets(checkID checkid.ID) checkid.ID

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -53,8 +53,6 @@ func (n *noopAutoConfig) AddScheduler(string, scheduler.Scheduler, bool) {}
 
 func (n *noopAutoConfig) RemoveScheduler(string) {}
 
-func (n *noopAutoConfig) MapOverLoadedConfigs(func(map[string]integration.Config)) {}
-
 func (n *noopAutoConfig) LoadedConfigs() []integration.Config {
 	return []integration.Config{}
 }

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -53,10 +53,6 @@ func (n *noopAutoConfig) AddScheduler(string, scheduler.Scheduler, bool) {}
 
 func (n *noopAutoConfig) RemoveScheduler(string) {}
 
-func (n *noopAutoConfig) LoadedConfigs() []integration.Config {
-	return []integration.Config{}
-}
-
 func (n *noopAutoConfig) GetUnresolvedTemplates() map[string][]integration.Config {
 	return map[string][]integration.Config{}
 }


### PR DESCRIPTION
### What does this PR do?

This PR removes 2 unnecessary functions from the autodiscovery interface:
- `MapOverLoadedConfigs`, which is only used in a unit test.
- `LoadedConfigs`, which is a duplicate of the existing `GetAllConfigs` function.

### Describe how you validated your changes
CI.
