### PR TITLE
[CWS-4523] fix ondemand rate limiter

### DIFF
--- a/pkg/security/probe/on_demand.go
+++ b/pkg/security/probe/on_demand.go
@@ -62,6 +62,11 @@ func (sm *OnDemandProbesManager) setHookPoints(hps []rules.OnDemandHookPoint) {
 }
 
 func (sm *OnDemandProbesManager) getHookNameFromID(id int) string {
+	if id == 0 {
+		seclog.Errorf("invalid on-demand hook ID: %d", id)
+	}
+	id-- // IDs start at 1
+
 	sm.RLock()
 	defer sm.RUnlock()
 
@@ -101,7 +106,7 @@ func (sm *OnDemandProbesManager) updateProbes() {
 		argsEditors := buildArgsEditors(hookPoint.Args)
 		argsEditors = append(argsEditors, manager.ConstantEditor{
 			Name:  "synth_id",
-			Value: uint64(hookID),
+			Value: uint64(hookID + 1),
 		})
 
 		editor := func(spec *ebpf.ProgramSpec) {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2403,8 +2403,10 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 	}
 
 	onDemandRate := rate.Inf
+	onDemandBurst := 0 // if rate is infinite, burst is not used
 	if config.RuntimeSecurity.OnDemandRateLimiterEnabled {
 		onDemandRate = MaxOnDemandEventsPerSecond
+		onDemandBurst = MaxOnDemandEventsPerSecond
 	}
 
 	ctx, cancelFnc := context.WithCancel(context.Background())
@@ -2422,7 +2424,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 		ctx:                  ctx,
 		cancelFnc:            cancelFnc,
 		newTCNetDevices:      make(chan model.NetDevice, 16),
-		onDemandRateLimiter:  rate.NewLimiter(onDemandRate, 1),
+		onDemandRateLimiter:  rate.NewLimiter(onDemandRate, onDemandBurst),
 		playSnapShotState:    atomic.NewBool(false),
 	}
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/netip"
 	"os"
@@ -2403,7 +2402,7 @@ func NewEBPFProbe(probe *Probe, config *config.Config, opts Opts) (*EBPFProbe, e
 		return nil, err
 	}
 
-	onDemandRate := rate.Limit(math.Inf(1))
+	onDemandRate := rate.Inf
 	if config.RuntimeSecurity.OnDemandRateLimiterEnabled {
 		onDemandRate = MaxOnDemandEventsPerSecond
 	}

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -132,8 +132,6 @@ func TestOnDemandChdir(t *testing.T) {
 }
 
 func TestOnDemandMprotect(t *testing.T) {
-	t.Skip("skipping mprotect test, because mprotect are too frequent globally to not trip the rate limiter")
-
 	SkipIfNotAvailable(t)
 
 	onDemands := []rules.OnDemandHookPoint{


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR:
- changes the hooks ID to start at 0. Since the eBPF constants are 0 by default, this will allow to have 0 be a strange, reportable error
- fixes the creation of the on-demand rate limiter to allow a higher burst
- re-enable mprotect on demand test (that was disabled because of the failures in the on demand rate limiter)

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->