### PR TITLE
ignore errors cleaning up temporary files

### DIFF
--- a/releasenotes/notes/ignore-7zr-cleanup-error-541e5e8db2cf5e34.yaml
+++ b/releasenotes/notes/ignore-7zr-cleanup-error-541e5e8db2cf5e34.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The Windows Agent MSI no longer fails if it is unable to delete temporary
+    files related to extracting the embedded Python distribution.

--- a/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/PythonDistributionCustomAction.cs
@@ -126,8 +126,24 @@ namespace Datadog.CustomActions
                     session.Log($"{embedded} not found, skipping decompression.");
                 }
 
-                File.Delete(Path.Combine(projectLocation, "bin", "7zr.exe"));
-                File.Delete(embedded);
+                // delete the files we don't need anymore
+                var cleanupFiles = new[] {
+                    Path.Combine(projectLocation, "bin", "7zr.exe"),
+                    embedded
+                };
+                foreach (var file in cleanupFiles)
+                {
+                    try
+                    {
+                        File.Delete(file);
+                    }
+                    catch (Exception e)
+                    {
+                        session.Log($"Error while deleting {file}: {e}");
+                        // don't fail if we can't delete the file, it's not critical
+                        // and we've seen cases where antivirus may have been holding the file open
+                    }
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Ignore errors when cleaning up temporary files used to extract the embedded Python distribution

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1471
Saw a case where the file was locked and it failed the install. Deleting these files isn't critical so we shouldn't fail the install. We suspect it may have been locked for scanning by an antimalware solution.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Our [E2E tests](https://github.com/DataDog/datadog-agent/blob/a51aa9a585a736ab8d787796dbd2c7491a10c5c0/test/new-e2e/tests/windows/install-test/installtester.go#L305-L316) already ensure these files are deleted in normal circumstances

Manual steps to reproduce the error:
Run the following command and then run the Agent MSI. It will mark the `7zr.exe` file read-only once it's written to disk, preventing it from being deleted.
```powershell
powershell.exe -Command {
$p="C:\Program Files\Datadog\Datadog Agent\bin\7zr.exe";
while (-not (Test-Path "$p")) { sleep -Milliseconds 500 };
attrib +r "$p"
}
```
Ensure the install succeeds, the 7zr file still exists on disk, and the following error is present in the MSI log
```
CA: 15:20:19: DecompressPythonDistribution. Error while deleting C:\Program Files\Datadog\Datadog Agent\bin\7zr.exe: System.UnauthorizedAccessException: Access to the path 'C:\Program Files\Datadog\Datadog Agent\bin\7zr.exe' is denied.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.File.InternalDelete(String path, Boolean checkHost)
   at Datadog.CustomActions.PythonDistributionCustomAction.DecompressPythonDistribution(ISession session, String outputDirectoryName, String compressedDistributionFile, Int32 pythonDistributionSize)
```
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->