### PR TITLE
[DJM-814] Set intaller span tag to true only when len > 0

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -208,7 +208,11 @@ func setClearIfExists(s *common.Setup, envKey, tagKey string, normalize func(str
 
 func setHostTag(s *common.Setup, tagKey, value string) {
 	s.Config.DatadogYAML.Tags = append(s.Config.DatadogYAML.Tags, tagKey+":"+value)
-	s.Span.SetTag("host_tag_set."+tagKey, "true")
+	if len(value) > 0 {
+		s.Span.SetTag("host_tag_set."+tagKey, "true")
+	} else {
+		s.Span.SetTag("host_tag_set."+tagKey, "false")
+	}
 }
 
 func setClearHostTag(s *common.Setup, tagKey, value string) {

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -208,11 +208,11 @@ func setClearIfExists(s *common.Setup, envKey, tagKey string, normalize func(str
 
 func setHostTag(s *common.Setup, tagKey, value string) {
 	s.Config.DatadogYAML.Tags = append(s.Config.DatadogYAML.Tags, tagKey+":"+value)
-	if len(value) > 0 {
-		s.Span.SetTag("host_tag_set."+tagKey, "true")
-	} else {
-		s.Span.SetTag("host_tag_set."+tagKey, "false")
+	isTagPresent := "false"
+	if value != "" {
+		isTagPresent = "true"
 	}
+	s.Span.SetTag("host_tag_set."+tagKey, isTagPresent)
 }
 
 func setClearHostTag(s *common.Setup, tagKey, value string) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Only set `host_tag_set.<key>` to `true` if the actual value of the host tag `key:value` was not empty, ie of length > 0.

### Motivation

Not consider the tag set if the env var was retrieved without any error but was empty

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->