### PR TITLE
fix(go_mod_tidy): Prevent job failure when there is nothing to commit

### DIFF
--- a/.github/workflows/go_mod_tidy.yml
+++ b/.github/workflows/go_mod_tidy.yml
@@ -36,11 +36,19 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies-go-tools') }}
         run: dda inv -- -e security-agent.gen-mocks # generate both security agent and process mocks
       - name: Create commit
+        id: commit
         run: |
-          git config --global user.name "Login will be determined by the Github API based on the creator of the token"
-          git config --global user.email ""
-          git commit -am "[dependabot skip] Auto-generate go.sum and LICENSE-3rdparty.csv changes"
+          if git diff --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git config --global user.name "Login will be determined by the Github API based on the creator of the token"
+            git config --global user.email ""
+            git commit -am "[dependabot skip] Auto-generate go.sum and LICENSE-3rdparty.csv changes"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
       - name: "Push signed commits"
+        if: steps.commit.outputs.has_changes == 'true'
         uses: asana/push-signed-commits@d615ca88d8e1a946734c24970d1e7a6c56f34897 # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Test if there are changes to commit before creating the actual commit.

### Motivation
Prevent misleading workflow failures like [here](https://github.com/DataDog/datadog-agent/actions/runs/14966280636/job/42036876427?pr=29704)

### Describe how you validated your changes
No test
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->