### PR TITLE
chore(ssi): bump major python tracer version

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -39,7 +39,7 @@ const commonRegistry = "gcr.io/datadoghq"
 var (
 	defaultLibraries = map[string]string{
 		"java":   "v1",
-		"python": "v2",
+		"python": "v3",
 		"ruby":   "v2",
 		"dotnet": "v3",
 		"js":     "v5",
@@ -2738,13 +2738,13 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 					Value: uuid,
 				},
 			},
-			expectedInjectedLibraries: map[string]string{"java": "v1.28.0", "python": "v2.5.1"},
+			expectedInjectedLibraries: map[string]string{"java": "v1.28.0", "python": "v3.6.0"},
 			expectedSecurityContext:   &corev1.SecurityContext{},
 			wantErr:                   false,
 			wantWebhookInitErr:        false,
 			setupConfig: funcs{
 				enableAPMInstrumentation,
-				withLibVersions(map[string]string{"java": "v1.28.0", "python": "v2.5.1"}),
+				withLibVersions(map[string]string{"java": "v1.28.0", "python": "v3.6.0"}),
 			},
 		},
 		{
@@ -2794,7 +2794,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			wantWebhookInitErr:        false,
 			setupConfig: funcs{
 				enableAPMInstrumentation,
-				withLibVersions(map[string]string{"java": "v1.28.0", "python": "v2.5.1"}),
+				withLibVersions(map[string]string{"java": "v1.28.0", "python": "v3.6.0"}),
 			},
 		},
 		{

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config_test.go
@@ -489,7 +489,7 @@ func TestGetPinnedLibraries(t *testing.T) {
 			name: "default libs (major versions)",
 			libVersions: map[string]string{
 				"java":   "v1",
-				"python": "v2",
+				"python": "v3",
 				"js":     "v5",
 				"dotnet": "v3",
 				"ruby":   "v2",
@@ -512,7 +512,7 @@ func TestGetPinnedLibraries(t *testing.T) {
 			name: "default libs (major versions mismatch)",
 			libVersions: map[string]string{
 				"java":   "v1",
-				"python": "v2",
+				"python": "v3",
 				"js":     "v3",
 				"dotnet": "v3",
 				"ruby":   "v2",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/language_versions.go
@@ -133,7 +133,7 @@ const defaultVersionMagicString = "default"
 var languageVersions = map[language]string{
 	java:   "v1", // https://datadoghq.atlassian.net/browse/APMON-1064
 	dotnet: "v3", // https://datadoghq.atlassian.net/browse/APMON-1390
-	python: "v2", // https://datadoghq.atlassian.net/browse/APMON-1068
+	python: "v3", // https://datadoghq.atlassian.net/browse/INPLAT-598
 	ruby:   "v2", // https://datadoghq.atlassian.net/browse/APMON-1066
 	js:     "v5", // https://datadoghq.atlassian.net/browse/APMON-1065
 	php:    "v1", // https://datadoghq.atlassian.net/browse/APMON-1128

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator_test.go
@@ -89,7 +89,7 @@ func TestMutatePod(t *testing.T) {
 			},
 			expectedInitContainerImages: []string{
 				"registry/apm-inject:0",
-				"registry/dd-lib-python-init:v2",
+				"registry/dd-lib-python-init:v3",
 			},
 			expectedEnv: map[string]string{
 				"DD_INJECT_SENDER_TYPE":           "k8s",
@@ -100,10 +100,10 @@ func TestMutatePod(t *testing.T) {
 				"DD_TRACE_ENABLED":                "true",
 				"DD_TRACE_HEALTH_METRICS_ENABLED": "true",
 				"LD_PRELOAD":                      "/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
-				AppliedTargetEnvVar:               "{\"name\":\"Application Namespace\",\"namespaceSelector\":{\"matchNames\":[\"application\"]},\"ddTraceVersions\":{\"python\":\"v2\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
+				AppliedTargetEnvVar:               "{\"name\":\"Application Namespace\",\"namespaceSelector\":{\"matchNames\":[\"application\"]},\"ddTraceVersions\":{\"python\":\"v3\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
 			},
 			expectedAnnotations: map[string]string{
-				AppliedTargetAnnotation: "{\"name\":\"Application Namespace\",\"namespaceSelector\":{\"matchNames\":[\"application\"]},\"ddTraceVersions\":{\"python\":\"v2\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
+				AppliedTargetAnnotation: "{\"name\":\"Application Namespace\",\"namespaceSelector\":{\"matchNames\":[\"application\"]},\"ddTraceVersions\":{\"python\":\"v3\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
 			},
 		},
 		"no matching rule does not mutate pod": {
@@ -125,7 +125,7 @@ func TestMutatePod(t *testing.T) {
 			},
 			expectedInitContainerImages: []string{
 				"registry/apm-inject:0",
-				"registry/dd-lib-python-init:v2",
+				"registry/dd-lib-python-init:v3",
 			},
 			expectedEnv: map[string]string{
 				"DD_PROFILING_ENABLED":            "true",
@@ -138,10 +138,10 @@ func TestMutatePod(t *testing.T) {
 				"DD_TRACE_ENABLED":                "true",
 				"DD_TRACE_HEALTH_METRICS_ENABLED": "true",
 				"LD_PRELOAD":                      "/opt/datadog-packages/datadog-apm-inject/stable/inject/launcher.preload.so",
-				AppliedTargetEnvVar:               "{\"name\":\"Python Apps\",\"podSelector\":{\"matchLabels\":{\"language\":\"python\"}},\"ddTraceVersions\":{\"python\":\"v2\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
+				AppliedTargetEnvVar:               "{\"name\":\"Python Apps\",\"podSelector\":{\"matchLabels\":{\"language\":\"python\"}},\"ddTraceVersions\":{\"python\":\"v3\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
 			},
 			expectedAnnotations: map[string]string{
-				AppliedTargetAnnotation: "{\"name\":\"Python Apps\",\"podSelector\":{\"matchLabels\":{\"language\":\"python\"}},\"ddTraceVersions\":{\"python\":\"v2\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
+				AppliedTargetAnnotation: "{\"name\":\"Python Apps\",\"podSelector\":{\"matchLabels\":{\"language\":\"python\"}},\"ddTraceVersions\":{\"python\":\"v3\"},\"ddTraceConfigs\":[{\"name\":\"DD_PROFILING_ENABLED\",\"value\":\"true\"},{\"name\":\"DD_DATA_JOBS_ENABLED\",\"value\":\"true\"}]}",
 			},
 		},
 		"service name is applied when set in tracer configs": {
@@ -411,7 +411,7 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "foo",
 					Annotations: map[string]string{
-						"admission.datadoghq.com/python-lib.version": "v2",
+						"admission.datadoghq.com/python-lib.version": "v3",
 					},
 				},
 			},
@@ -420,7 +420,7 @@ func TestGetTargetFromAnnotation(t *testing.T) {
 					{
 						ctrName: "",
 						lang:    python,
-						image:   "registry/dd-lib-python-init:v2",
+						image:   "registry/dd-lib-python-init:v3",
 					},
 				},
 			},
@@ -524,7 +524,7 @@ func TestGetTargetLibraries(t *testing.T) {
 					{
 						ctrName: "",
 						lang:    python,
-						image:   "registry/dd-lib-python-init:v2",
+						image:   "registry/dd-lib-python-init:v3",
 					},
 				},
 			},
@@ -645,7 +645,7 @@ func TestGetTargetLibraries(t *testing.T) {
 					{
 						ctrName: "",
 						lang:    python,
-						image:   "registry/dd-lib-python-init:v2",
+						image:   "registry/dd-lib-python-init:v3",
 					},
 					{
 						ctrName: "",

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/disabled_namespaces.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/disabled_namespaces.yaml
@@ -8,4 +8,3 @@ apm_config:
       python: "default"
     version: "v2"
     injector_image_tag: "foo"
-

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/enabled_namespaces.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/enabled_namespaces.yaml
@@ -8,4 +8,3 @@ apm_config:
       python: "default"
     version: "v2"
     injector_image_tag: "foo"
-

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/extra_fields.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/extra_fields.yaml
@@ -9,4 +9,4 @@ apm_config:
             language: "python"
         fooBar: "baz"
         ddTraceVersions:
-          python: "v2"
+          python: "v3"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter.yaml
@@ -12,9 +12,9 @@ apm_config:
             app: "billing-service"
         namespaceSelector:
           matchNames:
-          - "billing-service"
+            - "billing-service"
         ddTraceVersions:
-          python: "v2"
+          python: "v3"
       - name: "Microservices"
         podSelector:
           matchLabels:

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_invalid_configs.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_invalid_configs.yaml
@@ -8,7 +8,7 @@ apm_config:
           matchLabels:
             language: "python"
         ddTraceVersions:
-          python: "v2"
+          python: "v3"
         ddTraceConfigs:
           - name: "DD_PROFILING_ENABLED"
             value: "true"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_limited.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_limited.yaml
@@ -9,6 +9,6 @@ apm_config:
             app: "billing-service"
         namespaceSelector:
           matchNames:
-          - "billing-service"
+            - "billing-service"
         ddTraceVersions:
-          python: "v2"
+          python: "v3"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_configs.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_configs.yaml
@@ -8,7 +8,7 @@ apm_config:
           matchLabels:
             language: "python"
         ddTraceVersions:
-          python: "v2"
+          python: "v3"
         ddTraceConfigs:
           - name: "DD_PROFILING_ENABLED"
             value: "true"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_namespace.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_namespace.yaml
@@ -6,9 +6,9 @@ apm_config:
       - name: "Application Namespace"
         namespaceSelector:
           matchNames:
-          - "application"
+            - "application"
         ddTraceVersions:
-          python: "v2"
+          python: "v3"
         ddTraceConfigs:
           - name: "DD_PROFILING_ENABLED"
             value: "true"

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_service.yaml
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/testdata/filter_simple_service.yaml
@@ -8,7 +8,7 @@ apm_config:
           matchLabels:
             language: "python"
         ddTraceVersions:
-          python: "v2"
+          python: "v3"
         ddTraceConfigs:
           - name: "DD_SERVICE"
             value: "best-service"

--- a/pkg/fleet/installer/default_packages.go
+++ b/pkg/fleet/installer/default_packages.go
@@ -51,7 +51,7 @@ var apmPackageDefaultVersions = map[string]string{
 	"datadog-apm-library-ruby":   "2",
 	"datadog-apm-library-js":     "5",
 	"datadog-apm-library-dotnet": "3",
-	"datadog-apm-library-python": "2",
+	"datadog-apm-library-python": "3",
 	"datadog-apm-library-php":    "1",
 }
 

--- a/pkg/fleet/installer/default_packages_test.go
+++ b/pkg/fleet/installer/default_packages_test.go
@@ -8,9 +8,10 @@ package installer
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/oci"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultPackagesDefaultInstall(t *testing.T) {
@@ -35,7 +36,7 @@ func TestDefaultPackagesAPMInjectEnabled(t *testing.T) {
 		"oci://install.datadoghq.com/apm-library-ruby-package:2",
 		"oci://install.datadoghq.com/apm-library-js-package:5",
 		"oci://install.datadoghq.com/apm-library-dotnet-package:3",
-		"oci://install.datadoghq.com/apm-library-python-package:2",
+		"oci://install.datadoghq.com/apm-library-python-package:3",
 		"oci://install.datadoghq.com/apm-library-php-package:1",
 	}, packages)
 }
@@ -55,7 +56,7 @@ func TestCentos6PackagesAPMInjectEnabled(t *testing.T) {
 		"oci://install.datadoghq.com/apm-library-ruby-package:2",
 		"oci://install.datadoghq.com/apm-library-js-package:5",
 		"oci://install.datadoghq.com/apm-library-dotnet-package:3",
-		"oci://install.datadoghq.com/apm-library-python-package:2",
+		"oci://install.datadoghq.com/apm-library-python-package:3",
 		"oci://install.datadoghq.com/apm-library-php-package:1",
 	}, packages)
 }

--- a/releasenotes-dca/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
+++ b/releasenotes-dca/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
@@ -7,4 +7,4 @@
 # Each section note must be formatted as reStructuredText.
 enhancements:
   - |
-    Single Step Instrumentation will now use the Python tracer major version 3 by default.
+    Single Step Instrumentation now uses the Python tracer major version 3 by default.

--- a/releasenotes-dca/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
+++ b/releasenotes-dca/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+enhancements:
+  - |
+    Single Step Instrumentation will now use the Python tracer major version 3 by default.

--- a/releasenotes/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
+++ b/releasenotes/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
@@ -7,4 +7,4 @@
 # Each section note must be formatted as reStructuredText.
 enhancements:
   - |
-    Single Step Instrumentation will now use the Python tracer major version 3 by default.
+    Single Step Instrumentation now uses the Python tracer major version 3 by default.

--- a/releasenotes/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
+++ b/releasenotes/notes/python-major-version-3-ssi-28df5632dc49b9f0.yaml
@@ -1,0 +1,10 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+enhancements:
+  - |
+    Single Step Instrumentation will now use the Python tracer major version 3 by default.

--- a/test/new-e2e/tests/installer/script/default_script_test.go
+++ b/test/new-e2e/tests/installer/script/default_script_test.go
@@ -45,7 +45,7 @@ func (s *installScriptDefaultSuite) TestInstall() {
 	s.RunInstallScript(
 		s.url,
 		"DD_SITE=datadoghq.com",
-		"DD_APM_INSTRUMENTATION_LIBRARIES=java:1,python:2,js:5,dotnet:3",
+		"DD_APM_INSTRUMENTATION_LIBRARIES=java:1,python:3,js:5,dotnet:3",
 		"DD_APM_INSTRUMENTATION_ENABLED=host",
 		"DD_RUNTIME_SECURITY_CONFIG_ENABLED=true",
 		"DD_SBOM_CONTAINER_IMAGE_ENABLED=true",
@@ -97,7 +97,7 @@ func (s *installScriptDefaultSuite) TestInstallParity() {
 	// Full supported option set
 	params := []string{
 		"DD_SITE=datadoghq.com",
-		"DD_APM_INSTRUMENTATION_LIBRARIES=java:1,python:2,js:5,dotnet:3",
+		"DD_APM_INSTRUMENTATION_LIBRARIES=java:1,python:3,js:5,dotnet:3",
 		"DD_APM_INSTRUMENTATION_ENABLED=host",
 		"DD_RUNTIME_SECURITY_CONFIG_ENABLED=true",
 		"DD_SBOM_CONTAINER_IMAGE_ENABLED=true",

--- a/test/new-e2e/tests/installer/unix/all_packages_test.go
+++ b/test/new-e2e/tests/installer/unix/all_packages_test.go
@@ -52,7 +52,7 @@ var (
 	packagesTestsWithSkippedFlavors = []packageTestsWithSkippedFlavors{
 		{t: testInstaller},
 		{t: testAgent},
-		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault}, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
+		{t: testApmInjectAgent, skippedFlavors: []e2eos.Descriptor{e2eos.CentOS7, e2eos.RedHat9, e2eos.FedoraDefault, e2eos.AmazonLinux2}, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
 		{t: testUpgradeScenario, skippedInstallationMethods: []InstallMethodOption{InstallMethodAnsible}},
 	}
 )

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -449,7 +449,7 @@ func (s *packageApmInjectSuite) TestDefaultPackageVersion() {
 		envForceInstall("datadog-agent"),
 	)
 	defer s.Purge()
-	s.host.AssertPackagePrefix("datadog-apm-library-python", "2")
+	s.host.AssertPackagePrefix("datadog-apm-library-python", "3")
 }
 
 func (s *packageApmInjectSuite) TestInstallWithUmask() {


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This commit bumps the major python tracer version used for Single Step Instrumentation.

### Motivation
We have already updated to major version 3 in the Datadog UI. This change updates the defaults in the installer/cluster agent to match.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Updated unit tests

### Possible Drawbacks / Trade-offs
[Python version 3.7 is no longer supported](https://github.com/DataDog/dd-trace-py/releases/tag/v3.0.0). When looking at our SSI customers, there is a very low percentage of customers using 3.7 and lower. It's also worth noting that those customers will not get a new major tracer version without re-running the installation or upgrading their agent. 

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
We may wish to consider a better internal process for making this type of change in the future.