### PR TITLE
Fix data race in orchestrator check sensitive data scrubber

### DIFF
--- a/pkg/orchestrator/redact/metadata.go
+++ b/pkg/orchestrator/redact/metadata.go
@@ -5,19 +5,28 @@
 
 package redact
 
+import "sync"
+
 const consulOriginalPodAnnotation = "consul.hashicorp.com/original-pod"
 
 // hardcode the annotation to avoid importing k8s.io/api
 const kubectlLastAppliedConfigAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
 
-var sensitiveAnnotationsAndLabels = []string{kubectlLastAppliedConfigAnnotation, consulOriginalPodAnnotation}
+var (
+	sensitiveAnnotationsAndLabels      = []string{kubectlLastAppliedConfigAnnotation, consulOriginalPodAnnotation}
+	sensitiveAnnotationsAndLabelsMutex sync.Mutex
+)
 
 // UpdateSensitiveAnnotationsAndLabels adds new sensitive annotations or labels key to the list to redact.
 func UpdateSensitiveAnnotationsAndLabels(annotationsAndLabels []string) {
+	sensitiveAnnotationsAndLabelsMutex.Lock()
+	defer sensitiveAnnotationsAndLabelsMutex.Unlock()
 	sensitiveAnnotationsAndLabels = append(sensitiveAnnotationsAndLabels, annotationsAndLabels...)
 }
 
 // GetSensitiveAnnotationsAndLabels returns the list of sensitive annotations and labels.
 func GetSensitiveAnnotationsAndLabels() []string {
+	sensitiveAnnotationsAndLabelsMutex.Lock()
+	defer sensitiveAnnotationsAndLabelsMutex.Unlock()
 	return sensitiveAnnotationsAndLabels
 }

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -19,7 +19,7 @@ import (
 // "kubectl.kubernetes.io/last-applied-configuration" annotation value. As it
 // may contain duplicate information and secrets.
 func RemoveSensitiveAnnotationsAndLabels(annotations map[string]string, labels map[string]string) {
-	for _, v := range sensitiveAnnotationsAndLabels {
+	for _, v := range GetSensitiveAnnotationsAndLabels() {
 		if _, found := annotations[v]; found {
 			annotations[v] = redactedAnnotationValue
 		}

--- a/releasenotes-dca/notes/orchestrator-data-race-scrubber-fe1a629a31db8d4d.yaml
+++ b/releasenotes-dca/notes/orchestrator-data-race-scrubber-fe1a629a31db8d4d.yaml
@@ -8,5 +8,5 @@
 ---
 fixes:
   - |
-    Fix data race in orchestrator check sensitive data scrubber. Note this
-    would only occur when running the check on datadog cluster check runners.
+    Fix data race in the orchestrator check for the sensitive data scrubber. Note: This
+    would only occur when running the check on Datadog cluster check runners.

--- a/releasenotes-dca/notes/orchestrator-data-race-scrubber-fe1a629a31db8d4d.yaml
+++ b/releasenotes-dca/notes/orchestrator-data-race-scrubber-fe1a629a31db8d4d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix data race in orchestrator check sensitive data scrubber. Note this
+    would only occur when running the check on datadog cluster check runners.


### PR DESCRIPTION
Fix data race in the orchestrator check sensitive data scrubber. That would only impact environments making use of the datadog cluster checks runner setup.
```
WARNING: DATA RACE
Write at 0x00000a4d30a0 by goroutine 343:
  github.com/DataDog/datadog-agent/pkg/orchestrator/redact.UpdateSensitiveAnnotationsAndLabels()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/orchestrator/redact/metadata.go:17 +0x5e8
  github.com/DataDog/datadog-agent/pkg/orchestrator/config.(*OrchestratorConfig).Load()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/orchestrator/config/config.go:105 +0x50c
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*OrchestratorCheck).Configure()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go:140 +0x134
  github.com/DataDog/datadog-agent/pkg/collector/corechecks.(*GoCheckLoader).Load()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/loader.go:72 +0xd4
  github.com/DataDog/datadog-agent/pkg/collector.(*CheckScheduler).getChecks()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/scheduler.go:199 +0xc34
  github.com/DataDog/datadog-agent/pkg/collector.(*CheckScheduler).GetChecksFromConfigs()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/scheduler.go:253 +0x2a8
  github.com/DataDog/datadog-agent/pkg/collector.(*CheckScheduler).Schedule()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/scheduler.go:85 +0x84
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler.(*Controller).processNextWorkItem()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler/controller.go:175 +0x470
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler.(*Controller).worker()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler/controller.go:136 +0x34
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler.(*Controller).worker-fm()
      <autogenerated>:1 +0x20
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1()
      /go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:226 +0x48
  k8s.io/apimachinery/pkg/util/wait.BackoffUntil()
      /go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:227 +0x94
  k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:204 +0xe4
  k8s.io/apimachinery/pkg/util/wait.Until()
      /go/pkg/mod/k8s.io/apimachinery@v0.31.2/pkg/util/wait/backoff.go:161 +0x50
  github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler.(*Controller).Start.gowrap1()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/core/autodiscovery/scheduler/controller.go:71 +0x20
Previous read at 0x00000a4d30a0 by goroutine 480:
  github.com/DataDog/datadog-agent/pkg/orchestrator/redact.RemoveSensitiveAnnotationsAndLabels()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/orchestrator/redact/pod.go:22 +0x74
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s.(*RoleBindingHandlers).ScrubBeforeExtraction()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/rolebinding.go:108 +0x3c
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors.(*Processor).Process()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go:203 +0x214
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s.(*RoleBindingCollector).Process()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go:95 +0x8c
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s.(*RoleBindingCollector).Run()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collectors/k8s/rolebinding.go:88 +0x148
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*CollectorBundle).Run()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go:358 +0x3c0
  github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator.(*OrchestratorCheck).Run()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go:218 +0x2fc
  github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware.(*CheckWrapper).Run()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/comp/collector/collector/collectorimpl/internal/middleware/check_wrapper.go:49 +0xe0
  github.com/DataDog/datadog-agent/pkg/collector/worker.(*Worker).Run()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/worker/worker.go:165 +0x500
  github.com/DataDog/datadog-agent/pkg/collector/runner.(*Runner).newWorker.func1()
      /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/collector/runner/runner.go:138 +0xa0
```