### PR TITLE
Upgrading JMXFetch to 0.49.7

### DIFF
--- a/release.json
+++ b/release.json
@@ -3,8 +3,8 @@
     "current_milestone": "7.67.0",
     "dependencies": {
         "OMNIBUS_RUBY_VERSION": "95630818722a63cb9e6f3163984f363d799633a1",
-        "JMXFETCH_VERSION": "0.49.6",
-        "JMXFETCH_HASH": "f06bdac1f8ec41daf9b9839ac883f1865a068b04810ea82197b8a6afb9369cb9",
+        "JMXFETCH_VERSION": "0.49.7",
+        "JMXFETCH_HASH": "470b1a19933efca4a48157b54ce48ab08a6ec6fb51f0b10337003dc428f50676",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
         "WINDOWS_DDNPM_VERSION": "2.7.1",

--- a/releasenotes/notes/jmxfetch-0.49.7-578d16bad0959d71.yaml
+++ b/releasenotes/notes/jmxfetch-0.49.7-578d16bad0959d71.yaml
@@ -8,6 +8,6 @@
 ---
 upgrade:
   - |
-    Upgraded JMXFetch to `0.49.7 <https://github.com/DataDog/jmxfetch/releases/0.49.7>`_ which switches from snakeyaml to snakeyaml-engine,
+    Upgraded JMXFetch to `0.49.7 <https://github.com/DataDog/jmxfetch/releases/0.49.7>` which switches from snakeyaml to snakeyaml-engine,
     adding support for YAML 1.2.
-    See `0.49.7  <https://github.com/DataDog/jmxfetch/releases/tag/0.49.7>`_ for more details.
+    See `0.49.7  <https://github.com/DataDog/jmxfetch/releases/tag/0.49.7>` for more details.

--- a/releasenotes/notes/jmxfetch-0.49.7-578d16bad0959d71.yaml
+++ b/releasenotes/notes/jmxfetch-0.49.7-578d16bad0959d71.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+upgrade:
+  - |
+    Upgraded JMXFetch to `0.49.7 <https://github.com/DataDog/jmxfetch/releases/0.49.7>`_ which switches from snakeyaml to snakeyaml-engine,
+    adding support for YAML 1.2.
+    See `0.49.7  <https://github.com/DataDog/jmxfetch/releases/tag/0.49.7>`_ for more details.


### PR DESCRIPTION
### What does this PR do?

This PR updates JMXFetch to version `0.49.7`

### Motivation

This adds support for YAML 1.2.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

Update the misbehaving-jmx-server docker-compose ([link](https://github.com/DataDog/jmxfetch/tree/master/tools/misbehaving-jmx-server)) to use the new RC or dev image and ensure that metrics are collected properly.
