### PR TITLE
[NPM-4421] Add config to randomize SYN packet ID

### DIFF
--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -129,14 +129,16 @@ func parseParams(req *http.Request) (tracerouteutil.Config, error) {
 	}
 	protocol := query.Get("protocol")
 	tcpMethod := query.Get("tcp_method")
+	tcpSynCompatibilityMode := query.Get("tcp_syn_compatibility_mode")
 
 	return tracerouteutil.Config{
-		DestHostname: host,
-		DestPort:     uint16(port),
-		MaxTTL:       uint8(maxTTL),
-		Timeout:      time.Duration(timeout),
-		Protocol:     payload.Protocol(protocol),
-		TCPMethod:    payload.TCPMethod(tcpMethod),
+		DestHostname:            host,
+		DestPort:                uint16(port),
+		MaxTTL:                  uint8(maxTTL),
+		Timeout:                 time.Duration(timeout),
+		Protocol:                payload.Protocol(protocol),
+		TCPMethod:               payload.TCPMethod(tcpMethod),
+		TCPSynCompatibilityMode: tcpSynCompatibilityMode == "true",
 	}, nil
 }
 

--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -29,6 +29,7 @@ type collectorConfigs struct {
 	sourceExcludedConns          map[string][]string
 	destExcludedConns            map[string][]string
 	tcpMethod                    payload.TCPMethod
+	tcpSynCompatibilityMode      bool
 }
 
 func newConfig(agentConfig config.Component) *collectorConfigs {
@@ -53,6 +54,7 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		sourceExcludedConns:       agentConfig.GetStringMapStringSlice("network_path.collector.source_excludes"),
 		destExcludedConns:         agentConfig.GetStringMapStringSlice("network_path.collector.dest_excludes"),
 		tcpMethod:                 payload.MakeTCPMethod(agentConfig.GetString("network_path.collector.tcp_method")),
+		tcpSynCompatibilityMode:   agentConfig.GetBool("network_path.collector.tcp_syn_compatibility_mode"),
 		networkDevicesNamespace:   agentConfig.GetString("network_devices.namespace"),
 	}
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -343,12 +343,13 @@ func (s *npCollectorImpl) runTracerouteForPath(ptest *pathteststore.PathtestCont
 	s.logger.Debugf("Run Traceroute for ptest: %+v", ptest)
 
 	cfg := config.Config{
-		DestHostname: ptest.Pathtest.Hostname,
-		DestPort:     ptest.Pathtest.Port,
-		MaxTTL:       uint8(s.collectorConfigs.maxTTL),
-		Timeout:      s.collectorConfigs.timeout,
-		Protocol:     ptest.Pathtest.Protocol,
-		TCPMethod:    s.collectorConfigs.tcpMethod,
+		DestHostname:            ptest.Pathtest.Hostname,
+		DestPort:                ptest.Pathtest.Port,
+		MaxTTL:                  uint8(s.collectorConfigs.maxTTL),
+		Timeout:                 s.collectorConfigs.timeout,
+		Protocol:                ptest.Pathtest.Protocol,
+		TCPMethod:               s.collectorConfigs.tcpMethod,
+		TCPSynCompatibilityMode: s.collectorConfigs.tcpSynCompatibilityMode,
 	}
 
 	path, err := s.runTraceroute(cfg, s.telemetrycomp)

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -42,6 +42,8 @@ type InstanceConfig struct {
 
 	Protocol  string `yaml:"protocol"`
 	TCPMethod string `yaml:"tcp_method"`
+	// TCPSynCompatibilityMode makes TCP SYN mimic the tcptraceroute tool as closely as possible
+	TCPSynCompatibilityMode bool `yaml:"tcp_syn_compatibility_mode"`
 
 	SourceService      string `yaml:"source_service"`
 	DestinationService string `yaml:"destination_service"`
@@ -58,17 +60,19 @@ type InstanceConfig struct {
 // CheckConfig defines the configuration of the
 // Network Path integration
 type CheckConfig struct {
-	DestHostname          string
-	DestPort              uint16
-	SourceService         string
-	DestinationService    string
-	MaxTTL                uint8
-	Protocol              payload.Protocol
-	TCPMethod             payload.TCPMethod
-	Timeout               time.Duration
-	MinCollectionInterval time.Duration
-	Tags                  []string
-	Namespace             string
+	DestHostname       string
+	DestPort           uint16
+	SourceService      string
+	DestinationService string
+	MaxTTL             uint8
+	Protocol           payload.Protocol
+	TCPMethod          payload.TCPMethod
+	// TCPSynCompatibilityMode makes TCP SYN mimic the tcptraceroute tool as closely as possible
+	TCPSynCompatibilityMode bool
+	Timeout                 time.Duration
+	MinCollectionInterval   time.Duration
+	Tags                    []string
+	Namespace               string
 }
 
 // NewCheckConfig builds a new check config
@@ -94,6 +98,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	c.DestinationService = instance.DestinationService
 	c.Protocol = payload.Protocol(strings.ToUpper(instance.Protocol))
 	c.TCPMethod = payload.MakeTCPMethod(instance.TCPMethod)
+	c.TCPSynCompatibilityMode = instance.TCPSynCompatibilityMode
 
 	c.MinCollectionInterval = firstNonZero(
 		time.Duration(instance.MinCollectionInterval)*time.Second,

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -347,6 +347,24 @@ tcp_method: prefer_SACK
 				TCPMethod:             payload.TCPConfigPreferSACK,
 			},
 		},
+		{
+			name: "Enabling TCP SYN compatibility mode",
+			rawInstance: []byte(`
+hostname: 1.2.3.4
+protocol: tcp
+tcp_syn_compatibility_mode: true
+`),
+			rawInitConfig: []byte(``),
+			expectedConfig: &CheckConfig{
+				DestHostname:            "1.2.3.4",
+				MinCollectionInterval:   time.Duration(60) * time.Second,
+				Namespace:               "my-namespace",
+				Protocol:                payload.ProtocolTCP,
+				Timeout:                 setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                  setup.DefaultNetworkPathMaxTTL,
+				TCPSynCompatibilityMode: true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -51,12 +51,13 @@ func (c *Check) Run() error {
 	metricSender := metricsender.NewMetricSenderAgent(senderInstance)
 
 	cfg := config.Config{
-		DestHostname: c.config.DestHostname,
-		DestPort:     c.config.DestPort,
-		MaxTTL:       c.config.MaxTTL,
-		Timeout:      c.config.Timeout,
-		Protocol:     c.config.Protocol,
-		TCPMethod:    c.config.TCPMethod,
+		DestHostname:            c.config.DestHostname,
+		DestPort:                c.config.DestPort,
+		MaxTTL:                  c.config.MaxTTL,
+		Timeout:                 c.config.Timeout,
+		Protocol:                c.config.Protocol,
+		TCPMethod:               c.config.TCPMethod,
+		TCPSynCompatibilityMode: c.config.TCPSynCompatibilityMode,
 	}
 
 	tr, err := traceroute.New(cfg, c.telemetryComp)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -484,6 +484,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.disable_intra_vpc_collection", false)
 	config.BindEnvAndSetDefault("network_path.collector.source_excludes", map[string][]string{})
 	config.BindEnvAndSetDefault("network_path.collector.dest_excludes", map[string][]string{})
+	config.BindEnvAndSetDefault("network_path.collector.tcp_syn_compatibility_mode", false)
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
 	// HA Agent

--- a/pkg/networkpath/traceroute/config/config.go
+++ b/pkg/networkpath/traceroute/config/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Config specifies the configuration of an instance
-// of Traceroute
+// of Traceroute, on the system-probe side
 type Config struct {
 	// TODO: add common configuration
 	// Destination Hostname
@@ -35,4 +35,6 @@ type Config struct {
 	Protocol payload.Protocol
 	// TCPMethod is the method used to run a TCP traceroute.
 	TCPMethod payload.TCPMethod
+	// TCPSynCompatibilityMode makes TCP SYN mimic the tcptraceroute tool as closely as possible
+	TCPSynCompatibilityMode bool
 }

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -218,7 +218,7 @@ func (r *Runner) runTCP(cfg config.Config, hname string, target net.IP, maxTTL u
 	}
 
 	doSyn := func() (*common.Results, error) {
-		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout)
+		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout, cfg.TCPSynCompatibilityMode)
 		return tr.TracerouteSequential()
 	}
 	doSack := func() (*common.Results, error) {
@@ -229,7 +229,7 @@ func (r *Runner) runTCP(cfg config.Config, hname string, target net.IP, maxTTL u
 		return sack.RunSackTraceroute(context.TODO(), params)
 	}
 	doSynSocket := func() (*common.Results, error) {
-		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout)
+		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout, cfg.TCPSynCompatibilityMode)
 		return tr.TracerouteSequentialSocket()
 	}
 

--- a/pkg/networkpath/traceroute/sysprobe.go
+++ b/pkg/networkpath/traceroute/sysprobe.go
@@ -17,13 +17,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, maxTTL uint8, timeout time.Duration) ([]byte, error) {
+func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynCompatibilityMode bool, maxTTL uint8, timeout time.Duration) ([]byte, error) {
 	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
 	log.Tracef("Network Path traceroute HTTP request timeout: %s", httpTimeout)
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
-	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s", host, clientID, port, maxTTL, timeout, protocol, tcpMethod))
+	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s&tcp_syn_compatibility_mode=%t", host, clientID, port, maxTTL, timeout, protocol, tcpMethod, tcpSynCompatibilityMode))
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/networkpath/traceroute/tcp/tcpv4.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4.go
@@ -29,23 +29,26 @@ type (
 		MaxTTL   uint8
 		Delay    time.Duration // delay between sending packets (not applicable if we go the serial send/receive route)
 		Timeout  time.Duration // full timeout for all packets
-		buffer   gopacket.SerializeBuffer
+		// CompatibilityMode is whether to try to imitate tcptraceroute as much as possible
+		CompatibilityMode bool
+		buffer            gopacket.SerializeBuffer
 	}
 )
 
 // NewTCPv4 initializes a new TCPv4 traceroute instance
-func NewTCPv4(target net.IP, targetPort uint16, numPaths uint16, minTTL uint8, maxTTL uint8, delay time.Duration, timeout time.Duration) *TCPv4 {
+func NewTCPv4(target net.IP, targetPort uint16, numPaths uint16, minTTL uint8, maxTTL uint8, delay time.Duration, timeout time.Duration, compatibilityMode bool) *TCPv4 {
 	buffer := gopacket.NewSerializeBufferExpectedSize(40, 0)
 
 	return &TCPv4{
-		Target:   target,
-		DestPort: targetPort,
-		NumPaths: numPaths,
-		MinTTL:   minTTL,
-		MaxTTL:   maxTTL,
-		Delay:    delay,
-		Timeout:  timeout,
-		buffer:   buffer,
+		Target:            target,
+		DestPort:          targetPort,
+		NumPaths:          numPaths,
+		MinTTL:            minTTL,
+		MaxTTL:            maxTTL,
+		Delay:             delay,
+		Timeout:           timeout,
+		CompatibilityMode: compatibilityMode,
+		buffer:            buffer,
 	}
 }
 

--- a/pkg/networkpath/traceroute/tcp/tcpv4_test.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_test.go
@@ -29,7 +29,7 @@ func TestCreateRawTCPSyn(t *testing.T) {
 	seqNum := uint32(1000)
 	ttl := 64
 
-	tcp := NewTCPv4(dstIP, dstPort, 1, 1, 1, 0, 0)
+	tcp := NewTCPv4(dstIP, dstPort, 1, 1, 1, 0, 0, false)
 	tcp.srcIP = srcIP
 	tcp.srcPort = srcPort
 
@@ -67,7 +67,7 @@ func TestCreateRawTCPSynBuffer(t *testing.T) {
 	seqNum := uint32(1000)
 	ttl := 64
 
-	tcp := NewTCPv4(dstIP, dstPort, 1, 1, 1, 0, 0)
+	tcp := NewTCPv4(dstIP, dstPort, 1, 1, 1, 0, 0, false)
 	tcp.srcIP = srcIP
 	tcp.srcPort = srcPort
 

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -40,6 +40,9 @@ type (
 // TracerouteSequential runs a traceroute sequentially where a packet is
 // sent and we wait for a response before sending the next packet
 func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
+	if t.CompatibilityMode {
+		return nil, fmt.Errorf("TCP SYN compatibility mode is not yet supported")
+	}
 	// Get local address for the interface that connects to this
 	// host and store in in the probe
 	addr, conn, err := common.LocalAddrForHost(t.Target, t.DestPort)

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix_test.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestSendAndReceive(t *testing.T) {
 
-	tcpv4 := NewTCPv4(net.ParseIP("5.6.7.8"), 443, 1, 1, 1, 0, 0)
+	tcpv4 := NewTCPv4(net.ParseIP("5.6.7.8"), 443, 1, 1, 1, 0, 0, false)
 	tcpv4.srcIP = net.ParseIP("1.2.3.4") // set these after constructor
 	tcpv4.srcPort = 12345
 	tts := []struct {

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
@@ -98,6 +98,9 @@ func (t *TCPv4) sendAndReceiveSocket(s winconn.ConnWrapper, ttl int, timeout tim
 // TracerouteSequential runs a traceroute sequentially where a packet is
 // sent and we wait for a response before sending the next packet
 func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
+	if t.CompatibilityMode {
+		return nil, fmt.Errorf("TCP SYN compatibility mode is not yet supported")
+	}
 	log.Debugf("Running traceroute to %+v", t)
 	// Get local address for the interface that connects to this
 	// host and store in in the probe

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows_test.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestSendAndReceive(t *testing.T) {
 	dstIP := net.ParseIP("5.6.7.8")
-	tcpv4 := NewTCPv4(dstIP, 443, 1, 1, 30, 0, 0)
+	tcpv4 := NewTCPv4(dstIP, 443, 1, 1, 30, 0, 0, false)
 	tcpv4.srcIP = net.ParseIP("1.2.3.4")
 	tcpv4.srcPort = 12345
 	tts := []struct {

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows_test.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows_test.go
@@ -106,7 +106,7 @@ func TestSendAndReceive(t *testing.T) {
 
 func TestSendAndReceiveSocket(t *testing.T) {
 	dstIP := net.ParseIP("5.6.7.8")
-	tcpv4 := NewTCPv4(dstIP, 443, 1, 1, 30, 0, 0)
+	tcpv4 := NewTCPv4(dstIP, 443, 1, 1, 30, 0, 0, false)
 	tcpv4.srcIP = net.ParseIP("1.2.3.4")
 	tcpv4.srcPort = 12345
 	tts := []struct {

--- a/pkg/networkpath/traceroute/traceroute_unix.go
+++ b/pkg/networkpath/traceroute/traceroute_unix.go
@@ -51,7 +51,7 @@ func New(cfg config.Config, _ telemetry.Component) (*UnixTraceroute, error) {
 
 // Run executes a traceroute
 func (l *UnixTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.MaxTTL, l.cfg.Timeout)
+	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.TCPSynCompatibilityMode, l.cfg.MaxTTL, l.cfg.Timeout)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}

--- a/pkg/networkpath/traceroute/traceroute_windows.go
+++ b/pkg/networkpath/traceroute/traceroute_windows.go
@@ -44,7 +44,7 @@ func New(cfg config.Config, _ telemetry.Component) (*WindowsTraceroute, error) {
 
 // Run executes a traceroute
 func (w *WindowsTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.MaxTTL, w.cfg.Timeout)
+	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.TCPSynCompatibilityMode, w.cfg.MaxTTL, w.cfg.Timeout)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Adds a (not yet supported) configuration option to enable TCP SYN compatibility mode, where we will make packets as similar to `tcptraceroute` as possible.
### Motivation
There have been a bunch of cases where our SYN packets are seemingly getting dropped.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
New config test should pass

### Possible Drawbacks / Trade-offs
The process of adding a config to traceroutes is currently labor-intensive. It involves changing code in a bunch of places. If we add more of these, we should coalesce it into a single struct that gets copied around.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->