### PR TITLE
[Dynamic Instrumentation] Prevent BPF 512-byte stack limit exhaustion by avoiding forced inlining

### DIFF
--- a/pkg/dynamicinstrumentation/codegen/c/expressions.h
+++ b/pkg/dynamicinstrumentation/codegen/c/expressions.h
@@ -1,9 +1,23 @@
 #ifndef DI_EXPRESSIONS_H
 #define DI_EXPRESSIONS_H
 
+// The Linux kernel defines `noinline` as a macro:
+//     #define noinline __attribute__((__noinline__))
+// (reference: https://elixir.bootlin.com/linux/v5.15/source/include/linux/compiler_attributes.h#L231)
+// Our code (via bpf_helpers.h) defines `__noinline` as:
+//     #define __noinline __attribute__((noinline))
+// If the kernel's `noinline` macro is active during preprocessing,
+// it causes `__noinline` to expand into invalid syntax:
+//     __attribute__((__attribute__((__noinline__))))
+//
+// To avoid this conflict, we explicitly undefine `noinline`
+#ifdef noinline
+#undef noinline
+#endif
+
 // read_register reads `element_size` bytes from register `reg` into a u64 which is then pushed to
 // the top of the BPF parameter stack.
-static __always_inline int read_register(expression_context_t *context, __u64 reg, __u32 element_size)
+static int __noinline read_register(expression_context_t *context, __u64 reg, __u32 element_size)
 {
     long err;
     __u64 valueHolder = 0;
@@ -18,7 +32,7 @@ static __always_inline int read_register(expression_context_t *context, __u64 re
 
 // read_stack reads `element_size` bytes from the traced program's stack at offset `stack_offset`
 // into a u64 which is then pushed to the top of the BPF parameter stack.
-static __always_inline int read_stack(expression_context_t *context, size_t stack_offset, __u32 element_size)
+static int __noinline read_stack(expression_context_t *context, size_t stack_offset, __u32 element_size)
 {
     long err;
     __u64 valueHolder = 0;
@@ -33,7 +47,7 @@ static __always_inline int read_stack(expression_context_t *context, size_t stac
 
 // read_register_value_to_output reads `element_size` bytes from register `reg` into a u64 which is then written to
 // the output buffer.
-static __always_inline int read_register_value_to_output(expression_context_t *context, __u64 reg, __u32 element_size)
+static int __noinline read_register_value_to_output(expression_context_t *context, __u64 reg, __u32 element_size)
 {
     long err;
     err = bpf_probe_read_kernel(&context->event->output[(context->output_offset)], element_size, &context->ctx->DWARF_REGISTER(reg));
@@ -46,7 +60,7 @@ static __always_inline int read_register_value_to_output(expression_context_t *c
 
 // read_stack_to_output reads `element_size` bytes from the traced program's stack at offset `stack_offset`
 // into a u64 which is then written to the output buffer.
-static __always_inline int read_stack_value_to_output(expression_context_t *context, __u64 stack_offset, __u32 element_size)
+static int __noinline read_stack_value_to_output(expression_context_t *context, __u64 stack_offset, __u32 element_size)
 {
     long err;
     err = bpf_probe_read_kernel(&context->event->output[(context->output_offset)], element_size, &context->ctx->DWARF_STACK_REGISTER+stack_offset);
@@ -58,7 +72,7 @@ static __always_inline int read_stack_value_to_output(expression_context_t *cont
 }
 
 // pop writes to output `num_elements` elements, each of size `element_size, from the top of the stack.
-static __always_inline int pop(expression_context_t *context, __u64 num_elements, __u32 element_size)
+static int __noinline pop(expression_context_t *context, __u64 num_elements, __u32 element_size)
 {
     long return_err;
     long err;
@@ -83,7 +97,7 @@ static __always_inline int pop(expression_context_t *context, __u64 num_elements
 // it, reading a value of size `element_size` from it, and pushes that value (encoded as a u64)
 // back to the BPF parameter stack.
 // It should only be used for types of 8 bytes or less (see `dereference_large`).
-static __always_inline int dereference(expression_context_t *context, __u32 element_size)
+static int __noinline dereference(expression_context_t *context, __u32 element_size)
 {
     long err;
     __u64 addressHolder = 0;
@@ -113,7 +127,7 @@ static __always_inline int dereference(expression_context_t *context, __u32 elem
 // dereferences it, reading a value of size `element_size` from it, and writes that value
 // directly to the output buffer.
 // It should only be used for types of 8 bytes or less (see `dereference_large_to_output`).
-static __always_inline int dereference_to_output(expression_context_t *context, __u32 element_size)
+static int __noinline dereference_to_output(expression_context_t *context, __u32 element_size)
 {
     long return_err;
     long err;
@@ -150,7 +164,7 @@ static __always_inline int dereference_to_output(expression_context_t *context, 
 // it, reading a value of size `element_size` from it, and pushes that value, encoded in 8-byte chunks
 // to the BPF parameter stack. This is safe to use for types larger than 8-bytes.
 // back to the BPF parameter stack.
-static __always_inline int dereference_large(expression_context_t *context, __u32 element_size, __u8 num_chunks)
+static int __noinline dereference_large(expression_context_t *context, __u32 element_size, __u8 num_chunks)
 {
     long return_err;
     long err;
@@ -192,7 +206,7 @@ static __always_inline int dereference_large(expression_context_t *context, __u3
 // dereference_large pops the 8-byte address from the top of the BPF parameter stack and dereferences
 // it, reading a value of size `element_size` from it, and writes that value to the output buffer.
 // This is safe to use for types larger than 8-bytes.
-static __always_inline int dereference_large_to_output(expression_context_t *context, __u32 element_size)
+static int __noinline dereference_large_to_output(expression_context_t *context, __u32 element_size)
 {
     long err;
     __u64 addressHolder = 0;
@@ -207,7 +221,7 @@ static __always_inline int dereference_large_to_output(expression_context_t *con
 }
 
 // apply_offset adds `offset` to the 8-byte address on the top of the BPF parameter stack.
-static __always_inline int apply_offset(expression_context_t *context, size_t offset)
+static int __noinline apply_offset(expression_context_t *context, size_t offset)
 {
     __u64 addressHolder = 0;
     bpf_map_pop_elem(context->param_stack, &addressHolder);
@@ -222,7 +236,7 @@ static __always_inline int apply_offset(expression_context_t *context, size_t of
 // dereference_dynamic_to_output reads an 8-byte length from the top of the BPF parameter stack, followed by
 // an 8-byte address. It applies the maximum `bytes_limit` to the length, then dereferences the address to
 // the output buffer.
-static __always_inline int dereference_dynamic_to_output(expression_context_t *context, __u16 bytes_limit)
+static int __noinline dereference_dynamic_to_output(expression_context_t *context, __u16 bytes_limit)
 {
     long err = 0;
     __u64 lengthToRead = 0;
@@ -254,7 +268,7 @@ static __always_inline int dereference_dynamic_to_output(expression_context_t *c
 // collection from the top of the BPF parameter stack, applies the passed `limit` to it, and updates the `collection_limit`
 // map entry associated with `collection_identifier` to this limit. The `collection_identifier` is a user space generated
 // and track identifier for each collection which can be referenced in BPF code.
-static __always_inline int set_limit_entry(expression_context_t *context, __u16 limit, char collection_identifier[6])
+static int __noinline set_limit_entry(expression_context_t *context, __u16 limit, char collection_identifier[6])
 {
     // Read the 2 byte length from top of the stack, then set collectionLimit to the minimum of the two
     __u64 length;
@@ -277,7 +291,7 @@ static __always_inline int set_limit_entry(expression_context_t *context, __u16 
 }
 
 // copy duplicates the u64 element on the top of the BPF parameter stack.
-static __always_inline int copy(expression_context_t *context)
+static int __noinline copy(expression_context_t *context)
 {
     __u64 holder;
     bpf_map_peek_elem(context->param_stack, &holder);
@@ -287,10 +301,10 @@ static __always_inline int copy(expression_context_t *context)
 }
 
 // read_str_to_output reads a Go string to the output buffer, limited in length by `limit`.
-// In Go, strings are internally implemented as structs with two fields. The fields are length, 
+// In Go, strings are internally implemented as structs with two fields. The fields are length,
 // and a pointer to a character array. This expression expects the address of the string struct
 // itself to be on the top of the stack.
-static __always_inline int read_str_to_output(expression_context_t *context, __u16 limit)
+static int __noinline read_str_to_output(expression_context_t *context, __u16 limit)
 {
     long err;
     __u64 stringStructAddressHolder = 0;

--- a/pkg/dynamicinstrumentation/ebpf/ebpf.go
+++ b/pkg/dynamicinstrumentation/ebpf/ebpf.go
@@ -200,6 +200,7 @@ func getCFlags(config *ddebpf.Config) []string {
 	cflags := []string{
 		"-g",
 		"-Wno-unused-variable",
+		"-Wno-unused-function",
 	}
 	if config.BPFDebug {
 		cflags = append(cflags, "-DDEBUG=1")


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
[Exploration Tests](https://github.com/DataDog/datadog-agent/pull/34423) revealed a regression in Dynamic Instrumentation codegen of BPF programs. The following error started to pop up:
> error: /var/tmp/datadog-agent/system-probe/build/dynamicinstrumentation.c-be86c2e973338ef2f2688a235b67562ef7e4944aa8181070d03dafd9f1ecb171:6132:11: in function google_golang_org_protobuf_TestIntegration i32 (%struct.pt_regs*): Looks like the BPF stack limit of 512 bytes is exceeded. Please move large on stack variables into BPF per-cpu array map.

The root cause is due to our DI's basic block of expressions being inlined with the attribute `__always_inline`.  In Go Dynamic Instrumentation we use several expressions to build up a state machine that is able to serialize arbitrary variables out of memory. The composition of these expressions, when inlined, exceeded the BPF limitation of up to 512 bytes stack usage.
Marking functions with `always_inline` is [no longer a requirement since Kernel v4.16](https://github.com/torvalds/linux/commit/cc8b0b92a1699bc32f7fec71daa2bfc90de43a4d) where function calls were introduced.

### Motivation
Keep the stack usage of Dynamic Instrumentation BPF programs within the 512 bytes limit.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- Exploration tests is the main tool to capture these type of issues and make sure we don't have further regressions. Without this fix, most of the probes are failing with the 512 bytes limit error.
- There's a [separate DRAFT PR](https://github.com/DataDog/datadog-agent/pull/36791) where I aim to introduce new tests that validate this fix.