### PR TITLE
[Backport 7.64.x] bugfix: allow v1 of the auto instrumentation webhook

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation_test.go
@@ -3153,6 +3153,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			wmeta := common.FakeStoreWithDeployment(t, tt.langDetectionDeployments)
 
 			mockConfig = configmock.New(t)
+			mockConfig.SetWithoutSource("apm_config.instrumentation.version", "v1")
 			if tt.setupConfig != nil {
 				for _, f := range tt.setupConfig {
 					f()
@@ -3160,7 +3161,7 @@ func TestInjectAutoInstrumentationV1(t *testing.T) {
 			}
 
 			// N.B. Force v1 for these tests!
-			webhook, errInitAPMInstrumentation := maybeWebhook(wmeta, mockConfig, instrumentationV1)
+			webhook, errInitAPMInstrumentation := maybeWebhook(wmeta, mockConfig)
 			if tt.wantWebhookInitErr {
 				require.Error(t, errInitAPMInstrumentation)
 				return
@@ -3425,15 +3426,11 @@ func TestShouldInject(t *testing.T) {
 	}
 }
 
-func maybeWebhook(wmeta workloadmeta.Component, ddConfig config.Component, versionOverride version) (*Webhook, error) {
+func maybeWebhook(wmeta workloadmeta.Component, ddConfig config.Component) (*Webhook, error) {
 	config, err := NewConfig(ddConfig)
 	if err != nil {
 		return nil, err
 	}
-
-	// N.B. keeping this around to continue to have tests for v1,
-	// even though it is disabled
-	config.version = versionOverride
 
 	mutator, err := NewNamespaceMutator(config, wmeta)
 	if err != nil {

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version.go
@@ -24,8 +24,8 @@ const (
 func instrumentationVersion(v string) (version, error) {
 	switch v {
 	case "v1":
-		log.Warn("autoinstrumentation version=v1 is deprecated, defaulting to v2")
-		return instrumentationV2, nil
+		log.Warn("autoinstrumentation version=v1 is deprecated, please consider migrating to version=v2")
+		return instrumentationV1, nil
 	case "v2":
 		return instrumentationV2, nil
 	default:

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/version_test.go
@@ -23,10 +23,10 @@ func TestVersion(t *testing.T) {
 		usesInjector   bool
 	}{
 		{
-			name:           "v1 is deprecated, defaults to v2",
+			name:           "v1 doesnt use the injector",
 			version:        "v1",
-			expectsVersion: instrumentationV2,
-			usesInjector:   true,
+			expectsVersion: instrumentationV1,
+			usesInjector:   false,
 		},
 		{
 			name:           "v2 uses injector",

--- a/releasenotes-dca/notes/allow-deprecated-usages-of-v1-2301b1b4bd1d0460.yaml
+++ b/releasenotes-dca/notes/allow-deprecated-usages-of-v1-2301b1b4bd1d0460.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Customers relying on the deprecated v1 implementation of the auto instrumentation webhook will no longer be forced
+    to use the v2 implementation. This will provide additional time for customers to migrate to the v1 implementation
+    and ensure the v2 implementation adequately supports all existing use cases.


### PR DESCRIPTION
### What does this PR do?
This commit maintains the deprecation warning for v1 of the auto instrumentation webhook but will not force the usage of v2. This is to support customers who need additional time to migrate to the new webhook.

### Motivation
Customers relying on the deprecated v1 implementation of the auto instrumentation webhook will no longer be forced to use the v2 implementation. This will provide additional time for customers to migrate to the v1 implementation and ensure the v2 implementation adequately supports all existing use cases. We have at least one known case where a customer needs to upgrade their agent deployment but are unable to migrate to v2 of the auto instrumentation webhook.

### Describe how you validated your changes
&lt;!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
--&gt;
I used `injector-dev` to test this:
```bash
 injector-dev reset &amp;&amp; injector-dev apply -f scenario.yaml --wait --build
 ```
 
 I used the following scenario:
 ```yaml
helm:
  apps:
  - name: python
    namespace: application
    values:
      env:
      - name: DD_TRACE_DEBUG
        value: &quot;true&quot;
      - name: DD_APM_INSTRUMENTATION_DEBUG
        value: &quot;true&quot;
      image:
        repository: registry.ddbuild.io/ci/injector-dev/python
        tag: 2cd78ded
      podLabels:
        language: python
        tags.datadoghq.com/env: local
      service:
        port: &quot;8080&quot;
  versions:
    agent: 7.64.3
    cluster_agent:
      version: 7.64.3
      build: {}
    injector:
      version: 0.38.0
  config:
    datadog:
      apm:
        instrumentation:
          enabled: true
          targets:
          - ddTraceVersions:
              python: default
            name: python
            podSelector:
              matchLabels:
                language: python
    clusterAgent:
      envDict:
        DD_APM_INSTRUMENTATION_VERSION: &quot;v1&quot;
 ```
 
 I confirmed we are setting v1 in the logs:
 ```
 kubectl -n system logs -f svc/datadog-agent-cluster-agent | grep please
Defaulted container &quot;cluster-agent&quot; out of: cluster-agent, init-volume (init)
2025-04-29 18:50:03 UTC | CLUSTER | WARN | (pkg/clusteragent/admission/mutate/autoinstrumentation/version.go:27 in instrumentationVersion) | autoinstrumentation version=v1 is deprecated, please consider migrating to version=v2
```

I also confirmed we were setting `PYTHONPATH` and did not have the injector as an init container:
```
PYTHONPATH: /datadog-lib/
```

### Possible Drawbacks / Trade-offs
The main draw back is we will not be able to fully remove the v1 implementation and will need to continue to support it for a bit longer.

### Additional Notes
&lt;!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
--&gt;
To properly support this use case, this change will need backported to 7.64.x, 7.65.x, and 7.66.x releases.