### PR TITLE
Fix data race in autodiscovery cluster checks provider

### DIFF
--- a/releasenotes-dca/notes/ad-data-race-cluster-checks-provider-2b1a6a1cb781b296.yaml
+++ b/releasenotes-dca/notes/ad-data-race-cluster-checks-provider-2b1a6a1cb781b296.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix data race in autodiscovery cluster checks provider.


### PR DESCRIPTION
Fix a data race involving the heartbeat field in this provider.

```
WARNING: DATA RACE
Write at 0x00c00112d520 by goroutine 518:
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers.(*ClusterChecksConfigProvider).IsUpToDate()
      /home/datadog/go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/clusterchecks.go:131 +0x504
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*configPoller).poll()
      /home/datadog/go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:149 +0x54d
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*configPoller).start.gowrap2()
      /home/datadog/go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:76 +0x84

Previous read at 0x00c00112d520 by goroutine 336:
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers.(*ClusterChecksConfigProvider).heartbeatSender()
      /home/datadog/go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/clusterchecks.go:191 +0x37d
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers.NewClusterChecksConfigProvider.gowrap1()
      /home/datadog/go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/clusterchecks.go:80 +0x64
```