### PR TITLE
service discovery: Fix race in TestPythonFromBashScript

### DIFF
--- a/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
+++ b/pkg/collector/corechecks/servicediscovery/module/impl_linux_test.go
@@ -594,25 +594,29 @@ func testCaptureWrappedCommands(t *testing.T, script string, commandWrapper []st
 	var err error
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		proc, err = process.NewProcess(int32(cmd.Process.Pid))
-		assert.NoError(collect, err)
+		require.NoError(collect, err)
+
+		// If we wrap the script with `sh -c`, we can have differences between a
+		// local run and a kmt run, as for kmt `sh` is symbolic link to bash,
+		// while locally it can be a symbolic link to dash.
+		//
+		// In the dash case, we will see 2 processes `sh -c script.py` and a
+		// sub-process `python3 script.py`, while in the bash case we will see
+		// only `python3 script.py` (after initially potentially seeing `sh -c
+		// script.py` before the process execs). We need to check for the
+		// command line arguments of the process to make sure we are looking at
+		// the right process.
+		cmdline, err := proc.Cmdline()
+		require.NoError(t, err)
+		if cmdline == strings.Join(commandLineArgs, " ") && len(commandWrapper) > 0 {
+			var children []*process.Process
+			children, err = proc.Children()
+			require.NoError(collect, err)
+			require.Len(collect, children, 1)
+			proc = children[0]
+		}
 	}, 10*time.Second, 100*time.Millisecond)
 
-	cmdline, err := proc.Cmdline()
-	require.NoError(t, err)
-	// If we wrap the script with `sh -c`, we can have differences between a local run and a kmt run, as for
-	// kmt `sh` is symbolic link to bash, while locally it can be a symbolic link to dash. In the dash case, we will
-	// see 2 processes `sh -c script.py` and a sub-process `python3 script.py`, while in the bash case we will see
-	// only `python3 script.py`. We need to check for the command line arguments of the process to make sure we
-	// are looking at the right process.
-	if cmdline == strings.Join(commandLineArgs, " ") && len(commandWrapper) > 0 {
-		var children []*process.Process
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			children, err = proc.Children()
-			assert.NoError(collect, err)
-			assert.Len(collect, children, 1)
-		}, 10*time.Second, 100*time.Millisecond)
-		proc = children[0]
-	}
 	t.Cleanup(func() { _ = proc.Kill() })
 
 	discovery := setupDiscoveryModule(t)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->

### What does this PR do?

The logic for detecting dash vs bash has a race condition since the
forked process initially has the sh command line even in the bash case
so it's mistakenly identified as the dash case and waits for a
subprocess which never appears. Combine the two Eventually loops to fix
it.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-132

### Describe how you validated your changes

Change in test.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
