### PR TITLE
(fleet) remove the agent OCI on DEB/RPM installs

### DIFF
--- a/pkg/fleet/installer/packages/apm_inject_linux.go
+++ b/pkg/fleet/installer/packages/apm_inject_linux.go
@@ -38,7 +38,7 @@ func preInstallAPMInjector(ctx HookContext) (err error) {
 	// Remove DEB/RPM packages if they exist
 
 	for _, pkg := range apmDebRPMPackages {
-		if err := packagemanager.RemovePackage(ctx, pkg); err != nil {
+		if err := packagemanager.RemoveNativePackage(ctx, pkg); err != nil {
 			return err
 		}
 	}

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -220,11 +220,16 @@ func preInstallDatadogAgent(ctx HookContext) error {
 	if err := agentServiceOCI.RemoveStable(ctx); err != nil {
 		log.Warnf("failed to remove stable unit: %s", err)
 	}
-	return packagemanager.RemovePackage(ctx, agentPackage)
+	return packagemanager.RemoveNativePackage(ctx, agentPackage)
 }
 
 // postInstallDatadogAgent performs post-installation steps for the agent
 func postInstallDatadogAgent(ctx HookContext) (err error) {
+	if ctx.PackageType == PackageTypeDEB || ctx.PackageType == PackageTypeRPM {
+		if err := packagemanager.RemoveInstallerPackage(ctx, agentPackage); err != nil {
+			log.Warnf("failed to remove installer agent package: %s", err)
+		}
+	}
 	if err := setupFilesystem(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR removes the OCI package when DEB/RPM packages are installed.

This is done through the DEB/RPM `postinst`. It would be slightly better to do this through the `preinst` since it wouldn't require 2x the agent size but there's no way to access the installer in this context.
