### PR TITLE
Move the Windows default to v2 fleet

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1265,4 +1265,4 @@ workflow:
 #
 # Current default: Windows Server 2022
 .windows_docker_default:
-  extends: .windows_docker_2022
+  extends: .windows_docker_v2_2022


### PR DESCRIPTION
<details open><summary>

# Problem
</summary>

We are ready for the next phase of the migration to Windows runners v2
so want to onboard the datadog-agent repo.

</details>

<details open><summary>

# Solution
</summary>

Move the default to windows-v2
I couldn't find any other direct references / uses of the old windows runners

</details>
