### PR TITLE
[container-autoscaling] Fix nil pointer in Autoscaling controller

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -504,9 +504,10 @@ func getActiveScalingSources(currentTime time.Time, podAutoscalerInternal *model
 
 	// Check if horizontal scaling is disabled; if disabled, always use main values as source
 	if podAutoscalerInternal.Spec().ApplyPolicy != nil {
-		scaleUpStrategy := podAutoscalerInternal.Spec().ApplyPolicy.ScaleUp
-		scaleDownStrategy := podAutoscalerInternal.Spec().ApplyPolicy.ScaleDown
-		if (scaleUpStrategy != nil && *scaleUpStrategy.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect) && (scaleDownStrategy != nil && *scaleDownStrategy.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect) {
+		scaleUpPolicy := podAutoscalerInternal.Spec().ApplyPolicy.ScaleUp
+		scaleDownPolicy := podAutoscalerInternal.Spec().ApplyPolicy.ScaleDown
+
+		if (scaleUpPolicy != nil && scaleUpPolicy.Strategy != nil && *scaleUpPolicy.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect) && (scaleDownPolicy != nil && scaleDownPolicy.Strategy != nil && *scaleDownPolicy.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect) {
 			return pointer.Ptr(datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource), activeVerticalSource
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

A check is missing on an optional field, fixing the resulting panic.

### Motivation

### Describe how you validated your changes

Create a DPA CRD with:
```
...
applyMode:
  scaleUp:
    stabilizationWindowSeconds: 300
...
```

The Cluster Agent should not panic.

### Possible Drawbacks / Trade-offs

### Additional Notes