### PR TITLE
[CWS-4523] remove need for hooks section for on-demand probes

### DIFF
--- a/pkg/security/probe/on_demand.go
+++ b/pkg/security/probe/on_demand.go
@@ -74,7 +74,11 @@ func (sm *OnDemandProbesManager) getHookNameFromID(id int) string {
 		return ""
 	}
 
-	return sm.hookPoints[id].Name
+	hookPoint := sm.hookPoints[id]
+	if hookPoint.IsSyscall {
+		return "syscall:" + hookPoint.Name
+	}
+	return hookPoint.Name
 }
 
 func (sm *OnDemandProbesManager) updateProbes() {

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2056,7 +2056,11 @@ func (p *EBPFProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.ApplyRuleSetRepor
 	}
 
 	if p.config.RuntimeSecurity.OnDemandEnabled {
-		p.onDemandManager.setHookPoints(rs.GetOnDemandHookPoints())
+		hookPoints, err := rs.GetOnDemandHookPoints()
+		if err != nil {
+			seclog.Errorf("failed to get on-demand hook points from ruleset: %v", err)
+		}
+		p.onDemandManager.setHookPoints(hookPoints)
 	}
 
 	if err := p.updateProbes(eventTypes, needRawSyscalls); err != nil {

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -5671,6 +5671,7 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 		}, nil
 	case "ondemand.name":
 		return &eval.StringEvaluator{
+			OpOverrides: OnDemandNameOverrides,
 			EvalFnc: func(ctx *eval.Context) string {
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -827,7 +827,7 @@ type PathKey struct {
 // OnDemandEvent identifies an on-demand event generated from on-demand probes
 type OnDemandEvent struct {
 	ID       uint32    `field:"-"`
-	Name     string    `field:"name,handler:ResolveOnDemandName"`
+	Name     string    `field:"name,handler:ResolveOnDemandName" op_override:"OnDemandNameOverrides"`
 	Data     [256]byte `field:"-"`
 	Arg1Str  string    `field:"arg1.str,handler:ResolveOnDemandArg1Str"`
 	Arg1Uint uint64    `field:"arg1.uint,handler:ResolveOnDemandArg1Uint"`

--- a/pkg/security/secl/model/oo_ondemand.go
+++ b/pkg/security/secl/model/oo_ondemand.go
@@ -1,0 +1,33 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build unix
+
+// Package model holds model related files
+package model
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+var errUnsupportedOnDemandOp = errors.New("on-demand operator is not supported")
+
+// OnDemandNameOverrides is a set of overrides for on demand name field
+var OnDemandNameOverrides = &eval.OpOverrides{
+	StringEquals: func(a *eval.StringEvaluator, b *eval.StringEvaluator, state *eval.State) (*eval.BoolEvaluator, error) {
+		return eval.StringEquals(a, b, state)
+	},
+	StringValuesContains: func(_ *eval.StringEvaluator, _ *eval.StringValuesEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
+		return nil, errUnsupportedOnDemandOp
+	},
+	StringArrayContains: func(_ *eval.StringEvaluator, _ *eval.StringArrayEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
+		return nil, errUnsupportedOnDemandOp
+	},
+	StringArrayMatches: func(_ *eval.StringArrayEvaluator, _ *eval.StringValuesEvaluator, _ *eval.State) (*eval.BoolEvaluator, error) {
+		return nil, errUnsupportedOnDemandOp
+	},
+}

--- a/pkg/security/secl/rules/model.go
+++ b/pkg/security/secl/rules/model.go
@@ -177,23 +177,22 @@ type LogDefinition struct {
 
 // OnDemandHookPoint represents a hook point definition
 type OnDemandHookPoint struct {
-	Name      string         `yaml:"name" json:"name"`
-	IsSyscall bool           `yaml:"syscall" json:"syscall,omitempty"`
-	Args      []HookPointArg `yaml:"args" json:"args,omitempty"`
+	Name      string
+	IsSyscall bool
+	Args      []HookPointArg
 }
 
 // HookPointArg represents the definition of a hook point argument
 type HookPointArg struct {
-	N    int    `yaml:"n" json:"n" jsonschema:"description=Zero-based argument index"`
-	Kind string `yaml:"kind" json:"kind" jsonschema:"enum=uint,enum=null-terminated-string"`
+	N    int
+	Kind string
 }
 
 // PolicyDef represents a policy file definition
 type PolicyDef struct {
-	Version            string              `yaml:"version,omitempty" json:"version"`
-	Macros             []*MacroDefinition  `yaml:"macros,omitempty" json:"macros,omitempty"`
-	Rules              []*RuleDefinition   `yaml:"rules" json:"rules"`
-	OnDemandHookPoints []OnDemandHookPoint `yaml:"hooks,omitempty" json:"hooks,omitempty"`
+	Version string             `yaml:"version,omitempty" json:"version"`
+	Macros  []*MacroDefinition `yaml:"macros,omitempty" json:"macros,omitempty"`
+	Rules   []*RuleDefinition  `yaml:"rules" json:"rules"`
 }
 
 // HumanReadableDuration represents a duration that can unmarshalled from YAML from a human readable format (like `10m`)

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -181,8 +181,7 @@ type Policy struct {
 	// multiple macros can have the same ID but different filters (e.g. agent version)
 	macros map[MacroID][]*PolicyMacro
 	// multiple rules can have the same ID but different filters (e.g. agent version)
-	rules              map[RuleID][]*PolicyRule
-	onDemandHookPoints []OnDemandHookPoint
+	rules map[RuleID][]*PolicyRule
 }
 
 // GetAcceptedMacros returns the list of accepted macros that are part of the policy
@@ -303,8 +302,6 @@ RULES:
 			continue
 		}
 	}
-
-	p.onDemandHookPoints = p.Def.OnDemandHookPoints
 
 	return errs.ErrorOrNil()
 }

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -65,8 +65,6 @@ type RuleSet struct {
 
 	// event collector, used for tests
 	eventCollector EventCollector
-
-	OnDemandHookPoints []OnDemandHookPoint
 }
 
 // ListRuleIDs returns the list of RuleIDs from the ruleset
@@ -965,8 +963,6 @@ func (rs *RuleSet) LoadPolicies(loader *PolicyLoader, opts PolicyLoaderOpts) *mu
 				allRules = append(allRules, rule)
 			}
 		}
-
-		rs.OnDemandHookPoints = append(rs.OnDemandHookPoints, policy.onDemandHookPoints...)
 	}
 
 	if err := rs.AddMacros(parsingContext, allMacros); err.ErrorOrNil() != nil {

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -84,6 +84,9 @@ func (rs *RuleSet) GetRules() map[eval.RuleID]*Rule {
 // GetOnDemandHookPoints gets the on-demand hook points
 func (rs *RuleSet) GetOnDemandHookPoints() ([]OnDemandHookPoint, error) {
 	onDemandBucket := rs.GetBucket(model.OnDemandEventType.String())
+	if onDemandBucket == nil {
+		return nil, nil
+	}
 
 	var hookPoints []OnDemandHookPoint
 

--- a/pkg/security/secl/schemas/policy.schema.json
+++ b/pkg/security/secl/schemas/policy.schema.json
@@ -104,28 +104,6 @@
       "type": "object",
       "description": "HashDefinition describes the 'hash' section of a rule action"
     },
-    "HookPointArg": {
-      "properties": {
-        "n": {
-          "type": "integer",
-          "description": "Zero-based argument index"
-        },
-        "kind": {
-          "type": "string",
-          "enum": [
-            "uint",
-            "null-terminated-string"
-          ]
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "n",
-        "kind"
-      ],
-      "description": "HookPointArg represents the definition of a hook point argument"
-    },
     "KillDefinition": {
       "properties": {
         "signal": {
@@ -230,28 +208,6 @@
         "id"
       ],
       "description": "MacroDefinition holds the definition of a macro"
-    },
-    "OnDemandHookPoint": {
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "syscall": {
-          "type": "boolean"
-        },
-        "args": {
-          "items": {
-            "$ref": "#/$defs/HookPointArg"
-          },
-          "type": "array"
-        }
-      },
-      "additionalProperties": false,
-      "type": "object",
-      "required": [
-        "name"
-      ],
-      "description": "OnDemandHookPoint represents a hook point definition"
     },
     "OverrideOptions": {
       "properties": {
@@ -468,12 +424,6 @@
     "rules": {
       "items": {
         "$ref": "#/$defs/RuleDefinition"
-      },
-      "type": "array"
-    },
-    "hooks": {
-      "items": {
-        "$ref": "#/$defs/OnDemandHookPoint"
       },
       "type": "array"
     }

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -669,7 +669,7 @@ func assertFieldStringArrayIndexedOneOf(tb *testing.T, e *model.Event, field str
 	return false
 }
 
-func setTestPolicy(dir string, onDemandProbes []rules.OnDemandHookPoint, macroDefs []*rules.MacroDefinition, ruleDefs []*rules.RuleDefinition) (string, error) {
+func setTestPolicy(dir string, macroDefs []*rules.MacroDefinition, ruleDefs []*rules.RuleDefinition) (string, error) {
 	testPolicyFile, err := os.Create(path.Join(dir, "secagent-policy.policy"))
 	if err != nil {
 		return "", err
@@ -681,10 +681,9 @@ func setTestPolicy(dir string, onDemandProbes []rules.OnDemandHookPoint, macroDe
 	}
 
 	policyDef := &rules.PolicyDef{
-		Version:            "1.2.3",
-		Macros:             macroDefs,
-		Rules:              ruleDefs,
-		OnDemandHookPoints: onDemandProbes,
+		Version: "1.2.3",
+		Macros:  macroDefs,
+		Rules:   ruleDefs,
 	}
 
 	testPolicy, err := yaml.Marshal(policyDef)

--- a/pkg/security/tests/module_tester_linux.go
+++ b/pkg/security/tests/module_tester_linux.go
@@ -584,10 +584,6 @@ func (tm *testModule) validateExecEvent(tb *testing.T, kind wrapperType, validat
 }
 
 func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []*rules.RuleDefinition, fopts ...optFunc) (*testModule, error) {
-	return newTestModuleWithOnDemandProbes(t, nil, macroDefs, ruleDefs, fopts...)
-}
-
-func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDemandHookPoint, macroDefs []*rules.MacroDefinition, ruleDefs []*rules.RuleDefinition, fopts ...optFunc) (*testModule, error) {
 	var opts tmOpts
 	for _, opt := range fopts {
 		opt(&opts)
@@ -646,7 +642,7 @@ func newTestModuleWithOnDemandProbes(t testing.TB, onDemandHooks []rules.OnDeman
 		return nil, err
 	}
 
-	if _, err = setTestPolicy(commonCfgDir, onDemandHooks, macroDefs, ruleDefs); err != nil {
+	if _, err = setTestPolicy(commonCfgDir, macroDefs, ruleDefs); err != nil {
 		return nil, err
 	}
 

--- a/pkg/security/tests/module_tester_windows.go
+++ b/pkg/security/tests/module_tester_windows.go
@@ -126,7 +126,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	if err != nil {
 		return nil, err
 	}
-	if _, err = setTestPolicy(commonCfgDir, nil, macroDefs, ruleDefs); err != nil {
+	if _, err = setTestPolicy(commonCfgDir, macroDefs, ruleDefs); err != nil {
 		return nil, err
 	}
 	statsdClient := statsdclient.NewStatsdClient()

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -24,22 +24,6 @@ import (
 func TestOnDemandOpen(t *testing.T) {
 	SkipIfNotAvailable(t)
 
-	onDemands := []rules.OnDemandHookPoint{
-		{
-			Name: "do_sys_openat2",
-			Args: []rules.HookPointArg{
-				{
-					N:    1,
-					Kind: "uint",
-				},
-				{
-					N:    2,
-					Kind: "null-terminated-string",
-				},
-			},
-		},
-	}
-
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_open",
@@ -47,7 +31,7 @@ func TestOnDemandOpen(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModuleWithOnDemandProbes(t, onDemands, nil, ruleDefs, withStaticOpts(testOpts{disableOnDemandRateLimiter: true}))
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{disableOnDemandRateLimiter: true}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,19 +69,6 @@ func TestOnDemandOpen(t *testing.T) {
 func TestOnDemandChdir(t *testing.T) {
 	SkipIfNotAvailable(t)
 
-	onDemands := []rules.OnDemandHookPoint{
-		{
-			Name:      "chdir",
-			IsSyscall: true,
-			Args: []rules.HookPointArg{
-				{
-					N:    1,
-					Kind: "null-terminated-string",
-				},
-			},
-		},
-	}
-
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_chdir",
@@ -105,7 +76,7 @@ func TestOnDemandChdir(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModuleWithOnDemandProbes(t, onDemands, nil, ruleDefs)
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,22 +105,6 @@ func TestOnDemandChdir(t *testing.T) {
 func TestOnDemandMprotect(t *testing.T) {
 	SkipIfNotAvailable(t)
 
-	onDemands := []rules.OnDemandHookPoint{
-		{
-			Name: "security_file_mprotect",
-			Args: []rules.HookPointArg{
-				{
-					N:    2,
-					Kind: "uint",
-				},
-				{
-					N:    3,
-					Kind: "uint",
-				},
-			},
-		},
-	}
-
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_mprotect",
@@ -157,7 +112,7 @@ func TestOnDemandMprotect(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModuleWithOnDemandProbes(t, onDemands, nil, ruleDefs)
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/ondemand_test.go
+++ b/pkg/security/tests/ondemand_test.go
@@ -101,7 +101,7 @@ func TestOnDemandChdir(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_rule_chdir",
-			Expression: `ondemand.name == "chdir" && process.file.name == "testsuite"`,
+			Expression: `ondemand.name == "syscall:chdir" && ondemand.arg1.str != "" && process.file.name == "testsuite"`,
 		},
 	}
 


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

This PR allows to automagically derive the needed hooks for on-demand expression:
- the `ondemand.name` is used to derive the hook: `abc` for a regular function `syscall:abc` for a syscall
- the `ondemand.argN.kind` are used to derive the different arguments

Arguments are checked for compatibility between different expressions.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->