### PR TITLE
Fix manual static quality gates threshold adjustment job

### DIFF
--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -209,6 +209,10 @@ def update_quality_gates_threshold(ctx, metric_handler, github):
     branch_name = f"static_quality_gates/threshold_update_{os.environ['CI_COMMIT_SHORT_SHA']}"
     current_branch = github.repo.get_branch(os.environ["CI_COMMIT_BRANCH"])
     ctx.run(f"git checkout -b {branch_name}")
+    ctx.run(
+        f"git remote set-url origin https://x-access-token:{github._auth.token}@github.com/DataDog/datadog-agent.git",
+        hide=True,
+    )
     ctx.run(f"git push --set-upstream origin {branch_name}")
 
     # Push changes

--- a/tasks/quality_gates.py
+++ b/tasks/quality_gates.py
@@ -208,7 +208,8 @@ def update_quality_gates_threshold(ctx, metric_handler, github):
     # Create new branch
     branch_name = f"static_quality_gates/threshold_update_{os.environ['CI_COMMIT_SHORT_SHA']}"
     current_branch = github.repo.get_branch(os.environ["CI_COMMIT_BRANCH"])
-    github.repo.create_git_ref(ref=f'refs/heads/{branch_name}', sha=current_branch.commit.sha)
+    ctx.run(f"git checkout -b {branch_name}")
+    ctx.run(f"git push --set-upstream origin {branch_name}")
 
     # Push changes
     commit_message = "feat(gate): update static quality gates thresholds"


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the `manual_gate_threshold_update` gitlab job that aim to lower quality gates thresholds
### Motivation

The `manual_gate_threshold_update` gitlab job was failing to push a new reference to the newly created branch by the task (Error message : `Update is not a fast forward`). This error message isn't very explicit since even simple permission denial returns this message. 
Since some of our jobs are using the CLI instead of the API, I copied how we are doing it in [some of our other tasks](https://github.com/DataDog/datadog-agent/blob/88d160a57faf8b2e7a48611477faed3918c2b274/tasks/pipeline.py#L832) and it seems to fix the issue. Still not 100% sure if we had a recent permission change that caused the API to fail.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
