### PR TITLE
Assign ownership of docker builds to Agent Delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -252,10 +252,10 @@
 /dev/                                   @DataDog/agent-devx
 /devenv/                                @DataDog/agent-devx
 
-/Dockerfiles/                            @DataDog/container-integrations
-/Dockerfiles/agent/entrypoint.d.windows/ @DataDog/container-integrations @DataDog/windows-agent
-/Dockerfiles/agent/entrypoint.ps1        @DataDog/container-integrations @DataDog/windows-agent
-/Dockerfiles/agent/windows/              @DataDog/container-integrations @DataDog/windows-agent
+/Dockerfiles/                            @DataDog/agent-delivery
+/Dockerfiles/agent/entrypoint.d.windows/ @DataDog/agent-delivery @DataDog/windows-agent
+/Dockerfiles/agent/entrypoint.ps1        @DataDog/agent-delivery @DataDog/windows-agent
+/Dockerfiles/agent/windows/              @DataDog/agent-delivery @DataDog/windows-agent
 /Dockerfiles/agent-ddot                  @DataDog/opentelemetry-agent
 /Dockerfiles/agent/bouncycastle-fips     @DataDog/agent-metric-pipelines
 


### PR DESCRIPTION
### What does this PR do?

Assigns ownership of docker builds (Dockerfiles, etc.) to Agent Delivery.

### Motivation

My understanding that this is now within our scope, as being part of the Agent build.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes

I'm not sure whether some of the subfolders need to remain with container-integrations (the cluster agent comes to mind).