### PR TITLE
[DI] Add notion of associating procs to the version of dd-trace-go callback they have

### DIFF
--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -498,3 +498,4 @@ type FuncByPCEntry struct {
 // RemoteConfigCallback is the name of the function in dd-trace-go which we hook for retrieving
 // probe configurations
 const RemoteConfigCallback = "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.passProbeConfiguration"
+const RemoteConfigCallbackV2 = "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.passProbeConfiguration"

--- a/pkg/dynamicinstrumentation/ditypes/analysis.go
+++ b/pkg/dynamicinstrumentation/ditypes/analysis.go
@@ -495,7 +495,10 @@ type FuncByPCEntry struct {
 	Line       int64
 }
 
-// RemoteConfigCallback is the name of the function in dd-trace-go which we hook for retrieving
+// RemoteConfigCallback is the name of the function in dd-trace-go v1 which we hook for retrieving
 // probe configurations
 const RemoteConfigCallback = "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer.passProbeConfiguration"
+
+// RemoteConfigCallbackV2 is the name of the function in dd-trace-go v2 which we hook for retrieving
+// probe configurations
 const RemoteConfigCallbackV2 = "github.com/DataDog/dd-trace-go/v2/ddtrace/tracer.passProbeConfiguration"

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -308,7 +308,9 @@ type ProcessInfo struct {
 type DDTraceGoVersion byte
 
 const (
+	// DDTraceGoVersionV1 represents that the process is using dd-trace-go v1
 	DDTraceGoVersionV1 DDTraceGoVersion = iota + 1
+	// DDTraceGoVersionV2 represents that the process is using dd-trace-go v2
 	DDTraceGoVersionV2
 )
 

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -305,6 +305,7 @@ type ProcessInfo struct {
 	DDTracegoVersion       DDTraceGoVersion
 }
 
+// DDTraceGoVersion is the version of dd-trace-go that is used by the process
 type DDTraceGoVersion byte
 
 const (

--- a/pkg/dynamicinstrumentation/ditypes/config.go
+++ b/pkg/dynamicinstrumentation/ditypes/config.go
@@ -302,7 +302,15 @@ type ProcessInfo struct {
 	ProbesByID             *ProbesByID
 	InstrumentationUprobes *InstrumentationUprobesMap
 	InstrumentationObjects *InstrumentationObjectsMap
+	DDTracegoVersion       DDTraceGoVersion
 }
+
+type DDTraceGoVersion byte
+
+const (
+	DDTraceGoVersionV1 DDTraceGoVersion = iota + 1
+	DDTraceGoVersionV2
+)
 
 // SetupConfigUprobe sets the configuration probe for the process
 func (pi *ProcessInfo) SetupConfigUprobe() (*ebpf.Map, error) {

--- a/pkg/dynamicinstrumentation/proctracker/proctracker.go
+++ b/pkg/dynamicinstrumentation/proctracker/proctracker.go
@@ -77,7 +77,7 @@ func (pt *ProcessTracker) Stop() {
 func (pt *ProcessTracker) handleProcessStart(pid uint32) {
 	exePath := kernel.HostProc(strconv.Itoa(int(pid)), "exe")
 	log.Tracef("Handling process start for %d %s", pid, exePath)
-	go pt.inspectBinary(exePath, pid)
+	go pt.inspectBinaryForRegistration(exePath, pid)
 }
 
 func (pt *ProcessTracker) handleProcessStop(pid uint32) {
@@ -115,7 +115,7 @@ func remoteConfigCallback(_ delve.GoVersion, goarch string) ([]bininspect.Parame
 		}}, nil
 }
 
-func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
+func (pt *ProcessTracker) inspectBinaryForRegistration(exePath string, pid uint32) {
 	log.Tracef("Inspecting binary for %d %s", pid, exePath)
 	// Avoid self-inspection.
 	if int(pid) == os.Getpid() {
@@ -153,10 +153,24 @@ func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
 			ParamLookupFunction:    remoteConfigCallback,
 		},
 	}
+
+	var ddtracegoVersion = ditypes.DDTraceGoVersionV1
 	_, err = bininspect.InspectNewProcessBinary(elfFile, functionsConfig, noStructs)
 	if err != nil {
 		log.Errorf("error reading binary for %d %s: %s, %s", pid, serviceName, binPath, err)
-		return
+
+		// Since dd-trace-go v2 has a different import path (therefore different symbol name) for the remote config callback, we need to handle both cases.
+		functionsConfig[ditypes.RemoteConfigCallbackV2] = bininspect.FunctionConfiguration{
+			IncludeReturnLocations: false,
+			ParamLookupFunction:    remoteConfigCallback,
+		}
+		delete(functionsConfig, ditypes.RemoteConfigCallback)
+		_, err = bininspect.InspectNewProcessBinary(elfFile, functionsConfig, noStructs)
+		if err != nil {
+			log.Errorf("error reading binary for %d %s: %s, %s", pid, serviceName, binPath, err)
+			return
+		}
+		ddtracegoVersion = ditypes.DDTraceGoVersionV2
 	}
 
 	var stat syscall.Stat_t
@@ -170,10 +184,10 @@ func (pt *ProcessTracker) inspectBinary(exePath string, pid uint32) {
 		Ino:      stat.Ino,
 	}
 	log.Infof("Found instrumentation candidate for %d %s", pid, serviceName)
-	pt.registerProcess(binID, pid, stat.Mtim, binPath, serviceName)
+	pt.registerProcess(binID, pid, stat.Mtim, binPath, serviceName, ddtracegoVersion)
 }
 
-func (pt *ProcessTracker) registerProcess(binID binaryID, pid pid, mTime syscall.Timespec, binaryPath string, serviceName string) {
+func (pt *ProcessTracker) registerProcess(binID binaryID, pid pid, mTime syscall.Timespec, binaryPath string, serviceName string, ddtracegoVersion ditypes.DDTraceGoVersion) {
 	pt.lock.Lock()
 	defer pt.lock.Unlock()
 
@@ -184,11 +198,12 @@ func (pt *ProcessTracker) registerProcess(binID binaryID, pid pid, mTime syscall
 	} else {
 
 		pt.binaries[binID] = &runningBinary{
-			binID:        binID,
-			mTime:        mTime,
-			processCount: 1,
-			binaryPath:   binaryPath,
-			serviceName:  serviceName,
+			binID:            binID,
+			mTime:            mTime,
+			processCount:     1,
+			binaryPath:       binaryPath,
+			serviceName:      serviceName,
+			ddtracegoVersion: ddtracegoVersion,
 		}
 	}
 	state := pt.currentState()
@@ -247,6 +262,7 @@ func (pt *ProcessTracker) currentState() map[ditypes.PID]*ditypes.ProcessInfo {
 			ProbesByID:             ditypes.NewProbesByID(),
 			InstrumentationUprobes: ditypes.NewInstrumentationUprobesMap(),
 			InstrumentationObjects: ditypes.NewInstrumentationObjectsMap(),
+			DDTracegoVersion:       bin.ddtracegoVersion,
 		}
 	}
 	return state

--- a/pkg/dynamicinstrumentation/proctracker/types.go
+++ b/pkg/dynamicinstrumentation/proctracker/types.go
@@ -10,6 +10,7 @@ package proctracker
 import (
 	"syscall"
 
+	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/ditypes"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/gotls"
 )
 
@@ -37,6 +38,9 @@ type runningBinary struct {
 	// on the same machine. However, for simplicity in the prototype we
 	// assume a 1:1 mapping.
 	serviceName string
+
+	// The version of dd-trace-go that is used to instrument the binary.
+	ddtracegoVersion ditypes.DDTraceGoVersion
 }
 
 type binaries map[binaryID]*runningBinary

--- a/pkg/dynamicinstrumentation/testutil/sample/sample_service/sample_service.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/sample_service/sample_service.go
@@ -38,8 +38,12 @@ func main() {
 			ddAgentHost = "localhost"
 		}
 		// Start the tracer and defer the Stop method.
-		tracer.Start(tracer.WithAgentAddr(net.JoinHostPort(ddAgentHost, "8126")),
+		err := tracer.Start(tracer.WithAgentAddr(net.JoinHostPort(ddAgentHost, "8126")),
 			tracer.WithDebugMode(true))
+		if err != nil {
+			log.Printf("error starting tracer: %s", err)
+		}
+		defer tracer.Stop()
 	}
 
 	ticker := time.NewTicker(time.Second / 2)

--- a/pkg/dynamicinstrumentation/testutil/sample/sample_service/sample_service.go
+++ b/pkg/dynamicinstrumentation/testutil/sample/sample_service/sample_service.go
@@ -14,7 +14,7 @@ import (
 	"os/signal"
 	"time"
 
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"github.com/DataDog/dd-trace-go/v2/ddtrace/tracer"
 
 	"github.com/DataDog/datadog-agent/pkg/dynamicinstrumentation/testutil/sample"
 )


### PR DESCRIPTION
### What does this PR do?

Dynamic instrumentation gets configurations from services it's instrumenting via a callback function in services that it attaches a bpf program to. That function is one in dd-trace-go. With dd-trace-go v2 being released, the callbacks import path, and therefore it's symbol name, has changed. This PR adds a fix to account for supporting both.

### Motivation

Future proofing support for services with dd-trace-go v2

### Describe how you validated your changes

e2e testing with new dd-trace-go version

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->