### PR TITLE
POC extract USTs from instrumentation target

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -362,6 +362,7 @@
 # pkg
 /pkg/                                   @DataDog/agent-runtimes
 /pkg/api/                               @DataDog/agent-runtimes
+/pkg/apm/                               @DataDog/injection-platform
 /pkg/aggregator/                        @DataDog/agent-metric-pipelines
 /pkg/collector/                         @DataDog/agent-runtimes
 /pkg/commonchecks/                      @DataDog/agent-runtimes

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -705,22 +705,29 @@ var GetRunningContainers EntityFilterFunc[*Container] = func(container *Containe
 type KubernetesPod struct {
 	EntityID
 	EntityMeta
-	Owners                     []KubernetesPodOwner
-	PersistentVolumeClaimNames []string
-	InitContainers             []OrchestratorContainer
-	Containers                 []OrchestratorContainer
-	Ready                      bool
-	Phase                      string
-	IP                         string
-	PriorityClass              string
-	QOSClass                   string
-	GPUVendorList              []string
-	RuntimeClass               string
-	KubeServices               []string
-	NamespaceLabels            map[string]string
-	NamespaceAnnotations       map[string]string
-	FinishedAt                 time.Time
-	SecurityContext            *PodSecurityContext
+	Owners                                 []KubernetesPodOwner
+	PersistentVolumeClaimNames             []string
+	InitContainers                         []OrchestratorContainer
+	Containers                             []OrchestratorContainer
+	Ready                                  bool
+	Phase                                  string
+	IP                                     string
+	PriorityClass                          string
+	QOSClass                               string
+	GPUVendorList                          []string
+	RuntimeClass                           string
+	KubeServices                           []string
+	NamespaceLabels                        map[string]string
+	NamespaceAnnotations                   map[string]string
+	FinishedAt                             time.Time
+	SecurityContext                        *PodSecurityContext
+	EvaluatedInstrumentationWorkloadTarget *InstrumentationWorkloadTarget
+}
+
+// InstrumentationWorkloadTarget is data we've extracted based on autoinstrumentation
+// configuration for USTs.
+type InstrumentationWorkloadTarget struct {
+	Env, Service, Version string
 }
 
 // GetID implements Entity#GetID.
@@ -772,6 +779,13 @@ func (p KubernetesPod) String(verbose bool) string {
 		for _, c := range p.Containers {
 			_, _ = fmt.Fprint(&sb, c.String(verbose))
 		}
+	}
+
+	if t := p.EvaluatedInstrumentationWorkloadTarget; t != nil {
+		_, _ = fmt.Fprintln(&sb, "----------- Instrumentation Workload Target -----------")
+		_, _ = fmt.Fprintln(&sb, "Service:", t.Service)
+		_, _ = fmt.Fprintln(&sb, "Env:", t.Env)
+		_, _ = fmt.Fprintln(&sb, "Version:", t.Version)
 	}
 
 	_, _ = fmt.Fprintln(&sb, "----------- Pod Info -----------")

--- a/pkg/apm/instrumentation/config.go
+++ b/pkg/apm/instrumentation/config.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver || kubelet
+
+package instrumentation
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	// AppliedTargetAnnotation is the JSON of the target that was applied to the pod.
+	AppliedTargetAnnotation = "internal.apm.datadoghq.com/applied-target"
+)
+
+// Config is a struct to store the configuration for the autoinstrumentation logic. It can be populated
+// using the datadog config through NewInstrumentationConfig.
+type Config struct {
+	// Enabled is a flag to enable the auto instrumentation. If false, the auto instrumentation is disabled with the
+	// caveat of the annotation based instrumentation. Full config
+	// key: apm_config.instrumentation.enabled
+	Enabled bool `mapstructure:"enabled" json:"enabled"`
+	// EnabledNamespaces is a list of namespaces where the autoinstrumentation is enabled. If empty, it is enabled in
+	// all namespaces. EnabledNamespace and DisabledNamespaces are mutually exclusive and cannot be set together. Full
+	// config key: apm_config.instrumentation.enabled_namespaces
+	EnabledNamespaces []string `mapstructure:"enabled_namespaces" json:"enabled_namespaces"`
+	// DisabledNamespaces is a list of namespaces where the autoinstrumentation is disabled. If empty, it is enabled in
+	// all namespaces. EnabledNamespace and DisabledNamespaces are mutually exclusive and cannot be set together. Full
+	// config key: apm_config.instrumentation.disabled_namespaces
+	DisabledNamespaces []string `mapstructure:"disabled_namespaces" json:"disabled_namespaces"`
+	// LibVersions is a map of tracer libraries to inject with their versions. The key is the language and the value is
+	// the version of the library to inject. If empty, the auto instrumentation will inject all libraries. Full config
+	// key: apm_config.instrumentation.lib_versions
+	LibVersions map[string]string `mapstructure:"lib_versions" json:"lib_versions"`
+	// Version is the version of the autoinstrumentation logic to use. We don't expose this option to the user, and V1
+	// is deprecated and slated for removal. Full config key: apm_config.instrumentation.version
+	Version string `mapstructure:"version" json:"version"`
+	// InjectorImageTag is the tag of the image to use for the auto instrumentation injector library. Full config key:
+	// apm_config.instrumentation.injector_image_tag
+	InjectorImageTag string `mapstructure:"injector_image_tag" json:"injector_image_tag"`
+	// Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
+	// used. If no target matches, the auto instrumentation will not be applied. Full config key:
+	// apm_config.instrumentation.targets
+	Targets []Target `mapstructure:"targets" json:"targets"`
+}
+
+// Target is a rule to apply the auto instrumentation to a specific workload using the pod and namespace selectors.
+// Full config key: apm_config.instrumentation.targets to get the list of targets.
+type Target struct {
+	// Name is the name of the target. It will be appended to the pod annotations to identify the target that was used.
+	// Full config key: apm_config.instrumentation.targets[].name
+	Name string `mapstructure:"name" json:"name,omitempty"`
+	// PodSelector is the pod selector to match the pods to apply the auto instrumentation to. It will be used in
+	// conjunction with the NamespaceSelector to match the pods. Full config key:
+	// apm_config.instrumentation.targets[].selector
+	PodSelector *PodSelector `mapstructure:"podSelector" json:"podSelector,omitempty"`
+	// NamespaceSelector is the namespace selector to match the namespaces to apply the auto instrumentation to. It will
+	// be used in conjunction with the Selector to match the pods. Full config key:
+	// apm_config.instrumentation.targets[].namespaceSelector
+	NamespaceSelector *NamespaceSelector `mapstructure:"namespaceSelector" json:"namespaceSelector,omitempty"`
+	// TracerVersions is a map of tracer versions to inject for workloads that match the target. The key is the tracer
+	// name and the value is the version to inject. Full config key:
+	// apm_config.instrumentation.targets[].ddTraceVersions
+	TracerVersions map[string]string `mapstructure:"ddTraceVersions" json:"ddTraceVersions,omitempty"`
+	// TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
+	// as environment variables in addition to the injected tracer. Full config key:
+	// apm_config.instrumentation.targets[].ddTraceConfigs
+	TracerConfigs []TracerConfig `mapstructure:"ddTraceConfigs" json:"ddTraceConfigs,omitempty"`
+}
+
+// PodSelector is a reconstruction of the metav1.LabelSelector struct to be able to unmarshal the configuration. It
+// can be converted to a metav1.LabelSelector using the AsLabelSelector method. Full config key:
+// apm_config.instrumentation.targets[].selector
+type PodSelector struct {
+	// MatchLabels is a map of key-value pairs to match the labels of the pod. The labels and expressions are ANDed.
+	// Full config key: apm_config.instrumentation.targets[].podSelector.matchLabels
+	MatchLabels map[string]string `mapstructure:"matchLabels" json:"matchLabels,omitempty"`
+	// MatchExpressions is a list of label selector requirements to match the labels of the pod. The labels and
+	// expressions are ANDed. Full config key: apm_config.instrumentation.targets[].podSelector.matchExpressions
+	MatchExpressions []SelectorMatchExpression `mapstructure:"matchExpressions" json:"matchExpressions,omitempty"`
+}
+
+// AsLabelSelector converts the PodSelector to a labels.Selector. It returns an error if the conversion fails.
+func (p PodSelector) AsLabelSelector() (labels.Selector, error) {
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels:      p.MatchLabels,
+		MatchExpressions: make([]metav1.LabelSelectorRequirement, len(p.MatchExpressions)),
+	}
+	for i, expr := range p.MatchExpressions {
+		labelSelector.MatchExpressions[i] = metav1.LabelSelectorRequirement{
+			Key:      expr.Key,
+			Operator: expr.Operator,
+			Values:   expr.Values,
+		}
+	}
+
+	return metav1.LabelSelectorAsSelector(labelSelector)
+}
+
+// SelectorMatchExpression is a reconstruction of the metav1.LabelSelectorRequirement struct to be able to unmarshal
+// the configuration.
+type SelectorMatchExpression struct {
+	// Key is the key of the label to match.
+	Key string `mapstructure:"key" json:"key,omitempty"`
+	// Operator is the operator to use to match the label. Valid values are In, NotIn, Exists, DoesNotExist.
+	Operator metav1.LabelSelectorOperator `mapstructure:"operator" json:"operator,omitempty"`
+	// Values is a list of values to match the label against. If the operator is Exists or DoesNotExist, the values
+	// should be empty. If the operator is In or NotIn, the values should be non-empty.
+	Values []string `mapstructure:"values" json:"values,omitempty"`
+}
+
+// NamespaceSelector is a struct to store the configuration for the namespace selector. It can be used to match the
+// namespaces to apply the auto instrumentation to. Full config key:
+// apm_config.instrumentation.targets[].namespaceSelector
+type NamespaceSelector struct {
+	// MatchNames is a list of namespace names to match. If empty, all namespaces are matched. Full config key:
+	// apm_config.instrumentation.targets[].namespaceSelector.matchNames
+	MatchNames []string `mapstructure:"matchNames" json:"matchNames,omitempty"`
+	// MatchLabels is a map of key-value pairs to match the labels of the namespace. The labels and expressions are
+	// ANDed. This cannot be used with MatchNames. Full config key:
+	// apm_config.instrumentation.targets[].namespaceSelector.matchLabels
+	MatchLabels map[string]string `mapstructure:"matchLabels" json:"matchLabels,omitempty"`
+	// MatchExpressions is a list of label selector requirements to match the labels of the namespace. The labels and
+	// expressions are ANDed. This cannot be used with MatchNames. Full config key:
+	// apm_config.instrumentation.targets[].selector.matchExpressions
+	MatchExpressions []SelectorMatchExpression `mapstructure:"matchExpressions" json:"matchExpressions,omitempty"`
+}
+
+// AsLabelSelector converts the NamespaceSelector to a labels.Selector. It returns an error if the conversion fails.
+func (n NamespaceSelector) AsLabelSelector() (labels.Selector, error) {
+	labelSelector := &metav1.LabelSelector{
+		MatchLabels:      n.MatchLabels,
+		MatchExpressions: make([]metav1.LabelSelectorRequirement, len(n.MatchExpressions)),
+	}
+	for i, expr := range n.MatchExpressions {
+		labelSelector.MatchExpressions[i] = metav1.LabelSelectorRequirement{
+			Key:      expr.Key,
+			Operator: expr.Operator,
+			Values:   expr.Values,
+		}
+	}
+
+	return metav1.LabelSelectorAsSelector(labelSelector)
+}
+
+// TracerConfig is a struct that stores configuration options for a tracer. These will be injected as environment
+// variables to the workload that matches targeting.
+type TracerConfig struct {
+	// Name is the name of the environment variable.
+	Name string `json:"name,omitempty"`
+	// Value is the value to use.
+	Value string `json:"value,omitempty"`
+	// ValueFrom is the source for the environment variable's value.
+	ValueFrom *corev1.EnvVarSource `json:"valueFrom,omitempty"`
+}
+
+// AsEnvVar converts the TracerConfig to a corev1.EnvVar.
+func (c *TracerConfig) AsEnvVar() corev1.EnvVar {
+	return corev1.EnvVar{
+		Name:      c.Name,
+		Value:     c.Value,
+		ValueFrom: c.ValueFrom,
+	}
+}

--- a/pkg/apm/instrumentation/doc.go
+++ b/pkg/apm/instrumentation/doc.go
@@ -1,0 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package instrumentation contains common types used for
+// apm autoinstrumentation.
+package instrumentation

--- a/pkg/apm/instrumentation/env_extractor.go
+++ b/pkg/apm/instrumentation/env_extractor.go
@@ -1,0 +1,185 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver || kubelet
+
+package instrumentation
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/DataDog/datadog-agent/comp/core/tagger/tags"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// ExtractedTags are USTs that we could have been setting on the pod
+// with the instrumentation webhook via workload targeting.
+type ExtractedTags struct {
+	Service string
+	Env     string
+	Version string
+}
+
+// AsMap produces a map of UST to value for the ones that
+// are set on ExtractedTags.
+func (e *ExtractedTags) AsMap() map[string]string {
+	if e == nil {
+		return nil
+	}
+
+	usts := [3]string{tags.Service, tags.Env, tags.Version}
+	vals := [3]string{e.Service, e.Env, e.Version}
+
+	var out map[string]string
+	for idx, val := range vals {
+		if val != "" {
+			if out == nil {
+				out = map[string]string{}
+			}
+			out[usts[idx]] = val
+		}
+	}
+
+	return out
+}
+
+func writeService(e *ExtractedTags, name string) {
+	e.Service = name
+}
+
+func writeEnv(e *ExtractedTags, name string) {
+	e.Env = name
+}
+
+func writeVersion(e *ExtractedTags, name string) {
+	e.Version = name
+}
+
+func parseFromTracerConfig(tc TracerConfig, m metav1.ObjectMeta) (string, func(*ExtractedTags, string)) {
+	var do func(*ExtractedTags, string)
+	switch tc.Name {
+	case kubernetes.ServiceTagEnvVar:
+		log.Debug("setting writeService")
+		do = writeService
+	case kubernetes.VersionTagEnvVar:
+		log.Debug("setting writeVersion")
+		do = writeVersion
+	case kubernetes.EnvTagEnvVar:
+		log.Debug("setting writeEnv")
+		do = writeEnv
+	default:
+		return "", nil
+	}
+
+	value, extracted, err := extractSingleValueFromPodMeta(m, tc)
+	if err != nil {
+		log.Warnf("error parsing value workload data from pod metadata for env %s: %s", tc.Name, err)
+		return "", nil
+	}
+	if !extracted {
+		return "", nil
+	}
+
+	return value, do
+}
+
+// ExtractTagsFromPodMeta extracts ExtractedTags from a given pod metadata.
+//
+// This checks for the [[AppliedTargetAnnotation]] and checks for
+// any trace configurations that can be corresponding to USTs.
+func ExtractTagsFromPodMeta(in metav1.ObjectMeta) (*ExtractedTags, error) {
+	tJSON, ok := in.Annotations[AppliedTargetAnnotation]
+	if !ok {
+		return nil, nil
+	}
+
+	var t Target
+	if err := json.NewDecoder(strings.NewReader(tJSON)).Decode(&t); err != nil {
+		return nil, fmt.Errorf("error parsing instrumentation target JSON: %s", err)
+	}
+
+	var out *ExtractedTags
+	for _, tc := range t.TracerConfigs {
+		if value, writer := parseFromTracerConfig(tc, in); writer != nil && value != "" {
+			if out == nil {
+				out = new(ExtractedTags)
+			}
+			writer(out, value)
+		}
+	}
+
+	return out, nil
+}
+
+// extractSingleValueFromPodMeta is largely copied from kubernetes source but uses the tracer
+// config to provide the target.
+//
+// ref: https://github.com/kubernetes/kubernetes/blob/6da56bd4b782658a4060f65c24df5830ec01c6c1/pkg/fieldpath/fieldpath.go#L53-L120
+func extractSingleValueFromPodMeta(meta metav1.ObjectMeta, c TracerConfig) (string, bool, error) {
+	if c.ValueFrom == nil {
+		return c.Value, c.Value != "", nil
+	}
+
+	if c.ValueFrom.FieldRef == nil {
+		return "", false, nil
+	}
+
+	fieldPath := c.ValueFrom.FieldRef.FieldPath
+	if path, subscript, ok := splitMaybeSubscriptedPath(fieldPath); ok {
+		switch path {
+		case "metadata.annotations":
+			value, present := meta.Annotations[subscript]
+			return value, present, nil
+		case "metadata.labels":
+			value, present := meta.Labels[subscript]
+			return value, present, nil
+		default:
+			return "", false, fmt.Errorf("invalid fieldPath with subscript %s", fieldPath)
+		}
+	}
+
+	switch fieldPath {
+	case "metadata.name":
+		return meta.Name, true, nil
+	case "metadata.namespace":
+		return meta.Namespace, true, nil
+	case "metadata.uid":
+		return string(meta.GetUID()), true, nil
+	}
+
+	return "", false, fmt.Errorf("unsupported access of fieldPath %s", fieldPath)
+}
+
+// splitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//   - if yes, this function splits the fieldPath into path and subscript, and
+//     returns (path, subscript, true).
+//   - if no, this function returns (fieldPath, "", false).
+//
+// Example inputs and outputs:
+//
+//	"metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//	"metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//	"metadata.labels['']"           --> ("metadata.labels", "", true)
+//	"metadata.labels"               --> ("metadata.labels", "", false)
+func splitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, "", false
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, "", false
+	}
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go
@@ -13,10 +13,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/pkg/apm/instrumentation"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -32,7 +31,7 @@ type Config struct {
 	LanguageDetection *LanguageDetectionConfig
 
 	// Instrumentation is the configuration for the autoinstrumentation logic
-	Instrumentation *InstrumentationConfig
+	Instrumentation *instrumentation.Config
 
 	// containerRegistry is the container registry to use for the autoinstrumentation logic
 	containerRegistry string
@@ -162,41 +161,10 @@ func NewLanguageDetectionConfig(datadogConfig config.Component) *LanguageDetecti
 	}
 }
 
-// InstrumentationConfig is a struct to store the configuration for the autoinstrumentation logic. It can be populated
-// using the datadog config through NewInstrumentationConfig.
-type InstrumentationConfig struct {
-	// Enabled is a flag to enable the auto instrumentation. If false, the auto instrumentation is disabled with the
-	// caveat of the annotation based instrumentation. Full config
-	// key: apm_config.instrumentation.enabled
-	Enabled bool `mapstructure:"enabled" json:"enabled"`
-	// EnabledNamespaces is a list of namespaces where the autoinstrumentation is enabled. If empty, it is enabled in
-	// all namespaces. EnabledNamespace and DisabledNamespaces are mutually exclusive and cannot be set together. Full
-	// config key: apm_config.instrumentation.enabled_namespaces
-	EnabledNamespaces []string `mapstructure:"enabled_namespaces" json:"enabled_namespaces"`
-	// DisabledNamespaces is a list of namespaces where the autoinstrumentation is disabled. If empty, it is enabled in
-	// all namespaces. EnabledNamespace and DisabledNamespaces are mutually exclusive and cannot be set together. Full
-	// config key: apm_config.instrumentation.disabled_namespaces
-	DisabledNamespaces []string `mapstructure:"disabled_namespaces" json:"disabled_namespaces"`
-	// LibVersions is a map of tracer libraries to inject with their versions. The key is the language and the value is
-	// the version of the library to inject. If empty, the auto instrumentation will inject all libraries. Full config
-	// key: apm_config.instrumentation.lib_versions
-	LibVersions map[string]string `mapstructure:"lib_versions" json:"lib_versions"`
-	// Version is the version of the autoinstrumentation logic to use. We don't expose this option to the user, and V1
-	// is deprecated and slated for removal. Full config key: apm_config.instrumentation.version
-	Version string `mapstructure:"version" json:"version"`
-	// InjectorImageTag is the tag of the image to use for the auto instrumentation injector library. Full config key:
-	// apm_config.instrumentation.injector_image_tag
-	InjectorImageTag string `mapstructure:"injector_image_tag" json:"injector_image_tag"`
-	// Targets is a list of targets to apply the auto instrumentation to. The first target that matches the pod will be
-	// used. If no target matches, the auto instrumentation will not be applied. Full config key:
-	// apm_config.instrumentation.targets
-	Targets []Target `mapstructure:"targets" json:"targets"`
-}
-
 // NewInstrumentationConfig creates a new InstrumentationConfig from the datadog config. It returns an error if the
 // configuration is invalid.
-func NewInstrumentationConfig(datadogConfig config.Component) (*InstrumentationConfig, error) {
-	cfg := &InstrumentationConfig{}
+func NewInstrumentationConfig(datadogConfig config.Component) (*instrumentation.Config, error) {
+	cfg := &instrumentation.Config{}
 	err := structure.UnmarshalKey(datadogConfig, "apm_config.instrumentation", cfg, structure.ErrorUnused)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse apm_config.instrumentation: %w", err)
@@ -225,125 +193,6 @@ func NewInstrumentationConfig(datadogConfig config.Component) (*InstrumentationC
 	}
 
 	return cfg, nil
-}
-
-// Target is a rule to apply the auto instrumentation to a specific workload using the pod and namespace selectors.
-// Full config key: apm_config.instrumentation.targets to get the list of targets.
-type Target struct {
-	// Name is the name of the target. It will be appended to the pod annotations to identify the target that was used.
-	// Full config key: apm_config.instrumentation.targets[].name
-	Name string `mapstructure:"name" json:"name,omitempty"`
-	// PodSelector is the pod selector to match the pods to apply the auto instrumentation to. It will be used in
-	// conjunction with the NamespaceSelector to match the pods. Full config key:
-	// apm_config.instrumentation.targets[].selector
-	PodSelector *PodSelector `mapstructure:"podSelector" json:"podSelector,omitempty"`
-	// NamespaceSelector is the namespace selector to match the namespaces to apply the auto instrumentation to. It will
-	// be used in conjunction with the Selector to match the pods. Full config key:
-	// apm_config.instrumentation.targets[].namespaceSelector
-	NamespaceSelector *NamespaceSelector `mapstructure:"namespaceSelector" json:"namespaceSelector,omitempty"`
-	// TracerVersions is a map of tracer versions to inject for workloads that match the target. The key is the tracer
-	// name and the value is the version to inject. Full config key:
-	// apm_config.instrumentation.targets[].ddTraceVersions
-	TracerVersions map[string]string `mapstructure:"ddTraceVersions" json:"ddTraceVersions,omitempty"`
-	// TracerConfigs is a list of configuration options to use for the installed tracers. These options will be added
-	// as environment variables in addition to the injected tracer. Full config key:
-	// apm_config.instrumentation.targets[].ddTraceConfigs
-	TracerConfigs []TracerConfig `mapstructure:"ddTraceConfigs" json:"ddTraceConfigs,omitempty"`
-}
-
-// PodSelector is a reconstruction of the metav1.LabelSelector struct to be able to unmarshal the configuration. It
-// can be converted to a metav1.LabelSelector using the AsLabelSelector method. Full config key:
-// apm_config.instrumentation.targets[].selector
-type PodSelector struct {
-	// MatchLabels is a map of key-value pairs to match the labels of the pod. The labels and expressions are ANDed.
-	// Full config key: apm_config.instrumentation.targets[].podSelector.matchLabels
-	MatchLabels map[string]string `mapstructure:"matchLabels" json:"matchLabels,omitempty"`
-	// MatchExpressions is a list of label selector requirements to match the labels of the pod. The labels and
-	// expressions are ANDed. Full config key: apm_config.instrumentation.targets[].podSelector.matchExpressions
-	MatchExpressions []SelectorMatchExpression `mapstructure:"matchExpressions" json:"matchExpressions,omitempty"`
-}
-
-// AsLabelSelector converts the PodSelector to a labels.Selector. It returns an error if the conversion fails.
-func (p PodSelector) AsLabelSelector() (labels.Selector, error) {
-	labelSelector := &metav1.LabelSelector{
-		MatchLabels:      p.MatchLabels,
-		MatchExpressions: make([]metav1.LabelSelectorRequirement, len(p.MatchExpressions)),
-	}
-	for i, expr := range p.MatchExpressions {
-		labelSelector.MatchExpressions[i] = metav1.LabelSelectorRequirement{
-			Key:      expr.Key,
-			Operator: expr.Operator,
-			Values:   expr.Values,
-		}
-	}
-
-	return metav1.LabelSelectorAsSelector(labelSelector)
-}
-
-// SelectorMatchExpression is a reconstruction of the metav1.LabelSelectorRequirement struct to be able to unmarshal
-// the configuration.
-type SelectorMatchExpression struct {
-	// Key is the key of the label to match.
-	Key string `mapstructure:"key" json:"key,omitempty"`
-	// Operator is the operator to use to match the label. Valid values are In, NotIn, Exists, DoesNotExist.
-	Operator metav1.LabelSelectorOperator `mapstructure:"operator" json:"operator,omitempty"`
-	// Values is a list of values to match the label against. If the operator is Exists or DoesNotExist, the values
-	// should be empty. If the operator is In or NotIn, the values should be non-empty.
-	Values []string `mapstructure:"values" json:"values,omitempty"`
-}
-
-// NamespaceSelector is a struct to store the configuration for the namespace selector. It can be used to match the
-// namespaces to apply the auto instrumentation to. Full config key:
-// apm_config.instrumentation.targets[].namespaceSelector
-type NamespaceSelector struct {
-	// MatchNames is a list of namespace names to match. If empty, all namespaces are matched. Full config key:
-	// apm_config.instrumentation.targets[].namespaceSelector.matchNames
-	MatchNames []string `mapstructure:"matchNames" json:"matchNames,omitempty"`
-	// MatchLabels is a map of key-value pairs to match the labels of the namespace. The labels and expressions are
-	// ANDed. This cannot be used with MatchNames. Full config key:
-	// apm_config.instrumentation.targets[].namespaceSelector.matchLabels
-	MatchLabels map[string]string `mapstructure:"matchLabels" json:"matchLabels,omitempty"`
-	// MatchExpressions is a list of label selector requirements to match the labels of the namespace. The labels and
-	// expressions are ANDed. This cannot be used with MatchNames. Full config key:
-	// apm_config.instrumentation.targets[].selector.matchExpressions
-	MatchExpressions []SelectorMatchExpression `mapstructure:"matchExpressions" json:"matchExpressions,omitempty"`
-}
-
-// AsLabelSelector converts the NamespaceSelector to a labels.Selector. It returns an error if the conversion fails.
-func (n NamespaceSelector) AsLabelSelector() (labels.Selector, error) {
-	labelSelector := &metav1.LabelSelector{
-		MatchLabels:      n.MatchLabels,
-		MatchExpressions: make([]metav1.LabelSelectorRequirement, len(n.MatchExpressions)),
-	}
-	for i, expr := range n.MatchExpressions {
-		labelSelector.MatchExpressions[i] = metav1.LabelSelectorRequirement{
-			Key:      expr.Key,
-			Operator: expr.Operator,
-			Values:   expr.Values,
-		}
-	}
-
-	return metav1.LabelSelectorAsSelector(labelSelector)
-}
-
-// TracerConfig is a struct that stores configuration options for a tracer. These will be injected as environment
-// variables to the workload that matches targeting.
-type TracerConfig struct {
-	// Name is the name of the environment variable.
-	Name string `json:"name,omitempty"`
-	// Value is the value to use.
-	Value string `json:"value,omitempty"`
-	// ValueFrom is the source for the environment variable's value.
-	ValueFrom *corev1.EnvVarSource `json:"valueFrom,omitempty"`
-}
-
-// AsEnvVar converts the TracerConfig to a corev1.EnvVar.
-func (c *TracerConfig) AsEnvVar() corev1.EnvVar {
-	return corev1.EnvVar{
-		Name:      c.Name,
-		Value:     c.Value,
-		ValueFrom: c.ValueFrom,
-	}
 }
 
 var (

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/target_mutator.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/apm/instrumentation"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/metrics"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -26,7 +27,7 @@ import (
 
 const (
 	// AppliedTargetAnnotation is the JSON of the target that was applied to the pod.
-	AppliedTargetAnnotation = "internal.apm.datadoghq.com/applied-target"
+	AppliedTargetAnnotation = instrumentation.AppliedTargetAnnotation
 	// AppliedTargetEnvVar is the environment variable that contains the JSON of the target that was applied to the pod.
 	AppliedTargetEnvVar = "DD_INSTRUMENTATION_APPLIED_TARGET"
 )
@@ -357,7 +358,7 @@ func (t targetInternal) matchesPodSelector(podLabels map[string]string) bool {
 }
 
 // createJSON creates a json string of the target used to apply as an annotation.
-func createJSON(t Target) string {
+func createJSON(t instrumentation.Target) string {
 	data, err := json.Marshal(t)
 	if err != nil {
 		log.Errorf("error marshalling target %q: %v", t.Name, err)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
@@ -58,6 +58,9 @@ func Test_labelJoiner(t *testing.T) {
 									"qux_key":  "qux_value2",
 									"quux_key": "quux_value2",
 								},
+								Tags: map[string]string{
+									"foo": "bar",
+								},
 							},
 						},
 					},
@@ -81,6 +84,7 @@ func Test_labelJoiner(t *testing.T) {
 					inputLabels: map[string]string{"foo_key": "foo_value2"},
 					labelsToAdd: []label{
 						{key: "qux_tag", value: "qux_value2"},
+						{key: "foo", value: "bar"},
 					},
 				},
 			},

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/inventory/inventory.go
@@ -61,7 +61,7 @@ func NewCollectorInventory(cfg config.Component, store workloadmeta.Component, t
 			k8sCollectors.NewClusterRoleCollectorVersions(metadataAsTags),
 			k8sCollectors.NewCronJobCollectorVersions(metadataAsTags),
 			k8sCollectors.NewDaemonSetCollectorVersions(metadataAsTags),
-			k8sCollectors.NewDeploymentCollectorVersions(metadataAsTags),
+			k8sCollectors.NewDeploymentCollectorVersions(cfg, store, tagger, metadataAsTags),
 			k8sCollectors.NewHorizontalPodAutoscalerCollectorVersions(metadataAsTags),
 			k8sCollectors.NewIngressCollectorVersions(metadataAsTags),
 			k8sCollectors.NewJobCollectorVersions(metadataAsTags),

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -8,12 +8,16 @@
 package k8s
 
 import (
-	model "github.com/DataDog/agent-payload/v5/process"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/common"
-	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/util"
+	"fmt"
 
+	model "github.com/DataDog/agent-payload/v5/process"
+
+	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
+	taggertypes "github.com/DataDog/datadog-agent/comp/core/tagger/types"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/processors/common"
 	k8sTransformers "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator/util"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator/redact"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,6 +27,29 @@ import (
 // DeploymentHandlers implements the Handlers interface for Kubernetes Deployments.
 type DeploymentHandlers struct {
 	common.BaseHandlers
+
+	tagProvider func(*appsv1.Deployment) []string
+}
+
+// NewDeploymentHandlers creates handlers for Kubernetes Deployments given a tagger.
+func NewDeploymentHandlers(tagger tagger.Component) *DeploymentHandlers {
+	h := new(DeploymentHandlers)
+	h.tagProvider = func(d *appsv1.Deployment) []string {
+		entity := taggertypes.NewEntityID(taggertypes.KubernetesDeployment, fmt.Sprintf("%s/%s", d.Namespace, d.Name))
+		tags, err := tagger.Tag(entity, taggertypes.HighCardinality)
+		if err != nil {
+			return nil
+		}
+
+		stags, err := tagger.Standard(entity)
+		if err != nil {
+			return tags
+		}
+
+		return append(tags, stags...)
+	}
+
+	return h
 }
 
 // AfterMarshalling is a handler called after resource marshalling.
@@ -69,7 +96,7 @@ func (h *DeploymentHandlers) BuildMessageBody(ctx processors.ProcessorContext, r
 //nolint:revive // TODO(CAPP) Fix revive linter
 func (h *DeploymentHandlers) ExtractResource(ctx processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
 	r := resource.(*appsv1.Deployment)
-	return k8sTransformers.ExtractDeployment(ctx, r)
+	return k8sTransformers.ExtractDeployment(ctx, r, h.tagProvider)
 }
 
 // ResourceList is a handler called to convert a list passed as a generic

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -144,7 +144,14 @@ func (h *PodHandlers) BuildMessageBody(ctx processors.ProcessorContext, resource
 //nolint:revive // TODO(CAPP) Fix revive linter
 func (h *PodHandlers) ExtractResource(ctx processors.ProcessorContext, resource interface{}) (resourceModel interface{}) {
 	r := resource.(*corev1.Pod)
-	return k8sTransformers.ExtractPod(ctx, r)
+	return k8sTransformers.ExtractPod(ctx, r, func(p *corev1.Pod) []string {
+		tags, err := h.tagProvider.GetTags(p, taggertypes.HighCardinality)
+		if err != nil {
+			log.Debugf("Could not retrieve tags for pod: %s", err.Error())
+			return nil
+		}
+		return tags
+	})
 }
 
 // ResourceList is a handler called to convert a list passed as a generic

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_tag_provider/node_provider.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod_tag_provider/node_provider.go
@@ -26,5 +26,16 @@ func newNodePodTagProvider(tagger tagger.Component) PodTagProvider {
 
 // GetTags implements PodTagProvider#GetTags
 func (p *nodePodTagProvider) GetTags(pod *corev1.Pod, cardinality taggertypes.TagCardinality) ([]string, error) {
-	return p.tagger.Tag(taggertypes.NewEntityID(taggertypes.KubernetesPodUID, string(pod.UID)), cardinality)
+	entity := taggertypes.NewEntityID(taggertypes.KubernetesPodUID, string(pod.UID))
+	tags, err := p.tagger.Tag(entity, cardinality)
+	if err != nil {
+		return nil, err
+	}
+
+	stags, err := p.tagger.Standard(entity)
+	if err != nil {
+		return tags, nil
+	}
+
+	return append(tags, stags...), nil
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/deployment_test.go
@@ -156,7 +156,8 @@ func TestExtractDeployment(t *testing.T) {
 				Metadata:             &model.Metadata{},
 				ReplicasDesired:      1,
 				ResourceRequirements: getExpectedModelResourceRequirements(),
-			}},
+			},
+		},
 		"partial deploy": {
 			input: appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -229,7 +230,7 @@ func TestExtractDeployment(t *testing.T) {
 				LabelsAsTags:      tc.labelsAsTags,
 				AnnotationsAsTags: tc.annotationsAsTags,
 			}
-			actual := ExtractDeployment(pctx, &tc.input)
+			actual := ExtractDeployment(pctx, &tc.input, nil)
 			sort.Strings(actual.Tags)
 			sort.Strings(tc.expected.Tags)
 			assert.Equal(t, &tc.expected, actual)


### PR DESCRIPTION
### What does this PR do?

Extract USTs from data created by instrumentation targets in workload selection (via the annotation) and propagate them to container tags.

https://docs.google.com/document/d/1InoHTXcu92Jk1Re8YyDt3QhDJbXpNtuJbX9vUdR5Y6U

### Motivation

- A user can configure their service/env/version using [workload selection](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=kubernetesagentv764)
- It is possible to set `DD_SERVICE` using `ddTraceConfigs` in a workload target.
- An issue here is that when this is set, the pod doesn't get the service tag at all and infra+APM are not linked.

This PR uses the workload [target](https://github.com/DataDog/datadog-agent/blob/3f8291331d818caaa5501bd8188813af8e9bbe70/pkg/clusteragent/admission/mutate/autoinstrumentation/config.go#L230-L252) annotation to extract the configuration for the pod and add UST tags to the pod / deployment / etc.

```yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    internal.apm.datadoghq.com/applied-target: '{"name":"python","podSelector":{"matchLabels":{"language":"python"}},"ddTraceVersions":{"python":"default"},"ddTraceConfigs":[]}'
```