### PR TITLE
Collect EC2 instance information as host tags

### DIFF
--- a/comp/metadata/host/hostimpl/hosttags/tags.go
+++ b/comp/metadata/host/hostimpl/hosttags/tags.go
@@ -59,6 +59,10 @@ func getProvidersDefinitions(conf model.Reader) map[string]*providerDef {
 		providers["ec2"] = &providerDef{10, ec2tags.GetTags}
 	}
 
+	if conf.GetBool("collect_ec2_instance_info") {
+		providers["ec2_instance_info"] = &providerDef{3, ec2tags.GetInstanceInfo}
+	}
+
 	if env.IsFeaturePresent(env.Kubernetes) {
 		providers["kubernetes"] = &providerDef{10, k8s.NewKubeNodeTagsProvider(conf).GetTags}
 	}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -397,19 +397,37 @@ api_key:
 ## https://docs.datadoghq.com/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/
 #
 # collect_ec2_tags: false
+#
+
+## @param collect_ec2_instance_info - boolean - optional - default: false
+## @env DD_COLLECT_EC2_INSTANCE_INFO - boolean - optional - default: false
+## Extend host tags with AWS EC2 instance information. The added tags are:
+##  - region
+##  - instance-type
+##  - aws_account
+##  - image
+##  - availability-zone
+##
+## This should only be enabled when the Datadog AWS integration cannot be enabled (see
+## https://docs.datadoghq.com/integrations/amazon_web_services/ for more information on the AWS integration).
+## Using the AWS integration is recommended as it offers more features and a better integration with the AWS environment.
+#
+# collect_ec2_instance_info: false
 
 ## @param exclude_ec2_tags - list of strings - optional - default: []
 ## @env DD_EXCLUDE_EC2_TAGS - space separated list of strings - optional - default: []
-## EC2 tags to exclude from being converted into host tags -- only applicable when collect_ec2_tags is true. This does
-## not impact tags collected by the AWS Integration (see https://docs.datadoghq.com/integrations/amazon_web_services/
-## for more information on the AWS integration).
+## EC2 tags to exclude from being converted into host tags. This does not impact tags collected by the AWS Integration
+## (see https://docs.datadoghq.com/integrations/amazon_web_services/ for more information on the AWS integration).
+##
+## This requires 'collect_ec2_tags' setting to be set to true.
 #
 # exclude_ec2_tags: []
 
 ## @param collect_ec2_tags_use_imds - boolean - optional - default: false
 ## @env DD_COLLECT_EC2_TAGS_USE_IMDS - boolean - optional - default: false
 ## Use instance metadata service (IMDS) instead of EC2 API to collect AWS EC2 custom tags.
-## Requires `collect_ec2_tags`.
+##
+## This requires 'collect_ec2_tags' setting to be set to true.
 #
 # collect_ec2_tags_use_imds: false
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -571,6 +571,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("ec2_prioritize_instance_id_as_hostname", false) // used to bypass the hostname detection logic and force the EC2 instance ID as a hostname.
 	config.BindEnvAndSetDefault("ec2_use_dmi", true)                             // should the agent leverage DMI information to know if it's running on EC2 or not. Enabling this will add the instance ID from DMI to the host alias list.
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
+	config.BindEnvAndSetDefault("collect_ec2_instance_info", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)
 	config.BindEnvAndSetDefault("exclude_ec2_tags", []string{})
 	config.BindEnvAndSetDefault("ec2_imdsv2_transition_payload_enabled", true)

--- a/pkg/util/ec2/internal/helpers.go
+++ b/pkg/util/ec2/internal/helpers.go
@@ -135,3 +135,19 @@ func GetInstanceIdentity(ctx context.Context) (*EC2Identity, error) {
 
 	return instanceIdentity, nil
 }
+
+// GetInstanceDocument returns information about the local EC2 instance using the local AWS API
+func GetInstanceDocument(ctx context.Context) (map[string]string, error) {
+	res, err := DoHTTPRequest(ctx, InstanceIdentityURL, UseIMDSv2(), false)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch EC2 API to get instance information: %s", err)
+	}
+
+	info := map[string]string{}
+	err = json.Unmarshal([]byte(res), &info)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshall json, %s", err)
+	}
+
+	return info, nil
+}

--- a/pkg/util/ec2/tags/ec2_no_tags.go
+++ b/pkg/util/ec2/tags/ec2_no_tags.go
@@ -17,3 +17,9 @@ func GetTags(_ context.Context) ([]string, error) {
 func fetchTagsFromCache(_ context.Context) ([]string, error) {
 	return []string{}, nil
 }
+
+// GetInstanceInfo collects information about the EC2 instance as host tags. This mimic the tags set by the AWS
+// integration in Datadog backend allowing customer to collect those information without having to enable the crawler.
+func GetInstanceInfo(_ context.Context) ([]string, error) {
+	return []string{}, nil
+}

--- a/pkg/util/ec2/tags/ec2_tags.go
+++ b/pkg/util/ec2/tags/ec2_tags.go
@@ -29,6 +29,7 @@ import (
 // declare these as vars not const to ease testing
 var (
 	tagsCacheKey = cache.BuildAgentKey("ec2", "GetTags")
+	infoCacheKey = cache.BuildAgentKey("ec2", "GetInstanceInfo")
 
 	// This is used in ec2_tags.go which is behind the 'ec2' build flag
 	imdsTags = "/tags/instance" //nolint:unused
@@ -41,6 +42,50 @@ func isTagExcluded(tag string) bool {
 		}
 	}
 	return false
+}
+
+// GetInstanceInfo collects information about the EC2 instance as host tags. This mimic the tags set by the AWS
+// integration in Datadog backend allowing customer to collect those information without having to enable the crawler.
+func GetInstanceInfo(ctx context.Context) ([]string, error) {
+	if !pkgconfigsetup.IsCloudProviderEnabled(ec2internal.CloudProviderName, pkgconfigsetup.Datadog()) {
+		return nil, fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
+	if !pkgconfigsetup.Datadog().GetBool("collect_ec2_instance_info") {
+		return nil, nil
+	}
+
+	if ec2Info, found := cache.Cache.Get(infoCacheKey); found {
+		return ec2Info.([]string), nil
+	}
+
+	info, err := ec2internal.GetInstanceDocument(ctx)
+	if err != nil {
+		log.Debugf("could not fetch instance information: %s", err)
+		return nil, err
+	}
+
+	tags := []string{}
+	getAndSet := func(infoName string, tagName string) {
+		if isTagExcluded(tagName) {
+			return
+		}
+		if val, ok := info[infoName]; ok {
+			tags = append(tags, fmt.Sprintf("%s:%s", tagName, val))
+		} else {
+			tags = append(tags, fmt.Sprintf("%s:unavailable", tagName))
+		}
+	}
+
+	getAndSet("region", "region")
+	getAndSet("instanceType", "instance-type")
+	getAndSet("accountId", "aws_account")
+	getAndSet("imageId", "image")
+	getAndSet("availabilityZone", "availability-zone")
+
+	// save tags to the cache in case we exceed quotas later
+	cache.Cache.Set(infoCacheKey, tags, cache.NoExpiration)
+	return tags, nil
 }
 
 func fetchEc2Tags(ctx context.Context) ([]string, error) {

--- a/pkg/util/ec2/tags/ec2_tags_test.go
+++ b/pkg/util/ec2/tags/ec2_tags_test.go
@@ -186,3 +186,68 @@ func TestGetTagsFullWorkflow(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"tag1", "tag2"}, tags)
 }
+
+func TestCollectEC2InstanceInfo(t *testing.T) {
+	conf := configmock.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		switch r.RequestURI {
+		case "/latest/api/token":
+			io.WriteString(w, "some-secret-token") // no trailing newline
+		case "/latest/dynamic/instance-identity/document":
+			if conf.GetBool("ec2_prefer_imdsv2") {
+				assert.Equal(t, r.Header["X-Aws-Ec2-Metadata-Token"], []string{"some-secret-token"})
+			}
+			io.WriteString(w, `{
+  "accountId" : "123456abcdef",
+  "architecture" : "x86_64",
+  "availabilityZone" : "eu-west-3a",
+  "billingProducts" : null,
+  "devpayProductCodes" : null,
+  "marketplaceProductCodes" : null,
+  "imageId" : "ami-aaaaaaaaaaaaaaaaa",
+  "instanceId" : "i-aaaaaaaaaaaaaaaaa",
+  "instanceType" : "t2.medium",
+  "kernelId" : null,
+  "pendingTime" : "2025-05-06T10:04:40Z",
+  "privateIp" : "123.12.1.123",
+  "ramdiskId" : null,
+  "region" : "eu-west-3",
+  "version" : "2017-09-30"
+}`) // no trailing newline
+		default:
+			fmt.Printf("%s\n", r.RequestURI)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+	defer func(url string) { ec2internal.InstanceIdentityURL = url }(ec2internal.InstanceIdentityURL)
+	defer func(url string) { ec2internal.TokenURL = url }(ec2internal.TokenURL)
+
+	ec2internal.InstanceIdentityURL = ts.URL + "/latest/dynamic/instance-identity/document"
+	ec2internal.TokenURL = ts.URL + "/latest/api/token"
+
+	conf.SetWithoutSource("collect_ec2_instance_info", true)
+
+	tags, err := GetInstanceInfo(context.Background())
+	require.NoError(t, err)
+
+	expected := []string{
+		"region:eu-west-3",
+		"instance-type:t2.medium",
+		"aws_account:123456abcdef",
+		"image:ami-aaaaaaaaaaaaaaaaa",
+		"availability-zone:eu-west-3a",
+	}
+	assert.Equal(t, expected, tags)
+
+	ec2Info, found := cache.Cache.Get(infoCacheKey)
+	assert.True(t, found)
+	assert.Equal(t, expected, ec2Info.([]string))
+
+	conf.SetWithoutSource("collect_ec2_instance_info", false)
+	tags, err = GetInstanceInfo(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string(nil), tags)
+}

--- a/releasenotes/notes/adding-collect_ec2_instance_info-setting-d8495deacb7584e7.yaml
+++ b/releasenotes/notes/adding-collect_ec2_instance_info-setting-d8495deacb7584e7.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Introducing a new setting `collect_ec2_instance_info` to collect basic EC2 instance information as host tags. This
+    reproduces some of the behaviors of the AWS integration for users that can't enable it. The
+    [AWS integration](https://docs.datadoghq.com/integrations/amazon_web_services/) should still be use whenever possible as
+    it offers a better and more in depth integration.


### PR DESCRIPTION
### What does this PR do?

Some customers can't or don't want to enable the AWS integration we now can collect basic instance information as host tags. This new feature is disabled by default behind the `collect_ec2_instance_info` setting.

### Describe how you validated your changes

Start a new EC2 instance, set `collect_ec2_instance_info` to true and check the V5 payload contains the new host tags.