### PR TITLE
Increase max retentation for Autoscaling events to 1h

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler.go
@@ -25,10 +25,10 @@ import (
 const (
 	// longestScalingRulePeriodAllowed is the maximum period allowed for a scaling rule
 	// increasing duration increase the number of events to keep in memory and to process for recommendations.
-	longestScalingRulePeriodAllowed = 30 * time.Minute
+	longestScalingRulePeriodAllowed = 60 * time.Minute
 
 	// statusRetainedActions is the number of horizontal actions kept in status
-	statusRetainedActions = 5
+	statusRetainedActions = 10
 
 	// CustomRecommenderAnnotationKey is the key used to store custom recommender configuration in annotations
 	CustomRecommenderAnnotationKey = "autoscaling.datadoghq.com/custom-recommender"


### PR DESCRIPTION
### What does this PR do?

Increase maximum retention for Autoscaling events from 30m to 1h.

### Motivation

### Describe how you validated your changes

Set a `stablizationWindowSeconds` or long `scaleUp` or `scaleDown` duration

### Possible Drawbacks / Trade-offs

### Additional Notes