### PR TITLE
CXP-2086 [agent] add permissions check to windows process agent

### DIFF
--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -552,6 +552,7 @@ func OpenProcessHandle(pid int32) (windows.Handle, bool, error) {
 		log.Debugf("Couldn't open unprotected process with PROCESS_VM_READ access. Returning limited process info %v %v", pid, err)
 		return procHandle, isProtected, err
 	}
+	defer windows.Close(procHandle)
 	return procHandleMemoryAccess, isProtected, err
 }
 

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -20,22 +20,20 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
-var (
-	counterPaths = []string{
-		pdhutil.CounterAllProcessPID,
-		pdhutil.CounterAllProcessParentPID,
-		pdhutil.CounterAllProcessPctUserTime,
-		pdhutil.CounterAllProcessPctPrivilegedTime,
-		pdhutil.CounterAllProcessWorkingSet,
-		pdhutil.CounterAllProcessPoolPagedBytes,
-		pdhutil.CounterAllProcessThreadCount,
-		pdhutil.CounterAllProcessHandleCount,
-		pdhutil.CounterAllProcessIOReadOpsPerSec,
-		pdhutil.CounterAllProcessIOWriteOpsPerSec,
-		pdhutil.CounterAllProcessIOReadBytesPerSec,
-		pdhutil.CounterAllProcessIOWriteBytesPerSec,
-	}
-)
+var counterPaths = []string{
+	pdhutil.CounterAllProcessPID,
+	pdhutil.CounterAllProcessParentPID,
+	pdhutil.CounterAllProcessPctUserTime,
+	pdhutil.CounterAllProcessPctPrivilegedTime,
+	pdhutil.CounterAllProcessWorkingSet,
+	pdhutil.CounterAllProcessPoolPagedBytes,
+	pdhutil.CounterAllProcessThreadCount,
+	pdhutil.CounterAllProcessHandleCount,
+	pdhutil.CounterAllProcessIOReadOpsPerSec,
+	pdhutil.CounterAllProcessIOWriteOpsPerSec,
+	pdhutil.CounterAllProcessIOReadBytesPerSec,
+	pdhutil.CounterAllProcessIOWriteBytesPerSec,
+}
 
 // NewProcessProbe returns a Probe object
 func NewProcessProbe(...Option) Probe {
@@ -559,7 +557,7 @@ func OpenProcessHandle(pid int32) (windows.Handle, bool, error) {
 		log.Debugf("Couldn't open unprotected process with PROCESS_VM_READ access. Returning limited process info %v %v", pid, err)
 		return procHandle, isProtected, err
 	}
-	defer windows.Close(procHandle)
+	windows.Close(procHandle)
 	return procHandleMemoryAccess, isProtected, err
 }
 

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -222,7 +222,6 @@ func (p *probe) ProcessesByPID(_ time.Time, collectStats bool) (map[int32]*Proce
 		}
 
 		err := fillProcessDetails(pid, proc)
-
 		if err != nil {
 			continue
 		}
@@ -266,7 +265,6 @@ func (p *probe) enumCounters(collectMeta bool, collectStats bool) error {
 	}
 
 	err = p.formatter.Enum(pdhutil.CounterAllProcessPID, p.counters[pdhutil.CounterAllProcessPID], pdhutil.PDH_FMT_LARGE, ignored, valueToUint64(p.mapPID))
-
 	if err != nil {
 		return err
 	}
@@ -505,13 +503,14 @@ func fillProcessDetails(pid int32, proc *Process) error {
 
 	// we cannot read the command line if the process is protected
 	if !isProtected {
-		processCmdParams, err := winutil.GetCommandParamsForProcess(procHandle, false)
+		processCmdParams, err := winutil.GetCommandParamsForProcess(procHandle, true)
 		if err != nil {
 			log.Debugf("Error retrieving full command line %v", err)
 		}
 
 		if processCmdParams != nil {
 			proc.Cmdline = ParseCmdLineArgs(processCmdParams.CmdLine)
+			proc.Exe = processCmdParams.ImagePath
 			if len(processCmdParams.CmdLine) > 0 && len(proc.Cmdline) == 0 {
 				log.Warnf("Failed to parse the cmdline:%s for pid:%d", processCmdParams.CmdLine, pid)
 			}

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -549,7 +549,7 @@ func OpenProcessHandle(pid int32) (windows.Handle, bool, error) {
 	// more info: https://learn.microsoft.com/en-us/windows/win32/procthread/process-security-and-access-rights#protected-processes
 	isProtected, err := winutil.IsProcessProtected(procHandle)
 	if err != nil {
-		log.Debugf("Couldn't access process %v protection info %v", pid, err)
+		log.Debugf("Couldn't access process %v protection info %v. Will attempt to re-open with PROCESS_VM_READ access", pid, err)
 	}
 	if isProtected {
 		return procHandle, isProtected, err

--- a/pkg/process/procutil/process_windows_test.go
+++ b/pkg/process/procutil/process_windows_test.go
@@ -106,10 +106,9 @@ func TestWindowsProbe(t *testing.T) {
 			defer cmd.Process.Kill()
 
 			procs, err := probe.ProcessesByPID(time.Now(), true)
-
 			assert.NoError(t, err)
-			p, found := procs[int32(cmd.Process.Pid)]
 
+			p, found := procs[int32(cmd.Process.Pid)]
 			assert.True(t, found)
 			assert.True(t, strings.HasSuffix(p.Exe, "powershell.exe"))
 			assert.Equal(t, []string{"powershell.exe", "-c", `"sleep 10; foo bar baz"`}, p.Cmdline)

--- a/pkg/process/procutil/process_windows_test.go
+++ b/pkg/process/procutil/process_windows_test.go
@@ -106,9 +106,10 @@ func TestWindowsProbe(t *testing.T) {
 			defer cmd.Process.Kill()
 
 			procs, err := probe.ProcessesByPID(time.Now(), true)
-			assert.NoError(t, err)
 
+			assert.NoError(t, err)
 			p, found := procs[int32(cmd.Process.Pid)]
+
 			assert.True(t, found)
 			assert.True(t, strings.HasSuffix(p.Exe, "powershell.exe"))
 			assert.Equal(t, []string{"powershell.exe", "-c", `"sleep 10; foo bar baz"`}, p.Cmdline)

--- a/pkg/process/procutil/process_windows_toolhelp.go
+++ b/pkg/process/procutil/process_windows_toolhelp.go
@@ -136,7 +136,7 @@ func (p *windowsToolhelpProbe) ProcessesByPID(_ time.Time, collectStats bool) (m
 			p.cachedProcesses[pid] = cp
 		} else {
 			var err error
-			if cp.procHandle, err = OpenProcessHandle(int32(pe32.Th32ProcessID)); err != nil {
+			if cp.procHandle, _, err = OpenProcessHandle(int32(pe32.Th32ProcessID)); err != nil {
 				log.Debugf("Could not reopen process handle for pid %v %v", pid, err)
 				continue
 			}
@@ -231,7 +231,8 @@ type cachedProcess struct {
 }
 
 func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error) {
-	cp.procHandle, err = OpenProcessHandle(int32(pe32.Th32ProcessID))
+	var isProtected bool
+	cp.procHandle, isProtected, err = OpenProcessHandle(int32(pe32.Th32ProcessID))
 	if err != nil {
 		return err
 	}
@@ -240,14 +241,20 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 	if usererr != nil {
 		log.Debugf("Couldn't get process username %v %v", pe32.Th32ProcessID, err)
 	}
-	var cmderr error
 	cp.executablePath = winutil.ConvertWindowsString16(pe32.SzExeFile[:])
-	commandParams, cmderr := winutil.GetCommandParamsForProcess(cp.procHandle, false)
-	if cmderr != nil {
-		log.Debugf("Error retrieving full command line %v", cmderr)
-		cp.commandLine = cp.executablePath
-	} else {
-		cp.commandLine = commandParams.CmdLine
+	// set default commandLine value incase we can't read the actual commandLine due to the proteced process
+	cp.commandLine = cp.executablePath
+
+	// we cannot read the command line if the process is protected
+	if !isProtected {
+		var cmderr error
+		commandParams, cmderr := winutil.GetCommandParamsForProcess(cp.procHandle, false)
+		if cmderr != nil {
+			log.Debugf("Error retrieving full command line %v", cmderr)
+		}
+		if commandParams != nil {
+			cp.commandLine = commandParams.CmdLine
+		}
 	}
 
 	cp.parsedArgs = ParseCmdLineArgs(cp.commandLine)

--- a/pkg/process/procutil/process_windows_toolhelp.go
+++ b/pkg/process/procutil/process_windows_toolhelp.go
@@ -242,12 +242,10 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 		log.Debugf("Couldn't get process username %v %v", pe32.Th32ProcessID, err)
 	}
 	cp.executablePath = winutil.ConvertWindowsString16(pe32.SzExeFile[:])
-	// set default commandLine value incase we can't read the actual commandLine due to the proteced process
 	cp.commandLine = cp.executablePath
 
 	// we cannot read the command line if the process is protected
 	if !isProtected {
-		var cmderr error
 		commandParams, cmderr := winutil.GetCommandParamsForProcess(cp.procHandle, false)
 		if cmderr != nil {
 			log.Debugf("Error retrieving full command line %v", cmderr)

--- a/pkg/util/winutil/process_test.go
+++ b/pkg/util/winutil/process_test.go
@@ -108,6 +108,7 @@ func TestIsProcessProtected(t *testing.T) {
 			} else {
 				// unprotected process's should allow reading memory with a higher privilege handle
 				procHandle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, pid)
+				assert.NoError(t, err)
 				_, err = GetCommandParamsForProcess(procHandle, true)
 				assert.NoError(t, err)
 			}

--- a/pkg/util/winutil/process_test.go
+++ b/pkg/util/winutil/process_test.go
@@ -1,0 +1,117 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package winutil
+
+import (
+	"errors"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+	"testing"
+	"unsafe"
+)
+
+// similar to ProcessesByPID but needed a different implementation to find
+// specific protected processes by name
+func getPIDbyName(name string) (uint32, error) {
+	// create snapshot of processes
+	// 0x00000002 is the flag for a process snapshot called TH32CS_SNAPPROCESS
+	hSnap, err := windows.CreateToolhelp32Snapshot(0x00000002, 0)
+	if err != nil {
+		return 0, fmt.Errorf("CreateToolhelp32Snapshot: %w", err)
+	}
+
+	defer windows.CloseHandle(hSnap)
+
+	var pe windows.ProcessEntry32
+	pe.Size = uint32(unsafe.Sizeof(pe))
+
+	// get the first process
+	if err := windows.Process32First(hSnap, &pe); err != nil {
+		return 0, fmt.Errorf("Process32First: %w", err)
+	}
+
+	// iterate through list of processes
+	for {
+		processName := windows.UTF16ToString(pe.ExeFile[:])
+		if processName == name {
+			return pe.ProcessID, nil
+		}
+		if err := windows.Process32Next(hSnap, &pe); err != nil {
+			// no more entries
+			if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+				break
+			}
+			return 0, fmt.Errorf("Process32Next: %w", err)
+		}
+	}
+
+	return 0, fmt.Errorf("%s not found", name)
+}
+
+func TestIsProcessProtected(t *testing.T) {
+	for _, tc := range []struct {
+		description string
+		processName string
+		expected    bool
+	}{
+		{
+			description: "protected process 1",
+			processName: "csrss.exe",
+			expected:    true,
+		},
+		{
+			description: "protected process 2",
+			processName: "services.exe",
+			expected:    true,
+		},
+		{
+			description: "protected process 3",
+			processName: "smss.exe",
+			expected:    true,
+		},
+		{
+			description: "protected process 4",
+			processName: "wininit.exe",
+			expected:    true,
+		},
+		{
+			description: "unprotected process",
+			processName: "<CURRENT_PROCESS>",
+			expected:    false,
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			var pid uint32
+			var err error
+			if tc.processName == "<CURRENT_PROCESS>" {
+				pid = windows.GetCurrentProcessId()
+			} else {
+				pid, err = getPIDbyName(tc.processName)
+				fmt.Printf("pid: %d\n", pid)
+				require.NoError(t, err)
+			}
+
+			procHandle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+			require.NoError(t, err)
+
+			if tc.expected {
+				var procmem uintptr
+				var peb peb32
+				toRead := uint32(unsafe.Sizeof(peb))
+				bytesRead, err := ReadProcessMemory(procHandle, procmem, uintptr(unsafe.Pointer(&peb)), toRead)
+				require.Error(t, err)
+				assert.Equal(t, uint64(0), bytesRead)
+			}
+
+			isProcessProtected, err := IsProcessProtected(procHandle)
+			assert.Equal(t, tc.expected, isProcessProtected)
+		})
+	}
+}

--- a/pkg/util/winutil/process_test.go
+++ b/pkg/util/winutil/process_test.go
@@ -94,7 +94,6 @@ func TestIsProcessProtected(t *testing.T) {
 				pid = windows.GetCurrentProcessId()
 			} else {
 				pid, err = getPIDbyName(tc.processName)
-				fmt.Printf("pid: %d\n", pid)
 				require.NoError(t, err)
 			}
 
@@ -111,6 +110,7 @@ func TestIsProcessProtected(t *testing.T) {
 			}
 
 			isProcessProtected, err := IsProcessProtected(procHandle)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.expected, isProcessProtected)
 		})
 	}

--- a/pkg/util/winutil/process_test.go
+++ b/pkg/util/winutil/process_test.go
@@ -99,9 +99,8 @@ func TestIsProcessProtected(t *testing.T) {
 
 			isProcessProtected, err := IsProcessProtected(procHandle)
 			assert.NoError(t, err)
-			if tc.processName != "lsass.exe" {
-				assert.Equal(t, tc.expected, isProcessProtected)
-			}
+			assert.Equal(t, tc.expected, isProcessProtected)
+
 			// CHECKING MEMORY ACCESS PRIVILEGES
 			if tc.expected {
 				_, err := GetCommandParamsForProcess(procHandle, true)

--- a/pkg/util/winutil/process_test.go
+++ b/pkg/util/winutil/process_test.go
@@ -95,6 +95,7 @@ func TestIsProcessProtected(t *testing.T) {
 
 			procHandle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
 			require.NoError(t, err)
+			defer windows.CloseHandle(procHandle)
 
 			isProcessProtected, err := IsProcessProtected(procHandle)
 			assert.NoError(t, err)
@@ -107,9 +108,10 @@ func TestIsProcessProtected(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				// unprotected process's should allow reading memory with a higher privilege handle
-				procHandle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, pid)
+				privilegedProcHandle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION|windows.PROCESS_VM_READ, false, pid)
 				assert.NoError(t, err)
-				_, err = GetCommandParamsForProcess(procHandle, true)
+				defer windows.CloseHandle(privilegedProcHandle)
+				_, err = GetCommandParamsForProcess(privilegedProcHandle, true)
 				assert.NoError(t, err)
 			}
 		})

--- a/releasenotes/notes/windows-agent-protection-check-31ff7c154e6773e6.yaml
+++ b/releasenotes/notes/windows-agent-protection-check-31ff7c154e6773e6.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Windows: prevent unnecessary failing access to process memory when a process is protected
+    Windows: Prevent unnecessary failing access to process memory when a process is protected

--- a/releasenotes/notes/windows-agent-protection-check-31ff7c154e6773e6.yaml
+++ b/releasenotes/notes/windows-agent-protection-check-31ff7c154e6773e6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Windows: prevent unnecessary failing access to process memory when a process is protected

--- a/test/new-e2e/tests/process/testing.go
+++ b/test/new-e2e/tests/process/testing.go
@@ -135,6 +135,14 @@ func assertProcessCollectedNew(
 	assertProcesses(t, procs, withIOStats, process)
 }
 
+func assertProcessCommandLineArgs(t require.TestingT, processes []*agentmodel.Process, processCMDArgs []string) {
+	for _, proc := range processes {
+		// command arguments include the first command/program which can differ depending on the path,
+		// so we compare the user provided arguments starting from index 1
+		assert.Equalf(t, proc.Command.Args[1:], processCMDArgs[1:], "process args do not match. Expected %+v", processCMDArgs)
+	}
+}
+
 // assertProcesses asserts that the given processes are collected by the process check
 func assertProcesses(t require.TestingT, procs []*agentmodel.Process, withIOStats bool, process string) {
 	// verify process data is populated
@@ -200,6 +208,14 @@ func findProcess(
 	}
 
 	return found, populated
+}
+
+func filterProcessPayloadsByName(payloads []*aggregator.ProcessPayload, processName string) []*agentmodel.Process {
+	var procs []*agentmodel.Process
+	for _, payload := range payloads {
+		procs = append(procs, filterProcesses(processName, payload.Processes)...)
+	}
+	return procs
 }
 
 // filterProcesses returns processes which match the given process name

--- a/test/new-e2e/tests/process/windows_test.go
+++ b/test/new-e2e/tests/process/windows_test.go
@@ -6,7 +6,11 @@
 package process
 
 import (
+	"encoding/json"
 	"fmt"
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -161,7 +165,23 @@ func (s *windowsTestSuite) TestAPIKeyRefreshAdditionalEndpoints() {
 	}, 2*time.Minute, 10*time.Second)
 }
 
-func assertProcessCheck(t *testing.T, env *environments.Host) {
+func assertProcessCMDArgs(t require.TestingT, processes []*agentmodel.Process, processCMDArgs []string) {
+	for _, proc := range processes {
+		// command arguments include the first command/program which can differ depending on the path,
+		// so we compare the user provided arguments starting from index 1
+		assert.Truef(t, slices.Equal(proc.Command.Args[1:], processCMDArgs[1:]), "process args do not match. Expected %+v", processCMDArgs)
+	}
+}
+
+func getMatchingProcessesByName(payloads []*aggregator.ProcessPayload, processName string) []*agentmodel.Process {
+	var procs []*agentmodel.Process
+	for _, payload := range payloads {
+		procs = append(procs, filterProcesses(processName, payload.Processes)...)
+	}
+	return procs
+}
+
+func assertProcessCheck(t *testing.T, env *environments.Host, withIOStats bool, processName string, processCMDArgs []string) {
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assertRunningChecks(collect, env.Agent.Client, []string{"process", "rtprocess"}, false)
 	}, 1*time.Minute, 5*time.Second)
@@ -172,26 +192,56 @@ func assertProcessCheck(t *testing.T, env *environments.Host) {
 		payloads, err = env.FakeIntake.Client().GetProcesses()
 		assert.NoError(c, err, "failed to get process payloads from fakeintake")
 
-		// Wait for two payloads, as processes must be detected in two check runs to be returned
-		assert.GreaterOrEqual(c, len(payloads), 2, "fewer than 2 payloads returned")
-	}, 2*time.Minute, 10*time.Second)
+		assertProcessCollectedNew(c, payloads, withIOStats, processName)
 
-	assertProcessCollected(t, payloads, false, "MsMpEng.exe")
+		procs := getMatchingProcessesByName(payloads, processName)
+		require.NotEmpty(t, procs, "'%s' process not found in payloads: \n%+v", processName, payloads)
+		assertProcessCMDArgs(c, procs, processCMDArgs)
+	}, 2*time.Minute, 10*time.Second)
 }
 
-func (s *windowsTestSuite) TestProcessCheck() {
+func (s *windowsTestSuite) TestProtectedProcessCheck() {
 	s.UpdateEnv(awshost.Provisioner(
 		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr)),
 	))
-	assertProcessCheck(s.T(), s.Env())
+	// MsMpEng.exe is a protected process so we can't access any command line arguments
+	assertProcessCheck(s.T(), s.Env(), false, "MsMpEng.exe", []string{"MsMpEng.exe"})
 }
 
-func (s *windowsTestSuite) TestProcessChecksInCoreAgent() {
+func (s *windowsTestSuite) TestUnprotectedProcessCheck() {
+	t := s.T()
+	s.UpdateEnv(awshost.Provisioner(
+		awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
+		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
+	))
+
+	err := s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
+	}, 1*time.Minute, 5*time.Second)
+
+	// unprotected process
+	cmd := []string{
+		"chkdsk",
+		"C:",
+		"/i",
+		"/c",
+	}
+	process, err := runCMD(t, s.Env().RemoteHost, cmd)
+	require.NoError(s.T(), err)
+
+	assertProcessCheck(s.T(), s.Env(), false, process, cmd)
+}
+
+func (s *windowsTestSuite) TestProtectedProcessChecksInCoreAgent() {
 	t := s.T()
 	s.UpdateEnv(awshost.Provisioner(awshost.WithEC2InstanceOptions(ec2.WithOS(os.WindowsDefault)),
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckInCoreAgentConfigStr))))
-	assertProcessCheck(t, s.Env())
+	// MsMpEng.exe is a protected process so we can't access any command line arguments
+	assertProcessCheck(t, s.Env(), false, "MsMpEng.exe", []string{"MsMpEng.exe"})
 
 	// Verify the process component is not running in the core agent
 	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -236,17 +286,10 @@ func (s *windowsTestSuite) TestProcessCheckIO() {
 		assertRunningChecks(collect, s.Env().Agent.Client, []string{"process", "rtprocess"}, true)
 	}, 1*time.Minute, 5*time.Second)
 
-	err := runDiskSpd(s.T(), s.Env().RemoteHost)
+	process, cmd, err := runDiskSpd(s.T(), s.Env().RemoteHost)
 	require.NoError(s.T(), err)
 
-	var payloads []*aggregator.ProcessPayload
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		var err error
-		payloads, err = s.Env().FakeIntake.Client().GetProcesses()
-		assert.NoError(c, err, "failed to get process payloads from fakeintake")
-
-		assertProcessCollectedNew(c, payloads, true, "diskspd.exe")
-	}, 2*time.Minute, 10*time.Second)
+	assertProcessCheck(s.T(), s.Env(), true, process, cmd)
 }
 
 func (s *windowsTestSuite) TestManualProcessCheck() {
@@ -268,20 +311,31 @@ func (s *windowsTestSuite) TestManualProcessCheckWithIO() {
 		awshost.WithAgentOptions(agentparams.WithAgentConfig(processCheckConfigStr), agentparams.WithSystemProbeConfig(systemProbeConfigStr)),
 	))
 
-	err := runDiskSpd(s.T(), s.Env().RemoteHost)
+	process, cmd, err := runDiskSpd(s.T(), s.Env().RemoteHost)
 	require.NoError(s.T(), err)
 
 	// Try multiple times as all the I/O data may not be available in a given instant
 	assert.EventuallyWithT(s.T(), func(c *assert.CollectT) {
 		check := s.Env().RemoteHost.
 			MustExecute("& \"C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent\\process-agent.exe\" check process --json")
-		assertManualProcessCheck(c, check, true, "diskspd.exe")
+		assertManualProcessCheck(c, check, true, process)
+
+		var checkOutput struct {
+			Processes []*agentmodel.Process `json:"processes"`
+		}
+
+		err := json.Unmarshal([]byte(check), &checkOutput)
+		require.NoError(c, err, "failed to unmarshal process check output")
+
+		procs := filterProcesses(process, checkOutput.Processes)
+		require.NotEmpty(c, procs, "'%s' process not found in check:\n%s\n", process, check)
+		assertProcessCMDArgs(c, procs, cmd)
 	}, 1*time.Minute, 5*time.Second)
 }
 
 // Runs Diskspd in another ssh session
 // https://github.com/Microsoft/diskspd/wiki/Command-line-and-parameters
-func runDiskSpd(t *testing.T, remoteHost *components.RemoteHost) error {
+func runDiskSpd(t *testing.T, remoteHost *components.RemoteHost) (string, []string, error) {
 	// Disk speed parameters
 	// -d120: Duration of the test in seconds
 	// -c128M: Size of the test file in bytes
@@ -292,14 +346,32 @@ func runDiskSpd(t *testing.T, remoteHost *components.RemoteHost) error {
 	// -r: Random I/O
 	// -Sh: Disable both software caching and hardware write caching.
 	// -w50: Write percentage
-	session, stdin, _, err := remoteHost.Start("diskspd -d120 -c128M -t2 -o4 -b8k -L -r -Sh -w50 disk-speed-test.dat")
+	cmd := []string{
+		"diskspd",
+		"-d120",
+		"-c128M",
+		"-t2",
+		"-o4",
+		"-b8k",
+		"-L",
+		"-r",
+		"-Sh",
+		"-w50",
+		"disk-speed-test.dat",
+	}
+	processName, err := runCMD(t, remoteHost, cmd)
+	return processName, cmd, err
+}
+
+func runCMD(t *testing.T, remoteHost *components.RemoteHost, cmd []string) (string, error) {
+	session, stdin, _, err := remoteHost.Start(strings.Join(cmd, " "))
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	t.Cleanup(func() {
 		_ = session.Close()
 		_ = stdin.Close()
 	})
-	return nil
+	return fmt.Sprintf("%s.exe", cmd[0]), nil
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- introduces a new function `IsProcessProtected` via a system call to determine if the agent has access to reading the memory or not
- refactor command line processing to include executable/image path even if command line processsing fails (existing behaviour, but was impacted by this protection check)
    - align `process_windows` `fillProcessDetails` function to be more similar with `process_windows_toolhelp` `fillFromProcEntry` because they serve the same purpose

### Motivation
- previously log show that we attempt to call `ReadProcessMemory` even when we fail to open the process with `PROCESS_VM_READ`

```
2024-08-21 17:02:31 EDT | PROCESS | DEBUG | (pkg/process/procutil/process_windows.go:545 in OpenProcessHandle) | Couldn't open process with PROCESS_VM_READ 4 Access is denied.
2024-08-21 17:02:31 EDT | PROCESS | DEBUG | (pkg/util/winutil/process.go:101 in ReadProcessMemory) | Access denied error getting process memory
2024-08-21 17:02:31 EDT | PROCESS | DEBUG | (pkg/process/procutil/process_windows_toolhelp.go:247 in fillFromProcEntry) | Error retrieving full command line Access is denied.
```
We shouldn't bother trying to collect the command line if we don't have PROCESS_VM_READ  on the handle.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- added unit tests for the new `IsProcessProtected` function
- updated windows e2e tests to actually check if command line arguments exist for an unprotected process
- benchmarked new `OpenProcessHandle` function to verify performance impact (not significant)
    - thread in pr
> I also just ran some benchmarking just testing the openProcessHandle with 1 process at a time with the following results:
BenchmarkOpenProcessHandleProtected-4             255981              6009 ns/op
BenchmarkOldOpenProcessHandleProtected-4           15889             77775 ns/op
BenchmarkOpenProcessHandleUnprotected-4           197953              6709 ns/op
BenchmarkOldOpenProcessHandleUnprotected-4        358704              3219 ns/op
A single unprotected process takes 6 microseconds vs 3 compared to the old method.
What's interesting is for protected processes, the older method takes ~10x the time likely from handling an error since the older version attempts to get more privileged access initially and on an error would fall back to a less privileged version.
While with the newer version, we check for access or not before attempting.
Here is the testing file as a gist that I used if you'd like to check.
https://gist.github.com/gengnamstyle/8348a4edc51807922fbc90914e63e5aa


### Possible Drawbacks / Trade-offs
- additionally system check in `OpenProcess` handle and opening 2 process handles instead of 1 in the main codepath for an unprotected process leading to 3 microseconds of increased overhead per process so a host having 100 processes may have 0.3 millisecond impact (not substantial)


### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
- created a ticket to consolidate testing helper functions in e2e tests since they is a lot of duplicate functionality and refactors to do! (didn't want to increase the scope of this pr)
   - most notably, there is a `assertProcessCollectedNew` and a `assertProcessCollected` and `assertProcessCollectedNew` should be replacing `assertProcessCollected` but this was never done
   - https://datadoghq.atlassian.net/browse/CXP-2229
   