### PR TITLE
Set threshold at 55 in new docker-in-docker runners

### DIFF
--- a/.gitlab/functional_test/serverless.yml
+++ b/.gitlab/functional_test/serverless.yml
@@ -32,5 +32,5 @@ serverless_cold_start_performance-deb_x64_dind:
     - cp test/integration/serverless_perf/* /tmp/serverless-ci
     - cd /tmp/serverless-ci # Docker does not like syslinks, that's why it's easier to build the image in /tmp
     - docker build -t datadogci/lambda-extension .
-    - ./compute.sh
+    - OVERRIDE_STARTUP_TIME_THRESHOLD=55 ./compute.sh
   allow_failure: true

--- a/test/integration/serverless_perf/compute.sh
+++ b/test/integration/serverless_perf/compute.sh
@@ -4,6 +4,11 @@ set -o pipefail
 
 STARTUP_TIME_THRESHOLD=33
 
+# If OVERRIDE_STARTUP_TIME_THRESHOLD is set, use it as the threshold
+if [ -n "$OVERRIDE_STARTUP_TIME_THRESHOLD" ]; then
+    STARTUP_TIME_THRESHOLD=$OVERRIDE_STARTUP_TIME_THRESHOLD
+fi
+
 calculate_median() {
     local sorted=($(printf "%s\n" "${@}" | sort -n))
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The bump was already approved in: https://github.com/DataDog/datadog-agent/pull/35114
I created a shadow runner to try the new docker-in-docker runner but forgot to bump the threshold

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->