### PR TITLE
[NPM-4440] Add TracerouteSerial variant

### DIFF
--- a/pkg/networkpath/traceroute/common/traceroute_parallel.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel.go
@@ -7,10 +7,7 @@ package common
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/netip"
-	"slices"
 	"sync"
 	"time"
 
@@ -19,78 +16,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// ReceiveProbeNoPktError is returned when ReceiveProbe() didn't find anything new.
-// This is normal if the RTT is long
-type ReceiveProbeNoPktError struct {
-	Err error
-}
-
-func (e *ReceiveProbeNoPktError) Error() string {
-	return fmt.Sprintf("ReceiveProbe() didn't find any new packets: %s", e.Err)
-}
-func (e *ReceiveProbeNoPktError) Unwrap() error {
-	return e.Err
-}
-
-// BadPacketError is a non-fatal error that occurs when a packet is malformed.
-type BadPacketError struct {
-	Err error
-}
-
-func (e *BadPacketError) Error() string {
-	return fmt.Sprintf("Failed to parse packet: %s", e.Err)
-}
-func (e *BadPacketError) Unwrap() error {
-	return e.Err
-}
-
-// ProbeResponse is the response of a single probe in a traceroute
-type ProbeResponse struct {
-	// TTL is the Time To Live of the probe that was originally sent
-	TTL uint8
-	// IP is the IP address of the responding host
-	IP netip.Addr
-	// RTT is the round-trip time of the probe
-	RTT time.Duration
-	// IsDest is true if the responding host is the destination
-	IsDest bool
-}
-
-// TracerouteDriverInfo is metadata about a TracerouteDriver
-type TracerouteDriverInfo struct {
-	SupportsParallel bool
-}
-
-// TracerouteDriver is an implementation of traceroute send+receive of packets
-type TracerouteDriver interface {
-	// GetDriverInfo returns metadata about this driver
-	GetDriverInfo() TracerouteDriverInfo
-	// SendProbe sends a traceroute packet with a specific TTL
-	SendProbe(ttl uint8) error
-	// ReceiveProbe polls to get a traceroute response with a timeout.
-	ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
-}
-
 // TracerouteParallelParams are the parameters for TracerouteParallel
 type TracerouteParallelParams struct {
-	// MinTTL is the TTL to start the traceroute at
-	MinTTL uint8
-	// MaxTTL is the TTL to end the traceroute at
-	MaxTTL uint8
-	// TracerouteTimeout is the maximum time to wait for a response
-	TracerouteTimeout time.Duration
-	// PollFrequency is how often to poll for a response
-	PollFrequency time.Duration
-	// SendDelay is the delay between sending probes (typically small)
-	SendDelay time.Duration
-}
-
-// ProbeCount returns the number of probes that will be sent
-func (p TracerouteParallelParams) ProbeCount() int {
-	if p.MinTTL > p.MaxTTL {
-		return 0
-	}
-	return int(p.MaxTTL) - int(p.MinTTL) + 1
+	TracerouteParams
 }
 
 // MaxTimeout combines the timeout+probe delays into a total timeout for the traceroute
@@ -101,12 +29,10 @@ func (p TracerouteParallelParams) MaxTimeout() time.Duration {
 
 // TracerouteParallel runs a traceroute in parallel
 func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TracerouteParallelParams) ([]*ProbeResponse, error) {
-	if p.MinTTL > p.MaxTTL {
-		return nil, fmt.Errorf("min TTL must be less than or equal to max TTL")
+	if err := p.validate(); err != nil {
+		return nil, err
 	}
-	if p.MinTTL < 1 {
-		return nil, fmt.Errorf("min TTL must be at least 1")
-	}
+
 	info := t.GetDriverInfo()
 	if !info.SupportsParallel {
 		return nil, fmt.Errorf("tried to call TracerouteParallel on a TracerouteDriver that doesn't support parallel")
@@ -144,15 +70,13 @@ func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TraceroutePar
 	g.Go(func() error {
 		for i := int(p.MinTTL); i <= int(p.MaxTTL); i++ {
 			// leave if we got cancelled
-			select {
-			case <-writerCtx.Done():
+			if writerCtx.Err() != nil {
 				return nil
-			default:
 			}
 
 			err := t.SendProbe(uint8(i))
 			if err != nil {
-				return err
+				return fmt.Errorf("SendProbe() failed: %w", err)
 			}
 
 			time.Sleep(p.SendDelay)
@@ -163,27 +87,18 @@ func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TraceroutePar
 	g.Go(func() error {
 		for {
 			// leave if we got cancelled, SendProbe() failed, etc
-			select {
-			// doesn't use writerCtx because even if we writerCancel(), we want to keep reading
-			case <-groupCtx.Done():
+			// doesn't use writerCtx because when we find the destination, we writerCancel(), and we want to keep reading
+			if groupCtx.Err() != nil {
 				return nil
-			default:
 			}
 
 			probe, err := t.ReceiveProbe(p.PollFrequency)
-			if CheckParallelRetryable("ReceiveProbe", err) {
+			if CheckProbeRetryable("ReceiveProbe", err) {
 				continue
 			} else if err != nil {
+				return fmt.Errorf("ReceiveProbe() failed: %w", err)
+			} else if err = p.validateProbe(probe); err != nil {
 				return err
-			}
-			if probe == nil {
-				return fmt.Errorf("ReceiveProbe() returned nil without an error (this indicates a bug in the TracerouteDriver)")
-			}
-			if probe.TTL == 0 {
-				return fmt.Errorf("ReceiveProbe() got TTL 0 which is only allowed for TracerouteSerial (this indicates a bug in the TracerouteDriver)")
-			}
-			if probe.TTL < p.MinTTL || probe.TTL > p.MaxTTL {
-				return fmt.Errorf("ReceiveProbe() received an invalid TTL: expected TTL in [%d, %d], got %d", p.MinTTL, p.MaxTTL, probe.TTL)
 			}
 
 			writeProbe(probe)
@@ -205,48 +120,5 @@ func TracerouteParallel(ctx context.Context, t TracerouteDriver, p TraceroutePar
 		return nil, ctx.Err()
 	}
 
-	destIdx := slices.IndexFunc(results, func(pr *ProbeResponse) bool {
-		return pr != nil && pr.IsDest
-	})
-	// trim off anything after the destination
-	if destIdx != -1 {
-		results = slices.Clip(results[:destIdx+1])
-	}
-
-	return results[p.MinTTL:], nil
-}
-
-// ToHops converts a list of ProbeResponses to a Results
-// TODO remove this, and use a single type to represent results
-func ToHops(p TracerouteParallelParams, probes []*ProbeResponse) ([]*Hop, error) {
-	if p.MinTTL != 1 {
-		return nil, fmt.Errorf("ToHops: processResults() requires MinTTL == 1")
-	}
-	hops := make([]*Hop, len(probes))
-	for i, probe := range probes {
-		hops[i] = &Hop{}
-		if probe != nil {
-			hops[i].IP = probe.IP.AsSlice()
-			hops[i].RTT = probe.RTT
-			hops[i].IsDest = probe.IsDest
-		}
-	}
-	return hops, nil
-}
-
-var badPktLimit = log.NewLogLimit(10, 5*time.Minute)
-
-// CheckParallelRetryable returns whether ReceiveProbe failed due to a real error or just an irrelevant packet
-func CheckParallelRetryable(funcName string, err error) bool {
-	noPktErr := &ReceiveProbeNoPktError{}
-	badPktErr := &BadPacketError{}
-	if errors.As(err, &noPktErr) {
-		return true
-	} else if errors.As(err, &badPktErr) {
-		if badPktLimit.ShouldLog() {
-			log.Warnf("%s() saw a malformed packet: %s", funcName, err)
-		}
-		return true
-	}
-	return false
+	return clipResults(p.MinTTL, results), nil
 }

--- a/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 var parallelParams = TracerouteParallelParams{
-	TracerouteParams{
+	TracerouteParams: TracerouteParams{
 		MinTTL:            1,
 		MaxTTL:            10,
 		TracerouteTimeout: 500 * time.Millisecond,

--- a/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_parallel_test.go
@@ -19,70 +19,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type MockDriver struct {
-	t      *testing.T
-	params TracerouteParallelParams
-
-	sentTTLs map[uint8]struct{}
-
-	info           TracerouteDriverInfo
-	sendHandler    func(ttl uint8) error
-	receiveHandler func() (*ProbeResponse, error)
-}
-
-func initMockDriver(t *testing.T, params TracerouteParallelParams) *MockDriver {
-	return &MockDriver{
-		t:      t,
-		params: params,
-		info: TracerouteDriverInfo{
-			SupportsParallel: true,
-		},
-		sentTTLs:       make(map[uint8]struct{}),
-		sendHandler:    nil,
-		receiveHandler: nil,
-	}
-}
-
-func (m *MockDriver) GetDriverInfo() TracerouteDriverInfo {
-	return m.info
-}
-
-func (m *MockDriver) SendProbe(ttl uint8) error {
-	require.NotContains(m.t, m.sentTTLs, ttl, "same TTL sent twice")
-	m.sentTTLs[ttl] = struct{}{}
-
-	m.t.Logf("wrote %d\n", ttl)
-	if m.sendHandler == nil {
-		return nil
-	}
-	return m.sendHandler(ttl)
-}
-
-func (m *MockDriver) ReceiveProbe(timeout time.Duration) (*ProbeResponse, error) {
-	require.Equal(m.t, m.params.PollFrequency, timeout)
-
-	if m.receiveHandler == nil {
-		return noData(timeout)
-	}
-	res, err := m.receiveHandler()
-	var errNoPkt *ReceiveProbeNoPktError
-	if !errors.As(err, &errNoPkt) {
-		m.t.Logf("read %+v, %v\n", res, err)
-	}
-	return res, err
-}
-
-func noData(pollFrequency time.Duration) (*ProbeResponse, error) {
-	time.Sleep(pollFrequency)
-	return nil, &ReceiveProbeNoPktError{Err: fmt.Errorf("testing, no data")}
-}
-
-var testParams = TracerouteParallelParams{
-	MinTTL:            1,
-	MaxTTL:            10,
-	TracerouteTimeout: 500 * time.Millisecond,
-	PollFrequency:     1 * time.Millisecond,
-	SendDelay:         1 * time.Millisecond,
+var parallelParams = TracerouteParallelParams{
+	TracerouteParams{
+		MinTTL:            1,
+		MaxTTL:            10,
+		TracerouteTimeout: 500 * time.Millisecond,
+		PollFrequency:     1 * time.Millisecond,
+		SendDelay:         1 * time.Millisecond,
+	},
 }
 
 const mockDestTTL = 5
@@ -102,11 +46,11 @@ func mockResult(ttl uint8) *ProbeResponse {
 
 func TestParallelTraceroute(t *testing.T) {
 	// basic test that checks if the traceroute runs correctly
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
-	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+	receiveProbes := make(chan *ProbeResponse, parallelParams.MaxTTL)
 
 	expectedTTL := uint8(1)
 	m.sendHandler = func(ttl uint8) error {
@@ -128,12 +72,12 @@ func TestParallelTraceroute(t *testing.T) {
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		probe, ok := <-receiveProbes
 		if !ok {
-			return noData(testParams.PollFrequency)
+			return noData(parallelParams.PollFrequency)
 		}
 		return probe, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
 	require.Equal(t, expectedResults, results)
 	require.Len(t, results, mockDestTTL)
@@ -144,11 +88,11 @@ func testParallelTracerouteShuffled(t *testing.T, seed int64) {
 	// and expects them to come back in the correct order
 	r := rand.New(rand.NewSource(seed))
 
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
-	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+	receiveProbes := make(chan *ProbeResponse, parallelParams.MaxTTL)
 
 	m.sendHandler = func(ttl uint8) error {
 		result := mockResult(ttl)
@@ -168,12 +112,12 @@ func testParallelTracerouteShuffled(t *testing.T, seed int64) {
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		probe, ok := <-receiveProbes
 		if !ok {
-			return noData(testParams.PollFrequency)
+			return noData(parallelParams.PollFrequency)
 		}
 		return probe, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
 	require.Equal(t, expectedResults, results)
 	require.Len(t, results, mockDestTTL)
@@ -190,7 +134,7 @@ var errMock = errors.New("mock error")
 
 func TestParallelTracerouteSendErr(t *testing.T) {
 	// this test checks that TracerouteParallel returns an error if SendProbe() fails
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	hasCalled := false
@@ -201,14 +145,14 @@ func TestParallelTracerouteSendErr(t *testing.T) {
 		return errMock
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.Nil(t, results)
 	require.ErrorIs(t, err, errMock)
 }
 
 func TestParallelTracerouteReceiveErr(t *testing.T) {
 	// this test checks that TracerouteParallel returns an error if ReceiveProbe() fails
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	hasCalled := false
@@ -219,7 +163,7 @@ func TestParallelTracerouteReceiveErr(t *testing.T) {
 		return nil, errMock
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.Nil(t, results)
 	require.ErrorIs(t, err, errMock)
 }
@@ -227,21 +171,21 @@ func TestParallelTracerouteReceiveErr(t *testing.T) {
 func TestParallelTracerouteTimeout(t *testing.T) {
 	// this test checks that TracerouteParallel times out when it is waiting for
 	// a response during the traceroute
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	totalCalls := 0
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		totalCalls++
-		return noData(testParams.PollFrequency)
+		return noData(parallelParams.PollFrequency)
 	}
 
 	start := time.Now()
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
 
 	// divide by 2 to give margin for error
-	require.Greater(t, time.Since(start), testParams.TracerouteTimeout/2)
+	require.Greater(t, time.Since(start), parallelParams.TracerouteTimeout/2)
 	// make sure it kept polling repeatedly
 	require.Greater(t, totalCalls, 5)
 	for _, res := range results {
@@ -252,14 +196,14 @@ func TestParallelTracerouteTimeout(t *testing.T) {
 func TestParallelTracerouteMinTTL(t *testing.T) {
 	// same as TestParallelTraceroute but it checks that we don't send TTL=1 when MinTTL=2
 
-	// make a copy of testParams
-	testParams := testParams
-	testParams.MinTTL = 2
-	m := initMockDriver(t, testParams)
+	// make a copy of parallelParams
+	parallelParams := parallelParams
+	parallelParams.MinTTL = 2
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
-	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+	receiveProbes := make(chan *ProbeResponse, parallelParams.MaxTTL)
 
 	// expectedTTL starts at 2 in this test
 	expectedTTL := uint8(2)
@@ -282,12 +226,12 @@ func TestParallelTracerouteMinTTL(t *testing.T) {
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		probe, ok := <-receiveProbes
 		if !ok {
-			return noData(testParams.PollFrequency)
+			return noData(parallelParams.PollFrequency)
 		}
 		return probe, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
 	require.Equal(t, expectedResults, results)
 	require.Len(t, results, mockDestTTL-1)
@@ -295,14 +239,14 @@ func TestParallelTracerouteMinTTL(t *testing.T) {
 
 func TestParallelTracerouteReportsExternalCancellation(t *testing.T) {
 	// this test checks that TracerouteParallel forwards a cancellation from the context
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	ctx, cancel := context.WithCancelCause(context.Background())
 	// cancel it right away
 	cancel(errMock)
 
-	results, err := TracerouteParallel(ctx, m, testParams)
+	results, err := TracerouteParallel(ctx, m, parallelParams)
 	require.Nil(t, results)
 	require.ErrorIs(t, err, context.Canceled)
 	require.ErrorIs(t, context.Cause(ctx), errMock)
@@ -310,11 +254,11 @@ func TestParallelTracerouteReportsExternalCancellation(t *testing.T) {
 
 func TestParallelTracerouteMissingHop(t *testing.T) {
 	// this test simulates a missing hop at TTL=3
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
-	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+	receiveProbes := make(chan *ProbeResponse, parallelParams.MaxTTL)
 
 	m.sendHandler = func(ttl uint8) error {
 		result := mockResult(ttl)
@@ -339,12 +283,12 @@ func TestParallelTracerouteMissingHop(t *testing.T) {
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		probe, ok := <-receiveProbes
 		if !ok {
-			return noData(testParams.PollFrequency)
+			return noData(parallelParams.PollFrequency)
 		}
 		return probe, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
 	require.Equal(t, expectedResults, results)
 	require.Len(t, results, mockDestTTL)
@@ -352,11 +296,11 @@ func TestParallelTracerouteMissingHop(t *testing.T) {
 
 func TestParallelTracerouteMissingDest(t *testing.T) {
 	// this test simulates not getting the destination back - it should keep sending probes until MaxTTL
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
-	receiveProbes := make(chan *ProbeResponse, testParams.MaxTTL)
+	receiveProbes := make(chan *ProbeResponse, parallelParams.MaxTTL)
 
 	m.sendHandler = func(ttl uint8) error {
 		result := mockResult(ttl)
@@ -373,7 +317,7 @@ func TestParallelTracerouteMissingDest(t *testing.T) {
 			}
 		}
 
-		if ttl == testParams.MaxTTL {
+		if ttl == parallelParams.MaxTTL {
 			close(receiveProbes)
 		}
 
@@ -382,14 +326,14 @@ func TestParallelTracerouteMissingDest(t *testing.T) {
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		probe, ok := <-receiveProbes
 		if !ok {
-			return noData(testParams.PollFrequency)
+			return noData(parallelParams.PollFrequency)
 		}
 		return probe, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
-	require.Len(t, results, int(testParams.MaxTTL))
+	require.Len(t, results, int(parallelParams.MaxTTL))
 	for i, r := range results {
 		// up to but excluding the destination TTL, we should have results
 		if i < len(expectedResults) {
@@ -404,7 +348,7 @@ func TestParallelTracerouteMissingDest(t *testing.T) {
 func TestParallelTracerouteProbeSanityCheck(t *testing.T) {
 	// this probe checks that TracerouteParallel yells at you when it reads
 	// a an invalid TTL
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	hasReceived := false
@@ -417,14 +361,14 @@ func TestParallelTracerouteProbeSanityCheck(t *testing.T) {
 		return result, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.Nil(t, results)
 	require.ErrorContains(t, err, "received an invalid TTL")
 }
 
 func TestParallelTracerouteProbeReturnValueCheck(t *testing.T) {
 	// this probe checks that TracerouteParallel yells at you when you return nothing at all
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	hasReceived := false
@@ -434,7 +378,7 @@ func TestParallelTracerouteProbeReturnValueCheck(t *testing.T) {
 		return nil, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.Nil(t, results)
 	require.ErrorContains(t, err, "ReceiveProbe() returned nil without an error")
 }
@@ -442,11 +386,11 @@ func TestParallelTracerouteProbeReturnValueCheck(t *testing.T) {
 func TestParallelTracerouteDoubleReceive(t *testing.T) {
 	// same as TestParallelTraceroute but receives the probes a second time, with a larger RTT.
 	// it should not overwrite the RTT
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
-	receiveProbes := make(chan *ProbeResponse, 2*testParams.MaxTTL)
+	receiveProbes := make(chan *ProbeResponse, 2*parallelParams.MaxTTL)
 
 	expectedTTL := uint8(1)
 	m.sendHandler = func(ttl uint8) error {
@@ -475,33 +419,33 @@ func TestParallelTracerouteDoubleReceive(t *testing.T) {
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		probe, ok := <-receiveProbes
 		if !ok {
-			return noData(testParams.PollFrequency)
+			return noData(parallelParams.PollFrequency)
 		}
 		return probe, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
 	require.Equal(t, expectedResults, results)
 	require.Len(t, results, mockDestTTL)
 }
 
-func TestCheckParallelRetryable(t *testing.T) {
-	require.True(t, CheckParallelRetryable("test", &ReceiveProbeNoPktError{fmt.Errorf("foo")}))
-	require.True(t, CheckParallelRetryable("test", &BadPacketError{fmt.Errorf("foo")}))
+func TestCheckProbeRetryable(t *testing.T) {
+	require.True(t, CheckProbeRetryable("test", &ReceiveProbeNoPktError{fmt.Errorf("foo")}))
+	require.True(t, CheckProbeRetryable("test", &BadPacketError{fmt.Errorf("foo")}))
 
-	require.False(t, CheckParallelRetryable("test", fmt.Errorf("foo")))
-	require.False(t, CheckParallelRetryable("test", nil))
+	require.False(t, CheckProbeRetryable("test", fmt.Errorf("foo")))
+	require.False(t, CheckProbeRetryable("test", nil))
 }
 
 func TestParallelTracerouteDestOverwrite(t *testing.T) {
 	// this test checks that shouldUpdate is set to true when an IsDest == true probe comes
 	// for the first time, even overwriting an ICMP probe with IsDest == false
-	m := initMockDriver(t, testParams)
+	m := initMockDriver(t, parallelParams.TracerouteParams, parallelInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
-	receiveProbes := make(chan *ProbeResponse, 2*testParams.MaxTTL)
+	receiveProbes := make(chan *ProbeResponse, 2*parallelParams.MaxTTL)
 
 	expectedTTL := uint8(1)
 	m.sendHandler = func(ttl uint8) error {
@@ -531,13 +475,23 @@ func TestParallelTracerouteDestOverwrite(t *testing.T) {
 	m.receiveHandler = func() (*ProbeResponse, error) {
 		probe, ok := <-receiveProbes
 		if !ok {
-			return noData(testParams.PollFrequency)
+			return noData(parallelParams.PollFrequency)
 		}
 		return probe, nil
 	}
 
-	results, err := TracerouteParallel(context.Background(), m, testParams)
+	results, err := TracerouteParallel(context.Background(), m, parallelParams)
 	require.NoError(t, err)
 	require.Equal(t, expectedResults, results)
 	require.Len(t, results, mockDestTTL)
+}
+
+func TestParallelSupport(t *testing.T) {
+	m := initMockDriver(t, parallelParams.TracerouteParams, TracerouteDriverInfo{
+		SupportsParallel: false,
+	})
+	t.Parallel()
+
+	_, err := TracerouteParallel(context.Background(), m, parallelParams)
+	require.ErrorContains(t, err, "doesn't support parallel")
 }

--- a/pkg/networkpath/traceroute/common/traceroute_serial.go
+++ b/pkg/networkpath/traceroute/common/traceroute_serial.go
@@ -66,8 +66,6 @@ func TracerouteSerial(ctx context.Context, t TracerouteDriver, p TracerouteSeria
 
 		// wait for at least SendDelay to pass
 		<-sendDelay
-
-		cancel()
 	}
 
 	// if we got externally cancelled, report that

--- a/pkg/networkpath/traceroute/common/traceroute_serial.go
+++ b/pkg/networkpath/traceroute/common/traceroute_serial.go
@@ -16,15 +16,9 @@ type TracerouteSerialParams struct {
 	TracerouteParams
 }
 
-// MaxTimeout combines the timeout+probe delays into a total timeout for the traceroute
-func (p TracerouteSerialParams) MaxTimeout() time.Duration {
-	delaySum := p.TracerouteTimeout * time.Duration(p.ProbeCount())
-	return delaySum
-}
-
 // TracerouteSerial runs a traceroute in serial. Sometimes this is necessary over TracerouteParallel
 // because the driver doesn't support parallel.
-func TracerouteSerial(ctx context.Context, t TracerouteDriver, p TracerouteParallelParams) ([]*ProbeResponse, error) {
+func TracerouteSerial(ctx context.Context, t TracerouteDriver, p TracerouteSerialParams) ([]*ProbeResponse, error) {
 	if err := p.validate(); err != nil {
 		return nil, err
 	}

--- a/pkg/networkpath/traceroute/common/traceroute_serial.go
+++ b/pkg/networkpath/traceroute/common/traceroute_serial.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// TracerouteSerialParams are the parameters for TracerouteSerial
+type TracerouteSerialParams struct {
+	TracerouteParams
+}
+
+// MaxTimeout combines the timeout+probe delays into a total timeout for the traceroute
+func (p TracerouteSerialParams) MaxTimeout() time.Duration {
+	delaySum := p.TracerouteTimeout * time.Duration(p.ProbeCount())
+	return delaySum
+}
+
+// TracerouteSerial runs a traceroute in serial. Sometimes this is necessary over TracerouteParallel
+// because the driver doesn't support parallel.
+func TracerouteSerial(ctx context.Context, t TracerouteDriver, p TracerouteParallelParams) ([]*ProbeResponse, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+
+	results := make([]*ProbeResponse, int(p.MaxTTL)+1)
+	for i := int(p.MinTTL); i <= int(p.MaxTTL); i++ {
+		if ctx.Err() != nil {
+			break
+		}
+		sendDelay := time.After(p.SendDelay)
+
+		start := time.Now()
+		deadline := start.Add(p.TracerouteTimeout)
+		timeoutCtx, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
+
+		err := t.SendProbe(uint8(i))
+		if err != nil {
+			return nil, fmt.Errorf("SendProbe() failed: %w", err)
+		}
+
+		var probe *ProbeResponse
+		for probe == nil {
+			if timeoutCtx.Err() != nil {
+				break
+			}
+
+			probe, err = t.ReceiveProbe(p.PollFrequency)
+			if CheckProbeRetryable("ReceiveProbe", err) {
+				continue
+			} else if err != nil {
+				return nil, fmt.Errorf("ReceiveProbe() failed: %w", err)
+			} else if err := p.validateProbe(probe); err != nil {
+				return nil, err
+			}
+		}
+
+		// if we found the destination, no need to keep going
+		if probe != nil {
+			results[probe.TTL] = probe
+			if probe.IsDest {
+				break
+			}
+		}
+
+		// wait for at least SendDelay to pass
+		<-sendDelay
+
+		cancel()
+	}
+
+	// if we got externally cancelled, report that
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	return clipResults(p.MinTTL, results), nil
+}

--- a/pkg/networkpath/traceroute/common/traceroute_serial_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_serial_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var serialParams = TracerouteParallelParams{
+var serialParams = TracerouteSerialParams{
 	TracerouteParams{
 		MinTTL:            1,
 		MaxTTL:            10,
@@ -27,7 +27,7 @@ var serialInfo = TracerouteDriverInfo{
 }
 
 func TestTracerouteSerial(t *testing.T) {
-	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	m := initMockDriver(t, serialParams.TracerouteParams, serialInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
@@ -69,7 +69,7 @@ func TestTracerouteSerial(t *testing.T) {
 }
 
 func TestTracerouteSerialMissingHop(t *testing.T) {
-	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	m := initMockDriver(t, serialParams.TracerouteParams, serialInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
@@ -116,7 +116,7 @@ func TestTracerouteSerialMissingHop(t *testing.T) {
 
 func TestTracerouteSerialWrongHop(t *testing.T) {
 	// this test checks that TracerouteSerial correctly handles a probe that returns the wrong hop
-	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	m := initMockDriver(t, serialParams.TracerouteParams, serialInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse
@@ -164,7 +164,7 @@ func TestTracerouteSerialWrongHop(t *testing.T) {
 }
 
 func TestTracerouteSerialMissingDest(t *testing.T) {
-	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	m := initMockDriver(t, serialParams.TracerouteParams, serialInfo)
 	t.Parallel()
 
 	var expectedResults []*ProbeResponse

--- a/pkg/networkpath/traceroute/common/traceroute_serial_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_serial_test.go
@@ -1,0 +1,255 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var serialParams = TracerouteParallelParams{
+	TracerouteParams{
+		MinTTL:            1,
+		MaxTTL:            10,
+		TracerouteTimeout: 100 * time.Millisecond,
+		PollFrequency:     1 * time.Millisecond,
+		SendDelay:         1 * time.Millisecond,
+	},
+}
+var serialInfo = TracerouteDriverInfo{
+	SupportsParallel: false,
+}
+
+func TestTracerouteSerial(t *testing.T) {
+	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	t.Parallel()
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, 1)
+
+	sendTTL := uint8(0)
+	m.sendHandler = func(ttl uint8) error {
+		sendTTL++
+		require.Equal(t, sendTTL, ttl)
+
+		result := mockResult(sendTTL)
+		if result != nil {
+			expectedResults = append(expectedResults, result)
+			select {
+			case receiveProbes <- result:
+			default:
+				// we expect this channel to never fill
+				t.Fatalf("TTL %d never got read by receiveHandler", sendTTL-1)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		var probe *ProbeResponse
+		select {
+		case probe = <-receiveProbes:
+		default:
+		}
+		if probe == nil {
+			return noData(serialParams.PollFrequency)
+		}
+		return probe, nil
+	}
+	results, err := TracerouteSerial(context.Background(), m, serialParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL)
+}
+
+func TestTracerouteSerialMissingHop(t *testing.T) {
+	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	t.Parallel()
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, 1)
+
+	sendTTL := uint8(0)
+	m.sendHandler = func(ttl uint8) error {
+		sendTTL++
+		require.Equal(t, sendTTL, ttl)
+
+		result := mockResult(sendTTL)
+		if result != nil {
+			// fake a missing hop
+			if ttl == 2 {
+				result = nil
+			}
+			expectedResults = append(expectedResults, result)
+			select {
+			case receiveProbes <- result:
+			default:
+				// we expect this channel to never fill
+				t.Fatalf("TTL %d never got read by receiveHandler", sendTTL-1)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		var probe *ProbeResponse
+		select {
+		case probe = <-receiveProbes:
+		default:
+		}
+		if probe == nil {
+			return noData(serialParams.PollFrequency)
+		}
+		return probe, nil
+	}
+	results, err := TracerouteSerial(context.Background(), m, serialParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL)
+}
+
+func TestTracerouteSerialWrongHop(t *testing.T) {
+	// this test checks that TracerouteSerial correctly handles a probe that returns the wrong hop
+	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	t.Parallel()
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, 1)
+
+	sendTTL := uint8(0)
+	m.sendHandler = func(ttl uint8) error {
+		sendTTL++
+		require.Equal(t, sendTTL, ttl)
+
+		result := mockResult(sendTTL)
+		if result != nil {
+			resultToRead := result
+			// send the old hop twice
+			if ttl == 2 {
+				result = nil
+				resultToRead = mockResult(sendTTL - 1)
+			}
+			expectedResults = append(expectedResults, result)
+			select {
+			case receiveProbes <- resultToRead:
+			default:
+				// we expect this channel to never fill
+				t.Fatalf("TTL %d never got read by receiveHandler", sendTTL-1)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		var probe *ProbeResponse
+		select {
+		case probe = <-receiveProbes:
+		default:
+		}
+		if probe == nil {
+			return noData(serialParams.PollFrequency)
+		}
+		return probe, nil
+	}
+	results, err := TracerouteSerial(context.Background(), m, serialParams)
+	require.NoError(t, err)
+	require.Equal(t, expectedResults, results)
+	require.Len(t, results, mockDestTTL)
+}
+
+func TestTracerouteSerialMissingDest(t *testing.T) {
+	m := initMockDriver(t, serialParams.TracerouteParams, parallelInfo)
+	t.Parallel()
+
+	var expectedResults []*ProbeResponse
+	receiveProbes := make(chan *ProbeResponse, 1)
+
+	sendTTL := uint8(0)
+	m.sendHandler = func(ttl uint8) error {
+		sendTTL++
+		require.Equal(t, sendTTL, ttl)
+
+		result := mockResult(sendTTL)
+		if result != nil {
+			// fake a missing destination
+			if result.IsDest {
+				result = nil
+			}
+			expectedResults = append(expectedResults, result)
+			select {
+			case receiveProbes <- result:
+			default:
+				// we expect this channel to never fill
+				t.Fatalf("TTL %d never got read by receiveHandler", sendTTL-1)
+			}
+		}
+
+		return nil
+	}
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		var probe *ProbeResponse
+		select {
+		case probe = <-receiveProbes:
+		default:
+		}
+		if probe == nil {
+			return noData(serialParams.PollFrequency)
+		}
+		return probe, nil
+	}
+	results, err := TracerouteSerial(context.Background(), m, serialParams)
+	require.NoError(t, err)
+
+	require.Len(t, results, int(parallelParams.MaxTTL))
+	for i, r := range results {
+		// up to but excluding the destination TTL, we should have results
+		if i < len(expectedResults) {
+			require.Equal(t, expectedResults[i], r, "mismatch at index %d", i)
+		} else {
+			// after that, it should all be zero up to MaxTTL
+			require.Zero(t, r, "expected zero at index %d", i)
+		}
+	}
+}
+
+func TestTracerouteSerialSendErr(t *testing.T) {
+	// this test checks that TracerouteSerial returns an error if SendProbe() fails
+	m := initMockDriver(t, serialParams.TracerouteParams, serialInfo)
+	t.Parallel()
+
+	hasCalled := false
+	m.sendHandler = func(_ uint8) error {
+		require.False(t, hasCalled, "SendProbe() called more than once")
+		hasCalled = true
+
+		return errMock
+	}
+
+	results, err := TracerouteSerial(context.Background(), m, serialParams)
+	require.Nil(t, results)
+	require.ErrorIs(t, err, errMock)
+}
+
+func TestTracerouteSerialReceiveErr(t *testing.T) {
+	// this test checks that TracerouteSerial returns an error if ReceiveProbe() fails
+	m := initMockDriver(t, serialParams.TracerouteParams, serialInfo)
+	t.Parallel()
+
+	hasCalled := false
+	m.receiveHandler = func() (*ProbeResponse, error) {
+		require.False(t, hasCalled, "ReceiveProbe() called more than once")
+		hasCalled = true
+
+		return nil, errMock
+	}
+
+	results, err := TracerouteSerial(context.Background(), m, serialParams)
+	require.Nil(t, results)
+	require.ErrorIs(t, err, errMock)
+}

--- a/pkg/networkpath/traceroute/common/traceroute_types.go
+++ b/pkg/networkpath/traceroute/common/traceroute_types.go
@@ -1,0 +1,158 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// ReceiveProbeNoPktError is returned when ReceiveProbe() didn't find anything new.
+// This is normal if the RTT is long
+type ReceiveProbeNoPktError struct {
+	Err error
+}
+
+func (e *ReceiveProbeNoPktError) Error() string {
+	return fmt.Sprintf("ReceiveProbe() didn't find any new packets: %s", e.Err)
+}
+func (e *ReceiveProbeNoPktError) Unwrap() error {
+	return e.Err
+}
+
+// BadPacketError is a non-fatal error that occurs when a packet is malformed.
+type BadPacketError struct {
+	Err error
+}
+
+func (e *BadPacketError) Error() string {
+	return fmt.Sprintf("Failed to parse packet: %s", e.Err)
+}
+func (e *BadPacketError) Unwrap() error {
+	return e.Err
+}
+
+// ProbeResponse is the response of a single probe in a traceroute
+type ProbeResponse struct {
+	// TTL is the Time To Live of the probe that was originally sent
+	TTL uint8
+	// IP is the IP address of the responding host
+	IP netip.Addr
+	// RTT is the round-trip time of the probe
+	RTT time.Duration
+	// IsDest is true if the responding host is the destination
+	IsDest bool
+}
+
+// TracerouteDriverInfo is metadata about a TracerouteDriver
+type TracerouteDriverInfo struct {
+	SupportsParallel bool
+}
+
+// TracerouteDriver is an implementation of traceroute send+receive of packets
+type TracerouteDriver interface {
+	// GetDriverInfo returns metadata about this driver
+	GetDriverInfo() TracerouteDriverInfo
+	// SendProbe sends a traceroute packet with a specific TTL
+	SendProbe(ttl uint8) error
+	// ReceiveProbe polls to get a traceroute response with a timeout.
+	ReceiveProbe(timeout time.Duration) (*ProbeResponse, error)
+}
+
+// TracerouteParams are the parameters for a traceroute shared between serial and parallel
+type TracerouteParams struct {
+	// MinTTL is the TTL to start the traceroute at
+	MinTTL uint8
+	// MaxTTL is the TTL to end the traceroute at
+	MaxTTL uint8
+	// TracerouteTimeout is the maximum time to wait for a response
+	TracerouteTimeout time.Duration
+	// PollFrequency is how often to poll for a response
+	PollFrequency time.Duration
+	// SendDelay is the delay between sending probes (typically small)
+	SendDelay time.Duration
+}
+
+func (p TracerouteParams) validate() error {
+	if p.MinTTL > p.MaxTTL {
+		return fmt.Errorf("min TTL must be less than or equal to max TTL")
+	}
+	if p.MinTTL < 1 {
+		return fmt.Errorf("min TTL must be at least 1")
+	}
+	return nil
+}
+
+func (p TracerouteParams) validateProbe(probe *ProbeResponse) error {
+	if probe == nil {
+		return fmt.Errorf("ReceiveProbe() returned nil without an error (this indicates a bug in the TracerouteDriver)")
+	}
+	if probe.TTL < p.MinTTL || probe.TTL > p.MaxTTL {
+		return fmt.Errorf("ReceiveProbe() received an invalid TTL: expected TTL in [%d, %d], got %d", p.MinTTL, p.MaxTTL, probe.TTL)
+	}
+	return nil
+}
+
+// ProbeCount returns the number of probes that will be sent
+func (p TracerouteParams) ProbeCount() int {
+	if p.MinTTL > p.MaxTTL {
+		return 0
+	}
+	return int(p.MaxTTL) - int(p.MinTTL) + 1
+}
+
+// clipResults removes probes before the minTTL and after the destination
+func clipResults(minTTL uint8, results []*ProbeResponse) []*ProbeResponse {
+	destIdx := slices.IndexFunc(results, func(pr *ProbeResponse) bool {
+		return pr != nil && pr.IsDest
+	})
+	// trim off anything after the destination
+	if destIdx != -1 {
+		results = slices.Clip(results[:destIdx+1])
+	}
+
+	return results[minTTL:]
+}
+
+// ToHops converts a list of ProbeResponses to a Results
+// TODO remove this, and use a single type to represent results
+func ToHops(p TracerouteParallelParams, probes []*ProbeResponse) ([]*Hop, error) {
+	if p.MinTTL != 1 {
+		return nil, fmt.Errorf("ToHops: processResults() requires MinTTL == 1")
+	}
+	hops := make([]*Hop, len(probes))
+	for i, probe := range probes {
+		hops[i] = &Hop{}
+		if probe != nil {
+			hops[i].IP = probe.IP.AsSlice()
+			hops[i].RTT = probe.RTT
+			hops[i].IsDest = probe.IsDest
+		}
+	}
+	return hops, nil
+}
+
+var badPktLimit = log.NewLogLimit(10, 5*time.Minute)
+
+// CheckProbeRetryable returns whether ReceiveProbe failed due to a real error or just an irrelevant packet
+func CheckProbeRetryable(funcName string, err error) bool {
+	noPktErr := &ReceiveProbeNoPktError{}
+	badPktErr := &BadPacketError{}
+	if errors.As(err, &noPktErr) {
+		return true
+	} else if errors.As(err, &badPktErr) {
+		if badPktLimit.ShouldLog() {
+			log.Warnf("%s() saw a malformed packet: %s", funcName, err)
+		}
+		return true
+	}
+	return false
+}

--- a/pkg/networkpath/traceroute/common/traceroute_types_test.go
+++ b/pkg/networkpath/traceroute/common/traceroute_types_test.go
@@ -1,0 +1,114 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package common
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MockDriver struct {
+	t      *testing.T
+	params TracerouteParams
+
+	sentTTLs map[uint8]struct{}
+
+	info           TracerouteDriverInfo
+	sendHandler    func(ttl uint8) error
+	receiveHandler func() (*ProbeResponse, error)
+}
+
+var parallelInfo = TracerouteDriverInfo{
+	SupportsParallel: true,
+}
+
+func initMockDriver(t *testing.T, params TracerouteParams, info TracerouteDriverInfo) *MockDriver {
+	return &MockDriver{
+		t:              t,
+		params:         params,
+		info:           info,
+		sentTTLs:       make(map[uint8]struct{}),
+		sendHandler:    nil,
+		receiveHandler: nil,
+	}
+}
+
+func (m *MockDriver) GetDriverInfo() TracerouteDriverInfo {
+	return m.info
+}
+
+func (m *MockDriver) SendProbe(ttl uint8) error {
+	require.NotContains(m.t, m.sentTTLs, ttl, "same TTL sent twice")
+	m.sentTTLs[ttl] = struct{}{}
+
+	m.t.Logf("wrote %d\n", ttl)
+	if m.sendHandler == nil {
+		return nil
+	}
+	return m.sendHandler(ttl)
+}
+
+func (m *MockDriver) ReceiveProbe(timeout time.Duration) (*ProbeResponse, error) {
+	require.Equal(m.t, m.params.PollFrequency, timeout)
+
+	if m.receiveHandler == nil {
+		return noData(timeout)
+	}
+	res, err := m.receiveHandler()
+	var errNoPkt *ReceiveProbeNoPktError
+	if !errors.As(err, &errNoPkt) {
+		m.t.Logf("read %+v, %v\n", res, err)
+	}
+	return res, err
+}
+
+func noData(pollFrequency time.Duration) (*ProbeResponse, error) {
+	time.Sleep(pollFrequency)
+	return nil, &ReceiveProbeNoPktError{Err: fmt.Errorf("testing, no data")}
+}
+
+func TestClipResultsDest(t *testing.T) {
+	results := []*ProbeResponse{
+		nil,
+		{TTL: 1, IsDest: false},
+		{TTL: 2, IsDest: false},
+		{TTL: 3, IsDest: true},
+		nil,
+	}
+
+	clipped := clipResults(1, results)
+	require.Equal(t, results[1:4], clipped)
+}
+
+func TestClipResultsNoDest(t *testing.T) {
+	results := []*ProbeResponse{
+		nil,
+		{TTL: 1, IsDest: false},
+		{TTL: 2, IsDest: false},
+		{TTL: 3, IsDest: false},
+		nil,
+	}
+
+	clipped := clipResults(1, results)
+	require.Equal(t, results[1:], clipped)
+}
+
+func TestClipResultsMinTTL(t *testing.T) {
+	results := []*ProbeResponse{
+		nil,
+		nil,
+		{TTL: 2, IsDest: false},
+		{TTL: 3, IsDest: false},
+		nil,
+	}
+
+	clipped := clipResults(2, results)
+	require.Equal(t, results[2:], clipped)
+}

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -162,11 +162,13 @@ func makeSackParams(target net.IP, targetPort uint16, maxTTL uint8, timeout time
 		return sack.Params{}, fmt.Errorf("invalid target IP")
 	}
 	parallelParams := common.TracerouteParallelParams{
-		MinTTL:            DefaultMinTTL,
-		MaxTTL:            maxTTL,
-		TracerouteTimeout: timeout,
-		PollFrequency:     100 * time.Millisecond,
-		SendDelay:         10 * time.Millisecond,
+		TracerouteParams: common.TracerouteParams{
+			MinTTL:            DefaultMinTTL,
+			MaxTTL:            maxTTL,
+			TracerouteTimeout: timeout,
+			PollFrequency:     100 * time.Millisecond,
+			SendDelay:         10 * time.Millisecond,
+		},
 	}
 	params := sack.Params{
 		Target:           netip.AddrPortFrom(targetAddr, targetPort),

--- a/pkg/networkpath/traceroute/sack/portable_sack/portable_sack.go
+++ b/pkg/networkpath/traceroute/sack/portable_sack/portable_sack.go
@@ -53,11 +53,13 @@ func main() {
 		HandshakeTimeout: 500 * time.Millisecond,
 		FinTimeout:       500 * time.Millisecond,
 		ParallelParams: common.TracerouteParallelParams{
-			MinTTL:            1,
-			MaxTTL:            30,
-			TracerouteTimeout: 1 * time.Second,
-			PollFrequency:     100 * time.Millisecond,
-			SendDelay:         10 * time.Millisecond,
+			TracerouteParams: common.TracerouteParams{
+				MinTTL:            1,
+				MaxTTL:            30,
+				TracerouteTimeout: 1 * time.Second,
+				PollFrequency:     100 * time.Millisecond,
+				SendDelay:         10 * time.Millisecond,
+			},
 		},
 		LoosenICMPSrc: true,
 	}

--- a/pkg/networkpath/traceroute/sack/sack_driver_linux.go
+++ b/pkg/networkpath/traceroute/sack/sack_driver_linux.go
@@ -288,7 +288,7 @@ func (s *sackDriver) ReadHandshake(localPort uint16) error {
 		if errors.Is(err, os.ErrDeadlineExceeded) {
 			return fmt.Errorf("sackDriver readHandshake timed out")
 			// deadline exceeded is normally retryable, so this comes second in order
-		} else if common.CheckParallelRetryable("ReadHandshake", err) {
+		} else if common.CheckProbeRetryable("ReadHandshake", err) {
 			continue
 		} else if err != nil {
 			return fmt.Errorf("sackDriver failed to readAndParse: %w", err)


### PR DESCRIPTION
Stacked on [\[NPM-4440\] Change SACK traceroute to use AF_PACKET](https://github.com/DataDog/datadog-agent/pull/36893)
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR adds TracerouteSerial which uses a TracerouteDriver to make a sequential traceroute.

### Motivation
Unfortunately this is required for TCP SYN if we want to start randomizing the packet ID like `tcptraceroute` does, because when we get back the SYNACK, the packet ID is _not_ reflected in the response. Because of this, `tcptraceroute` is fundamentally not parallelizable unless we try additional tricks like the TCP timestamp option.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
New tests + existing tests should pass:
```
go test -timeout 30s -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/common
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->