### PR TITLE
Fix secret refresh status and potentially not being enabled.

### DIFF
--- a/comp/core/secrets/secretsimpl/info_nix_test.go
+++ b/comp/core/secrets/secretsimpl/info_nix_test.go
@@ -112,6 +112,8 @@ Secrets handle resolved:
 	used in 'test2' configuration in entry 'instances/1/password'
 - 'pass3':
 	used in 'test2' configuration in entry 'instances/0/password'
+
+'secret_refresh interval' is disabled
 `
 
 	assert.Equal(t, expectedResult, buffer.String())
@@ -155,6 +157,8 @@ Secrets handle resolved:
 	used in 'test2' configuration in entry 'instances/1/password'
 - 'pass3':
 	used in 'test2' configuration in entry 'instances/0/password'
+
+'secret_refresh interval' is disabled
 `
 
 	assert.Equal(t, expectedResult, buffer.String())

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -227,8 +227,13 @@ func (r *secretResolver) Configure(params secrets.ConfigParams) {
 	if r.responseMaxSize == 0 {
 		r.responseMaxSize = SecretBackendOutputMaxSizeDefault
 	}
+
 	r.refreshInterval = time.Duration(params.RefreshInterval) * time.Second
 	r.refreshIntervalScatter = params.RefreshIntervalScatter
+	if r.refreshInterval != 0 {
+		r.startRefreshRoutine()
+	}
+
 	r.commandAllowGroupExec = params.GroupExecPerm
 	r.removeTrailingLinebreak = params.RemoveLinebreak
 	if r.commandAllowGroupExec {
@@ -285,7 +290,6 @@ func (r *secretResolver) SubscribeToChanges(cb secrets.SecretChangeCallback) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	r.startRefreshRoutine()
 	r.subscriptions = append(r.subscriptions, cb)
 }
 

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -256,7 +256,7 @@ func (r *secretResolver) startRefreshRoutine() {
 	}
 
 	if r.refreshIntervalScatter {
-		r.scatterDuration = time.Duration(rand.Int63n(int64(r.refreshInterval)))
+		r.scatterDuration = time.Duration(rand.Int63n(int64(r.refreshInterval))) / time.Second * time.Second
 		log.Infof("first secret refresh will happen in %s", r.scatterDuration)
 	} else {
 		r.scatterDuration = r.refreshInterval

--- a/comp/core/secrets/secretsimpl/secrets.go
+++ b/comp/core/secrets/secretsimpl/secrets.go
@@ -695,8 +695,11 @@ func (r *secretResolver) GetDebugInfo(w io.Writer) {
 		fmt.Fprintf(w, "error rendering secret info: %s\n", err)
 	}
 
-	if r.refreshIntervalScatter {
+	fmt.Fprintf(w, "\n")
+	if r.refreshInterval > 0 {
 		fmt.Fprintf(w, "'secret_refresh interval' is enabled: the first refresh will happen %s after startup and then every %s\n", r.scatterDuration, r.refreshInterval)
+	} else {
+		fmt.Fprintf(w, "'secret_refresh interval' is disabled\n")
 	}
 
 }

--- a/comp/core/secrets/secretsimpl/secrets_test.go
+++ b/comp/core/secrets/secretsimpl/secrets_test.go
@@ -872,6 +872,7 @@ func TestStartRefreshRoutineWithScatter(t *testing.T) {
 					"test-handle": fmt.Sprintf("updated-value-%d", refreshCalls),
 				}, nil
 			}
+			resolver.startRefreshRoutine()
 
 			changeDetected := make(chan struct{}, 3)
 			resolver.SubscribeToChanges(func(_, _ string, _ []string, _, _ any) {


### PR DESCRIPTION
### What does this PR do?

This PR improves the status page and fix a issue where secret refresh could potentially not be enabled

*    Fix secret refresh not being enabled when nobody subscribes to secret update.
    The secrets comp allows resolving secrets without subscription (check configuration for example). We need to always enable secret refresh if configured for those cases too.
    This bug can't currently occurs as the `config` always subscribes for updates. But the `secrets` comp could be embedded in another binary where the bug would occur.
*   Fix status page showing 0s refresh rate
    
    Showing 'the first refresh will happen 0s after startup and then every 0s' is not user friendly and implies a constant refresh rate.
*    Make the scatter mechanism a number of seconds
    This produce a more user friendly output in the status page.
    ex:
    `the first refresh will happen 21m20s after startup and then every 1h0m0s`
    instead of:
    `the first refresh will happen 21m20.479738423s after startup and then every 1h0m0s`

### Describe how you validated your changes

Running the CI is enough.