### PR TITLE
[CWS] Fix DNS error: Dropping packets with a length greater than 512 + warn

### DIFF
--- a/pkg/security/ebpf/c/include/hooks/network/dns.h
+++ b/pkg/security/ebpf/c/include/hooks/network/dns.h
@@ -139,7 +139,7 @@ TAIL_CALL_CLASSIFIER_FNC(dns_response, struct __sk_buff *skb) {
     int len = pkt->payload_len;
 
     if (len > DNS_RECEIVE_MAX_LENGTH) {
-        len = DNS_RECEIVE_MAX_LENGTH;
+        return ACT_OK;
     }
 
     if(len <= sizeof(struct dnshdr)) {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1324,7 +1324,7 @@ func (p *EBPFProbe) handleEvent(CPU int, data []byte) {
 
 			var dnsLayer = new(layers.DNS)
 			if err := dnsLayer.DecodeFromBytes(data[offset:], gopacket.NilDecodeFeedback); err != nil {
-				seclog.Errorf("failed to decode DNS response: %s", err)
+				seclog.Warnf("failed to decode DNS response: %s", err)
 				return
 			}
 			p.addToDNSResolver(dnsLayer)


### PR DESCRIPTION
### What does this PR do?

* Drop every message > 512 bytes even if it's not flagged as tc (truncated).

* Change error to a warning

### Motivation

It appears that we have non-truncated eDNS messages (under investigation) and this is causing problems with our parser.
