### PR TITLE
[CWS] make sure model events have unique string values

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1328,6 +1328,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 				return
 			}
 			p.addToDNSResolver(dnsLayer)
+			event.Type = uint32(model.DNSEventType) // remap to regular DNS event type
 			event.DNS = model.DNSEvent{
 				ID: dnsLayer.ID,
 				Question: model.DNSQuestion{

--- a/pkg/security/secl/model/events.go
+++ b/pkg/security/secl/model/events.go
@@ -274,7 +274,7 @@ func (t EventType) String() string {
 	case SysCtlEventType:
 		return "sysctl"
 	case FullDNSResponseEventType:
-		return "dns"
+		return "dns_response"
 	default:
 		return "unknown"
 	}

--- a/pkg/security/seclwin/model/events.go
+++ b/pkg/security/seclwin/model/events.go
@@ -274,7 +274,7 @@ func (t EventType) String() string {
 	case SysCtlEventType:
 		return "sysctl"
 	case FullDNSResponseEventType:
-		return "dns"
+		return "dns_response"
 	default:
 		return "unknown"
 	}

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -416,12 +416,6 @@ func NewBaseEventSerializer(event *model.Event, rule *rules.Rule) *BaseEventSeri
 
 	eventType := model.EventType(event.Type)
 
-	// map event type back to regular DNS so that we send a DNS event
-	// for both requests and responses.
-	if eventType == model.FullDNSResponseEventType {
-		eventType = model.DNSEventType
-	}
-
 	s := &BaseEventSerializer{
 		EventContextSerializer: EventContextSerializer{
 			Name:        eventType.String(),

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -416,6 +416,12 @@ func NewBaseEventSerializer(event *model.Event, rule *rules.Rule) *BaseEventSeri
 
 	eventType := model.EventType(event.Type)
 
+	// map event type back to regular DNS so that we send a DNS event
+	// for both requests and responses.
+	if eventType == model.FullDNSResponseEventType {
+		eventType = model.DNSEventType
+	}
+
 	s := &BaseEventSerializer{
 		EventContextSerializer: EventContextSerializer{
 			Name:        eventType.String(),

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1537,9 +1537,6 @@ func NewEventSerializer(event *model.Event, rule *rules.Rule) *EventSerializer {
 	case model.DNSEventType:
 		s.EventContextSerializer.Outcome = serializeOutcome(0)
 		s.DNSEventSerializer = newDNSEventSerializer(&event.DNS)
-	case model.FullDNSResponseEventType:
-		s.EventContextSerializer.Outcome = serializeOutcome(0)
-		s.DNSEventSerializer = newDNSEventSerializer(&event.DNS)
 	case model.IMDSEventType:
 		s.EventContextSerializer.Outcome = serializeOutcome(0)
 		s.IMDSEventSerializer = newIMDSEventSerializer(&event.IMDS)

--- a/pkg/security/tests/dns_response_test.go
+++ b/pkg/security/tests/dns_response_test.go
@@ -11,15 +11,16 @@ package tests
 // Package tests holds tests related files
 import (
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/config/env"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/stretchr/testify/assert"
 	"net"
 	"os"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config/env"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/stretchr/testify/assert"
 )
 
 const DNSPort = 5553


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR fixes the event type `.String()`ification for DNS event types to make sure the result is unique. This is important, because this unicity is used to build maps of string -> event types when parsing some config options, and this was preventing DNS events from being added correctly to activity dumps.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->