### PR TITLE
[CONTP-547] add csi driver installation to kind e2e tests

### DIFF
--- a/test/new-e2e/pkg/provisioners/aws/kubernetes/kind.go
+++ b/test/new-e2e/pkg/provisioners/aws/kubernetes/kind.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/etcd"
+	csidriver "github.com/DataDog/test-infra-definitions/components/datadog/csi-driver"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
@@ -115,6 +116,11 @@ func KindRunFunc(ctx *pulumi.Context, env *environments.Kubernetes, params *Prov
 		Kubeconfig:            kindCluster.KubeConfig,
 	})
 	if err != nil {
+		return err
+	}
+
+	// Deploy the datadog CSI driver
+	if err := csidriver.NewDatadogCSIDriver(&awsEnv, kubeProvider); err != nil {
 		return err
 	}
 

--- a/test/new-e2e/tests/containers/kindvm_test.go
+++ b/test/new-e2e/tests/containers/kindvm_test.go
@@ -21,6 +21,11 @@ type kindSuite struct {
 }
 
 func TestKindSuite(t *testing.T) {
+	helmValues := `
+clusterAgent:
+    envDict:
+        DD_CSI_ENABLED: "true"
+`
 	e2e.Run(t, &kindSuite{}, e2e.WithProvisioner(awskubernetes.KindProvisioner(
 		awskubernetes.WithEC2VMOptions(
 			ec2.WithInstanceType("t3.xlarge"),
@@ -30,6 +35,7 @@ func TestKindSuite(t *testing.T) {
 		awskubernetes.WithDeployTestWorkload(),
 		awskubernetes.WithAgentOptions(
 			kubernetesagentparams.WithDualShipping(),
+			kubernetesagentparams.WithHelmValues(helmValues),
 		),
 	)))
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR adds CSI driver installation in kind e2e tests.

This includes:
* Installation of csi driver in `datadog-csi` namespace.
* Activating csi feature in the cluster agent
* Deploying a sample workload app that requests a CSI volume to mount UDS socket for dogstatsd. 

### Motivation

Implement e2e tests for csi driver.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->