### PR TITLE
[autodiscovery/types] Delete unused error from GetADIdentifiers

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -667,9 +667,7 @@ func (ac *AutoConfig) GetProviderCatalog() map[string]providers.ConfigProviderFa
 // processNewService takes a service, tries to match it against templates and
 // triggers scheduling events if it finds a valid config for it.
 func (ac *AutoConfig) processNewService(svc listeners.Service) {
-	// get all the templates matching service identifiers
-	ADIdentifiers := svc.GetADIdentifiers()
-	changes := ac.cfgMgr.processNewService(ADIdentifiers, svc)
+	changes := ac.cfgMgr.processNewService(svc)
 	ac.applyChanges(changes)
 }
 

--- a/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/autoconfig.go
@@ -668,12 +668,7 @@ func (ac *AutoConfig) GetProviderCatalog() map[string]providers.ConfigProviderFa
 // triggers scheduling events if it finds a valid config for it.
 func (ac *AutoConfig) processNewService(svc listeners.Service) {
 	// get all the templates matching service identifiers
-	ADIdentifiers, err := svc.GetADIdentifiers()
-	if err != nil {
-		log.Errorf("Failed to get AD identifiers for service %s, it will not be monitored - %s", svc.GetServiceID(), err)
-		return
-	}
-
+	ADIdentifiers := svc.GetADIdentifiers()
 	changes := ac.cfgMgr.processNewService(ADIdentifiers, svc)
 	ac.applyChanges(changes)
 }

--- a/comp/core/autodiscovery/autodiscoveryimpl/common_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/common_test.go
@@ -34,8 +34,8 @@ func (s *dummyService) GetServiceID() string {
 }
 
 // GetADIdentifiers returns dummy identifiers
-func (s *dummyService) GetADIdentifiers() ([]string, error) {
-	return s.ADIdentifiers, nil
+func (s *dummyService) GetADIdentifiers() []string {
+	return s.ADIdentifiers
 }
 
 // GetHosts returns dummy hosts

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
@@ -25,8 +25,8 @@ import (
 //
 // This type is threadsafe, internally using a mutex to serialize operations.
 type configManager interface {
-	// processNewService handles a new service, with the given AD identifiers
-	processNewService(adIdentifiers []string, svc listeners.Service) integration.ConfigChanges
+	// processNewService handles a new service
+	processNewService(svc listeners.Service) integration.ConfigChanges
 
 	// processDelService handles removal of a service, unscheduling any configs
 	// that had been resolved for it.
@@ -117,7 +117,7 @@ func newReconcilingConfigManager(secretResolver secrets.Component) configManager
 }
 
 // processNewService implements configManager#processNewService.
-func (cm *reconcilingConfigManager) processNewService(adIdentifiers []string, svc listeners.Service) integration.ConfigChanges {
+func (cm *reconcilingConfigManager) processNewService(svc listeners.Service) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 
@@ -126,6 +126,8 @@ func (cm *reconcilingConfigManager) processNewService(adIdentifiers []string, sv
 		log.Debugf("Service %s is already tracked by autodiscovery", svcID)
 		return integration.ConfigChanges{}
 	}
+
+	adIdentifiers := svc.GetADIdentifiers()
 
 	// Execute the steps outlined in the comment on reconcilingConfigManager:
 	//

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
@@ -247,7 +247,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
-	changes = suite.cm.processNewService(myService.ADIdentifiers, myService)
+	changes = suite.cm.processNewService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -268,7 +268,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
-	changes = suite.cm.processNewService(myService.ADIdentifiers, myService)
+	changes = suite.cm.processNewService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -285,7 +285,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirs
 // is resolved and scheduled when such a template arrives; deleting the template
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst() {
-	changes := suite.cm.processNewService(myService.ADIdentifiers, myService)
+	changes := suite.cm.processNewService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -306,7 +306,7 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst
 // is resolved and scheduled when such a template arrives; deleting the service
 // unschedules the resolved configs.
 func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ServiceRemovedFirst() {
-	changes := suite.cm.processNewService(myService.ADIdentifiers, myService)
+	changes := suite.cm.processNewService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
@@ -398,7 +398,7 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 				if _, found := services[id]; !found {
 					services[id] = svc
 					fmt.Printf("add service %s with AD idents [%s]\n", id, strings.Join(adIDs, ", "))
-					applyChanges(cm.processNewService(adIDs, svc))
+					applyChanges(cm.processNewService(svc))
 				}
 			case p < 40 && op < removeAfterOps: // add non-template config
 				cfg := makeNonTemplateConfig(r)
@@ -497,13 +497,13 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 	}
 
 	// adding service with no templates has no effect
-	changes := suite.cm.processNewService(myService.ADIdentifiers, myService)
+	changes := suite.cm.processNewService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 	assertLoadedConfigsMatch(suite.T(), suite.cm)
 
 	// adding service with no templates has no effect
-	changes = suite.cm.processNewService(filterSvc.ADIdentifiers, filterSvc)
+	changes = suite.cm.processNewService(filterSvc)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 	assertLoadedConfigsMatch(suite.T(), suite.cm)

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
@@ -394,7 +394,7 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 			case p < 20 && op < removeAfterOps: // add service
 				svc := makeService(r)
 				id := svc.GetServiceID()
-				adIDs, _ := svc.GetADIdentifiers()
+				adIDs := svc.GetADIdentifiers()
 				if _, found := services[id]; !found {
 					services[id] = svc
 					fmt.Printf("add service %s with AD idents [%s]\n", id, strings.Join(adIDs, ", "))
@@ -424,7 +424,7 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 				for id, svc := range services {
 					if i == 0 {
 						delete(services, id)
-						adIDs, _ := svc.GetADIdentifiers()
+						adIDs := svc.GetADIdentifiers()
 						fmt.Printf("remove service %s with AD idents %s\n", id, strings.Join(adIDs, ", "))
 						applyChanges(cm.processDelService(context.TODO(), svc))
 						break

--- a/comp/core/autodiscovery/configresolver/configresolver_test.go
+++ b/comp/core/autodiscovery/configresolver/configresolver_test.go
@@ -43,8 +43,8 @@ func (s *dummyService) GetServiceID() string {
 }
 
 // GetADIdentifiers returns dummy identifiers
-func (s *dummyService) GetADIdentifiers() ([]string, error) {
-	return s.ADIdentifiers, nil
+func (s *dummyService) GetADIdentifiers() []string {
+	return s.ADIdentifiers
 }
 
 // GetHosts returns dummy hosts

--- a/comp/core/autodiscovery/listeners/cloudfoundry.go
+++ b/comp/core/autodiscovery/listeners/cloudfoundry.go
@@ -213,8 +213,8 @@ func (s *CloudFoundryService) GetServiceID() string {
 }
 
 // GetADIdentifiers returns a set of AD identifiers for a container.
-func (s *CloudFoundryService) GetADIdentifiers() ([]string, error) {
-	return []string{s.adIdentifier.String()}, nil
+func (s *CloudFoundryService) GetADIdentifiers() []string {
+	return []string{s.adIdentifier.String()}
 }
 
 // GetHosts returns the container's hosts

--- a/comp/core/autodiscovery/listeners/cloudfoundry_test.go
+++ b/comp/core/autodiscovery/listeners/cloudfoundry_test.go
@@ -441,8 +441,7 @@ func TestCloudFoundryListener(t *testing.T) {
 
 		for range tc.expNew {
 			s := (<-newSvc).(*CloudFoundryService)
-			adID, err := s.GetADIdentifiers()
-			assert.Nil(t, err)
+			adID := s.GetADIdentifiers()
 			// we make the comparison easy by leaving out the ADIdentifier structs out
 			oldID := s.adIdentifier
 			s.adIdentifier = cloudfoundry.ADIdentifier{}
@@ -451,8 +450,7 @@ func TestCloudFoundryListener(t *testing.T) {
 		}
 		for range tc.expDel {
 			s := (<-delSvc).(*CloudFoundryService)
-			adID, err := s.GetADIdentifiers()
-			assert.Nil(t, err)
+			adID := s.GetADIdentifiers()
 			s.adIdentifier = cloudfoundry.ADIdentifier{}
 			assert.Equal(t, tc.expDel[adID[0]], s)
 		}

--- a/comp/core/autodiscovery/listeners/dbm_aurora.go
+++ b/comp/core/autodiscovery/listeners/dbm_aurora.go
@@ -218,8 +218,8 @@ func (d *DBMAuroraService) GetTaggerEntity() string {
 }
 
 // GetADIdentifiers return the single AD identifier for a static config service
-func (d *DBMAuroraService) GetADIdentifiers() ([]string, error) {
-	return []string{d.adIdentifier}, nil
+func (d *DBMAuroraService) GetADIdentifiers() []string {
+	return []string{d.adIdentifier}
 }
 
 // GetHosts returns the host for the aurora endpoint

--- a/comp/core/autodiscovery/listeners/environment.go
+++ b/comp/core/autodiscovery/listeners/environment.go
@@ -87,8 +87,8 @@ func (s *EnvironmentService) GetServiceID() string {
 }
 
 // GetADIdentifiers return the single AD identifier for an environment service
-func (s *EnvironmentService) GetADIdentifiers() ([]string, error) {
-	return []string{s.adIdentifier}, nil
+func (s *EnvironmentService) GetADIdentifiers() []string {
+	return []string{s.adIdentifier}
 }
 
 // GetHosts is not supported

--- a/comp/core/autodiscovery/listeners/kube_endpoints.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints.go
@@ -450,8 +450,8 @@ func (s *KubeEndpointService) GetServiceID() string {
 }
 
 // GetADIdentifiers returns the service AD identifiers
-func (s *KubeEndpointService) GetADIdentifiers() ([]string, error) {
-	return []string{s.entity}, nil
+func (s *KubeEndpointService) GetADIdentifiers() []string {
+	return []string{s.entity}
 }
 
 // GetHosts returns the pod hosts

--- a/comp/core/autodiscovery/listeners/kube_endpoints_test.go
+++ b/comp/core/autodiscovery/listeners/kube_endpoints_test.go
@@ -59,8 +59,7 @@ func TestProcessEndpoints(t *testing.T) {
 
 	assert.Equal(t, "kube_endpoint_uid://default/myservice/10.0.0.1", eps[0].GetServiceID())
 
-	adID, err := eps[0].GetADIdentifiers()
-	assert.NoError(t, err)
+	adID := eps[0].GetADIdentifiers()
 	assert.Equal(t, []string{"kube_endpoint_uid://default/myservice/10.0.0.1"}, adID)
 
 	hosts, err := eps[0].GetHosts()
@@ -77,7 +76,7 @@ func TestProcessEndpoints(t *testing.T) {
 
 	assert.Equal(t, "kube_endpoint_uid://default/myservice/10.0.0.2", eps[1].GetServiceID())
 
-	adID, err = eps[1].GetADIdentifiers()
+	adID = eps[1].GetADIdentifiers()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"kube_endpoint_uid://default/myservice/10.0.0.2"}, adID)
 

--- a/comp/core/autodiscovery/listeners/kube_services.go
+++ b/comp/core/autodiscovery/listeners/kube_services.go
@@ -339,9 +339,9 @@ func (s *KubeServiceService) GetServiceID() string {
 }
 
 // GetADIdentifiers returns the service AD identifiers
-func (s *KubeServiceService) GetADIdentifiers() ([]string, error) {
+func (s *KubeServiceService) GetADIdentifiers() []string {
 	// Only the entity for now, to match on annotation
-	return []string{s.entity}, nil
+	return []string{s.entity}
 }
 
 // GetHosts returns the pod hosts

--- a/comp/core/autodiscovery/listeners/kube_services_test.go
+++ b/comp/core/autodiscovery/listeners/kube_services_test.go
@@ -49,8 +49,7 @@ func TestProcessService(t *testing.T) {
 	svc := processService(ksvc)
 	assert.Equal(t, "kube_service://default/myservice", svc.GetServiceID())
 
-	adID, err := svc.GetADIdentifiers()
-	assert.NoError(t, err)
+	adID := svc.GetADIdentifiers()
 	assert.Equal(t, []string{"kube_service://default/myservice"}, adID)
 
 	hosts, err := svc.GetHosts()

--- a/comp/core/autodiscovery/listeners/service.go
+++ b/comp/core/autodiscovery/listeners/service.go
@@ -74,8 +74,8 @@ func (s *service) GetServiceID() string {
 }
 
 // GetADIdentifiers returns the service's AD identifiers.
-func (s *service) GetADIdentifiers() ([]string, error) {
-	return s.adIdentifiers, nil
+func (s *service) GetADIdentifiers() []string {
+	return s.adIdentifiers
 }
 
 // GetHosts returns the service's IPs for each host.

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -439,8 +439,8 @@ func (s *SNMPService) GetServiceID() string {
 }
 
 // GetADIdentifiers returns a set of AD identifiers
-func (s *SNMPService) GetADIdentifiers() ([]string, error) {
-	return []string{s.adIdentifier}, nil
+func (s *SNMPService) GetADIdentifiers() []string {
+	return []string{s.adIdentifier}
 }
 
 // GetHosts returns the device IP

--- a/comp/core/autodiscovery/listeners/staticconfig.go
+++ b/comp/core/autodiscovery/listeners/staticconfig.go
@@ -74,8 +74,8 @@ func (s *StaticConfigService) GetServiceID() string {
 }
 
 // GetADIdentifiers return the single AD identifier for a static config service
-func (s *StaticConfigService) GetADIdentifiers() ([]string, error) {
-	return []string{s.adIdentifier}, nil
+func (s *StaticConfigService) GetADIdentifiers() []string {
+	return []string{s.adIdentifier}
 }
 
 // GetHosts is not supported

--- a/comp/core/autodiscovery/listeners/types.go
+++ b/comp/core/autodiscovery/listeners/types.go
@@ -29,7 +29,7 @@ type ContainerPort struct {
 type Service interface {
 	Equal(Service) bool                                          // compare two services
 	GetServiceID() string                                        // unique service name
-	GetADIdentifiers() ([]string, error)                         // identifiers on which templates will be matched
+	GetADIdentifiers() []string                                  // identifiers on which templates will be matched
 	GetHosts() (map[string]string, error)                        // network --> IP address
 	GetPorts() ([]ContainerPort, error)                          // network ports
 	GetTags() ([]string, error)                                  // tags


### PR DESCRIPTION
### What does this PR do?

This PR is a refactor that simplifies part of the code in the autodiscovery component.

Specifically, it deletes the returned error from the `GetADIdentifiers` function in the `Service` interface, since none of its implementations actually return an error.

As a result, the `adIdentifiers` parameter in the `processNewService` function of the `configManager` interface can also be deleted. This change is made in the second commit of this PR.

### Describe how you validated your changes

CI
