### PR TITLE
Get check loader priorities lazily

### DIFF
--- a/pkg/collector/corechecks/loader.go
+++ b/pkg/collector/corechecks/loader.go
@@ -86,9 +86,10 @@ func (gl *GoCheckLoader) String() string {
 }
 
 func init() {
-	factory := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, error) {
-		return NewGoCheckLoader()
+	factory := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, int, error) {
+		loader, err := NewGoCheckLoader()
+		return loader, 30, err
 	}
 
-	loaders.RegisterLoader(30, factory)
+	loaders.RegisterLoader(factory)
 }

--- a/pkg/collector/loaders/loaders.go
+++ b/pkg/collector/loaders/loaders.go
@@ -21,15 +21,15 @@ import (
 // LoaderFactory helps to defer actual instantiation of Check Loaders,
 // mostly helpful with code involving calls to cgo (for example, the Python
 // interpreter might not be initialized when `init`ing a package)
-type LoaderFactory func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, error)
+type LoaderFactory func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, int, error)
 
-var factoryCatalog = make(map[int][]LoaderFactory)
+var factoryCatalog = []LoaderFactory{}
 var loaderCatalog = []check.Loader{}
 var once sync.Once
 
 // RegisterLoader adds a loader to the loaderCatalog
-func RegisterLoader(order int, factory LoaderFactory) {
-	factoryCatalog[order] = append(factoryCatalog[order], factory)
+func RegisterLoader(factory LoaderFactory) {
+	factoryCatalog = append(factoryCatalog, factory)
 }
 
 // LoaderCatalog returns the loaders sorted by desired sequence order
@@ -37,9 +37,19 @@ func LoaderCatalog(senderManager sender.SenderManager, logReceiver option.Option
 	// the catalog is supposed to be built only once, don't see a clear
 	// use case to add Loaders at runtime
 	once.Do(func() {
+		loaders := make(map[int][]check.Loader, len(factoryCatalog))
+		for _, factory := range factoryCatalog {
+			loader, order, err := factory(senderManager, logReceiver, tagger)
+			if err != nil {
+				log.Infof("Failed to instantiate %s: %v", loader, err)
+				continue
+			}
+			loaders[order] = append(loaders[order], loader)
+		}
+
 		// get the desired sequences, sorted least to greatest
 		var keys []int
-		for k := range factoryCatalog {
+		for k := range loaders {
 			keys = append(keys, k)
 		}
 		sort.Ints(keys)
@@ -47,15 +57,7 @@ func LoaderCatalog(senderManager sender.SenderManager, logReceiver option.Option
 		// use the desired sequences to access the catalog and build
 		// the final slice of loaders
 		for _, k := range keys {
-			for _, factory := range factoryCatalog[k] {
-				loader, err := factory(senderManager, logReceiver, tagger)
-				if err != nil {
-					log.Infof("Failed to instantiate %s: %v", loader, err)
-					continue
-				}
-
-				loaderCatalog = append(loaderCatalog, loader)
-			}
+			loaderCatalog = append(loaderCatalog, loaders[k]...)
 		}
 
 	})

--- a/pkg/collector/loaders/loaders_test.go
+++ b/pkg/collector/loaders/loaders_test.go
@@ -57,21 +57,21 @@ func (lt *LoaderThree) Load(_ sender.SenderManager, _ integration.Config, _ inte
 
 func TestLoaderCatalog(t *testing.T) {
 	l1 := LoaderOne{}
-	factory1 := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, error) {
-		return l1, nil
+	factory1 := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, int, error) {
+		return l1, 20, nil
 	}
 	l2 := LoaderTwo{}
-	factory2 := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, error) {
-		return l2, nil
+	factory2 := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, int, error) {
+		return l2, 10, nil
 	}
 	var l3 *LoaderThree
-	factory3 := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, error) {
-		return l3, errors.New("error")
+	factory3 := func(sender.SenderManager, option.Option[integrations.Component], tagger.Component) (check.Loader, int, error) {
+		return l3, 30, errors.New("error")
 	}
 
-	RegisterLoader(20, factory1)
-	RegisterLoader(10, factory2)
-	RegisterLoader(30, factory3)
+	RegisterLoader(factory1)
+	RegisterLoader(factory2)
+	RegisterLoader(factory3)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
 	logReceiver := option.None[integrations.Component]()
 	tagger := nooptagger.NewComponent()

--- a/pkg/collector/python/loader.go
+++ b/pkg/collector/python/loader.go
@@ -65,10 +65,11 @@ const (
 const PythonCheckLoaderName string = "python"
 
 func init() {
-	factory := func(senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component) (check.Loader, error) {
-		return NewPythonCheckLoader(senderManager, logReceiver, tagger)
+	factory := func(senderManager sender.SenderManager, logReceiver option.Option[integrations.Component], tagger tagger.Component) (check.Loader, int, error) {
+		loader, err := NewPythonCheckLoader(senderManager, logReceiver, tagger)
+		return loader, 20, err
 	}
-	loaders.RegisterLoader(20, factory)
+	loaders.RegisterLoader(factory)
 
 	configureErrors = map[string][]string{}
 	py3Linted = map[string]struct{}{}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
When registering a check loader, do not provide the priority directly but instead make it lazily returned by the factory.

### Motivation
We will soon need to pick loader priority depending on the configuration, so it can't be statically defined in an `init` function.
Having the priority returned by the factory function allows delaying the choice until the configuration is available.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
CI is enough as there should be no functional change in this PR. 

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->