### PR TITLE
[DEBUG-3885] dyninst/ir: straw-man pass at a di IR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -465,6 +465,7 @@
 /pkg/diagnose/ports/*windows*.go        @DataDog/windows-agent
 /pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
 /pkg/dynamicinstrumentation/            @DataDog/debugger-go
+/pkg/dyninst/                           @DataDog/debugger-go
 /pkg/flare/                             @DataDog/agent-configuration
 /pkg/flare/clusteragent/manifests.go    @DataDog/container-ecosystems @DataDog/agent-configuration
 /pkg/flare/*_win.go                     @Datadog/windows-agent @DataDog/agent-configuration

--- a/pkg/dyninst/doc.go
+++ b/pkg/dyninst/doc.go
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package dyninst contains the implementation of the dynamic instrumentation as
+// provided by the agent that supports such products as Live Debugger and
+// Dynamic Instrumentation for Go.
+package dyninst

--- a/pkg/dyninst/ir/doc.go
+++ b/pkg/dyninst/ir/doc.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package ir contains a representation of probes as applied
+// to a specific binary.
+//
+// The key data structure is ir.Program, which represents all the
+// information needed to describe the set of probes that will be
+// connected to a single binary.
+package ir

--- a/pkg/dyninst/ir/expression.go
+++ b/pkg/dyninst/ir/expression.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ir
+
+// Expression is a typed and validated set of operations for compilation
+// and evaluation.
+type Expression struct {
+	// The type of the expression.
+	Type Type
+	// The operations that make up the expression, in reverse-polish notation.
+	Operations []Op
+}
+
+var (
+	_ Op = (*LocationOp)(nil)
+)
+
+// Op is an operation that can be performed on an expression.
+type Op interface {
+	irOp() // marker
+}
+
+// LocationOp references data of Size bytes
+// at Offset in Variable.
+type LocationOp struct {
+	// The variable that is referenced.
+	Variable *Variable
+
+	// The offset in bytes from the start of the variable to extract.
+	Offset uint32
+
+	// The size of the data to extract in bytes.
+	Size uint32
+}
+
+func (LocationOp) irOp() {}
+
+// TODO: Define expressions as needed for probe generation.

--- a/pkg/dyninst/ir/program.go
+++ b/pkg/dyninst/ir/program.go
@@ -1,0 +1,144 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ir
+
+import "github.com/DataDog/datadog-agent/pkg/network/go/bininspect"
+
+// ProgramID is a ID corresponding to an instance of a Program.  It is used to
+// identify messages from this program as they are communicated over the ring
+// buffer.
+type ProgramID uint32
+
+// TypeID is a ID corresponding to a type in a program.
+type TypeID uint32
+
+// EventID is a ID corresponding to an event output by the program.  It is used
+// to identify events as they are communicated over the ring buffer.
+type EventID uint32
+
+// Program defines the information needed to generate an eBPF program for a set
+// of probes as they apply to a specific binary. This structure is used to drive
+// both eBPF program generation and the interpretation of data that comes out of
+// the generated program.
+type Program struct {
+	// ID is the ID of the program. This is used to identify messages from this
+	// program as they are communicated over the ring buffer.
+	ID ProgramID
+	// Probes are the set of probes that comprise the program.
+	Probes []*Probe
+	// Subprograms are a list of subprograms that will be probed.
+	Subprograms []*Subprogram
+	// Types are the types that are used in the program.
+	Types []Type
+	// MaxTypeID is the maximum type ID that has been assigned.
+	MaxTypeID TypeID
+}
+
+// Subprogram represents a function or method in the program.
+type Subprogram struct {
+	// Name is the name of the subprogram.
+	Name string
+	// OutOfLinePCRanges are the ranges of PC values that will be probed for the
+	// out-of-line-instances of the subprogram. These are sorted by start PC.
+	//
+	// What does this mean for inlined subprograms?
+	OutOfLinePCRanges []PCRange
+	// InlinePCRanges are the ranges of PC values that will be probed for the
+	// inlined instances of the subprogram. These are sorted by start PC.
+	InlinePCRanges [][]PCRange
+	// Variables are the variables that are used in the subprogram.
+	Variables []Variable
+	// Lines are the lines of the subprogram.
+	Lines []SubprogramLine
+}
+
+// SubprogramLine represents a line in the subprogram.
+type SubprogramLine struct {
+	PC              uint64
+	File            string
+	Line            uint32
+	Column          uint32
+	IsStatement     bool
+	IsPrologueEnd   bool
+	IsEpilogueStart bool
+}
+
+// Variable represents a variable or parameter in the subprogram.
+type Variable struct {
+	// Name is the name of the variable.
+	Name string
+	// Type is the type of the variable.
+	Type Type
+	// Locations are the locations of the variable in the subprogram.
+	Locations []Location
+	// IsParameter is true if the variable is a parameter.
+	IsParameter bool
+}
+
+// Location is the location of a parameter or variable in the subprogram.
+type Location struct {
+	// PCRange is the range of PC values that will be probed.
+	Range PCRange
+	// The locations of the pieces of the parameter or variable.
+	Location []bininspect.ParameterPiece
+}
+
+// PCRange is the range of PC values that will be probed.
+type PCRange struct {
+	// Start is the start PC value of the range.
+	Start uint64
+	// End is the end PC value of the range.
+	End uint64
+}
+
+// Probe represents a probe from the config as it applies to the program.
+type Probe struct {
+	// The config UUID of the probe.
+	ID string
+	// The kind of the probe.
+	Type ProbeKind
+	// The version of the probe.
+	Version int
+	// Tags that are passed through the probe.
+	Tags []string
+	// The subprogram to which the probe is attached.
+	Subprogram *Subprogram
+	// The events that trigger the probe.
+	Events []Event
+	// Whether the probe should capture a snapshot of the state of the program.
+	Snapshot bool
+	// TODO: Add template support:
+	//	TemplateSegments []TemplateSegment
+}
+
+// ProbeKind is the kind of probe.
+type ProbeKind uint8
+
+const (
+	_ ProbeKind = iota
+
+	// ProbeKindLog is a probe that emits a log.
+	ProbeKindLog
+	// ProbeKindSpan is a probe that emits a span.
+	ProbeKindSpan
+	// ProbeKindMetric is a probe that updates a metric.
+	ProbeKindMetric
+)
+
+// Event corresponds to an action that will occur when a PC is hit.
+type Event struct {
+	// ID of the event. This is used to identify data produced by the event over
+	// the ring buffer.
+	ID EventID
+	// The datatype of the event.
+	Type *EventRootType
+	// The PC values at which the event should be injected.
+	InjectionPCs []uint64
+	// The condition that must be met for the event to be injected.
+	Condition *Expression
+}

--- a/pkg/dyninst/ir/types.go
+++ b/pkg/dyninst/ir/types.go
@@ -1,0 +1,327 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+package ir
+
+import (
+	"reflect"
+)
+
+// Type represents a an in-memory representation of a type in the target
+// program, or a synthetic type used by the probe to communicate information
+// from eBPF to the userspace.
+type Type interface {
+	// GetID returns the ID of the type.
+	GetID() TypeID
+	// GetName returns the name of the type.
+	GetName() string
+	// GetByteSize returns the size of the type in bytes.
+	GetByteSize() int
+	// GetGoRuntimeType returns the runtime type of the type, if it is associated
+	// with a Go type.
+	GetGoRuntimeType() (uint32, bool)
+	// GetGoKind returns the kind of the type, if it is associated with a Go type.
+	GetGoKind() (reflect.Kind, bool)
+
+	irType() // marker
+}
+
+// GoTypeAttributes is a struct that contains the attributes of a type that is
+// associated with a Go type.
+type GoTypeAttributes struct {
+	// GoRuntimeType is the runtime type of the type, if it is associated with a
+	// Go type.
+	GoRuntimeType uint32
+	// HasGoRuntimeType is true if the type has a Go runtime type.
+	HasGoRuntimeType bool
+	// GoKind is the kind of the type, if it is associated with a Go type.
+	GoKind reflect.Kind
+	// HasGoKind is true if the type has a Go kind.
+	HasGoKind bool
+}
+
+// GetGoRuntimeType returns the runtime type of the type, if it is associated
+// with a Go type.
+func (t *GoTypeAttributes) GetGoRuntimeType() (uint32, bool) {
+	return t.GoRuntimeType, t.HasGoRuntimeType
+}
+
+// GetGoKind returns the kind of the type, if it is associated with a Go type.
+func (t *GoTypeAttributes) GetGoKind() (reflect.Kind, bool) { return t.GoKind, t.HasGoKind }
+
+var (
+	_ Type = (*BaseType)(nil)
+	_ Type = (*PointerType)(nil)
+	_ Type = (*StructureType)(nil)
+	_ Type = (*ArrayType)(nil)
+
+	_ Type = (*GoSliceHeaderType)(nil)
+	_ Type = (*GoSliceDataType)(nil)
+	_ Type = (*GoStringHeaderType)(nil)
+	_ Type = (*GoStringDataType)(nil)
+	_ Type = (*GoMapType)(nil)
+	_ Type = (*GoHMapHeaderType)(nil)
+	_ Type = (*GoHMapBucketType)(nil)
+	_ Type = (*GoSwissMapHeaderType)(nil)
+	_ Type = (*GoSwissMapGroupsType)(nil)
+	_ Type = (*GoChannelType)(nil)
+	_ Type = (*GoEmptyInterfaceType)(nil)
+	_ Type = (*GoInterfaceType)(nil)
+
+	_ Type = (*EventRootType)(nil)
+)
+
+// GetID returns the ID of the type.
+func (t *TypeCommon) GetID() TypeID {
+	return t.ID
+}
+
+// GetName returns the name of the type.
+func (t *TypeCommon) GetName() string {
+	return t.Name
+}
+
+// GetByteSize returns the size of the type in bytes.
+func (t *TypeCommon) GetByteSize() int {
+	return t.Size
+}
+
+// TypeCommon has common fields for all types.
+type TypeCommon struct {
+	// ID is the ID of the type.
+	ID TypeID
+	// Name is the name of the type.
+	Name string
+	// Size is the size of the type in bytes.
+	Size int
+}
+
+// BaseType is a basic type in the target program.
+type BaseType struct {
+	TypeCommon
+	GoTypeAttributes
+}
+
+func (t *BaseType) irType() {}
+
+// PointerType is a pointer type in the target program.
+type PointerType struct {
+	TypeCommon
+	GoTypeAttributes
+
+	// Pointee is the type that the pointer points to.
+	Pointee Type
+}
+
+func (t *PointerType) irType() {}
+
+// StructureType is a structure type in the target program.
+type StructureType struct {
+	TypeCommon
+	GoTypeAttributes
+
+	// Fields contains the fields of the structure.
+	Fields []Field
+}
+
+var _ Type = &StructureType{}
+
+func (t *StructureType) irType() {}
+
+// Field is a field in a structure.
+type Field struct {
+	// Name is the name of the field.
+	Name string
+	// Offset in the parent structure.
+	Offset uint32
+	// Type is the type of the field.
+	Type TypeID
+}
+
+// ArrayType is an array type in the target program.
+type ArrayType struct {
+	TypeCommon
+	GoTypeAttributes
+
+	// Count is the number of elements in the array.
+	Count int
+	// HasCount is true if the array has a count.
+	HasCount bool
+	// Element is the type of the element in the array.
+	Element Type
+}
+
+func (t *ArrayType) irType() {}
+
+// GoEmptyInterfaceType is the type of the empty interface (any / interface{}).
+type GoEmptyInterfaceType struct {
+	TypeCommon
+	GoTypeAttributes
+
+	// UnderlyingStructure is the structure that is the underlying type of the
+	// runtime.eface.
+	UnderlyingStructure *StructureType
+}
+
+func (t *GoEmptyInterfaceType) irType() {}
+
+// GoInterfaceType is a type that represents an interface in the target program.
+type GoInterfaceType struct {
+	TypeCommon
+	GoTypeAttributes
+
+	// UnderlyingStructure is the structure that is the underlying type of the
+	// runtime.iface.
+	UnderlyingStructure *StructureType
+}
+
+func (t *GoInterfaceType) irType() {}
+
+// GoSliceHeaderType is the type of the slice header.
+type GoSliceHeaderType struct {
+	StructureType
+
+	// ArrayType is the synthetic type that represents the variable-length array
+	// of elements in the slice.
+	ArrayType *GoSliceDataType
+}
+
+func (GoSliceHeaderType) irType() {}
+
+// GoSliceDataType is a synthetic type that represents the data pointed to by a
+// slice header.
+type GoSliceDataType struct {
+	TypeCommon
+	syntheticType
+
+	// Type of the elements in the slice.
+	Element Type
+}
+
+func (GoSliceDataType) irType() {}
+
+// GoChannelType is a synthetic type that represents a channel.
+type GoChannelType struct {
+	TypeCommon
+	syntheticType
+
+	// TODO: fill in the details
+}
+
+func (GoChannelType) irType() {}
+
+// GoStringHeaderType is the type of the string header.
+type GoStringHeaderType struct {
+	StructureType
+	ArrayType *GoStringDataType
+}
+
+func (GoStringHeaderType) irType() {}
+
+// GoStringDataType is a synthetic type that represents the data pointed
+// to by a string header.
+type GoStringDataType struct {
+	TypeCommon
+	syntheticType
+}
+
+func (GoStringDataType) irType() {}
+
+// GoMapType is a type that represents a map in the target program.
+type GoMapType struct {
+	TypeCommon
+	GoTypeAttributes
+
+	HeaderType Type
+}
+
+func (GoMapType) irType() {}
+
+// GoHMapHeaderType is the type of the hash map header.
+type GoHMapHeaderType struct {
+	StructureType
+	// BucketType is the type of the bucket in the hash map.
+	BucketType *GoHMapBucketType
+	// BucketsType is the type of the slice of buckets in the hash map.
+	BucketsType *GoSliceDataType
+}
+
+func (GoHMapHeaderType) irType() {}
+
+// GoHMapBucketType is the type of the bucket in the hash map.
+type GoHMapBucketType struct {
+	StructureType
+	// KeyType is the type of the key in the hash map.
+	KeyType Type
+	// ValueType is the type of the value in the hash map.
+	ValueType Type
+}
+
+func (GoHMapBucketType) irType() {}
+
+// GoSwissMapHeaderType is the type of the header of a SwissMap.
+type GoSwissMapHeaderType struct {
+	StructureType
+	// TablePtrSliceType is the slide data type stored conditionally under
+	// `dirPtr`.
+	TablePtrSliceType Type
+	// GroupType is the pointer type stored conditionally under `dirPtr`.
+	GroupType Type
+}
+
+func (GoSwissMapHeaderType) irType() {}
+
+// GoSwissMapGroupsType is the type of the groups of a SwissMap.
+type GoSwissMapGroupsType struct {
+	StructureType
+	// GroupType is the type stored in the slice under `data`.
+	GroupType Type
+	// GroupSliceType is the type of the slice under `data`.
+	GroupSliceType Type
+}
+
+func (GoSwissMapGroupsType) irType() {}
+
+type syntheticType struct{}
+
+func (syntheticType) GetGoRuntimeType() (uint32, bool) {
+	return 0, false
+}
+
+func (syntheticType) GetGoKind() (reflect.Kind, bool) {
+	return reflect.Invalid, false
+}
+
+// EventRootType is the type of the event output.
+type EventRootType struct {
+	TypeCommon
+	syntheticType
+
+	// Bitset tracking successful expression evaluation (one bit per
+	// expression).
+	PresenseBitsetSize int
+	// Expressions is the list of expressions that are used to evaluate the
+	// value of the event.
+	Expressions []RootExpression
+}
+
+func (EventRootType) irType() {}
+
+// RootExpression is an expression that is used to evaluate the value of the
+// event.
+type RootExpression struct {
+	// Name is the name of the expression.
+	//
+	// The name is used in templating to refer to the expression and
+	// in the snapshot to name the variable.
+	Name string
+	// Offset is the offset of the expression in the event output.
+	Offset int
+	// Expression is the logical operations to be evaluated to produce the
+	// value of the event.
+	Expression Expression
+}


### PR DESCRIPTION
This commit introduces key concepts that'll be produced by combining config with a binary and then will be used to generate eBPF programs and to decode their output.

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR introduces the first stab at an IR to be used for the next stab at Go DI. 

### Motivation

As we begin to build out the next generation of Go DI, we need some shared concepts to couple the work. The `ir` layer intends to combine information from a specific binary with the set of probes from the configuration that apply to that binary. With an `ir.Program`, the system should be able to generate an eBPF program and decode data that that program produces into its ultimate output format without needing any further access to the binary or the config.

See [DEBUG-3885](https://datadoghq.atlassian.net/browse/DEBUG-3885) for internal details.



[DEBUG-3885]: https://datadoghq.atlassian.net/browse/DEBUG-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ