### PR TITLE
Set host name for Oracle autonomous database

### DIFF
--- a/pkg/collector/corechecks/oracle/init.go
+++ b/pkg/collector/corechecks/oracle/init.go
@@ -154,7 +154,7 @@ func (c *Check) init() error {
 		}
 	}
 
-	if ht == oci && c.dbHostname == "" {
+	if ht == oci && c.dbResolvedHostname == "" {
 		var hostname string
 		err = getWrapper(c, &hostname, `SELECT JSON_VALUE(cloud_identity, '$.DATABASE_NAME') || '.'
   ||JSON_VALUE(cloud_identity, '$.PUBLIC_DOMAIN_NAME') AS host_name

--- a/pkg/collector/corechecks/oracle/init.go
+++ b/pkg/collector/corechecks/oracle/init.go
@@ -154,6 +154,19 @@ func (c *Check) init() error {
 		}
 	}
 
+	if ht == oci && c.dbHostname == "" {
+		var hostname string
+		err = getWrapper(c, &hostname, `SELECT JSON_VALUE(cloud_identity, '$.DATABASE_NAME') || '.'
+  ||JSON_VALUE(cloud_identity, '$.PUBLIC_DOMAIN_NAME') AS host_name
+  FROM v$pdbs`)
+		if err != nil {
+			log.Errorf("failed to query OCI hostname: %s", err)
+		}
+		if hostname != "" {
+			c.dbHostname = hostname
+		}
+	}
+
 	tags = append(tags, fmt.Sprintf("hosting_type:%s", ht))
 	c.hostingType = ht
 	c.tagsWithoutDbRole = make([]string, len(tags))

--- a/pkg/collector/corechecks/oracle/init.go
+++ b/pkg/collector/corechecks/oracle/init.go
@@ -164,6 +164,7 @@ func (c *Check) init() error {
 		}
 		if hostname != "" {
 			c.dbHostname = hostname
+			c.dbResolvedHostname = hostname
 		}
 	}
 

--- a/releasenotes/notes/oad-hostname-de1a81190a0d00a7.yaml
+++ b/releasenotes/notes/oad-hostname-de1a81190a0d00a7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [oracle]: Set hostname for Oracle autonomous database.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Set host name for Oracle autonomous database (OAD).

### Motivation

`v$instance.host_name` is empty in OAD. We're setting the host name from an alternative location for OAD:

`
SELECT JSON_VALUE(cloud_identity, '$.DATABASE_NAME') || '.'
  ||JSON_VALUE(cloud_identity, '$.PUBLIC_DOMAIN_NAME') AS host_name
  FROM v$pdbs
`

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Checked that the host name is set:

`2025-05-05 15:14:22 CEST | CORE | TRACE | (pkg/aggregator/sender.go:189 in sendMetricSample) | Count  sample:  dd.oracle.activity.samples_count :  0  for hostname:  NENADOCIDB.adb.us-ashburn-1.oraclecloud.com  tags:  [tag1:vtag1 tag2:vtag2 dbms:oracle ddagentversion:7.67.0-devel dbm:true port:1522 server:adb.us-ashburn-1.oraclecloud.com service:g9e39edfc7e3bc3_nenadocidb_medium.adb.oraclecloud.com ddagenthostname:COMP-M54N44LRFG oracle_version:19.27.0.1.0 cdb:fceikb31 database_instance:$resolved_hostname dd.internal.resource:database_instance: hosting_type:OCI sql_substring_length:4000 tag1:vtag1 tag2:vtag2]`
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->