### PR TITLE
[AGNTLOG-176] Add compression override over config for epforwaders

### DIFF
--- a/comp/core/agenttelemetry/impl/config.go
+++ b/comp/core/agenttelemetry/impl/config.go
@@ -213,6 +213,8 @@ var defaultProfiles = `
         - name: logs.decoded
         - name: logs.dropped
         - name: logs.encoded_bytes_sent
+          aggregate_tags:
+            - compression_kind
         - name: logs.sender_latency
         - name: logs.auto_multi_line_aggregator_flush
           aggregate_tags:

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -67,6 +67,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
 		// High input chan size is needed to handle high number of DBM events being flushed by DBM integrations
 		defaultInputChanSize: 500,
+		forceCompressionKind: "gzip",
 	},
 	{
 		eventType:              eventTypeDBMMetrics,
@@ -81,6 +82,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
 		// High input chan size is needed to handle high number of DBM events being flushed by DBM integrations
 		defaultInputChanSize: 500,
+		forceCompressionKind: "gzip",
 	},
 	{
 		eventType:   eventTypeDBMMetadata,
@@ -98,6 +100,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
 		// High input chan size is needed to handle high number of DBM events being flushed by DBM integrations
 		defaultInputChanSize: 500,
+		forceCompressionKind: "gzip",
 	},
 	{
 		eventType:              eventTypeDBMActivity,
@@ -112,6 +115,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		defaultBatchMaxSize:           pkgconfigsetup.DefaultBatchMaxSize,
 		// High input chan size is needed to handle high number of DBM events being flushed by DBM integrations
 		defaultInputChanSize: 500,
+		forceCompressionKind: "gzip",
 	},
 	{
 		eventType:                     eventplatform.EventTypeNetworkDevicesMetadata,
@@ -374,6 +378,7 @@ type passthroughPipelineDesc struct {
 	defaultBatchMaxContentSize    int
 	defaultBatchMaxSize           int
 	defaultInputChanSize          int
+	forceCompressionKind          string
 }
 
 // newHTTPPassthroughPipeline creates a new HTTP-only event platform pipeline that sends messages directly to intake
@@ -388,6 +393,9 @@ func newHTTPPassthroughPipeline(
 ) (p *passthroughPipeline, err error) {
 
 	configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, coreConfig)
+	if desc.forceCompressionKind != "" {
+		configKeys = configKeys.WithForcedCompression(desc.forceCompressionKind)
+	}
 	endpoints, err := config.BuildHTTPEndpointsWithConfig(
 		coreConfig,
 		configKeys,

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -18,9 +18,10 @@ import (
 
 // LogsConfigKeys stores logs configuration keys stored in YAML configuration files
 type LogsConfigKeys struct {
-	prefix       string
-	vectorPrefix string
-	config       pkgconfigmodel.Reader
+	prefix            string
+	vectorPrefix      string
+	config            pkgconfigmodel.Reader
+	forcedCompression string
 }
 
 // CompressionKind constants
@@ -119,6 +120,11 @@ func (l *LogsConfigKeys) devModeUseProto() bool {
 }
 
 func (l *LogsConfigKeys) compressionKind() string {
+	if l.forcedCompression != "" {
+		log.Debugf("Pipeline %s is using forced compression: %s", l.prefix, l.forcedCompression)
+		return l.forcedCompression
+	}
+
 	configKey := l.getConfigKey("compression_kind")
 	compressionKind := l.getConfig().GetString(configKey)
 
@@ -339,4 +345,14 @@ func (l *LogsConfigKeys) getObsPipelineURL() (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// WithForcedCompression returns a new LogsConfigKeys with the forced compression kind set
+func (l *LogsConfigKeys) WithForcedCompression(kind string) *LogsConfigKeys {
+	return &LogsConfigKeys{
+		prefix:            l.prefix,
+		vectorPrefix:      l.vectorPrefix,
+		config:            l.config,
+		forcedCompression: kind,
+	}
 }

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -303,6 +303,11 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	}
 	metrics.BytesSent.Add(int64(payload.UnencodedSize))
 	var sourceTag string
+	var compressionKind string
+
+	if d.endpoint.UseCompression {
+		compressionKind = d.endpoint.CompressionKind
+	}
 
 	if strings.Contains(d.Metadata().TelemetryName(), "logs") {
 		sourceTag = "logs"
@@ -312,7 +317,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 
 	metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), sourceTag)
 	metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
-	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag)
+	metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
 
 	req, err := http.NewRequest("POST", d.url, bytes.NewReader(payload.Encoded))
 	if err != nil {

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -303,7 +303,7 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	}
 	metrics.BytesSent.Add(int64(payload.UnencodedSize))
 	var sourceTag string
-	var compressionKind string
+	compressionKind := "none"
 
 	if d.endpoint.UseCompression {
 		compressionKind = d.endpoint.CompressionKind

--- a/pkg/logs/client/tcp/destination.go
+++ b/pkg/logs/client/tcp/destination.go
@@ -124,10 +124,12 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 
 		// TCP is only used for logs data, so we always use "logs" as the source tag
 		sourceTag := "logs"
+		// Default Compression for TCP is none
+		compressionKind := "none"
 
 		metrics.TlmBytesSent.Add(float64(payload.UnencodedSize), sourceTag)
 		metrics.EncodedBytesSent.Add(int64(len(payload.Encoded)))
-		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag)
+		metrics.TlmEncodedBytesSent.Add(float64(len(payload.Encoded)), sourceTag, compressionKind)
 		output <- payload
 
 		if d.connManager.ShouldReset(d.connCreationTime) {

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -57,7 +57,7 @@ var (
 	EncodedBytesSent = expvar.Int{}
 	// TlmEncodedBytesSent is the total number of sent bytes after encoding if any
 	TlmEncodedBytesSent = telemetry.NewCounter("logs", "encoded_bytes_sent",
-		[]string{"source"}, "Total number of sent bytes after encoding if any")
+		[]string{"source", "compression_kind"}, "Total number of sent bytes after encoding if any")
 	// BytesMissed is the number of bytes lost before they could be consumed by the agent, such as after a log rotation
 	BytesMissed = expvar.Int{}
 	// TlmBytesMissed is the number of bytes lost before they could be consumed by the agent, such as after log rotation

--- a/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
+++ b/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Adds a new compression_kind tag to the ``logs.encoded_bytes_sent`` telemetry metric, enabling aggregation and monitoring of log compression type usage for rollout monitoring.

--- a/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
+++ b/releasenotes/notes/log-agent-cross-org-telemetry-93a9c76063e51aec.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Adds a new compression_kind tag to the ``logs.encoded_bytes_sent`` telemetry metric, enabling aggregation and monitoring of log compression type usage for rollout monitoring.
+    Adds a compression_kind tag to the ``logs.encoded_bytes_sent`` telemetry metric, enabling aggregation and monitoring of log compression type usage during rollout.


### PR DESCRIPTION
### What does this PR do?
This PR modifies the event platform forwarder to force GZIP compression for DBM (Database Monitoring) events, overriding any existing configuration. This change ensures that DBM events are always compressed using GZIP instead of ZSTD, as the DBM backend currently does not support ZSTD compression.

Changes include:
- Added `forcedCompression` field to `LogsConfigKeys` struct to support compression override
- Added `WithForcedCompression` method to `LogsConfigKeys` to set forced compression
- Modified `compressionKind` method to respect forced compression settings
- Updated all DBM pipeline descriptions to use GZIP compression
- Added appropriate debug logging for compression type changes

### Motivation
The DBM backend currently does not support ZSTD compression, but our default configuration uses ZSTD. 

This causes issues when DBM events are compressed with ZSTD and sent to the backend. 

By forcing GZIP compression specifically for DBM events (and leave options for other events if necessary), we ensure compatibility with the current backend capabilities while allowing other event types to continue using ZSTD compression as configured.

### Describe how you validated your changes
1. Manual Testing:
   - Configured agent with ZSTD compression
   - Verified DBM events are sent with GZIP compression despite ZSTD configuration
   - Verified non-DBM events still use configured compression type
   - Monitored debug logs to confirm correct compression type is being used
   - Verified DBM backend successfully processes the GZIP compressed events

2. Validation Steps:
   ```bash
   # Run the agent with debug logging enabled
   DD_LOG_LEVEL=debug ./bin/agent/agent run

   # Verify compression type in logs
   # Should see "Pipeline database_monitoring.* is using forced compression: gzip"
   # Instead of "Pipeline database_monitoring.* is using compression: zstd"
   ```

### Possible Drawbacks / Trade-offs

### Additional Notes