### PR TITLE
language detection: Fix telemetry histogram buckets

### DIFF
--- a/pkg/languagedetection/detector.go
+++ b/pkg/languagedetection/detector.go
@@ -100,11 +100,14 @@ func languageNameFromCommand(command string) languagemodels.LanguageName {
 
 const subsystem = "language_detection"
 
+// prometheus.DefBuckets, converted to milliseconds.
+var buckets = []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000}
+
 var (
 	detectLanguageRuntimeMs = telemetry.NewHistogram(subsystem, "detect_language_ms", nil,
-		"The amount of time it took for the call to DetectLanguage to complete.", nil)
+		"The amount of time it took for the call to DetectLanguage to complete.", buckets)
 	systemProbeLanguageDetectionMs = telemetry.NewHistogram(subsystem, "system_probe_rpc_ms", nil,
-		"The amount of time it took for the process agent to message the system probe.", nil)
+		"The amount of time it took for the process agent to message the system probe.", buckets)
 )
 
 // DetectLanguage uses a combination of commandline parsing and binary analysis to detect a process' language


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The default buckets are in terms of seconds, but the values added to
this metric are in milliseconds, so the data currently maxes out at 10
ms, limiting its usefulness.

### Motivation

https://datadoghq.atlassian.net/browse/DSCVR-101

### Describe how you validated your changes

Will be tested on staging.

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
