### PR TITLE
Sanitize fetch_secrets script

### DIFF
--- a/tools/ci/fetch_secret.sh
+++ b/tools/ci/fetch_secret.sh
@@ -13,11 +13,11 @@ while [[ $retry_count -lt $max_retries ]]; do
         if [[ "$(uname -s)" == "Darwin" ]]; then
             vault_name="kv/aws/arn:aws:iam::486234852809:role/ci-datadog-agent"
         fi
-        result=$(vault kv get -field="${parameter_field}" "${vault_name}"/"${parameter_name}" 2> errorFile)
+        result="$(vault kv get -field="${parameter_field}" "${vault_name}"/"${parameter_name}" 2> errorFile)"
     else
-        result=$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> errorFile)
+        result="$(aws ssm get-parameter --region us-east-1 --name "$parameter_name" --with-decryption --query "Parameter.Value" --output text 2> errorFile)"
     fi
-    error=$(<errorFile)
+    error="$(<errorFile)"
     if [ -n "$result" ]; then
         echo "$result"
         exit 0
@@ -27,8 +27,8 @@ while [[ $retry_count -lt $max_retries ]]; do
         >&2 echo "Permanent error: unable to locate credentials, not retrying"
         exit 42
     fi
-    retry_count=$((retry_count+1))
-    sleep $((2**retry_count))
+    retry_count="$((retry_count+1))"
+    sleep "$((2**retry_count))"
 done
 
 echo "Failed to retrieve parameter after $max_retries retries" >&2

--- a/tools/ci/fetch_secret.sh
+++ b/tools/ci/fetch_secret.sh
@@ -31,5 +31,5 @@ while [[ $retry_count -lt $max_retries ]]; do
     sleep $((2**retry_count))
 done
 
-echo "Failed to retrieve parameter after $max_retries retries"
+echo "Failed to retrieve parameter after $max_retries retries" >&2
 exit 1


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

It's sometimes hard to debug errors within the secrets fetcher script, fixed this and also avoided leaking secrets.

1. Sanitizes the script to avoid leaking secrets (mostly due to unquoted variables or sub shells)
2. Echo errors on stderr

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->