### PR TITLE
[OTAGENT-392] Set EVP origin for logs coming from DDOT

### DIFF
--- a/cmd/otel-agent/subcommands/run/command.go
+++ b/cmd/otel-agent/subcommands/run/command.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorinterface"
+	logconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
 	collectorcontribFx "github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/fx"
 	collectordef "github.com/DataDog/datadog-agent/comp/otelcol/collector/def"
@@ -164,6 +165,9 @@ func runOTelAgentCommand(ctx context.Context, params *subcommands.GlobalParams, 
 
 		fx.Provide(func(_ coreconfig.Component) log.Params {
 			return log.ForDaemon(params.LoggerName, "log_file", pkgconfigsetup.DefaultOTelAgentLogFile)
+		}),
+		fx.Provide(func() logconfig.IntakeOrigin {
+			return logconfig.DDOTIntakeOrigin
 		}),
 		logsagentpipelineimpl.Module(),
 		logscompressionfx.Module(),

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -115,7 +115,6 @@ func BuildEndpointsWithVectorOverride(coreConfig pkgconfigmodel.Reader, httpConn
 
 // BuildEndpointsWithConfig returns the endpoints to send logs.
 func BuildEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
-	fmt.Println("In BuildEndpointsWithConfig")
 	if logsConfig.devModeNoSSL() {
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, "+
 			"please use '%s' and '%s' instead", logsConfig.getConfigKey("logs_dd_url"), logsConfig.getConfigKey("logs_no_ssl"))
@@ -148,7 +147,6 @@ func IsExpectedTagsSet(coreConfig pkgconfigmodel.Reader) bool {
 }
 
 func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys) (*Endpoints, error) {
-	fmt.Println("In buildTCPEndpoints")
 	useProto := logsConfig.devModeUseProto()
 	main := newTCPEndpoint(logsConfig)
 
@@ -195,7 +193,6 @@ func BuildHTTPEndpointsWithVectorOverride(coreConfig pkgconfigmodel.Reader, inta
 
 // BuildHTTPEndpointsWithConfig uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to. This function is able to default to the 'classic' BuildHTTPEndpoints() w ldHTTPEndpointsWithConfigdefault variables logsConfigDefaultKeys and httpEndpointPrefix
 func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
-	fmt.Println("In BuildHTTPEndpointsWithConfig")
 	// Provide default values for legacy settings when the configuration key does not exist
 	defaultNoSSL := logsConfig.logsNoSSL()
 
@@ -206,7 +203,6 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *
 		main.TrackType = intakeTrackType
 		main.Protocol = intakeProtocol
 		main.Origin = intakeOrigin
-		fmt.Println("In useV2API")
 	} else {
 		main.Version = EPIntakeVersion1
 	}

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -42,6 +42,12 @@ const DefaultIntakeOrigin IntakeOrigin = "agent"
 // ServerlessIntakeOrigin is the lambda extension origin
 const ServerlessIntakeOrigin IntakeOrigin = "lambda-extension"
 
+// DDOTIntakeOrigin is the DDOT Collector origin
+const DDOTIntakeOrigin IntakeOrigin = "ddot"
+
+// OTelCollectorIntakeOrigin is the OSS OTel Collector origin
+const OTelCollectorIntakeOrigin = "otel-collector"
+
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
 	"agent-intake.logs.datadoghq.com": 10516,

--- a/comp/logs/agent/config/config.go
+++ b/comp/logs/agent/config/config.go
@@ -46,7 +46,7 @@ const ServerlessIntakeOrigin IntakeOrigin = "lambda-extension"
 const DDOTIntakeOrigin IntakeOrigin = "ddot"
 
 // OTelCollectorIntakeOrigin is the OSS OTel Collector origin
-const OTelCollectorIntakeOrigin = "otel-collector"
+const OTelCollectorIntakeOrigin IntakeOrigin = "otel-collector"
 
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
@@ -115,6 +115,7 @@ func BuildEndpointsWithVectorOverride(coreConfig pkgconfigmodel.Reader, httpConn
 
 // BuildEndpointsWithConfig returns the endpoints to send logs.
 func BuildEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
+	fmt.Println("In BuildEndpointsWithConfig")
 	if logsConfig.devModeNoSSL() {
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, "+
 			"please use '%s' and '%s' instead", logsConfig.getConfigKey("logs_dd_url"), logsConfig.getConfigKey("logs_no_ssl"))
@@ -147,6 +148,7 @@ func IsExpectedTagsSet(coreConfig pkgconfigmodel.Reader) bool {
 }
 
 func buildTCPEndpoints(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys) (*Endpoints, error) {
+	fmt.Println("In buildTCPEndpoints")
 	useProto := logsConfig.devModeUseProto()
 	main := newTCPEndpoint(logsConfig)
 
@@ -193,6 +195,7 @@ func BuildHTTPEndpointsWithVectorOverride(coreConfig pkgconfigmodel.Reader, inta
 
 // BuildHTTPEndpointsWithConfig uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to. This function is able to default to the 'classic' BuildHTTPEndpoints() w ldHTTPEndpointsWithConfigdefault variables logsConfigDefaultKeys and httpEndpointPrefix
 func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
+	fmt.Println("In BuildHTTPEndpointsWithConfig")
 	// Provide default values for legacy settings when the configuration key does not exist
 	defaultNoSSL := logsConfig.logsNoSSL()
 
@@ -203,6 +206,7 @@ func BuildHTTPEndpointsWithConfig(coreConfig pkgconfigmodel.Reader, logsConfig *
 		main.TrackType = intakeTrackType
 		main.Protocol = intakeProtocol
 		main.Origin = intakeOrigin
+		fmt.Println("In useV2API")
 	} else {
 		main.Version = EPIntakeVersion1
 	}

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent.go
@@ -67,7 +67,6 @@ type Agent struct {
 
 // NewLogsAgentComponent returns a new instance of Agent as a Component
 func NewLogsAgentComponent(deps Dependencies) option.Option[logsagentpipeline.Component] {
-	deps.IntakeOrigin = config.DDOTIntakeOrigin
 	logsAgent := NewLogsAgent(deps)
 	if logsAgent == nil {
 		return option.None[logsagentpipeline.Component]()

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
@@ -186,7 +186,8 @@ func TestBuildEndpoints(t *testing.T) {
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 	))
 
-	endpoints, err := buildEndpoints(deps.Config, deps.Log)
+	endpoints, err := buildEndpoints(deps.Config, deps.Log, config.OTelCollectorIntakeOrigin)
 	assert.Nil(t, err)
 	assert.Equal(t, "agent-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, config.OTelCollectorIntakeOrigin, endpoints.Main.Origin)
 }

--- a/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
+++ b/comp/otelcol/logsagentpipeline/logsagentpipelineimpl/agent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	compressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/mock"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/tcp"
@@ -185,9 +186,10 @@ func TestBuildEndpoints(t *testing.T) {
 		configComponent.MockModule(),
 		fx.Provide(func() log.Component { return logmock.New(t) }),
 	))
+	deps.Config.Set("logs_config.force_use_http", true, pkgconfigmodel.SourceDefault)
 
 	endpoints, err := buildEndpoints(deps.Config, deps.Log, config.OTelCollectorIntakeOrigin)
 	assert.Nil(t, err)
-	assert.Equal(t, "agent-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, "agent-http-intake.logs.datadoghq.com", endpoints.Main.Host)
 	assert.Equal(t, config.OTelCollectorIntakeOrigin, endpoints.Main.Origin)
 }

--- a/comp/otelcol/otlp/integrationtest/integration_test.go
+++ b/comp/otelcol/otlp/integrationtest/integration_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/forwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/defaultforwarder"
 	"github.com/DataDog/datadog-agent/comp/forwarder/orchestrator/orchestratorimpl"
+	logconfig "github.com/DataDog/datadog-agent/comp/logs/agent/config"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventoryagent/inventoryagentimpl"
 	collectorcontribFx "github.com/DataDog/datadog-agent/comp/otelcol/collector-contrib/fx"
 	collectordef "github.com/DataDog/datadog-agent/comp/otelcol/collector/def"
@@ -119,6 +120,9 @@ func runTestOTelAgent(ctx context.Context, params *subcommands.GlobalParams) err
 
 		fx.Provide(func(_ coreconfig.Component) logdef.Params {
 			return logdef.ForDaemon(params.LoggerName, "log_file", pkgconfigsetup.DefaultOTelAgentLogFile)
+		}),
+		fx.Provide(func() logconfig.IntakeOrigin {
+			return logconfig.DDOTIntakeOrigin
 		}),
 		logsagentpipelineimpl.Module(),
 		logscompressionfx.Module(),


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Sets EVP intake origin to `ddot` for logs coming from DDOT and `otel-collector` for logs coming from the OSS OTel Collector (to be implemented in upstream PR). This is done by adding `IntakeOrigin` to the logs agent component dependencies, which is a parameter for `NewLogsAgent` that is called in both DDOT and in [upstream](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/logs_exporter.go#L190-L195).

### Motivation
To be able to differentiate between logs coming from DDOT and OSS OTel Collector.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Added unit test.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->