### PR TITLE
[CWS] Fix path ID generation

### DIFF
--- a/pkg/security/ebpf/c/include/tests/path_id_test.h
+++ b/pkg/security/ebpf/c/include/tests/path_id_test.h
@@ -1,0 +1,25 @@
+#ifndef _PATH_ID_TEST_H_
+#define _PATH_ID_TEST_H_
+
+SEC("test/path_id")
+int test_path_id() {
+    u32 mount_id1 = 123;
+    u32 mount_id2 = 456;
+
+    u32 initial_mount_1_path_id = get_path_id(mount_id1, 0);
+    u32 initial_mount_2_path_id = get_path_id(mount_id2, 0);
+
+    // get path id mount 1 and invalidate the path
+    u32 mount_1_path_id_after_invalidation = get_path_id(mount_id1, 1);
+    assert_equals(mount_1_path_id_after_invalidation, initial_mount_1_path_id, "path id should be the same");
+    
+    u32 mount_1_next_path_id = get_path_id(mount_id1, 0);
+    assert_equals(mount_1_next_path_id, mount_1_path_id_after_invalidation + 1, "path id should be incremented");
+
+    u32 mount_2_path_id_after_mount_1_invalidation = get_path_id(mount_id2, 0);
+    assert_equals(mount_2_path_id_after_mount_1_invalidation, initial_mount_2_path_id, "path id for mount 2 should be left unchanged");
+
+    return 1;
+}
+
+#endif /* _PATH_ID_TEST_H_ */

--- a/pkg/security/ebpf/c/include/tests/tests.h
+++ b/pkg/security/ebpf/c/include/tests/tests.h
@@ -4,5 +4,6 @@
 #include "discarders_test.h"
 #include "activity_dump_ratelimiter_test.h"
 #include "raw_packet_test.h"
+#include "path_id_test.h"
 
 #endif

--- a/pkg/security/ebpf/tests/path_id_test.go
+++ b/pkg/security/ebpf/tests/path_id_test.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && ebpf_bindata
+
+// Package tests holds tests related files
+package tests
+
+import (
+	"testing"
+
+	"github.com/safchain/baloum/pkg/baloum"
+)
+
+func TestPathID(t *testing.T) {
+	var ctx baloum.StdContext
+	code, err := newVM(t).RunProgram(&ctx, "test/path_id")
+	if err != nil || code != 1 {
+		t.Errorf("unexpected error: %v, %d", err, code)
+	}
+}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This fixes the kernel-side path ID generation.
When invalidating a path, the `get_path_id` function was returning the incremented path ID. It should instead be returning the previous value and then increment the counter so that next path keys use a new value.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->