### PR TITLE
Fix new-e2e-containers-eks job constantly timing out

### DIFF
--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -173,6 +173,9 @@ new-e2e-containers-eks:
   rules:
     - !reference [.on_container_or_e2e_changes]
     - !reference [.manual]
+  needs:
+    - !reference [.new_e2e_template_needs_container_deploy, needs]
+    - new-e2e-containers-eks-init
   variables:
     TARGETS: ./tests/containers
     TEAM: container-integrations

--- a/.gitlab/e2e/e2e.yml
+++ b/.gitlab/e2e/e2e.yml
@@ -169,15 +169,10 @@ new-e2e-containers-eks-init:
   allow_failure: true
 
 new-e2e-containers-eks:
-  extends: .new_e2e_template
+  extends: .new_e2e_template_needs_container_deploy
   rules:
     - !reference [.on_container_or_e2e_changes]
     - !reference [.manual]
-  needs:
-    - !reference [.needs_new_e2e_template]
-    - new-e2e-containers-eks-init
-    - qa_agent
-    - qa_dca
   variables:
     TARGETS: ./tests/containers
     TEAM: container-integrations


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Reduces likelihood of the new-e2e-containers-eks e2e test job timing out due to a missing image

### Motivation

See [this timeout](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/933779587)

The job runs for 2 hours and times out, but the suite tries and fails multiple times to start up with the following error:
```
         +  kubernetes:apps/v1:DaemonSet dogstatsd-standalone creating (3s) warning: [Pod dogstatsd-standalone/dogstatsd-standalone-7dk6t]: containers with unready status: [dogstatsd-standalone][ErrImagePull] rpc error: code = NotFound desc = failed to pull and unpack image "669783387624.dkr.ecr.us-east-1.amazonaws.com/dogstatsd:64805343-946c3285": failed to resolve reference "669783387624.dkr.ecr.us-east-1.amazonaws.com/dogstatsd:64805343-946c3285": 669783387624.dkr.ecr.us-east-1.amazonaws.com/dogstatsd:64805343-946c3285: not found
```

looking at the log timestamps, it looks like this job triggered almost a full hour before [this job which built the missing image](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/933779547)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->