### PR TITLE
[CWS] inline `UnmarshalDNSResponse` to prevent inclusion in security-agent

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1328,7 +1328,18 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 				return
 			}
 			p.addToDNSResolver(dnsLayer)
-			event.DNS.UnmarshalDNSResponse(dnsLayer, uint16(len(data[offset:])))
+			event.DNS = model.DNSEvent{
+				ID: dnsLayer.ID,
+				Question: model.DNSQuestion{
+					Name:  string(dnsLayer.Questions[0].Name),
+					Class: uint16(dnsLayer.Questions[0].Class),
+					Type:  uint16(dnsLayer.Questions[0].Type),
+					Size:  uint16(len(data[offset:])),
+				},
+				Response: &model.DNSResponse{
+					ResponseCode: uint8(dnsLayer.ResponseCode),
+				},
+			}
 		}
 
 	case model.IMDSEventType:

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/gopacket/layers"
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -1085,20 +1084,6 @@ func (e *NetworkContext) UnmarshalBinary(data []byte) (int, error) {
 		e.Destination.IPNet = *eval.IPNetFromIP(dstIP[:])
 	}
 	return read + 48, nil
-}
-
-// UnmarshalDNSResponse unmarshalls a binary representation of itself
-func (e *DNSEvent) UnmarshalDNSResponse(dnsLayer *layers.DNS, size uint16) {
-	e.ID = dnsLayer.ID
-	e.Response = &DNSResponse{
-		ResponseCode: uint8(dnsLayer.ResponseCode),
-	}
-
-	e.Question.Count = dnsLayer.QDCount
-	e.Question.Name = string(dnsLayer.Questions[0].Name)
-	e.Question.Class = uint16(dnsLayer.Questions[0].Class)
-	e.Question.Type = uint16(dnsLayer.Questions[0].Type)
-	e.Question.Size = size
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This will allow gopacket to not be included in the security agent.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->