### PR TITLE
[EBPF] kmt: avoid re-downloading docker images

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1896,7 +1896,10 @@ def save_test_dockers(ctx, output_dir, arch, use_crane=False):
 
     # only download images not present in preprepared vm disk
     resp = requests.get('https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker.ls')
-    docker_ls = {line for line in resp.text.split('\n') if line.strip()}
+
+    # remove the public.ecr.aws/docker/library/ prefix as we might be downloading official images
+    # from the AWS mirror instead of dockerhub to avoid rate limits
+    docker_ls = {line.removeprefix("public.ecr.aws/docker/library/") for line in resp.text.split('\n') if line.strip()}
 
     images = _test_docker_image_list()
     for image in images - docker_ls:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Changes the logic for pulling images for docker disks, to avoid re-downloading images that have been pulled from the AWS registry.

### Motivation

Avoid extra downloads.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Checked that the download job doesn't re-download unneeded images.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->