### PR TITLE
[CONTINT-4688] Better document the potential impact of using FQDN

### DIFF
--- a/comp/logs/agent/config/config_test.go
+++ b/comp/logs/agent/config/config_test.go
@@ -583,7 +583,7 @@ func (suite *ConfigTestSuite) TestEndpointsSetDDSite() {
 		configSettingPath:      "api_key",
 		isAdditionalEndpoint:   false,
 		additionalEndpointsIdx: 0,
-		Host:                   "default-intake.logs.mydomain.com.",
+		Host:                   "default-intake.logs.mydomain.com",
 		Port:                   0,
 		useSSL:                 true,
 		UseCompression:         true,

--- a/comp/trace/config/config_test.go
+++ b/comp/trace/config/config_test.go
@@ -206,7 +206,7 @@ func TestTelemetryEndpointsConfig(t *testing.T) {
 
 		assert.True(t, cfg.TelemetryConfig.Enabled)
 		assert.Len(t, cfg.TelemetryConfig.Endpoints, 1)
-		assert.Equal(t, "https://instrumentation-telemetry-intake.new_site.example.com.", cfg.TelemetryConfig.Endpoints[0].Host)
+		assert.Equal(t, "https://instrumentation-telemetry-intake.new_site.example.com", cfg.TelemetryConfig.Endpoints[0].Host)
 	})
 
 	t.Run("additional-hosts", func(t *testing.T) {
@@ -835,7 +835,7 @@ func TestLoadEnv(t *testing.T) {
 		cfg := config.Object()
 
 		assert.NotNil(t, cfg)
-		assert.Equal(t, apiEndpointPrefix+"my-site.com.", cfg.Endpoints[0].Host)
+		assert.Equal(t, apiEndpointPrefix+"my-site.com", cfg.Endpoints[0].Host)
 	})
 
 	env = "DD_APM_ENABLED"

--- a/pkg/config/utils/endpoints.go
+++ b/pkg/config/utils/endpoints.go
@@ -168,10 +168,15 @@ func GetMultipleEndpoints(c pkgconfigmodel.Reader) (map[string][]APIKeys, error)
 	return mergeAdditionalEndpoints(keysPerDomain, additionalEndpoints)
 }
 
-// BuildURLWithPrefix will return an HTTP(s) URL for a site given a certain prefix
+var wellKnownSitesRe = regexp.MustCompile(`(?:datadoghq|datad0g)\.(?:com|eu)$|ddog-gov\.com$`)
+
+// BuildURLWithPrefix will return an HTTP(s) URL for a site given a certain prefix.
+// If the site is a datadog well-known one, it is suffixed with a dot to make it a FQDN.
+// Using FQDN will prevent useless DNS queries built with the search domains of `/etc/resolv.conf`.
+// https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site
 func BuildURLWithPrefix(prefix, site string) string {
 	site = strings.TrimSpace(site)
-	if !strings.HasSuffix(site, ".") {
+	if wellKnownSitesRe.MatchString(site) && !strings.HasSuffix(site, ".") {
 		site += "."
 	}
 	return prefix + site

--- a/pkg/process/runner/endpoints_test.go
+++ b/pkg/process/runner/endpoints_test.go
@@ -122,8 +122,8 @@ func TestGetAPIEndpointsSite(t *testing.T) {
 		{
 			name:                   "site only",
 			site:                   "datadoghq.io",
-			expectedHostname:       "process.datadoghq.io.",
-			expectedEventsHostname: "process-events.datadoghq.io.",
+			expectedHostname:       "process.datadoghq.io",
+			expectedEventsHostname: "process-events.datadoghq.io",
 		},
 		{
 			name:                   "dd_url only",

--- a/releasenotes/notes/no-useless-DNS-queries-1ed8ff14e0684da1.yaml
+++ b/releasenotes/notes/no-useless-DNS-queries-1ed8ff14e0684da1.yaml
@@ -6,6 +6,12 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
+upgrade:
+  - |
+    In order to avoid useless DNS queries, the agent now uses FQDN when connecting to datadog intakes.
+    Concretely, it adds a trailing dot at the end of the datadog intake hostnames.
+    While this change should be transparent to most users, it can have an impact when the agent is deployed on intrusive setups where the connections between the agent and the datadog intakes are intercepted by a proxy or a firewall that is doing deep packet inspection or TLS man-in-the-middle.
+    Users that have such a proxy or L7 firewall should ensure that the rules for agent connections to ``*.datadoghq.com`` hosts are also valid for connections to ``*.datadoghq.com.`` (with an additional trailing dot) hosts.
 fixes:
   - |
     Use FQDNs when the Agent builds intake hostnames with ``DD_SITE`` to prevent generating as many DNS queries as there are entries in the ``search`` section of the ``/etc/resolv.conf` file.

--- a/releasenotes/notes/no-useless-DNS-queries-1ed8ff14e0684da1.yaml
+++ b/releasenotes/notes/no-useless-DNS-queries-1ed8ff14e0684da1.yaml
@@ -8,9 +8,9 @@
 ---
 upgrade:
   - |
-    In order to avoid useless DNS queries, the agent now uses FQDN when connecting to datadog intakes.
-    Concretely, it adds a trailing dot at the end of the datadog intake hostnames.
-    While this change should be transparent to most users, it can have an impact when the agent is deployed on intrusive setups where the connections between the agent and the datadog intakes are intercepted by a proxy or a firewall that is doing deep packet inspection or TLS man-in-the-middle.
+    In order to avoid unnecessary DNS queries, the agent now uses FQDN when connecting to Datadog intakes.
+    Specifically, it adds a trailing dot at the end of the Datadog intake hostnames.
+While most users may not notice this change, it can affect setups where connections between the agent and Datadog intakes are intercepted for deep pocket inspection or TLS man-in-the-middle by proxies or firewalls.
     Users that have such a proxy or L7 firewall should ensure that the rules for agent connections to ``*.datadoghq.com`` hosts are also valid for connections to ``*.datadoghq.com.`` (with an additional trailing dot) hosts.
 fixes:
   - |

--- a/releasenotes/notes/no-useless-DNS-queries-1ed8ff14e0684da1.yaml
+++ b/releasenotes/notes/no-useless-DNS-queries-1ed8ff14e0684da1.yaml
@@ -10,7 +10,7 @@ upgrade:
   - |
     In order to avoid unnecessary DNS queries, the agent now uses FQDN when connecting to Datadog intakes.
     Specifically, it adds a trailing dot at the end of the Datadog intake hostnames.
-While most users may not notice this change, it can affect setups where connections between the agent and Datadog intakes are intercepted for deep pocket inspection or TLS man-in-the-middle by proxies or firewalls.
+    While most users may not notice this change, it can affect setups where connections between the agent and Datadog intakes are intercepted for deep packet inspection or TLS man-in-the-middle by proxies or firewalls.
     Users that have such a proxy or L7 firewall should ensure that the rules for agent connections to ``*.datadoghq.com`` hosts are also valid for connections to ``*.datadoghq.com.`` (with an additional trailing dot) hosts.
 fixes:
   - |


### PR DESCRIPTION
### What does this PR do?

* Better document the potential impact of using FQDN for the datadog intakes.
* Silently convert intake hostnames to FQDN only for well-known sites.

### Motivation

Better anticipate issues that customers that put a proxy between the agent and the intakes might face.

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

* Follow-up of #36644.