### PR TITLE
[autodiscovery/configmgr] Delete unused context from processDelService()

### DIFF
--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr.go
@@ -6,7 +6,6 @@
 package autodiscoveryimpl
 
 import (
-	"context"
 	"fmt"
 	"sync"
 
@@ -30,7 +29,7 @@ type configManager interface {
 
 	// processDelService handles removal of a service, unscheduling any configs
 	// that had been resolved for it.
-	processDelService(ctx context.Context, svc listeners.Service) integration.ConfigChanges
+	processDelService(svc listeners.Service) integration.ConfigChanges
 
 	// processNewConfig handles a new config
 	processNewConfig(config integration.Config) (integration.ConfigChanges, map[checkid.ID]checkid.ID)
@@ -148,7 +147,7 @@ func (cm *reconcilingConfigManager) processNewService(adIdentifiers []string, sv
 }
 
 // processDelService implements configManager#processDelService.
-func (cm *reconcilingConfigManager) processDelService(_ context.Context, svc listeners.Service) integration.ConfigChanges {
+func (cm *reconcilingConfigManager) processDelService(svc listeners.Service) integration.ConfigChanges {
 	cm.m.Lock()
 	defer cm.m.Unlock()
 

--- a/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
+++ b/comp/core/autodiscovery/autodiscoveryimpl/configmgr_test.go
@@ -6,7 +6,6 @@
 package autodiscoveryimpl
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -255,7 +254,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
-	changes = suite.cm.processDelService(context.TODO(), myService)
+	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 }
@@ -272,7 +271,7 @@ func (suite *ConfigManagerSuite) TestNewTemplateBeforeService_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
-	changes = suite.cm.processDelService(context.TODO(), myService)
+	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
@@ -297,7 +296,7 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ConfigRemovedFirst
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
-	changes = suite.cm.processDelService(context.TODO(), myService)
+	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 }
@@ -314,7 +313,7 @@ func (suite *ConfigManagerSuite) TestNewServiceBeforeTemplate_ServiceRemovedFirs
 	assertConfigsMatch(suite.T(), changes.Schedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 	assertConfigsMatch(suite.T(), changes.Unschedule)
 
-	changes = suite.cm.processDelService(context.TODO(), myService)
+	changes = suite.cm.processDelService(myService)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("template"), matchLogsConfig("source: myhost\n")))
 
@@ -426,7 +425,7 @@ func (suite *ConfigManagerSuite) TestFuzz() {
 						delete(services, id)
 						adIDs, _ := svc.GetADIdentifiers()
 						fmt.Printf("remove service %s with AD idents %s\n", id, strings.Join(adIDs, ", "))
-						applyChanges(cm.processDelService(context.TODO(), svc))
+						applyChanges(cm.processDelService(svc))
 						break
 					}
 					i--
@@ -530,7 +529,7 @@ func (suite *ReconcilingConfigManagerSuite) TestServiceTemplateFiltering() {
 	)
 
 	// removing a service removes only the scheduled configs
-	changes = suite.cm.processDelService(context.TODO(), filterSvc)
+	changes = suite.cm.processDelService(filterSvc)
 	assertConfigsMatch(suite.T(), changes.Schedule)
 	assertConfigsMatch(suite.T(), changes.Unschedule, matchAll(matchName("cfg2-keep"), matchSvc("filter")))
 	assertLoadedConfigsMatch(suite.T(), suite.cm,


### PR DESCRIPTION
### What does this PR do?

This PR is a simple refactor. It removes an unused context parameter from the autodiscovery code.

### Describe how you validated your changes

CI.
