### PR TITLE
Rename ContainerStatus.AllocatedResources field to fix conflict

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -267,7 +267,7 @@ func parsePodContainers(
 		}
 
 		var allocatedResources []workloadmeta.ContainerAllocatedResource
-		for _, resource := range container.AllocatedResources {
+		for _, resource := range container.ResolvedAllocatedResources {
 			allocatedResources = append(allocatedResources, workloadmeta.ContainerAllocatedResource{
 				Name: resource.Name,
 				ID:   resource.ID,
@@ -310,15 +310,15 @@ func parsePodContainers(
 						kubernetes.CriContainerNamespaceLabel: pod.Metadata.Namespace,
 					},
 				},
-				Image:              image,
-				EnvVars:            env,
-				SecurityContext:    containerSecurityContext,
-				Ports:              ports,
-				Runtime:            workloadmeta.ContainerRuntime(runtime),
-				State:              containerState,
-				Owner:              parent,
-				Resources:          resources,
-				AllocatedResources: allocatedResources,
+				Image:                      image,
+				EnvVars:                    env,
+				SecurityContext:            containerSecurityContext,
+				Ports:                      ports,
+				Runtime:                    workloadmeta.ContainerRuntime(runtime),
+				State:                      containerState,
+				Owner:                      parent,
+				Resources:                  resources,
+				ResolvedAllocatedResources: allocatedResources,
 			},
 		})
 	}

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -559,9 +559,9 @@ type Container struct {
 	SecurityContext *ContainerSecurityContext
 	Resources       ContainerResources
 
-	// AllocatedResources is the list of resources allocated to this pod. Requires the
+	// ResolvedAllocatedResources is the list of resources allocated to this pod. Requires the
 	// PodResources API to query that data.
-	AllocatedResources []ContainerAllocatedResource
+	ResolvedAllocatedResources []ContainerAllocatedResource
 	// CgroupPath is a path to the cgroup of the container.
 	// It can be relative to the cgroup parent.
 	// Linux only.
@@ -616,7 +616,7 @@ func (c Container) String(verbose bool) string {
 	_, _ = fmt.Fprint(&sb, c.Resources.String(verbose))
 
 	_, _ = fmt.Fprintln(&sb, "----------- Allocated Resources -----------")
-	for _, r := range c.AllocatedResources {
+	for _, r := range c.ResolvedAllocatedResources {
 		_, _ = fmt.Fprintln(&sb, r.String())
 	}
 

--- a/comp/core/workloadmeta/impl/dump_test.go
+++ b/comp/core/workloadmeta/impl/dump_test.go
@@ -80,7 +80,7 @@ func TestDump(t *testing.T) {
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
 Name: ctr-name
-Namespace:
+Namespace: 
 ----------- Image -----------
 Name: ctr-image
 Tag: latest
@@ -109,22 +109,22 @@ Name: nvidia.com/gpu, ID: GPU-1234
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
 Name: ctr-name
-Namespace:
-Annotations:
-Labels:
+Namespace: 
+Annotations: 
+Labels: 
 ----------- Image -----------
 Name: ctr-image
-Tag:
-ID:
-Raw Name:
-Short Name:
-Repo Digest:
+Tag: 
+ID: 
+Raw Name: 
+Short Name: 
+Repo Digest: 
 ----------- Container Info -----------
 Runtime: docker
 RuntimeFlavor: kata
 Running: false
-Status:
-Health:
+Status: 
+Health: 
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
@@ -132,38 +132,38 @@ Finished At: 0001-01-01 00:00:00 +0000 UTC
 GPUVendor: [nvidia]
 ----------- Allocated Resources -----------
 Name: nvidia.com/gpu, ID: GPU-1234
-Hostname:
-Network IPs:
+Hostname: 
+Network IPs: 
 PID: 0
-Cgroup path:
+Cgroup path: 
 `,
 					"source:source2 id: ctr-id": `----------- Entity ID -----------
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
-Name:
-Namespace:
-Annotations:
-Labels: foo:bar
+Name: 
+Namespace: 
+Annotations: 
+Labels: foo:bar 
 ----------- Image -----------
-Name:
+Name: 
 Tag: latest
-ID:
-Raw Name:
-Short Name:
-Repo Digest:
+ID: 
+Raw Name: 
+Short Name: 
+Repo Digest: 
 ----------- Container Info -----------
-Runtime:
-RuntimeFlavor:
+Runtime: 
+RuntimeFlavor: 
 Running: false
-Status:
-Health:
+Status: 
+Health: 
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
 ----------- Allocated Resources -----------
-Hostname:
-Network IPs:
+Hostname: 
+Network IPs: 
 PID: 1
 Cgroup path: /default/ctr-id
 `,
@@ -171,22 +171,22 @@ Cgroup path: /default/ctr-id
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
 Name: ctr-name
-Namespace:
-Annotations:
-Labels: foo:bar
+Namespace: 
+Annotations: 
+Labels: foo:bar 
 ----------- Image -----------
 Name: ctr-image
 Tag: latest
-ID:
-Raw Name:
-Short Name:
-Repo Digest:
+ID: 
+Raw Name: 
+Short Name: 
+Repo Digest: 
 ----------- Container Info -----------
 Runtime: docker
 RuntimeFlavor: kata
 Running: false
-Status:
-Health:
+Status: 
+Health: 
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
@@ -194,8 +194,8 @@ Finished At: 0001-01-01 00:00:00 +0000 UTC
 GPUVendor: [nvidia]
 ----------- Allocated Resources -----------
 Name: nvidia.com/gpu, ID: GPU-1234
-Hostname:
-Network IPs:
+Hostname: 
+Network IPs: 
 PID: 1
 Cgroup path: /default/ctr-id
 `,

--- a/comp/core/workloadmeta/impl/dump_test.go
+++ b/comp/core/workloadmeta/impl/dump_test.go
@@ -30,7 +30,7 @@ func TestDump(t *testing.T) {
 		Resources: wmdef.ContainerResources{
 			GPUVendorList: []string{"nvidia"},
 		},
-		AllocatedResources: []wmdef.ContainerAllocatedResource{
+		ResolvedAllocatedResources: []wmdef.ContainerAllocatedResource{
 			{Name: "nvidia.com/gpu", ID: "GPU-1234"},
 		},
 		Runtime:       wmdef.ContainerRuntimeDocker,
@@ -80,7 +80,7 @@ func TestDump(t *testing.T) {
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
 Name: ctr-name
-Namespace: 
+Namespace:
 ----------- Image -----------
 Name: ctr-image
 Tag: latest
@@ -109,22 +109,22 @@ Name: nvidia.com/gpu, ID: GPU-1234
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
 Name: ctr-name
-Namespace: 
-Annotations: 
-Labels: 
+Namespace:
+Annotations:
+Labels:
 ----------- Image -----------
 Name: ctr-image
-Tag: 
-ID: 
-Raw Name: 
-Short Name: 
-Repo Digest: 
+Tag:
+ID:
+Raw Name:
+Short Name:
+Repo Digest:
 ----------- Container Info -----------
 Runtime: docker
 RuntimeFlavor: kata
 Running: false
-Status: 
-Health: 
+Status:
+Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
@@ -132,38 +132,38 @@ Finished At: 0001-01-01 00:00:00 +0000 UTC
 GPUVendor: [nvidia]
 ----------- Allocated Resources -----------
 Name: nvidia.com/gpu, ID: GPU-1234
-Hostname: 
-Network IPs: 
+Hostname:
+Network IPs:
 PID: 0
-Cgroup path: 
+Cgroup path:
 `,
 					"source:source2 id: ctr-id": `----------- Entity ID -----------
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
-Name: 
-Namespace: 
-Annotations: 
-Labels: foo:bar 
+Name:
+Namespace:
+Annotations:
+Labels: foo:bar
 ----------- Image -----------
-Name: 
+Name:
 Tag: latest
-ID: 
-Raw Name: 
-Short Name: 
-Repo Digest: 
+ID:
+Raw Name:
+Short Name:
+Repo Digest:
 ----------- Container Info -----------
-Runtime: 
-RuntimeFlavor: 
+Runtime:
+RuntimeFlavor:
 Running: false
-Status: 
-Health: 
+Status:
+Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
 ----------- Resources -----------
 ----------- Allocated Resources -----------
-Hostname: 
-Network IPs: 
+Hostname:
+Network IPs:
 PID: 1
 Cgroup path: /default/ctr-id
 `,
@@ -171,22 +171,22 @@ Cgroup path: /default/ctr-id
 Kind: container ID: ctr-id
 ----------- Entity Meta -----------
 Name: ctr-name
-Namespace: 
-Annotations: 
-Labels: foo:bar 
+Namespace:
+Annotations:
+Labels: foo:bar
 ----------- Image -----------
 Name: ctr-image
 Tag: latest
-ID: 
-Raw Name: 
-Short Name: 
-Repo Digest: 
+ID:
+Raw Name:
+Short Name:
+Repo Digest:
 ----------- Container Info -----------
 Runtime: docker
 RuntimeFlavor: kata
 Running: false
-Status: 
-Health: 
+Status:
+Health:
 Created At: 0001-01-01 00:00:00 +0000 UTC
 Started At: 0001-01-01 00:00:00 +0000 UTC
 Finished At: 0001-01-01 00:00:00 +0000 UTC
@@ -194,8 +194,8 @@ Finished At: 0001-01-01 00:00:00 +0000 UTC
 GPUVendor: [nvidia]
 ----------- Allocated Resources -----------
 Name: nvidia.com/gpu, ID: GPU-1234
-Hostname: 
-Network IPs: 
+Hostname:
+Network IPs:
 PID: 1
 Cgroup path: /default/ctr-id
 `,

--- a/comp/core/workloadmeta/proto/proto.go
+++ b/comp/core/workloadmeta/proto/proto.go
@@ -134,22 +134,22 @@ func protoContainerFromWorkloadmetaContainer(container *workloadmeta.Container) 
 		return nil, err
 	}
 
-	protoAllocatedResources := toProtoAllocatedResources(container.AllocatedResources)
+	protoResolvedAllocatedResources := toProtoResolvedAllocatedResources(container.ResolvedAllocatedResources)
 
 	return &pb.Container{
-		EntityId:           protoEntityID,
-		EntityMeta:         toProtoEntityMetaFromContainer(container),
-		EnvVars:            container.EnvVars,
-		Hostname:           container.Hostname,
-		Image:              toProtoImage(&container.Image),
-		NetworkIps:         container.NetworkIPs,
-		Pid:                int32(container.PID),
-		Ports:              pbContainerPorts,
-		Runtime:            protoRuntime,
-		State:              protoContainerState,
-		CollectorTags:      container.CollectorTags,
-		CgroupPath:         container.CgroupPath,
-		AllocatedResources: protoAllocatedResources,
+		EntityId:                   protoEntityID,
+		EntityMeta:                 toProtoEntityMetaFromContainer(container),
+		EnvVars:                    container.EnvVars,
+		Hostname:                   container.Hostname,
+		Image:                      toProtoImage(&container.Image),
+		NetworkIps:                 container.NetworkIPs,
+		Pid:                        int32(container.PID),
+		Ports:                      pbContainerPorts,
+		Runtime:                    protoRuntime,
+		State:                      protoContainerState,
+		CollectorTags:              container.CollectorTags,
+		CgroupPath:                 container.CgroupPath,
+		ResolvedAllocatedResources: protoResolvedAllocatedResources,
 	}, nil
 }
 
@@ -284,16 +284,16 @@ func toProtoContainerState(state *workloadmeta.ContainerState) (*pb.ContainerSta
 	return res, nil
 }
 
-func toProtoAllocatedResources(resources []workloadmeta.ContainerAllocatedResource) []*pb.ContainerAllocatedResource {
-	var protoAllocatedResources []*pb.ContainerAllocatedResource
+func toProtoResolvedAllocatedResources(resources []workloadmeta.ContainerAllocatedResource) []*pb.ContainerAllocatedResource {
+	var protoResolvedAllocatedResources []*pb.ContainerAllocatedResource
 	for _, resource := range resources {
-		protoAllocatedResources = append(protoAllocatedResources, &pb.ContainerAllocatedResource{
+		protoResolvedAllocatedResources = append(protoResolvedAllocatedResources, &pb.ContainerAllocatedResource{
 			Name: resource.Name,
 			ID:   resource.ID,
 		})
 	}
 
-	return protoAllocatedResources
+	return protoResolvedAllocatedResources
 }
 
 func toProtoContainerStatus(status workloadmeta.ContainerStatus) (pb.ContainerStatus, error) {
@@ -615,22 +615,22 @@ func toWorkloadmetaContainer(protoContainer *pb.Container) (*workloadmeta.Contai
 		return nil, err
 	}
 
-	resources := toWorkloadmetaAllocatedResources(protoContainer.AllocatedResources)
+	resources := toWorkloadmetaResolvedAllocatedResources(protoContainer.ResolvedAllocatedResources)
 
 	return &workloadmeta.Container{
-		EntityID:           entityID,
-		EntityMeta:         toWorkloadmetaEntityMeta(protoContainer.EntityMeta),
-		EnvVars:            protoContainer.EnvVars,
-		Hostname:           protoContainer.Hostname,
-		Image:              toWorkloadmetaImage(protoContainer.Image),
-		NetworkIPs:         protoContainer.NetworkIps,
-		PID:                int(protoContainer.Pid),
-		Ports:              ports,
-		Runtime:            runtime,
-		State:              state,
-		CollectorTags:      protoContainer.CollectorTags,
-		CgroupPath:         protoContainer.CgroupPath,
-		AllocatedResources: resources,
+		EntityID:                   entityID,
+		EntityMeta:                 toWorkloadmetaEntityMeta(protoContainer.EntityMeta),
+		EnvVars:                    protoContainer.EnvVars,
+		Hostname:                   protoContainer.Hostname,
+		Image:                      toWorkloadmetaImage(protoContainer.Image),
+		NetworkIPs:                 protoContainer.NetworkIps,
+		PID:                        int(protoContainer.Pid),
+		Ports:                      ports,
+		Runtime:                    runtime,
+		State:                      state,
+		CollectorTags:              protoContainer.CollectorTags,
+		CgroupPath:                 protoContainer.CgroupPath,
+		ResolvedAllocatedResources: resources,
 	}, nil
 }
 
@@ -642,9 +642,9 @@ func toWorkloadmetaContainerPort(protoPort *pb.ContainerPort) workloadmeta.Conta
 	}
 }
 
-func toWorkloadmetaAllocatedResources(protoAllocatedResources []*pb.ContainerAllocatedResource) []workloadmeta.ContainerAllocatedResource {
+func toWorkloadmetaResolvedAllocatedResources(protoResolvedAllocatedResources []*pb.ContainerAllocatedResource) []workloadmeta.ContainerAllocatedResource {
 	var resources []workloadmeta.ContainerAllocatedResource
-	for _, protoResource := range protoAllocatedResources {
+	for _, protoResource := range protoResolvedAllocatedResources {
 		resources = append(resources, workloadmeta.ContainerAllocatedResource{
 			Name: protoResource.Name,
 			ID:   protoResource.ID,

--- a/comp/core/workloadmeta/proto/proto_test.go
+++ b/comp/core/workloadmeta/proto/proto_test.go
@@ -84,7 +84,7 @@ func TestConversions(t *testing.T) {
 					CollectorTags: []string{
 						"tag1",
 					},
-					AllocatedResources: []workloadmeta.ContainerAllocatedResource{
+					ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
 						{Name: "nvidia.com/gpu", ID: "gpu1"},
 					},
 				},
@@ -141,7 +141,7 @@ func TestConversions(t *testing.T) {
 					CollectorTags: []string{
 						"tag1",
 					},
-					AllocatedResources: []*pb.ContainerAllocatedResource{
+					ResolvedAllocatedResources: []*pb.ContainerAllocatedResource{
 						{Name: "nvidia.com/gpu", ID: "gpu1"},
 					},
 				},

--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -324,13 +324,13 @@ func (c *Check) getContainerTags(containerID string) []string {
 
 func (c *Check) getGPUToContainersMap() map[string][]*workloadmeta.Container {
 	containers := c.wmeta.ListContainersWithFilter(func(cont *workloadmeta.Container) bool {
-		return len(cont.AllocatedResources) > 0
+		return len(cont.ResolvedAllocatedResources) > 0
 	})
 
 	gpuToContainers := make(map[string][]*workloadmeta.Container)
 
 	for _, container := range containers {
-		for _, resource := range container.AllocatedResources {
+		for _, resource := range container.ResolvedAllocatedResources {
 			if resource.Name == "nvidia.com/gpu" {
 				gpuToContainers[resource.ID] = append(gpuToContainers[resource.ID], container)
 			}

--- a/pkg/gpu/context.go
+++ b/pkg/gpu/context.go
@@ -176,7 +176,7 @@ func (ctx *systemContext) filterDevicesForContainer(devices []ddnvml.Device, con
 
 	var filteredDevices []ddnvml.Device
 	numContainerGPUs := 0
-	for _, resource := range container.AllocatedResources {
+	for _, resource := range container.ResolvedAllocatedResources {
 		// Only consider NVIDIA GPUs
 		if resource.Name != nvidiaResourceName {
 			continue
@@ -216,7 +216,7 @@ func (ctx *systemContext) filterDevicesForContainer(devices []ddnvml.Device, con
 	// If the container has GPUs assigned to it but we couldn't match it to our
 	// devices, return the error for this case and show the allocated resources
 	// for debugging purposes.
-	return nil, fmt.Errorf("no GPU devices found for container %s that matched its allocated resources %+v", containerID, container.AllocatedResources)
+	return nil, fmt.Errorf("no GPU devices found for container %s that matched its allocated resources %+v", containerID, container.ResolvedAllocatedResources)
 }
 
 // getCurrentActiveGpuDevice returns the active GPU device for a given process and thread, based on the

--- a/pkg/gpu/context_test.go
+++ b/pkg/gpu/context_test.go
@@ -54,7 +54,7 @@ func TestFilterDevicesForContainer(t *testing.T) {
 		EntityMeta: workloadmeta.EntityMeta{
 			Name: containerID,
 		},
-		AllocatedResources: []workloadmeta.ContainerAllocatedResource{
+		ResolvedAllocatedResources: []workloadmeta.ContainerAllocatedResource{
 			{
 				Name: nvidiaResourceName,
 				ID:   gpuUUID,
@@ -71,7 +71,7 @@ func TestFilterDevicesForContainer(t *testing.T) {
 		EntityMeta: workloadmeta.EntityMeta{
 			Name: containerIDNoGpu,
 		},
-		AllocatedResources: nil,
+		ResolvedAllocatedResources: nil,
 	}
 
 	wmetaMock.Set(container)
@@ -160,7 +160,7 @@ func TestGetCurrentActiveGpuDevice(t *testing.T) {
 			Name: nvidiaResourceName,
 			ID:   gpuUUID,
 		}
-		container.AllocatedResources = append(container.AllocatedResources, resource)
+		container.ResolvedAllocatedResources = append(container.ResolvedAllocatedResources, resource)
 	}
 
 	wmetaMock.Set(container)

--- a/pkg/proto/datadog/workloadmeta/workloadmeta.proto
+++ b/pkg/proto/datadog/workloadmeta/workloadmeta.proto
@@ -113,7 +113,7 @@ message Container {
   ContainerState state = 10;
   repeated string collectorTags = 11;
   string cgroupPath = 12;
-  repeated ContainerAllocatedResource allocatedResources = 13;
+  repeated ContainerAllocatedResource resolvedAllocatedResources = 13;
 }
 
 message KubernetesPodOwner {

--- a/pkg/proto/pbgo/core/workloadmeta.pb.go
+++ b/pkg/proto/pbgo/core/workloadmeta.pb.go
@@ -898,22 +898,22 @@ func (x *ContainerAllocatedResource) GetID() string {
 }
 
 type Container struct {
-	state              protoimpl.MessageState        `protogen:"open.v1"`
-	EntityId           *WorkloadmetaEntityId         `protobuf:"bytes,1,opt,name=entityId,proto3" json:"entityId,omitempty"`
-	EntityMeta         *EntityMeta                   `protobuf:"bytes,2,opt,name=entityMeta,proto3" json:"entityMeta,omitempty"`
-	EnvVars            map[string]string             `protobuf:"bytes,3,rep,name=envVars,proto3" json:"envVars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Hostname           string                        `protobuf:"bytes,4,opt,name=hostname,proto3" json:"hostname,omitempty"`
-	Image              *ContainerImage               `protobuf:"bytes,5,opt,name=image,proto3" json:"image,omitempty"`
-	NetworkIps         map[string]string             `protobuf:"bytes,6,rep,name=networkIps,proto3" json:"networkIps,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	Pid                int32                         `protobuf:"varint,7,opt,name=pid,proto3" json:"pid,omitempty"`
-	Ports              []*ContainerPort              `protobuf:"bytes,8,rep,name=ports,proto3" json:"ports,omitempty"`
-	Runtime            Runtime                       `protobuf:"varint,9,opt,name=runtime,proto3,enum=datadog.workloadmeta.Runtime" json:"runtime,omitempty"`
-	State              *ContainerState               `protobuf:"bytes,10,opt,name=state,proto3" json:"state,omitempty"`
-	CollectorTags      []string                      `protobuf:"bytes,11,rep,name=collectorTags,proto3" json:"collectorTags,omitempty"`
-	CgroupPath         string                        `protobuf:"bytes,12,opt,name=cgroupPath,proto3" json:"cgroupPath,omitempty"`
-	AllocatedResources []*ContainerAllocatedResource `protobuf:"bytes,13,rep,name=allocatedResources,proto3" json:"allocatedResources,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	state                      protoimpl.MessageState        `protogen:"open.v1"`
+	EntityId                   *WorkloadmetaEntityId         `protobuf:"bytes,1,opt,name=entityId,proto3" json:"entityId,omitempty"`
+	EntityMeta                 *EntityMeta                   `protobuf:"bytes,2,opt,name=entityMeta,proto3" json:"entityMeta,omitempty"`
+	EnvVars                    map[string]string             `protobuf:"bytes,3,rep,name=envVars,proto3" json:"envVars,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Hostname                   string                        `protobuf:"bytes,4,opt,name=hostname,proto3" json:"hostname,omitempty"`
+	Image                      *ContainerImage               `protobuf:"bytes,5,opt,name=image,proto3" json:"image,omitempty"`
+	NetworkIps                 map[string]string             `protobuf:"bytes,6,rep,name=networkIps,proto3" json:"networkIps,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Pid                        int32                         `protobuf:"varint,7,opt,name=pid,proto3" json:"pid,omitempty"`
+	Ports                      []*ContainerPort              `protobuf:"bytes,8,rep,name=ports,proto3" json:"ports,omitempty"`
+	Runtime                    Runtime                       `protobuf:"varint,9,opt,name=runtime,proto3,enum=datadog.workloadmeta.Runtime" json:"runtime,omitempty"`
+	State                      *ContainerState               `protobuf:"bytes,10,opt,name=state,proto3" json:"state,omitempty"`
+	CollectorTags              []string                      `protobuf:"bytes,11,rep,name=collectorTags,proto3" json:"collectorTags,omitempty"`
+	CgroupPath                 string                        `protobuf:"bytes,12,opt,name=cgroupPath,proto3" json:"cgroupPath,omitempty"`
+	ResolvedAllocatedResources []*ContainerAllocatedResource `protobuf:"bytes,13,rep,name=resolvedAllocatedResources,proto3" json:"resolvedAllocatedResources,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
 }
 
 func (x *Container) Reset() {
@@ -1030,9 +1030,9 @@ func (x *Container) GetCgroupPath() string {
 	return ""
 }
 
-func (x *Container) GetAllocatedResources() []*ContainerAllocatedResource {
+func (x *Container) GetResolvedAllocatedResources() []*ContainerAllocatedResource {
 	if x != nil {
-		return x.AllocatedResources
+		return x.ResolvedAllocatedResources
 	}
 	return nil
 }
@@ -1599,7 +1599,7 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\bexitCode\x18\a \x01(\x03R\bexitCode\"@\n" +
 	"\x1aContainerAllocatedResource\x12\x12\n" +
 	"\x04Name\x18\x01 \x01(\tR\x04Name\x12\x0e\n" +
-	"\x02ID\x18\x02 \x01(\tR\x02ID\"\xeb\x06\n" +
+	"\x02ID\x18\x02 \x01(\tR\x02ID\"\xfb\x06\n" +
 	"\tContainer\x12F\n" +
 	"\bentityId\x18\x01 \x01(\v2*.datadog.workloadmeta.WorkloadmetaEntityIdR\bentityId\x12@\n" +
 	"\n" +
@@ -1619,8 +1619,8 @@ const file_datadog_workloadmeta_workloadmeta_proto_rawDesc = "" +
 	"\rcollectorTags\x18\v \x03(\tR\rcollectorTags\x12\x1e\n" +
 	"\n" +
 	"cgroupPath\x18\f \x01(\tR\n" +
-	"cgroupPath\x12`\n" +
-	"\x12allocatedResources\x18\r \x03(\v20.datadog.workloadmeta.ContainerAllocatedResourceR\x12allocatedResources\x1a:\n" +
+	"cgroupPath\x12p\n" +
+	"\x1aresolvedAllocatedResources\x18\r \x03(\v20.datadog.workloadmeta.ContainerAllocatedResourceR\x1aresolvedAllocatedResources\x1a:\n" +
 	"\fEnvVarsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a=\n" +
@@ -1794,7 +1794,7 @@ var file_datadog_workloadmeta_workloadmeta_proto_depIdxs = []int32{
 	12, // 14: datadog.workloadmeta.Container.ports:type_name -> datadog.workloadmeta.ContainerPort
 	3,  // 15: datadog.workloadmeta.Container.runtime:type_name -> datadog.workloadmeta.Runtime
 	13, // 16: datadog.workloadmeta.Container.state:type_name -> datadog.workloadmeta.ContainerState
-	14, // 17: datadog.workloadmeta.Container.allocatedResources:type_name -> datadog.workloadmeta.ContainerAllocatedResource
+	14, // 17: datadog.workloadmeta.Container.resolvedAllocatedResources:type_name -> datadog.workloadmeta.ContainerAllocatedResource
 	11, // 18: datadog.workloadmeta.OrchestratorContainer.image:type_name -> datadog.workloadmeta.ContainerImage
 	9,  // 19: datadog.workloadmeta.KubernetesPod.entityId:type_name -> datadog.workloadmeta.WorkloadmetaEntityId
 	10, // 20: datadog.workloadmeta.KubernetesPod.entityMeta:type_name -> datadog.workloadmeta.EntityMeta

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -323,7 +323,7 @@ func (ku *KubeUtil) addResourcesToContainerList(containerToDevicesMap map[Contai
 		for _, device := range devices {
 			name := device.GetResourceName()
 			for _, id := range device.GetDeviceIds() {
-				container.AllocatedResources = append(container.AllocatedResources, ContainerAllocatedResource{
+				container.ResolvedAllocatedResources = append(container.ResolvedAllocatedResources, ContainerAllocatedResource{
 					Name: name,
 					ID:   id,
 				})

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -222,15 +222,15 @@ type Conditions struct {
 
 // ContainerStatus contains fields for unmarshalling a Pod.Status.Containers
 type ContainerStatus struct {
-	Name               string                       `json:"name"`
-	Image              string                       `json:"image"`
-	ImageID            string                       `json:"imageID"`
-	ID                 string                       `json:"containerID"`
-	Ready              bool                         `json:"ready"`
-	RestartCount       int                          `json:"restartCount"`
-	State              ContainerState               `json:"state"`
-	LastState          ContainerState               `json:"lastState"`
-	AllocatedResources []ContainerAllocatedResource `json:"allocatedResources,omitempty"`
+	Name                       string                       `json:"name"`
+	Image                      string                       `json:"image"`
+	ImageID                    string                       `json:"imageID"`
+	ID                         string                       `json:"containerID"`
+	Ready                      bool                         `json:"ready"`
+	RestartCount               int                          `json:"restartCount"`
+	State                      ContainerState               `json:"state"`
+	LastState                  ContainerState               `json:"lastState"`
+	ResolvedAllocatedResources []ContainerAllocatedResource `json:"resolvedAllocatedResources,omitempty"`
 }
 
 // ContainerAllocatedResource contains the fields for an assigned resource to a container

--- a/releasenotes/notes/kubelet-fix-pod-list-2278f8f8920510da.yaml
+++ b/releasenotes/notes/kubelet-fix-pod-list-2278f8f8920510da.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes issue parsing pod list from kubelet when the `InPlacePodVerticalScaling`
+    feature gate is enabled on the cluster.


### PR DESCRIPTION
### What does this PR do?

This PR renames the `AllocatedResources` field in the ContainerStatus struct to `ResolvedAllocatedResources`

### Motivation

Within the agent, the `AllocatedResources` field represents data which we ourselves are parsing and attaching to the data after the fact, the name of the field does not matter for our purposes. Unfortunately, there is already an `AllocatedResources` field [exposed on the ContainerStatus](https://github.com/kubernetes/kubernetes/blob/1b4c5b3f8605dc1c86050ae941a24556d4fbd678/pkg/apis/core/types.go#L2886-L2891) which is reported by the kubelet, which is gated behind the `InPlacePodVerticalScaling` feature flag (and it looks like this flag is [enabled by default on k8s 1.33+](https://github.com/kubernetes/kubernetes/blob/660df229bf3929741cf31659187060d0c651dcf9/pkg/features/kube_features.go#L1385-L1388))

The end result is that unmarshalling data from the /pods endpoint fails with:
```
Expected nil, but got: &errors.AgentError{message:"couldn't fetch \"podlist\": unable to unmarshal podlist, invalid or null: kubelet.Pod.Status: kubelet.Status.Containers: []kubelet.ContainerStatus: kubelet.ContainerStatus.AllocatedResources: []kubelet.ContainerAllocatedResource: decode slice: expect [ or n, but found {, error found in #10 byte of ...|sources\":{\n         |..., bigger context ...|4\",\n                        \"allocatedResources\":{\n                            \"cpu\":\"42m\",\n        |...", errorReason:1}
```

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->