### PR TITLE
feat(admission-controller): improve LabelSelector settings

### DIFF
--- a/pkg/clusteragent/admission/common/label_selectors_test.go
+++ b/pkg/clusteragent/admission/common/label_selectors_test.go
@@ -1,0 +1,111 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/config/model"
+)
+
+var (
+	globalUnlabelledSetting  = "admission_controller.validation.unlabelled"
+	webhookUnlabelledSetting = "admission_controller.test.unlabelled"
+)
+
+// DefaultValidatingLabelSelectors returns the validating webhooks object selector based on the configuration.
+func TestDefaultValidatingLabelSelectors(t *testing.T) {
+	tests := []struct {
+		name string
+
+		useNamespaceSelector bool
+		globalUnlabelled     *string
+		webhookUnlabelled    *string
+
+		wantNamespaceSelector *metav1.LabelSelector
+		wantObjectSelector    *metav1.LabelSelector
+	}{
+		{
+			name:                  "Default unlabelled settings",
+			useNamespaceSelector:  false,
+			wantNamespaceSelector: nil,
+			wantObjectSelector:    &acceptAllLabelSelector,
+		},
+		{
+			name:                 "Webhook unlabelled setting explicitly set to true",
+			useNamespaceSelector: false,
+			webhookUnlabelled: func() *string {
+				s := "true"
+				return &s
+			}(),
+			wantNamespaceSelector: nil,
+			wantObjectSelector:    &acceptAllLabelSelector,
+		},
+		{
+			name:                 "Webhook unlabelled setting explicitly set to false, global unlabelled set to true",
+			useNamespaceSelector: false,
+			globalUnlabelled: func() *string {
+				s := "true"
+				return &s
+			}(),
+			webhookUnlabelled: func() *string {
+				s := "false"
+				return &s
+			}(),
+			wantNamespaceSelector: nil,
+			wantObjectSelector:    &acceptOnlyLabelSelector,
+		},
+		{
+			name:                 "Global unlabelled set to true",
+			useNamespaceSelector: false,
+			globalUnlabelled: func() *string {
+				s := "true"
+				return &s
+			}(),
+			wantNamespaceSelector: nil,
+			wantObjectSelector:    &acceptAllLabelSelector,
+		},
+		{
+			name:                 "Global unlabelled set to false",
+			useNamespaceSelector: false,
+			globalUnlabelled: func() *string {
+				s := "false"
+				return &s
+			}(),
+			wantNamespaceSelector: nil,
+			wantObjectSelector:    &acceptOnlyLabelSelector,
+		},
+		{
+			name:                  "useNamespaceSelector set to true",
+			useNamespaceSelector:  true,
+			wantNamespaceSelector: &acceptAllLabelSelector,
+			wantObjectSelector:    nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockConfig := configmock.New(t)
+			if tt.globalUnlabelled != nil {
+				mockConfig.SetWithoutSource(globalUnlabelledSetting, *tt.globalUnlabelled)
+				defer mockConfig.UnsetForSource(globalUnlabelledSetting, model.SourceUnknown)
+			}
+			if tt.webhookUnlabelled != nil {
+				mockConfig.SetWithoutSource(webhookUnlabelledSetting, *tt.webhookUnlabelled)
+				defer mockConfig.UnsetForSource(webhookUnlabelledSetting, model.SourceUnknown)
+			}
+
+			namespaceSelector, objectSelector := DefaultValidatingLabelSelectors(tt.useNamespaceSelector, mockConfig, webhookUnlabelledSetting)
+			assert.Equal(t, tt.wantNamespaceSelector, namespaceSelector)
+			assert.Equal(t, tt.wantObjectSelector, objectSelector)
+		})
+	}
+}

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -961,6 +961,8 @@ func TestGenerateTemplatesV1(t *testing.T) {
 
 func TestGetValidatingWebhookSkeletonV1(t *testing.T) {
 	mockConfig := configmock.New(t)
+	testUnlabelledSetting := "admission_controller.test.unlabelled"
+	mockConfig.BindEnvAndSetDefault(testUnlabelledSetting, false)
 	failurePolicy := admiv1.Ignore
 	matchPolicy := admiv1.Exact
 	sideEffects := admiv1.SideEffectClassNone
@@ -968,8 +970,8 @@ func TestGetValidatingWebhookSkeletonV1(t *testing.T) {
 	path := "/bar"
 	defaultTimeout := mockConfig.GetInt32("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
-	namespaceSelector, _ := common.DefaultLabelSelectors(true)
-	_, objectSelector := common.DefaultLabelSelectors(false)
+	namespaceSelector, _ := common.DefaultValidatingLabelSelectors(true, mockConfig, testUnlabelledSetting)
+	_, objectSelector := common.DefaultValidatingLabelSelectors(false, mockConfig, testUnlabelledSetting)
 	webhook := func(to *int32, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition) admiv1.ValidatingWebhook {
 		return admiv1.ValidatingWebhook{
 			Name: "datadog.webhook.foo",
@@ -1056,7 +1058,7 @@ func TestGetValidatingWebhookSkeletonV1(t *testing.T) {
 			c := &ControllerV1{}
 			c.config = NewConfig(false, tt.namespaceSelector, false, mockConfig)
 
-			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
+			nsSelector, objSelector := common.DefaultValidatingLabelSelectors(tt.namespaceSelector, mockConfig, testUnlabelledSetting)
 
 			assert.EqualValues(t, tt.want, c.getValidatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
 		})
@@ -1073,8 +1075,8 @@ func TestGetMutatingWebhookSkeletonV1(t *testing.T) {
 	path := "/bar"
 	defaultTimeout := mockConfig.GetInt32("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
-	namespaceSelector, _ := common.DefaultLabelSelectors(true)
-	_, objectSelector := common.DefaultLabelSelectors(false)
+	namespaceSelector, _ := common.DefaultMutatingLabelSelectors(true)
+	_, objectSelector := common.DefaultMutatingLabelSelectors(false)
 	webhook := func(to *int32, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1.MatchCondition) admiv1.MutatingWebhook {
 		return admiv1.MutatingWebhook{
 			Name: "datadog.webhook.foo",
@@ -1162,7 +1164,7 @@ func TestGetMutatingWebhookSkeletonV1(t *testing.T) {
 			c := &ControllerV1{}
 			c.config = NewConfig(false, tt.namespaceSelector, false, mockConfig)
 
-			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
+			nsSelector, objSelector := common.DefaultMutatingLabelSelectors(tt.namespaceSelector)
 
 			assert.EqualValues(t, tt.want, c.getMutatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1.OperationType{admiv1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
 		})

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -955,6 +955,8 @@ func TestGenerateTemplatesV1beta1(t *testing.T) {
 
 func TestGetValidatingWebhookSkeletonV1beta1(t *testing.T) {
 	mockConfig := configmock.New(t)
+	testUnlabelledSetting := "admission_controller.test.unlabelled"
+	mockConfig.BindEnvAndSetDefault(testUnlabelledSetting, false)
 	failurePolicy := admiv1beta1.Ignore
 	matchPolicy := admiv1beta1.Exact
 	sideEffects := admiv1beta1.SideEffectClassNone
@@ -962,8 +964,8 @@ func TestGetValidatingWebhookSkeletonV1beta1(t *testing.T) {
 	path := "/bar"
 	defaultTimeout := mockConfig.GetInt32("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
-	namespaceSelector, _ := common.DefaultLabelSelectors(true)
-	_, objectSelector := common.DefaultLabelSelectors(false)
+	namespaceSelector, _ := common.DefaultValidatingLabelSelectors(true, mockConfig, testUnlabelledSetting)
+	_, objectSelector := common.DefaultValidatingLabelSelectors(false, mockConfig, testUnlabelledSetting)
 	webhook := func(to *int32, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition) admiv1beta1.ValidatingWebhook {
 		return admiv1beta1.ValidatingWebhook{
 			Name: "datadog.webhook.foo",
@@ -1050,7 +1052,7 @@ func TestGetValidatingWebhookSkeletonV1beta1(t *testing.T) {
 			c := &ControllerV1beta1{}
 			c.config = NewConfig(false, tt.namespaceSelector, false, mockConfig)
 
-			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
+			nsSelector, objSelector := common.DefaultValidatingLabelSelectors(tt.namespaceSelector, mockConfig, testUnlabelledSetting)
 
 			assert.EqualValues(t, tt.want, c.getValidatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
 		})
@@ -1067,8 +1069,8 @@ func TestGetMutatingWebhookSkeletonV1beta1(t *testing.T) {
 	path := "/bar"
 	defaultTimeout := mockConfig.GetInt32("admission_controller.timeout_seconds")
 	customTimeout := int32(2)
-	namespaceSelector, _ := common.DefaultLabelSelectors(true)
-	_, objectSelector := common.DefaultLabelSelectors(false)
+	namespaceSelector, _ := common.DefaultMutatingLabelSelectors(true)
+	_, objectSelector := common.DefaultMutatingLabelSelectors(false)
 	webhook := func(to *int32, objSelector, nsSelector *metav1.LabelSelector, matchConditions []admiv1beta1.MatchCondition) admiv1beta1.MutatingWebhook {
 		return admiv1beta1.MutatingWebhook{
 			Name: "datadog.webhook.foo",
@@ -1156,7 +1158,7 @@ func TestGetMutatingWebhookSkeletonV1beta1(t *testing.T) {
 			c := &ControllerV1beta1{}
 			c.config = NewConfig(false, tt.namespaceSelector, false, mockConfig)
 
-			nsSelector, objSelector := common.DefaultLabelSelectors(tt.namespaceSelector)
+			nsSelector, objSelector := common.DefaultMutatingLabelSelectors(tt.namespaceSelector)
 
 			assert.EqualValues(t, tt.want, c.getMutatingWebhookSkeleton(tt.args.nameSuffix, tt.args.path, []admiv1beta1.OperationType{admiv1beta1.Create}, map[string][]string{"": {"pods"}}, nsSelector, objSelector, nil))
 		})

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -104,7 +104,7 @@ func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 // LabelSelectors returns the label selectors that specify when the webhook
 // should be invoked
 func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector) {
-	return common.DefaultLabelSelectors(useNamespaceSelector)
+	return common.DefaultMutatingLabelSelectors(useNamespaceSelector)
 }
 
 // MatchConditions returns the Match Conditions used for fine-grained

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -129,7 +129,7 @@ func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 // LabelSelectors returns the label selectors that specify when the webhook
 // should be invoked
 func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector) {
-	return common.DefaultLabelSelectors(useNamespaceSelector)
+	return common.DefaultMutatingLabelSelectors(useNamespaceSelector)
 }
 
 // MatchConditions returns the Match Conditions used for fine-grained

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -86,7 +86,7 @@ func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 // LabelSelectors returns the label selectors that specify when the webhook
 // should be invoked
 func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector) {
-	return common.DefaultLabelSelectors(useNamespaceSelector)
+	return common.DefaultMutatingLabelSelectors(useNamespaceSelector)
 }
 
 // MatchConditions returns the Match Conditions used for fine-grained

--- a/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents.go
+++ b/pkg/clusteragent/admission/validate/kubernetesadmissionevents/kubernetesadmissionevents.go
@@ -38,6 +38,7 @@ type Webhook struct {
 	resources               map[string][]string
 	operations              []admissionregistrationv1.OperationType
 	matchConditions         []admissionregistrationv1.MatchCondition
+	datadogConfig           config.Component
 	demultiplexer           aggregator.Demultiplexer
 	supportsMatchConditions bool
 	checkid                 checkid.ID
@@ -66,6 +67,7 @@ func NewWebhook(datadogConfig config.Component, demultiplexer aggregator.Demulti
 				Expression: "!(request.userInfo.username.startsWith('system:'))",
 			},
 		},
+		datadogConfig:           datadogConfig,
 		demultiplexer:           demultiplexer,
 		supportsMatchConditions: supportsMatchConditions,
 		checkid:                 "kubernetes_admission_events",
@@ -107,7 +109,7 @@ func (w *Webhook) Operations() []admissionregistrationv1.OperationType {
 // LabelSelectors returns the label selectors that specify when the webhook
 // should be invoked
 func (w *Webhook) LabelSelectors(useNamespaceSelector bool) (namespaceSelector *metav1.LabelSelector, objectSelector *metav1.LabelSelector) {
-	return common.DefaultLabelSelectors(useNamespaceSelector)
+	return common.DefaultValidatingLabelSelectors(useNamespaceSelector, w.datadogConfig, "admission_controller.kubernetes_admission_events.unlabelled")
 }
 
 // MatchConditions returns the Match Conditions used for fine-grained

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -753,6 +753,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Admission controller
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
 	config.BindEnvAndSetDefault("admission_controller.validation.enabled", true)
+	config.BindEnvAndSetDefault("admission_controller.validation.unlabelled", true)
 	config.BindEnvAndSetDefault("admission_controller.mutation.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
 	config.BindEnvAndSetDefault("admission_controller.port", 8000)
@@ -819,6 +820,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.image_tag", "latest")
 	config.BindEnvAndSetDefault("admission_controller.agent_sidecar.cluster_agent.enabled", "true")
 	config.BindEnvAndSetDefault("admission_controller.kubernetes_admission_events.enabled", false)
+	config.BindEnvAndSetDefault("admission_controller.kubernetes_admission_events.unlabelled", false)
 
 	// Declare other keys that don't have a default/env var.
 	// Mostly, keys we use IsSet() on, because IsSet always returns true if a key has a default.

--- a/releasenotes-dca/notes/improve-labelselector-admission-settings-84192cd55fb15867.yaml
+++ b/releasenotes-dca/notes/improve-labelselector-admission-settings-84192cd55fb15867.yaml
@@ -1,0 +1,21 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    New LabelSelector Admission Controller settings have been introduced
+    to improve the usability of the LabelSelector Admission Controller
+    for both ValidatingAdmissionWebhook and MutatingAdmissionWebhook.
+    The new settings are:
+    - `admission_controller.validation.unlabelled` to allow
+      unlabelled resources to be admitted for all webhooks.
+    - `admission_controller.kubernetes_admission_events.unlabelled` to
+      allow unlabelled resources to be admitted specifically for the
+      Kubernetes Admission Events webhook.
+    Precedence is given to the webhook-specific settings over the
+    global settings.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Introduces new `LabelSelector` admission controller settings to improve usability for both the `ValidatingAdmissionWebhook` and `MutatingAdmissionWebhook`.

The new settings are:
- `admission_controller.validation.unlabelled`: allows unlabelled resources to be admitted across all webhooks.  
- `admission_controller.kubernetes_admission_events.unlabelled`: allows unlabelled resources to be admitted specifically for the Kubernetes Admission Events webhook.

Precedence is given to the webhook-specific settings over the global settings.

### Motivation

Currently, the validation and mutation admission controllers are using the same settings. They need to be decoupled to allow finer-grained control over the behavior of each feature.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
QA is done by unit and E2E tests. It was also done manually for the different settings.

### Possible Drawbacks / Trade-offs

None

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
N/A