### PR TITLE
[EBPF] kmt: reduce memory usage of the complexity calculator

### DIFF
--- a/pkg/ebpf/verifier/stats.go
+++ b/pkg/ebpf/verifier/stats.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -260,6 +261,11 @@ func generateLoadFunction(file string, opts *StatsOptions, results *StatsResult,
 
 					// Set to empty string to avoid the GC from keeping the verifier log in memory
 					p.VerifierLog = ""
+
+					// Force the GC to run. The calculator is not using the verifier log anymore and it's a big
+					// string (potentially 1GB). While Go should free it, we have seen issues running this program
+					// in KMT VMs.
+					runtime.GC()
 				default:
 					return fmt.Errorf("Unexpected type %T", field)
 				}

--- a/test/new-e2e/system-probe/test/micro-vm-init.sh
+++ b/test/new-e2e/system-probe/test/micro-vm-init.sh
@@ -42,8 +42,8 @@ if [ "${COLLECT_COMPLEXITY:-}" = "yes" ]; then
     test_root=$(echo "$@" | sed 's/.*-test-root \([^ ]*\).*/\1/')
     export DD_SYSTEM_PROBE_BPF_DIR="${test_root}/pkg/ebpf/bytecode/build/${arch}"
 
-    # Limit maximum memory usage of the calculator to 5GB to avoid OOM errors affecting the entire connector
-    ulimit -v $((5 * 1024 * 1024))
+    # Limit maximum memory usage of the calculator to avoid OOM errors affecting the entire connector
+    ulimit -v $((6 * 1024 * 1024))
 
     if /opt/testing-tools/verifier-calculator -line-complexity -complexity-data-dir /verifier-complexity/complexity-data  -summary-output /verifier-complexity/verifier_stats.json &> /verifier-complexity/calculator.log ; then
         echo "Data collected, creating tarball at /verifier-complexity.tar.gz"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR reduces and limits the memory usage of the complexity calculator. It improves where we call Go to garbage collect, making it more frequent, and it also uses `ulimit` to ensure that the system kills the calculator and not the entire SSH process.

### Motivation

As the eBPF programs we have grow, the memory usage grows too due to the verifier log. Given that the calculator runs inside of the VMs, even if Go ends up releasing the memory, the VM might not do so. 

Additionally, we have seen that if the calculator uses too much memory, the system might kill either the SSH connector program, which makes it harder to distinguish which failures are due to memory usage and which ones due to connectivity issues.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI passing.

Also ensure that, with lower limits, `ulimit` kills only the calculator process: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/930975382

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->