### PR TITLE
[HAMR] - Fix fallback settings if not set 

### DIFF
--- a/comp/remote-config/rcclient/rcclientimpl/rcclient.go
+++ b/comp/remote-config/rcclient/rcclientimpl/rcclient.go
@@ -177,31 +177,9 @@ func (rc rcClient) start() {
 // It fetches all the configs targeting the agent and applies the failover settings
 // using an OR strategy. In case of nil the value is not updated, for a false it does not update if
 // the setting is already set to true.
+//
+// If a setting is not set via any config, it will fallback if the source was RC.
 func (rc rcClient) mrfUpdateCallback(updates map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
-	// If the updates map is empty, we should unset the failover settings if they were set via RC previously
-	if len(updates) == 0 {
-		mrfFailoverMetricsSource := pkgconfigsetup.Datadog().GetSource("multi_region_failover.failover_metrics")
-		mrfFailoverLogsSource := pkgconfigsetup.Datadog().GetSource("multi_region_failover.failover_logs")
-		mrfFailoverAPMSource := pkgconfigsetup.Datadog().GetSource("multi_region_failover.failover_apm")
-
-		// Unset the RC-sourced failover values regardless of what they are
-		pkgconfigsetup.Datadog().UnsetForSource("multi_region_failover.failover_metrics", model.SourceRC)
-		pkgconfigsetup.Datadog().UnsetForSource("multi_region_failover.failover_logs", model.SourceRC)
-		pkgconfigsetup.Datadog().UnsetForSource("multi_region_failover.failover_apm", model.SourceRC)
-
-		// If either of the values were previously set via RC, log the current values now that we've unset them
-		if mrfFailoverMetricsSource == model.SourceRC {
-			pkglog.Infof("Falling back to `multi_region_failover.failover_metrics: %t`", pkgconfigsetup.Datadog().GetBool("multi_region_failover.failover_metrics"))
-		}
-		if mrfFailoverLogsSource == model.SourceRC {
-			pkglog.Infof("Falling back to `multi_region_failover.failover_logs: %t`", pkgconfigsetup.Datadog().GetBool("multi_region_failover.failover_logs"))
-		}
-		if mrfFailoverAPMSource == model.SourceRC {
-			pkglog.Infof("Falling back to `multi_region_failover.failover_apm: %t`", pkgconfigsetup.Datadog().GetBool("multi_region_failover.failover_apm"))
-		}
-		return
-	}
-
 	var enableLogs, enableMetrics, enableAPM *bool
 	var enableLogsCfgPth, enableMetricsCfgPth, enableAPMCfgPth string
 	for cfgPath, update := range updates {
@@ -255,6 +233,12 @@ func (rc rcClient) mrfUpdateCallback(updates map[string]state.RawConfig, applySt
 		}
 		pkglog.Infof("Received remote update for Multi-Region Failover configuration: %s failover for metrics", change)
 		applyStateCallback(enableMetricsCfgPth, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	} else {
+		mrfFailoverMetricsSource := pkgconfigsetup.Datadog().GetSource("multi_region_failover.failover_metrics")
+		pkgconfigsetup.Datadog().UnsetForSource("multi_region_failover.failover_metrics", model.SourceRC)
+		if mrfFailoverMetricsSource == model.SourceRC {
+			pkglog.Infof("Falling back to `multi_region_failover.failover_metrics: %t`", pkgconfigsetup.Datadog().GetBool("multi_region_failover.failover_metrics"))
+		}
 	}
 
 	if enableLogs != nil {
@@ -273,6 +257,12 @@ func (rc rcClient) mrfUpdateCallback(updates map[string]state.RawConfig, applySt
 		}
 		pkglog.Infof("Received remote update for Multi-Region Failover configuration: %s failover for logs", change)
 		applyStateCallback(enableLogsCfgPth, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	} else {
+		mrfFailoverLogsSource := pkgconfigsetup.Datadog().GetSource("multi_region_failover.failover_logs")
+		pkgconfigsetup.Datadog().UnsetForSource("multi_region_failover.failover_logs", model.SourceRC)
+		if mrfFailoverLogsSource == model.SourceRC {
+			pkglog.Infof("Falling back to `multi_region_failover.failover_logs: %t`", pkgconfigsetup.Datadog().GetBool("multi_region_failover.failover_logs"))
+		}
 	}
 
 	if enableAPM != nil {
@@ -291,6 +281,12 @@ func (rc rcClient) mrfUpdateCallback(updates map[string]state.RawConfig, applySt
 		}
 		pkglog.Infof("Received remote update for Multi-Region Failover configuration: %s failover for apm", change)
 		applyStateCallback(enableAPMCfgPth, state.ApplyStatus{State: state.ApplyStateAcknowledged})
+	} else {
+		mrfFailoverAPMSource := pkgconfigsetup.Datadog().GetSource("multi_region_failover.failover_apm")
+		pkgconfigsetup.Datadog().UnsetForSource("multi_region_failover.failover_apm", model.SourceRC)
+		if mrfFailoverAPMSource == model.SourceRC {
+			pkglog.Infof("Falling back to `multi_region_failover.failover_apm: %t`", pkgconfigsetup.Datadog().GetBool("multi_region_failover.failover_apm"))
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the fallback if the setting is not set. 

### Motivation
In case two updates were set and one of them was disabled, it would not update the setting (fallback to value before RC) if it was not set anymore.
[FA-953](https://datadoghq.atlassian.net/browse/FA-953?atlOrigin=eyJpIjoiMjYxZDE4NGE5ODllNDEzOWE3YTk5ZTZmZTAyYTc0MWQiLCJwIjoiaiJ9)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Manual testing on VM

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

[FA-953]: https://datadoghq.atlassian.net/browse/FA-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ