### PR TITLE
Rename Disk Check Struct to Maintain Consistent Naming

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_common_test.go
@@ -27,14 +27,14 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/utils/e2e/client/agentclient"
 )
 
-type baseCheckSuite struct {
+type diskCheckSuite struct {
 	e2e.BaseSuite[environments.Host]
 	descriptor            e2eos.Descriptor
 	metricCompareFraction float64
 	metricCompareDecimals int
 }
 
-func (v *baseCheckSuite) getSuiteOptions() []e2e.SuiteOption {
+func (v *diskCheckSuite) getSuiteOptions() []e2e.SuiteOption {
 	suiteOptions := []e2e.SuiteOption{}
 	suiteOptions = append(suiteOptions, e2e.WithProvisioner(
 		awshost.Provisioner(
@@ -45,7 +45,7 @@ func (v *baseCheckSuite) getSuiteOptions() []e2e.SuiteOption {
 	return suiteOptions
 }
 
-func (v *baseCheckSuite) TestCheckDisk() {
+func (v *diskCheckSuite) TestCheckDisk() {
 	testCases := []struct {
 		name        string
 		checkConfig string
@@ -118,7 +118,7 @@ func metricPayloadCompare(a, b check.Metric) int {
 	)
 }
 
-func (v *baseCheckSuite) runDiskCheck(agentConfig string, checkConfig string, useNewVersion bool) []check.Metric {
+func (v *diskCheckSuite) runDiskCheck(agentConfig string, checkConfig string, useNewVersion bool) []check.Metric {
 	v.T().Helper()
 
 	diskCheckVersion := "old"

--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_nix_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 )
 
-type linuxStatusSuite struct {
-	baseCheckSuite
+type linuxDiskCheckSuite struct {
+	diskCheckSuite
 }
 
 func TestLinuxDiskSuite(t *testing.T) {
 	t.Parallel()
-	suite := &linuxStatusSuite{baseCheckSuite{descriptor: e2eos.UbuntuDefault, metricCompareFraction: 0.02, metricCompareDecimals: 1}}
+	suite := &linuxDiskCheckSuite{diskCheckSuite{descriptor: e2eos.UbuntuDefault, metricCompareFraction: 0.02, metricCompareDecimals: 1}}
 	e2e.Run(t, suite, suite.getSuiteOptions()...)
 }

--- a/test/new-e2e/tests/agent-runtimes/check_disk/disk_win_test.go
+++ b/test/new-e2e/tests/agent-runtimes/check_disk/disk_win_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
 )
 
-type windowsStatusSuite struct {
-	baseCheckSuite
+type windowsDiskCheckSuite struct {
+	diskCheckSuite
 }
 
 func TestWindowsDiskSuite(t *testing.T) {
 	t.Parallel()
-	suite := &windowsStatusSuite{baseCheckSuite{descriptor: e2eos.WindowsDefault, metricCompareFraction: 0.05, metricCompareDecimals: 1}}
+	suite := &windowsDiskCheckSuite{diskCheckSuite{descriptor: e2eos.WindowsDefault, metricCompareFraction: 0.05, metricCompareDecimals: 1}}
 	e2e.Run(t, suite, suite.getSuiteOptions()...)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR renames the disk check struct to align with the existing naming conventions used across the codebase.

### Motivation

To ensure consistency across check implementations and adhere to internal naming standards.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->