### PR TITLE
Compute directory size only counting sizes for files and links

### DIFF
--- a/tasks/libs/package/size.py
+++ b/tasks/libs/package/size.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 from datetime import datetime
+from pathlib import Path
 
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.constants import ORIGIN_CATEGORY, ORIGIN_PRODUCT, ORIGIN_SERVICE
@@ -115,14 +116,12 @@ def file_size(path):
     return os.path.getsize(path)
 
 
-def directory_size(ctx, path):
-    # HACK: For uncompressed size, fall back to native Unix utilities - computing a directory size with Python
-    # NOTE: We use the -b (--bytes, equivalent to --apparent-size --block-size 1) option to make the computation
-    # consistent. Otherwise, each file's size is counted as the number of blocks it uses, which means a file's size
-    # depends on how it is written to disk.
-    # See https://unix.stackexchange.com/questions/173947/du-s-apparent-size-vs-du-s
-    # TODO: To make this work on other OSes, the complete directory walk would need to be implemented
-    return int(ctx.run(f"du --apparent-size -sB1 {path}", hide=True).stdout.split()[0])
+def directory_size(path):
+    """Compute the size of a directory as the sum of all the files inside (recursively)"""
+    return sum(
+        sum((dirpath / basename).lstat().st_size for basename in filenames)
+        for dirpath, _, filenames in Path(path).walk()
+    )
 
 
 def compute_package_size_metrics(
@@ -150,7 +149,7 @@ def compute_package_size_metrics(
         extract_package(ctx=ctx, package_os=package_os, package_path=package_path, extract_dir=extract_dir)
 
         package_compressed_size = file_size(path=package_path)
-        package_uncompressed_size = directory_size(ctx, path=extract_dir)
+        package_uncompressed_size = directory_size(path=extract_dir)
 
         timestamp = int(datetime.utcnow().timestamp())
         common_tags = [

--- a/tasks/static_quality_gates/lib/package_agent_lib.py
+++ b/tasks/static_quality_gates/lib/package_agent_lib.py
@@ -9,7 +9,7 @@ def calculate_package_size(ctx, package_os, package_path, gate_name, metric_hand
     with tempfile.TemporaryDirectory() as extract_dir:
         extract_package(ctx=ctx, package_os=package_os, package_path=package_path, extract_dir=extract_dir)
         package_on_wire_size = file_size(path=package_path)
-        package_on_disk_size = directory_size(ctx, path=extract_dir)
+        package_on_disk_size = directory_size(path=extract_dir)
 
         metric_handler.register_metric(gate_name, "current_on_wire_size", package_on_wire_size)
         metric_handler.register_metric(gate_name, "current_on_disk_size", package_on_disk_size)

--- a/tasks/static_quality_gates/static_quality_gate_agent_msi.py
+++ b/tasks/static_quality_gates/static_quality_gate_agent_msi.py
@@ -9,7 +9,7 @@ def calculate_package_size(ctx, package_os, package_zip_path, package_msi_path):
     with tempfile.TemporaryDirectory() as extract_dir:
         extract_package(ctx=ctx, package_os=package_os, package_path=package_zip_path, extract_dir=extract_dir)
         package_on_wire_size = file_size(path=package_msi_path)
-        package_on_disk_size = directory_size(ctx, path=extract_dir)
+        package_on_disk_size = directory_size(path=extract_dir)
     return package_on_wire_size, package_on_disk_size
 
 


### PR DESCRIPTION
### What does this PR do?

It changes the way we compute the directory size for uncompressed quality gates such that it doesn't take "folder sizes" into account, making it a repeatable measurement. It also changes the implementation from using `du` to a pure Python approach.

### Motivation

The current implementation has been puzzling us with its unrepeatable behavior for a bit. Despite of the use of the `--apparent-size` flag, which looks like it should allow to discount filesystem-induced discrepancies between machines, the same artifact would get different uncompressed sizes even on two identical jobs on the same pipeline (i.e. when retrying a job).

After some research, we found that the size of "folder" entries are also being taken into account when using `du`, which leaves room for the kinds of discrepancies that `--apparent-size` is meant to avoid.

### Describe how you validated your changes

Size comparisons done by retrying a job with these changes (on a separate debugging branch):
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/929678517
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/929855049

Those sizes also being consistent with the results obtained locally.

### Possible Drawbacks / Trade-offs

### Additional Notes

The proposed implementation also gives identical results to doing:

```
find $extracted_folder -type f,l -exec stat --format='%s' {} + | awk '{s+=$1} END {print s}'
```