### PR TITLE
[Backport 7.65.x] Backport 35826 to 7.65.x

### DIFF
--- a/test/new-e2e/tests/containers/k8s_test.go
+++ b/test/new-e2e/tests/containers/k8s_test.go
@@ -111,7 +111,10 @@ func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
 	suite.Run("agent pods are ready and not restarting", func() {
 		suite.EventuallyWithTf(func(c *assert.CollectT) {
 			linuxNodes, err := suite.Env().KubernetesCluster.Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{
-				LabelSelector: fields.OneTermEqualSelector("kubernetes.io/os", "linux").String(),
+				LabelSelector: fields.AndSelectors(
+					fields.OneTermEqualSelector("kubernetes.io/os", "linux"),
+					fields.OneTermNotEqualSelector("eks.amazonaws.com/compute-type", "fargate"),
+				).String(),
 			})
 			// Can be replaced by require.NoErrorf(…) once https://github.com/stretchr/testify/pull/1481 is merged
 			if !assert.NoErrorf(c, err, "Failed to list Linux nodes") {


### PR DESCRIPTION
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/35826/files#diff-2bca1254c33d752a13e15a261a21b1282ec394f1e06fba2b8d850c4215cf5102R118-R121

### Motivation

Fix e2e tests on `7.65.x` branch since the merge of #36721 that pulled DataDog/test-infra-definitions#1487.

### Describe how you validated your changes

Wait for e2e tests results.

### Possible Drawbacks / Trade-offs

### Additional Notes
