### PR TITLE
[autodiscovery] Delete unnecessary READMEs

### DIFF
--- a/comp/core/autodiscovery/configresolver/README.md
+++ b/comp/core/autodiscovery/configresolver/README.md
@@ -1,4 +1,0 @@
-# package `configresolver`
-
-This package is providing the `Resolve` function that will resolve a given configuration template
-against a given service by replacing templates variables with corresponding data from the service

--- a/comp/core/autodiscovery/configresolver/configresolver.go
+++ b/comp/core/autodiscovery/configresolver/configresolver.go
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package configresolver resolves config templates using information from a
+// Package configresolver resolves configuration templates against a given
+// service by replacing template variables with corresponding data from the
 // service.
 package configresolver
 

--- a/comp/core/autodiscovery/integration/README.md
+++ b/comp/core/autodiscovery/integration/README.md
@@ -1,3 +1,0 @@
-# package `integration`
-
-This package is responsible of defining the types representing an integration which can be used by several components of the agent to configure checks or logs collectors for example.

--- a/comp/core/autodiscovery/integration/config.go
+++ b/comp/core/autodiscovery/integration/config.go
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package integration contains the type that represents a configuration.
+// Package integration defines types representing an integration configuration,
+// which can be used by several components of the agent to configure checks or
+// log collectors, for example.
 package integration
 
 import (

--- a/comp/core/autodiscovery/telemetry/README.md
+++ b/comp/core/autodiscovery/telemetry/README.md
@@ -1,3 +1,0 @@
-## package `telemetry`
-
-This package defines Autodiscovery's telemetry metrics.


### PR DESCRIPTION
### What does this PR do?

This is a cleanup PR. It removes unnecessary READMEs from the autodiscovery package.
Each README contained only a single sentence, which is now better documented as a godoc comment for the package.


### Describe how you validated your changes
CI