### PR TITLE
[AGENTRUN-309] make GetAllInstanceIDs private as no usage outside of the component 

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -332,21 +332,6 @@ func (c *collectorImpl) GetChecks() []check.Check {
 	return chks
 }
 
-// GetAllInstanceIDs returns the ID's of all instances of a check
-func (c *collectorImpl) GetAllInstanceIDs(checkName string) []checkid.ID {
-	c.m.RLock()
-	defer c.m.RUnlock()
-
-	instances := []checkid.ID{}
-	for id, check := range c.checks {
-		if check.String() == checkName {
-			instances = append(instances, id)
-		}
-	}
-
-	return instances
-}
-
 // ReloadAllCheckInstances completely restarts a check with a new configuration and returns a list of killed check IDs
 func (c *collectorImpl) ReloadAllCheckInstances(name string, newInstances []check.Check) ([]checkid.ID, error) {
 	if !c.started() {
@@ -354,7 +339,7 @@ func (c *collectorImpl) ReloadAllCheckInstances(name string, newInstances []chec
 	}
 
 	// Stop all the old instances
-	killed := c.GetAllInstanceIDs(name)
+	killed := c.getAllInstanceIDs(name)
 	for _, id := range killed {
 		e := c.StopCheck(id)
 		if e != nil {
@@ -370,4 +355,19 @@ func (c *collectorImpl) ReloadAllCheckInstances(name string, newInstances []chec
 		}
 	}
 	return killed, nil
+}
+
+// getAllInstanceIDs returns the ID's of all instances of a check
+func (c *collectorImpl) getAllInstanceIDs(checkName string) []checkid.ID {
+	c.m.RLock()
+	defer c.m.RUnlock()
+
+	instances := []checkid.ID{}
+	for id, check := range c.checks {
+		if check.String() == checkName {
+			instances = append(instances, id)
+		}
+	}
+
+	return instances
 }

--- a/comp/collector/collector/collectorimpl/collector_mock.go
+++ b/comp/collector/collector/collectorimpl/collector_mock.go
@@ -77,11 +77,6 @@ func (c *mockimpl) GetChecks() []check.Check {
 	return nil
 }
 
-// GetAllInstanceIDs returns the ID's of all instances of a check
-func (c *mockimpl) GetAllInstanceIDs(_ string) []checkid.ID {
-	return nil
-}
-
 // ReloadAllCheckInstances completely restarts a check with a new configuration
 func (c *mockimpl) ReloadAllCheckInstances(_ string, _ []check.Check) ([]checkid.ID, error) {
 	return []checkid.ID{checkid.ID("")}, nil

--- a/comp/collector/collector/collectorimpl/collector_test.go
+++ b/comp/collector/collector/collectorimpl/collector_test.go
@@ -214,7 +214,7 @@ func (suite *CollectorTestSuite) TestStarted() {
 	assert.False(suite.T(), suite.c.started())
 }
 
-func (suite *CollectorTestSuite) TestGetAllInstanceIDs() {
+func (suite *CollectorTestSuite) TestgetAllInstanceIDs() {
 	// Schedule 2 instances of TestCheck1 and 1 instance of TestCheck2
 	ch1 := NewCheckUnique("foo", "TestCheck1")
 	ch2 := NewCheckUnique("bar", "TestCheck1")
@@ -230,7 +230,7 @@ func (suite *CollectorTestSuite) TestGetAllInstanceIDs() {
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 3, len(suite.c.checks))
 
-	ids := suite.c.GetAllInstanceIDs("TestCheck1")
+	ids := suite.c.getAllInstanceIDs("TestCheck1")
 	assert.Equal(suite.T(), 2, len(ids))
 	sort.Sort(ChecksList(ids))
 	expected := []checkid.ID{"bar", "foo"}

--- a/comp/collector/collector/component.go
+++ b/comp/collector/collector/component.go
@@ -40,8 +40,6 @@ type Component interface {
 	MapOverChecks(cb func([]check.Info))
 	// GetChecks copies checks
 	GetChecks() []check.Check
-	// GetAllInstanceIDs returns the ID's of all instances of a check
-	GetAllInstanceIDs(checkName string) []checkid.ID
 	// ReloadAllCheckInstances completely restarts a check with a new configuration and returns a list of killed check IDs
 	ReloadAllCheckInstances(name string, newInstances []check.Check) ([]checkid.ID, error)
 	// AddEventReceiver adds a callback to the collector to be called each time a check is added or removed.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Make the `GetAllInstanceIDs` public function from the collector private. The function is only used inside the component. 

### Motivation

Having less API surface for components is desirable, that way future changes to the component would be easier to perform 

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->