### PR TITLE
[AMCC-28] dogstatsd: do not ack a config that has been reported as an error

### DIFF
--- a/comp/dogstatsd/server/rc.go
+++ b/comp/dogstatsd/server/rc.go
@@ -55,6 +55,14 @@ func (s *server) onBlocklistUpdateCallback(updates map[string]state.RawConfig, a
 			s.log.Errorf("can't unmarshal received blocklist config: %v", err)
 			continue
 		}
+
+		// from here, the configuration is usable
+		applyStateCallback(configPath, state.ApplyStatus{
+			State: state.ApplyStateAcknowledged,
+		})
+
+		// this one has no metric in its list, strange but
+		// not an error
 		if len(config.BlockedMetrics.ByName.Metrics) == 0 {
 			s.log.Debug("received a blocklist configuration with no metrics")
 			continue
@@ -78,12 +86,5 @@ func (s *server) onBlocklistUpdateCallback(updates map[string]state.RawConfig, a
 	} else {
 		// special case: if the metric names list is empty, fallback to local
 		s.restoreBlocklistFromLocalConfig()
-	}
-
-	// ack the processing of the updates to RC
-	for configPath := range updates {
-		applyStateCallback(configPath, state.ApplyStatus{
-			State: state.ApplyStateAcknowledged,
-		})
 	}
 }

--- a/comp/dogstatsd/server/rc_test.go
+++ b/comp/dogstatsd/server/rc_test.go
@@ -1,0 +1,131 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package server implements a component to run the dogstatsd server
+package server
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/listeners"
+
+	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
+)
+
+// to validate the outcome of running the config update,
+// the callback will update this object
+type updateRes map[state.ApplyState][]string
+
+type resultTester struct {
+	Acked    int
+	Unacked  int
+	Errors   int
+	Unknowns int
+}
+
+// Validating that the Agent isn't crashing on malformed updates.
+func TestMalformedBlocklistUpdate(t *testing.T) {
+	require := require.New(t)
+	test := func(results updateRes, tester resultTester) {
+		require.Len(results[state.ApplyStateAcknowledged], tester.Acked, "wrong amount of acked")
+		require.Len(results[state.ApplyStateUnacknowledged], tester.Unacked, "wrong amount of unacked")
+		require.Len(results[state.ApplyStateError], tester.Errors, "wrong amount of errors")
+		require.Len(results[state.ApplyStateUnknown], tester.Unknowns, "wrong amount of unknowns")
+	}
+	reset := func() updateRes { return updateRes{} }
+
+	cfg := make(map[string]interface{})
+	cfg["dogstatsd_port"] = listeners.RandomPortName
+
+	deps := fulfillDepsWithConfigOverride(t, cfg)
+	s := deps.Server.(*server)
+
+	results := reset()
+
+	callback := func(path string, status state.ApplyStatus) {
+		results[status.State] = append(results[status.State], path)
+	}
+
+	// this call should fail because the content is malformed
+	updates := map[string]state.RawConfig{
+		"first": {Config: []byte(`malformedjson":{}}`)},
+	}
+	s.onBlocklistUpdateCallback(updates, callback)
+	test(results, resultTester{
+		Acked:    0,
+		Unacked:  0,
+		Errors:   1,
+		Unknowns: 0,
+	})
+	results = reset()
+
+	// both of these should fail
+	updates = map[string]state.RawConfig{
+		"first":  {Config: []byte(`malformedjson":{}}`)},
+		"second": {Config: []byte(`malformedjson":{}}`)},
+	}
+	s.onBlocklistUpdateCallback(updates, callback)
+	test(results, resultTester{
+		Acked:    0,
+		Unacked:  0,
+		Errors:   2,
+		Unknowns: 0,
+	})
+	results = reset()
+
+	// one is incorrect json, the other is an unknown struct we don't know
+	// how to interpret, but that'll still be processed without errors (acked)
+	updates = map[string]state.RawConfig{
+		"first":  {Config: []byte(`malformedjson":{}}`)},
+		"second": {Config: []byte(`{"random":"json","field":[]}`)},
+	}
+	s.onBlocklistUpdateCallback(updates, callback)
+	test(results, resultTester{
+		Acked:    1,
+		Unacked:  0,
+		Errors:   1,
+		Unknowns: 0,
+	})
+	results = reset()
+
+	// two correct ones, with one metric
+	updates = map[string]state.RawConfig{
+		"first":  {Config: []byte(`{"blocking_metrics":{"by_name":["hello","world"]}`)},
+		"second": {Config: []byte(`{"random":"json","field":[]}`)},
+	}
+	s.onBlocklistUpdateCallback(updates, callback)
+	test(results, resultTester{
+		Acked:    1,
+		Unacked:  0,
+		Errors:   1,
+		Unknowns: 0,
+	})
+	results = reset()
+
+	// nothing
+	updates = map[string]state.RawConfig{}
+	s.onBlocklistUpdateCallback(updates, callback)
+	test(results, resultTester{
+		Acked:    0,
+		Unacked:  0,
+		Errors:   0,
+		Unknowns: 0,
+	})
+	results = reset()
+
+	// one config but empty, it should be unparseable
+	updates = map[string]state.RawConfig{
+		"first": {Config: []byte("")},
+	}
+	s.onBlocklistUpdateCallback(updates, callback)
+	test(results, resultTester{
+		Acked:    0,
+		Unacked:  0,
+		Errors:   1,
+		Unknowns: 0,
+	})
+	results = reset()
+}


### PR DESCRIPTION
### What does this PR do?

* Do not `Acknowledge` a config which has already been reported as an error.
* Add unit tests validating that even malformed payloads are processed without problem

## QA

Manually validated with the same plan as #36761 