### PR TITLE
Add tests for package diff and download invoke tasks

### DIFF
--- a/tasks/unit_tests/diff_tests.py
+++ b/tasks/unit_tests/diff_tests.py
@@ -1,0 +1,260 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tasks.libs.common.diff import diff
+
+
+class TestDiff(unittest.TestCase):
+    @patch('os.stat')
+    @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('os.walk')
+    @patch('builtins.print')
+    def test_identical_directories(self, mock_print, mock_walk, mock_exists, mock_islink, mock_stat):
+        """Test case where directories have identical files with identical sizes."""
+        # Setup directory structure
+        mock_walk.side_effect = [
+            # Files in dir1
+            [('/dir1', [], ['file1.txt', 'file2.txt'])],
+            # Files in dir2
+            [('/dir2', [], ['file1.txt', 'file2.txt'])],
+        ]
+
+        # All files exist in both directories
+        mock_exists.return_value = True
+        mock_islink.return_value = False
+
+        # Same file sizes
+        def stat_side_effect(path, _=None):
+            stat_result = MagicMock()
+            stat_result.st_size = 1000
+            return stat_result
+
+        mock_stat.side_effect = stat_side_effect
+
+        # Call the function
+        diff('/dir1', '/dir2')
+
+        # Verify no size mismatch was printed (only the newline prints should be called)
+        self.assertEqual(mock_print.call_count, 1)  # Just one newline print for identical directories
+        mock_print.assert_called_with()
+
+    @patch('os.stat')
+    @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('os.walk')
+    @patch('builtins.print')
+    def test_size_mismatch(self, mock_print, mock_walk, mock_exists, mock_islink, mock_stat):
+        """Test case where files exist in both directories but have different sizes."""
+        # Setup directory structure
+        mock_walk.side_effect = [
+            # Files in dir1
+            [('/dir1', [], ['file1.txt', 'file2.txt'])],
+            # Files in dir2
+            [('/dir2', [], ['file1.txt', 'file2.txt'])],
+        ]
+
+        # All files exist in both directories
+        mock_exists.return_value = True
+        mock_islink.return_value = False
+
+        # Different file sizes based on file path
+        def stat_side_effect(path, _=None):
+            stat_result = MagicMock()
+            if 'file1.txt' in path:
+                if '/dir1' in path:
+                    stat_result.st_size = 1000
+                else:
+                    stat_result.st_size = 1500
+            elif 'file2.txt' in path:
+                if '/dir1' in path:
+                    stat_result.st_size = 2000
+                else:
+                    stat_result.st_size = 1800
+            return stat_result
+
+        mock_stat.side_effect = stat_side_effect
+
+        # Call the function
+        diff('/dir1', '/dir2')
+
+        # Verify size mismatches were printed
+        mock_print.assert_any_call("Size mismatch: /file1.txt 1000 vs 1500 (+500B)")
+        mock_print.assert_any_call("Size mismatch: /file2.txt 2000 vs 1800 (-200B)")
+
+    @patch('os.stat')
+    @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('os.walk')
+    @patch('builtins.print')
+    def test_files_in_dir1_not_in_dir2(self, mock_print, mock_walk, mock_exists, mock_islink, mock_stat):
+        """Test case where some files exist in dir1 but not in dir2."""
+        # Setup directory structure
+        mock_walk.side_effect = [
+            # Files in dir1
+            [('/dir1', [], ['file1.txt', 'file2.txt', 'file3.txt'])],
+            # Files in dir2
+            [('/dir2', [], ['file1.txt'])],
+        ]
+
+        # Only file1.txt exists in both
+        def exists_side_effect(path):
+            return 'file1.txt' in path or not path.startswith('/dir2')
+
+        mock_exists.side_effect = exists_side_effect
+        mock_islink.return_value = False
+
+        # Same file sizes for the common file
+        def stat_side_effect(path, _=None):
+            stat_result = MagicMock()
+            stat_result.st_size = 1000
+            return stat_result
+
+        mock_stat.side_effect = stat_side_effect
+
+        # Call the function
+        diff('/dir1', '/dir2')
+
+        # Verify output includes files in dir1 but not in dir2
+        mock_print.assert_any_call("Files in /dir1 but not in /dir2:")
+        mock_print.assert_any_call("/file2.txt")
+        mock_print.assert_any_call("/file3.txt")
+
+    @patch('os.stat')
+    @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('os.walk')
+    @patch('builtins.print')
+    def test_files_in_dir2_not_in_dir1(self, mock_print, mock_walk, mock_exists, mock_islink, mock_stat):
+        """Test case where some files exist in dir2 but not in dir1."""
+        # Setup directory structure
+        mock_walk.side_effect = [
+            # Files in dir1
+            [('/dir1', [], ['file1.txt'])],
+            # Files in dir2
+            [('/dir2', [], ['file1.txt', 'file2.txt', 'file3.txt'])],
+        ]
+
+        # All files in dir2 exist; only some files have matching ones in dir1
+        mock_exists.return_value = True
+        mock_islink.return_value = False
+
+        # Same file sizes for common files
+        def stat_side_effect(path, _=None):
+            stat_result = MagicMock()
+            stat_result.st_size = 1000
+            return stat_result
+
+        mock_stat.side_effect = stat_side_effect
+
+        # Call the function
+        diff('/dir1', '/dir2')
+
+        # Verify output includes files in dir2 but not in dir1
+        mock_print.assert_any_call("Files in /dir2 but not in /dir1:")
+        mock_print.assert_any_call("/file2.txt")
+        mock_print.assert_any_call("/file3.txt")
+
+    @patch('os.stat')
+    @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('os.walk')
+    @patch('builtins.print')
+    def test_complex_comparison(self, mock_print, mock_walk, mock_exists, mock_islink, mock_stat):
+        """Test a complex case with various differences."""
+        # Setup directory structure
+        mock_walk.side_effect = [
+            # Files in dir1 with subdirectories
+            [
+                ('/dir1', ['subdir'], ['file1.txt', 'file2.txt']),
+                ('/dir1/subdir', [], ['file3.txt', 'file4.txt']),
+            ],
+            # Files in dir2 with different subdirectories
+            [
+                ('/dir2', ['other'], ['file1.txt', 'unique.txt']),
+                ('/dir2/other', [], ['file5.txt']),
+            ],
+        ]
+
+        # Control which files exist in which directories
+        def exists_side_effect(path):
+            return path in [
+                '/dir2/file1.txt',  # Common file
+            ]
+
+        mock_exists.side_effect = exists_side_effect
+        mock_islink.return_value = False
+
+        # Different file sizes for the common file
+        def stat_side_effect(path, _=None):
+            stat_result = MagicMock()
+            if 'file1.txt' in path:
+                if '/dir1' in path:
+                    stat_result.st_size = 1000
+                else:
+                    stat_result.st_size = 1200
+            else:
+                stat_result.st_size = 500  # Default for other files
+            return stat_result
+
+        mock_stat.side_effect = stat_side_effect
+
+        # Call the function
+        diff('/dir1', '/dir2')
+
+        # Verify all expected outputs
+        # Size mismatch for file1.txt
+        mock_print.assert_any_call("Size mismatch: /file1.txt 1000 vs 1200 (+200B)")
+
+        # Files in dir1 but not in dir2
+        mock_print.assert_any_call("Files in /dir1 but not in /dir2:")
+        mock_print.assert_any_call("/file2.txt")
+        mock_print.assert_any_call("/subdir/file3.txt")
+        mock_print.assert_any_call("/subdir/file4.txt")
+
+        # Files in dir2 but not in dir1
+        mock_print.assert_any_call("Files in /dir2 but not in /dir1:")
+        mock_print.assert_any_call("/unique.txt")
+        mock_print.assert_any_call("/other/file5.txt")
+
+    @patch('os.stat')
+    @patch('os.path.islink')
+    @patch('os.path.exists')
+    @patch('os.walk')
+    @patch('builtins.print')
+    def test_symlinks_handled_correctly(self, mock_print, mock_walk, mock_exists, mock_islink, mock_stat):
+        """Test that symlinks are handled correctly."""
+        # Setup directory structure
+        mock_walk.side_effect = [
+            # Files in dir1
+            [('/dir1', [], ['file1.txt', 'symlink.txt'])],
+            # Files in dir2
+            [('/dir2', [], ['file1.txt', 'symlink.txt'])],
+        ]
+
+        # Control which files exist and which are symlinks
+        def exists_side_effect(path):
+            return True
+
+        def islink_side_effect(path):
+            return 'symlink.txt' in path
+
+        mock_exists.side_effect = exists_side_effect
+        mock_islink.side_effect = islink_side_effect
+
+        # Same file sizes for non-symlink files
+        def stat_side_effect(path, _=None):
+            stat_result = MagicMock()
+            if 'file1.txt' in path:
+                stat_result.st_size = 1000
+            else:
+                stat_result.st_size = 0  # Default for other files
+            return stat_result
+
+        mock_stat.side_effect = stat_side_effect
+
+        # Call the function
+        diff('/dir1', '/dir2')
+
+        # Verify symlinks were properly skipped
+        self.assertEqual(mock_print.call_count, 1)  # Only the newline should be printed

--- a/tasks/unit_tests/diff_tests.py
+++ b/tasks/unit_tests/diff_tests.py
@@ -25,7 +25,8 @@ class TestDiff(unittest.TestCase):
         mock_islink.return_value = False
 
         # Same file sizes
-        def stat_side_effect(path, _=None):
+        def stat_side_effect(path, follow_symlinks=None):
+            self.assertEqual(follow_symlinks, False)
             stat_result = MagicMock()
             stat_result.st_size = 1000
             return stat_result
@@ -59,7 +60,8 @@ class TestDiff(unittest.TestCase):
         mock_islink.return_value = False
 
         # Different file sizes based on file path
-        def stat_side_effect(path, _=None):
+        def stat_side_effect(path, follow_symlinks=None):
+            self.assertEqual(follow_symlinks, False)
             stat_result = MagicMock()
             if 'file1.txt' in path:
                 if '/dir1' in path:
@@ -105,7 +107,8 @@ class TestDiff(unittest.TestCase):
         mock_islink.return_value = False
 
         # Same file sizes for the common file
-        def stat_side_effect(path, _=None):
+        def stat_side_effect(path, follow_symlinks=None):
+            self.assertEqual(follow_symlinks, False)
             stat_result = MagicMock()
             stat_result.st_size = 1000
             return stat_result
@@ -140,7 +143,8 @@ class TestDiff(unittest.TestCase):
         mock_islink.return_value = False
 
         # Same file sizes for common files
-        def stat_side_effect(path, _=None):
+        def stat_side_effect(path, follow_symlinks=None):
+            self.assertEqual(follow_symlinks, False)
             stat_result = MagicMock()
             stat_result.st_size = 1000
             return stat_result
@@ -186,7 +190,8 @@ class TestDiff(unittest.TestCase):
         mock_islink.return_value = False
 
         # Different file sizes for the common file
-        def stat_side_effect(path, _=None):
+        def stat_side_effect(path, follow_symlinks=None):
+            self.assertEqual(follow_symlinks, False)
             stat_result = MagicMock()
             if 'file1.txt' in path:
                 if '/dir1' in path:
@@ -243,7 +248,8 @@ class TestDiff(unittest.TestCase):
         mock_islink.side_effect = islink_side_effect
 
         # Same file sizes for non-symlink files
-        def stat_side_effect(path, _=None):
+        def stat_side_effect(path, follow_symlinks=None):
+            self.assertEqual(follow_symlinks, False)
             stat_result = MagicMock()
             if 'file1.txt' in path:
                 stat_result.st_size = 1000

--- a/tasks/unit_tests/download_tests.py
+++ b/tasks/unit_tests/download_tests.py
@@ -1,0 +1,138 @@
+import unittest
+from unittest.mock import MagicMock, call, mock_open, patch
+
+import requests
+
+from tasks.libs.common.download import download
+
+
+class TestDownload(unittest.TestCase):
+    @patch('os.path.isdir')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('requests.get')
+    @patch('rich.progress.Progress')
+    def test_download_to_file(self, mock_progress, mock_get, mock_open, mock_isdir):
+        # Setup mocks
+        mock_isdir.return_value = False
+
+        # Create mock response
+        mock_response = MagicMock()
+        mock_response.headers.get.return_value = '1000'
+        mock_response.iter_content.return_value = [b'chunk1', b'chunk2', b'chunk3']
+        mock_get.return_value = mock_response
+
+        # Create mock progress context
+        mock_progress_context = MagicMock()
+        mock_progress_instance = mock_progress_context.__enter__.return_value
+        mock_progress_instance.add_task.return_value = 'task1'
+        mock_progress.return_value = mock_progress_context
+
+        # Call the function
+        url = 'https://example.com/file.txt'
+        path = '/path/to/file.txt'
+        result = download(url, path)
+
+        # Verify results
+        self.assertEqual(result, path)
+
+        # Verify requests.get was called with the right parameters
+        mock_get.assert_called_once_with(url, stream=True, timeout=None)
+        mock_response.raise_for_status.assert_called_once()
+
+        # Verify file was opened
+        mock_open.assert_called_once_with(path, 'wb')
+
+        # Verify content was written
+        mock_file = mock_open()
+        expected_write_calls = [call(b'chunk1'), call(b'chunk2'), call(b'chunk3')]
+        self.assertEqual(mock_file.write.call_args_list, expected_write_calls)
+
+        # Verify progress was updated
+        mock_progress_instance.add_task.assert_called_once_with('Downloading file.txt', total=1000)
+        self.assertEqual(mock_progress_instance.update.call_count, 3)
+        for i, chunk in enumerate([b'chunk1', b'chunk2', b'chunk3']):
+            self.assertEqual(mock_progress_instance.update.call_args_list[i], call('task1', advance=len(chunk)))
+
+    @patch('os.path.isdir')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('requests.get')
+    @patch('rich.progress.Progress')
+    def test_download_to_directory(self, mock_progress, mock_get, mock_open, mock_isdir):
+        # Setup mocks
+        mock_isdir.return_value = True
+
+        # Create mock response
+        mock_response = MagicMock()
+        mock_response.headers.get.return_value = '500'
+        mock_response.iter_content.return_value = [b'data']
+        mock_get.return_value = mock_response
+
+        # Create mock progress context
+        mock_progress_context = MagicMock()
+        mock_progress_instance = mock_progress_context.__enter__.return_value
+        mock_progress_instance.add_task.return_value = 'task1'
+        mock_progress.return_value = mock_progress_context
+
+        # Call the function
+        url = 'https://example.com/file.txt'
+        path = '/path/to/dir'
+        result = download(url, path)
+
+        # Verify results
+        self.assertEqual(result, '/path/to/dir/file.txt')
+
+        # Verify file operations
+        mock_open.assert_called_once_with('/path/to/dir/file.txt', 'wb')
+
+    @patch('os.path.isdir')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('requests.get')
+    def test_download_http_error(self, mock_get, mock_open, mock_isdir):
+        # Setup mocks
+        mock_isdir.return_value = False
+
+        # Configure the response to raise an HTTP error
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
+        mock_get.return_value = mock_response
+
+        # Call the function and expect an exception
+        url = 'https://example.com/nonexistent.txt'
+        path = '/path/to/file.txt'
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            download(url, path)
+
+        # Verify the file was not opened
+        mock_open.assert_not_called()
+
+    @patch('os.path.isdir')
+    @patch('builtins.open', new_callable=mock_open)
+    @patch('requests.get')
+    @patch('rich.progress.Progress')
+    def test_download_no_content_length(self, mock_progress, mock_get, mock_open, mock_isdir):
+        # Setup mocks
+        mock_isdir.return_value = False
+
+        # Create mock response with no content-length header
+        mock_response = MagicMock()
+        mock_response.headers.get.return_value = 0  # No content length
+        mock_response.iter_content.return_value = [b'some', b'content']
+        mock_get.return_value = mock_response
+
+        # Create mock progress context
+        mock_progress_context = MagicMock()
+        mock_progress_instance = mock_progress_context.__enter__.return_value
+        mock_progress_instance.add_task.return_value = 'task1'
+        mock_progress.return_value = mock_progress_context
+
+        # Call the function
+        url = 'https://example.com/unknown_size.txt'
+        path = '/path/to/file.txt'
+        result = download(url, path)
+
+        # Verify results
+        self.assertEqual(result, path)
+
+        # Verify progress was configured with None for the total
+        mock_progress_instance.add_task.assert_called_once_with('Downloading file.txt', total=None)

--- a/tasks/unit_tests/url_tests.py
+++ b/tasks/unit_tests/url_tests.py
@@ -1,0 +1,422 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+from invoke.context import Context
+from invoke.exceptions import Exit
+
+from tasks.libs.package.url import (
+    DEB_TESTING_BUCKET_URL,
+    RPM_TESTING_BUCKET_URL,
+    _deb_get_filename_for_package,
+    get_deb_package_url,
+    get_rpm_package_url,
+)
+
+
+class TestGetRpmPackageUrl(unittest.TestCase):
+    @patch('tempfile.mktemp')
+    @patch('tasks.libs.common.download.download')
+    @patch('requests.get')
+    def test_get_rpm_package_url_amd64(self, mock_get, mock_download, mock_mktemp):
+        # Setup mocks
+        # Mock tempfile.mktemp
+        mock_mktemp.return_value = "/tmp/fake_temp_file"
+
+        # Mock download to do nothing - we'll just verify it was called with the correct parameters
+        def download_side_effect(url, filename):
+            # Do nothing but pass through the call
+            pass
+
+        mock_download.side_effect = download_side_effect
+
+        # Mock requests.get
+        mock_response = MagicMock()
+        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo">
+  <data type="primary">
+    <location href="repodata/primary.xml.gz"/>
+  </data>
+</repomd>"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Create a context mock with run method
+        ctx = Context()
+        ctx.run = MagicMock()
+        ctx.run.return_value = MagicMock(
+            stdout="""<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common">
+  <package type="rpm">
+    <name>datadog-agent</name>
+    <version>7.45.0</version>
+    <location href="Packages/d/datadog-agent-7.45.0-1.x86_64.rpm"/>
+  </package>
+  <package type="rpm">
+    <name>datadog-agent-dev</name>
+    <version>7.45.0</version>
+    <location href="Packages/d/datadog-agent-dev-7.45.0-1.x86_64.rpm"/>
+  </package>
+</metadata>"""
+        )
+
+        # Call the function
+        pipeline_id = 123456
+        package_name = "datadog-agent"
+        arch = "amd64"
+
+        result = get_rpm_package_url(ctx, pipeline_id, package_name, arch)
+
+        # Verify results
+        arch2 = "x86_64"  # Expected conversion for amd64
+        packages_url = f"{RPM_TESTING_BUCKET_URL}/testing/pipeline-{pipeline_id}-a7/7/{arch2}"
+        repomd_url = f"{packages_url}/repodata/repomd.xml"
+        expected_url = f"{packages_url}/Packages/d/datadog-agent-7.45.0-1.x86_64.rpm"
+
+        self.assertEqual(result, expected_url)
+
+        # Verify that we called requests.get with the repomd_url
+        mock_get.assert_any_call(repomd_url, timeout=None)
+
+        # Verify gunzip was called
+        ctx.run.assert_called_once_with("gunzip --stdout /tmp/fake_temp_file", hide=True)
+
+    @patch('tempfile.mktemp')
+    @patch('tasks.libs.common.download.download')
+    @patch('requests.get')
+    def test_get_rpm_package_url_arm64(self, mock_get, mock_download, mock_mktemp):
+        # Setup mocks
+        # Mock tempfile.mktemp
+        mock_mktemp.return_value = "/tmp/fake_temp_file"
+
+        # Mock download to do nothing - we'll just verify it was called with the correct parameters
+        def download_side_effect(url, filename):
+            # Do nothing but pass through the call
+            pass
+
+        mock_download.side_effect = download_side_effect
+
+        # Mock requests.get
+        mock_response = MagicMock()
+        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo">
+  <data type="primary">
+    <location href="repodata/primary.xml.gz"/>
+  </data>
+</repomd>"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Create a context mock with run method
+        ctx = Context()
+        ctx.run = MagicMock()
+        ctx.run.return_value = MagicMock(
+            stdout="""<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common">
+  <package type="rpm">
+    <name>datadog-agent</name>
+    <version>7.45.0</version>
+    <location href="Packages/d/datadog-agent-7.45.0-1.aarch64.rpm"/>
+  </package>
+</metadata>"""
+        )
+
+        # Call the function
+        pipeline_id = 987654
+        package_name = "datadog-agent"
+        arch = "arm64"
+
+        result = get_rpm_package_url(ctx, pipeline_id, package_name, arch)
+
+        # Verify results
+        arch2 = "aarch64"  # Expected conversion for arm64
+        packages_url = f"{RPM_TESTING_BUCKET_URL}/testing/pipeline-{pipeline_id}-a7/7/{arch2}"
+        repomd_url = f"{packages_url}/repodata/repomd.xml"
+        expected_url = f"{packages_url}/Packages/d/datadog-agent-7.45.0-1.aarch64.rpm"
+
+        self.assertEqual(result, expected_url)
+
+        # Verify that we called requests.get with the repomd_url
+        mock_get.assert_any_call(repomd_url, timeout=None)
+
+        # Verify gunzip was called
+        ctx.run.assert_called_once_with("gunzip --stdout /tmp/fake_temp_file", hide=True)
+
+    @patch('tempfile.mktemp')
+    @patch('tasks.libs.common.download.download')
+    @patch('requests.get')
+    def test_get_rpm_package_url_no_primary_data(self, mock_get, mock_download, mock_mktemp):
+        # Mock download to do nothing
+        def download_side_effect(url, filename):
+            pass
+
+        mock_download.side_effect = download_side_effect
+
+        # Mock requests.get
+        mock_response = MagicMock()
+        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo">
+  <data type="other">
+    <location href="repodata/other.xml.gz"/>
+  </data>
+</repomd>"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Create a context mock
+        ctx = Context()
+
+        # Call the function and expect an assert
+        pipeline_id = 123456
+        package_name = "datadog-agent"
+        arch = "amd64"
+
+        with self.assertRaises(AssertionError) as context:
+            get_rpm_package_url(ctx, pipeline_id, package_name, arch)
+
+        # Verify error message
+        packages_url = f"{RPM_TESTING_BUCKET_URL}/testing/pipeline-{pipeline_id}-a7/7/x86_64"
+        repomd_url = f"{packages_url}/repodata/repomd.xml"
+        self.assertTrue(f"Could not find primary data in {repomd_url}" in str(context.exception))
+
+    @patch('tempfile.mktemp')
+    @patch('tasks.libs.common.download.download')
+    @patch('requests.get')
+    def test_get_rpm_package_url_no_location(self, mock_get, mock_download, mock_mktemp):
+        # Mock download to do nothing
+        def download_side_effect(url, filename):
+            pass
+
+        mock_download.side_effect = download_side_effect
+
+        # Mock requests.get
+        mock_response = MagicMock()
+        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo">
+  <data type="primary">
+    <!-- Missing location element -->
+  </data>
+</repomd>"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Create a context mock
+        ctx = Context()
+
+        # Call the function and expect an assert
+        pipeline_id = 123456
+        package_name = "datadog-agent"
+        arch = "amd64"
+
+        with self.assertRaises(AssertionError) as context:
+            get_rpm_package_url(ctx, pipeline_id, package_name, arch)
+
+        # Verify error message
+        packages_url = f"{RPM_TESTING_BUCKET_URL}/testing/pipeline-{pipeline_id}-a7/7/x86_64"
+        repomd_url = f"{packages_url}/repodata/repomd.xml"
+        self.assertTrue(f"Could not find location for primary data in {repomd_url}" in str(context.exception))
+
+    @patch('tempfile.mktemp')
+    @patch('tasks.libs.common.download.download')
+    @patch('requests.get')
+    def test_get_rpm_package_url_package_not_found(self, mock_get, mock_download, mock_mktemp):
+        # Setup mocks
+        # Mock tempfile.mktemp
+        mock_mktemp.return_value = "/tmp/fake_temp_file"
+
+        # Mock download to do nothing
+        def download_side_effect(url, filename):
+            pass
+
+        mock_download.side_effect = download_side_effect
+
+        # Mock requests.get
+        mock_response = MagicMock()
+        mock_response.text = """<?xml version="1.0" encoding="UTF-8"?>
+<repomd xmlns="http://linux.duke.edu/metadata/repo">
+  <data type="primary">
+    <location href="repodata/primary.xml.gz"/>
+  </data>
+</repomd>"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Create a context mock with run method
+        ctx = Context()
+        ctx.run = MagicMock()
+        ctx.run.return_value = MagicMock(
+            stdout="""<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common">
+  <package type="rpm">
+    <name>some-other-package</name>
+    <version>1.0.0</version>
+    <location href="Packages/s/some-other-package-1.0.0-1.x86_64.rpm"/>
+  </package>
+</metadata>"""
+        )
+
+        # Call the function
+        pipeline_id = 123456
+        package_name = "datadog-agent"
+        arch = "amd64"
+
+        with self.assertRaises(Exit) as context:
+            get_rpm_package_url(ctx, pipeline_id, package_name, arch)
+
+        # Verify error
+        packages_url = f"{RPM_TESTING_BUCKET_URL}/testing/pipeline-{pipeline_id}-a7/7/x86_64"
+        primary_url = f"{packages_url}/repodata/primary.xml.gz"
+        self.assertEqual(context.exception.code, 1)
+        self.assertEqual(context.exception.message, f"Could not find package {package_name} in {primary_url}")
+
+    @patch('requests.get')
+    def test_get_rpm_package_url_http_error(self, mock_get):
+        # Mock requests.get to raise an exception
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError("404 Not Found")
+        mock_get.return_value = mock_response
+
+        # Create a context mock
+        ctx = Context()
+
+        # Call the function and expect an exception
+        pipeline_id = 123456
+        package_name = "datadog-agent"
+        arch = "amd64"
+
+        with self.assertRaises(requests.exceptions.HTTPError):
+            get_rpm_package_url(ctx, pipeline_id, package_name, arch)
+
+
+class TestGetDebPackageUrl(unittest.TestCase):
+    @patch('tasks.libs.package.url._deb_get_filename_for_package')
+    def test_get_deb_package_url_amd64(self, mock_get_filename):
+        # Setup the mock
+        mock_get_filename.return_value = "pool/main/d/datadog-agent/datadog-agent_7.45.0-1_amd64.deb"
+
+        # Call the function with test parameters
+        ctx = Context()
+        pipeline_id = 123456
+        package_name = "datadog-agent"
+        arch = "amd64"
+
+        # Execute the function
+        result = get_deb_package_url(ctx, pipeline_id, package_name, arch)
+
+        # Assert the result
+        expected_url = f"{DEB_TESTING_BUCKET_URL}/pool/main/d/datadog-agent/datadog-agent_7.45.0-1_amd64.deb"
+        self.assertEqual(result, expected_url)
+
+        # Assert the mock was called with the correct parameters
+        expected_packages_url = (
+            f"{DEB_TESTING_BUCKET_URL}/dists/pipeline-{pipeline_id}-a7-x86_64/7/binary-{arch}/Packages"
+        )
+        mock_get_filename.assert_called_once_with(expected_packages_url, package_name)
+
+    @patch('tasks.libs.package.url._deb_get_filename_for_package')
+    def test_get_deb_package_url_arm64(self, mock_get_filename):
+        # Setup the mock
+        mock_get_filename.return_value = "pool/main/d/datadog-agent/datadog-agent_7.45.0-1_arm64.deb"
+
+        # Call the function with test parameters
+        ctx = Context()
+        pipeline_id = 987654
+        package_name = "datadog-agent"
+        arch = "arm64"
+
+        # Execute the function
+        result = get_deb_package_url(ctx, pipeline_id, package_name, arch)
+
+        # Assert the result
+        expected_url = f"{DEB_TESTING_BUCKET_URL}/pool/main/d/datadog-agent/datadog-agent_7.45.0-1_arm64.deb"
+        self.assertEqual(result, expected_url)
+
+        # Assert the mock was called with the correct parameters
+        expected_packages_url = (
+            f"{DEB_TESTING_BUCKET_URL}/dists/pipeline-{pipeline_id}-a7-{arch}/7/binary-{arch}/Packages"
+        )
+        mock_get_filename.assert_called_once_with(expected_packages_url, package_name)
+
+
+class TestDebGetFilenameForPackage(unittest.TestCase):
+    @patch('requests.get')
+    def test_deb_get_filename_for_package(self, mock_get):
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.text = """Package: datadog-agent
+Version: 7.45.0-1
+Architecture: amd64
+Filename: pool/main/d/datadog-agent/datadog-agent_7.45.0-1_amd64.deb
+Size: 12345
+MD5sum: abcd1234
+
+Package: datadog-agent-dev
+Version: 7.45.0-1
+Architecture: amd64
+Filename: pool/main/d/datadog-agent-dev/datadog-agent-dev_7.45.0-1_amd64.deb
+Size: 54321
+MD5sum: efgh5678
+"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Test parameters
+        package_name = "datadog-agent"
+        packages_url = f"{DEB_TESTING_BUCKET_URL}/dists/pipeline-123-a7-x86_64/7/binary-amd64/Packages"
+
+        # Execute the function
+        result = _deb_get_filename_for_package(packages_url, package_name)
+
+        # Assert results
+        self.assertEqual(result, "pool/main/d/datadog-agent/datadog-agent_7.45.0-1_amd64.deb")
+        mock_get.assert_called_once_with(packages_url, timeout=None)
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch('requests.get')
+    def test_deb_get_filename_for_package_not_found(self, mock_get):
+        # Mock the response
+        mock_response = MagicMock()
+        mock_response.text = """Package: some-other-package
+Version: 1.0.0
+Architecture: amd64
+Filename: pool/main/s/some-other-package/some-other-package_1.0.0_amd64.deb
+Size: 12345
+MD5sum: abcd1234
+"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Test parameters
+        package_name = "datadog-agent"
+        packages_url = f"{DEB_TESTING_BUCKET_URL}/dists/pipeline-123-a7-x86_64/7/binary-amd64/Packages"
+
+        # Execute the function and assert it raises the expected exception
+        with self.assertRaises(Exit) as context:
+            _deb_get_filename_for_package(packages_url, package_name)
+
+        self.assertEqual(context.exception.code, 1)
+        self.assertEqual(context.exception.message, f"Could not find filename for {package_name} in {packages_url}")
+
+    @patch('requests.get')
+    def test_deb_get_filename_for_package_missing_filename(self, mock_get):
+        # Mock the response with a package that has no Filename field
+        mock_response = MagicMock()
+        mock_response.text = """Package: datadog-agent
+Version: 7.45.0-1
+Architecture: amd64
+Size: 12345
+MD5sum: abcd1234
+"""
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        # Test parameters
+        package_name = "datadog-agent"
+        packages_url = f"{DEB_TESTING_BUCKET_URL}/dists/pipeline-123-a7-x86_64/7/binary-amd64/Packages"
+
+        # Execute the function and assert it raises the expected exception
+        with self.assertRaises(Exit) as context:
+            _deb_get_filename_for_package(packages_url, package_name)
+
+        self.assertEqual(context.exception.code, 1)
+        self.assertEqual(context.exception.message, f"Could not find filename for {package_name} in {packages_url}")

--- a/tasks/unit_tests/utils_tests.py
+++ b/tasks/unit_tests/utils_tests.py
@@ -1,6 +1,7 @@
 import unittest
 
 from tasks.libs.common.utils import clean_nested_paths
+from tasks.libs.package.utils import get_package_name
 
 
 class TestUtils(unittest.TestCase):
@@ -32,3 +33,32 @@ class TestUtils(unittest.TestCase):
         ]
         expected_paths = ["."]
         self.assertEqual(clean_nested_paths(paths), expected_paths)
+
+
+class TestGetPackageName(unittest.TestCase):
+    def test_get_package_name_no_flavor(self):
+        """Test get_package_name with no flavor (empty string)"""
+        binary = "agent"
+        flavor = ""
+
+        result = get_package_name(binary, flavor)
+
+        self.assertEqual(result, "datadog-agent")
+
+    def test_get_package_name_with_flavor(self):
+        """Test get_package_name with a flavor specified"""
+        binary = "agent"
+        flavor = "iot"
+
+        result = get_package_name(binary, flavor)
+
+        self.assertEqual(result, "datadog-iot-agent")
+
+    def test_get_package_name_different_binary(self):
+        """Test get_package_name with a different binary name"""
+        binary = "dogstatsd"
+        flavor = ""
+
+        result = get_package_name(binary, flavor)
+
+        self.assertEqual(result, "datadog-dogstatsd")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add tests for functions added in https://github.com/DataDog/datadog-agent/pull/36359/s. 

### Motivation
Ensure the functions don't break when changing them.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
The tests are generated, but I proofread and fixed what was needed.