### PR TITLE
CAP-1917 fix terminated resources collection

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -45,7 +45,7 @@ func NewTerminatedResourceBundle(check *OrchestratorCheck, runCfg *collectors.Co
 }
 
 // Add adds a terminated object into TerminatedResourceBundle
-func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, resource interface{}) {
+func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, obj interface{}) {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
@@ -53,7 +53,7 @@ func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, re
 		tb.terminatedResources[k8sCollector] = []interface{}{}
 	}
 
-	resource, err := getResourceIfDeletedFinalStateUnknown(resource)
+	resource, err := getResourceIfDeletedFinalStateUnknown(obj)
 	if err != nil {
 		log.Warn(err)
 		return
@@ -138,17 +138,17 @@ func toTypedSlice(k8sCollector collectors.K8sCollector, list []interface{}) inte
 
 // getResourceIfDeletedFinalStateUnknown checks if the resource is of type DeletedFinalStateUnknown
 // and returns the underlying object if it is, or an error if the object is nil.
-func getResourceIfDeletedFinalStateUnknown(resource interface{}) (interface{}, error) {
-	obj := resource
+func getResourceIfDeletedFinalStateUnknown(obj interface{}) (interface{}, error) {
+	resource := obj
 	if deletedState, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-		obj = deletedState.Obj
+		resource = deletedState.Obj
 	}
 
-	if obj == nil || (reflect.ValueOf(obj).Kind() == reflect.Ptr && reflect.ValueOf(obj).IsNil()) {
-		return nil, fmt.Errorf("object is nil, skipping, got type: %T", resource)
+	if resource == nil || (reflect.ValueOf(resource).Kind() == reflect.Ptr && reflect.ValueOf(resource).IsNil()) {
+		return nil, fmt.Errorf("object is nil, skipping, got type: %T", obj)
 	}
 
-	return obj, nil
+	return resource, nil
 }
 
 func insertDeletionTimestampIfPossible(obj interface{}) interface{} {

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -53,7 +53,7 @@ func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, ob
 		tb.terminatedResources[k8sCollector] = []interface{}{}
 	}
 
-	resource, err := getResourceIfDeletedFinalStateUnknown(obj)
+	resource, err := getResource(obj)
 	if err != nil {
 		log.Warn(err)
 		return
@@ -136,9 +136,9 @@ func toTypedSlice(k8sCollector collectors.K8sCollector, list []interface{}) inte
 	return typedList.Interface()
 }
 
-// getResourceIfDeletedFinalStateUnknown checks if the resource is of type DeletedFinalStateUnknown
+// getResource checks if the resource is of type DeletedFinalStateUnknown
 // and returns the underlying object if it is, or an error if the object is nil.
-func getResourceIfDeletedFinalStateUnknown(obj interface{}) (interface{}, error) {
+func getResource(obj interface{}) (interface{}, error) {
 	resource := obj
 	if deletedState, ok := obj.(cache.DeletedFinalStateUnknown); ok {
 		resource = deletedState.Obj

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
@@ -89,7 +89,7 @@ func TestGetResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := getResourceIfDeletedFinalStateUnknown(tt.resource)
+			_, err := getResource(tt.resource)
 			require.Equal(t, tt.wantOk, err == nil)
 		})
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s"
 	mockconfig "github.com/DataDog/datadog-agent/pkg/config/mock"
@@ -44,4 +45,52 @@ func TestToTypedSlice(t *testing.T) {
 
 func toInterface(i interface{}) interface{} {
 	return i
+}
+
+func TestGetResource(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource interface{}
+		wantOk   bool
+	}{
+		{
+			name:     "nil resource",
+			resource: nil,
+			wantOk:   false,
+		},
+		{
+			name: "DeletedFinalStateUnknown with nil object",
+			resource: cache.DeletedFinalStateUnknown{
+				Obj: nil,
+			},
+			wantOk: false,
+		},
+		{
+			name: "DeletedFinalStateUnknown with ReplicaSet",
+			resource: cache.DeletedFinalStateUnknown{
+				Obj: &appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "rs",
+					},
+				},
+			},
+			wantOk: true,
+		},
+		{
+			name: "direct ReplicaSet",
+			resource: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rs",
+				},
+			},
+			wantOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := getResourceIfDeletedFinalStateUnknown(tt.resource)
+			require.Equal(t, tt.wantOk, err == nil)
+		})
+	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

We see this panic when the feature is enabled. This is because in informer deletion handler we can receive `cache.DeletedFinalStateUnknown`
https://github.com/kubernetes/kubernetes/blob/b63fe3d6670a434190918b9efca8012514df28c9/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go#L722-L729

In this PR, we add func `getResourceIfDeletedFinalStateUnknown ` to check the type 
```
2025-04-25 23:59:40 UTC | CORE | ERROR | (pkg/collector/corechecks/cluster/orchestrator/processors/errors.go:30 in RecoverOnPanic) | unable to process resources (panic!): goroutine 513 [running]:
runtime/debug.Stack()
    /usr/local/go/src/runtime/debug/stack.go:26 +0x64
[github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors.RecoverOnPanic()](http://github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors.RecoverOnPanic())
    /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/errors.go:29 +0x2c
panic({0x423e300?, 0x4005c2c900?})
    /usr/local/go/src/runtime/panic.go:791 +0x124
[github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s.(*JobHandlers).ResourceList(0x40060eb658](http://github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s.(*JobHandlers).ResourceList(0x40060eb658)?, {0x4a79bc?, 0xf1a4217de028?}, {0x40411cf900?, 0x4030f09d40?})
    /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go:79 +0x11c
[github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors.(*Processor).Process(0x400101c8e0](http://github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors.(*Processor).Process(0x400101c8e0), {0x518c210, 0x4014646a00}, {0x40411cf900?, 0x4030f09d40?})
    /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go:197 +0x78
[github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s.(*JobCollector).Process(0x4000d39590](http://github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s.(*JobCollector).Process(0x4000d39590), 0x4000d39590?, {0x40411cf900, 0x4030f09d40})
    /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/job.go:94 +0x64
[github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*TerminatedResourceBundle).Run(0x4000a78090)](http://github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*TerminatedResourceBundle).Run(0x4000a78090))
    /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go:73 +0x204
[github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*CollectorBundle).Run(0x4000cd9400](http://github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*CollectorBundle).Run(0x4000cd9400), {0x51c68a0, 0x4034eafa00})
    /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:383 +0x6e0
[github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*OrchestratorCheck).Run(0x4000de9b00)](http://github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*OrchestratorCheck).Run(0x4000de9b00))
    /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go:212 +0x224
[github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware.(*CheckWrapper).Run(0x40004ba500?)](http://github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware.(*CheckWrapper).Run(0x40004ba500?))

```

### Describe how you validated your changes

It’s difficult to QA this because we would need to simulate a disconnection from the API server. We can do two things here:

1. Verify that this PR doesn’t affect any basic behavior. Deploy the Cluster Agent, delete any Kubernetes resource, and check if you see logs like this:
```
2025-05-05 13:30:47 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go:86 in Run) | Terminated Resource collector xxxx/v1/xxxx run stats: listed=2 processed=2 messages=1
```
2. Let the Cluster Agents run on staging for a week and monitor to see if the panic still occurs.