### PR TITLE
Skip a flaky otel-agent test on Windows

### DIFF
--- a/cmd/otel-agent/main_test.go
+++ b/cmd/otel-agent/main_test.go
@@ -9,12 +9,16 @@ package main
 
 import (
 	"os/exec"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestExitCode_Disabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test takes too long and is flaky on Windows")
+	}
 	t.Setenv("DD_OTELCOLLECTOR_ENABLED", "false")
 	cmd := exec.Command("go", "run", "-tags", "otlp", "main.go", "--config", "test_config.yaml")
 	err := cmd.Run()


### PR DESCRIPTION
### What does this PR do?
This test is highly flaky on Windows, possibly due to it takes too long to build the otel-agent binary within the 3min timeout. There are other tests covering the code path so it is fine to skip on Windows

### Motivation
[#incident-38355](https://dd.enterprise.slack.com/archives/C08S492TGT0)

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->