### PR TITLE
[AGENT-13494] Using a proxy with the redirect client

### DIFF
--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -267,6 +267,7 @@ func NewHTTPClient(config config.Component, numberOfWorkers int, log log.Compone
 	}
 }
 
+// NewHTTPTransport creates a new http.Transport
 func NewHTTPTransport(config config.Component, numberOfWorkers int, log log.Component) *http.Transport {
 	var transport *http.Transport
 

--- a/comp/forwarder/defaultforwarder/domain_forwarder.go
+++ b/comp/forwarder/defaultforwarder/domain_forwarder.go
@@ -260,6 +260,14 @@ func newBearerAuthHTTPClient(numberOfWorkers int) *http.Client {
 
 // NewHTTPClient creates a new http.Client
 func NewHTTPClient(config config.Component, numberOfWorkers int, log log.Component) *http.Client {
+	transport := NewHTTPTransport(config, numberOfWorkers, log)
+	return &http.Client{
+		Timeout:   config.GetDuration("forwarder_timeout") * time.Second,
+		Transport: transport,
+	}
+}
+
+func NewHTTPTransport(config config.Component, numberOfWorkers int, log log.Component) *http.Transport {
 	var transport *http.Transport
 
 	transportConfig := config.Get("forwarder_http_protocol")
@@ -274,10 +282,7 @@ func NewHTTPClient(config config.Component, numberOfWorkers int, log log.Compone
 		transport = httputils.CreateHTTPTransport(config, httputils.WithHTTP2(), httputils.MaxConnsPerHost(numberOfWorkers))
 	}
 
-	return &http.Client{
-		Timeout:   config.GetDuration("forwarder_timeout") * time.Second,
-		Transport: transport,
-	}
+	return transport
 }
 
 // Stop stops a domainForwarder, all transactions not yet flushed will be lost.

--- a/pkg/diagnose/connectivity/core_endpoint_test.go
+++ b/pkg/diagnose/connectivity/core_endpoint_test.go
@@ -65,6 +65,9 @@ func TestSendHTTPRequestToEndpoint(t *testing.T) {
 }
 
 func TestAcceptRedirection(t *testing.T) {
+	mockConfig := configmock.New(t)
+	mockLog := logmock.New(t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		//  * the original flare request URL, which redirects on HEAD to /post-target
 		if r.Method == "HEAD" && r.RequestURI == "/support/flare" {
@@ -79,7 +82,7 @@ func TestAcceptRedirection(t *testing.T) {
 
 	ddURL := ts.URL
 
-	client := clientWithOneRedirects()
+	client := clientWithOneRedirects(mockConfig, 1, mockLog)
 
 	url := ddURL + "/support/flare"
 	statusCode, err := sendHTTPHEADRequestToEndpoint(url, client)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
We noticed [an issue](https://datadoghq.atlassian.net/browse/AGENT-13494?focusedCommentId=2311675) where, if the command `datadog-agent diagnose connectivity-datadog-core-endpoints -vo | grep flare -B1 -A3` is applied with a bad proxy configured, the flare endpoint returns a 307 (redirect) code, instead of a failing >400 code, as expected. This is because, while the typical client for the core endpoint incorporates the proxy, when making a `HEAD` request to the endpoint, a redirect-version of the client is used, which didn't incorporate the configured proxy. We add proxy support to this client.
### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I ran the command with the changes and a bad proxy configured--it fails as expected. When the proxy isn't configured, the command passes. Existing tests for the core endpoint and the default forwarder pass.
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->