### PR TITLE
(fleet) move service management form deb/rpm postinst in installer

### DIFF
--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -4,8 +4,6 @@
 #
 # .deb: STEP 5 of 5
 
-CONFIG_DIR=/etc/datadog-agent
-SERVICE_NAME=datadog-agent
 INSTALL_DIR=/opt/datadog-agent
 
 # If we are inside the Docker container, do nothing
@@ -19,46 +17,7 @@ if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
     ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
 fi
 
-# Run post install script. Instructions can be found in pkg/fleet/installer/packages/datadog_agent.go
+# Run post install script. Instructions can be found in pkg/fleet/installer/packages/datadog_agent_linux.go
 ${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent deb
-
-# Enable and restart the agent service here on Debian platforms
-# On RHEL, this is done in the posttrans script
-# supports systemd, upstart and sysvinit
-echo "Enabling service $SERVICE_NAME"
-if command -v systemctl >/dev/null 2>&1; then
-    # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-    SYSTEMCTL_SKIP_SYSV=true systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
-elif command -v initctl >/dev/null 2>&1; then
-    # Nothing to do, this is defined directly in the upstart job file
-    :
-elif command -v update-rc.d >/dev/null 2>&1; then
-    update-rc.d $SERVICE_NAME defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with update-rc.d"
-    update-rc.d $SERVICE_NAME-process defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-process with update-rc.d"
-    update-rc.d $SERVICE_NAME-trace defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-trace with update-rc.d"
-    update-rc.d $SERVICE_NAME-security defaults || echo "[ WARNING ]\tCannot enable $SERVICE_NAME-security with update-rc.d"
-else
-    echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
-fi
-
-
-# TODO: Use a configcheck command on the agent to determine if it's safe to restart,
-# and avoid restarting when a check conf is invalid
-if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
-    echo "(Re)starting $SERVICE_NAME now..."
-    if command -v systemctl >/dev/null 2>&1; then
-        systemctl restart $SERVICE_NAME || true
-    elif command -v initctl >/dev/null 2>&1; then
-        initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
-    elif command -v service >/dev/null 2>&1; then
-        service $SERVICE_NAME restart || true
-    else
-        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
-    fi
-else
-    # No datadog.yaml file is present. This is probably a clean install made with the
-    # step-by-step instructions/an automation tool, and the config file will be added next.
-    echo "No datadog.yaml file detected, not starting the agent"
-fi
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -6,8 +6,6 @@
 #
 # .rpm: STEP 6 of 6
 
-CONFIG_DIR=/etc/datadog-agent
-SERVICE_NAME=datadog-agent
 INSTALL_DIR=/opt/datadog-agent
 
 # Run FIPS installation script if available. Mandatory to execute the agent binary in FIPS mode.
@@ -15,34 +13,7 @@ if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
     ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
 fi
 
-# Run postinstall script. Instructions can be found in pkg/fleet/installer/packages/datadog_agent.go
+# Run postinstall script. Instructions can be found in pkg/fleet/installer/packages/datadog_agent_linux.go
 ${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent rpm
-
-echo "Enabling service $SERVICE_NAME"
-if command -v systemctl >/dev/null 2>&1; then
-    systemctl enable $SERVICE_NAME || echo "[ WARNING ]\tCannot enable $SERVICE_NAME with systemctl"
-elif command -v initctl >/dev/null 2>&1; then
-    # start/stop policy is already defined in the upstart job file
-    :
-else
-    echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
-fi
-
-# TODO: Use a configcheck command on the agent to determine if it's safe to restart,
-# and avoid restarting when a check conf is invalid
-if [ -f "$CONFIG_DIR/datadog.yaml" ]; then
-    echo "(Re)starting $SERVICE_NAME now..."
-    if command -v systemctl >/dev/null 2>&1; then
-        systemctl restart $SERVICE_NAME || true
-    elif command -v initctl >/dev/null 2>&1; then
-        initctl start $SERVICE_NAME || initctl restart $SERVICE_NAME || true
-    else
-        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
-    fi
-else
-    # No datadog.yaml file is present. This is probably a clean install made with the
-    # step-by-step instructions/an automation tool, and the config file will be added next.
-    echo "No datadog.yaml file detected, not starting the agent"
-fi
 
 exit 0

--- a/pkg/fleet/installer/packages/apminject/apm_sockets.go
+++ b/pkg/fleet/installer/packages/apminject/apm_sockets.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/systemd"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"gopkg.in/yaml.v2"

--- a/pkg/fleet/installer/packages/apminject/app_armor.go
+++ b/pkg/fleet/installer/packages/apminject/app_armor.go
@@ -16,7 +16,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/systemd"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/fleet/installer/packages/datadog_installer_linux.go
+++ b/pkg/fleet/installer/packages/datadog_installer_linux.go
@@ -12,7 +12,7 @@ import (
 	"os/exec"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/file"
-	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/systemd"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/service/systemd"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/user"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/fleet/installer/packages/service/service.go
+++ b/pkg/fleet/installer/packages/service/service.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package service provides service manager utilities
+package service
+
+import "os/exec"
+
+// Type is the service manager type
+type Type string
+
+const (
+	// UnknownType is returned when the service manager type is not identified
+	UnknownType Type = "unknown"
+	// SysvinitType is returned when the service manager is sysvinit
+	SysvinitType Type = "sysvinit"
+	// UpstartType is returned when the service manager is upstart
+	UpstartType Type = "upstart"
+	// SystemdType is returned when the service manager is systemd
+	SystemdType Type = "systemd"
+)
+
+// GetServiceManagerType returns the service manager of the current system
+func GetServiceManagerType() Type {
+	_, err := exec.LookPath("systemctl")
+	if err == nil {
+		return SystemdType
+	}
+	_, err = exec.LookPath("initctl")
+	if err == nil {
+		return UpstartType
+	}
+	_, err = exec.LookPath("update-rc.d")
+	if err == nil {
+		return SysvinitType
+	}
+	return UnknownType
+}

--- a/pkg/fleet/installer/packages/service/sysvinit/sysvinit.go
+++ b/pkg/fleet/installer/packages/service/sysvinit/sysvinit.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package sysvinit provides a set of functions to manage sysvinit services
+package sysvinit
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+)
+
+// Install installs a sys-v init script using update-rc.d
+func Install(ctx context.Context, name string) error {
+	return telemetry.CommandContext(ctx, "update-rc.d", name, "defaults").Run()
+}
+
+// Restart restarts a sys-v init script using service
+func Restart(ctx context.Context, name string) error {
+	return telemetry.CommandContext(ctx, "service", name, "restart").Run()
+}

--- a/pkg/fleet/installer/packages/service/upstart/upstart.go
+++ b/pkg/fleet/installer/packages/service/upstart/upstart.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+// Package upstart provides a set of functions to manage upstart services
+package upstart
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
+)
+
+// Restart restarts an upstart service using initctl
+func Restart(ctx context.Context, name string) error {
+	errStart := telemetry.CommandContext(ctx, "initctl", "start", name).Run()
+	if errStart == nil {
+		return nil
+	}
+	errRestart := telemetry.CommandContext(ctx, "initctl", "restart", name).Run()
+	if errRestart == nil {
+		return nil
+	}
+	return fmt.Errorf("failed to restart %s: %w || %w", name, errStart, errRestart)
+}

--- a/pkg/fleet/installer/telemetry/cmd_wrapper.go
+++ b/pkg/fleet/installer/telemetry/cmd_wrapper.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// TracedCmd is a wrapper around exec.Cmd that adds telemetry
+type TracedCmd struct {
+	*exec.Cmd
+	span *Span
+}
+
+// CommandContext runs a command using exec.CommandContext and adds telemetry
+func CommandContext(ctx context.Context, name string, args ...string) *TracedCmd {
+	span, _ := StartSpanFromContext(ctx, fmt.Sprintf("exec.%s", name))
+	span.SetTag("name", name)
+	span.SetTag("args", strings.Join(args, " "))
+	cmd := exec.CommandContext(ctx, name, args...)
+	return &TracedCmd{
+		Cmd:  cmd,
+		span: span,
+	}
+}
+
+// Run runs the command and finishes the span
+func (c *TracedCmd) Run() (err error) {
+	defer func() { c.span.Finish(err) }()
+	err = c.Cmd.Run()
+	exitErr := &exec.ExitError{}
+	if !errors.As(err, &exitErr) {
+		return err
+	}
+	c.span.SetTag("exit_code", exitErr.ExitCode())
+	c.span.SetTag("stderr", string(exitErr.Stderr))
+	return err
+}


### PR DESCRIPTION
This PR moves the service management parts of deb/rpm `postinst` to the installer.

Ultimately we want to align deb/rpm/oci here but there's still a few items remaining (`prerm` in installer, merging units).