### PR TITLE
[CXP-2145] Moves the process checks enabled tests into the process component tests.

### DIFF
--- a/comp/process/processcheck/component.go
+++ b/comp/process/processcheck/component.go
@@ -12,7 +12,7 @@ import (
 
 // team: container-intake
 
-//nolint:revive // TODO(PROC) Fix revive linter
+// Component is the component type.
 type Component interface {
 	types.CheckComponent
 }

--- a/comp/process/processcheck/processcheckimpl/check_linux_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_linux_test.go
@@ -23,7 +23,7 @@ import (
 	"go.uber.org/fx"
 )
 
-// Make sure process checks run on the core agent only
+// TestProcessCheckEnablementOnCoreAgent Tests the process checks run on the core agent only
 func TestProcessCheckEnablementOnCoreAgent(t *testing.T) {
 	originalFlavor := flavor.GetFlavor()
 	defer flavor.SetFlavor(originalFlavor)

--- a/comp/process/processcheck/processcheckimpl/check_linux_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_linux_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+
+package processcheckimpl
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	gpusubscriberfxmock "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/process/processcheck"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+)
+
+// Make sure process checks run on the core agent only
+func TestProcessCheckEnablementOnCoreAgent(t *testing.T) {
+	originalFlavor := flavor.GetFlavor()
+	defer flavor.SetFlavor(originalFlavor)
+
+	tests := []struct {
+		name    string
+		flavor  string
+		enabled bool
+	}{
+		{
+			name:    "Process check should not run in the process agent when run_in_core_agent is enabled",
+			flavor:  flavor.ProcessAgent,
+			enabled: false,
+		},
+		{
+			name:    "Process check runs in the core agent when run_in_core_agent is enabled",
+			flavor:  flavor.DefaultAgent,
+			enabled: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			configs := map[string]interface{}{
+				"process_config.process_collection.enabled": true,
+				"process_config.run_in_core_agent.enabled":  true,
+			}
+
+			flavor.SetFlavor(tc.flavor)
+			c := fxutil.Test[processcheck.Component](t, fx.Options(
+				core.MockBundle(),
+				fx.Replace(config.MockParams{Overrides: configs}),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+				gpusubscriberfxmock.MockModule(),
+				fx.Provide(func() statsd.ClientInterface {
+					return &statsd.NoOpClient{}
+				}),
+				Module(),
+			))
+			assert.Equal(t, tc.enabled, c.Object().IsEnabled())
+		})
+	}
+}

--- a/comp/process/processcheck/processcheckimpl/check_test.go
+++ b/comp/process/processcheck/processcheckimpl/check_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package processcheckimpl
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	gpusubscriberfxmock "github.com/DataDog/datadog-agent/comp/process/gpusubscriber/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/process/processcheck"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-go/v5/statsd"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+)
+
+func TestProcessChecksIsEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		configs map[string]interface{}
+		enabled bool
+	}{
+		{
+			name: "enabled",
+			configs: map[string]interface{}{
+				"process_config.process_collection.enabled": true,
+			},
+			enabled: true,
+		},
+		{
+			name: "disabled",
+			configs: map[string]interface{}{
+				"process_config.process_collection.enabled": false,
+			},
+			enabled: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := fxutil.Test[processcheck.Component](t, fx.Options(
+				core.MockBundle(),
+				fx.Replace(config.MockParams{Overrides: tc.configs}),
+				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+				gpusubscriberfxmock.MockModule(),
+				fx.Provide(func() statsd.ClientInterface {
+					return &statsd.NoOpClient{}
+				}),
+				Module(),
+			))
+			assert.Equal(t, tc.enabled, c.Object().IsEnabled())
+		})
+	}
+}

--- a/pkg/process/checks/enabled_checks_linux_test.go
+++ b/pkg/process/checks/enabled_checks_linux_test.go
@@ -63,25 +63,3 @@ func TestConnectionsCheckLinux(t *testing.T) {
 		assertContainsCheck(t, enabledChecks, ConnectionsCheckName)
 	})
 }
-
-func TestProcessCheckLinux(t *testing.T) {
-	deps := createDeps(t)
-	originalFlavor := flavor.GetFlavor()
-	defer flavor.SetFlavor(originalFlavor)
-
-	// Make sure process checks run on the core agent only
-	// when run in core agent mode is enabled
-	t.Run("run in core agent", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_collection.enabled", true)
-		cfg.SetWithoutSource("process_config.run_in_core_agent.enabled", true)
-
-		flavor.SetFlavor("process_agent")
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertNotContainsCheck(t, enabledChecks, ProcessCheckName)
-
-		flavor.SetFlavor("agent")
-		enabledChecks = getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertContainsCheck(t, enabledChecks, ProcessCheckName)
-	})
-}

--- a/pkg/process/checks/enabled_checks_test.go
+++ b/pkg/process/checks/enabled_checks_test.go
@@ -51,24 +51,6 @@ func getEnabledChecks(t *testing.T, cfg, sysprobeYamlConfig pkgconfigmodel.Reade
 	return enabledChecks
 }
 
-func TestProcessCheck(t *testing.T) {
-	deps := createProcessCheckDeps(t)
-	t.Run("disabled", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_collection.enabled", false)
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertNotContainsCheck(t, enabledChecks, ProcessCheckName)
-	})
-
-	// Make sure the process check can be enabled
-	t.Run("enabled", func(t *testing.T) {
-		cfg, scfg := configmock.New(t), configmock.NewSystemProbe(t)
-		cfg.SetWithoutSource("process_config.process_collection.enabled", true)
-		enabledChecks := getEnabledChecks(t, cfg, scfg, deps.WMeta, deps.GpuSubscriber, deps.NpCollector, deps.Statsd)
-		assertContainsCheck(t, enabledChecks, ProcessCheckName)
-	})
-}
-
 func TestConnectionsCheck(t *testing.T) {
 	deps := createProcessCheckDeps(t)
 	originalFlavor := flavor.GetFlavor()


### PR DESCRIPTION
### What does this PR do?
This moves the tests out to the component and creates the component with mock component deps  to verify if the checks are enabled.

### Motivation
https://datadoghq.atlassian.net/browse/CXP-2145

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->