### PR TITLE
[CXP-2145] Moves the process-discovery enablement tests into process-discovery check file

### DIFF
--- a/pkg/process/checks/enabled_checks_test.go
+++ b/pkg/process/checks/enabled_checks_test.go
@@ -51,35 +51,6 @@ func getEnabledChecks(t *testing.T, cfg, sysprobeYamlConfig pkgconfigmodel.Reade
 	return enabledChecks
 }
 
-func TestProcessDiscovery(t *testing.T) {
-	deps := createProcessCheckDeps(t)
-
-	// Make sure the process_discovery check can be enabled
-	t.Run("enabled", func(t *testing.T) {
-		cfg, sysprobeCfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-		enabledChecks := getEnabledChecks(t, cfg, sysprobeCfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertContainsCheck(t, enabledChecks, DiscoveryCheckName)
-	})
-
-	// Make sure the process_discovery check can be disabled
-	t.Run("disabled", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_discovery.enabled", false)
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
-	})
-
-	// Make sure the process and process_discovery checks are mutually exclusive
-	t.Run("mutual exclusion", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-		cfg.SetWithoutSource("process_config.process_collection.enabled", true)
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
-	})
-}
-
 func TestProcessCheck(t *testing.T) {
 	deps := createProcessCheckDeps(t)
 	t.Run("disabled", func(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
Moves the process-discovery based tests which tests the `IsEnabled()` method to the specific process-discovery check test file.

This is part of the effort to remove the exported [All()](https://github.com/DataDog/datadog-agent/blob/d84840abe8e635729662e77919935c312084fbcb/pkg/process/checks/checks.go#L115) as it is a construct for testing. Check enablement is config based and should not be affected by other checks being created.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->