### PR TITLE
feat(renovate): Add a `stop updating` capability for renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabledManagers": ["custom.regex", "pre-commit"],
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
+    "stopUpdatingLabel": "stop-updating",
     "platformCommit": "enabled",
     "packageRules": [
       {

--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -66,7 +66,10 @@ def ask_reviews(_, pr_id):
                 (chan for team, chan in GITHUB_SLACK_REVIEW_MAP.items() if team.casefold() == reviewer.casefold()),
                 HELP_SLACK_CHANNEL,
             )
-            message = f'Hello :{random.choice(waves)}:!\n*{actor}* is asking review for PR <{pr.html_url}/s|{pr.title}>.\nCould you please have a look?\nThanks in advance!'
+            stop_updating = ""
+            if pr.user.login == "renovate[bot]" and pr.title.startswith("chore(deps): update integrations-core"):
+                stop_updating = "Add the `stop-updating` label before trying to merge this PR, to prevent it from being updated by Renovate.\n"
+            message = f'Hello :{random.choice(waves)}:!\n*{actor}* is asking review for PR <{pr.html_url}/s|{pr.title}>.\nCould you please have a look?\n{stop_updating}Thanks in advance!\n'
             if channel == HELP_SLACK_CHANNEL:
                 message = f'Hello :{random.choice(waves)}:!\nA review channel is missing for {reviewer}, can you please ask them to update `github_slack_review_map.yaml` and transfer them this review <{pr.html_url}/s|{pr.title}>?\n Thanks in advance!'
             try:


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- Add the `stopUpdatingLabel` [option](https://docs.renovatebot.com/configuration-options/#stopupdatinglabel) to our config
- Add a custom message to remind the usage of this label for `integrations-core` bump PR.

### Motivation
Prevent auto-update from renovate on the bump PR which re-triggers the ci and make integration tedious.

### Describe how you validated your changes
Tested the renovate configuration [on a test repo](https://github.com/chouetz/psychic-guacamole/pull/108)
- Prevented the update with the label
- [Validated](https://developer.mend.io/github/chouetz/psychic-guacamole/-/job/0196cd06-4420-72c1-8b3f-65471e8eaeca) no update was done despite new commits on source
```
INFO: Branch updating is skipped because stopUpdatingLabel is present in config (branch="renovate/integrations-core-digest")
```
- Tested capacity to force the update using the description tickbox
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->