### PR TITLE
[AGNTLOG-174 ] Add telemetry for log compression kind

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -213,6 +213,8 @@ var defaultProfiles = `
         - name: logs.decoded
         - name: logs.dropped
         - name: logs.encoded_bytes_sent
+          aggregate_tags:
+            - compression_kind
         - name: logs.sender_latency
         - name: logs.auto_multi_line_aggregator_flush
           aggregate_tags:

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -303,6 +303,11 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	}
 	metrics.BytesSent.Add(int64(payload.UnencodedSize))
 	var sourceTag string
+	var compressionKind string
+
+	if d.endpoint.UseCompression {
+		compressionKind = d.endpoint.CompressionKind
+	}
 
 	if strings.Contains(d.Metadata().TelemetryName(), "logs") {
 		sourceTag = "logs"
@@ -312,7 +317,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 
 	metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), sourceTag)
 	metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
-	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag)
+	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
 
 	req, err := http.NewRequest("POST", d.url, bytes.NewReader(payload.Encoded))
 	if err != nil {

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -303,7 +303,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	}
 	metrics.BytesSent.Add(int64(payload.UnencodedSize))
 	var sourceTag string
-	var compressionKind string
+	compressionKind := "none"
 
 	if d.endpoint.UseCompression {
 		compressionKind = d.endpoint.CompressionKind

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -124,10 +124,12 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 
 		// TCP is only used for logs data, so we always use "logs" as the source tag
 		sourceTag := "logs"
+		// Default Compression for TCP is none
+		compressionKind := "none"
 
 		metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), sourceTag)
 		metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
-		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag)
+		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
 		output <- payload
 
 		if d.connManager.ShouldReset(d.connCreationTime) {

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -57,7 +57,7 @@ var (
 	EncodedBytesSent = expvar.Int{}
 	// TlmEncodedBytesSent is the total number of sent bytes after encoding if any
 	TlmEncodedBytesSent = telemetry.NewCounter("logs", "encoded_bytes_sent",
-		[]string{"source"}, "Total number of sent bytes after encoding if any")
+		[]string{"source", "compression_kind"}, "Total number of sent bytes after encoding if any")
 	// BytesMissed is the number of bytes lost before they could be consumed by the agent, such as after a log rotation
 	BytesMissed = expvar.Int{}
 	// TlmBytesMissed is the number of bytes lost before they could be consumed by the agent, such as after log rotation

--- a/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
+++ b/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds a new compression_kind tag to the ``logs.encoded_bytes_sent`` telemetry metric, enabling aggregation and monitoring of log compression type usage for rollout monitoring.

--- a/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
+++ b/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Adds a new compression_kind tag to the ``logs.encoded_bytes_sent`` telemetry metric, enabling aggregation and monitoring of log compression type usage for rollout monitoring.
+    Adds a compression_kind tag to the ``logs.encoded_bytes_sent`` telemetry metric, enabling aggregation and monitoring of log compression type usage during rollout.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds telemetry tracking for compression kind in log payloads. Specifically:

1. Adds a `compression_kind` tag to the `logs.encoded_bytes_sent` metric
2. Tracks compression type (zstd, gzip, or none) for both HTTP and TCP destinations
3. Adds comprehensive unit tests to verify compression telemetry behavior

### Motivation
We can track the rollout for zstd compression and other compressions.

### Describe how you validated your changes
1. **Unit Tests**:
   - Tests both zstd and gzip compression scenarios
   - Verifies correct tag values in telemetry metrics

2. **Manual Testing**:
   - Verified telemetry metrics are emitted correctly
   - Confirmed compression kind tags are properly set

```
curl http://localhost:5000/telemetry | grep "encoded_bytes_sent"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 59290    0 59290    0     0  32.6M      0 --:--:-- --:--:-- --:--:-- 56.5M
# HELP logs__encoded_bytes_sent Total number of sent bytes after encoding if any
# TYPE logs__encoded_bytes_sent counter
logs__encoded_bytes_sent{compression_kind="zstd",source="epforwarder"} 2
logs__encoded_bytes_sent{compression_kind="zstd",source="logs"} 20103
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->