### PR TITLE
feat: use restrictedSecurityContext by default

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/utils/ptr"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
@@ -437,17 +438,29 @@ func initDefaultResources(datadogConfig config.Component) (initResourceRequireme
 	return conf, nil
 }
 
-func parseInitSecurityContext(datadogConfig config.Component) (*corev1.SecurityContext, error) {
-	securityContext := corev1.SecurityContext{}
-	confKey := "admission_controller.auto_instrumentation.init_security_context"
+var defaultRestrictedSecurityContext = &corev1.SecurityContext{
+	AllowPrivilegeEscalation: ptr.To(false),
+	RunAsNonRoot:             ptr.To(true),
+	SeccompProfile:           &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+	Capabilities: &corev1.Capabilities{
+		Drop: []corev1.Capability{
+			"ALL",
+		},
+	},
+}
 
+func parseInitSecurityContext(datadogConfig config.Component) (*corev1.SecurityContext, error) {
+	confKey := "admission_controller.auto_instrumentation.init_security_context"
 	if datadogConfig.IsSet(confKey) {
 		confValue := datadogConfig.GetString(confKey)
+		var securityContext corev1.SecurityContext
 		err := json.Unmarshal([]byte(confValue), &securityContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get init security context from configuration, %s=`%s`: %v", confKey, confValue, err)
 		}
+
+		return &securityContext, nil
 	}
 
-	return &securityContext, nil
+	return nil, nil
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/dynamic"
 
-	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
@@ -331,15 +330,13 @@ func (m *TargetMutator) getMatchingTarget(pod *corev1.Pod) *targetInternal {
 func (t targetInternal) matchesNamespaceSelector(namespace string) (bool, error) {
 	// If we are using the namespace selector, check if the namespace matches the selector.
 	if t.useNamespaceSelector {
-		// Get the namespace metadata.
-		id := util.GenerateKubeMetadataEntityID("", "namespaces", "", namespace)
-		ns, err := t.wmeta.GetKubernetesMetadata(id)
+		nsLabels, err := getNamespaceLabels(t.wmeta, namespace)
 		if err != nil {
-			return false, fmt.Errorf("could not get kubernetes namespace to match against for %s: %w", namespace, err)
+			return false, fmt.Errorf("could not get labels to match: %w", err)
 		}
 
 		// Check if the namespace labels match the selector.
-		return t.nameSpaceSelector.Matches(labels.Set(ns.EntityMeta.Labels)), nil
+		return t.nameSpaceSelector.Matches(labels.Set(nsLabels)), nil
 	}
 
 	// If there are no match names, we match all namespaces.

--- a/releasenotes-dca/notes/autoinstru-default-security-ctx-324bd66ef3cc24d3.yaml
+++ b/releasenotes-dca/notes/autoinstru-default-security-ctx-324bd66ef3cc24d3.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The autoinstrumentation webhook will now set a default security context for init containers
+    if the pod is in a namespace with a restricted security context.  This can still be overridden by setting
+    the environment variable ``DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_SECURITY_CONTEXT``.


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/INPLAT-492

If we detect that a namespace enforces a restricted security policy we can default to having a restricted securitycontext to apply for the init containers instead of having our users have to provide it as an override.

### Motivation

One fewer issue a customer can run into when setting up SSI in a restricted security environment, we can provide a security context for them.

### Describe how you validated your changes

- Added and updated unit tests. 
- using `injector-dev` to create a namespace with the security policy restriction and testing that pods startup as expected using SSI.

```yaml
apiVersion: v1
kind: Namespace
metadata:
  name: restricted
  labels:
    pod-security.kubernetes.io/enforce: restricted
```

Without this patch, pods will not be started at all.

### Additional Notes

Changed the behavior of `initSecurityContext` to _not be an empty one_, but `nil` when it is not present, this simplifies tests and makes it easier to see if we can override it based on the namespace security policy.
