### PR TITLE
[EBPF-702] gpu: convert ddnvml.Device to an interface

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -219,7 +219,7 @@ func (c *Check) processSysprobeStats(snd sender.Sender, stats model.GPUStats, gp
 	// map each device UUID to the set of tags corresponding to entities (processes) using it
 	activeEntitiesPerDevice := make(map[string]common.StringSet)
 	for _, dev := range c.deviceCache.All() {
-		activeEntitiesPerDevice[dev.UUID] = common.NewStringSet()
+		activeEntitiesPerDevice[dev.GetDeviceInfo().UUID] = common.NewStringSet()
 	}
 
 	// Emit the usage metrics
@@ -269,11 +269,12 @@ func (c *Check) processSysprobeStats(snd sender.Sender, stats model.GPUStats, gp
 	// workloadmeta store, as the latter might not be up-to-date and we want these limit metrics
 	// to match the usage metrics reported above
 	for _, dev := range c.deviceCache.All() {
-		deviceTags := c.deviceTags[dev.UUID]
+		devInfo := dev.GetDeviceInfo()
+		deviceTags := c.deviceTags[devInfo.UUID]
 
 		// Retrieve the tags for all the active processes on this device. This will include pid, container
 		// tags and will enable matching between the usage of an entity and the corresponding limit.
-		activeEntitiesTags := activeEntitiesPerDevice[dev.UUID]
+		activeEntitiesTags := activeEntitiesPerDevice[devInfo.UUID]
 		if activeEntitiesTags == nil {
 			// Might be nil if there are no active processes on this device
 			activeEntitiesTags = common.NewStringSet()
@@ -282,7 +283,7 @@ func (c *Check) processSysprobeStats(snd sender.Sender, stats model.GPUStats, gp
 		// Also, add the tags for all containers that have this GPU allocated. Add to the set to avoid repetitions.
 		// Adding this ensures we correctly report utilization even if some of the GPUs allocated to the container
 		// are not being used.
-		for _, container := range gpuToContainersMap[dev.UUID] {
+		for _, container := range gpuToContainersMap[devInfo.UUID] {
 			for _, tag := range c.getContainerTags(container.EntityID.ID) {
 				activeEntitiesTags.Add(tag)
 			}
@@ -290,8 +291,8 @@ func (c *Check) processSysprobeStats(snd sender.Sender, stats model.GPUStats, gp
 
 		allTags := append(deviceTags, activeEntitiesTags.GetAll()...)
 
-		snd.Gauge(metricNameCoreLimit, float64(dev.CoreCount), "", allTags)
-		snd.Gauge(metricNameMemoryLimit, float64(dev.Memory), "", allTags)
+		snd.Gauge(metricNameCoreLimit, float64(devInfo.CoreCount), "", allTags)
+		snd.Gauge(metricNameMemoryLimit, float64(devInfo.Memory), "", allTags)
 	}
 
 	return nil

--- a/pkg/collector/corechecks/gpu/nvidia/collector.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector.go
@@ -91,7 +91,7 @@ func buildCollectors(deps *CollectorDependencies, builders map[CollectorName]sub
 		for name, builder := range builders {
 			c, err := builder(dev)
 			if errors.Is(err, errUnsupportedDevice) {
-				log.Warnf("device %s does not support collector %s", dev.UUID, name)
+				log.Warnf("device %s does not support collector %s", dev.GetDeviceInfo().UUID, name)
 				continue
 			} else if err != nil {
 				log.Warnf("failed to create collector %s: %s", name, err)
@@ -115,19 +115,20 @@ func GetDeviceTagsMapping(deviceCache ddnvml.DeviceCache, tagger tagger.Componen
 	tagsMapping := make(map[string][]string, devCount)
 
 	for _, dev := range deviceCache.All() {
-		entityID := taggertypes.NewEntityID(taggertypes.GPU, dev.UUID)
+		uuid := dev.GetDeviceInfo().UUID
+		entityID := taggertypes.NewEntityID(taggertypes.GPU, uuid)
 		tags, err := tagger.Tag(entityID, taggertypes.ChecksConfigCardinality)
 		if err != nil {
-			log.Warnf("Error collecting GPU tags for GPU UUID %s: %s", dev.UUID, err)
+			log.Warnf("Error collecting GPU tags for GPU UUID %s: %s", uuid, err)
 		}
 
 		if len(tags) == 0 {
 			// If we get no tags (either WMS hasn't collected GPUs yet, or we are running the check standalone with 'agent check')
 			// add at least the UUID as a tag to distinguish the values.
-			tags = []string{fmt.Sprintf("gpu_uuid:%s", dev.UUID)}
+			tags = []string{fmt.Sprintf("gpu_uuid:%s", uuid)}
 		}
 
-		tagsMapping[dev.UUID] = tags
+		tagsMapping[uuid] = tags
 	}
 
 	return tagsMapping

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -41,7 +41,7 @@ type systemContext struct {
 
 	// visibleDevicesCache is a cache of visible devices for each process, to avoid
 	// looking into the environment variables every time
-	visibleDevicesCache map[int][]*ddnvml.Device
+	visibleDevicesCache map[int][]ddnvml.Device
 
 	// workloadmeta is the workloadmeta component that we use to get necessary container metadata
 	workloadmeta workloadmeta.Component
@@ -107,7 +107,7 @@ func getSystemContext(optList ...systemContextOption) (*systemContext, error) {
 	ctx := &systemContext{
 		procRoot:                  opts.procRoot,
 		selectedDeviceByPIDAndTID: make(map[int]map[int]int32),
-		visibleDevicesCache:       make(map[int][]*ddnvml.Device),
+		visibleDevicesCache:       make(map[int][]ddnvml.Device),
 		workloadmeta:              opts.wmeta,
 	}
 
@@ -154,7 +154,7 @@ func (ctx *systemContext) cleanOld() {
 // container. If the ID is not empty, we check the assignment of GPU resources
 // to the container and return only the devices that are available to the
 // container.
-func (ctx *systemContext) filterDevicesForContainer(devices []*ddnvml.Device, containerID string) ([]*ddnvml.Device, error) {
+func (ctx *systemContext) filterDevicesForContainer(devices []ddnvml.Device, containerID string) ([]ddnvml.Device, error) {
 	if containerID == "" {
 		// If the process is not running in a container, we assume all devices are available.
 		return devices, nil
@@ -174,7 +174,7 @@ func (ctx *systemContext) filterDevicesForContainer(devices []*ddnvml.Device, co
 		return nil, fmt.Errorf("cannot retrieve data for container %s: %s", containerID, err)
 	}
 
-	var filteredDevices []*ddnvml.Device
+	var filteredDevices []ddnvml.Device
 	numContainerGPUs := 0
 	for _, resource := range container.AllocatedResources {
 		// Only consider NVIDIA GPUs
@@ -185,7 +185,7 @@ func (ctx *systemContext) filterDevicesForContainer(devices []*ddnvml.Device, co
 		numContainerGPUs++
 
 		for _, device := range devices {
-			if resource.ID == device.UUID {
+			if resource.ID == device.GetDeviceInfo().UUID {
 				filteredDevices = append(filteredDevices, device)
 				break
 			}
@@ -225,7 +225,7 @@ func (ctx *systemContext) filterDevicesForContainer(devices []*ddnvml.Device, co
 // does the expensive operations of looking into the process state and filtering devices one time for each process
 // containerIDFunc is a function that returns the container ID for the given process. As retrieving the container ID
 // might be expensive, we pass a function that can be called to retrieve it only when needed
-func (ctx *systemContext) getCurrentActiveGpuDevice(pid int, tid int, containerIDFunc func() string) (*ddnvml.Device, error) {
+func (ctx *systemContext) getCurrentActiveGpuDevice(pid int, tid int, containerIDFunc func() string) (ddnvml.Device, error) {
 	visibleDevices, ok := ctx.visibleDevicesCache[pid]
 	if !ok {
 		containerID := containerIDFunc()

--- a/pkg/gpu/cuda/env.go
+++ b/pkg/gpu/cuda/env.go
@@ -36,7 +36,7 @@ const cudaVisibleDevicesEnvVar = "CUDA_VISIBLE_DEVICES"
 // devices whose index precedes the invalid index are visible to CUDA
 // applications." If an invalid index is found, an error is returned together
 // with the list of valid devices found up until that point.
-func GetVisibleDevicesForProcess(systemDevices []*ddnvml.Device, pid int, procfs string) ([]*ddnvml.Device, error) {
+func GetVisibleDevicesForProcess(systemDevices []ddnvml.Device, pid int, procfs string) ([]ddnvml.Device, error) {
 	cudaVisibleDevices, err := kernel.GetProcessEnvVariable(pid, procfs, cudaVisibleDevicesEnvVar)
 	if err != nil {
 		return nil, fmt.Errorf("cannot get env var %s for process %d: %w", cudaVisibleDevicesEnvVar, pid, err)
@@ -47,16 +47,16 @@ func GetVisibleDevicesForProcess(systemDevices []*ddnvml.Device, pid int, procfs
 
 // getVisibleDevices processes the list of GPU devices according to the value of
 // the CUDA_VISIBLE_DEVICES environment variable
-func getVisibleDevices(systemDevices []*ddnvml.Device, cudaVisibleDevices string) ([]*ddnvml.Device, error) {
+func getVisibleDevices(systemDevices []ddnvml.Device, cudaVisibleDevices string) ([]ddnvml.Device, error) {
 	if cudaVisibleDevices == "" {
 		return systemDevices, nil
 	}
 
-	var filteredDevices []*ddnvml.Device
+	var filteredDevices []ddnvml.Device
 	visibleDevicesList := strings.Split(cudaVisibleDevices, ",")
 
 	for _, visibleDevice := range visibleDevicesList {
-		var matchingDevice *ddnvml.Device
+		var matchingDevice ddnvml.Device
 		var err error
 		switch {
 		case strings.HasPrefix(visibleDevice, "GPU-"):
@@ -84,17 +84,17 @@ func getVisibleDevices(systemDevices []*ddnvml.Device, cudaVisibleDevices string
 // getDeviceWithMatchingUUIDPrefix returns the first device with a UUID that
 // matches the given prefix. If there are multiple devices with the same prefix
 // or the device is not found, an error is returned.
-func getDeviceWithMatchingUUIDPrefix(systemDevices []*ddnvml.Device, uuidPrefix string) (*ddnvml.Device, error) {
-	var matchingDevice *ddnvml.Device
+func getDeviceWithMatchingUUIDPrefix(systemDevices []ddnvml.Device, uuidPrefix string) (ddnvml.Device, error) {
+	var matchingDevice ddnvml.Device
 	var matchingDeviceUUID string
 
 	for _, device := range systemDevices {
-		if strings.HasPrefix(device.UUID, uuidPrefix) {
+		if strings.HasPrefix(device.GetDeviceInfo().UUID, uuidPrefix) {
 			if matchingDevice != nil {
-				return nil, fmt.Errorf("non-unique UUID prefix %s, found UUIDs %s and %s", uuidPrefix, matchingDeviceUUID, device.UUID)
+				return nil, fmt.Errorf("non-unique UUID prefix %s, found UUIDs %s and %s", uuidPrefix, matchingDeviceUUID, device.GetDeviceInfo().UUID)
 			}
 			matchingDevice = device
-			matchingDeviceUUID = device.UUID
+			matchingDeviceUUID = device.GetDeviceInfo().UUID
 		}
 	}
 
@@ -107,7 +107,7 @@ func getDeviceWithMatchingUUIDPrefix(systemDevices []*ddnvml.Device, uuidPrefix 
 
 // getDeviceWithIndex returns the device with the given index. If the index is
 // out of range or the index is not a number, an error is returned.
-func getDeviceWithIndex(systemDevices []*ddnvml.Device, visibleDevice string) (*ddnvml.Device, error) {
+func getDeviceWithIndex(systemDevices []ddnvml.Device, visibleDevice string) (ddnvml.Device, error) {
 	idx, err := strconv.Atoi(visibleDevice)
 	if err != nil {
 		return nil, fmt.Errorf("invalid device index %s: %w", visibleDevice, err)

--- a/pkg/gpu/cuda/env_test.go
+++ b/pkg/gpu/cuda/env_test.go
@@ -20,19 +20,23 @@ func TestGetVisibleDevices(t *testing.T) {
 	uuid1 := commonPrefix + "32f937-d72c-4106-c12f-20bd9faed9f6"
 	uuid2 := commonPrefix + "02f078-a8da-4036-a78f-4032bbddeaf2"
 
-	dev1 := &ddnvml.Device{
-		UUID: uuid1,
+	dev1 := &ddnvml.PhysicalDevice{
+		DeviceInfo: ddnvml.DeviceInfo{
+			UUID: uuid1,
+		},
 	}
 
-	dev2 := &ddnvml.Device{
-		UUID: uuid2,
+	dev2 := &ddnvml.PhysicalDevice{
+		DeviceInfo: ddnvml.DeviceInfo{
+			UUID: uuid2,
+		},
 	}
 
-	devList := []*ddnvml.Device{dev1, dev2}
+	devList := []ddnvml.Device{dev1, dev2}
 	cases := []struct {
 		name            string
 		visibleDevices  string
-		expectedDevices []*ddnvml.Device
+		expectedDevices []ddnvml.Device
 		expectsError    bool
 	}{
 		{
@@ -44,13 +48,13 @@ func TestGetVisibleDevices(t *testing.T) {
 		{
 			name:            "UUIDs",
 			visibleDevices:  uuid1,
-			expectedDevices: []*ddnvml.Device{devList[0]},
+			expectedDevices: []ddnvml.Device{devList[0]},
 			expectsError:    false,
 		},
 		{
 			name:            "Index",
 			visibleDevices:  "1",
-			expectedDevices: []*ddnvml.Device{devList[1]},
+			expectedDevices: []ddnvml.Device{devList[1]},
 			expectsError:    false,
 		},
 		{
@@ -74,19 +78,19 @@ func TestGetVisibleDevices(t *testing.T) {
 		{
 			name:            "UnorderedIndexes",
 			visibleDevices:  "1,0",
-			expectedDevices: []*ddnvml.Device{devList[1], devList[0]},
+			expectedDevices: []ddnvml.Device{devList[1], devList[0]},
 			expectsError:    false,
 		},
 		{
 			name:            "MixedIndexesAndUUIDs",
 			visibleDevices:  "0," + uuid2,
-			expectedDevices: []*ddnvml.Device{devList[0], devList[1]},
+			expectedDevices: []ddnvml.Device{devList[0], devList[1]},
 			expectsError:    false,
 		},
 		{
 			name:            "InvalidIndexInMiddle",
 			visibleDevices:  "0,235,1",
-			expectedDevices: []*ddnvml.Device{devList[0]},
+			expectedDevices: []ddnvml.Device{devList[0]},
 			expectsError:    true,
 		},
 		{

--- a/pkg/gpu/safenvml/cache.go
+++ b/pkg/gpu/safenvml/cache.go
@@ -16,23 +16,23 @@ import (
 // DeviceCache is a cache of GPU devices, with some methods to easily access devices by UUID or index
 type DeviceCache interface {
 	// GetByUUID returns a device by its UUID
-	GetByUUID(uuid string) (*Device, bool)
+	GetByUUID(uuid string) (Device, bool)
 	// GetByIndex returns a device by its index
-	GetByIndex(index int) (*Device, error)
+	GetByIndex(index int) (Device, error)
 	// Count returns the number of devices in the cache
 	Count() int
 	// SMVersionSet returns a set of all SM versions in the cache
 	SMVersionSet() map[uint32]struct{}
 	// All returns all devices in the cache
-	All() []*Device
+	All() []Device
 	// Cores returns the number of cores for a device with a given UUID. Returns an error if the device is not found.
 	Cores(uuid string) (uint64, error)
 }
 
 // deviceCache is an implementation of DeviceCache
 type deviceCache struct {
-	allDevices   []*Device
-	uuidToDevice map[string]*Device
+	allDevices   []Device
+	uuidToDevice map[string]Device
 	smVersionSet map[uint32]struct{}
 }
 
@@ -49,7 +49,7 @@ func NewDeviceCache() (DeviceCache, error) {
 // NewDeviceCacheWithOptions creates a new DeviceCache with an already initialized NVML library
 func NewDeviceCacheWithOptions(lib SafeNVML) (DeviceCache, error) {
 	cache := &deviceCache{
-		uuidToDevice: make(map[string]*Device),
+		uuidToDevice: make(map[string]Device),
 		smVersionSet: make(map[uint32]struct{}),
 	}
 
@@ -66,7 +66,7 @@ func NewDeviceCacheWithOptions(lib SafeNVML) (DeviceCache, error) {
 		}
 
 		// Convert from SafeDevice to *Device
-		dev, ok := nvmlDev.(*Device)
+		dev, ok := nvmlDev.(*PhysicalDevice)
 		if !ok {
 			// This should never happen
 			log.Warnf("error converting device at index %d to *Device", i)
@@ -82,13 +82,13 @@ func NewDeviceCacheWithOptions(lib SafeNVML) (DeviceCache, error) {
 }
 
 // GetByUUID returns a device by its UUID
-func (c *deviceCache) GetByUUID(uuid string) (*Device, bool) {
+func (c *deviceCache) GetByUUID(uuid string) (Device, bool) {
 	device, ok := c.uuidToDevice[uuid]
 	return device, ok
 }
 
 // GetByIndex returns a device by its index in the host
-func (c *deviceCache) GetByIndex(index int) (*Device, error) {
+func (c *deviceCache) GetByIndex(index int) (Device, error) {
 	if index < 0 || index >= len(c.allDevices) {
 		return nil, fmt.Errorf("index %d out of range", index)
 	}
@@ -107,7 +107,7 @@ func (c *deviceCache) SMVersionSet() map[uint32]struct{} {
 }
 
 // All returns all devices in the cache
-func (c *deviceCache) All() []*Device {
+func (c *deviceCache) All() []Device {
 	return c.allDevices
 }
 
@@ -117,5 +117,5 @@ func (c *deviceCache) Cores(uuid string) (uint64, error) {
 	if !ok {
 		return 0, fmt.Errorf("device %s not found", uuid)
 	}
-	return uint64(device.CoreCount), nil
+	return uint64(device.GetDeviceInfo().CoreCount), nil
 }

--- a/pkg/gpu/safenvml/cache_test.go
+++ b/pkg/gpu/safenvml/cache_test.go
@@ -66,11 +66,11 @@ func TestDeviceCachePartialFailure(t *testing.T) {
 	// Verify we can get the working devices
 	device0, ok := cache.GetByUUID(testutil.GPUUUIDs[0])
 	require.True(t, ok)
-	require.Equal(t, 0, device0.Index)
+	require.Equal(t, 0, device0.GetDeviceInfo().Index)
 
 	device1, ok := cache.GetByUUID(testutil.GPUUUIDs[1])
 	require.True(t, ok)
-	require.Equal(t, 1, device1.Index)
+	require.Equal(t, 1, device1.GetDeviceInfo().Index)
 
 	// Verify we can't get the failed device
 	_, ok = cache.GetByUUID("non-existent-uuid")
@@ -94,7 +94,7 @@ func TestDeviceCacheGetByIndex(t *testing.T) {
 	// Test get by index
 	device, err := cache.GetByIndex(0)
 	require.NoError(t, err)
-	require.Equal(t, 0, device.Index)
+	require.Equal(t, 0, device.GetDeviceInfo().Index)
 
 	// Test with invalid index
 	_, err = cache.GetByIndex(-1)
@@ -147,9 +147,9 @@ func TestDeviceCacheAll(t *testing.T) {
 	require.Len(t, devices, len(testutil.GPUUUIDs))
 
 	for i, device := range devices {
-		require.Equal(t, testutil.GPUUUIDs[i], device.UUID)
-		require.Equal(t, testutil.GPUCores[i], device.CoreCount)
-		require.Equal(t, i, device.Index)
+		require.Equal(t, testutil.GPUUUIDs[i], device.GetDeviceInfo().UUID)
+		require.Equal(t, testutil.GPUCores[i], device.GetDeviceInfo().CoreCount)
+		require.Equal(t, i, device.GetDeviceInfo().Index)
 	}
 }
 

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -95,6 +95,8 @@ type DeviceInfo struct {
 	// Memory size of the device in bytes
 	Memory uint64
 }
+
+// Device represents a GPU device, implementing SafeDevice and providing common device info
 type Device interface {
 	SafeDevice
 
@@ -155,6 +157,7 @@ func NewPhysicalDevice(dev nvml.Device) (*PhysicalDevice, error) {
 	return device, nil
 }
 
+// GetDeviceInfo returns the common device info for a GPU device
 func (d *PhysicalDevice) GetDeviceInfo() *DeviceInfo {
 	return &d.DeviceInfo
 }

--- a/pkg/gpu/safenvml/device.go
+++ b/pkg/gpu/safenvml/device.go
@@ -7,7 +7,11 @@
 
 package safenvml
 
-import "github.com/NVIDIA/go-nvml/pkg/nvml"
+import (
+	"fmt"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
 
 // SafeDevice represents a safe wrapper around NVML device operations.
 // It ensures that operations are only performed when the corresponding
@@ -78,22 +82,36 @@ type SafeDevice interface {
 	GetUtilizationRates() (nvml.Utilization, error)
 }
 
-// Device represents a GPU device with some properties already computed.
-// It embeds SafeDevice for safe API access and contains cached properties.
-type Device struct {
-	SafeDevice
-
-	// Cached fields for quick access
+// DeviceInfo holds common cached properties for a GPU device
+type DeviceInfo struct {
 	SMVersion uint32
 	UUID      string
 	Name      string
 	CoreCount int
-	Index     int
-	Memory    uint64
+
+	// Index of the device in the host. For MIG devices, this is the index of the MIG device in the parent device.
+	Index int
+
+	// Memory size of the device in bytes
+	Memory uint64
+}
+type Device interface {
+	SafeDevice
+
+	// GetDeviceInfo returns the common device info for a GPU device
+	GetDeviceInfo() *DeviceInfo
 }
 
-// NewDevice creates a new Device from the nvml.Device and caches some properties
-func NewDevice(dev nvml.Device) (*Device, error) {
+// PhysicalDevice represents a physical GPU device
+type PhysicalDevice struct {
+	SafeDevice
+	DeviceInfo
+}
+
+var _ Device = &PhysicalDevice{}
+
+// NewPhysicalDevice creates a new Device from the nvml.Device and caches some properties.
+func NewPhysicalDevice(dev nvml.Device) (*PhysicalDevice, error) {
 	lib, err := GetSafeNvmlLib()
 	if err != nil {
 		return nil, err
@@ -106,46 +124,58 @@ func NewDevice(dev nvml.Device) (*Device, error) {
 	}
 
 	// Create the device with embedded safe device
-	device := &Device{
+	device := &PhysicalDevice{
 		SafeDevice: safeDev,
 	}
 
-	// Now use safe methods to populate the cached fields
-	major, minor, err := safeDev.GetCudaComputeCapability()
+	if err := device.fillBasicDataFromNVML(safeDev); err != nil {
+		return nil, fmt.Errorf("error filling basic data from NVML: %w", err)
+	}
+
+	major, minor, err := device.SafeDevice.GetCudaComputeCapability()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error getting CUDA compute capability: %w", err)
 	}
 	device.SMVersion = uint32(major*10 + minor)
 
-	uuid, err := safeDev.GetUUID()
+	// Get the number of cores and memory size. This is not part of the fillBasicDataFromNVML
+	// because it might not work for MIG devices.
+	cores, err := device.SafeDevice.GetNumGpuCores()
 	if err != nil {
 		return nil, err
 	}
-	device.UUID = uuid
+	device.CoreCount = int(cores)
 
-	cores, err := safeDev.GetNumGpuCores()
-	if err != nil {
-		return nil, err
-	}
-	device.CoreCount = cores
-
-	name, err := safeDev.GetName()
-	if err != nil {
-		return nil, err
-	}
-	device.Name = name
-
-	index, err := safeDev.GetIndex()
-	if err != nil {
-		return nil, err
-	}
-	device.Index = index
-
-	memInfo, err := safeDev.GetMemoryInfo()
+	memInfo, err := device.SafeDevice.GetMemoryInfo()
 	if err != nil {
 		return nil, err
 	}
 	device.Memory = memInfo.Total
 
 	return device, nil
+}
+
+func (d *PhysicalDevice) GetDeviceInfo() *DeviceInfo {
+	return &d.DeviceInfo
+}
+
+// fillBasicDataFromNVML fills the basic data (common for MIG and non-MIG) for a device from the nvml.Device object
+func (d *DeviceInfo) fillBasicDataFromNVML(dev SafeDevice) error {
+	var err error
+	d.UUID, err = dev.GetUUID()
+	if err != nil {
+		return err
+	}
+
+	d.Name, err = dev.GetName()
+	if err != nil {
+		return err
+	}
+
+	d.Index, err = dev.GetIndex()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/gpu/safenvml/device_impl.go
+++ b/pkg/gpu/safenvml/device_impl.go
@@ -157,7 +157,10 @@ func (d *safeDeviceImpl) GetMigDeviceHandleByIndex(index int) (SafeDevice, error
 	if err := NewNvmlAPIErrorOrNil("GetMigDeviceHandleByIndex", ret); err != nil {
 		return nil, err
 	}
-	return NewDevice(device)
+	return &safeDeviceImpl{
+		nvmlDevice: device,
+		lib:        d.lib,
+	}, nil
 }
 
 // GetMigMode returns the MIG mode of the device

--- a/pkg/gpu/safenvml/device_impl_test.go
+++ b/pkg/gpu/safenvml/device_impl_test.go
@@ -30,7 +30,7 @@ func TestNewDevice(t *testing.T) {
 
 	// Test device creation
 	mockDevice := testutil.GetDeviceMock(0)
-	device, err := NewDevice(mockDevice)
+	device, err := NewPhysicalDevice(mockDevice)
 
 	// Verify results
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestNewDeviceUUIDFailure(t *testing.T) {
 	}
 
 	// Test device creation with failing UUID
-	device, err := NewDevice(failingMockDevice)
+	device, err := NewPhysicalDevice(failingMockDevice)
 
 	// Verify failure
 	require.Error(t, err)
@@ -98,7 +98,7 @@ func TestDeviceWithMissingSymbol(t *testing.T) {
 
 	// Create device
 	mockDevice := testutil.GetDeviceMock(0)
-	device, err := NewDevice(mockDevice)
+	device, err := NewPhysicalDevice(mockDevice)
 	require.NoError(t, err)
 	require.NotNil(t, device)
 
@@ -127,7 +127,7 @@ func TestDeviceSafeMethodSuccess(t *testing.T) {
 
 	// Create device
 	mockDevice := testutil.GetDeviceMock(0)
-	device, err := NewDevice(mockDevice)
+	device, err := NewPhysicalDevice(mockDevice)
 	require.NoError(t, err)
 	require.NotNil(t, device)
 

--- a/pkg/gpu/safenvml/lib.go
+++ b/pkg/gpu/safenvml/lib.go
@@ -145,7 +145,7 @@ func (s *safeNvml) DeviceGetHandleByIndex(idx int) (SafeDevice, error) {
 	if err := NewNvmlAPIErrorOrNil("DeviceGetHandleByIndex", ret); err != nil {
 		return nil, err
 	}
-	return NewDevice(dev)
+	return NewPhysicalDevice(dev)
 }
 
 // populateCapabilities verifies nvml API symbols exist in the native library (libnvidia-ml.so).

--- a/pkg/gpu/safenvml/testutil/nvml.go
+++ b/pkg/gpu/safenvml/testutil/nvml.go
@@ -20,10 +20,10 @@ import (
 )
 
 // ToDDNVMLDevices converts a slice of nvml.Device to a slice of ddnvml.Device
-func ToDDNVMLDevices(t testing.TB, devices []nvml.Device) []*ddnvml.Device {
-	ddnvmlDevices := make([]*ddnvml.Device, len(devices))
+func ToDDNVMLDevices(t testing.TB, devices []nvml.Device) []ddnvml.Device {
+	ddnvmlDevices := make([]ddnvml.Device, len(devices))
 	for i, dev := range devices {
-		dev, err := ddnvml.NewDevice(dev)
+		dev, err := ddnvml.NewPhysicalDevice(dev)
 		require.NoError(t, err, "error converting nvml.Device %d to ddnvml.Device", i)
 		ddnvmlDevices[i] = dev
 	}
@@ -31,8 +31,8 @@ func ToDDNVMLDevices(t testing.TB, devices []nvml.Device) []*ddnvml.Device {
 }
 
 // GetDDNVMLMocksWithIndexes returns a slice of ddnvml.Device mocks with the given indexes
-func GetDDNVMLMocksWithIndexes(t testing.TB, indexes ...int) []*ddnvml.Device {
-	devices := make([]*ddnvml.Device, len(indexes))
+func GetDDNVMLMocksWithIndexes(t testing.TB, indexes ...int) []ddnvml.Device {
+	devices := make([]ddnvml.Device, len(indexes))
 	for i, idx := range indexes {
 		devices[i] = GetDDNVMLMockWithIndex(t, idx)
 	}
@@ -41,27 +41,27 @@ func GetDDNVMLMocksWithIndexes(t testing.TB, indexes ...int) []*ddnvml.Device {
 
 // GetDDNVMLMockWithIndex returns a ddnvml.Device mock with the given index, based on the data
 // present in mocks.go
-func GetDDNVMLMockWithIndex(t testing.TB, index int) *ddnvml.Device {
+func GetDDNVMLMockWithIndex(t testing.TB, index int) ddnvml.Device {
 	dev := testutil.GetDeviceMock(index)
-	dddev, err := ddnvml.NewDevice(dev)
+	dddev, err := ddnvml.NewPhysicalDevice(dev)
 	require.NoError(t, err, "error converting nvml.Device to ddnvml.Device")
 	return dddev
 }
 
 // RequireDevicesEqual checks that the two devices are equal by comparing their UUIDs, which gives a better
 // output than using require.Equal on the devices themselves
-func RequireDevicesEqual(t *testing.T, expected, actual *ddnvml.Device, msgAndArgs ...interface{}) {
+func RequireDevicesEqual(t *testing.T, expected, actual ddnvml.Device, msgAndArgs ...interface{}) {
 	extraFmt := ""
 	if len(msgAndArgs) > 0 {
 		extraFmt = fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...) + ": "
 	}
 
-	require.Equal(t, expected.UUID, actual.UUID, "%sUUIDs do not match", extraFmt)
+	require.Equal(t, expected.GetDeviceInfo().UUID, actual.GetDeviceInfo().UUID, "%sUUIDs do not match", extraFmt)
 }
 
 // RequireDeviceListsEqual checks that the two device lists are equal by comparing their UUIDs, which gives a better
 // output than using require.ElementsMatch on the lists themselves
-func RequireDeviceListsEqual(t *testing.T, expected, actual []*ddnvml.Device, msgAndArgs ...interface{}) {
+func RequireDeviceListsEqual(t *testing.T, expected, actual []ddnvml.Device, msgAndArgs ...interface{}) {
 	extraFmt := ""
 	if len(msgAndArgs) > 0 {
 		extraFmt = fmt.Sprintf(msgAndArgs[0].(string), msgAndArgs[1:]...) + ": "
@@ -70,6 +70,6 @@ func RequireDeviceListsEqual(t *testing.T, expected, actual []*ddnvml.Device, ms
 	require.Len(t, actual, len(expected), "%sdevice lists have different lengths", extraFmt)
 
 	for i := range expected {
-		require.Equal(t, expected[i].UUID, actual[i].UUID, "%sUUIDs do not match for element %d", extraFmt, i)
+		require.Equal(t, expected[i].GetDeviceInfo().UUID, actual[i].GetDeviceInfo().UUID, "%sUUIDs do not match for element %d", extraFmt, i)
 	}
 }

--- a/pkg/gpu/stats.go
+++ b/pkg/gpu/stats.go
@@ -185,19 +185,19 @@ func (g *statsGenerator) getNormalizationFactors(stats []model.StatsTuple) (map[
 		var deviceFactors normalizationFactors
 
 		// This factor guarantees that usage[uuid] / normFactor <= maxThreads
-		if usage.cores > float64(device.CoreCount) {
-			deviceFactors.cores = usage.cores / float64(device.CoreCount)
+		if usage.cores > float64(device.GetDeviceInfo().CoreCount) {
+			deviceFactors.cores = usage.cores / float64(device.GetDeviceInfo().CoreCount)
 		} else {
 			deviceFactors.cores = 1
 		}
 
-		if usage.memory > float64(device.Memory) {
-			deviceFactors.memory = usage.memory / float64(device.Memory)
+		if usage.memory > float64(device.GetDeviceInfo().Memory) {
+			deviceFactors.memory = usage.memory / float64(device.GetDeviceInfo().Memory)
 		} else {
 			deviceFactors.memory = 1
 		}
 
-		normFactors[device.UUID] = deviceFactors
+		normFactors[device.GetDeviceInfo().UUID] = deviceFactors
 	}
 
 	return normFactors, nil

--- a/pkg/gpu/stream_collection.go
+++ b/pkg/gpu/stream_collection.go
@@ -123,7 +123,7 @@ func (sc *streamCollection) getGlobalStream(header *gpuebpf.CudaEventHeader) (*S
 
 	key := globalStreamKey{
 		pid:     pid,
-		gpuUUID: device.UUID,
+		gpuUUID: device.GetDeviceInfo().UUID,
 	}
 
 	stream, ok := sc.globalStreams[key]
@@ -165,7 +165,7 @@ func (sc *streamCollection) getNonGlobalStream(header *gpuebpf.CudaEventHeader) 
 
 // createStreamHandler creates a new StreamHandler for a given CUDA stream.
 // If the device not provided (it's nil), it will be retrieved from the system context.
-func (sc *streamCollection) createStreamHandler(header *gpuebpf.CudaEventHeader, device *ddnvml.Device, containerIDFunc func() string) (*StreamHandler, error) {
+func (sc *streamCollection) createStreamHandler(header *gpuebpf.CudaEventHeader, device ddnvml.Device, containerIDFunc func() string) (*StreamHandler, error) {
 	if sc.streamCount() >= sc.maxStreams {
 		sc.telemetry.rejectedStreams.Inc()
 		return nil, fmt.Errorf("max streams reached")
@@ -188,8 +188,8 @@ func (sc *streamCollection) createStreamHandler(header *gpuebpf.CudaEventHeader,
 		}
 	}
 
-	metadata.gpuUUID = device.UUID
-	metadata.smVersion = device.SMVersion
+	metadata.gpuUUID = device.GetDeviceInfo().UUID
+	metadata.smVersion = device.GetDeviceInfo().SMVersion
 
 	return newStreamHandler(metadata, sc.sysCtx, sc.streamLimits, sc.telemetry)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Makes `Device` an interface that exposes the cached fields through `GetDeviceInfo()`.

### Motivation

Initial refactor to be able to introduce MIG devices in #36377

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Refactor is validated by existing unit tests.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->