### PR TITLE
APM: reduce calls to get container tags to improve performance (APMSP-1986)

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -3308,13 +3308,6 @@ func TestProcessedTrace(t *testing.T) {
 			Meta:     map[string]string{"env": "test", "version": "v1.0.1"},
 		}
 		chunk := testutil.TraceChunkWithSpan(root)
-		cfg := config.New()
-		cfg.ContainerTags = func(cid string) ([]string, error) {
-			if cid == "1" {
-				return []string{"image_tag:abc", "git.commit.sha:abc123"}, nil
-			}
-			return nil, nil
-		}
 		// Only fill out the relevant fields for processedTrace().
 		apiPayload := &api.Payload{
 			TracerPayload: &pb.TracerPayload{
@@ -3326,7 +3319,7 @@ func TestProcessedTrace(t *testing.T) {
 			},
 			ClientDroppedP0s: 1,
 		}
-		pt := processedTrace(apiPayload, chunk, root, "1", cfg)
+		pt := processedTrace(apiPayload, chunk, root, "abc", "abc123")
 		expectedPt := &traceutil.ProcessedTrace{
 			TraceChunk:             chunk,
 			Root:                   root,
@@ -3351,13 +3344,6 @@ func TestProcessedTrace(t *testing.T) {
 			Meta:     map[string]string{"env": "test", "version": "v1.0.1", "_dd.git.commit.sha": "abc123"},
 		}
 		chunk := testutil.TraceChunkWithSpan(root)
-		cfg := config.New()
-		cfg.ContainerTags = func(cid string) ([]string, error) {
-			if cid == "1" {
-				return []string{"image_tag:abc", "git.commit.sha:def456"}, nil
-			}
-			return nil, nil
-		}
 		// Only fill out the relevant fields for processedTrace().
 		apiPayload := &api.Payload{
 			TracerPayload: &pb.TracerPayload{
@@ -3369,7 +3355,7 @@ func TestProcessedTrace(t *testing.T) {
 			},
 			ClientDroppedP0s: 1,
 		}
-		pt := processedTrace(apiPayload, chunk, root, "1", cfg)
+		pt := processedTrace(apiPayload, chunk, root, "abc", "def456")
 		expectedPt := &traceutil.ProcessedTrace{
 			TraceChunk:             chunk,
 			Root:                   root,
@@ -3409,7 +3395,7 @@ func TestProcessedTrace(t *testing.T) {
 			},
 			ClientDroppedP0s: 1,
 		}
-		pt := processedTrace(apiPayload, chunk, root, "1", cfg)
+		pt := processedTrace(apiPayload, chunk, root, "", "")
 		expectedPt := &traceutil.ProcessedTrace{
 			TraceChunk:             chunk,
 			Root:                   root,

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -651,12 +651,12 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 	ts.TracesReceived.Add(int64(len(tp.Chunks)))
 	ts.TracesBytes.Add(req.Body.(*apiutil.LimitedReader).Count)
 	ts.PayloadAccepted.Inc()
-
-	if ctags := getContainerTags(r.conf.ContainerTags, tp.ContainerID); ctags != "" {
+	ctags := getContainerTagsList(r.conf.ContainerTags, tp.ContainerID)
+	if len(ctags) > 0 {
 		if tp.Tags == nil {
 			tp.Tags = make(map[string]string)
 		}
-		tp.Tags[tagContainersTags] = ctags
+		tp.Tags[tagContainersTags] = strings.Join(ctags, ",")
 	}
 	ptags := getProcessTags(req.Header, tp)
 	if ptags != "" {
@@ -672,6 +672,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		ClientComputedStats:    isHeaderTrue(header.ComputedStats, req.Header.Get(header.ComputedStats)),
 		ClientDroppedP0s:       droppedTracesFromHeader(req.Header, ts),
 		ProcessTags:            ptags,
+		ContainerTags:          ctags,
 	}
 	r.out <- payload
 }
@@ -917,23 +918,28 @@ func traceChunksFromTraces(traces pb.Traces) []*pb.TraceChunk {
 	return traceChunks
 }
 
-// getContainerTag returns container and orchestrator tags belonging to containerID. If containerID
-// is empty or no tags are found, an empty string is returned.
-func getContainerTags(fn func(string) ([]string, error), containerID string) string {
+func getContainerTagsList(fn func(string) ([]string, error), containerID string) []string {
 	if containerID == "" {
-		return ""
+		return nil
 	}
 	if fn == nil {
 		log.Warn("ContainerTags not configured")
-		return ""
+		return nil
 	}
 	list, err := fn(containerID)
 	if err != nil {
 		log.Tracef("Getting container tags for ID %q: %v", containerID, err)
-		return ""
+		return nil
 	}
 	log.Tracef("Getting container tags for ID %q: %v", containerID, list)
-	return strings.Join(list, ",")
+	return list
+}
+
+// getContainerTag returns container and orchestrator tags belonging to containerID. If containerID
+// is empty or no tags are found, an empty string is returned.
+func getContainerTags(fn func(string) ([]string, error), containerID string) string {
+	ctags := getContainerTagsList(fn, containerID)
+	return strings.Join(ctags, ",")
 }
 
 // getMediaType attempts to return the media type from the Content-Type MIME header. If it fails

--- a/pkg/trace/api/payload.go
+++ b/pkg/trace/api/payload.go
@@ -32,6 +32,9 @@ type Payload struct {
 
 	// ProcessTags is a list of tags describing an instrumented process.
 	ProcessTags string
+
+	// ContainerTags is a list of tags describing the container we received this payload from
+	ContainerTags []string
 }
 
 // Chunks returns chunks in TracerPayload

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -181,10 +181,11 @@ func (a *ClientStatsAggregator) setVersionDataFromContainerTags(p *pb.ClientStat
 		return
 	}
 	if p.ContainerID != "" {
-		gitCommitSha, imageTag, err := version.GetVersionDataFromContainerTags(p.ContainerID, a.conf)
+		cTags, err := a.conf.ContainerTags(p.ContainerID)
 		if err != nil {
 			log.Error("Client stats aggregator is unable to resolve container ID (%s) to container tags: %v", p.ContainerID, err)
 		} else {
+			gitCommitSha, imageTag := version.GetVersionDataFromContainerTags(cTags)
 			// Only override if the payload's original values were empty strings.
 			if p.ImageTag == "" {
 				p.ImageTag = imageTag

--- a/pkg/trace/version/version.go
+++ b/pkg/trace/version/version.go
@@ -7,11 +7,9 @@
 package version
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 )
 
 const (
@@ -22,17 +20,7 @@ const (
 )
 
 // GetVersionDataFromContainerTags will return the git commit sha and image tag from container tags, if present.
-func GetVersionDataFromContainerTags(containerID string, conf *config.AgentConfig) (gitCommitSha, imageTag string, err error) {
-	if conf == nil || conf.ContainerTags == nil {
-		return "", "", nil
-	}
-	cTags, err := conf.ContainerTags(containerID)
-	if err != nil {
-		if errors.Is(err, config.ErrContainerTagsFuncNotDefined) {
-			return "", "", nil
-		}
-		return "", "", err
-	}
+func GetVersionDataFromContainerTags(cTags []string) (gitCommitSha, imageTag string) {
 	for _, t := range cTags {
 		if gitCommitSha == "" {
 			if sha, ok := strings.CutPrefix(t, gitCommitShaTagPrefix); ok {
@@ -48,7 +36,7 @@ func GetVersionDataFromContainerTags(containerID string, conf *config.AgentConfi
 			break
 		}
 	}
-	return gitCommitSha, imageTag, nil
+	return gitCommitSha, imageTag
 }
 
 // GetGitCommitShaFromTrace returns the first "git_commit_sha" tag found in trace t.

--- a/pkg/trace/version/version_test.go
+++ b/pkg/trace/version/version_test.go
@@ -6,47 +6,21 @@
 package version
 
 import (
-	"fmt"
 	"testing"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"github.com/stretchr/testify/assert"
+
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
 func TestGetVersionDataFromContainerTags(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		cfg := config.New()
-		cfg.ContainerTags = func(cid string) ([]string, error) {
-			if cid == "1" {
-				return []string{"some_tag:blah", "image_tag:x", "git.commit.sha:y"}, nil
-			}
-			return nil, nil
-		}
-		gitCommitSha, imageTag, err := GetVersionDataFromContainerTags("1", cfg)
-		assert.NoError(t, err)
+		cTags := []string{"some_tag:blah", "image_tag:x", "git.commit.sha:y"}
+		gitCommitSha, imageTag := GetVersionDataFromContainerTags(cTags)
 		assert.Equal(t, "x", imageTag)
 		assert.Equal(t, "y", gitCommitSha)
-		gitCommitSha, imageTag, err = GetVersionDataFromContainerTags("2", cfg)
-		assert.NoError(t, err)
-		assert.Equal(t, "", imageTag)
-		assert.Equal(t, "", gitCommitSha)
-	})
-	t.Run("error", func(t *testing.T) {
-		cfg := config.New()
-		cfg.ContainerTags = func(_ string) ([]string, error) {
-			return nil, fmt.Errorf("error")
-		}
-		gitCommitSha, imageTag, err := GetVersionDataFromContainerTags("1", cfg)
-		assert.Error(t, err)
-		assert.Equal(t, "", imageTag)
-		assert.Equal(t, "", gitCommitSha)
-	})
-	t.Run("undefined", func(t *testing.T) {
-		cfg := config.New()
-		gitCommitSha, imageTag, err := GetVersionDataFromContainerTags("1", cfg)
-		assert.NoError(t, err)
+		gitCommitSha, imageTag = GetVersionDataFromContainerTags([]string{})
 		assert.Equal(t, "", imageTag)
 		assert.Equal(t, "", gitCommitSha)
 	})


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Reduce the number of times we call the remote tagger to fetch container tags. Each time we do this we allocate more memory unnecessarily, especially in the case of `GetVersionDataFromContainerTags` which only needs two specific tags. @paullegranddc pointed out this function specifically as a place we could optimize.

In the process of looking at that function and the allocations profiles I realized that we were calling it for every _chunk_ in a payload which is unnecessary as the container ID is set at the payload level so there is no possibility for the tags to change within a payload. This drastically increases the number of allocations for this function compared to the exact same call being made in api.go.

This is a pure refactor and the resulting behavior should not change.

### Motivation
Reducing allocations / cpu time spent fetching container tags is good for performance overall. 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Using existing unit / integration / e2e tests to verify behavior has not changed. I also performed a quick local smoke test to ensure behavior was unchanged when no container ID is provided.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->