### PR TITLE
[cmd/cluster-agent] Fail to start DCA if autoscaling enabled and no cluster name

### DIFF
--- a/cmd/cluster-agent/subcommands/start/command.go
+++ b/cmd/cluster-agent/subcommands/start/command.go
@@ -377,6 +377,9 @@ func start(log log.Component,
 		pkglog.Errorf("Failed to generate or retrieve the cluster ID, err: %v", err)
 	}
 	if clusterName == "" {
+		if config.GetBool("autoscaling.workload.enabled") {
+			return fmt.Errorf("Failed to start: autoscaling is enabled but no cluster name detected, exiting")
+		}
 		pkglog.Warn("Failed to auto-detect a Kubernetes cluster name. We recommend you set it manually via the cluster_name config option")
 	}
 	pkglog.Infof("Cluster ID: %s, Cluster Name: %s", clusterID, clusterName)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Prevents the cluster agent from starting up in the case that autoscaling is enabled and no cluster name is detected.

### Motivation

Not having the cluster name causes some weird behavior with autoscaling - failing to start the cluster agent at this point prevents the user from encountering issues during regular operation. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
1. Deployed to minikube with no `clusterName` set
2. Verified that when autoscaling enabled, cluster agent fails to start with log `Failed to start: autoscaling is enabled but no cluster name detected, exiting`
3. Verified that if autoscaling not enabled, cluster agent starts with log `Failed to auto-detect a Kubernetes cluster name. We recommend you set it manually via the cluster_name config option`
4. Verified that if `clusterName` is set, cluster agent starts even if autoscaling enabled
```
datadog:
  clusterName: jenn-test
  apiKeyExistingSecret: datadog-secret
  appKeyExistingSecret: datadog-secret
  logLevel: DEBUG
  logs:
    containerCollectAll: true
    containerCollectUsingFiles: true
    enabled: true
  kubelet:
    tlsVerify: false
  autoscaling:
    workload:
      enabled: true
...
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
A case could be made for failing to start the cluster agent whenever the cluster name is not detected (regardless of whether autoscaling is enabled/not). At this time it is not done.