### PR TITLE
APM: Keep Unix Socket File (APMS-15670)

### DIFF
--- a/pkg/trace/api/api_nix_test.go
+++ b/pkg/trace/api/api_nix_test.go
@@ -154,6 +154,22 @@ func TestHTTPReceiverStart(t *testing.T) {
 	}
 }
 
+func TestShutdown(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "agent.sock")
+	cfg := config.New()
+	cfg.ReceiverEnabled = true
+	cfg.ReceiverPort = 0
+	cfg.ReceiverSocket = socket
+	r := newTestReceiverFromConfig(cfg)
+	r.Start()
+	_, err := os.Stat(socket)
+	assert.NoError(t, err)
+	r.Stop()
+	// Ensure we do not delete the socket
+	_, err = os.Stat(socket)
+	assert.NoError(t, err)
+}
+
 // freePort returns a random and free TCP port.
 func freeTCPPort() int {
 	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")

--- a/releasenotes/notes/APMNoDeleteSocket-559ce568afc088bd.yaml
+++ b/releasenotes/notes/APMNoDeleteSocket-559ce568afc088bd.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    APM: Fix issue where Trace-Agent socket could be deleted during an Agent upgrade by the previous Trace-Agent as it was shutting down.
+    APM: Fix an issue where the Trace-Agent socket could be deleted during an Agent upgrade by the previous Trace-Agent during shutdown.

--- a/releasenotes/notes/APMNoDeleteSocket-559ce568afc088bd.yaml
+++ b/releasenotes/notes/APMNoDeleteSocket-559ce568afc088bd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix issue where Trace-Agent socket could be deleted during an Agent upgrade by the previous Trace-Agent as it was shutting down.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix issue where Trace-Agent socket could be deleted during an Agent upgrade by the previous Trace-Agent as it was shutting down.

This also resolves a semi-related issue where the trace-agent wouldn't shutdown the http server if it was configured to _only_ use unix sockets or windows named pipes.

### Motivation
In Go by default a UnixListener will delete the socket file that was created by it when it is shutdown. This creates an issue where if multiple trace agent's are running simultaneously (like during an agent upgrade). It is possible that this deletes the socket file of the NEW trace agent, thereby preventing any new connections from being formed.

This results in any new connection attempts by any of the APM tracing libraries failing forever until the trace-agent is restarted.
### Describe how you validated your changes
Unfortunately this change is a bit tough to test in an automated way. I performed a manual test here where I configured the trace-agent to only use a unix socket. I then started instance A of the trace-agent, emitted some test trace data verifying it was received. Then started an additional trace-agent B, verifying again that trace data continues to flow. I then stopped Trace-Agent A and observed that the socket file continued to exist (Before this change the file would be deleted). I also added a unit test to verify the socket is not deleted by shutting down the receiver.

### Possible Drawbacks / Trade-offs
Leaving this file around shouldn't cause any issues as we check for it on startup and this file is located in /var/run by default.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->