### PR TITLE
Fix data race in manifest buffer

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go
@@ -26,6 +26,7 @@ import (
 )
 
 var (
+	globalMu                sync.Mutex
 	bufferExpVars           = expvar.NewMap("orchestrator-manifest-buffer")
 	manifestFlushed         = &expvar.Int{}
 	bufferFlushedTotal      = &expvar.Int{}
@@ -164,6 +165,9 @@ func BufferManifestProcessResult(messages []model.MessageBody, buffer *ManifestB
 }
 
 func setManifestStats(manifests []interface{}) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+
 	// Number of manifests flushed
 	manifestFlushed.Set(int64(len(manifests)))
 	tlmManifestFlushed.Add(float64(len(manifests)))


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix a data race 

```
WARNING: DATA RACE
Write at 0x00c000861830 by goroutine 1187:
  runtime.mapaccess2_fast64()
      /usr/local/go/src/runtime/map_fast64.go:62 +0x1cc
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.setManifestStats()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:179 +0x264
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*ManifestBuffer).flushManifest()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:107 +0x444
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*ManifestBuffer).appendManifest()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:115 +0x208
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*ManifestBuffer).Start.func1()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:140 +0x1b8
Previous read at 0x00c000861830 by goroutine 1031:
  runtime.mapassign_fast32()
      /usr/local/go/src/runtime/map_fast32.go:113 +0x34c
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.setManifestStats()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:178 +0x214
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*ManifestBuffer).flushManifest()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:107 +0x444
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*ManifestBuffer).appendManifest()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:115 +0x208
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*ManifestBuffer).Start.func1()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/manifest_buffer.go:140 +0x1b8

```

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->