### PR TITLE
Remove flaky mark from TestWindowsDiskSuite

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
@@ -92,12 +92,12 @@ instances:
 					if !gocmp.Equal(a.Tags, b.Tags, gocmpopts.SortSlices(cmp.Less[string])) {
 						return false
 					}
-					a_value := a.Points[0][1]
-					b_value := b.Points[0][1]
+					aValue := a.Points[0][1]
+					bValue := b.Points[0][1]
 					if isConstantMetric(a.Metric) {
-						return a_value == b_value
+						return aValue == bValue
 					}
-					return compareValuesWithRelativeMargin(a_value, b_value, p, metricCompareFraction)
+					return compareValuesWithRelativeMargin(aValue, bValue, p, metricCompareFraction)
 				}),
 				gocmpopts.SortSlices(metricPayloadCompare), // sort metrics
 			)
@@ -117,7 +117,7 @@ func isConstantMetric(name string) bool {
 func compareValuesWithRelativeMargin(a, b, p, fraction float64) bool {
 	x := math.Round(a*p) / p
 	y := math.Round(b*p) / p
-	relMarg := metricCompareFraction * math.Min(math.Abs(x), math.Abs(y))
+	relMarg := fraction * math.Min(math.Abs(x), math.Abs(y))
 	return math.Abs(x-y) <= relMarg
 }
 

--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
@@ -97,7 +97,7 @@ instances:
 					if isConstantMetric(a.Metric) {
 						return a_value == b_value
 					}
-					return comparePointsWithRelativeMargin(a.Points[0][1], b.Points[0][1], p, metricCompareFraction)
+					return compareValuesWithRelativeMargin(a_value, b_value, p, metricCompareFraction)
 				}),
 				gocmpopts.SortSlices(metricPayloadCompare), // sort metrics
 			)
@@ -114,7 +114,7 @@ func isConstantMetric(name string) bool {
 	return false
 }
 
-func comparePointsWithRelativeMargin(a, b, p, fraction float64) bool {
+func compareValuesWithRelativeMargin(a, b, p, fraction float64) bool {
 	x := math.Round(a*p) / p
 	y := math.Round(b*p) / p
 	relMarg := metricCompareFraction * math.Min(math.Abs(x), math.Abs(y))

--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
@@ -56,6 +56,11 @@ const metricCompareFraction = 0.05
 // number of decimals when comparing metrics
 const metricCompareDecimals = 1
 
+// metrics that remain constant
+var constantMetricsSet = map[string]struct{}{
+	"system.disk.total": {},
+}
+
 func (v *baseCheckSuite) TestCheckDisk() {
 	testCases := []struct {
 		name        string
@@ -94,7 +99,7 @@ instances:
 					}
 					aValue := a.Points[0][1]
 					bValue := b.Points[0][1]
-					if isConstantMetric(a.Metric) {
+					if _, ok := constantMetricsSet[a.Metric]; ok {
 						return aValue == bValue
 					}
 					return compareValuesWithRelativeMargin(aValue, bValue, p, metricCompareFraction)
@@ -104,14 +109,6 @@ instances:
 			require.Empty(v.T(), diff)
 		})
 	}
-}
-
-func isConstantMetric(name string) bool {
-	switch name {
-	case "system.disk.total":
-		return true
-	}
-	return false
 }
 
 func compareValuesWithRelativeMargin(a, b, p, fraction float64) bool {

--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_win_test.go
@@ -10,7 +10,6 @@ import (
 
 	e2eos "github.com/DataDog/test-infra-definitions/components/os"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 )
 
@@ -19,7 +18,6 @@ type windowsStatusSuite struct {
 }
 
 func TestWindowsDiskSuite(t *testing.T) {
-	flake.Mark(t)
 	t.Parallel()
 	suite := &windowsStatusSuite{baseCheckSuite{descriptor: e2eos.WindowsDefault, agentOptions: getAgentOptions()}}
 	e2e.Run(t, suite, suite.getSuiteOptions()...)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Remove flaky test flag from `TestWindowsDiskSuite`.
Increase the accepted percentage difference for some metrics between the Python and Go versions of the check to _5%_, thus reducing the chances of test failures.
Set some metrics (e.g., `system.disk.total`) as constants, since their value should not change between runs of the check (Python and Go)

### Motivation
The mark was introduced temporarily after detecting the test as flaky in our CI.
The test almost always failed on Windows (no failure was detected on Linux) possibly because the processes running in the background (updates, scans, etc.) make greater use of the disk and this caused the metrics `system.disk.used` and `system.disk.utilized` to increase by more than 2% (the previous limit of the difference margin), thus causing the test to fail.
We want the test to always run.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
The test should always pass unless the difference in the value of any metric exceeds 5% between both executions of the check (python and Go)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
It has been verified that the [Python](https://github.com/giampaolo/psutil/blob/077d9c66e18ce9bacd93de98490a1b3999e67eb8/psutil/arch/windows/disk.c#L60) and [Go](https://github.com/shirou/gopsutil/blob/ec85c0b45bcbcc7e53ffa57e4b81ab58d9c933a5/disk/disk_windows.go#L62) code to obtain the failing metrics is very similar and in both cases ended up calling the `GetDiskFreeSpaceExW` primitive, which rules out a test error due to differences in the code executed by the check in Python and Go.