### PR TITLE
[autodiscovery] Delete IsStarted func from interface

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -50,8 +50,7 @@ func LoadComponents(_ secrets.Component, wmeta workloadmeta.Component, ac autodi
 	// TODO: (components) - This is a temporary fix to start the autodiscovery component in CLI mode (agent flare and diagnose in forcelocal checks)
 	// because the autodiscovery component is not started by the agent automatically. Probably we can start it inside
 	// fx lifecycle and remove this call.
-	if !ac.IsStarted() {
-		ac.Start()
-	}
+	ac.Start()
+
 	setupAutoDiscovery(confSearchPaths, wmeta, ac)
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -82,11 +82,11 @@ type AutoConfig struct {
 	cfgMgr                   configManager
 	serviceListenerFactories map[string]listeners.ServiceListenerFactory
 	providerCatalog          map[string]providers.ConfigProviderFactory
-	started                  bool
 	wmeta                    option.Option[workloadmeta.Component]
 	taggerComp               tagger.Component
 	logs                     logComp.Component
 	telemetryStore           *acTelemetry.Store
+	startOnce                sync.Once
 
 	// m covers the `configPollers`, `listenerCandidates`, `listeners`, and `listenerRetryStop`, but
 	// not the values they point to.
@@ -206,7 +206,6 @@ func createNewAutoConfig(schedulerController *scheduler.Controller, secretResolv
 		ranOnce:                  atomic.NewBool(false),
 		serviceListenerFactories: make(map[string]listeners.ServiceListenerFactory),
 		providerCatalog:          make(map[string]providers.ConfigProviderFactory),
-		started:                  false,
 		wmeta:                    wmeta,
 		taggerComp:               taggerComp,
 		logs:                     logs,
@@ -401,17 +400,13 @@ func (ac *AutoConfig) fillFlare(fb flaretypes.FlareBuilder) error {
 // Usually, Start and Stop methods should not be in the component interface as it should be handled using Lifecycle hooks.
 // We make exceptions here because we need to disable it at runtime.
 func (ac *AutoConfig) Start() {
-	listeners.RegisterListeners(ac.serviceListenerFactories)
-	providers.RegisterProviders(ac.providerCatalog)
-	setupAcErrors()
-	ac.started = true
-	// Start the service listener
-	go ac.serviceListening()
-}
-
-// IsStarted returns true if the AutoConfig has been started.
-func (ac *AutoConfig) IsStarted() bool {
-	return ac.started
+	ac.startOnce.Do(func() {
+		listeners.RegisterListeners(ac.serviceListenerFactories)
+		providers.RegisterProviders(ac.providerCatalog)
+		setupAcErrors()
+		// Start the service listener
+		go ac.serviceListening()
+	})
 }
 
 // Stop just shuts down AutoConfig in a clean way.

--- a/comp/core/autodiscovery/component.go
+++ b/comp/core/autodiscovery/component.go
@@ -41,5 +41,4 @@ type Component interface {
 	Stop()
 	// TODO (component): once cluster agent uses the API component remove this function
 	GetConfigCheck() integration.ConfigCheckResponse
-	IsStarted() bool
 }

--- a/comp/core/autodiscovery/noopimpl/autoconfig.go
+++ b/comp/core/autodiscovery/noopimpl/autoconfig.go
@@ -87,10 +87,6 @@ func (n *noopAutoConfig) GetConfigCheck() integration.ConfigCheckResponse {
 	return integration.ConfigCheckResponse{}
 }
 
-func (n *noopAutoConfig) IsStarted() bool {
-	return false
-}
-
 func newAutoConfig() autodiscovery.Component {
 	return &noopAutoConfig{}
 }


### PR DESCRIPTION
### What does this PR do?

This PR is a small refactor to avoid exposing the `IsStarted` function in the autodiscovery interface.
It was only used in one place, and that logic is now better handled internally using `sync.Once`.

### Describe how you validated your changes
CI