### PR TITLE
fix `go-deps.graph` support for iot-agent

### DIFF
--- a/tasks/diff.py
+++ b/tasks/diff.py
@@ -27,7 +27,7 @@ BINARIES: dict[str, dict] = {
     },
     "iot-agent": {
         "build": "agent",
-        "entrypoint": "cmd/agent",
+        "entrypoint": "cmd/iot-agent",
         "flavor": AgentFlavor.iot,
         "platforms": ["linux/x64", "linux/arm64"],
     },

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -206,7 +206,7 @@ def show(ctx: Context, build: str, flavor: str = AgentFlavor.base.name, os: str 
 def graph(
     ctx: Context,
     build: str,
-    flavor: str = AgentFlavor.base.name,
+    flavor: str | None = None,
     os: str | None = None,
     arch: str | None = None,
     entrypoint: str | None = None,
@@ -251,13 +251,18 @@ def graph(
     stdarg = "-std" if std else ""
     clusterarg = "-cluster" if cluster else ""
 
+    binaries_entry = BINARIES[build]
+
     if entrypoint is None:
-        entrypoint = BINARIES[build]["entrypoint"]
+        entrypoint = binaries_entry["entrypoint"]
         entrypoint = f"github.com/DataDog/datadog-agent/{entrypoint}:all"
 
-    build_tags = get_default_build_tags(
-        build=build, flavor=AgentFlavor[flavor], platform=key_for_value(GOOS_MAPPING, os)
-    )
+    build = binaries_entry.get("build", build)
+
+    if flavor is None:
+        flavor = binaries_entry.get("flavor", AgentFlavor.base)
+
+    build_tags = get_default_build_tags(build=build, flavor=flavor, platform=key_for_value(GOOS_MAPPING, os))
     for tag in build_tags:
         entrypoint = f"{tag}=1({entrypoint})"
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Currently when you run
```
inv -e go-deps.graph -o linux -b iot-agent
```
you get
```
Warning: unrecognized build type, no build tags included.
```

This PR fixes this by ensuring the `build` field is correctly propagated, and the entrypoint is correct for the iot-agent.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->