### PR TITLE
move InsertDeletionTimestampIfPossible to common processing

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collector_bundle.go
@@ -67,25 +67,35 @@ type CollectorBundle struct {
 // If that's not the case then it'll select all available collectors that are
 // marked as stable.
 func NewCollectorBundle(chk *OrchestratorCheck) *CollectorBundle {
-	bundle := &CollectorBundle{
-		discoverCollectors: chk.orchestratorConfig.CollectorDiscoveryEnabled,
-		check:              chk,
-		inventory:          inventory.NewCollectorInventory(chk.cfg, chk.wlmStore, chk.tagger),
-		runCfg: &collectors.CollectorRunConfig{
-			K8sCollectorRunConfig: collectors.K8sCollectorRunConfig{
-				APIClient:                   chk.apiClient,
-				OrchestratorInformerFactory: chk.orchestratorInformerFactory,
-			},
-			ClusterID:   chk.clusterID,
-			Config:      chk.orchestratorConfig,
-			MsgGroupRef: chk.groupID,
+	runCfg := &collectors.CollectorRunConfig{
+		K8sCollectorRunConfig: collectors.K8sCollectorRunConfig{
+			APIClient:                   chk.apiClient,
+			OrchestratorInformerFactory: chk.orchestratorInformerFactory,
 		},
-		stopCh:              chk.stopCh,
-		manifestBuffer:      NewManifestBuffer(chk),
-		collectorDiscovery:  discovery.NewDiscoveryCollectorForInventory(),
-		activatedCollectors: map[string]struct{}{},
+		ClusterID:   chk.clusterID,
+		Config:      chk.orchestratorConfig,
+		MsgGroupRef: chk.groupID,
 	}
-	bundle.terminatedResourceBundle = NewTerminatedResourceBundle(chk, bundle.runCfg, bundle.manifestBuffer)
+	terminatedResourceRunCfg := &collectors.CollectorRunConfig{
+		K8sCollectorRunConfig: runCfg.K8sCollectorRunConfig,
+		ClusterID:             runCfg.ClusterID,
+		Config:                runCfg.Config,
+		MsgGroupRef:           runCfg.MsgGroupRef,
+		TerminatedResources:   true,
+	}
+	manifestBuffer := NewManifestBuffer(chk)
+
+	bundle := &CollectorBundle{
+		discoverCollectors:       chk.orchestratorConfig.CollectorDiscoveryEnabled,
+		check:                    chk,
+		inventory:                inventory.NewCollectorInventory(chk.cfg, chk.wlmStore, chk.tagger),
+		runCfg:                   runCfg,
+		stopCh:                   chk.stopCh,
+		manifestBuffer:           manifestBuffer,
+		collectorDiscovery:       discovery.NewDiscoveryCollectorForInventory(),
+		activatedCollectors:      map[string]struct{}{},
+		terminatedResourceBundle: NewTerminatedResourceBundle(chk, terminatedResourceRunCfg, manifestBuffer),
+	}
 	bundle.prepare()
 
 	return bundle

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/collector.go
@@ -96,9 +96,10 @@ type ECSCollectorRunConfig struct {
 type CollectorRunConfig struct {
 	K8sCollectorRunConfig
 	ECSCollectorRunConfig
-	ClusterID   string
-	Config      *config.OrchestratorConfig
-	MsgGroupRef *atomic.Int32
+	ClusterID           string
+	Config              *config.OrchestratorConfig
+	MsgGroupRef         *atomic.Int32
+	TerminatedResources bool
 }
 
 // CollectorRunResult contains information about what the collector has done.

--- a/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/collectors/k8scollector.go
@@ -64,14 +64,15 @@ type OrchestratorInformerFactory struct {
 func NewK8sProcessorContext(rcfg *CollectorRunConfig, metadata *CollectorMetadata) *processors.K8sProcessorContext {
 	return &processors.K8sProcessorContext{
 		BaseProcessorContext: processors.BaseProcessorContext{
-			Cfg:              rcfg.Config,
-			MsgGroupID:       rcfg.MsgGroupRef.Inc(),
-			NodeType:         metadata.NodeType,
-			ManifestProducer: true,
-			ClusterID:        rcfg.ClusterID,
-			Kind:             metadata.Kind,
-			APIVersion:       metadata.Version,
-			ExtraTags:        util.ImmutableTagsJoin(rcfg.Config.ExtraTags, metadata.CollectorTags()),
+			Cfg:                 rcfg.Config,
+			MsgGroupID:          rcfg.MsgGroupRef.Inc(),
+			NodeType:            metadata.NodeType,
+			ManifestProducer:    true,
+			ClusterID:           rcfg.ClusterID,
+			Kind:                metadata.Kind,
+			APIVersion:          metadata.Version,
+			ExtraTags:           util.ImmutableTagsJoin(rcfg.Config.ExtraTags, metadata.CollectorTags()),
+			TerminatedResources: rcfg.TerminatedResources,
 		},
 		APIClient:         rcfg.APIClient,
 		LabelsAsTags:      metadata.LabelsAsTags,

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go
@@ -8,11 +8,15 @@
 package processors
 
 import (
+	"reflect"
+	"time"
+
 	jsoniter "github.com/json-iterator/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	model "github.com/DataDog/agent-payload/v5/process"
-
 	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	pkgorchestratormodel "github.com/DataDog/datadog-agent/pkg/orchestrator/model"
@@ -33,18 +37,20 @@ type ProcessorContext interface {
 	IsManifestProducer() bool
 	GetKind() string
 	GetAPIVersion() string
+	IsTerminatedResources() bool
 }
 
 // BaseProcessorContext is the base context for all processors
 type BaseProcessorContext struct {
-	Cfg              *config.OrchestratorConfig
-	NodeType         pkgorchestratormodel.NodeType
-	MsgGroupID       int32
-	ClusterID        string
-	ManifestProducer bool
-	Kind             string
-	APIVersion       string
-	ExtraTags        []string
+	Cfg                 *config.OrchestratorConfig
+	NodeType            pkgorchestratormodel.NodeType
+	MsgGroupID          int32
+	ClusterID           string
+	ManifestProducer    bool
+	Kind                string
+	APIVersion          string
+	ExtraTags           []string
+	TerminatedResources bool
 }
 
 // GetOrchestratorConfig returns the orchestrator config
@@ -80,6 +86,11 @@ func (c *BaseProcessorContext) GetKind() string {
 // GetAPIVersion returns the version
 func (c *BaseProcessorContext) GetAPIVersion() string {
 	return c.APIVersion
+}
+
+// IsTerminatedResources returns true if resources are terminated
+func (c *BaseProcessorContext) IsTerminatedResources() bool {
+	return c.TerminatedResources
 }
 
 // K8sProcessorContext holds k8s resource processing attributes
@@ -196,8 +207,12 @@ func (p *Processor) Process(ctx ProcessorContext, list interface{}) (processResu
 	resourceList := p.h.ResourceList(ctx, list)
 	resourceMetadataModels := make([]interface{}, 0, len(resourceList))
 	resourceManifestModels := make([]interface{}, 0, len(resourceList))
+	now := time.Now()
 
 	for _, resource := range resourceList {
+		if ctx.IsTerminatedResources() {
+			resource = insertDeletionTimestampIfPossible(resource, now)
+		}
 		// Scrub before extraction.
 		p.h.ScrubBeforeExtraction(ctx, resource)
 
@@ -293,4 +308,48 @@ func ChunkMetadata(ctx ProcessorContext, p *Processor, resourceMetadataModels, r
 	}
 
 	return metadataMessages
+}
+
+func insertDeletionTimestampIfPossible(obj interface{}, ts time.Time) interface{} {
+	v := reflect.ValueOf(obj)
+	if v.Kind() != reflect.Ptr || v.IsNil() {
+		log.Debugf("object is not a pointer to a nil pointer, got type: %T", obj)
+		return obj
+	}
+
+	v = v.Elem()
+	if v.Kind() != reflect.Struct {
+		log.Debugf("obj must point to a struct, got type: %T", obj)
+		return obj
+	}
+
+	metaTs := metav1.NewTime(ts)
+
+	if _, ok := obj.(*unstructured.Unstructured); ok {
+		obj.(*unstructured.Unstructured).SetDeletionTimestamp(&metaTs)
+		return obj
+	}
+
+	// Look for metadata field
+	metadataField := v.FieldByName("ObjectMeta")
+	if !metadataField.IsValid() || metadataField.Kind() != reflect.Struct {
+		log.Debugf("obj does not have ObjectMeta field, got type: %T", obj)
+		return obj
+	}
+
+	// Access deletionTimestamp field within ObjectMeta
+	deletionTimestampField := metadataField.FieldByName("DeletionTimestamp")
+	if !deletionTimestampField.IsValid() || !deletionTimestampField.CanSet() {
+		log.Debugf("ObjectMeta does not have a settable DeletionTimestamp, got field: %T", obj)
+		return obj
+	}
+
+	// Do nothing if it's already set
+	if !deletionTimestampField.IsNil() {
+		return obj
+	}
+
+	// Set the deletionTimestamp
+	deletionTimestampField.Set(reflect.ValueOf(&metaTs))
+	return obj
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/processor_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/processor_test.go
@@ -9,10 +9,14 @@ package processors
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	model "github.com/DataDog/agent-payload/v5/process"
 )
@@ -258,4 +262,84 @@ func TestSortedMarshal(t *testing.T) {
 	//nolint:revive // TODO(CAPP) Fix revive linter
 	actualJson := string(json)
 	assert.JSONEq(t, expectedJson, actualJson)
+}
+
+func TestInsertDeletionTimestampIfPossible(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		obj      interface{}
+		expected interface{}
+	}{
+		{
+			name:     "nil object",
+			obj:      nil,
+			expected: nil,
+		},
+		{
+			name:     "non-pointer type",
+			obj:      appsv1.ReplicaSet{},
+			expected: appsv1.ReplicaSet{},
+		},
+		{
+			name:     "non-struct type",
+			obj:      &[]string{},
+			expected: &[]string{},
+		},
+		{
+			name: "object without ObjectMeta",
+			obj: &struct {
+				Name string
+			}{Name: "test"},
+			expected: &struct {
+				Name string
+			}{Name: "test"},
+		},
+		{
+			name: "object with existing DeletionTimestamp",
+			obj: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rs",
+					DeletionTimestamp: &metav1.Time{Time: now.Add(-time.Hour)},
+				},
+			},
+			expected: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rs",
+					DeletionTimestamp: &metav1.Time{Time: now.Add(-time.Hour)},
+				},
+			},
+		},
+		{
+			name: "unstructured object",
+			obj:  &unstructured.Unstructured{},
+			expected: func() interface{} {
+				u := &unstructured.Unstructured{}
+				u.SetDeletionTimestamp(&metav1.Time{Time: now})
+				return u
+			}(),
+		},
+		{
+			name: "regular kubernetes object",
+			obj: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "rs",
+				},
+			},
+			expected: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "rs",
+					DeletionTimestamp: &metav1.Time{Time: now},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := insertDeletionTimestampIfPossible(tt.obj, now)
+			require.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle.go
@@ -12,10 +12,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
-	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
 
@@ -59,7 +56,7 @@ func (tb *TerminatedResourceBundle) Add(k8sCollector collectors.K8sCollector, ob
 		return
 	}
 
-	tb.terminatedResources[k8sCollector] = append(tb.terminatedResources[k8sCollector], insertDeletionTimestampIfPossible(resource))
+	tb.terminatedResources[k8sCollector] = append(tb.terminatedResources[k8sCollector], resource)
 }
 
 // Run sends all buffered terminated resources
@@ -149,48 +146,4 @@ func getResource(obj interface{}) (interface{}, error) {
 	}
 
 	return resource, nil
-}
-
-func insertDeletionTimestampIfPossible(obj interface{}) interface{} {
-	v := reflect.ValueOf(obj)
-	if v.Kind() != reflect.Ptr || v.IsNil() {
-		log.Debugf("object is not a pointer to a nil pointer, got type: %T", obj)
-		return obj
-	}
-
-	v = v.Elem()
-	if v.Kind() != reflect.Struct {
-		log.Debugf("obj must point to a struct, got type: %T", obj)
-		return obj
-	}
-
-	now := metav1.NewTime(time.Now())
-
-	if _, ok := obj.(*unstructured.Unstructured); ok {
-		obj.(*unstructured.Unstructured).SetDeletionTimestamp(&now)
-		return obj
-	}
-
-	// Look for metadata field
-	metadataField := v.FieldByName("ObjectMeta")
-	if !metadataField.IsValid() || metadataField.Kind() != reflect.Struct {
-		log.Debugf("obj does not have ObjectMeta field, got type: %T", obj)
-		return obj
-	}
-
-	// Access deletionTimestamp field within ObjectMeta
-	deletionTimestampField := metadataField.FieldByName("DeletionTimestamp")
-	if !deletionTimestampField.IsValid() || !deletionTimestampField.CanSet() {
-		log.Debugf("ObjectMeta does not have a settable DeletionTimestamp, got field: %T", obj)
-		return obj
-	}
-
-	// Do nothing if it's already set
-	if !deletionTimestampField.IsNil() {
-		return obj
-	}
-
-	// Set the deletionTimestamp to the current time
-	deletionTimestampField.Set(reflect.ValueOf(&now))
-	return obj
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/terminated_resource_bundle_test.go
@@ -21,16 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
 )
 
-func TestInsertDeletionTimestampIfPossible(t *testing.T) {
-	rs := &appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "rs",
-		},
-	}
-	obj := insertDeletionTimestampIfPossible(rs)
-	require.NotNil(t, obj.(*appsv1.ReplicaSet).DeletionTimestamp)
-}
-
 func TestToTypedSlice(t *testing.T) {
 	rs := &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
InsertDeletionTimestampIfPossible can update resources before processing, which can introduce data races.

This PR moves InsertDeletionTimestampIfPossible into the [common collector process](https://github.com/DataDog/datadog-agent/blob/2df5b9f292ba2381bad3a01b9cab311cbaa0391d/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go#L190).

Collector process methods now [make deep copies of resources before processing.](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/clusterrole.go#L83)

Additionally, this PR adds a parameter to the [collector process context](https://github.com/DataDog/datadog-agent/blob/2df5b9f292ba2381bad3a01b9cab311cbaa0391d/pkg/collector/corechecks/cluster/orchestrator/processors/processor.go#L85) to indicate whether terminated resources are being processed.

### Motivation

https://github.com/DataDog/datadog-agent/pull/36778

### Describe how you validated your changes

Enabled the feature by adding `DD_ORCHESTRATOR_EXPLORER_TERMINATED_RESOURCES_ENABLED=true` to cluster agent.

We have two ways to verify this:

1. Open a PR similar to [this one](https://github.com/DataDog/datadog-agent/pull/36586/files), then trigger the docker_trigger_internal-full job to publish an internal staging image. Deploy the image following the instructions [here](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/2568356951/Deploy+the+agent+on+internal+Kubernetes+cluster+s#Deploy-your-change) in a staging cluster. This allows us to check for any data races.
2. Enable the feature flag internally for a week and monitor for any panics.

