### PR TITLE
Set kprobe max active for tcp queue length check

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
@@ -29,6 +29,10 @@ import (
 
 const (
 	statsMapName = "tcp_queue_stats"
+
+	// maxActive configures the maximum number of instances of the kretprobe-probed functions handled simultaneously.
+	// This value should be enough for typical workloads (e.g. some amount of processes blocked on the `accept` syscall).
+	maxActive = 512
 )
 
 // Tracer is the eBPF side of the TCP Queue Length check
@@ -74,6 +78,7 @@ func startTCPQueueLengthProbe(buf bytecode.AssetReader, managerOptions manager.O
 	}
 
 	managerOptions.RemoveRlimit = true
+	managerOptions.DefaultKProbeMaxActive = maxActive
 
 	if err := m.InitWithOptions(buf, managerOptions); err != nil {
 		return nil, fmt.Errorf("failed to init manager: %w", err)


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The kretprobe on tcp_recvmsg was missing a lot due to insufficient max active value.

[Metric](https://ddstaging.datadoghq.com/metric/explorer?state=H4sIAAAAAAAAA12R3WrDMAyF30WXw5Qm69bWrzKKMbGcCvyTWk4hDXn3oaTtYHfS4fPRkTzDHQtTTqCh3bcH0zRm34CCvtjhyqB_ZnDoKVFdoRkq1YCgAdRWGqaH9M33W7GBejEM6KuI0yBApYiMhZBBQcHbiFy3AQV5yInR-Fyirf_Z27hVgiYbxUukSWI6W63hPJZO5Ii1UPd6M4EGe-81T1wx7rph3I2MZf5YYLkokGFjsJvvs_mzXi7LZRGMh0DVOIqY5E6Cv9UuJ0_9ahAoUgXd7BVwLlUulYvDAhoccgerl6zly7rCDFytcM3xcGzPp3N7Oh-OCjC5Tfvct19PraAvyFcTs5MtOZCj1IOCwY6MDrS3gXFR4ClULM-I78jmTg_z-oQ8BOIKyy_mHRIl-QEAAA&start=1747298928947&end=1747302528947&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYAMwGIFCeGE4a+NoAxkrIIOoIulmWgWZxyhp4qshwAEbyggB0ANby2ji1mi1GCG0dcE4exBhZEgBuA6oQGloawKo4UHhocMgIWfJOQWZOKyIwTDwABLVYR8B9MNpRTpHqFJfXqk5yihQLSys8jRgaTln4EQIAAUAEoQDwALpUVzuZa-aygWGqeExMoJCHQkAaOQrGQgeQYFYIBC5ZI4GD-TAzCBZJJoUQDV5kjIMqD0xlOehMZQiNweNAQ-jTeSYLAvBRkhkiJRQnh8bGi8QAYSkwhgKBEyzQPCAA).

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->