### PR TITLE
Fix dwarf parsing, add more logs to Go DI

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
+++ b/pkg/dynamicinstrumentation/diconfig/binary_inspection.go
@@ -49,27 +49,25 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 		functions = append(functions, probe.FuncName)
 		targetFunctions[probe.FuncName] = true
 	}
-	log.Infof("Starting binary analysis for PID %d, path %s", procInfo.PID, procInfo.BinaryPath)
+	log.Infof("Starting binary analysis for PID %d, service %s", procInfo.PID, procInfo.ServiceName)
 
 	elfFile, err := safeelf.Open(procInfo.BinaryPath)
 	if err != nil {
 		return fmt.Errorf("could not open elf file %w", err)
 	}
 	defer elfFile.Close()
-	log.Infof("Successfully opened ELF file %s for PID %d", procInfo.BinaryPath, procInfo.PID)
 
 	dwarfData, ok := bininspect.HasDwarfInfo(elfFile)
 	if !ok || dwarfData == nil {
 		return errors.New("could not get debug information from binary")
 	}
-	log.Infof("Found DWARF information for PID %d", procInfo.PID)
 
 	typeMap, err := getTypeMap(dwarfData, targetFunctions)
 	if err != nil {
 		return fmt.Errorf("could not retrieve type information from binary %w", err)
 	}
-	log.Infof("Retrieved type map for PID %d", procInfo.PID)
 
+	log.Infof("Successfully retrieved type map for %s (pid %d)", procInfo.ServiceName, procInfo.PID)
 	procInfo.TypeMap = typeMap
 
 	// Enforce limit on number of parameters
@@ -78,10 +76,10 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 			if i >= ditypes.MaxFieldCount {
 				param.DoNotCapture = true
 				param.NotCaptureReason = ditypes.FieldLimitReached
+				log.Infof("Enforced parameter limits for %s (pid %d): %s(...%s", procInfo.ServiceName, procInfo.PID, funcName, param.Name)
 			}
 		}
 	}
-	log.Infof("Enforced parameter limits for PID %d", procInfo.PID)
 
 	fieldIDs := []bininspect.FieldIdentifier{}
 	for _, funcParams := range typeMap.Functions {
@@ -90,35 +88,30 @@ func AnalyzeBinary(procInfo *ditypes.ProcessInfo) error {
 				collectFieldIDs(param)...)
 		}
 	}
-	log.Infof("Collected field IDs for PID %d", procInfo.PID)
 
 	r, err := bininspect.InspectWithDWARF(elfFile, dwarfData, functions, fieldIDs)
 	if err != nil {
 		return fmt.Errorf("could not determine locations of variables from debug information (functions: %v): %w", functions, err)
 	}
-	log.Infof("Completed DWARF inspection for PID %d", procInfo.PID)
 
 	stringPtrIdentifier := bininspect.FieldIdentifier{StructName: "string", FieldName: "str"}
 	stringLenIdentifier := bininspect.FieldIdentifier{StructName: "string", FieldName: "len"}
 	r.StructOffsets[stringPtrIdentifier] = 0
 	r.StructOffsets[stringLenIdentifier] = 8
-	log.Infof("Added string offsets for PID %d", procInfo.PID)
 
 	// Use the result from InspectWithDWARF to populate the locations of parameters
 	for functionName, functionMetadata := range r.Functions {
 		putLocationsInParams(functionMetadata.Parameters, r.StructOffsets, procInfo.TypeMap.Functions, functionName)
 		populateLocationExpressionsForFunction(r.Functions, procInfo, functionName)
 	}
-	log.Infof("Populated parameter locations and expressions for PID %d", procInfo.PID)
 
-	log.Infof("Finished binary analysis for PID %d", procInfo.PID)
+	log.Infof("Finished binary analysis for %s (pid %d)", procInfo.ServiceName, procInfo.PID)
 	return nil
 }
 
 // collectFieldIDs returns all struct fields if there are any amongst types of parameters
 // including if there's structs that are nested deep within complex types
 func collectFieldIDs(param *ditypes.Parameter) []bininspect.FieldIdentifier {
-	log.Infof("Collecting field IDs for parameter: %v", param)
 	fieldIDs := []bininspect.FieldIdentifier{}
 	stack := append([]*ditypes.Parameter{param}, param.ParameterPieces...)
 
@@ -134,7 +127,6 @@ func collectFieldIDs(param *ditypes.Parameter) []bininspect.FieldIdentifier {
 		}
 
 		if current.Kind == uint(reflect.Struct) || current.Kind == uint(reflect.Slice) {
-			log.Infof("Processing struct/slice type: %s", current.Type)
 			for _, structField := range current.ParameterPieces {
 				if structField == nil || structField.Name == "" || current.Type == "" {
 					// these can be blank in anonymous types or embedded fields
@@ -146,7 +138,6 @@ func collectFieldIDs(param *ditypes.Parameter) []bininspect.FieldIdentifier {
 					StructName: current.Type,
 					FieldName:  structField.Name,
 				}
-				log.Infof("Adding field ID: %s.%s", fieldID, current.Type, structField.Name)
 				fieldIDs = append(fieldIDs, fieldID)
 				if len(fieldIDs) >= ditypes.MaxFieldCount {
 					log.Infof("Field limit reached (%d/%d) for type %s.%s, stopping collection.",

--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -127,15 +127,17 @@ func (cm *RCConfigManager) updateProcesses(runningProcs ditypes.DIProcs) {
 			delete(cm.mu.diProcs, pid)
 		}
 	}
-
+	log.Infof("Attempting to install config probes for %d processes", len(runningProcs))
 	for pid, runningProcInfo := range runningProcs {
 		_, ok := cm.mu.diProcs[pid]
 		if !ok {
 			cm.mu.diProcs[pid] = runningProcInfo
 			err := cm.installConfigProbe(runningProcInfo)
 			if err != nil {
-				log.Infof("could not install config probe for service %s (pid %d): %s", runningProcInfo.ServiceName, runningProcInfo.PID, err)
+				log.Errorf("could not install config probe for service %s (pid %d): %s", runningProcInfo.ServiceName, runningProcInfo.PID, err)
 			}
+		} else {
+			log.Infof("config probe already installed for %d %s", pid, runningProcInfo.ServiceName)
 		}
 	}
 }
@@ -148,7 +150,7 @@ func (cm *RCConfigManager) installConfigProbe(procInfo *ditypes.ProcessInfo) err
 	svcConfigProbe.ServiceName = procInfo.ServiceName
 	procInfo.ProbesByID.Set(configProbe.ID, &svcConfigProbe)
 
-	log.Infof("Installing config probe for service: %s", svcConfigProbe.ServiceName)
+	log.Infof("Installing config probe for service: %d %s %s", procInfo.PID, svcConfigProbe.ServiceName, procInfo.BinaryPath)
 	procInfo.TypeMap = &ditypes.TypeMap{
 		Functions: make(map[string][]*ditypes.Parameter),
 	}
@@ -156,27 +158,27 @@ func (cm *RCConfigManager) installConfigProbe(procInfo *ditypes.ProcessInfo) err
 
 	err = codegen.GenerateBPFParamsCode(procInfo, configProbe)
 	if err != nil {
-		return fmt.Errorf("could not generate bpf code for config probe: %w", err)
+		return fmt.Errorf("could not generate bpf code for config probe: %d %s %w", procInfo.PID, procInfo.ServiceName, err)
 	}
 
 	err = ebpf.CompileBPFProgram(configProbe)
 	if err != nil {
-		return fmt.Errorf("could not compile bpf code for config probe: %w", err)
+		return fmt.Errorf("could not compile bpf code for config probe: %d %s %w", procInfo.PID, procInfo.ServiceName, err)
 	}
 
 	err = ebpf.AttachBPFUprobe(procInfo, configProbe)
 	if err != nil {
-		return fmt.Errorf("could not attach bpf code for config probe: %w", err)
+		return fmt.Errorf("could not attach bpf code for config probe: %d %s %w", procInfo.PID, procInfo.ServiceName, err)
 	}
 
 	m, err := procInfo.SetupConfigUprobe()
 	if err != nil {
-		return fmt.Errorf("could not setup config probe for service %s: %w", procInfo.ServiceName, err)
+		return fmt.Errorf("could not setup config probe for service %d %s: %w", procInfo.PID, procInfo.ServiceName, err)
 	}
 
 	r, err := ringbuf.NewReader(m)
 	if err != nil {
-		return fmt.Errorf("could not read from config probe %s", procInfo.ServiceName)
+		return fmt.Errorf("could not read from config probe %d %s: %w", procInfo.PID, procInfo.ServiceName, err)
 	}
 
 	go cm.readConfigs(r, procInfo)
@@ -185,37 +187,37 @@ func (cm *RCConfigManager) installConfigProbe(procInfo *ditypes.ProcessInfo) err
 }
 
 func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.ProcessInfo) {
-	log.Tracef("Waiting for configs for service: %s", procInfo.ServiceName)
+	log.Tracef("Waiting for configs for service: %d %s", procInfo.PID, procInfo.ServiceName)
 	configRateLimiter := ratelimiter.NewMultiProbeRateLimiter(0.0)
 	configRateLimiter.SetRate(ditypes.ConfigBPFProbeID, 0)
 
 	for {
 		record, err := r.Read()
 		if err != nil {
-			log.Errorf("error reading raw configuration from bpf: %v", err)
+			log.Errorf("error reading raw configuration from bpf: %d %s %v", procInfo.PID, procInfo.ServiceName, err)
 			continue
 		}
 
 		configEvent, err := eventparser.ParseEvent(record.RawSample, configRateLimiter)
 		if err != nil {
-			log.Errorf("error parsing configuration for PID %d: %v", procInfo.PID, err)
+			log.Errorf("error parsing configuration for PID %d %s: %v", procInfo.PID, procInfo.ServiceName, err)
 			continue
 		}
 		configEventParams := configEvent.Argdata
 		if len(configEventParams) != 3 {
-			log.Errorf("error parsing configuration for PID: %d: not enough arguments (got %d): %s", procInfo.PID, len(configEventParams), string(record.RawSample))
+			log.Errorf("error parsing configuration for PID %d %s: not enough arguments (got %d): %s", procInfo.PID, procInfo.ServiceName, len(configEventParams), string(record.RawSample))
 			continue
 		}
 
 		runtimeID, err := uuid.ParseBytes([]byte(configEventParams[0].ValueStr))
 		if err != nil {
-			log.Errorf("Runtime ID \"%s\" is not a UUID: %v)", configEventParams[0].ValueStr, err)
+			log.Errorf("error parsing event uuid: \"%s\" is not a uuid: %d %s %v", configEventParams[0].ValueStr, procInfo.PID, procInfo.ServiceName, err)
 			continue
 		}
 
 		configPath, err := ditypes.ParseConfigPath(string(configEventParams[1].ValueStr))
 		if err != nil {
-			log.Errorf("couldn't parse config path (%s): %v", string(configEventParams[1].ValueStr), err)
+			log.Errorf("couldn't parse config path (%s): %d %s %v", string(configEventParams[1].ValueStr), procInfo.PID, procInfo.ServiceName, err)
 			continue
 		}
 
@@ -231,7 +233,7 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 		err = json.Unmarshal([]byte(configEventParams[2].ValueStr), &conf)
 		if err != nil {
 			diagnostics.Diagnostics.SetError(procInfo.ServiceName, procInfo.RuntimeID, configPath.ProbeUUID.String(), "ATTACH_ERROR", err.Error())
-			log.Errorf("could not unmarshal configuration, cannot apply: %v (Probe-ID: %s)\n", err, configPath.ProbeUUID)
+			log.Errorf("could not unmarshal configuration, cannot apply: %d %s %v (Probe-ID: %s)\n", procInfo.PID, procInfo.ServiceName, err, configPath.ProbeUUID)
 			continue
 		}
 
@@ -255,10 +257,14 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 			cm.mu.diProcs.SetProbe(procInfo.PID, procInfo.ServiceName, conf.Where.TypeName, conf.Where.MethodName, configPath.ProbeUUID, runtimeID, opts)
 			diagnostics.Diagnostics.SetStatus(procInfo.ServiceName, runtimeID.String(), configPath.ProbeUUID.String(), ditypes.StatusReceived)
 			probe = procInfo.ProbesByID.Get(configPath.ProbeUUID.String())
+			if probe != nil {
+				log.Infof("Received config for %d %s %s", procInfo.PID, procInfo.ServiceName, probe.FuncName)
+			}
 		}
 
 		// Check hash to see if the configuration changed
 		if configPath.Hash != probe.InstrumentationInfo.ConfigurationHash {
+			log.Infof("Configuration hash changed for %d %s %s", procInfo.PID, procInfo.ServiceName, probe.FuncName)
 			err := AnalyzeBinary(procInfo)
 			if err != nil {
 				log.Errorf("couldn't inspect binary (%s): %v\n", procInfo.BinaryPath, err)
@@ -274,7 +280,7 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 }
 
 func applyConfigUpdate(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) {
-	log.Debugf("Applying config update for: %s in %s (ID: %s)\n", probe.FuncName, probe.ServiceName, probe.ID)
+	log.Infof("Applying config update for: %d %s %s (ID: %s)\n", procInfo.PID, procInfo.ServiceName, probe.FuncName, probe.ID)
 	for {
 		log.Infof("Attempting to generate and attach BPF program for %d %s %s (ID: %s)", procInfo.PID, procInfo.ServiceName, probe.FuncName, probe.ID)
 		if err := tryGenerateAndAttach(procInfo, probe); err == nil {
@@ -291,7 +297,7 @@ func tryGenerateAndAttach(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) e
 	log.Infof("Attempting to generate and attach BPF program for %d %s %s (ID: %s)", procInfo.PID, procInfo.ServiceName, probe.FuncName, probe.ID)
 	err := codegen.GenerateBPFParamsCode(procInfo, probe)
 	if err != nil {
-		log.Errorf("Couldn't generate BPF programs for %s: %v", probe.FuncName, err)
+		log.Errorf("Couldn't generate BPF programs for %d %s %s: %v", procInfo.PID, procInfo.ServiceName, probe.FuncName, err)
 		if !haveExhaustedReferenceDepthDecrementing(probe) {
 			return err
 		}
@@ -299,7 +305,7 @@ func tryGenerateAndAttach(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) e
 	}
 	err = ebpf.CompileBPFProgram(probe)
 	if err != nil {
-		log.Errorf("Couldn't compile BPF object for function %s (ID: %s): %v", probe.FuncName, probe.ID, err)
+		log.Errorf("Couldn't compile BPF object for function %d %s %s (ID: %s): %v", procInfo.PID, procInfo.ServiceName, probe.FuncName, probe.ID, err)
 		if !haveExhaustedReferenceDepthDecrementing(probe) {
 			return err
 		}
@@ -307,7 +313,7 @@ func tryGenerateAndAttach(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) e
 	}
 	err = ebpf.AttachBPFUprobe(procInfo, probe)
 	if err != nil {
-		log.Errorf("Couldn't load and attach bpf programs for function %s (ID: %s): %v", probe.FuncName, probe.ID, err)
+		log.Errorf("Couldn't load and attach bpf programs for function %d %s %s (ID: %s): %v", procInfo.PID, procInfo.ServiceName, probe.FuncName, probe.ID, err)
 		if !haveExhaustedReferenceDepthDecrementing(probe) {
 			return err
 		}
@@ -335,7 +341,7 @@ func checkAndDecrementReferenceDepth(probe *ditypes.Probe) bool {
 		return false
 	}
 	probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth--
-	log.Tracef("Retrying after decrementing capture depth to: %d", probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth)
+	log.Tracef("Retrying after decrementing capture depth to: %d %s %s", probe.InstrumentationInfo.InstrumentationOptions.MaxReferenceDepth, probe.ServiceName, probe.FuncName)
 	return true
 }
 

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -27,11 +27,6 @@ func getTypeMap(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditype
 	return loadFunctionDefinitions(dwarfData, targetFunctions)
 }
 
-type seenTypeCounter struct {
-	parameter *ditypes.Parameter
-	count     uint8
-}
-
 func loadFunctionDefinitions(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditypes.TypeMap, error) {
 	entryReader := dwarfData.Reader()
 	typeReader := dwarfData.Reader()
@@ -614,10 +609,7 @@ func kindIsSupported(k reflect.Kind) bool {
 }
 
 func typeIsSupported(t string) bool {
-	if t == "unsafe.Pointer" {
-		return false
-	}
-	return true
+	return t != "unsafe.Pointer"
 }
 
 func entryTypeIsSupported(e *dwarf.Entry) bool {

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -28,7 +28,7 @@ func getTypeMap(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditype
 }
 
 func loadFunctionDefinitions(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditypes.TypeMap, error) {
-	fmt.Println("Loading function definitions: ", targetFunctions)
+	log.Infof("Loading function definitions: %v", targetFunctions)
 	entryReader := dwarfData.Reader()
 	typeReader := dwarfData.Reader()
 	readingAFunction := false
@@ -50,6 +50,11 @@ entryLoop:
 	for {
 		entry, err = entryReader.Next()
 		if err == io.EOF || entry == nil {
+			log.Infof("Reached end of function definitions")
+			break
+		}
+		if err != nil {
+			log.Errorf("Error reading function definitions: %s", err)
 			break
 		}
 
@@ -131,6 +136,7 @@ entryLoop:
 					if _, ok := targetFunctions[funcName]; !ok {
 						continue entryLoop
 					}
+					log.Infof("Found target function: %s", funcName)
 					params := make([]*ditypes.Parameter, 0)
 					result.Functions[funcName] = params
 					readingAFunction = true

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -28,6 +28,7 @@ func getTypeMap(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditype
 }
 
 func loadFunctionDefinitions(dwarfData *dwarf.Data, targetFunctions map[string]bool) (*ditypes.TypeMap, error) {
+	fmt.Println("Loading function definitions: ", targetFunctions)
 	entryReader := dwarfData.Reader()
 	typeReader := dwarfData.Reader()
 	readingAFunction := false
@@ -127,7 +128,7 @@ entryLoop:
 			for _, field := range entry.Field {
 				if field.Attr == dwarf.AttrName {
 					funcName = strings.Clone(field.Val.(string))
-					if !targetFunctions[funcName] {
+					if _, ok := targetFunctions[funcName]; !ok {
 						continue entryLoop
 					}
 					params := make([]*ditypes.Parameter, 0)
@@ -142,7 +143,7 @@ entryLoop:
 			continue
 		}
 		if entry.Tag != dwarf.TagFormalParameter {
-			readingAFunction = false
+			readingAFunction = true
 			continue entryLoop
 		}
 		// This branch should only be reached if we're currently reading ditypes.Parameters of a function

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -49,7 +49,6 @@ func loadFunctionDefinitions(dwarfData *dwarf.Data, targetFunctions map[string]b
 		entry      *dwarf.Entry
 		err        error
 	)
-	seenTypes := make(map[string]*seenTypeCounter)
 
 entryLoop:
 	for {
@@ -62,7 +61,6 @@ entryLoop:
 			readingAFunction = false
 			continue entryLoop
 		}
-
 		if entry.Tag == dwarf.TagCompileUnit {
 			_, ok := entry.Val(dwarf.AttrName).(string)
 			if !ok {
@@ -71,13 +69,12 @@ entryLoop:
 			name = strings.Clone(entry.Val(dwarf.AttrName).(string))
 			ranges, err := dwarfData.Ranges(entry)
 			if err != nil {
-				log.Infof("couldnt retrieve ranges for compile unit %s: %s", name, err)
+				log.Warnf("couldnt retrieve ranges for compile unit %s: %s", name, err)
 				continue entryLoop
 			}
-
 			cuLineReader, err := dwarfData.LineReader(entry)
 			if err != nil {
-				log.Errorf("could not get file line reader for compile unit: %v", err)
+				log.Warnf("could not get file line reader for compile unit: %v", err)
 				continue entryLoop
 			}
 			var files []*dwarf.LineFile
@@ -87,7 +84,6 @@ entryLoop:
 						files = append(files, &dwarf.LineFile{Name: "no file", Mtime: 0, Length: 0})
 						continue
 					}
-
 					files = append(files, &dwarf.LineFile{
 						Name:   strings.Clone(file.Name),
 						Mtime:  file.Mtime,
@@ -95,7 +91,6 @@ entryLoop:
 					})
 				}
 			}
-
 			for i := range ranges {
 				result.DeclaredFiles = append(result.DeclaredFiles, &ditypes.DwarfFilesEntry{
 					LowPC: ranges[i][0],
@@ -151,18 +146,15 @@ entryLoop:
 		if !readingAFunction {
 			continue
 		}
-
 		if entry.Tag != dwarf.TagFormalParameter {
 			readingAFunction = false
 			continue entryLoop
 		}
-
 		// This branch should only be reached if we're currently reading ditypes.Parameters of a function
 		// Meaning: This is a formal ditypes.Parameter entry, and readingAFunction = true
 
 		// Go through fields of the entry collecting type, name, size information
 		for i := range entry.Field {
-
 			// ditypes.Parameter name
 			if entry.Field[i].Attr == dwarf.AttrName {
 				name = strings.Clone(entry.Field[i].Val.(string))
@@ -179,14 +171,14 @@ entryLoop:
 				if err != nil {
 					return nil, err
 				}
+				// Initialize seenTypes map for this specific top-level type expansion.
+				seenTypes := make(map[dwarf.Offset]uint8)
 				typeFields, err = expandTypeData(typeEntry.Offset, dwarfData, seenTypes)
 				if err != nil {
 					return nil, fmt.Errorf("error while parsing debug information: %w", err)
 				}
-				clear(seenTypes)
 			}
 		}
-
 		if typeFields != nil && !isReturn /* we ignore return values for now */ {
 			// We've collected information about this ditypes.Parameter, append it to the slice of ditypes.Parameters for this function
 			typeFields.Name = name
@@ -206,26 +198,53 @@ entryLoop:
 	return &result, nil
 }
 
-func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[string]*seenTypeCounter) (*ditypes.Parameter, error) {
+// expandTypeData recursively expands DWARF type information starting from a given offset.
+// It handles basic types, structs, arrays, pointers, and typedefs.
+// It handles logic for cycle/depth detection.
+func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[dwarf.Offset]uint8) (*ditypes.Parameter, error) {
+	seenTypes[offset]++
+	if seenTypes[offset] > 4 {
+		seenTypes[offset]--
+		if seenTypes[offset] == 0 {
+			delete(seenTypes, offset)
+		}
+		return &ditypes.Parameter{Type: "<cycle/depth limit>"}, nil
+	}
+
+	// Ensure the count is decremented when this function returns
+	defer func() {
+		seenTypes[offset]--
+		if seenTypes[offset] == 0 {
+			delete(seenTypes, offset)
+		}
+	}()
+
 	typeReader := dwarfData.Reader()
 
 	typeReader.Seek(offset)
 	typeEntry, err := typeReader.Next()
 	if err != nil || typeEntry == nil {
+		log.Errorf("Could not get type entry at offset %x: %s", offset, err)
 		return nil, fmt.Errorf("could not get type entry: %w", err)
 	}
 
 	if !entryTypeIsSupported(typeEntry) {
+		log.Warnf("Type entry at offset %x (%s) is not supported, resolving unsupported entry", offset, typeEntry.Tag)
 		return resolveUnsupportedEntry(typeEntry), nil
 	}
 
 	if typeEntry.Tag == dwarf.TagTypedef {
-		typeEntry, err = resolveTypedefToRealType(typeEntry, typeReader)
+		// Initialize seen map for this specific typedef resolution chain
+		seenTypedefOffsets := make(map[dwarf.Offset]bool)
+		typeEntry, err = resolveTypedefToRealType(typeEntry, typeReader, seenTypedefOffsets)
 		if err != nil {
+			log.Errorf("error while resolving typedef at offset %x: %s", offset, err)
 			return nil, err
 		}
 		if typeEntry == nil {
-			return nil, errors.New("could not resolve type entry")
+			// This can happen if a typedef cycle was detected
+			log.Warnf("could not resolve type entry from typedef at offset %x, possibly due to a typedef cycle", offset)
+			return nil, errors.New("could not resolve type entry, possibly due to a typedef cycle")
 		}
 	}
 
@@ -234,19 +253,6 @@ func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[st
 		Type:      typeName,
 		TotalSize: typeSize,
 		Kind:      typeKind,
-	}
-
-	v, typeParsedAlready := seenTypes[typeHeader.Type]
-	if typeParsedAlready && typeHeader.Kind != uint(reflect.Pointer) {
-		v.count++
-		if v.count > ditypes.MaxReferenceDepth {
-			return &ditypes.Parameter{}, nil
-		}
-	} else {
-		seenTypes[typeHeader.Type] = &seenTypeCounter{
-			parameter: &typeHeader,
-			count:     1,
-		}
 	}
 
 	if typeEntry.Tag == dwarf.TagStructType || typeKind == uint(reflect.Slice) || typeKind == uint(reflect.String) {
@@ -273,16 +279,13 @@ func expandTypeData(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[st
 		typeHeader.ID = randomLabel()
 	}
 
-	for k := range seenTypes {
-		if seenTypes[k].count > 0 {
-			seenTypes[k].count--
-		}
-	}
-
 	return &typeHeader, nil
 }
 
-func getIndividualArrayElements(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[string]*seenTypeCounter) ([]*ditypes.Parameter, error) {
+// getIndividualArrayElements expands information about array types, including element type and length.
+// It recursively calls expandTypeData for the element type, passing the seenTypes map for cycle/depth detection.
+func getIndividualArrayElements(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[dwarf.Offset]uint8) ([]*ditypes.Parameter, error) {
+	log.Infof("Starting getIndividualArrayElements for offset %x", offset)
 	savedArrayEntryOffset := offset
 	typeReader := dwarfData.Reader()
 
@@ -307,9 +310,14 @@ func getIndividualArrayElements(offset dwarf.Offset, dwarfData *dwarf.Data, seen
 		elementFields = resolveUnsupportedEntry(underlyingType)
 		elementTypeName, elementTypeSize, elementTypeKind = getTypeEntryBasicInfo(underlyingType)
 	} else {
-		arrayElementTypeEntry, err := resolveTypedefToRealType(underlyingType, typeReader)
+		// Initialize seen map for this specific typedef resolution chain
+		seenTypedefOffsets := make(map[dwarf.Offset]bool)
+		arrayElementTypeEntry, err := resolveTypedefToRealType(underlyingType, typeReader, seenTypedefOffsets)
 		if err != nil {
 			return nil, err
+		}
+		if arrayElementTypeEntry == nil {
+			return nil, errors.New("could not resolve array element type entry, possibly due to a typedef cycle")
 		}
 
 		elementFields, err = expandTypeData(arrayElementTypeEntry.Offset, dwarfData, seenTypes)
@@ -349,11 +357,12 @@ func getIndividualArrayElements(offset dwarf.Offset, dwarfData *dwarf.Data, seen
 		newParam.TotalSize = elementTypeSize
 		arrayElements = append(arrayElements, &newParam)
 	}
-
 	return arrayElements, nil
 }
 
-func getStructFields(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[string]*seenTypeCounter) ([]*ditypes.Parameter, error) {
+// getStructFields expands information about struct types, collecting information about each field.
+// It recursively calls expandTypeData for field types, passing the seenTypes map for cycle/depth detection.
+func getStructFields(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[dwarf.Offset]uint8) ([]*ditypes.Parameter, error) {
 	inOrderReader := dwarfData.Reader()
 	typeReader := dwarfData.Reader()
 
@@ -404,17 +413,36 @@ func getStructFields(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[s
 				}
 
 				if typeEntry.Tag == dwarf.TagTypedef {
-					typeEntry, err = resolveTypedefToRealType(typeEntry, typeReader)
+					// Initialize seen map for this specific typedef resolution chain
+					seenTypedefOffsets := make(map[dwarf.Offset]bool)
+					typeEntry, err = resolveTypedefToRealType(typeEntry, typeReader, seenTypedefOffsets)
 					if err != nil {
 						return []*ditypes.Parameter{}, err
+					}
+					if typeEntry == nil {
+						unsupportedType := resolveUnsupportedEntry(fieldEntry)
+						structFields = append(structFields, unsupportedType)
+						continue
 					}
 				}
 
 				newStructField.Type, newStructField.TotalSize, newStructField.Kind = getTypeEntryBasicInfo(typeEntry)
 				if typeEntry.Tag != dwarf.TagBaseType {
 					field, err := expandTypeData(typeEntry.Offset, dwarfData, seenTypes)
-					if err != nil || field == nil {
+					if err != nil {
 						return []*ditypes.Parameter{}, err
+					}
+					// Check if the returned field *is* the cycle/depth limit marker
+					if field != nil && field.Type == "<cycle/depth limit>" {
+						log.Warnf("Skipping field expansion for '%s' due to cycle/depth limit detected at DWARF offset %x", newStructField.Name, typeEntry.Offset)
+						// Append the marker itself, but ensure Name is set
+						field.Name = newStructField.Name
+						structFields = append(structFields, field)
+						continue
+					}
+					if field == nil {
+						log.Errorf("expandTypeData returned nil without error for offset %x, skipping field %s", typeEntry.Offset, newStructField.Name)
+						continue
 					}
 					field.Name = newStructField.Name
 					structFields = append(structFields, field)
@@ -429,14 +457,15 @@ func getStructFields(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[s
 
 // getPointerLayers is used to populate the underlying type of pointers. The returned slice of parameters
 // would contain a single element which represents the entire type tree that the pointer points to.
-func getPointerLayers(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[string]*seenTypeCounter) ([]*ditypes.Parameter, error) {
+// It recursively calls expandTypeData for the pointed-to type, passing the seenTypes map for cycle/depth detection.
+func getPointerLayers(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[dwarf.Offset]uint8) ([]*ditypes.Parameter, error) {
 	typeReader := dwarfData.Reader()
 	typeReader.Seek(offset)
 	pointerEntry, err := typeReader.Next()
 	if err != nil {
 		return nil, err
 	}
-	var underlyingType *ditypes.Parameter
+	var underlyingTypeParam *ditypes.Parameter
 	for i := range pointerEntry.Field {
 
 		if pointerEntry.Field[i].Attr == dwarf.AttrType {
@@ -445,17 +474,29 @@ func getPointerLayers(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[
 			if err != nil {
 				return nil, err
 			}
-
-			underlyingType, err = expandTypeData(typeEntry.Offset, dwarfData, seenTypes)
+			underlyingTypeParam, err = expandTypeData(typeEntry.Offset, dwarfData, seenTypes)
 			if err != nil {
 				return nil, err
 			}
+			// No need to break, the AttrType should appear only once (or the last one wins?)
 		}
 	}
-	if underlyingType == nil {
+
+	// Check if underlyingTypeParam is nil OR the cycle/depth marker
+	if underlyingTypeParam == nil {
+		log.Errorf("expandTypeData returned nil without error for pointer base type at offset %x", offset) // Assuming offset is the pointer offset
+		// Return empty slice, indicating pointer to unknown/error type
 		return []*ditypes.Parameter{}, nil
 	}
-	return []*ditypes.Parameter{underlyingType}, nil
+
+	// If it's the cycle/depth marker, return it directly within the slice
+	if underlyingTypeParam.Type == "<cycle/depth limit>" {
+		log.Warnf("Pointer points to a type that reached cycle/depth limit at offset %x", offset) // Assuming offset is the pointer offset
+		return []*ditypes.Parameter{underlyingTypeParam}, nil
+	}
+
+	// If underlyingType is valid (and not a cycle/depth marker), return it
+	return []*ditypes.Parameter{underlyingTypeParam}, nil
 }
 
 // Can use `Children` field, but there's also always a NULL/empty entry at the end of entry trees.
@@ -515,18 +556,30 @@ func followType(outerType *dwarf.Entry, reader *dwarf.Reader) (*dwarf.Entry, err
 // go packages the type underneath a typdef DWARF entry. The typedef DWARF entry has a 'type' entry
 // which points to the actual type, which is what this function 'resolves'.
 // Typedef's are used in for structs, pointers, maps, and likely other types.
-func resolveTypedefToRealType(outerType *dwarf.Entry, reader *dwarf.Reader) (*dwarf.Entry, error) {
-
+// seenOffsets tracks offsets visited in *this specific resolution chain* to detect cycles.
+func resolveTypedefToRealType(outerType *dwarf.Entry, reader *dwarf.Reader, seenOffsets map[dwarf.Offset]bool) (*dwarf.Entry, error) {
 	if outerType.Tag == dwarf.TagTypedef {
+		// Check if we've already seen this offset in the current resolution path
+		if seenOffsets[outerType.Offset] {
+			log.Infof("Typedef cycle detected at offset %x", outerType.Offset)
+			return nil, errors.New("typedef cycle detected")
+		}
+		// Mark current offset as seen for this path
+		seenOffsets[outerType.Offset] = true
+
 		followedType, err := followType(outerType, reader)
 		if err != nil {
+			delete(seenOffsets, outerType.Offset) // Unmark before returning error
 			return nil, err
 		}
 
-		if followedType.Tag == dwarf.TagTypedef {
-			return resolveTypedefToRealType(followedType, reader)
-		}
-		return followedType, nil
+		// Recursively resolve, passing the *same* map
+		resolvedType, err := resolveTypedefToRealType(followedType, reader, seenOffsets)
+
+		// Unmark current offset as we backtrack
+		delete(seenOffsets, outerType.Offset)
+
+		return resolvedType, err
 	}
 
 	return outerType, nil
@@ -561,7 +614,10 @@ func kindIsSupported(k reflect.Kind) bool {
 }
 
 func typeIsSupported(t string) bool {
-	return t != "unsafe.Pointer"
+	if t == "unsafe.Pointer" {
+		return false
+	}
+	return true
 }
 
 func entryTypeIsSupported(e *dwarf.Entry) bool {

--- a/pkg/dynamicinstrumentation/diconfig/dwarf_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf_test.go
@@ -8,12 +8,12 @@
 package diconfig
 
 import (
-	"debug/elf"
 	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
+	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 	"github.com/stretchr/testify/require"
 )
 
@@ -50,7 +50,7 @@ func TestLoadFunctionDefinitions(t *testing.T) {
 			}
 
 			// Open the ELF file
-			elfFile, err := elf.Open(tc.binaryPath)
+			elfFile, err := safeelf.Open(tc.binaryPath)
 			require.NoError(t, err, "Failed to open ELF file %s", tc.binaryPath)
 			defer elfFile.Close()
 

--- a/pkg/dynamicinstrumentation/diconfig/dwarf_test.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf_test.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package diconfig
+
+import (
+	"debug/elf"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFunctionDefinitions(t *testing.T) {
+	testCases := []struct {
+		name            string
+		binaryPath      string
+		targetFuncNames []string
+		expectError     bool
+		postAssertions  func(t *testing.T, typeMap *ditypes.TypeMap)
+	}{
+		{
+			name:            "Basic Load",
+			binaryPath:      filepath.Join("testdata", "ref-table-edge.debug"),
+			targetFuncNames: []string{"main.(*Server).HandleCreateSync"},
+			expectError:     false,
+			postAssertions: func(t *testing.T, typeMap *ditypes.TypeMap) {
+				fmt.Println("typeMap.Functions", typeMap.Functions)
+				require.NotNil(t, typeMap, "TypeMap should not be nil")
+				for i := range typeMap.Functions {
+					fmt.Println(">", i)
+				}
+			},
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		tc := tc // Capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			targetFuncsMap := make(map[string]bool, len(tc.targetFuncNames))
+			for _, name := range tc.targetFuncNames {
+				targetFuncsMap[name] = false
+			}
+
+			// Open the ELF file
+			elfFile, err := elf.Open(tc.binaryPath)
+			require.NoError(t, err, "Failed to open ELF file %s", tc.binaryPath)
+			defer elfFile.Close()
+
+			// Get DWARF data
+			dwarfData, err := elfFile.DWARF()
+			require.NoError(t, err, "Failed to get DWARF data from ELF file")
+			require.NotNil(t, dwarfData, "DWARF data should not be nil")
+
+			// Call the function under test
+			typeMap, err := loadFunctionDefinitions(dwarfData, targetFuncsMap)
+
+			// Basic assertions
+			if tc.expectError {
+				require.Error(t, err, "Expected an error from loadFunctionDefinitions")
+			} else {
+				require.NoError(t, err, "loadFunctionDefinitions returned an unexpected error")
+			}
+
+			// Run specific assertions for this test case if provided
+			if tc.postAssertions != nil {
+				tc.postAssertions(t, typeMap)
+			}
+		})
+	}
+}

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -54,7 +54,6 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 		for pathElementIndex := range pathElements {
 			var elementParam *ditypes.Parameter = getParamFromTriePaths(pathElements[pathElementIndex])
 			if elementParam == nil {
-				log.Infof("Path not found to target: %s", pathElements[pathElementIndex])
 				continue
 			}
 			// Check if this instrumentation target is directly assigned

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -173,7 +173,7 @@ func (procs DIProcs) CloseUprobe(pid PID, probeID ProbeID) {
 	}
 	err := proc.CloseUprobeLink(probeID)
 	if err != nil {
-		log.Infof("could not close uprobe: %s", err)
+		log.Errorf("could not close uprobe: %s", err)
 	}
 }
 
@@ -421,7 +421,7 @@ func (pi *ProcessInfo) DeleteProbe(probeID ProbeID) {
 	}
 	err := pi.CloseUprobeLink(probeID)
 	if err != nil {
-		log.Infof("could not close uprobe link: %s", err)
+		log.Errorf("could not close uprobe link: %s", err)
 	}
 	if pi.ProbesByID != nil {
 		pi.ProbesByID.Delete(probeID)

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -58,8 +58,8 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 
 	numCPUs, err := kernel.PossibleCPUs()
 	if err != nil {
-		numCPUs = 96
-		log.Error("unable to detect number of CPUs. assuming 96 cores")
+		numCPUs = 128
+		log.Error("unable to detect number of CPUs. assuming 128 cores")
 	}
 	outerMapSpec := spec.Maps["param_stacks"]
 	outerMapSpec.MaxEntries = uint32(numCPUs)
@@ -111,7 +111,8 @@ func AttachBPFUprobe(procInfo *ditypes.ProcessInfo, probe *ditypes.Probe) error 
 	if err != nil {
 		var ve *ebpf.VerifierError
 		if errors.As(err, &ve) {
-			log.Infof("Verifier error: %+v\n", ve)
+			log.Errorf("Verifier rejection occurred while loading bpf collection for probe %s", probe.ID)
+			log.Tracef("Verifier output for probe %s: %+v\n", probe.ID, ve)
 		}
 		diagnostics.Diagnostics.SetError(procInfo.ServiceName, procInfo.RuntimeID, probe.ID, "ATTACH_ERROR", err.Error())
 		return fmt.Errorf("could not load bpf collection for probe %s: %w", probe.ID, err)

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -58,6 +58,7 @@ func NewProcessTracker(pm process.Subscriber, callback processTrackerCallback) *
 // aware of new processes that may need to be instrumented or instrumented processes
 // that should no longer be instrumented
 func (pt *ProcessTracker) Start() error {
+	log.Infof("Starting process tracker")
 	unsubscribeExec := pt.pm.SubscribeExec(pt.handleProcessStart)
 	unsubscribeExit := pt.pm.SubscribeExit(pt.handleProcessStop)
 
@@ -67,6 +68,7 @@ func (pt *ProcessTracker) Start() error {
 
 // Stop unsubscribes from exec and exit events
 func (pt *ProcessTracker) Stop() {
+	log.Infof("Stopping process tracker")
 	for _, unsubscribe := range pt.unsubscribe {
 		unsubscribe()
 	}
@@ -74,6 +76,7 @@ func (pt *ProcessTracker) Stop() {
 
 func (pt *ProcessTracker) handleProcessStart(pid uint32) {
 	exePath := kernel.HostProc(strconv.Itoa(int(pid)), "exe")
+	log.Tracef("Handling process start for %d %s", pid, exePath)
 	go pt.inspectBinary(exePath, pid)
 }
 
@@ -113,24 +116,34 @@ func remoteConfigCallback(_ delve.GoVersion, goarch string) ([]bininspect.Parame
 }
 
 func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
+	log.Tracef("Inspecting binary for %d %s", pid, exePath)
+	// Avoid self-inspection.
+	if int(pid) == os.Getpid() {
+		log.Infof("Skipping self-inspection for %d %s", pid, exePath)
+		return
+	}
+
 	serviceName, diEnabled := getEnvVars(pid)
 	if serviceName == "" || !diEnabled {
+		log.Tracef("Skipping binary inspection for %d %s", pid, exePath)
 		// if the expected env vars are not set we don't inspect the binary
 		return
 	}
+
+	log.Infof("Inspecting binary for %d %s", pid, exePath)
 	// TODO: switch to using exePath for the demo, use conditional logic above moving forward
 	binPath := exePath
 	f, err := os.Open(exePath)
 	if err != nil {
 		// this should be a debug log, but we want to know if this happens
-		log.Infof("could not open file %s, %s", binPath, err)
+		log.Errorf("could not open file for %s: %s, %s", serviceName, binPath, err)
 		return
 	}
 	defer f.Close()
 
 	elfFile, err := safeelf.NewFile(f)
 	if err != nil {
-		log.Infof("file %s could not be parsed as an ELF file: %s", binPath, err)
+		log.Errorf("binary file could not be parsed as an ELF file for %d %s: %s, %s", pid, serviceName, binPath, err)
 		return
 	}
 	noStructs := make(map[bininspect.FieldIdentifier]bininspect.StructLookupFunction)
@@ -142,13 +155,13 @@ func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
 	}
 	_, err = bininspect.InspectNewProcessBinary(elfFile, functionsConfig, noStructs)
 	if err != nil {
-		log.Infof("error reading exe: %s", err)
+		log.Errorf("error reading binary for %d %s: %s, %s", pid, serviceName, binPath, err)
 		return
 	}
 
 	var stat syscall.Stat_t
 	if err = syscall.Stat(binPath, &stat); err != nil {
-		log.Infof("could not stat binary path %s: %s", binPath, err)
+		log.Errorf("error stating binary for %d %s: %s, %s", pid, serviceName, binPath, err)
 		return
 	}
 	binID := binaryID{
@@ -156,7 +169,7 @@ func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
 		Id_minor: unix.Minor(stat.Dev),
 		Ino:      stat.Ino,
 	}
-	log.Info("Found instrumentation candidate", serviceName)
+	log.Infof("Found instrumentation candidate for %d %s", pid, serviceName)
 	pt.registerProcess(binID, pid, stat.Mtim, binPath, serviceName)
 }
 

--- a/pkg/dynamicinstrumentation/util/file_watcher.go
+++ b/pkg/dynamicinstrumentation/util/file_watcher.go
@@ -55,7 +55,7 @@ func (fw *FileWatcher) Watch() (<-chan []byte, error) {
 			case <-ticker.C:
 				content, err := fw.readFile()
 				if err != nil {
-					log.Infof("Error reading file %s: %s", fw.filePath, err)
+					log.Errorf("Error reading file %s: %s", fw.filePath, err)
 					return
 				}
 				if len(content) > 0 && string(content) != string(prevContent) {

--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -9,7 +9,6 @@ package bininspect
 
 import (
 	"debug/dwarf"
-	"errors"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
@@ -132,7 +131,11 @@ func (d dwarfInspector) findFunctionDebugInfoEntries(functions []string) (map[st
 	}
 
 	if len(functionsToSearch) != 0 {
-		return nil, errors.New("not all functions found")
+		missingFunctions := make([]string, 0, len(functionsToSearch))
+		for funcName := range functionsToSearch {
+			missingFunctions = append(missingFunctions, funcName)
+		}
+		return nil, fmt.Errorf("not all functions found: %v", missingFunctions)
 	}
 
 	return functionEntries, nil

--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -10,6 +10,9 @@ package bininspect
 import (
 	"debug/dwarf"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils/locexpr"
@@ -131,11 +134,7 @@ func (d dwarfInspector) findFunctionDebugInfoEntries(functions []string) (map[st
 	}
 
 	if len(functionsToSearch) != 0 {
-		missingFunctions := make([]string, 0, len(functionsToSearch))
-		for funcName := range functionsToSearch {
-			missingFunctions = append(missingFunctions, funcName)
-		}
-		return nil, fmt.Errorf("not all functions found: %v", missingFunctions)
+		return nil, fmt.Errorf("not all functions found: %s", strings.Join(slices.Collect(maps.Keys(functionsToSearch)), ","))
 	}
 
 	return functionEntries, nil


### PR DESCRIPTION
### What does this PR do?

This fixes an issue with how DWARF information for specific types was being parsed that would cause a failure for Go DI to detect cycles in type definition.

It also adds logs, and cleans up code for retrying building of bpf code.

### Motivation

Fixing the above described issue.

### Describe how you validated your changes

E2E tests, Manual deployment of custom built images.

### Possible Drawbacks / Trade-offs

### Additional Notes
