### PR TITLE
[netpath] Rename ReceiveICMPProbe -> ReceiveSecondaryProbe

### DIFF
--- a/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
@@ -35,7 +35,7 @@ func initMockDriver(t *testing.T, params TracerouteParallelParams) *MockDriver {
 	return &MockDriver{
 		t:              t,
 		params:         params,
-		info:           TracerouteDriverInfo{UsesReceiveICMPProbe: true},
+		info:           TracerouteDriverInfo{UsesReceiveSecondaryProbe: true},
 		sentTTLs:       make(map[uint8]struct{}),
 		sendHandler:    nil,
 		receiveHandler: nil,
@@ -70,7 +70,7 @@ func (m *MockDriver) ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
 	return res, err
 }
 
-func (m *MockDriver) ReceiveICMPProbe(timeout time.Duration) (*ProbeResponse, error) {
+func (m *MockDriver) ReceiveSecondaryProbe(timeout time.Duration) (*ProbeResponse, error) {
 	require.Equal(m.t, m.params.PollFrequency, timeout)
 
 	if m.icmpReceiveHandler == nil {
@@ -602,14 +602,15 @@ func TestParallelTracerouteDestOverwrite(t *testing.T) {
 }
 
 func TestParallelTracerouteDisableICMP(t *testing.T) {
-	// this test checks that TracerouteParallel doesn't call ReceiveICMPProbe when it's disabled
+	// this test checks that TracerouteParallel doesn't call ReceiveSecondaryProbe when it's disabled
 	m := initMockDriver(t, testParams)
-	m.info.UsesReceiveICMPProbe = false
+
+	m.info.UsesReceiveSecondaryProbe = false
 	t.Parallel()
 
 	m.icmpReceiveHandler = func() (*ProbeResponse, error) {
-		t.Fatal("should not have called ReceiveICMPProbe")
-		return nil, fmt.Errorf("should not have called ReceiveICMPProbe")
+		t.Fatal("should not have called ReceiveSecondaryProbe")
+		return nil, fmt.Errorf("should not have called ReceiveSecondaryProbe")
 	}
 
 	_, err := TracerouteParallel(context.Background(), m, testParams)

--- a/pkg/networkpath/traceroute/sack/sack_driver_linux.go
+++ b/pkg/networkpath/traceroute/sack/sack_driver_linux.go
@@ -80,7 +80,7 @@ func (s *sackDriver) Close() {
 
 func (s *sackDriver) GetDriverInfo() common.TracerouteDriverInfo {
 	return common.TracerouteDriverInfo{
-		UsesReceiveICMPProbe: true,
+		UsesReceiveSecondaryProbe: true,
 	}
 }
 
@@ -122,7 +122,7 @@ func (s *sackDriver) SendProbe(ttl uint8) error {
 func (s *sackDriver) ReceiveProbe(timeout time.Duration) (*common.ProbeResponse, error) {
 	return s.receiveProbe(s.tcpHandle, timeout)
 }
-func (s *sackDriver) ReceiveICMPProbe(timeout time.Duration) (*common.ProbeResponse, error) {
+func (s *sackDriver) ReceiveSecondaryProbe(timeout time.Duration) (*common.ProbeResponse, error) {
 	return s.receiveProbe(s.icmpHandle, timeout)
 }
 func (s *sackDriver) receiveProbe(handle *handle, timeout time.Duration) (*common.ProbeResponse, error) {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Renames ReceiveICMPProbe -> ReceiveSecondaryProbe. If you can think of a better name, let me know... More info in Motivation
### Motivation
The naming of ReceiveICMPProbe was imagined for this kind of case:
* Main socket sends/receives TCP
* On linux, an extra raw socket is required to get ICMP traffic

However ICMP traceroutes present a different scenario, where the main socket _is_ the ICMP socket. So I don't really have a good name for the goroutine for the second socket.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
I don't like this name lol

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->