### PR TITLE
[CWS] Add missing fallback for device_nd_net_net_offset constant

### DIFF
--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -974,7 +974,13 @@ func getMountIDOffset(kv *kernel.Version) uint64 {
 
 func getDeviceStructNdNet(kv *kernel.Version) uint64 {
 	switch {
+	case kv.IsRH7Kernel():
+		return 1000
 	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel4_15):
+		return 1256
+	case kv.IsUbuntuKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_18, kernel.Kernel4_19):
+		return 1312
+	case kv.IsDebianKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel4_20):
 		return 1256
 	default:
 		return 1264

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -123,6 +123,7 @@ func computeCallbacksTable() map[string]func(*kernel.Version) uint64 {
 		OffsetNameFileFinode:                  getFileFinodeOffset,
 		OffsetNameFileFpath:                   getFileFpathOffset,
 		OffsetNameMountMntID:                  getMountIDOffset,
+		OffsetNameDeviceStructNdNet:           getDeviceStructNdNet,
 	}
 }
 
@@ -968,5 +969,14 @@ func getMountIDOffset(kv *kernel.Version) uint64 {
 		return 268
 	default:
 		return 284
+	}
+}
+
+func getDeviceStructNdNet(kv *kernel.Version) uint64 {
+	switch {
+	case kv.IsAmazonLinuxKernel() && kv.IsInRangeCloseOpen(kernel.Kernel4_14, kernel.Kernel4_15):
+		return 1256
+	default:
+		return 1264
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Add the missing constant fallback.

### Motivation

We had an issue where on last AmazonLinux2 kernel update (4.14.355-276.639.amzn2.x86_64) the offset changed and broke demo environment.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->