### PR TITLE
Fix data race in autodiscovery kube services provider

### DIFF
--- a/comp/core/autodiscovery/providers/kube_services.go
+++ b/comp/core/autodiscovery/providers/kube_services.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"strings"
 
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	listersv1 "k8s.io/client-go/listers/core/v1"
@@ -35,7 +36,7 @@ const (
 // KubeServiceConfigProvider implements the ConfigProvider interface for the apiserver.
 type KubeServiceConfigProvider struct {
 	lister         listersv1.ServiceLister
-	upToDate       bool
+	upToDate       *atomic.Bool
 	configErrors   map[string]ErrorMsgSet
 	telemetryStore *telemetry.Store
 }
@@ -58,6 +59,7 @@ func NewKubeServiceConfigProvider(_ *pkgconfigsetup.ConfigurationProviders, tele
 		lister:         servicesInformer.Lister(),
 		configErrors:   make(map[string]ErrorMsgSet),
 		telemetryStore: telemetryStore,
+		upToDate:       atomic.NewBool(false),
 	}
 
 	if _, err := servicesInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -91,7 +93,7 @@ func (k *KubeServiceConfigProvider) Collect(ctx context.Context) ([]integration.
 	if err != nil {
 		return nil, err
 	}
-	k.upToDate = true
+	k.upToDate.Store(true)
 
 	return k.parseServiceAnnotations(services, pkgconfigsetup.Datadog())
 }
@@ -100,13 +102,13 @@ func (k *KubeServiceConfigProvider) Collect(ctx context.Context) ([]integration.
 //
 //nolint:revive // TODO(CINT) Fix revive linter
 func (k *KubeServiceConfigProvider) IsUpToDate(ctx context.Context) (bool, error) {
-	return k.upToDate, nil
+	return k.upToDate.Load(), nil
 }
 
 func (k *KubeServiceConfigProvider) invalidate(obj interface{}) {
 	if obj != nil {
 		log.Trace("Invalidating configs on new/deleted service")
-		k.upToDate = false
+		k.upToDate.Store(false)
 	}
 }
 
@@ -122,7 +124,7 @@ func (k *KubeServiceConfigProvider) invalidateIfChanged(old, obj interface{}) {
 	castedOld, ok := old.(*v1.Service)
 	if !ok {
 		log.Errorf("Expected a *v1.Service type, got: %T", old)
-		k.upToDate = false
+		k.upToDate.Store(false)
 		return
 	}
 	// Quick exit if resversion did not change
@@ -132,7 +134,7 @@ func (k *KubeServiceConfigProvider) invalidateIfChanged(old, obj interface{}) {
 	// Compare annotations
 	if valuesDiffer(castedObj.Annotations, castedOld.Annotations, kubeServiceAnnotationPrefix) {
 		log.Trace("Invalidating configs on service change")
-		k.upToDate = false
+		k.upToDate.Store(false)
 		return
 	}
 }

--- a/comp/core/autodiscovery/providers/kube_services_test.go
+++ b/comp/core/autodiscovery/providers/kube_services_test.go
@@ -248,6 +248,7 @@ func TestParseKubeServiceAnnotations(t *testing.T) {
 
 			provider := KubeServiceConfigProvider{
 				telemetryStore: telemetryStore,
+				upToDate:       atomic.NewBool(false),
 			}
 			cfgs, _ := provider.parseServiceAnnotations([]*v1.Service{tc.service}, cfg)
 			assert.EqualValues(t, tc.expectedOut, cfgs)
@@ -476,6 +477,7 @@ func TestGetConfigErrors_KubeServices(t *testing.T) {
 				lister:         lister,
 				configErrors:   test.currentErrors,
 				telemetryStore: telemetryStore,
+				upToDate:       atomic.NewBool(false),
 			}
 
 			configs, err := provider.Collect(context.TODO())

--- a/comp/core/autodiscovery/providers/kube_services_test.go
+++ b/comp/core/autodiscovery/providers/kube_services_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -337,7 +338,7 @@ func TestInvalidateIfChanged(t *testing.T) {
 	} {
 		t.Run("", func(t *testing.T) {
 			ctx := context.Background()
-			provider := &KubeServiceConfigProvider{upToDate: true}
+			provider := &KubeServiceConfigProvider{upToDate: atomic.NewBool(true)}
 			provider.invalidateIfChanged(tc.old, tc.obj)
 
 			upToDate, err := provider.IsUpToDate(ctx)

--- a/releasenotes-dca/notes/ad-data-race-kube-services-provider-8cbf74f32595c448.yaml
+++ b/releasenotes-dca/notes/ad-data-race-kube-services-provider-8cbf74f32595c448.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix data race in autodiscovery kube services provider.


### PR DESCRIPTION
Fix data race involving the upToDate field in this provider.
```
WARNING: DATA RACE
Write at 0x00c0012dff60 by main goroutine:
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers.(*KubeServiceConfigProvider).Collect()
      /go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/kube_services.go:94 +0xd4
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*configPoller).collect()
      /go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:213 +0x172
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*configPoller).collectOnce()
      /go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:168 +0x86
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*configPoller).start()
      /go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/config_poller.go:70 +0x184
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl.(*AutoConfig).LoadAndRun()
      /go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go:468 +0xcf
  github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start.start()
      /go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start/command.go:422 +0x1e11
  runtime.call512()
      /usr/local/go/src/runtime/asm_amd64.s:780 +0x5d
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:368 +0xb5
  github.com/DataDog/datadog-agent/pkg/util/fxutil.(*delayedFxInvocation).call()
      /go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/args.go:72 +0xcc
  github.com/DataDog/datadog-agent/pkg/util/fxutil.OneShot()
      /go/src/github.com/DataDog/datadog-agent/pkg/util/fxutil/oneshot.go:54 +0x424
  github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start.Commands.func1()
      /go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/subcommands/start/command.go:143 +0x25b3
  github.com/spf13/cobra.(*Command).execute()
      /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1015 +0x10d3
  github.com/spf13/cobra.(*Command).ExecuteC()
      /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x655
  github.com/spf13/cobra.(*Command).Execute()
      /go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071 +0x26
  main.main()
      /go/src/github.com/DataDog/datadog-agent/cmd/cluster-agent/main.go:30 +0x4ca

Previous write at 0x00c0012dff60 by goroutine 516:
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers.(*KubeServiceConfigProvider).invalidate()
      /go/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/kube_services.go:109 +0xaa
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers.(*KubeServiceConfigProvider).invalidate-fm()
      <autogenerated>:1 +0x29
  k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd()
      /go/pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/controller.go:246 +0x63
  k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnAdd()
      <autogenerated>:1 +0x1b
  k8s.io/client-go/tools/cache.(*processorListener).run.func1()
      /go/pkg/mod/k8s.io/client-go@v0.31.2/tools/cache/shared_informer.go:978 +0x287
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:226 +0x41
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:227 +0xc4
  k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:204 +0x10a
  k8s.io/apimachinery/pkg/util/wait.Until()
```