### PR TITLE
fix some GoDI tests

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/codegen.go
+++ b/pkg/dynamicinstrumentation/codegen/codegen.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	template "github.com/DataDog/datadog-agent/pkg/template/text"
+	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -98,7 +99,7 @@ func generateHeadersText(params []*ditypes.Parameter, out io.Writer) error {
 
 func generateParameterIndexText(index int, out io.Writer) error {
 	expr := ditypes.SetParameterIndexLocationExpression(uint16(index))
-	t, err := resolveLocationExpressionTemplate(expr)
+	t, err := resolveLocationExpressionTemplate(expr.Opcode)
 	if err != nil {
 		return err
 	}
@@ -129,7 +130,7 @@ func generateParametersTextViaLocationExpressions(params []*ditypes.Parameter, o
 	for i := range params {
 		collectedExpressions := collectLocationExpressions(params[i])
 		for _, locationExpression := range collectedExpressions {
-			template, err := resolveLocationExpressionTemplate(locationExpression)
+			template, err := resolveLocationExpressionTemplate(locationExpression.Opcode)
 			if err != nil {
 				return err
 			}
@@ -190,8 +191,8 @@ func collectSubLocationExpressions(location ditypes.LocationExpression) []ditype
 	return collectedExpressions
 }
 
-func resolveLocationExpressionTemplate(locationExpression ditypes.LocationExpression) (*template.Template, error) {
-	switch locationExpression.Opcode {
+var resolveLocationExpressionTemplate = funcs.MemoizeArg(func(opcode ditypes.LocationExpressionOpcode) (*template.Template, error) {
+	switch opcode {
 	case ditypes.OpReadUserRegister:
 		return template.New("read_register_location_expression").Parse(readRegisterTemplateText)
 	case ditypes.OpReadUserStack:
@@ -239,7 +240,7 @@ func resolveLocationExpressionTemplate(locationExpression ditypes.LocationExpres
 	default:
 		return nil, errors.New("invalid location expression opcode")
 	}
-}
+})
 
 func generateSliceHeader(slice *ditypes.Parameter, out io.Writer) error {
 	// Slices are defined with an "array" pointer as piece 0, which is a pointer to the actual

--- a/pkg/dynamicinstrumentation/codegen/templates.go
+++ b/pkg/dynamicinstrumentation/codegen/templates.go
@@ -13,8 +13,8 @@ var headerTemplateText = `
 param_type = {{.Kind}};
 bpf_probe_read_kernel(&event->output[context.output_offset], sizeof(param_type), &param_type);
 param_size = {{.TotalSize}};
-bpf_probe_read_kernel(&event->output[context.output_offset+1], sizeof(param_size), &param_size);
-context.output_offset += 3;
+bpf_probe_read_kernel(&event->output[context.output_offset+sizeof(param_type)], sizeof(param_size), &param_size);
+context.output_offset += sizeof(param_type) + sizeof(param_size);
 `
 var sliceRegisterHeaderTemplateText = `
 // Name={{.Parameter.Name}} ID={{.Parameter.ID}} TotalSize={{.Parameter.TotalSize}} Kind={{.Parameter.Kind}}
@@ -22,7 +22,7 @@ var sliceRegisterHeaderTemplateText = `
 param_type = {{.Parameter.Kind}};
 bpf_probe_read_kernel(&event->output[context.output_offset], sizeof(param_type), &param_type);
 
-context.output_offset += 1;
+context.output_offset += sizeof(param_type);
 
 __u16 indexSlice{{.Parameter.ID}};
 slice_length = param_size;
@@ -44,7 +44,7 @@ var sliceStackHeaderTemplateText = `
 param_type = {{.Parameter.Kind}};
 bpf_probe_read_kernel(&event->output[context.output_offset], sizeof(param_type), &param_type);
 
-context.output_offset += 1;
+context.output_offset += sizeof(param_type);
 
 {{.SliceTypeHeaderText}}
 `
@@ -54,5 +54,5 @@ var stringHeaderTemplateText = `
 // Write the string kind to output buffer
 param_type = {{.Kind}};
 bpf_probe_read_kernel(&event->output[context.output_offset], sizeof(param_type), &param_type);
-context.output_offset += 1;
+context.output_offset += sizeof(param_type);
 `

--- a/pkg/dynamicinstrumentation/diconfig/dwarf.go
+++ b/pkg/dynamicinstrumentation/diconfig/dwarf.go
@@ -398,6 +398,7 @@ func getStructFields(offset dwarf.Offset, dwarfData *dwarf.Data, seenTypes map[s
 
 				if !entryTypeIsSupported(typeEntry) {
 					unsupportedType := resolveUnsupportedEntry(typeEntry)
+					unsupportedType.Name = newStructField.Name
 					structFields = append(structFields, unsupportedType)
 					continue
 				}

--- a/pkg/dynamicinstrumentation/diconfig/location_expression.go
+++ b/pkg/dynamicinstrumentation/diconfig/location_expression.go
@@ -9,10 +9,9 @@ package diconfig
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"strings"
-
-	"math/rand"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -264,6 +263,7 @@ func GenerateLocationExpression(limitsInfo *ditypes.InstrumentationInfo, param *
 					if elementParam.ParameterPieces[0] == nil {
 						continue
 					}
+					targetExpressions = append(targetExpressions, ditypes.ApplyOffsetLocationExpression(uint(elementParam.FieldOffset)))
 					GenerateLocationExpression(limitsInfo, elementParam.ParameterPieces[0])
 					expressionsToUseForEachArrayElement := collectAllLocationExpressions(elementParam.ParameterPieces[0], true)
 					for i := range elementParam.ParameterPieces {

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -357,9 +357,9 @@ var structCaptures = fixtures{
 				"a": {
 					Type: "github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.hasUnsupportedFields",
 					Fields: fieldMap{
-						"a": capturedValue("int", "1"),
-						"b": capturedValue("float32", ""),
-						"c": {
+						"b": capturedValue("int", "1"),
+						"c": &ditypes.CapturedValue{Type: "float32", Value: nil, NotCapturedReason: "unsupported"},
+						"d": {
 							Type: "[]uint8",
 							Elements: []ditypes.CapturedValue{
 								*capturedValue("uint8", "3"),

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -447,7 +447,7 @@ var structCaptures = fixtures{
 								*capturedValue("uint8", "4"),
 							},
 						},
-						"z": capturedValue("int", "5"),
+						"z": capturedValue("uint64", "5"),
 					},
 				},
 			},

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -575,7 +575,7 @@ var structCaptures = fixtures{
 								*capturedValue("uint64", "3"),
 							},
 						},
-						"b": capturedValue("int", "4"),
+						"b": capturedValue("uint8", "4"),
 						"c": {
 							Type: "[5]int64",
 							Elements: []ditypes.CapturedValue{

--- a/pkg/dynamicinstrumentation/testutil/fixtures.go
+++ b/pkg/dynamicinstrumentation/testutil/fixtures.go
@@ -374,7 +374,7 @@ var structCaptures = fixtures{
 		},
 	},
 
-	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_pointer_method_receiver": []CapturedValueMapWithOptions{
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.(*receiver).test_pointer_method_receiver": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"r": {
@@ -394,7 +394,7 @@ var structCaptures = fixtures{
 		},
 	},
 
-	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.test_method_receiver": []CapturedValueMapWithOptions{
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample.receiver.test_method_receiver": []CapturedValueMapWithOptions{
 		{
 			CapturedValueMap: map[string]*ditypes.CapturedValue{
 				"r": {

--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -9,10 +9,8 @@ package bininspect
 
 import (
 	"debug/dwarf"
+	"errors"
 	"fmt"
-	"maps"
-	"slices"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils/locexpr"
@@ -134,7 +132,7 @@ func (d dwarfInspector) findFunctionDebugInfoEntries(functions []string) (map[st
 	}
 
 	if len(functionsToSearch) != 0 {
-		return nil, fmt.Errorf("not all functions found: %s", strings.Join(slices.Collect(maps.Keys(functionsToSearch)), ","))
+		return nil, errors.New("not all functions found")
 	}
 
 	return functionEntries, nil

--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -9,8 +9,8 @@ package bininspect
 
 import (
 	"debug/dwarf"
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils/locexpr"
@@ -132,7 +132,7 @@ func (d dwarfInspector) findFunctionDebugInfoEntries(functions []string) (map[st
 	}
 
 	if len(functionsToSearch) != 0 {
-		return nil, errors.New("not all functions found")
+		return nil, fmt.Errorf("not all functions found: %s", strings.Join(functions, ","))
 	}
 
 	return functionEntries, nil

--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -10,6 +10,8 @@ package bininspect
 import (
 	"debug/dwarf"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
@@ -132,7 +134,7 @@ func (d dwarfInspector) findFunctionDebugInfoEntries(functions []string) (map[st
 	}
 
 	if len(functionsToSearch) != 0 {
-		return nil, fmt.Errorf("not all functions found: %s", strings.Join(functions, ","))
+		return nil, fmt.Errorf("not all functions found: %s", strings.Join(slices.Collect(maps.Keys(functionsToSearch)), ","))
 	}
 
 	return functionEntries, nil


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Fixes the following tests:
- `test_struct_with_arrays`
- `test_struct_with_unsupported_fields`
- `test_method_receiver`
- `test_pointer_method_receiver`
- `test_struct_with_a_slice`

Some minor improvements included too:
- Memoizes the location expression templates
- Removes some magic numbers from param header ebpf code

### Motivation

More passing tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->