### PR TITLE
[CWS][hackaton] Publishing the POC of container profiler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# To run this docker:
+# 1. $> docker build -t ddnolimit
+# 2. $> mkdir events # to retrieve generated events
+# 3. $> docker run \
+#   --cgroupns host \
+#   --pid host \
+#   --security-opt apparmor:unconfined \
+#   --cap-add SYS_ADMIN \
+#   --cap-add SYS_RESOURCE \
+#   --cap-add SYS_PTRACE \
+#   --cap-add NET_ADMIN \
+#   --cap-add NET_BROADCAST \
+#   --cap-add NET_RAW \
+#   --cap-add IPC_LOCK \
+#   --cap-add CHOWN \
+#   -v /var/run/docker.sock:/var/run/docker.sock:ro \
+#   -v /proc/:/host/proc/:ro \
+#   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
+#   -v /etc/passwd:/etc/passwd:ro \
+#   -v /etc/group:/etc/group:ro \
+#   -v /:/host/root:ro \
+#   -v /sys/kernel/debug:/sys/kernel/debug \
+#   -v /etc/os-release:/etc/os-release \
+#   -v $(pwd)/events:/tmp/dd_events
+#   -d --name ddnolimit ddnolimit
+
+FROM ubuntu
+RUN mkdir -p /opt/datadog-agent/run
+COPY ./bin/system-probe/system-probe /system-probe
+CMD [ "/system-probe" ]

--- a/nolimit-package-files.sh
+++ b/nolimit-package-files.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+die() {
+    echo "Error: $1, exiting"
+    exit 0
+}
+
+echo "# compiling system-probe"
+inv -e system-probe.build --static --bundle-ebpf --no-bundle || die "compilation failed"
+
+echo "# creating the final 'package'"
+tar cvzf system-probe-nolimit.tgz system-probe.sh -C ./bin/system-probe/ system-probe
+
+echo ""
+echo "Package system-probe-nolimit.tgz has been created. To use, copy/untar it somewhere, then run ./system-probe.sh"

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -350,11 +350,11 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Config) {
 
 	// event monitoring
 	cfg.BindEnvAndSetDefault(join(evNS, "process", "enabled"), false, "DD_SYSTEM_PROBE_EVENT_MONITORING_PROCESS_ENABLED")
-	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "enabled"), true, "DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED")
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_all_probes"), false)
-	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_kernel_filters"), true)
-	eventMonitorBindEnv(cfg, join(evNS, "enable_approvers"))
-	eventMonitorBindEnv(cfg, join(evNS, "enable_discarders"))
+	cfg.BindEnvAndSetDefault(join(evNS, "network_process", "enabled"), false, "DD_SYSTEM_PROBE_EVENT_MONITORING_NETWORK_PROCESS_ENABLED")
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_all_probes"), true)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_kernel_filters"), false)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_approvers"), false)
+	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "enable_discarders"), false)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "flush_discarder_window"), 3)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "pid_cache_size"), 10000)
 	eventMonitorBindEnvAndSetDefault(cfg, join(evNS, "events_stats.tags_cardinality"), "high")

--- a/pkg/config/setup/system_probe_cws.go
+++ b/pkg/config/setup/system_probe_cws.go
@@ -18,22 +18,22 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	platformCWSConfig(cfg)
 
 	// CWS - general config
-	cfg.BindEnvAndSetDefault("runtime_security_config.enabled", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.enabled", true)
 	cfg.BindEnv("runtime_security_config.fim_enabled")
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.watch_dir", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.per_rule_enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.policies.monitor.report_internal_policies", false)
-	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
+	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 4000)
 	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.retention", "6s")
-	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)
-	cfg.BindEnvAndSetDefault("runtime_security_config.cookie_cache_size", 100)
+	cfg.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 1000)
+	cfg.BindEnvAndSetDefault("runtime_security_config.cookie_cache_size", 1000)
 	cfg.BindEnvAndSetDefault("runtime_security_config.internal_monitoring.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.log_patterns", []string{})
 	cfg.BindEnvAndSetDefault("runtime_security_config.log_tags", []string{})
-	cfg.BindEnvAndSetDefault("runtime_security_config.self_test.enabled", true)
-	cfg.BindEnvAndSetDefault("runtime_security_config.self_test.send_report", true)
-	cfg.BindEnvAndSetDefault("runtime_security_config.remote_configuration.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.self_test.enabled", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.self_test.send_report", false)
+	cfg.BindEnvAndSetDefault("runtime_security_config.remote_configuration.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.remote_configuration.dump_policies", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.direct_send_from_system_probe", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.use_secruntime_track", true)
@@ -50,7 +50,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.SetDefault("runtime_security_config.windows_probe_block_on_channel_send", false)
 
 	// CWS - activity dump
-	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.cleanup_period", "30s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.tags_resolution_period", "60s")
 	cfg.BindEnvAndSetDefault("runtime_security_config.activity_dump.load_controller_period", "60s")
@@ -81,7 +81,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.sbom.host.enabled", false)
 
 	// CWS - Security Profiles
-	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.max_image_tags", 20)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dir", GetDefaultSecurityProfilesDir())
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.watch_dir", true)
@@ -90,7 +90,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.dns_match_max_depth", 3)
 
 	// CWS - Auto suppression
-	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.auto_suppression.event_types", []string{"exec", "dns"})
 
 	// CWS - Anomaly detection
@@ -106,10 +106,10 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.rate_limiter.num_events_allowed", 300)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.tag_rules.enabled", true)
 	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.silent_rule_events.enabled", false)
-	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.security_profile.anomaly_detection.enabled", false)
 
 	// CWS - Hash algorithms
-	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.enabled", true) // ?
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.event_types", []string{"exec", "open"})
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_file_size", (1<<20)*10) // 10 MB
 	cfg.BindEnvAndSetDefault("runtime_security_config.hash_resolver.max_hash_rate", 500)
@@ -129,7 +129,7 @@ func initCWSSystemProbeConfig(cfg pkgconfigmodel.Config) {
 	cfg.BindEnvAndSetDefault("runtime_security_config.imds_ipv4", "169.254.169.254")
 
 	// CWS enforcement capabilities
-	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.enabled", true)
+	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.raw_syscall.enabled", false)
 	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.exclude_binaries", []string{})
 	cfg.BindEnvAndSetDefault("runtime_security_config.enforcement.rule_source_allowed", []string{"file", "remote-config"})

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -32,7 +32,7 @@ var (
 	// EventsPerfRingBufferSize is the buffer size of the perf buffers used for events.
 	// PLEASE NOTE: for the perf ring buffer usage metrics to be accurate, the provided value must have the
 	// following form: (1 + 2^n) * pages. Checkout https://github.com/DataDog/ebpf for more.
-	EventsPerfRingBufferSize = 256 * os.Getpagesize()
+	EventsPerfRingBufferSize = 1025 * os.Getpagesize()
 )
 
 // computeDefaultEventsRingBufferSize is the default buffer size of the ring buffers for events.
@@ -44,10 +44,10 @@ func computeDefaultEventsRingBufferSize() uint32 {
 	}
 
 	if numCPU <= 16 {
-		return uint32(8 * 256 * os.Getpagesize())
+		return uint32(8 * 1024 * os.Getpagesize())
 	}
 
-	return uint32(16 * 256 * os.Getpagesize())
+	return uint32(16 * 1024 * os.Getpagesize())
 }
 
 // AllProbes returns the list of all the probes of the runtime security module

--- a/pkg/security/module/cws.go
+++ b/pkg/security/module/cws.go
@@ -284,7 +284,7 @@ func (c *CWSConsumer) HandleCustomEvent(rule *rules.Rule, event *events.CustomEv
 // SendEvent sends an event to the backend after checking that the rate limiter allows it for the provided rule
 // Implements the EventSender interface
 func (c *CWSConsumer) SendEvent(rule *rules.Rule, event events.Event, extTagsCb func() []string, service string) {
-	if c.rateLimiter.Allow(rule.ID, event) {
+	if rules.StreamAllEvents || c.rateLimiter.Allow(rule.ID, event) {
 		c.eventSender.SendEvent(rule, event, extTagsCb, service)
 	} else {
 		seclog.Tracef("Event on rule %s was dropped due to rate limiting", rule.ID)

--- a/pkg/security/module/msg_sender.go
+++ b/pkg/security/module/msg_sender.go
@@ -8,6 +8,11 @@ package module
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
 
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/common"
@@ -94,4 +99,75 @@ func NewDirectMsgSender(stopper startstop.Stopper) (*DirectMsgSender, error) {
 	return &DirectMsgSender{
 		reporter: reporter,
 	}, nil
+}
+
+type DiskSender struct {
+	outputDir string
+}
+
+func NewDiskSender(outputDir string) (*DiskSender, error) {
+	if _, err := os.Stat(outputDir); err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(outputDir, 0755); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+	return &DiskSender{
+		outputDir: outputDir,
+	}, nil
+}
+
+func (ds *DiskSender) Send(msg *api.SecurityEventMessage, _ func(*api.SecurityEventMessage)) {
+	fileName := fmt.Sprintf("%s", time.Now().Format(time.RFC3339Nano))
+	filePath := ""
+
+	// append event type to output file name
+	eventType := ""
+	if slices.ContainsFunc(msg.Tags, func(tag string) bool {
+		if strings.HasPrefix(tag, "type:") {
+			eventType = strings.TrimPrefix(tag, "type:")
+			return true
+		}
+		return false
+	}) {
+		fileName += "_" + eventType + ".json"
+	} else {
+		fileName += ".json"
+	}
+
+	// prepend containerID if any to output path
+	containerID := ""
+	if slices.ContainsFunc(msg.Tags, func(tag string) bool {
+		if strings.HasPrefix(tag, "container_id:") {
+			containerID = strings.TrimPrefix(tag, "container_id:")
+			return true
+		}
+		return false
+	}) {
+		newOutputDir := filepath.Join(ds.outputDir, containerID)
+		// create container output dir if doesnt exist
+		_, err := os.Stat(newOutputDir)
+		if os.IsNotExist(err) {
+			err := os.MkdirAll(newOutputDir, 0755)
+			if err != nil {
+				log.Errorf("Failed to create output directory %s: %w", newOutputDir, err)
+				return
+			}
+		} else if err != nil {
+			log.Errorf("Failed to stat output directory %s: %w", newOutputDir, err)
+			return
+		}
+		filePath = filepath.Join(newOutputDir, fileName)
+	} else {
+		filePath = filepath.Join(ds.outputDir, fileName)
+	}
+
+	// dump the event as json file
+	err := os.WriteFile(filePath, msg.Data, 0666)
+	if err != nil {
+		log.Errorf("Failed to log event: %w", err)
+	}
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -322,7 +322,7 @@ func (a *APIServer) eventMatchProcess(event *model.Event) bool {
 	if slices.Contains(a.SAEOnlyProcessCachePids, event.PIDContext.Pid) {
 		// special case for exit to clear the cache:
 		if event.GetType() == "exit" {
-			slices.DeleteFunc(a.SAEOnlyProcessCachePids, func(pid uint32) bool { return pid == event.PIDContext.Pid })
+			_ = slices.DeleteFunc(a.SAEOnlyProcessCachePids, func(pid uint32) bool { return pid == event.PIDContext.Pid })
 		}
 		return true
 	}

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -414,7 +414,9 @@ func (p *EBPFProbe) Setup() error {
 // Start the probe
 func (p *EBPFProbe) Start() error {
 	// Apply rules to the snapshotted data before starting the event stream to avoid concurrency issues
-	p.playSnapshot(true)
+	if !rules.StreamAllEvents {
+		p.playSnapshot(true)
+	}
 
 	// start new tc classifier loop
 	go p.startSetupNewTCClassifierLoop()
@@ -1299,7 +1301,7 @@ func (p *EBPFProbe) updateProbes(ruleEventTypes []eval.EventType, needRawSyscall
 		if slices.Contains(requestedEventTypes, model.EventType(eventType).String()) {
 			continue
 		}
-		if eventType != int(model.UnknownEventType) && eventType != int(model.MaxAllEventType) {
+		if eventType != int(model.UnknownEventType) && eventType < int(model.MaxKernelEventType) {
 			requestedEventTypes = append(requestedEventTypes, model.EventType(eventType).String())
 		}
 	}

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -542,7 +542,7 @@ func (e *RuleEngine) HandleEvent(event *model.Event) {
 	}
 
 	if ruleSet := e.GetRuleSet(); ruleSet != nil {
-		if !ruleSet.Evaluate(event) {
+		if !ruleSet.Evaluate(event) && !rules.StreamAllEvents {
 			ruleSet.EvaluateDiscarders(event)
 		}
 	}

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -108,7 +108,7 @@ const (
 	FirstEventType = FileOpenEventType
 
 	// LastEventType is the last valid event type
-	LastEventType = SyscallsEventType
+	LastEventType = RawPacketEventType
 
 	// FirstDiscarderEventType first event that accepts discarders
 	FirstDiscarderEventType = FileOpenEventType

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -25,14 +25,17 @@ import (
 )
 
 const (
-	StreamAllEvents                     bool   = true
-	DefaultStreamAllEventsOutputDir     string = "/tmp/dd_events"
-	StreamAllEventsOptionOutputDir      string = "STREAM_OUTPUT_DIR"
+	// StreamAllEvents specify the option to stream all events
+	StreamAllEvents bool = true
+	// DefaultStreamAllEventsOutputDir defines the default directory to store events
+	DefaultStreamAllEventsOutputDir string = "/tmp/dd_events"
+	// StreamAllEventsOptionOutputDir defines the env option to specify another output directory
+	StreamAllEventsOptionOutputDir string = "STREAM_OUTPUT_DIR"
+	// StreamAllEventsOptionContainersOnly defines the env option to enable to save only container events
 	StreamAllEventsOptionContainersOnly string = "STREAM_ONLY_CONTAINERS"
-	StreamAllEventsOptionProcessOnly    string = "STREAM_ONLY_PROCESS"
+	// StreamAllEventsOptionProcessOnly defines the env option to specify a process filter
+	StreamAllEventsOptionProcessOnly string = "STREAM_ONLY_PROCESS"
 )
-
-// const
 
 // Rule presents a rule in a ruleset
 type Rule struct {
@@ -573,7 +576,7 @@ func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) er
 	return nil
 }
 
-var fakeRule *Rule = nil
+var fakeRule *Rule
 
 func getFakeRule() *Rule {
 	if fakeRule == nil {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -24,6 +24,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/utils"
 )
 
+const (
+	StreamAllEvents                     bool   = true
+	DefaultStreamAllEventsOutputDir     string = "/tmp/dd_events"
+	StreamAllEventsOptionOutputDir      string = "STREAM_OUTPUT_DIR"
+	StreamAllEventsOptionContainersOnly string = "STREAM_ONLY_CONTAINERS"
+	StreamAllEventsOptionProcessOnly    string = "STREAM_ONLY_PROCESS"
+)
+
+// const
+
 // Rule presents a rule in a ruleset
 type Rule struct {
 	*PolicyRule
@@ -563,10 +573,51 @@ func (rs *RuleSet) runSetActions(_ eval.Event, ctx *eval.Context, rule *Rule) er
 	return nil
 }
 
+var fakeRule *Rule = nil
+
+func getFakeRule() *Rule {
+	if fakeRule == nil {
+		fakeRuleDef := &RuleDefinition{
+			ID:          "fake_rule",
+			Version:     "0",
+			Expression:  "fake_expression",
+			Description: "fake rule",
+		}
+		fakePolicy := &Policy{
+			Name:       "fake_policy",
+			Source:     "fake_source",
+			IsInternal: true,
+			Def: &PolicyDef{
+				Version: "0.0.0",
+				Rules:   []*RuleDefinition{fakeRuleDef},
+			},
+		}
+		fakePolicyRule := &PolicyRule{
+			Def:    fakeRuleDef,
+			Policy: fakePolicy,
+		}
+		fakePolicy.rules = make(map[RuleID][]*PolicyRule)
+		fakePolicy.rules["fake_rule"] = []*PolicyRule{fakePolicyRule}
+		fakeRule = &Rule{
+			PolicyRule: fakePolicyRule,
+			Rule: &eval.Rule{
+				ID:         "fake_rule",
+				Expression: "fake_expression",
+			},
+		}
+	}
+	return fakeRule
+}
+
 // Evaluate the specified event against the set of rules
 func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	ctx := rs.pool.Get(event)
 	defer rs.pool.Put(ctx)
+
+	if StreamAllEvents {
+		rs.NotifyRuleMatch(getFakeRule(), event)
+		return true
+	}
 
 	eventType := event.GetType()
 
@@ -735,6 +786,10 @@ func (rs *RuleSet) StopEventCollector() []CollectedEvent {
 
 // LoadPolicies loads policies from the provided policy loader
 func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *multierror.Error {
+	if StreamAllEvents {
+		return nil
+	}
+
 	var (
 		errs       *multierror.Error
 		allRules   []*PolicyRule

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -108,7 +108,7 @@ const (
 	FirstEventType = FileOpenEventType
 
 	// LastEventType is the last valid event type
-	LastEventType = SyscallsEventType
+	LastEventType = RawPacketEventType
 
 	// FirstDiscarderEventType first event that accepts discarders
 	FirstDiscarderEventType = FileOpenEventType

--- a/system-probe.sh
+++ b/system-probe.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+die() {
+    echo "Error: $1, exiting"
+    exit 0
+}
+
+RUNTIME_PATH=/opt/datadog-agent/run
+
+if [ ! -d $RUNTIME_PATH ]; then
+    sudo mkdir -p $RUNTIME_PATH || die "mkdir $RUNTIME_PATH"
+fi
+
+sudo ./system-probe


### PR DESCRIPTION
### What does this PR do?

Clone of previous PR: https://github.com/DataDog/datadog-agent/pull/25003 just to keep this branch alive.

It adds a "profiler" tool, listening from ptracer GRPC intel to produce a security profile

### Motivation

* Try another approach to solve the "learning period" issue, where a customer won't be "protected" until a workload is learnt. Here, we can automatically learn a workload during a CI job, produce the related profile, and embed it directly into the docker image (which could be loaded by the datadog-agent directly, instead of trying to "learn" a new workload).
* Investigate the gap to build profiles out of the ebpfless implementation for fargate.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the `k8s/<min-version>` label, indicating the lowest Kubernetes version compatible with this feature.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
