### PR TITLE
[DI] dynamicstrumentation/diconfig: clarify mutex usage

### DIFF
--- a/pkg/dynamicinstrumentation/diconfig/config_manager.go
+++ b/pkg/dynamicinstrumentation/diconfig/config_manager.go
@@ -62,49 +62,50 @@ type ConfigManager interface {
 
 // RCConfigManager is the configuration manager which utilizes remote-config
 type RCConfigManager struct {
-	sync.RWMutex
 	procTracker *proctracker.ProcessTracker
 
-	diProcs  ditypes.DIProcs
-	callback configUpdateCallback
+	mu struct {
+		sync.RWMutex
+		diProcs  ditypes.DIProcs
+		callback configUpdateCallback
+	}
 }
 
 // NewRCConfigManager creates a new configuration manager which utilizes remote-config
 func NewRCConfigManager(pm process.Subscriber) (*RCConfigManager, error) {
 	log.Info("Creating new RC config manager")
-	cm := &RCConfigManager{
-		callback: applyConfigUpdate,
-	}
+	cm := &RCConfigManager{}
+	cm.mu.callback = applyConfigUpdate
+	cm.mu.diProcs = ditypes.NewDIProcs()
 
 	cm.procTracker = proctracker.NewProcessTracker(pm, cm.updateProcesses)
 	err := cm.procTracker.Start()
 	if err != nil {
 		return nil, fmt.Errorf("could not start process tracker: %w", err)
 	}
-	cm.diProcs = ditypes.NewDIProcs()
 	return cm, nil
 }
 
-// GetProcInfos returns a copy of the state of the RCConfigManager
+// GetProcInfos returns a copy of the state of the RCConfigManager.
 func (cm *RCConfigManager) GetProcInfos() ditypes.DIProcs {
-	cm.RLock()
-	defer cm.RUnlock()
-	return maps.Clone(cm.diProcs)
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return maps.Clone(cm.mu.diProcs)
 }
 
-// GetProcInfo returns a copy of the state of the RCConfigManager
+// GetProcInfo returns the ProcessInfo for the given PID.
 func (cm *RCConfigManager) GetProcInfo(pid ditypes.PID) *ditypes.ProcessInfo {
-	cm.RLock()
-	defer cm.RUnlock()
-	return cm.diProcs[pid]
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.mu.diProcs[pid]
 }
 
 // Stop closes the config and proc trackers used by the RCConfigManager
 func (cm *RCConfigManager) Stop() {
-	cm.Lock()
-	defer cm.Unlock()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
 	cm.procTracker.Stop()
-	for _, procInfo := range cm.diProcs {
+	for _, procInfo := range cm.mu.diProcs {
 		procInfo.CloseAllUprobeLinks()
 	}
 }
@@ -115,21 +116,21 @@ func (cm *RCConfigManager) Stop() {
 // It compares the previously known state of services on the machine and creates a hook on the remote-config
 // callback for configurations on new ones, and deletes the hook on old ones.
 func (cm *RCConfigManager) updateProcesses(runningProcs ditypes.DIProcs) {
-	cm.Lock()
-	defer cm.Unlock()
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
 	// Remove processes that are no longer running from state and close their uprobe links
-	for pid, procInfo := range cm.diProcs {
+	for pid, procInfo := range cm.mu.diProcs {
 		_, ok := runningProcs[pid]
 		if !ok {
 			procInfo.CloseAllUprobeLinks()
-			delete(cm.diProcs, pid)
+			delete(cm.mu.diProcs, pid)
 		}
 	}
 
 	for pid, runningProcInfo := range runningProcs {
-		_, ok := cm.diProcs[pid]
+		_, ok := cm.mu.diProcs[pid]
 		if !ok {
-			cm.diProcs[pid] = runningProcInfo
+			cm.mu.diProcs[pid] = runningProcInfo
 			err := cm.installConfigProbe(runningProcInfo)
 			if err != nil {
 				log.Infof("could not install config probe for service %s (pid %d): %s", runningProcInfo.ServiceName, runningProcInfo.PID, err)
@@ -219,9 +220,9 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 
 		// An empty config means that this probe has been removed for this process
 		if configEventParams[2].ValueStr == "" {
-			cm.Lock()
-			cm.diProcs.DeleteProbe(procInfo.PID, configPath.ProbeUUID.String())
-			cm.Unlock()
+			cm.mu.Lock()
+			cm.mu.diProcs.DeleteProbe(procInfo.PID, configPath.ProbeUUID.String())
+			cm.mu.Unlock()
 			continue
 		}
 
@@ -247,10 +248,10 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 			MaxFieldCount:     conf.Capture.MaxFieldCount,
 		}
 
-		cm.Lock()
+		cm.mu.Lock()
 		probe := procInfo.ProbesByID.Get(configPath.ProbeUUID.String())
 		if probe == nil {
-			cm.diProcs.SetProbe(procInfo.PID, procInfo.ServiceName, conf.Where.TypeName, conf.Where.MethodName, configPath.ProbeUUID, runtimeID, opts)
+			cm.mu.diProcs.SetProbe(procInfo.PID, procInfo.ServiceName, conf.Where.TypeName, conf.Where.MethodName, configPath.ProbeUUID, runtimeID, opts)
 			diagnostics.Diagnostics.SetStatus(procInfo.ServiceName, runtimeID.String(), configPath.ProbeUUID.String(), ditypes.StatusReceived)
 			probe = procInfo.ProbesByID.Get(configPath.ProbeUUID.String())
 		}
@@ -260,14 +261,14 @@ func (cm *RCConfigManager) readConfigs(r *ringbuf.Reader, procInfo *ditypes.Proc
 			err := AnalyzeBinary(procInfo)
 			if err != nil {
 				log.Errorf("couldn't inspect binary (%s): %v\n", procInfo.BinaryPath, err)
-				cm.Unlock()
+				cm.mu.Unlock()
 				continue
 			}
 
 			probe.InstrumentationInfo.ConfigurationHash = configPath.Hash
 			applyConfigUpdate(procInfo, probe)
 		}
-		cm.Unlock()
+		cm.mu.Unlock()
 	}
 }
 


### PR DESCRIPTION
This mutex was previously exported, and the fields it protected were unclear.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR moves the `dynamicinstrumentation/diconfig.Config`'s `RWMutex` from being an exported, embedded struct to living inside a `mu` field which clarifies what it protects. This is a common idiom in Go. 

### Motivation

Exporting these mutexes muddies the public interface, and, generally it's good to be explicit about what state is protected by a mutex.

### Additional Notes

There's other exported mutexes floating around that deserve similar treatment if this code is going to be sticking around.