### PR TITLE
Fixed worktree issue when branch not present

### DIFF
--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -105,9 +105,9 @@ def enter_env(ctx, branch: str | None, skip_checkout=False, commit: str | None =
     os.chdir(WORKTREE_DIRECTORY)
     if skip_checkout and branch:
         current_branch = get_current_branch(ctx)
-        assert current_branch == branch, (
-            f"skip_checkout is True but the current branch ({current_branch}) is not {branch}. You should check out the branch before using this command, this can be safely done with `dda inv worktree.checkout {branch}`."
-        )
+        assert (
+            current_branch == branch
+        ), f"skip_checkout is True but the current branch ({current_branch}) is not {branch}. You should check out the branch before using this command, this can be safely done with `dda inv worktree.checkout {branch}`."
 
 
 def exit_env():

--- a/tasks/libs/common/worktree.py
+++ b/tasks/libs/common/worktree.py
@@ -43,10 +43,8 @@ def init_env(ctx, branch: str | None = None, commit: str | None = None):
 
     # Copy the configuration file
     ctx.run(f"cp {LOCAL_DIRECTORY}/.git/config {WORKTREE_DIRECTORY}/.git/config", hide=True)
-    ctx.run(
-        f"git -C '{WORKTREE_DIRECTORY}' branch --set-upstream-to=origin/{branch or 'main'} {branch or 'main'}",
-        hide=True,
-    )
+    # Be sure the target branch is present locally and set up to track the remote branch
+    ctx.run(f"git -C '{WORKTREE_DIRECTORY}' branch {branch or 'main'} origin/{branch or 'main'} || true", hide=True)
     # If the state is not clean, clean it
     if ctx.run(f"git -C '{WORKTREE_DIRECTORY}' status --porcelain", hide=True).stdout.strip():
         print(f'{color_message("Info", Color.BLUE)}: Cleaning worktree directory', file=sys.stderr)
@@ -107,9 +105,9 @@ def enter_env(ctx, branch: str | None, skip_checkout=False, commit: str | None =
     os.chdir(WORKTREE_DIRECTORY)
     if skip_checkout and branch:
         current_branch = get_current_branch(ctx)
-        assert (
-            current_branch == branch
-        ), f"skip_checkout is True but the current branch ({current_branch}) is not {branch}. You should check out the branch before using this command, this can be safely done with `dda inv worktree.checkout {branch}`."
+        assert current_branch == branch, (
+            f"skip_checkout is True but the current branch ({current_branch}) is not {branch}. You should check out the branch before using this command, this can be safely done with `dda inv worktree.checkout {branch}`."
+        )
 
 
 def exit_env():

--- a/tasks/unit_tests/libs/common/worktree_tests.py
+++ b/tasks/unit_tests/libs/common/worktree_tests.py
@@ -64,7 +64,7 @@ class WorktreeMockContext(MockContext):
             re.match(r'git.*status --porcelain.*', command)
             or re.match(r'git.*reset --hard.*', command)
             or re.match(r'git.*clean -f.*', command)
-            or re.match(r'git.*branch --set-upstream-to.*', command)
+            or re.match(r'git.*branch.*', command)
             or re.match(r'cp.*', command)
         ):
             return Result(stdout='')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

There was an issue when the branch wasn't present on the worktree, this ensures that the branch is set up and tracks the remote.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Scenarios:
- Remove worktree, init, change context
- Change context
- Init, change context
- Remove worktree, change context

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->