### PR TITLE
Fix notarization step for agent dmg

### DIFF
--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -128,7 +128,7 @@ if [ "$SIGN" = true ]; then
         EXIT_CODE=
         RESULT=$(xcrun notarytool submit --timeout "$NOTARIZATION_TIMEOUT" --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$LATEST_DMG" --wait || EXIT_CODE=$?)
         echo "Results: $RESULT"
-        SUBMISSION_ID=$(echo "$RESULT" | awk "$1 == \"id:\"{print $2; exit}")
+        SUBMISSION_ID=$(echo "$RESULT" | awk "\$1 == \"id:\"{print \$2; exit}")
         echo "Submission ID: $SUBMISSION_ID"
         echo "Submission logs:"
         xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID" || true

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -121,29 +121,19 @@ if [ "$SIGN" = true ]; then
 
     # Send package for notarization; retrieve REQUEST_UUID
     echo "Sending notarization request."
-
-    # Apply timeout / retry
-    for attempt in $(seq 1 $NOTARIZATION_ATTEMPTS); do
+    export NOTARIZATION_TIMEOUT
+    export LATEST_DMG
+    # shellcheck disable=SC2016
+    ./tools/ci/retry.sh -n "$NOTARIZATION_ATTEMPTS" bash -c '
         EXIT_CODE=
-        RESULT=$(timeout "$NOTARIZATION_TIMEOUT" xcrun notarytool submit --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$LATEST_DMG" --wait) || EXIT_CODE=$?
+        RESULT=$(xcrun notarytool submit --timeout "$NOTARIZATION_TIMEOUT" --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$LATEST_DMG" --wait || EXIT_CODE=$?)
         echo "Results: $RESULT"
-        SUBMISSION_ID=$(echo "$RESULT" | awk '$1 == "id:"{print $2; exit}')
+        SUBMISSION_ID=$(echo "$RESULT" | awk "$1 == \"id:\"{print $2; exit}")
         echo "Submission ID: $SUBMISSION_ID"
         echo "Submission logs:"
-        xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID" || EXIT_CODE=$?
-        if [ -n "$EXIT_CODE" ]; then
-            if [ "$attempt" -lt "$NOTARIZATION_ATTEMPTS" ]; then
-                echo "Notarization attempt #$attempt/$NOTARIZATION_ATTEMPTS failed, retrying in $NOTARIZATION_WAIT_TIME"
-                sleep "$NOTARIZATION_WAIT_TIME"
-            else
-                echo "Notarization failed after $NOTARIZATION_ATTEMPTS attempts"
-                exit "$EXIT_CODE"
-            fi
-        else
-            echo "Successfully notarized the package"
-            break
-        fi
-    done
+        xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID" || true
+        exit "$EXIT_CODE"
+    '
     echo -e "\e[0Ksection_end:`date +%s`:notarization\r\e[0K"
 fi
 

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -125,13 +125,13 @@ if [ "$SIGN" = true ]; then
     export LATEST_DMG
     # shellcheck disable=SC2016
     ./tools/ci/retry.sh -n "$NOTARIZATION_ATTEMPTS" bash -c '
-        EXIT_CODE=
+        EXIT_CODE=0
         RESULT=$(xcrun notarytool submit --timeout "$NOTARIZATION_TIMEOUT" --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$LATEST_DMG" --wait || EXIT_CODE=$?)
         echo "Results: $RESULT"
-        SUBMISSION_ID=$(echo "$RESULT" | awk "\$1 == \"id:\"{print \$2; exit}")
+        SUBMISSION_ID="$(echo "$RESULT" | awk "\$1 == \"id:\"{print \$2; exit}")"
         echo "Submission ID: $SUBMISSION_ID"
         echo "Submission logs:"
-        xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID" || true
+        xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID"
         exit "$EXIT_CODE"
     '
     echo -e "\e[0Ksection_end:`date +%s`:notarization\r\e[0K"

--- a/.gitlab/package_build/build_agent_dmg.sh
+++ b/.gitlab/package_build/build_agent_dmg.sh
@@ -130,7 +130,10 @@ if [ "$SIGN" = true ]; then
         echo "Results: $RESULT"
         SUBMISSION_ID="$(echo "$RESULT" | awk "\$1 == \"id:\"{print \$2; exit}")"
         echo "Submission ID: $SUBMISSION_ID"
+        # Wait for logs to be available
+        sleep 1
         echo "Submission logs:"
+        # Always show logs even if notarization fails to have more context
         xcrun notarytool log --apple-id "$APPLE_ACCOUNT" --team-id "$TEAM_ID" --password "$NOTARIZATION_PWD" "$SUBMISSION_ID"
         exit "$EXIT_CODE"
     '

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -36,7 +36,7 @@ agent_dmg-x64-a7:
     INTEGRATION_WHEELS_CACHE_BUCKET: dd-agent-omnibus
     INTEGRATION_WHEELS_SKIP_CACHE_UPLOAD: true
     S3_OMNIBUS_CACHE_BUCKET: dd-ci-datadog-agent-omnibus-cache-build-stable
-    NOTARIZATION_TIMEOUT: 30m
+    NOTARIZATION_TIMEOUT: 15m
     NOTARIZATION_ATTEMPTS: 3
     NOTARIZATION_WAIT_TIME: 15s
   timeout: 2h

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -2,17 +2,9 @@
 .macos_setup_python:
   # Selecting the current Python version
   - !reference [.select_python_env_commands]
+  # List Python and Go existing environments and their disk space
+  - !reference [.list_python_versions_commands]
   - !reference [.install_python_dependencies]
-
-.macos_setup_go:
-  - echo Setting up Go
-  - mkdir -p ~/go
-  - export GO_VERSION="$(cat .go-version)"
-  - eval "$(gimme $GO_VERSION)"
-  - export PATH="$PATH:$GOROOT/bin"
-  - echo Go version should be $GO_VERSION
-  - go version
-  - dda inv check-go-version
 
 .macos_setup_cache:
   # Clean up previous builds
@@ -64,9 +56,6 @@ agent_dmg-x64-a7:
     - set -eo pipefail
     - !reference [.vault_login]
     - !reference [.macos_setup_python]
-    - !reference [.macos_setup_go]
-    # List Python and Go existing environments and their disk space
-    - !reference [.macos_clean_env]
     - !reference [.macos_setup_cache]
     - bash .gitlab/package_build/build_agent_dmg.sh
     - !reference [.upload_sbom_artifacts]

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -2,9 +2,17 @@
 .macos_setup_python:
   # Selecting the current Python version
   - !reference [.select_python_env_commands]
-  # List Python and Go existing environments and their disk space
-  - !reference [.list_python_versions_commands]
   - !reference [.install_python_dependencies]
+
+.macos_setup_go:
+  - echo Setting up Go
+  - mkdir -p ~/go
+  - export GO_VERSION="$(cat .go-version)"
+  - eval "$(gimme $GO_VERSION)"
+  - export PATH="$PATH:$GOROOT/bin"
+  - echo Go version should be $GO_VERSION
+  - go version
+  - dda inv check-go-version
 
 .macos_setup_cache:
   # Clean up previous builds
@@ -56,6 +64,9 @@ agent_dmg-x64-a7:
     - set -eo pipefail
     - !reference [.vault_login]
     - !reference [.macos_setup_python]
+    - !reference [.macos_setup_go]
+    # List Python and Go existing environments and their disk space
+    - !reference [.macos_clean_env]
     - !reference [.macos_setup_cache]
     - bash .gitlab/package_build/build_agent_dmg.sh
     - !reference [.upload_sbom_artifacts]

--- a/tools/ci/retry.sh
+++ b/tools/ci/retry.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
 if [ "$#" -lt 1 ]; then
-    print "usage: $0 <command> [arguments]"
+    print "usage: $0 [-n <n-attempts>] <command> [arguments]"
     print "The script will execute the provided commands and retry in case of failures"
     exit 1
 fi
 
-NB_RETRIES=5
+if [ "$1" = "-n" ]; then
+    shift
+    NB_ATTEMPTS="$1"
+    shift
+else
+    NB_ATTEMPTS=5
+fi
 
-for i in $(seq 1 $NB_RETRIES); do
+NB_ATTEMPTS=5
+
+for i in $(seq 1 $NB_ATTEMPTS); do
     "$@" && exit 0;
     errorcode=$?
     echo "Attempt #${i} failed with error code ${errorcode}"
     # Don't bother sleeping before exiting with an error
-    if [ "$i" -lt $NB_RETRIES ]; then
+    if [ "$i" -lt $NB_ATTEMPTS ]; then
         sleep $((i ** 2))
     fi
 done

--- a/tools/ci/retry.sh
+++ b/tools/ci/retry.sh
@@ -14,8 +14,6 @@ else
     NB_ATTEMPTS=5
 fi
 
-NB_ATTEMPTS=5
-
 for i in $(seq 1 $NB_ATTEMPTS); do
     "$@" && exit 0;
     errorcode=$?


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The error handling was not always working properly due to the `-e` option of the script.
Better handled errors with `EXIT_CODE` that is reset and also updated on log error.

Example [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/929085996#L2174) where the retry wasn't done.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->