### PR TITLE
[CWS] small clean up around DNS port configuration

### DIFF
--- a/pkg/security/probe/config/config.go
+++ b/pkg/security/probe/config/config.go
@@ -170,9 +170,6 @@ type Config struct {
 
 	// SpanTrackingCacheSize is the size of the span tracking cache
 	SpanTrackingCacheSize int
-
-	// The DNS Port
-	DNSPort uint16
 }
 
 // NewConfig returns a new Config object
@@ -230,9 +227,6 @@ func NewConfig() (*Config, error) {
 		// span tracking
 		SpanTrackingEnabled:   getBool("span_tracking.enabled"),
 		SpanTrackingCacheSize: getInt("span_tracking.cache_size"),
-
-		// dns
-		DNSPort: 53,
 	}
 
 	if err := c.sanitize(); err != nil {

--- a/pkg/security/probe/opts_linux.go
+++ b/pkg/security/probe/opts_linux.go
@@ -9,7 +9,6 @@
 package probe
 
 import (
-	"encoding/binary"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/tags"
 	"github.com/DataDog/datadog-go/v5/statsd"
 )
@@ -44,8 +43,4 @@ func (o *Opts) normalize() {
 	if o.DNSPort == 0 {
 		o.DNSPort = 53
 	}
-
-	b := make([]byte, 2)
-	binary.LittleEndian.PutUint16(b, o.DNSPort)
-	o.DNSPort = binary.BigEndian.Uint16(b)
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2226,7 +2226,7 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 		},
 		manager.ConstantEditor{
 			Name:  "dns_port",
-			Value: uint64(p.probe.Opts.DNSPort),
+			Value: uint64(utils.HostToNetworkShort(p.probe.Opts.DNSPort)),
 		},
 		manager.ConstantEditor{
 			Name:  "use_ring_buffer",

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -811,7 +811,6 @@ func genTestConfigs(cfgDir string, opts testOpts) (*emconfig.Config, *secconfig.
 		"EnforcementDisarmerExecutablePeriod":        opts.enforcementDisarmerExecutablePeriod,
 		"EventServerRetention":                       opts.eventServerRetention,
 		"EnableSelfTests":                            opts.enableSelfTests,
-		"DnsPort":                                    opts.dnsPort,
 		"NetworkFlowMonitorEnabled":                  opts.networkFlowMonitorEnabled,
 	}); err != nil {
 		return nil, nil, err

--- a/pkg/security/utils/utils.go
+++ b/pkg/security/utils/utils.go
@@ -7,6 +7,8 @@
 package utils
 
 import (
+	"encoding/binary"
+
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -28,4 +30,11 @@ func BoolTouint64(value bool) uint64 {
 		return 1
 	}
 	return 0
+}
+
+// HostToNetworkShort htons
+func HostToNetworkShort(short uint16) uint16 {
+	b := make([]byte, 2)
+	binary.NativeEndian.PutUint16(b, short)
+	return binary.BigEndian.Uint16(b)
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR cleans up the code paths around DNS port, removing all the unused fields and variables, and making sure we do the `htons` at the correct time (so that `opts.DNSPort` keeps being the correct value, only the eBPF constant is changed).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->