### PR TITLE
fix(installer): Remove Deb/RPM SSI packages before installing the OCI injector

### DIFF
--- a/pkg/fleet/installer/packages/apm_inject_linux.go
+++ b/pkg/fleet/installer/packages/apm_inject_linux.go
@@ -9,15 +9,41 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/apminject"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/packagemanager"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 )
 
 var (
 	apmInjectPackage = hooks{
+		preInstall:  preInstallAPMInjector,
 		postInstall: postInstallAPMInjector,
 		preRemove:   preRemoveAPMInjector,
 	}
+
+	apmDebRPMPackages = []string{
+		"datadog-apm-inject",
+		"datadog-apm-library-all",
+		"datadog-apm-library-dotnet",
+		"datadog-apm-library-js",
+		"datadog-apm-library-java",
+		"datadog-apm-library-python",
+		"datadog-apm-library-ruby",
+	}
 )
+
+// preInstallAPMInjector is called before the APM injector is installed
+func preInstallAPMInjector(ctx HookContext) (err error) {
+	span, ctx := ctx.StartSpan("pre_install_injector")
+	defer func() { span.Finish(err) }()
+	// Remove DEB/RPM packages if they exist
+
+	for _, pkg := range apmDebRPMPackages {
+		if err := packagemanager.RemovePackage(ctx, pkg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // postInstallAPMInjector is called after the APM injector is installed
 func postInstallAPMInjector(ctx HookContext) (err error) {

--- a/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
+++ b/test/new-e2e/tests/installer/unix/package_apm_inject_test.go
@@ -202,6 +202,7 @@ func (s *packageApmInjectSuite) TestUpgrade_InjectorDeb_To_InjectorOCI() {
 	s.assertLDPreloadInstrumented(injectOCIPath)
 	s.assertSocketPath()
 	s.assertDockerdInstrumented(injectOCIPath)
+	s.host.AssertPackageNotInstalledByPackageManager("datadog-apm-inject", "datadog-apm-library-python")
 
 }
 


### PR DESCRIPTION
### What does this PR do?
Cleans up Deb/RPM SSI packages before installing the OCI injector. This avoids situations where an upgrade keeps the old package that eventually triggers security tools.

### Motivation

### Describe how you validated your changes
E2E

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->