### PR TITLE
Guard against displaying fips-proxy configuration in datadog-fips-agent status output

### DIFF
--- a/comp/core/status/statusimpl/common_header_provider.go
+++ b/comp/core/status/statusimpl/common_header_provider.go
@@ -109,9 +109,14 @@ func populateConfig(config config.Component) map[string]string {
 	conf["confd_path"] = config.GetString("confd_path")
 	conf["additional_checksd"] = config.GetString("additional_checksd")
 
-	conf["fips_enabled"] = config.GetString("fips.enabled")
-	conf["fips_local_address"] = config.GetString("fips.local_address")
-	conf["fips_port_range_start"] = config.GetString("fips.port_range_start")
+	// fips.Enabled() returns true for datadog-fips-agent builds which is incompatible for use with the fips-proxy
+	// so we need to guard against displaying the fips-proxy configuration in the header since it is ignored
+	fipsBuildFlavor, _ := fips.Enabled()
+	if !fipsBuildFlavor {
+		conf["fips_enabled"] = config.GetString("fips.enabled")
+		conf["fips_local_address"] = config.GetString("fips.local_address")
+		conf["fips_port_range_start"] = config.GetString("fips.port_range_start")
+	}
 
 	return conf
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The `datadog-fips-agent` isn't compatible for use with the `fips-proxy` and [we guard](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/setup/config.go#L2186) against configuring it.

However we did not guard against displaying the configuration on the `agent status` output. This PR prevents the configuration that is not used from being displayed.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

Manually with a build and toggling the configuration.

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->