### PR TITLE
Separate needs for ot_agent_standalone builds by architecture

### DIFF
--- a/.gitlab/container_build/docker_linux.yml
+++ b/.gitlab/container_build/docker_linux.yml
@@ -199,8 +199,6 @@ docker_build_base_image_arm64:
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  needs:
-    - job: docker_build_base_image_arm64
   variables:
     IMAGE: registry.ddbuild.io/ci/datadog-agent/otel-agent
     BUILD_CONTEXT: Dockerfiles/otel-agent
@@ -211,10 +209,14 @@ docker_build_base_image_arm64:
 docker_build_ot_agent_standalone_amd64:
   extends:
     [.docker_build_ot_agent_standalone, .docker_build_job_definition_amd64]
+  needs:
+    - job: docker_build_base_image_amd64
 
 docker_build_ot_agent_standalone_arm64:
   extends:
     [.docker_build_ot_agent_standalone, .docker_build_job_definition_arm64]
+  needs:
+    - job: docker_build_base_image_arm64
 
 docker_build_agent7_full:
   extends: [.docker_build_job_definition_amd64, .docker_build_artifact]


### PR DESCRIPTION
### What does this PR do?

Specifies the actual dependency for each architecture of the ot_agent_standalone builds.

### Motivation

Fixing this kind of error: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/928465297.

Both `docker_build_ot_agent_standalone_amd64` and `docker_build_ot_agent_standalone_arm64` are depending on `docker_build_base_image_arm64` on GitLab terms, but the `amd64` image actually depends on its matching base image being present in the registry. This leads to situations where the amd64 build can fail because its base image is still not there. In the above example, the base image build failed for amd64 on the first attempt while the arm64 didn't, causing it to fail.

### Describe how you validated your changes

Pipeline passing would be enough.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->