### PR TITLE
Unify stages in the deploy containers child pipeline

### DIFF
--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -9,7 +9,7 @@
 
 stages:
   - deploy_containers
-
+  - deploy_mutable_image_tags
 include:
   - .gitlab/common/container_publish_job_templates.yml
   - .gitlab/deploy_containers/conditions.yml

--- a/.gitlab/deploy_containers/deploy_containers_a7.yml
+++ b/.gitlab/deploy_containers/deploy_containers_a7.yml
@@ -10,6 +10,7 @@
 stages:
   - deploy_containers
   - deploy_mutable_image_tags
+
 include:
   - .gitlab/common/container_publish_job_templates.yml
   - .gitlab/deploy_containers/conditions.yml

--- a/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
+++ b/.gitlab/deploy_containers/deploy_mutable_image_tags.yml
@@ -2,6 +2,7 @@
 # Contains jobs which deploy Agent 7 related mutable image tags to the registries. That means - not uploading the image, but only creating the tags.
 
 stages:
+  - deploy_containers
   - deploy_mutable_image_tags
 
 include:


### PR DESCRIPTION
### What does this PR do?

In https://github.com/DataDog/datadog-agent/pull/36470 we added new set of jobs which push mutable tags for already uploaded images. Due to the way how gitlab merges files which build triggered child pipeline, only the jobs from `deploy_mutable_image_tags.yml` were added (stages conflict - only the last one stays after merge).

I put the same stages definition in both files. Another option would be to have a separate file with only stages defined and then included in both child files, but I think in this case this is good enough.

Jobs defined for child pipeline has to have stages defined, so we cannot put those definitions in some other common file.

### Motivation

Fix deploy_containers job.

### Describe how you validated your changes
To be tested with the next RC.