### PR TITLE
[SVLS-6247] Add metric origins to serverless-init/sidecar enhanced metrics

### DIFF
--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -25,6 +25,8 @@ const (
 	WebsiteStack = "WEBSITE_STACK"
 	//nolint:revive // TODO(SERV) Fix revive linter
 	AppLogsTrace = "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED"
+
+	AppServiceOrigin = "appservice"
 )
 
 // GetTags returns a map of Azure-related tags
@@ -35,8 +37,8 @@ func (a *AppService) GetTags() map[string]string {
 	tags := map[string]string{
 		"app_name":   appName,
 		"region":     region,
-		"origin":     a.GetOrigin(),
-		"_dd.origin": a.GetOrigin(),
+		"origin":     AppServiceOrigin,
+		"_dd.origin": AppServiceOrigin,
 	}
 
 	maps.Copy(tags, traceutil.GetAppServicesTags())
@@ -47,7 +49,7 @@ func (a *AppService) GetTags() map[string]string {
 // GetOrigin returns the `origin` attribute type for the given
 // cloud service.
 func (a *AppService) GetOrigin() string {
-	return "appservice"
+	return AppServiceOrigin
 }
 
 // GetPrefix returns the prefix that we're prefixing all

--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -26,7 +26,7 @@ const (
 	//nolint:revive // TODO(SERV) Fix revive linter
 	AppLogsTrace = "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED"
 
-	// AppService origin tag value
+	// AppServiceOrigin origin tag value
 	AppServiceOrigin = "appservice"
 )
 

--- a/cmd/serverless-init/cloudservice/appservice.go
+++ b/cmd/serverless-init/cloudservice/appservice.go
@@ -26,6 +26,7 @@ const (
 	//nolint:revive // TODO(SERV) Fix revive linter
 	AppLogsTrace = "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED"
 
+	// AppService origin tag value
 	AppServiceOrigin = "appservice"
 )
 

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -7,13 +7,16 @@ package cloudservice
 
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"io"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+const CloudRunOrigin = "cloudrun"
 
 const (
 	// Environment var needed for service
@@ -68,8 +71,8 @@ type CloudRun struct {
 func (c *CloudRun) GetTags() map[string]string {
 	isCloudRun := c.spanNamespace == cloudRunService
 	tags := metadataHelperFunc(GetDefaultConfig(), isCloudRun)
-	tags["origin"] = c.GetOrigin()
-	tags["_dd.origin"] = c.GetOrigin()
+	tags["origin"] = CloudRunOrigin
+	tags["_dd.origin"] = CloudRunOrigin
 
 	revisionNameVal := os.Getenv(revisionNameEnvVar)
 	serviceNameVal := os.Getenv(ServiceNameEnvVar)
@@ -127,7 +130,7 @@ func (c *CloudRun) getFunctionTags(tags map[string]string) map[string]string {
 // GetOrigin returns the `origin` attribute type for the given
 // cloud service.
 func (c *CloudRun) GetOrigin() string {
-	return "cloudrun"
+	return CloudRunOrigin
 }
 
 // GetPrefix returns the prefix that we're prefixing all

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// CloudRun origin tag value
+// CloudRunOrigin origin tag value
 const CloudRunOrigin = "cloudrun"
 
 const (

--- a/cmd/serverless-init/cloudservice/cloudrun.go
+++ b/cmd/serverless-init/cloudservice/cloudrun.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// CloudRun origin tag value
 const CloudRunOrigin = "cloudrun"
 
 const (

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -44,6 +44,7 @@ const (
 	acaRevision       = "aca.app.revision"
 	acaSubscriptionID = "aca.subscription.id"
 
+	// ContainerApp origin tag value
 	ContainerAppOrigin = "containerapp"
 )
 

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -44,7 +44,7 @@ const (
 	acaRevision       = "aca.app.revision"
 	acaSubscriptionID = "aca.subscription.id"
 
-	// ContainerApp origin tag value
+	// ContainerAppOrigin origin tag value
 	ContainerAppOrigin = "containerapp"
 )
 

--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -43,6 +43,8 @@ const (
 	acaRegion         = "aca.app.region"
 	acaRevision       = "aca.app.revision"
 	acaSubscriptionID = "aca.subscription.id"
+
+	ContainerAppOrigin = "containerapp"
 )
 
 // GetTags returns a map of Azure-related tags
@@ -70,8 +72,8 @@ func (c *ContainerApp) GetTags() map[string]string {
 		acaRevision:    revision,
 		acaReplicaName: replica,
 
-		"origin":     c.GetOrigin(),
-		"_dd.origin": c.GetOrigin(),
+		"origin":     ContainerAppOrigin,
+		"_dd.origin": ContainerAppOrigin,
 	}
 
 	if c.SubscriptionId != "" {
@@ -97,7 +99,7 @@ func (c *ContainerApp) GetTags() map[string]string {
 // GetOrigin returns the `origin` attribute type for the given
 // cloud service.
 func (c *ContainerApp) GetOrigin() string {
-	return "containerapp"
+	return ContainerAppOrigin
 }
 
 // GetPrefix returns the prefix that we're prefixing all

--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -104,8 +104,10 @@ func run(_ secrets.Component, _ autodiscovery.Component, _ healthprobeDef.Compon
 	cloudService, logConfig, traceAgent, metricAgent, logsAgent := setup(modeConf, tagger, compression)
 
 	err := modeConf.Runner(logConfig)
+	prefix := cloudService.GetPrefix()
+	origin := cloudService.GetOrigin()
 
-	metric.AddShutdownMetric(cloudService.GetPrefix(), metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
+	metric.AddShutdownMetric(prefix, origin, metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
 	lastFlush(logConfig.FlushTimeout, metricAgent, traceAgent, logsAgent)
 
 	return err
@@ -147,7 +149,7 @@ func setup(_ mode.Conf, tagger tagger.Component, compression logscompression.Com
 	traceAgent := setupTraceAgent(tags, tagger)
 
 	metricAgent := setupMetricAgent(tags, tagger)
-	metric.AddColdStartMetric(prefix, metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
+	metric.AddColdStartMetric(prefix, origin, metricAgent.GetExtraTags(), time.Now(), metricAgent.Demux)
 
 	setupOtlpAgent(metricAgent, tagger)
 

--- a/cmd/serverless-init/metric/metric.go
+++ b/cmd/serverless-init/metric/metric.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -48,11 +49,11 @@ func add(name string, origin string, tags []string, timestamp time.Time, demux a
 
 func originToMetricSource(origin string) metrics.MetricSource {
 	switch origin {
-	case "cloudrun":
+	case cloudservice.CloudRunOrigin:
 		return metrics.MetricSourceGoogleCloudRunEnhanced
-	case "appservice":
+	case cloudservice.AppServiceOrigin:
 		return metrics.MetricSourceAzureAppServiceEnhanced
-	case "containerapp":
+	case cloudservice.ContainerAppOrigin:
 		return metrics.MetricSourceAzureContainerAppEnhanced
 	default:
 		return metrics.MetricSourceServerless

--- a/cmd/serverless-init/metric/metric.go
+++ b/cmd/serverless-init/metric/metric.go
@@ -18,18 +18,18 @@ import (
 // AddColdStartMetric adds the coldstart metric to the demultiplexer
 //
 //nolint:revive // TODO(SERV) Fix revive linter
-func AddColdStartMetric(metricPrefix string, tags []string, _ time.Time, demux aggregator.Demultiplexer) {
-	add(fmt.Sprintf("%v.enhanced.cold_start", metricPrefix), tags, time.Now(), demux)
+func AddColdStartMetric(metricPrefix string, origin string, tags []string, _ time.Time, demux aggregator.Demultiplexer) {
+	add(fmt.Sprintf("%v.enhanced.cold_start", metricPrefix), origin, tags, time.Now(), demux)
 }
 
 // AddShutdownMetric adds the shutdown metric to the demultiplexer
 //
 //nolint:revive // TODO(SERV) Fix revive linter
-func AddShutdownMetric(metricPrefix string, tags []string, _ time.Time, demux aggregator.Demultiplexer) {
-	add(fmt.Sprintf("%v.enhanced.shutdown", metricPrefix), tags, time.Now(), demux)
+func AddShutdownMetric(metricPrefix string, origin string, tags []string, _ time.Time, demux aggregator.Demultiplexer) {
+	add(fmt.Sprintf("%v.enhanced.shutdown", metricPrefix), origin, tags, time.Now(), demux)
 }
 
-func add(name string, tags []string, timestamp time.Time, demux aggregator.Demultiplexer) {
+func add(name string, origin string, tags []string, timestamp time.Time, demux aggregator.Demultiplexer) {
 	if demux == nil {
 		log.Debugf("Cannot add metric %s, the metric agent is not running", name)
 		return
@@ -42,5 +42,20 @@ func add(name string, tags []string, timestamp time.Time, demux aggregator.Demul
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  metricTimestamp,
+		Source:     originToMetricSource(origin),
 	})
+}
+
+func originToMetricSource(origin string) metrics.MetricSource {
+	switch origin {
+	case "cloudrun":
+		return metrics.MetricSourceGoogleCloudRunEnhanced
+	case "appservice":
+		return metrics.MetricSourceAzureAppServiceEnhanced
+	case "containerapp":
+		return metrics.MetricSourceAzureContainerAppEnhanced
+	default:
+		return metrics.MetricSourceServerless
+	}
+
 }

--- a/cmd/serverless-init/metric/metric_test.go
+++ b/cmd/serverless-init/metric/metric_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/fx"
 
+	"github.com/DataDog/datadog-agent/cmd/serverless-init/cloudservice"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
 	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
@@ -41,7 +42,7 @@ func TestAdd(t *testing.T) {
 func TestAddColdStartMetric(t *testing.T) {
 	demux := createDemultiplexer(t)
 	timestamp := time.Now()
-	AddColdStartMetric("gcp.run", "cloudrun", []string{"taga:valuea", "tagb:valueb"}, timestamp, demux)
+	AddColdStartMetric("gcp.run", cloudservice.CloudRunOrigin, []string{"taga:valuea", "tagb:valueb"}, timestamp, demux)
 	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, 0, len(timedMetrics))
 	assert.Equal(t, 1, len(generatedMetrics))
@@ -56,7 +57,7 @@ func TestAddColdStartMetric(t *testing.T) {
 func TestAddShutdownMetric(t *testing.T) {
 	demux := createDemultiplexer(t)
 	timestamp := time.Now()
-	AddShutdownMetric("gcp.run", "cloudrun", []string{"taga:valuea", "tagb:valueb"}, timestamp, demux)
+	AddShutdownMetric("gcp.run", cloudservice.CloudRunOrigin, []string{"taga:valuea", "tagb:valueb"}, timestamp, demux)
 	generatedMetrics, timedMetrics := demux.WaitForSamples(100 * time.Millisecond)
 	assert.Equal(t, 0, len(timedMetrics))
 	assert.Equal(t, 1, len(generatedMetrics))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds a metric origin applied to enhanced metrics sent by serverless-init/sidecar.

### Motivation
Sister PR: https://github.com/DataDog/datadog-agent/pull/35844

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->