### PR TITLE
Unbundle Oracle active session history (ASH) snapshots into separate payloads

### DIFF
--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -46,24 +46,23 @@ func (c *Check) getSQLRow(SQLID sql.NullString, forceMatchingSignature *string, 
 	return SQLRow, nil
 }
 
-func sendPayload(c *Check, sessionRows []OracleActivityRow, timestamp float64) error {
+func sendPayload(c *Check, payloadRows []OracleActivityRow, utcMs float64) error {
 	var collectionInterval float64
-	if c.config.QuerySamples.ActiveSessionHistory {
+	ash := c.config.QuerySamples.ActiveSessionHistory
+	if ash {
 		collectionInterval = 1
 	} else {
 		collectionInterval = float64(c.config.MinCollectionInterval)
 	}
 	var ts float64
-	if timestamp > 0 {
-		ts = timestamp
+	if utcMs > 0 {
+		ts = utcMs
 	} else {
 		ts = float64(c.clock.Now().UnixMilli())
 	}
-	log.Debugf("%s STIMESTAMP FETCHED %f", c.logPrompt, timestamp)
-	log.Debugf("%s STIMESTAMP UNIX    %f", c.logPrompt, float64(c.clock.Now().UnixMilli()))
+	log.Debugf("%s STIMESTAMP UNIX    %f", c.logPrompt, ts)
 	payload := ActivitySnapshot{
 		Metadata: Metadata{
-			//Timestamp:      float64(c.clock.Now().UnixMilli()),
 			Timestamp:        ts,
 			Host:             c.dbHostname,
 			DatabaseInstance: c.dbInstanceIdentifier,
@@ -73,11 +72,10 @@ func sendPayload(c *Check, sessionRows []OracleActivityRow, timestamp float64) e
 		},
 		CollectionInterval: collectionInterval,
 		Tags:               c.tags,
-		OracleActivityRows: sessionRows,
+		OracleActivityRows: payloadRows,
 	}
-
-	c.lastOracleActivityRows = make([]OracleActivityRow, len(sessionRows))
-	copy(c.lastOracleActivityRows, sessionRows)
+	c.lastOracleActivityRows = make([]OracleActivityRow, len(payloadRows))
+	copy(c.lastOracleActivityRows, payloadRows)
 
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -93,8 +91,34 @@ func sendPayload(c *Check, sessionRows []OracleActivityRow, timestamp float64) e
 		return err
 	}
 	sender.EventPlatformEvent(payloadBytes, "dbm-activity")
-	sendMetric(c, count, "dd.oracle.activity.samples_count", float64(len(sessionRows)), append(c.tags, fmt.Sprintf("sql_substring_length:%d", c.sqlSubstringLength)))
+	sendMetric(c, count, "dd.oracle.activity.samples_count", float64(len(payloadRows)), append(c.tags, fmt.Sprintf("sql_substring_length:%d", c.sqlSubstringLength)))
+	return nil
+}
 
+func sendRows(c *Check, sessionRows []OracleActivityRow) error {
+	var err error
+	var payloadRows []OracleActivityRow
+	var lastNow string
+	var lastUtcMs float64
+	for _, r := range sessionRows {
+		if lastNow == "" || r.Now == lastNow {
+			payloadRows = append(payloadRows, r)
+			lastNow = r.Now
+			lastUtcMs = r.UtcMs
+		} else {
+			err = sendPayload(c, payloadRows, lastUtcMs)
+			if err != nil {
+				log.Errorf("%s error sending payload %s", c.logPrompt, err)
+			}
+			payloadRows = []OracleActivityRow{r}
+			lastNow = r.Now
+			lastUtcMs = r.UtcMs
+		}
+	}
+	err = sendPayload(c, payloadRows, lastUtcMs)
+	if err != nil {
+		log.Errorf("%s error sending payload %s", c.logPrompt, err)
+	}
 	return nil
 }
 
@@ -159,7 +183,6 @@ AND status = 'ACTIVE'`)
 
 	o := c.LazyInitObfuscator()
 	var payloadSent bool
-	var lastNow string
 	for _, sample := range sessionSamples {
 		var sessionRow OracleActivityRow
 
@@ -168,14 +191,7 @@ AND status = 'ACTIVE'`)
 		}
 
 		sessionRow.Now = sample.Now
-		if lastNow != sessionRow.Now && lastNow != "" {
-			err = sendPayload(c, sessionRows, sample.UtcMs)
-			if err != nil {
-				log.Errorf("%s error sending payload %s", c.logPrompt, err)
-			}
-			payloadSent = true
-		}
-		lastNow = sessionRow.Now
+		sessionRow.UtcMs = sample.UtcMs
 
 		sessionRow.SessionID = sample.SessionID
 		sessionRow.SessionSerial = sample.SessionSerial
@@ -355,7 +371,7 @@ AND status = 'ACTIVE'`)
 		sessionRows = append(sessionRows, sessionRow)
 	}
 	if !payloadSent {
-		err = sendPayload(c, sessionRows, 0)
+		err = sendRows(c, sessionRows)
 		if err != nil {
 			log.Errorf("%s error sending payload %s", c.logPrompt, err)
 		}

--- a/pkg/collector/corechecks/oracle/activity.go
+++ b/pkg/collector/corechecks/oracle/activity.go
@@ -204,6 +204,9 @@ AND status = 'ACTIVE'`)
 
 		sessionType := ""
 		if sample.Type.Valid {
+			if sample.Type.String == "FOREGROUND" {
+				sample.Type.String = "USER"
+			}
 			sessionRow.Type = sample.Type.String
 			sessionType = sample.Type.String
 		}

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -114,15 +114,16 @@ func TestActiveSessionHistory(t *testing.T) {
 	c, _ := newDefaultCheck(t, "", "")
 	defer c.Teardown()
 
+	var err error
 	var count uint64
-	getWrapper(&c, &count, "SELECT BANNER FROM V$VERSION WHERE BANNER LIKE '%Enterprise%Edition%'")
-	if count == 0 {
+	getWrapper(&c, &count, "SELECT count(*) FROM V$VERSION WHERE BANNER LIKE '%Enterprise%Edition%'")
+	if count != 0 {
 		t.Skip("Active Session History is only available in Oracle Enterprise Edition")
 	}
 	c.dbmEnabled = true
 	c.config.QuerySamples.ActiveSessionHistory = true
 
-	err := c.Run()
+	err = c.Run()
 	assert.NoError(t, err, "check run")
 
 	err = c.SampleSession()
@@ -152,4 +153,12 @@ END;`
 	require.NoError(t, err, "activity sample failed")
 
 	assert.Greater(t, c.lastSampleID, prevSamplId, "sample id should have increased")
+
+	for _, r := range c.lastOracleActivityRows {
+		assert.True(t, isValidSessionType(r.Type), "invalid session type: %s", r.Type)
+	}
+}
+
+func isValidSessionType(sessionType string) bool {
+	return sessionType == "USER1" || sessionType == "BACKGROUND1"
 }

--- a/pkg/collector/corechecks/oracle/activity_integration_test.go
+++ b/pkg/collector/corechecks/oracle/activity_integration_test.go
@@ -117,7 +117,7 @@ func TestActiveSessionHistory(t *testing.T) {
 	var err error
 	var count uint64
 	getWrapper(&c, &count, "SELECT count(*) FROM V$VERSION WHERE BANNER LIKE '%Enterprise%Edition%'")
-	if count != 0 {
+	if count == 0 {
 		t.Skip("Active Session History is only available in Oracle Enterprise Edition")
 	}
 	c.dbmEnabled = true
@@ -160,5 +160,5 @@ END;`
 }
 
 func isValidSessionType(sessionType string) bool {
-	return sessionType == "USER1" || sessionType == "BACKGROUND1"
+	return sessionType == "USER" || sessionType == "BACKGROUND"
 }

--- a/pkg/collector/corechecks/oracle/activity_structs.go
+++ b/pkg/collector/corechecks/oracle/activity_structs.go
@@ -49,6 +49,7 @@ type OracleSQLRow struct {
 //nolint:revive // TODO(DBM) Fix revive linter
 type OracleActivityRow struct {
 	Now           string `json:"now"`
+	UtcMs         float64
 	SessionID     uint64 `json:"sid,omitempty"`
 	SessionSerial uint64 `json:"serial,omitempty"`
 	User          string `json:"user,omitempty"`

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -36,8 +36,8 @@ const (
 )
 
 const (
-	expectedSessionsDefault           = 3
-	expectedSessionsWithCustomQueries = 3
+	expectedSessionsDefault           = 6
+	expectedSessionsWithCustomQueries = 6
 )
 
 func getConnectData(t *testing.T, userType int) config.ConnectionConfig {
@@ -167,10 +167,6 @@ func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceC
 		c.config.InstanceConfig.OracleClient = true
 	}
 
-	var n int
-	err = getWrapper(&c, &n, "select 1 from dual")
-	require.NoError(t, err, "can't execute a test query")
-
 	return c, sender
 }
 
@@ -181,7 +177,13 @@ func newLegacyCheck(t *testing.T, instanceConfigAddition string, initConfig stri
 }
 
 func newDefaultCheck(t *testing.T, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {
-	return newTestCheck(t, getConnectData(t, useDefaultUser), instanceConfigAddition, initConfig)
+	c, m := newTestCheck(t, getConnectData(t, useDefaultUser), instanceConfigAddition, initConfig)
+	var err error
+	var n int
+	err = getWrapper(&c, &n, "select 1 from dual")
+	require.NoError(t, err, "can't execute a test query")
+
+	return c, m
 }
 
 func newSysCheck(t *testing.T, instanceConfigAddition string, initConfig string) (Check, *mocksender.MockSender) {

--- a/pkg/collector/corechecks/oracle/testutil.go
+++ b/pkg/collector/corechecks/oracle/testutil.go
@@ -167,6 +167,10 @@ func newTestCheck(t *testing.T, connectConfig config.ConnectionConfig, instanceC
 		c.config.InstanceConfig.OracleClient = true
 	}
 
+	var n int
+	err = getWrapper(&c, &n, "select 1 from dual")
+	require.NoError(t, err, "can't execute a test query")
+
 	return c, sender
 }
 

--- a/releasenotes/notes/oracle-active-session-history-2e41089ce2d473f5.yaml
+++ b/releasenotes/notes/oracle-active-session-history-2e41089ce2d473f5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [oracle]: Fix Active Connections with ``active_session_history: true``.

--- a/releasenotes/notes/oracle-ash-payloads-69001dd9e37c5f6d.yaml
+++ b/releasenotes/notes/oracle-ash-payloads-69001dd9e37c5f6d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix incorrect connection stats with active session history (ASH) sampling by sending each ASH snapshot in a separate payload.


### PR DESCRIPTION
### What does this PR do?

Sends Oracle ASH snapshots in separate payloads instead of bundling them.

### Motivation

Previously, multiple ASH snapshots were sent together, causing the backend to treat them as one and report incorrect stats (e.g., active connections). Splitting them fixes this.

### Describe how you validated your changes

Checked that Active Connections shows the correct value after enabling ASH sampling.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->