### PR TITLE
[metrics-origin] add apm origin on runtime metrics

### DIFF
--- a/comp/dogstatsd/server/enrich.go
+++ b/comp/dogstatsd/server/enrich.go
@@ -18,8 +18,9 @@ import (
 )
 
 var (
-	hostTagPrefix     = "host:"
-	entityIDTagPrefix = "dd.internal.entity_id:"
+	hostTagPrefix       = "host:"
+	runtimeMetricPrefix = "runtime."
+	entityIDTagPrefix   = "dd.internal.entity_id:"
 	//nolint:revive // TODO(AML) Fix revive linter
 	CardinalityTagPrefix = constants.CardinalityTagPrefix
 	jmxCheckNamePrefix   = "dd.internal.jmx_check_name:"
@@ -139,6 +140,10 @@ func enrichMetricSample(dest []metrics.MetricSample, ddSample dogstatsdMetricSam
 
 	if conf.metricBlocklist.test(metricName) {
 		return []metrics.MetricSample{}
+	}
+
+	if strings.HasPrefix(metricName, runtimeMetricPrefix) {
+		extractedOrigin.ProductOrigin = origindetection.ProductOriginAPM
 	}
 
 	if conf.serverlessMode { // we don't want to set the host while running in serverless mode

--- a/comp/dogstatsd/server/enrich_test.go
+++ b/comp/dogstatsd/server/enrich_test.go
@@ -140,6 +140,28 @@ func TestConvertParseSingle(t *testing.T) {
 	}
 }
 
+func TestConvertRuntimeOrigin(t *testing.T) {
+	conf := enrichConfig{
+		defaultHostname: "default-hostname",
+	}
+
+	for metricSymbol := range symbolToType {
+
+		parsed, err := parseAndEnrichMultipleMetricMessage(t, []byte("runtime.node:666|"+metricSymbol), conf)
+
+		assert.NoError(t, err)
+		require.Len(t, parsed, 1)
+
+		assert.Equal(t, "runtime.node", parsed[0].Name)
+		assert.InEpsilon(t, 666.0, parsed[0].Value, epsilon)
+
+		assert.Equal(t, origindetection.ProductOriginAPM, parsed[0].OriginInfo.ProductOrigin)
+		assert.Equal(t, "", parsed[0].OriginInfo.ContainerIDFromSocket)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.PodUID)
+		assert.Equal(t, "", parsed[0].OriginInfo.LocalData.ContainerID)
+	}
+}
+
 func TestConvertParseSingleWithTags(t *testing.T) {
 	conf := enrichConfig{
 		defaultHostname: "default-hostname",


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
APM runtime metrics product origin is now attributed to APM.
The APM runtime metrics are actually generated by tracing libraries, forwarded through statsd and are part of the core APM experience.


### Motivation
Metrics product attribution

### Describe how you validated your changes
0. Use a host with SSI and python installed
```
DD_APM_INSTRUMENTATION_ENABLED=host \
DD_APM_INSTRUMENTATION_LIBRARIES=python:3 \
bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
```
2. Installed the agent based on the commit hash with the installer
```
sudo datadog-installer install "oci://installtesting.datad0g.com/agent-package:ee6295ff2504b32f86dc06b20530e9d7dcc6ab89"
```
3. Switched the API_KEY to one of my dogfood account with no runtime metrics prepopulated

4. launched python runtime metrics
```
DD_RUNTIME_METRICS_ENABLED=true python3
```
5. verify resulting metrics
KO

<img width="997" alt="Screenshot 2025-05-06 at 22 23 08" src="https://github.com/user-attachments/assets/9d6b2aa1-8fb2-45b9-89f2-51dbe1d5a713" />


### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->