### PR TITLE
Convert Oracle session_type FOREGROUND to USER

### DIFF
--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -204,6 +204,9 @@ AND status = 'ACTIVE'`)
 
 		sessionType := ""
 		if sample.Type.Valid {
+			if sample.Type.String == "FOREGROUND" {
+				sample.Type.String = "USER"
+			}
 			sessionRow.Type = sample.Type.String
 			sessionType = sample.Type.String
 		}

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -114,15 +114,16 @@ func TestActiveSessionHistory(t *testing.T) {
 	c, _ := newDefaultCheck(t, "", "")
 	defer c.Teardown()
 
+	var err error
 	var count uint64
-	getWrapper(&c, &count, "SELECT BANNER FROM V$VERSION WHERE BANNER LIKE '%Enterprise%Edition%'")
-	if count == 0 {
+	getWrapper(&c, &count, "SELECT count(*) FROM V$VERSION WHERE BANNER LIKE '%Enterprise%Edition%'")
+	if count != 0 {
 		t.Skip("Active Session History is only available in Oracle Enterprise Edition")
 	}
 	c.dbmEnabled = true
 	c.config.QuerySamples.ActiveSessionHistory = true
 
-	err := c.Run()
+	err = c.Run()
 	assert.NoError(t, err, "check run")
 
 	err = c.SampleSession()
@@ -152,4 +153,12 @@ END;`
 	require.NoError(t, err, "activity sample failed")
 
 	assert.Greater(t, c.lastSampleID, prevSamplId, "sample id should have increased")
+
+	for _, r := range c.lastOracleActivityRows {
+		assert.True(t, isValidSessionType(r.Type), "invalid session type: %s", r.Type)
+	}
+}
+
+func isValidSessionType(sessionType string) bool {
+	return sessionType == "USER1" || sessionType == "BACKGROUND1"
 }

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -117,7 +117,7 @@ func TestActiveSessionHistory(t *testing.T) {
 	var err error
 	var count uint64
 	getWrapper(&c, &count, "SELECT count(*) FROM V$VERSION WHERE BANNER LIKE '%Enterprise%Edition%'")
-	if count != 0 {
+	if count == 0 {
 		t.Skip("Active Session History is only available in Oracle Enterprise Edition")
 	}
 	c.dbmEnabled = true
@@ -160,5 +160,5 @@ END;`
 }
 
 func isValidSessionType(sessionType string) bool {
-	return sessionType == "USER1" || sessionType == "BACKGROUND1"
+	return sessionType == "USER" || sessionType == "BACKGROUND"
 }

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -36,8 +36,8 @@ const (
 )
 
 const (
-	expectedSessionsDefault           = 3
-	expectedSessionsWithCustomQueries = 3
+	expectedSessionsDefault           = 6
+	expectedSessionsWithCustomQueries = 6
 )
 
 func getConnectData(t *testing.T, userType int) config.ConnectionConfig {
@@ -167,10 +167,6 @@ func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceC
 		c.config.InstanceConfig.OracleClient = true
 	}
 
-	var n int
-	err = getWrapper(&c, &n, "select 1 from dual")
-	require.NoError(t, err, "can't execute a test query")
-
 	return c, sender
 }
 
@@ -181,7 +177,13 @@ func newLegacyCheck(t *testing.T, instanceConfigAddition string, initConfig stri
 }
 
 func newDefaultCheck(t *testing.T, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {
-	return newTestCheck(t, getConnectData(t, useDefaultUser), instanceConfigAddition, initConfig)
+	c, m := newTestCheck(t, getConnectData(t, useDefaultUser), instanceConfigAddition, initConfig)
+	var err error
+	var n int
+	err = getWrapper(&c, &n, "select 1 from dual")
+	require.NoError(t, err, "can't execute a test query")
+
+	return c, m
 }
 
 func newSysCheck(t *testing.T, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -167,6 +167,10 @@ func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceC
 		c.config.InstanceConfig.OracleClient = true
 	}
 
+	var n int
+	err = getWrapper(&c, &n, "select 1 from dual")
+	require.NoError(t, err, "can't execute a test query")
+
 	return c, sender
 }
 

--- a/releasenotes/notes/oracle-active-session-history-2e41089ce2d473f5.yaml
+++ b/releasenotes/notes/oracle-active-session-history-2e41089ce2d473f5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [oracle]: Fix Active Connections with ``active_session_history: true``.


### PR DESCRIPTION
### What does this PR do?

Convert Oracle `session_type` `FOREGROUND` to `USER`.

### Motivation

When selecting activity samples from `v$active_session_history` the Agent was emitting `session_type` `FORGROUND` for `USER` sessions. As a consequence, active sessions weren't properly rendered in the UI.

### Describe how you validated your changes

![image](https://github.com/user-attachments/assets/b2fd2cec-5ed8-43e1-8496-238e0d29150a)

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->