### PR TITLE
[CXP-2145] Moves the process-discovery enablement tests into process-discovery check file

### DIFF
--- a/pkg/process/checks/enabled_checks_linux_test.go
+++ b/pkg/process/checks/enabled_checks_linux_test.go
@@ -85,26 +85,3 @@ func TestProcessCheckLinux(t *testing.T) {
 		assertContainsCheck(t, enabledChecks, ProcessCheckName)
 	})
 }
-
-func TestProcessDiscoveryLinux(t *testing.T) {
-	deps := createDeps(t)
-	originalFlavor := flavor.GetFlavor()
-	defer flavor.SetFlavor(originalFlavor)
-
-	// Make sure process discovery checks run on the core agent only
-	// when run in core agent mode is enabled
-	t.Run("run in core agent", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_collection.enabled", false)
-		cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-		cfg.SetWithoutSource("process_config.run_in_core_agent.enabled", true)
-
-		flavor.SetFlavor("process_agent")
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
-
-		flavor.SetFlavor("agent")
-		enabledChecks = getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertContainsCheck(t, enabledChecks, DiscoveryCheckName)
-	})
-}

--- a/pkg/process/checks/enabled_checks_test.go
+++ b/pkg/process/checks/enabled_checks_test.go
@@ -51,35 +51,6 @@ func getEnabledChecks(t *testing.T, cfg, sysprobeYamlConfig pkgconfigmodel.Reade
 	return enabledChecks
 }
 
-func TestProcessDiscovery(t *testing.T) {
-	deps := createProcessCheckDeps(t)
-
-	// Make sure the process_discovery check can be enabled
-	t.Run("enabled", func(t *testing.T) {
-		cfg, sysprobeCfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-		enabledChecks := getEnabledChecks(t, cfg, sysprobeCfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertContainsCheck(t, enabledChecks, DiscoveryCheckName)
-	})
-
-	// Make sure the process_discovery check can be disabled
-	t.Run("disabled", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_discovery.enabled", false)
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
-	})
-
-	// Make sure the process and process_discovery checks are mutually exclusive
-	t.Run("mutual exclusion", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-		cfg.SetWithoutSource("process_config.process_collection.enabled", true)
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertNotContainsCheck(t, enabledChecks, DiscoveryCheckName)
-	})
-}
-
 func TestProcessCheck(t *testing.T) {
 	deps := createProcessCheckDeps(t)
 	t.Run("disabled", func(t *testing.T) {

--- a/pkg/process/checks/process_discovery_check_linux_test.go
+++ b/pkg/process/checks/process_discovery_check_linux_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package checks
+
+import (
+	"testing"
+
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessDiscoveryLinuxWithRunInCoreAgent(t *testing.T) {
+	originalFlavor := flavor.GetFlavor()
+	defer flavor.SetFlavor(originalFlavor)
+
+	// Ensure the process discovery checks run on the core agent only when run in core agent mode is enabled
+	cfg := configmock.New(t)
+	cfg.SetWithoutSource("process_config.process_collection.enabled", false)
+	cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
+	cfg.SetWithoutSource("process_config.run_in_core_agent.enabled", true)
+
+	tests := []struct {
+		name    string
+		flavor  string
+		enabled bool
+	}{
+		{
+			name:    "enabled on the core agent",
+			flavor:  flavor.DefaultAgent,
+			enabled: true,
+		},
+		{
+			name:    "disabled on the process agent",
+			flavor:  flavor.ProcessAgent,
+			enabled: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			flavor.SetFlavor(tc.flavor)
+			check := NewProcessDiscoveryCheck(cfg)
+			assert.Equal(t, tc.enabled, check.IsEnabled())
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?
- Moves the process-discovery based tests which tests the IsEnabled() method to the specific process-discovery check test file.
- Moves the linux specific process-discovery tests for validating the the check only runs in the core agent when the process_config.run_in_core_agent.enabled is set.

### Motivation
This is part of the effort to remove the exported [All()](https://github.com/DataDog/datadog-agent/blob/d84840abe8e635729662e77919935c312084fbcb/pkg/process/checks/checks.go#L115) as it is a construct for testing. Check enablement is config based and should not be affected by other checks being created.


### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->