### PR TITLE
avoid ebpf instructions for apply_offset(0)

### DIFF
--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -368,6 +368,9 @@ func ReadStringToOutputLocationExpression(limit uint16) LocationExpression {
 // adds `offset` to the 8-byte address on the top of the bpf parameter stack.
 // Arg1 = uint value (offset) we're adding to the 8-byte address on top of the stack
 func ApplyOffsetLocationExpression(offset uint) LocationExpression {
+	if offset == 0 {
+		return LocationExpression{Opcode: OpComment, Label: "apply_offset(0) == no-op"}
+	}
 	return LocationExpression{Opcode: OpApplyOffset, Arg1: offset}
 }
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Does not insert a call to `apply_offset` when the argument is `0`.

### Motivation

Reduce number of ebpf instructions. `apply_offset` pops an elem off the stack, adds the offset, and then pushes it back onto the stack. If the offset is `0`, this results in no changes, so just avoid the instructions altogether.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->