### PR TITLE
(bugfix) Remove existing fipsmodule.cnf on install and rebuild

### DIFF
--- a/omnibus/config/templates/openssl-fips-provider/fipsinstall.sh.erb
+++ b/omnibus/config/templates/openssl-fips-provider/fipsinstall.sh.erb
@@ -19,10 +19,12 @@ FIPS_SO_PATH="${INSTALL_DIR}/lib/ossl-modules/fips.so"
 OPENSSL_BIN="${INSTALL_DIR}/bin/openssl"
 
 
-if [ ! -f "${FIPS_MODULE_PATH}" ]; then
-    "${OPENSSL_BIN}" fipsinstall -module "${FIPS_SO_PATH}" -out "${FIPS_MODULE_PATH}"
-    mv "${OPENSSL_CONF_PATH}.tmp" "${OPENSSL_CONF_PATH}"
+if [ -f "${FIPS_MODULE_PATH}" ]; then
+    rm "${FIPS_MODULE_PATH}"
 fi
+
+"${OPENSSL_BIN}" fipsinstall -module "${FIPS_SO_PATH}" -out "${FIPS_MODULE_PATH}"
+mv "${OPENSSL_CONF_PATH}.tmp" "${OPENSSL_CONF_PATH}"
 
 if ! "${OPENSSL_BIN}" fipsinstall -module "${FIPS_SO_PATH}" -in "${FIPS_MODULE_PATH}" -verify; then
     echo "openssl fipsinstall: verification of FIPS compliance failed. $INSTALL_DIR/fipsmodule.cnf was corrupted or the installation failed."

--- a/releasenotes/notes/bugfix-fipsisntall-script-during-upgrade-73529cb19be22109.yaml
+++ b/releasenotes/notes/bugfix-fipsisntall-script-during-upgrade-73529cb19be22109.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    (datadog-fips-agent) Bugfix for the post install script to always rebuild the
+    fipsmodule.cnf in case the embedded OpenSSL has been updated.

--- a/releasenotes/notes/bugfix-fipsisntall-script-during-upgrade-73529cb19be22109.yaml
+++ b/releasenotes/notes/bugfix-fipsisntall-script-during-upgrade-73529cb19be22109.yaml
@@ -8,5 +8,4 @@
 ---
 fixes:
   - |
-    (datadog-fips-agent) Bugfix for the post install script to always rebuild the
-    fipsmodule.cnf in case the embedded OpenSSL has been updated.
+    (datadog-fips-agent)  Ensure the post-install script always rebuilds fipsmodule.cnf in case the embedded OpenSSL is updated.


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `datadog-fips-agent` has a [post install script](https://github.com/DataDog/datadog-agent/blob/main/omnibus/package-scripts/agent-rpm/posttrans#L15) that will install the [openssl fips-provider](https://github.com/DataDog/datadog-agent/blob/b95d33404bed8d6ffd341feea4aa5c85fc7148a8/omnibus/config/templates/openssl-fips-provider/fipsinstall.sh.erb#L22-L25) on the packaged openssl provided with the agent.

Currently it will not do this if the [fipsmodule.cnf is already present](https://github.com/DataDog/datadog-agent/blob/b95d33404bed8d6ffd341feea4aa5c85fc7148a8/omnibus/config/templates/openssl-fips-provider/fipsinstall.sh.erb#L22).

On new installations this is not an issue but if you're upgrading to a new version that was packaged with an updated version of openssl, the fipsmodule.cnf internal tests and checksums of the fips-provider will fail and the agent will panic. The only workaround is to reinstall the `datadog-fips-agent` at that point or manually clear the fipsmodule.cnf and run the fipsinstall.sh.

This PR modifies the fipsinstall.sh to remove a present fipsmodule.cnf and always rebuild it on an install/update to avoid this issue.

### Motivation

### Describe how you validated your changes

```
$ DD_AGENT_FLAVOR="datadog-fips-agent" DD_SITE="ddog-gov.com" DD_AGENT_MINOR_VERSION=64.1 bash -c "$(https://install.datadoghq.com/scripts/install_script_agent7.sh)"

  ...

$ /opt/datadog-agent/embedded/bin/openssl version
OpenSSL 3.4.0 22 Oct 2024 (Library: OpenSSL 3.4.0 22 Oct 2024)

$ sudo dnf upgrade datadog-fips-agent-7.64.3-1

  ...

$ sudo datadog-agent status
panic: opensslcrypto: can't enable FIPS mode for OpenSSL 3.4.1 11 Feb 2025: openssl: FIPS mode not supported by any provider

goroutine 1 [running]:
crypto/internal/backend.init.1()
	/usr/local/msgo/src/crypto/internal/backend/openssl_linux.go:85 +0x210

$ /opt/datadog-agent/embedded/bin/openssl version
OpenSSL 3.4.1 11 Feb 2025 (Library: OpenSSL 3.4.1 11 Feb 2025)

$ sudo rm /opt/datadog-agent/embedded/ssl/fipsmodule.cnf
$ sudo /opt/datadog-agent/embedded/bin/fipsinstall.sh 

  ...

$ sudo systemctl restart datadog*
$ sudo datadog-agent status

===============
Agent (v7.64.3)
===============
  Status date: 2025-05-08 16:39:17.551 EDT / 2025-05-08 20:39:17.551 UTC (1746736757551)
  Agent start: 2025-05-08 16:39:13.957 EDT / 2025-05-08 20:39:13.957 UTC (1746736753957)
  Pid: 617887
  Go Version: go1.23.8
  Python Version: 3.12.9
  Build arch: arm64
  Agent flavor: agent
  FIPS Mode: enabled

  ...
  ```
### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->