### PR TITLE
Run serverless coldstart on dind shadow

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -143,6 +143,7 @@ trace_agent_integration_tests @DataDog/agent-apm
 
 # Functional test
 serverless_cold_start_performance-deb_x64      @DataDog/serverless
+serverless_cold_start_performance-deb_x64_dind @DataDog/agent-devx
 static_quality_gates                           @DataDog/agent-delivery
 manual_gate_threshold_update                   @DataDog/agent-delivery
 oracle*                                        @DataDog/database-monitoring

--- a/.gitlab/functional_test/serverless.yml
+++ b/.gitlab/functional_test/serverless.yml
@@ -15,3 +15,22 @@ serverless_cold_start_performance-deb_x64:
     - cd /tmp/serverless-ci # Docker does not like syslinks, that's why it's easier to build the image in /tmp
     - docker build -t datadogci/lambda-extension .
     - ./compute.sh
+
+serverless_cold_start_performance-deb_x64_dind:
+  stage: functional_test
+  rules:
+    - !reference [.except_mergequeue]
+    - when: on_success
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$DATADOG_AGENT_BUILDIMAGES_SUFFIX:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["docker-in-docker:amd64"]
+  needs: ["go_deps", "build_serverless-deb_x64"]
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - mkdir -p /tmp/serverless-ci
+    - cp cmd/serverless/datadog-agent-x64 /tmp/serverless-ci/datadog-agent
+  script:
+    - cp test/integration/serverless_perf/* /tmp/serverless-ci
+    - cd /tmp/serverless-ci # Docker does not like syslinks, that's why it's easier to build the image in /tmp
+    - docker build -t datadogci/lambda-extension .
+    - ./compute.sh
+  allow_failure: true


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Run a shadow version of serverless test in docker in docker runner. In order to see if there's still flakes in the new environment.
Should replace the old runner once we are confident it is stable enough.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->