### PR TITLE
[EBPF] kmt: disable complexity collection in amazon 5.4

### DIFF
--- a/.gitlab/kernel_matrix_testing/common.yml
+++ b/.gitlab/kernel_matrix_testing/common.yml
@@ -60,7 +60,8 @@
 
 .define_if_collect_complexity:
   # Collect only from specific platforms to avoid high memory usage
-  - PLATFORMS_FOR_COMPLEXITY_COLLECTION="amazon_5.4 debian_10 ubuntu_18.04 centos_8 opensuse_15.3 suse_12.5 fedora_38"
+  # This list should match the dependencies of the notify_ebpf_complexity_changes job
+  - PLATFORMS_FOR_COMPLEXITY_COLLECTION="debian_10 ubuntu_18.04 centos_8 opensuse_15.3 suse_12.5 fedora_38"
   - |
     if [ "${TEST_SET}" = "no_usm" ] && echo "${PLATFORMS_FOR_COMPLEXITY_COLLECTION}" | grep -qw "${TAG}" ; then
       export COLLECT_COMPLEXITY=yes
@@ -313,7 +314,6 @@ notify_ebpf_complexity_changes:
       parallel:
         matrix:
           - TAG:
-              - amazon_5.4
               - debian_10
               - ubuntu_18.04
               - centos_8
@@ -326,7 +326,6 @@ notify_ebpf_complexity_changes:
       parallel:
         matrix:
           - TAG:
-              - amazon_5.4
               - debian_10
               - ubuntu_18.04
               - centos_8


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR disables complexity collection on amazon 5.4 images, as it's the distro where we're having the biggest issues with memory usage and blocking tests.

### Motivation

Avoid failing tests.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

CI should pass.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->