### PR TITLE
Export GOTOOLCHAIN in diff go-deps task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -33,6 +33,7 @@ from tasks import (
     git,
     github_tasks,
     gitlab_helpers,
+    go,
     go_deps,
     installer,
     invoke_unit_tests,
@@ -183,6 +184,7 @@ ns.add_collection(vim)
 ns.add_collection(macos)
 ns.add_collection(epforwarder)
 ns.add_collection(fips)
+ns.add_collection(go)
 ns.add_collection(go_deps)
 ns.add_collection(linter)
 ns.add_collection(msi)

--- a/tasks/diff.py
+++ b/tasks/diff.py
@@ -14,6 +14,7 @@ from invoke.exceptions import Exit
 from tasks.build_tags import get_default_build_tags
 from tasks.flavor import AgentFlavor
 from tasks.go import GOARCH_MAPPING, GOOS_MAPPING
+from tasks.go import version as dot_go_version
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.datadog_api import create_count, send_metrics
 from tasks.libs.common.git import check_uncommitted_changes, get_commit_sha, get_current_branch
@@ -145,7 +146,12 @@ def go_deps(
                             build = details.get("build", binary)
                             build_tags = get_default_build_tags(build=build, platform=platform, flavor=flavor)
                             # need to explicitly enable CGO to also include CGO-only deps when checking different platforms
-                            env = {"GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "1"}
+                            env = {
+                                "GOOS": goos,
+                                "GOARCH": goarch,
+                                "CGO_ENABLED": "1",
+                                "GOTOOLCHAIN": f"go{dot_go_version(ctx)}",
+                            }
                             ctx.run(f"{dep_cmd} -tags \"{' '.join(build_tags)}\" > {depsfile}", env=env)
         finally:
             ctx.run(f"git checkout -q {current_branch}")

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -341,6 +341,11 @@ def tidy(ctx, verbose: bool = False):
         promise.join()
 
 
+@task(autoprint=True)
+def version(_):
+    return Path(".go-version").read_text(encoding="utf-8").strip()
+
+
 @task
 def check_go_version(ctx):
     go_version_output = ctx.run('go version')


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Export the GOTOOLCHAIN environment variable in `diff.go-deps` task.

### Motivation
The task checkouts a different branches and runs some `go` command, so when doing a Go update it will actually be running the wrong version of Go on the old branch, potentially resulting in errors or incorrect output.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Tested locally.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->