### PR TITLE
[NPM-4440] Change SACK traceroute to use AF_PACKET

### DIFF
--- a/pkg/networkpath/traceroute/common/afpacket_source_linux.go
+++ b/pkg/networkpath/traceroute/common/afpacket_source_linux.go
@@ -24,23 +24,14 @@ type AFPacketSource struct {
 
 var _ PacketSource = &AFPacketSource{}
 
+// ethPAllNetwork is all protocols, in network byte order
+var ethPAllNetwork = htons(uint16(unix.ETH_P_ALL))
+
 // NewAFPacketSource creates a new AFPacketSource
 func NewAFPacketSource() (*AFPacketSource, error) {
-	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW|unix.SOCK_NONBLOCK, unix.ETH_P_ALL)
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW|unix.SOCK_NONBLOCK, int(ethPAllNetwork))
 	if err != nil {
 		return nil, fmt.Errorf("NewAFPacketSource failed to create socket: %s", err)
-	}
-
-	// TODO attach dropAllFilter here once we are using BPF filtering
-
-	s := &unix.SockaddrLinklayer{
-		Protocol: htons(uint16(unix.ETH_P_ALL)),
-		Ifindex:  0, // bind to all interfaces
-	}
-	err = unix.Bind(fd, s)
-	if err != nil {
-		unix.Close(fd)
-		return nil, fmt.Errorf("NewAFPacketSource failed to bind socket: %s", err)
 	}
 
 	sock := os.NewFile(uintptr(fd), "")

--- a/pkg/networkpath/traceroute/common/afpacket_source_linux.go
+++ b/pkg/networkpath/traceroute/common/afpacket_source_linux.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// AFPacketSource is a PacketSource implementation using AF_PACKET.
+// Why not use gopacket? Mainly because gopacket doesn't have read deadlines which we rely on.
+// Also, the zero-copy ringbuffer setup is unnecessary for traceroutes.
+type AFPacketSource struct {
+	sock *os.File
+}
+
+var _ PacketSource = &AFPacketSource{}
+
+// NewAFPacketSource creates a new AFPacketSource
+func NewAFPacketSource() (*AFPacketSource, error) {
+	fd, err := unix.Socket(unix.AF_PACKET, unix.SOCK_RAW|unix.SOCK_NONBLOCK, unix.ETH_P_ALL)
+	if err != nil {
+		return nil, fmt.Errorf("NewAFPacketSource failed to create socket: %s", err)
+	}
+
+	// TODO attach dropAllFilter here once we are using BPF filtering
+
+	s := &unix.SockaddrLinklayer{
+		Protocol: htons(uint16(unix.ETH_P_ALL)),
+		Ifindex:  0, // bind to all interfaces
+	}
+	err = unix.Bind(fd, s)
+	if err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("NewAFPacketSource failed to bind socket: %s", err)
+	}
+
+	sock := os.NewFile(uintptr(fd), "")
+	return &AFPacketSource{sock: sock}, nil
+}
+
+// SetReadDeadline sets the deadline for when a Read() call must finish
+func (a *AFPacketSource) SetReadDeadline(t time.Time) error {
+	return a.sock.SetReadDeadline(t)
+}
+
+// Read reads a packet (including the ethernet frame)
+func (a *AFPacketSource) Read(buf []byte) (int, error) {
+	return a.sock.Read(buf)
+}
+
+// Close closes the socket
+func (a *AFPacketSource) Close() error {
+	return a.sock.Close()
+}
+
+// htons converts a short (uint16) from host-to-network byte order.
+func htons(i uint16) uint16 {
+	return i<<8 | i>>8
+}

--- a/pkg/networkpath/traceroute/common/frame_parser.go
+++ b/pkg/networkpath/traceroute/common/frame_parser.go
@@ -7,6 +7,7 @@ package common
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net/netip"
 	"slices"
@@ -23,20 +24,35 @@ type FrameParser struct {
 	ICMP4    layers.ICMPv4
 	Payload  gopacket.Payload
 	Layers   []gopacket.LayerType
-	v4Parser *gopacket.DecodingLayerParser
+	parser   *gopacket.DecodingLayerParser
 }
+
+var ignoredLayerErr = &ReceiveProbeNoPktError{
+	Err: fmt.Errorf("FrameParser saw an a layer type not used by traceroute (e.g. ARP) and decided to ignore it"),
+}
+
+const expectedLayerCount = 3
 
 // NewFrameParser constructs a new FrameParser
 func NewFrameParser() *FrameParser {
 	p := &FrameParser{}
-	p.v4Parser = gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &p.Ethernet, &p.IP4, &p.TCP, &p.ICMP4, &p.Payload)
-	// p.v4Parser.IgnoreUnsupported = true
+	p.parser = gopacket.NewDecodingLayerParser(layers.LayerTypeEthernet, &p.Ethernet, &p.IP4, &p.TCP, &p.ICMP4, &p.Payload)
+
 	return p
 }
 
 // Parse parses an ethernet packet
 func (p *FrameParser) Parse(buffer []byte) error {
-	err := p.v4Parser.DecodeLayers(buffer, &p.Layers)
+	err := p.parser.DecodeLayers(buffer, &p.Layers)
+	var unsupportedErr gopacket.UnsupportedLayerType
+	if errors.As(err, &unsupportedErr) {
+		if len(p.Layers) < expectedLayerCount {
+			// we saw some other protocol we don't care about, skip
+			return ignoredLayerErr
+		}
+		// there are extra layers beyond TLS, ignore those too
+		err = nil
+	}
 	if err != nil {
 		return fmt.Errorf("Parse: %w", err)
 	}
@@ -48,7 +64,7 @@ func (p *FrameParser) Parse(buffer []byte) error {
 
 // GetIPLayer gets the layer type of the IP layer (right now, only IPv4)
 func (p *FrameParser) GetIPLayer() gopacket.LayerType {
-	if len(p.Layers) < 2 {
+	if len(p.Layers) < expectedLayerCount {
 		return gopacket.LayerTypeZero
 	}
 	return p.Layers[1]
@@ -56,7 +72,7 @@ func (p *FrameParser) GetIPLayer() gopacket.LayerType {
 
 // GetTransportLayer gets the layer type of the transport layer (e.g. TCP, ICMP)
 func (p *FrameParser) GetTransportLayer() gopacket.LayerType {
-	if len(p.Layers) < 3 {
+	if len(p.Layers) < expectedLayerCount {
 		return gopacket.LayerTypeZero
 	}
 	return p.Layers[2]
@@ -68,9 +84,6 @@ var transportLayers = []gopacket.LayerType{layers.LayerTypeTCP, layers.LayerType
 
 // checkLayers sanity checks the layers of the parse.
 func (p *FrameParser) checkLayers() error {
-	if len(p.Layers) < 3 {
-		return fmt.Errorf("CheckLayers: not enough layers (got %d, expected >= 3)", len(p.Layers))
-	}
 	if !slices.Contains(ipLayers, p.GetIPLayer()) {
 		return fmt.Errorf("CheckLayers: first layer %s is not IP", p.GetIPLayer())
 	}

--- a/pkg/networkpath/traceroute/common/frame_parser_test.go
+++ b/pkg/networkpath/traceroute/common/frame_parser_test.go
@@ -138,3 +138,77 @@ func TestFrameParserICMP4(t *testing.T) {
 	}
 	require.Equal(t, expectedInfo, tcpInfo)
 }
+
+func TestFrameParserUnrecognizedPacket(t *testing.T) {
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+		DstMAC:       net.HardwareAddr{0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
+		EthernetType: layers.EthernetTypeARP,
+	}
+	arp := &layers.ARP{
+		Protocol: layers.EthernetTypeARP,
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+	err := gopacket.SerializeLayers(buf, opts, eth, arp)
+	require.NoError(t, err)
+
+	parser := NewFrameParser()
+
+	err = parser.Parse(buf.Bytes())
+	require.ErrorIs(t, err, ignoredLayerErr)
+}
+
+func TestFrameParserTLSPacket(t *testing.T) {
+	// tests a TLS packet which has one extra layer we don't care about
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+		DstMAC:       net.HardwareAddr{0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := &layers.IPv4{
+		Version:  4,
+		TTL:      123,
+		SrcIP:    net.ParseIP("127.0.0.1"),
+		DstIP:    net.ParseIP("127.0.0.2"),
+		Id:       41821,
+		Protocol: layers.IPProtocolTCP,
+	}
+	tcp := &layers.TCP{
+		SrcPort: layers.TCPPort(345),
+		DstPort: layers.TCPPort(678),
+		ACK:     true,
+		PSH:     true,
+		Seq:     1234,
+		Ack:     5678,
+		Window:  1024,
+		Options: []layers.TCPOption{},
+	}
+	err := tcp.SetNetworkLayerForChecksum(ip4)
+	require.NoError(t, err)
+
+	tls := &layers.TLS{}
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+	err = gopacket.SerializeLayers(buf, opts, eth, ip4, tcp, tls)
+	require.NoError(t, err)
+
+	parser := NewFrameParser()
+
+	err = parser.Parse(buf.Bytes())
+	require.NoError(t, err)
+
+	clearBuffers(parser)
+
+	require.EqualExportedValues(t, eth, &parser.Ethernet)
+	require.EqualExportedValues(t, ip4, &parser.IP4)
+	require.EqualExportedValues(t, tcp, &parser.TCP)
+}

--- a/pkg/networkpath/traceroute/common/packet_source.go
+++ b/pkg/networkpath/traceroute/common/packet_source.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// PacketSource is an interface representing ethernet packet capture
+type PacketSource interface {
+	// SetReadDeadline sets the deadline for when a Read() call must finish
+	SetReadDeadline(t time.Time) error
+	// Read reads a packet (including the ethernet frame)
+	Read(buf []byte) (int, error)
+	// Close closes the socket
+	Close() error
+}
+
+// ReadAndParse reads from the given source into the buffer, and parses it with parser
+func ReadAndParse(source PacketSource, buffer []byte, parser *FrameParser) error {
+	n, err := source.Read(buffer)
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return &ReceiveProbeNoPktError{Err: err}
+	}
+	if err != nil {
+		return fmt.Errorf("ConnHandle failed to Read: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("ConnHandle Read() returned 0 bytes")
+	}
+
+	err = parser.Parse(buffer[:n])
+	if err != nil {
+		log.DebugFunc(func() string {
+			data := hex.EncodeToString(buffer[:n])
+			return fmt.Sprintf("error parsing packet of length %d: %s, %s", n, err, data)
+		})
+		return &BadPacketError{Err: fmt.Errorf("sackDriver failed to parse packet of length %d: %w", n, err)}
+	}
+
+	return nil
+}

--- a/pkg/networkpath/traceroute/common/traceroute_parallel.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel.go
@@ -68,9 +68,6 @@ type TracerouteDriver interface {
 	// SendProbe sends a traceroute packet with a specific TTL
 	SendProbe(ttl uint8) error
 	// ReceiveProbe polls to get a traceroute response with a timeout.
-	// If the TTL is 0, that means we couldn't determine what hop it was from the packet data.
-	// * For TracerouteSerial (coming soon), TTL=0 is fine, it gets added as the next hop of the traceroute.
-	// * For TracerouteParallel, TTL=0 should never happen (SupportsParallel should be false).
 	ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
 }
 

--- a/pkg/networkpath/traceroute/common/traceroute_parallel.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel.go
@@ -19,9 +19,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// ErrReceiveProbeNoPkt is returned when ReceiveProbe() didn't find anything new.
+// ReceiveProbeNoPktError is returned when ReceiveProbe() didn't find anything new.
 // This is normal if the RTT is long
-var ErrReceiveProbeNoPkt = errors.New("ReceiveProbe() doesn't have new packets")
+type ReceiveProbeNoPktError struct {
+	Err error
+}
+
+func (e *ReceiveProbeNoPktError) Error() string {
+	return fmt.Sprintf("ReceiveProbe() didn't find any new packets: %s", e.Err)
+}
+func (e *ReceiveProbeNoPktError) Unwrap() error {
+	return e.Err
+}
 
 // BadPacketError is a non-fatal error that occurs when a packet is malformed.
 type BadPacketError struct {
@@ -30,6 +39,9 @@ type BadPacketError struct {
 
 func (e *BadPacketError) Error() string {
 	return fmt.Sprintf("Failed to parse packet: %s", e.Err)
+}
+func (e *BadPacketError) Unwrap() error {
+	return e.Err
 }
 
 // ProbeResponse is the response of a single probe in a traceroute
@@ -46,8 +58,7 @@ type ProbeResponse struct {
 
 // TracerouteDriverInfo is metadata about a TracerouteDriver
 type TracerouteDriverInfo struct {
-	// whether this driver uses a separate socket to read ICMP, and implements ReceiveICMPProbe
-	UsesReceiveICMPProbe bool
+	SupportsParallel bool
 }
 
 // TracerouteDriver is an implementation of traceroute send+receive of packets
@@ -56,10 +67,11 @@ type TracerouteDriver interface {
 	GetDriverInfo() TracerouteDriverInfo
 	// SendProbe sends a traceroute packet with a specific TTL
 	SendProbe(ttl uint8) error
-	// ReceiveProbe polls to get a traceroute response with a timeout
+	// ReceiveProbe polls to get a traceroute response with a timeout.
+	// If the TTL is 0, that means we couldn't determine what hop it was from the packet data.
+	// * For TracerouteSerial (coming soon), TTL=0 is fine, it gets added as the next hop of the traceroute.
+	// * For TracerouteParallel, TTL=0 should never happen (SupportsParallel should be false).
 	ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
-	// ReceiveICMPProbe is identical to ReceiveProbe, just running in another goroutine
-	ReceiveICMPProbe(timeout time.Duration) (*ProbeResponse, error)
 }
 
 // TracerouteParallelParams are the parameters for TracerouteParallel
@@ -99,6 +111,9 @@ func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TraceroutePar
 		return nil, fmt.Errorf("min TTL must be at least 1")
 	}
 	info := t.GetDriverInfo()
+	if !info.SupportsParallel {
+		return nil, fmt.Errorf("tried to call TracerouteParallel on a TracerouteDriver that doesn't support parallel")
+	}
 
 	results := make([]*ProbeResponse, int(p.MaxTTL)+1)
 	resultsMu := sync.Mutex{}
@@ -148,42 +163,39 @@ func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TraceroutePar
 		return nil
 	})
 
-	handleProbeFunc := func(funcName string, probeFunc func(timeout time.Duration) (*ProbeResponse, error)) {
-		g.Go(func() error {
-			for {
-				// leave if we got cancelled, SendProbe() failed, etc
-				select {
-				// doesn't use writerCtx because even if we writerCancel(), we want to keep reading
-				case <-groupCtx.Done():
-					return nil
-				default:
-				}
-
-				probe, err := probeFunc(p.PollFrequency)
-				if CheckParallelRetryable(funcName, err) {
-					continue
-				} else if err != nil {
-					return err
-				}
-				if probe == nil {
-					return fmt.Errorf("%s() returned nil without an error (this indicates a bug in the TracerouteDriver)", funcName)
-				}
-				if probe.TTL < p.MinTTL || probe.TTL > p.MaxTTL {
-					return fmt.Errorf("%s() received an invalid TTL (expected TTL in [%d, %d]): %d", funcName, p.MinTTL, p.MaxTTL, probe.TTL)
-				}
-
-				writeProbe(probe)
-				// no need to send more probes if we found the destination
-				if probe.IsDest {
-					writerCancel()
-				}
+	g.Go(func() error {
+		for {
+			// leave if we got cancelled, SendProbe() failed, etc
+			select {
+			// doesn't use writerCtx because even if we writerCancel(), we want to keep reading
+			case <-groupCtx.Done():
+				return nil
+			default:
 			}
-		})
-	}
-	handleProbeFunc("ReceiveProbe", t.ReceiveProbe)
-	if info.UsesReceiveICMPProbe {
-		handleProbeFunc("ReceiveICMPProbe", t.ReceiveICMPProbe)
-	}
+
+			probe, err := t.ReceiveProbe(p.PollFrequency)
+			if CheckParallelRetryable("ReceiveProbe", err) {
+				continue
+			} else if err != nil {
+				return err
+			}
+			if probe == nil {
+				return fmt.Errorf("ReceiveProbe() returned nil without an error (this indicates a bug in the TracerouteDriver)")
+			}
+			if probe.TTL == 0 {
+				return fmt.Errorf("ReceiveProbe() got TTL 0 which is only allowed for TracerouteSerial (this indicates a bug in the TracerouteDriver)")
+			}
+			if probe.TTL < p.MinTTL || probe.TTL > p.MaxTTL {
+				return fmt.Errorf("ReceiveProbe() received an invalid TTL: expected TTL in [%d, %d], got %d", p.MinTTL, p.MaxTTL, probe.TTL)
+			}
+
+			writeProbe(probe)
+			// no need to send more probes if we found the destination
+			if probe.IsDest {
+				writerCancel()
+			}
+		}
+	})
 
 	// check for an error from the goroutines
 	err := g.Wait()
@@ -229,8 +241,9 @@ var badPktLimit = log.NewLogLimit(10, 5*time.Minute)
 
 // CheckParallelRetryable returns whether ReceiveProbe failed due to a real error or just an irrelevant packet
 func CheckParallelRetryable(funcName string, err error) bool {
+	noPktErr := &ReceiveProbeNoPktError{}
 	badPktErr := &BadPacketError{}
-	if errors.Is(err, ErrReceiveProbeNoPkt) {
+	if errors.As(err, &noPktErr) {
 		return true
 	} else if errors.As(err, &badPktErr) {
 		if badPktLimit.ShouldLog() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This creates a packet source based on AF_PACKET and moves SACK traceroute to start using it. Previously it was using two raw sockets, one for TCP, one for ICMP.
 * Deletes the `ReceiveICMPProbe` logic from TracerouteParallel (not needed since AF_PACKET can do everything with a single socket)
 * Creates the `PacketSource` interface and `AFPacketSource` struct which will also be implemented by Windows and MacOS
 * Changes FrameParser to start at the ethernet layer which is agnostic to IPv4/IPv6

### Motivation
We have three platforms: Linux, Windows, and MacOS. Previously, Linux used two raw sockets, one for TCP, one for ICMP. The last two currently differ from Linux, in that their packet capture solutions grab the ethernet frame and use a single socket for all protocols. This is what AF_PACKET does on linux -- it allows for a single goroutine to handle both TCP and ICMP, and parsing at the ethernet level also means we are agnostic to IPv4 or IPv6. In other words, we need this refactor to be able to expand to a larger set of platforms.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Updates to FrameParser and TracerouteParallel tests should pass:
```
go test -timeout 30s -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common
```

SACK traceroute should still work properly:
```
go build -race github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/sack/portable_sack
LOG_LEVEL=trace sudo -E ./portable_sack 205.251.242.103:443
```

### Possible Drawbacks / Trade-offs
* AFPacketSource doesn't have tests yet. I am planning to add that in my next PR, where I port the socket filtering/TCP SYN to AF_PACKET.
* More code temporarily, but this will delete a lot in the future.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->