### PR TITLE
[NPM-4421] Add packet ID to matching logic, use it for compatibility mode

### DIFF
--- a/pkg/networkpath/traceroute/common/common.go
+++ b/pkg/networkpath/traceroute/common/common.go
@@ -51,7 +51,7 @@ type (
 
 	// MatcherFunc defines functions for matching a packet from the wire to
 	// a traceroute based on the source/destination addresses and an identifier
-	MatcherFunc func(*ipv4.Header, []byte, net.IP, uint16, net.IP, uint16, uint32) (net.IP, error)
+	MatcherFunc func(*ipv4.Header, []byte, net.IP, uint16, net.IP, uint16, uint32, uint16) (net.IP, error)
 )
 
 // Error implements the error interface for

--- a/pkg/networkpath/traceroute/icmp/parser.go
+++ b/pkg/networkpath/traceroute/icmp/parser.go
@@ -26,7 +26,7 @@ type (
 	// Parser defines the interface for parsing
 	// ICMP packets
 	Parser interface {
-		Match(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32) (net.IP, error)
+		Match(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32, packetID uint16) (net.IP, error)
 		Parse(header *ipv4.Header, packet []byte) (*Response, error)
 	}
 
@@ -36,6 +36,7 @@ type (
 		SrcIP        net.IP
 		DstIP        net.IP
 		TypeCode     layers.ICMPv4TypeCode
+		InnerIPID    uint16
 		InnerSrcIP   net.IP
 		InnerDstIP   net.IP
 		InnerSrcPort uint16
@@ -52,12 +53,13 @@ type (
 // Matches checks if an ICMPResponse matches the expected response
 // based on the local and remote IP, port, and identifier. In this context,
 // identifier will either be the TCP sequence number OR the UDP checksum
-func (i *Response) Matches(localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32) bool {
+func (i *Response) Matches(localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32, packetID uint16) bool {
 	return localIP.Equal(i.InnerSrcIP) &&
 		remoteIP.Equal(i.InnerDstIP) &&
 		localPort == i.InnerSrcPort &&
 		remotePort == i.InnerDstPort &&
-		innerIdentifier == i.InnerIdentifier
+		innerIdentifier == i.InnerIdentifier &&
+		packetID == i.InnerIPID
 }
 
 func validatePacket(header *ipv4.Header, payload []byte) error {

--- a/pkg/networkpath/traceroute/icmp/tcp_parser.go
+++ b/pkg/networkpath/traceroute/icmp/tcp_parser.go
@@ -49,7 +49,7 @@ func NewICMPTCPParser() Parser {
 }
 
 // Match encapsulates to logic to both parse and match an ICMP packet
-func (p *TCPParser) Match(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32) (net.IP, error) {
+func (p *TCPParser) Match(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32, packetID uint16) (net.IP, error) {
 	if header.Protocol != IPProtoICMP {
 		return net.IP{}, errors.New("expected an ICMP packet")
 	}
@@ -57,7 +57,7 @@ func (p *TCPParser) Match(header *ipv4.Header, packet []byte, localIP net.IP, lo
 	if err != nil {
 		return net.IP{}, fmt.Errorf("ICMP parse error: %w", err)
 	}
-	if !icmpResponse.Matches(localIP, localPort, remoteIP, remotePort, innerIdentifier) {
+	if !icmpResponse.Matches(localIP, localPort, remoteIP, remotePort, innerIdentifier, packetID) {
 		return net.IP{}, common.MismatchError("ICMP packet doesn't match")
 	}
 
@@ -113,6 +113,7 @@ func (p *TCPParser) Parse(header *ipv4.Header, payload []byte) (*Response, error
 	p.icmpResponse.InnerDstIP = p.innerIPLayer.DstIP
 	p.icmpResponse.InnerSrcPort = uint16(p.innerTCPLayer.SrcPort)
 	p.icmpResponse.InnerDstPort = uint16(p.innerTCPLayer.DstPort)
+	p.icmpResponse.InnerIPID = p.innerIPLayer.Id
 	p.icmpResponse.InnerIdentifier = p.innerTCPLayer.Seq
 
 	return p.icmpResponse, nil

--- a/pkg/networkpath/traceroute/icmp/udp_parser.go
+++ b/pkg/networkpath/traceroute/icmp/udp_parser.go
@@ -47,7 +47,7 @@ func NewICMPUDPParser() Parser {
 }
 
 // Match encapsulates to logic to both parse and match an ICMP packet
-func (p *UDPParser) Match(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32) (net.IP, error) {
+func (p *UDPParser) Match(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32, packetID uint16) (net.IP, error) {
 	if header.Protocol != IPProtoICMP {
 		return net.IP{}, errors.New("expected an ICMP packet")
 	}
@@ -55,7 +55,7 @@ func (p *UDPParser) Match(header *ipv4.Header, packet []byte, localIP net.IP, lo
 	if err != nil {
 		return net.IP{}, fmt.Errorf("ICMP parse error: %w", err)
 	}
-	if !icmpResponse.Matches(localIP, localPort, remoteIP, remotePort, innerIdentifier) {
+	if !icmpResponse.Matches(localIP, localPort, remoteIP, remotePort, innerIdentifier, packetID) {
 		return net.IP{}, common.MismatchError("ICMP packet doesn't match")
 	}
 
@@ -101,6 +101,7 @@ func (p *UDPParser) Parse(header *ipv4.Header, payload []byte) (*Response, error
 	p.icmpResponse.InnerDstPort = uint16(p.innerUDPLayer.DstPort)
 	// the packet's checksum is used as the identifier for UDP packets
 	p.icmpResponse.InnerIdentifier = uint32(p.innerUDPLayer.Checksum)
+	p.icmpResponse.InnerIPID = p.innerIPLayer.Id
 
 	return p.icmpResponse, nil
 }

--- a/pkg/networkpath/traceroute/tcp/parser.go
+++ b/pkg/networkpath/traceroute/tcp/parser.go
@@ -79,7 +79,7 @@ func (tp *parser) parseTCP(header *ipv4.Header, payload []byte) (*tcpResponse, e
 // MatchTCP parses a TCP packet from a header and packet bytes and compares the information
 // contained in the packet to what's expected and returns the source IP of the incoming packet
 // if it's successful or a MismatchError if the packet can be read but doesn't match
-func (tp *parser) MatchTCP(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32, _packetID uint16) (net.IP, error) {
+func (tp *parser) MatchTCP(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32, _ uint16) (net.IP, error) {
 	if header.Protocol != 6 { // TCP
 		return net.IP{}, errors.New("expected a TCP packet")
 	}

--- a/pkg/networkpath/traceroute/tcp/parser.go
+++ b/pkg/networkpath/traceroute/tcp/parser.go
@@ -79,7 +79,7 @@ func (tp *parser) parseTCP(header *ipv4.Header, payload []byte) (*tcpResponse, e
 // MatchTCP parses a TCP packet from a header and packet bytes and compares the information
 // contained in the packet to what's expected and returns the source IP of the incoming packet
 // if it's successful or a MismatchError if the packet can be read but doesn't match
-func (tp *parser) MatchTCP(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32) (net.IP, error) {
+func (tp *parser) MatchTCP(header *ipv4.Header, packet []byte, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32, _packetID uint16) (net.IP, error) {
 	if header.Protocol != 6 { // TCP
 		return net.IP{}, errors.New("expected a TCP packet")
 	}

--- a/pkg/networkpath/traceroute/tcp/parser_test.go
+++ b/pkg/networkpath/traceroute/tcp/parser_test.go
@@ -179,7 +179,9 @@ func Test_MatchTCP(t *testing.T) {
 	for _, test := range tts {
 		t.Run(test.description, func(t *testing.T) {
 			tp := newParser()
-			actualIP, err := tp.MatchTCP(test.header, test.payload, test.localIP, test.localPort, test.remoteIP, test.remotePort, test.seqNum)
+			// packetID is not used for TCP matching
+			packetID := uint16(2222)
+			actualIP, err := tp.MatchTCP(test.header, test.payload, test.localIP, test.localPort, test.remoteIP, test.remotePort, test.seqNum, packetID)
 			if test.expectedErrMsg != "" {
 				require.Error(t, err)
 				assert.True(t, strings.Contains(err.Error(), test.expectedErrMsg), fmt.Sprintf("expected %q, got %q", test.expectedErrMsg, err.Error()))

--- a/pkg/networkpath/traceroute/tcp/tcpv4.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4.go
@@ -60,8 +60,8 @@ func (t *TCPv4) Close() error {
 }
 
 // createRawTCPSyn creates a TCP packet with the specified parameters
-func (t *TCPv4) createRawTCPSyn(seqNum uint32, ttl int) (*ipv4.Header, []byte, error) {
-	ipHdr, packet, hdrlen, err := t.createRawTCPSynBuffer(seqNum, ttl)
+func (t *TCPv4) createRawTCPSyn(packetID uint16, seqNum uint32, ttl int) (*ipv4.Header, []byte, error) {
+	ipHdr, packet, hdrlen, err := t.createRawTCPSynBuffer(packetID, seqNum, ttl)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -69,14 +69,14 @@ func (t *TCPv4) createRawTCPSyn(seqNum uint32, ttl int) (*ipv4.Header, []byte, e
 	return ipHdr, packet[hdrlen:], nil
 }
 
-func (t *TCPv4) createRawTCPSynBuffer(seqNum uint32, ttl int) (*ipv4.Header, []byte, int, error) {
+func (t *TCPv4) createRawTCPSynBuffer(packetID uint16, seqNum uint32, ttl int) (*ipv4.Header, []byte, int, error) {
 	// if this function is modified in a way that changes the size,
 	// update the NewSerializeBufferExpectedSize call in NewTCPv4
 	ipLayer := &layers.IPv4{
 		Version:  4,
 		Length:   20,
 		TTL:      uint8(ttl),
-		Id:       uint16(41821),
+		Id:       packetID,
 		Protocol: 6,
 		DstIP:    t.Target,
 		SrcIP:    t.srcIP,

--- a/pkg/networkpath/traceroute/tcp/tcpv4.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4.go
@@ -8,6 +8,7 @@ package tcp
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 	"time"
 
@@ -118,4 +119,26 @@ func (t *TCPv4) createRawTCPSynBuffer(packetID uint16, seqNum uint32, ttl int) (
 	}
 
 	return &ipHdr, packet, 20, nil
+}
+
+// initPacketIDAndSeqNum sets up the per-traceroute constant values.
+func (t *TCPv4) initPacketIDAndSeqNum() (uint16, uint32) {
+	if t.CompatibilityMode {
+		// in compatibility mode, the seqNum is held constant (to a random value)
+		return 0, rand.Uint32()
+	}
+
+	// in regular mode, the packetID is held constant (to 41821)
+	return 41821, 0
+}
+
+// nextPacketIDAndSeqNum performs per-packet randomization
+func (t *TCPv4) nextPacketIDAndSeqNum(packetID *uint16, seqNum *uint32) {
+	if t.CompatibilityMode {
+		// in compatibility mode, the packetID is randomized per-packet
+		*packetID = uint16(rand.Uint32())
+	} else {
+		// in regular mode, the seqNum is randomized per-packet
+		*seqNum = rand.Uint32()
+	}
 }

--- a/pkg/networkpath/traceroute/tcp/tcpv4_test.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_test.go
@@ -27,6 +27,7 @@ func TestCreateRawTCPSyn(t *testing.T) {
 	srcPort := uint16(12345)
 	dstPort := uint16(80)
 	seqNum := uint32(1000)
+	packetID := uint16(41821)
 	ttl := 64
 
 	tcp := NewTCPv4(dstIP, dstPort, 1, 1, 1, 0, 0, false)
@@ -49,7 +50,7 @@ func TestCreateRawTCPSyn(t *testing.T) {
 		0x30, 0x39, 0x0, 0x50, 0x0, 0x0, 0x3, 0xe8, 0x0, 0x0, 0x0, 0x0, 0x50, 0x2, 0x4, 0x0, 0x67, 0x5e, 0x0, 0x0,
 	}
 
-	ipHeader, pktBytes, err := tcp.createRawTCPSyn(seqNum, ttl)
+	ipHeader, pktBytes, err := tcp.createRawTCPSyn(packetID, seqNum, ttl)
 	require.NoError(t, err)
 	assert.Equal(t, expectedIPHeader, ipHeader)
 	assert.Equal(t, expectedPktBytes, pktBytes)
@@ -65,6 +66,7 @@ func TestCreateRawTCPSynBuffer(t *testing.T) {
 	srcPort := uint16(12345)
 	dstPort := uint16(80)
 	seqNum := uint32(1000)
+	packetID := uint16(41821)
 	ttl := 64
 
 	tcp := NewTCPv4(dstIP, dstPort, 1, 1, 1, 0, 0, false)
@@ -74,7 +76,7 @@ func TestCreateRawTCPSynBuffer(t *testing.T) {
 	expectedIPHeader := &ipv4.Header{
 		Version:  4,
 		TTL:      ttl,
-		ID:       41821,
+		ID:       int(packetID),
 		Protocol: 6,
 		Dst:      dstIP,
 		Src:      srcIP,
@@ -87,10 +89,34 @@ func TestCreateRawTCPSynBuffer(t *testing.T) {
 		0x45, 0x0, 0x0, 0x28, 0xa3, 0x5d, 0x0, 0x0, 0x40, 0x6, 0xc7, 0x5f, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x30, 0x39, 0x0, 0x50, 0x0, 0x0, 0x3, 0xe8, 0x0, 0x0, 0x0, 0x0, 0x50, 0x2, 0x4, 0x0, 0x67, 0x5e, 0x0, 0x0,
 	}
 
-	ipHeader, pktBytes, headerLength, err := tcp.createRawTCPSynBuffer(seqNum, ttl)
+	ipHeader, pktBytes, headerLength, err := tcp.createRawTCPSynBuffer(packetID, seqNum, ttl)
 
 	require.NoError(t, err)
 	assert.Equal(t, expectedIPHeader, ipHeader)
 	assert.Equal(t, 20, headerLength)
 	assert.Equal(t, expectedPktBytes, pktBytes)
+}
+
+func TestCreateRawTCPSynBufferPacketID(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("TestCreateRawTCPSyn is broken on macOS")
+	}
+	srcIP := net.ParseIP("1.2.3.4")
+	dstIP := net.ParseIP("5.6.7.8")
+	srcPort := uint16(12345)
+	dstPort := uint16(80)
+	seqNum := uint32(1000)
+	packetID := uint16(54321)
+	ttl := 64
+
+	tcp := NewTCPv4(dstIP, dstPort, 1, 1, 1, 0, 0, false)
+	tcp.srcIP = srcIP
+	tcp.srcPort = srcPort
+
+	ipHeader, _, _, err := tcp.createRawTCPSynBuffer(packetID, seqNum, ttl)
+
+	require.NoError(t, err)
+
+	// check that when we re-parse the packet ID, it has the ID we expect
+	require.Equal(t, ipHeader.ID, int(packetID))
 }

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -96,9 +96,8 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 	// hops should be of length # of hops
 	hops := make([]*common.Hop, 0, t.MaxTTL-t.MinTTL)
 
-	packetID, seqNumber := t.initPacketIDAndSeqNum()
 	for i := int(t.MinTTL); i <= int(t.MaxTTL); i++ {
-		t.nextPacketIDAndSeqNum(&packetID, &seqNumber)
+		seqNumber, packetID := t.nextSeqNumAndPacketID()
 		hop, err := t.sendAndReceive(rawIcmpConn, rawTCPConn, i, seqNumber, packetID, t.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run traceroute: %w", err)

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -40,9 +40,6 @@ type (
 // TracerouteSequential runs a traceroute sequentially where a packet is
 // sent and we wait for a response before sending the next packet
 func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
-	if t.CompatibilityMode {
-		return nil, fmt.Errorf("TCP SYN compatibility mode is not yet supported")
-	}
 	// Get local address for the interface that connects to this
 	// host and store in in the probe
 	addr, conn, err := common.LocalAddrForHost(t.Target, t.DestPort)
@@ -100,9 +97,20 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 	// hops should be of length # of hops
 	hops := make([]*common.Hop, 0, t.MaxTTL-t.MinTTL)
 
+	var packetID uint16
+	var seqNumber uint32
+	if t.CompatibilityMode {
+		seqNumber = rand.Uint32()
+	} else {
+		packetID = uint16(41821)
+	}
 	for i := int(t.MinTTL); i <= int(t.MaxTTL); i++ {
-		seqNumber := rand.Uint32()
-		hop, err := t.sendAndReceive(rawIcmpConn, rawTCPConn, i, seqNumber, t.Timeout)
+		if t.CompatibilityMode {
+			packetID = uint16(rand.Uint32())
+		} else {
+			seqNumber = rand.Uint32()
+		}
+		hop, err := t.sendAndReceive(rawIcmpConn, rawTCPConn, i, seqNumber, packetID, t.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run traceroute: %w", err)
 		}
@@ -121,12 +129,12 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 		Target:     t.Target,
 		DstPort:    t.DestPort,
 		Hops:       hops,
-		Tags:       []string{"tcp_method:syn"},
+		Tags:       []string{"tcp_method:syn", fmt.Sprintf("compatibility_mode:%t", t.CompatibilityMode)},
 	}, nil
 }
 
-func (t *TCPv4) sendAndReceive(rawIcmpConn rawConnWrapper, rawTCPConn rawConnWrapper, ttl int, seqNum uint32, timeout time.Duration) (*common.Hop, error) {
-	tcpHeader, tcpPacket, err := t.createRawTCPSyn(seqNum, ttl)
+func (t *TCPv4) sendAndReceive(rawIcmpConn rawConnWrapper, rawTCPConn rawConnWrapper, ttl int, seqNum uint32, packetID uint16, timeout time.Duration) (*common.Hop, error) {
+	tcpHeader, tcpPacket, err := t.createRawTCPSyn(packetID, seqNum, ttl)
 	if err != nil {
 		log.Errorf("failed to create TCP packet with TTL: %d, error: %s", ttl, err.Error())
 		return nil, err
@@ -139,7 +147,7 @@ func (t *TCPv4) sendAndReceive(rawIcmpConn rawConnWrapper, rawTCPConn rawConnWra
 	}
 
 	start := time.Now()
-	resp := listenPacketsFunc(rawIcmpConn, rawTCPConn, timeout, t.srcIP, t.srcPort, t.Target, t.DestPort, seqNum)
+	resp := listenPacketsFunc(rawIcmpConn, rawTCPConn, timeout, t.srcIP, t.srcPort, t.Target, t.DestPort, seqNum, packetID)
 	if resp.Err != nil {
 		log.Errorf("failed to listen for packets: %s", resp.Err.Error())
 		return nil, resp.Err

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -11,7 +11,6 @@ package tcp
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/netip"
 	"syscall"
@@ -97,19 +96,9 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 	// hops should be of length # of hops
 	hops := make([]*common.Hop, 0, t.MaxTTL-t.MinTTL)
 
-	var packetID uint16
-	var seqNumber uint32
-	if t.CompatibilityMode {
-		seqNumber = rand.Uint32()
-	} else {
-		packetID = uint16(41821)
-	}
+	packetID, seqNumber := t.initPacketIDAndSeqNum()
 	for i := int(t.MinTTL); i <= int(t.MaxTTL); i++ {
-		if t.CompatibilityMode {
-			packetID = uint16(rand.Uint32())
-		} else {
-			seqNumber = rand.Uint32()
-		}
+		t.nextPacketIDAndSeqNum(&packetID, &seqNumber)
 		hop, err := t.sendAndReceive(rawIcmpConn, rawTCPConn, i, seqNumber, packetID, t.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run traceroute: %w", err)

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix_test.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix_test.go
@@ -31,7 +31,7 @@ func TestSendAndReceive(t *testing.T) {
 		description string
 		ttl         int
 		sendFunc    func(rawConnWrapper, *ipv4.Header, []byte) error
-		listenFunc  func(rawConnWrapper, rawConnWrapper, time.Duration, net.IP, uint16, net.IP, uint16, uint32) packetResponse
+		listenFunc  func(rawConnWrapper, rawConnWrapper, time.Duration, net.IP, uint16, net.IP, uint16, uint32, uint16) packetResponse
 		expected    *common.Hop
 		errMsg      string
 	}{
@@ -41,7 +41,7 @@ func TestSendAndReceive(t *testing.T) {
 			sendFunc: func(_ rawConnWrapper, _ *ipv4.Header, _ []byte) error {
 				return fmt.Errorf("sendPacket error")
 			},
-			listenFunc: func(_ rawConnWrapper, _ rawConnWrapper, _ time.Duration, _ net.IP, _ uint16, _ net.IP, _ uint16, _ uint32) packetResponse {
+			listenFunc: func(_ rawConnWrapper, _ rawConnWrapper, _ time.Duration, _ net.IP, _ uint16, _ net.IP, _ uint16, _ uint32, _ uint16) packetResponse {
 				return packetResponse{}
 			},
 			expected: nil,
@@ -53,7 +53,7 @@ func TestSendAndReceive(t *testing.T) {
 			sendFunc: func(_ rawConnWrapper, _ *ipv4.Header, _ []byte) error {
 				return nil
 			},
-			listenFunc: func(_ rawConnWrapper, _ rawConnWrapper, _ time.Duration, _ net.IP, _ uint16, _ net.IP, _ uint16, _ uint32) packetResponse {
+			listenFunc: func(_ rawConnWrapper, _ rawConnWrapper, _ time.Duration, _ net.IP, _ uint16, _ net.IP, _ uint16, _ uint32, _ uint16) packetResponse {
 				return packetResponse{Err: fmt.Errorf("listenPackets error")}
 			},
 			expected: nil,
@@ -65,7 +65,7 @@ func TestSendAndReceive(t *testing.T) {
 			sendFunc: func(_ rawConnWrapper, _ *ipv4.Header, _ []byte) error {
 				return nil
 			},
-			listenFunc: func(_ rawConnWrapper, _ rawConnWrapper, _ time.Duration, _ net.IP, _ uint16, _ net.IP, _ uint16, _ uint32) packetResponse {
+			listenFunc: func(_ rawConnWrapper, _ rawConnWrapper, _ time.Duration, _ net.IP, _ uint16, _ net.IP, _ uint16, _ uint32, _ uint16) packetResponse {
 				return packetResponse{
 					IP:   net.ParseIP("7.8.9.0"),
 					Type: 2,
@@ -90,7 +90,7 @@ func TestSendAndReceive(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			sendPacketFunc = test.sendFunc
 			listenPacketsFunc = test.listenFunc
-			actual, err := tcpv4.sendAndReceive(nil, nil, test.ttl, 418, 1*time.Second)
+			actual, err := tcpv4.sendAndReceive(nil, nil, test.ttl, 418, 1234, 1*time.Second)
 			if test.errMsg != "" {
 				require.Error(t, err)
 				assert.True(t, strings.Contains(err.Error(), test.errMsg), "error mismatch: excpected %q, got %q", test.errMsg, err.Error())

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
@@ -98,9 +98,6 @@ func (t *TCPv4) sendAndReceiveSocket(s winconn.ConnWrapper, ttl int, timeout tim
 // TracerouteSequential runs a traceroute sequentially where a packet is
 // sent and we wait for a response before sending the next packet
 func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
-	if t.CompatibilityMode {
-		return nil, fmt.Errorf("TCP SYN compatibility mode is not yet supported")
-	}
 	log.Debugf("Running traceroute to %+v", t)
 	// Get local address for the interface that connects to this
 	// host and store in in the probe
@@ -120,9 +117,20 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 
 	hops := make([]*common.Hop, 0, int(t.MaxTTL-t.MinTTL)+1)
 
+	var packetID uint16
+	var seqNumber uint32
+	if t.CompatibilityMode {
+		seqNumber = rand.Uint32()
+	} else {
+		packetID = uint16(41821)
+	}
 	for i := int(t.MinTTL); i <= int(t.MaxTTL); i++ {
-		seqNumber := rand.Uint32()
-		hop, err := t.sendAndReceive(rs, i, seqNumber, t.Timeout)
+		if t.CompatibilityMode {
+			packetID = uint16(rand.Uint32())
+		} else {
+			seqNumber = rand.Uint32()
+		}
+		hop, err := t.sendAndReceive(rs, i, seqNumber, packetID, t.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run traceroute: %w", err)
 		}
@@ -141,11 +149,12 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 		Target:     t.Target,
 		DstPort:    t.DestPort,
 		Hops:       hops,
-		Tags:       []string{"tcp_method:syn"},
+		Tags:       []string{"tcp_method:syn", fmt.Sprintf("compatibility_mode:%t", t.CompatibilityMode)},
 	}, nil
 }
-func (t *TCPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, seqNum uint32, timeout time.Duration) (*common.Hop, error) {
-	_, buffer, _, err := t.createRawTCPSynBuffer(seqNum, ttl)
+
+func (t *TCPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, seqNum uint32, packetID uint16, timeout time.Duration) (*common.Hop, error) {
+	_, buffer, _, err := t.createRawTCPSynBuffer(packetID, seqNum, ttl)
 	if err != nil {
 		log.Errorf("failed to create TCP packet with TTL: %d, error: %s", ttl, err.Error())
 		return nil, err
@@ -164,7 +173,7 @@ func (t *TCPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, seqNum uint32
 		windows.IPPROTO_TCP:  tcpParser.MatchTCP,
 	}
 	start := time.Now() // TODO: is this the best place to start?
-	hopIP, end, err := rs.ListenPackets(timeout, t.srcIP, t.srcPort, t.Target, t.DestPort, seqNum, matcherFuncs)
+	hopIP, end, err := rs.ListenPackets(timeout, t.srcIP, t.srcPort, t.Target, t.DestPort, seqNum, packetID, matcherFuncs)
 	if err != nil {
 		log.Errorf("failed to listen for packets: %s", err.Error())
 		return nil, err

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
@@ -116,9 +116,8 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 
 	hops := make([]*common.Hop, 0, int(t.MaxTTL-t.MinTTL)+1)
 
-	packetID, seqNumber := t.initPacketIDAndSeqNum()
 	for i := int(t.MinTTL); i <= int(t.MaxTTL); i++ {
-		t.nextPacketIDAndSeqNum(&packetID, &seqNumber)
+		seqNumber, packetID := t.nextSeqNumAndPacketID()
 		hop, err := t.sendAndReceive(rs, i, seqNumber, packetID, t.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run traceroute: %w", err)

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
@@ -8,7 +8,6 @@ package tcp
 
 import (
 	"fmt"
-	"math/rand"
 	"net"
 	"time"
 
@@ -117,19 +116,9 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 
 	hops := make([]*common.Hop, 0, int(t.MaxTTL-t.MinTTL)+1)
 
-	var packetID uint16
-	var seqNumber uint32
-	if t.CompatibilityMode {
-		seqNumber = rand.Uint32()
-	} else {
-		packetID = uint16(41821)
-	}
+	packetID, seqNumber := t.initPacketIDAndSeqNum()
 	for i := int(t.MinTTL); i <= int(t.MaxTTL); i++ {
-		if t.CompatibilityMode {
-			packetID = uint16(rand.Uint32())
-		} else {
-			seqNumber = rand.Uint32()
-		}
+		t.nextPacketIDAndSeqNum(&packetID, &seqNumber)
 		hop, err := t.sendAndReceive(rs, i, seqNumber, packetID, t.Timeout)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run traceroute: %w", err)

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows_test.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows_test.go
@@ -85,9 +85,9 @@ func TestSendAndReceive(t *testing.T) {
 			mockRawConn := winconn.NewMockRawConnWrapper(controller)
 			mockRawConn.EXPECT().SendRawPacket(gomock.Any(), gomock.Any(), gomock.Any()).Return(test.mockSendError)
 			if test.mockSendError == nil { // only expect ListenPackets call if SendRawPacket is successful
-				mockRawConn.EXPECT().ListenPackets(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.mockHopIP, test.mockEnd, test.mockListenError)
+				mockRawConn.EXPECT().ListenPackets(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(test.mockHopIP, test.mockEnd, test.mockListenError)
 			}
-			actual, err := tcpv4.sendAndReceive(mockRawConn, 1, 418, 1*time.Second)
+			actual, err := tcpv4.sendAndReceive(mockRawConn, 1, 418, 1234, 1*time.Second)
 			if test.errMsg != "" {
 				require.Error(t, err)
 				assert.True(t, strings.Contains(err.Error(), test.errMsg), "error mismatch: excpected %q, got %q", test.errMsg, err.Error())

--- a/pkg/networkpath/traceroute/tcp/utils_unix.go
+++ b/pkg/networkpath/traceroute/tcp/utils_unix.go
@@ -49,7 +49,7 @@ func sendPacket(rawConn rawConnWrapper, header *ipv4.Header, payload []byte) err
 // receives a matching packet within the timeout, a blank response is returned.
 // Once a matching packet is received by a listener, it will cause the other listener
 // to be canceled, and data from the matching packet will be returned to the caller
-func listenPackets(icmpConn rawConnWrapper, tcpConn rawConnWrapper, timeout time.Duration, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32) packetResponse {
+func listenPackets(icmpConn rawConnWrapper, tcpConn rawConnWrapper, timeout time.Duration, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32, packetID uint16) packetResponse {
 	respChan := make(chan packetResponse, 2)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -60,12 +60,12 @@ func listenPackets(icmpConn rawConnWrapper, tcpConn rawConnWrapper, timeout time
 
 	wg.Add(1)
 	go func() {
-		respChan <- handlePackets(ctx, tcpConn, localIP, localPort, remoteIP, remotePort, seqNum)
+		respChan <- handlePackets(ctx, tcpConn, localIP, localPort, remoteIP, remotePort, seqNum, packetID)
 		wg.Done()
 	}()
 	wg.Add(1)
 	go func() {
-		respChan <- handlePackets(ctx, icmpConn, localIP, localPort, remoteIP, remotePort, seqNum)
+		respChan <- handlePackets(ctx, icmpConn, localIP, localPort, remoteIP, remotePort, seqNum, packetID)
 		wg.Done()
 	}()
 
@@ -101,7 +101,7 @@ func listenPackets(icmpConn rawConnWrapper, tcpConn rawConnWrapper, timeout time
 // handlePackets in its current implementation should listen for the first matching
 // packet on the connection and then return. If no packet is received within the
 // timeout or if the listener is canceled, it should return a canceledError
-func handlePackets(ctx context.Context, conn rawConnWrapper, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32) packetResponse {
+func handlePackets(ctx context.Context, conn rawConnWrapper, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, seqNum uint32, packetID uint16) packetResponse {
 	buf := make([]byte, 1024)
 	tp := newParser()
 	icmpParser := icmp.NewICMPTCPParser()
@@ -140,7 +140,7 @@ func handlePackets(ctx context.Context, conn rawConnWrapper, localIP net.IP, loc
 				log.Tracef("failed to parse ICMP packet: %s", err)
 				continue
 			}
-			if icmpResponse.Matches(localIP, localPort, remoteIP, remotePort, seqNum) {
+			if icmpResponse.Matches(localIP, localPort, remoteIP, remotePort, seqNum, packetID) {
 				return packetResponse{
 					IP:   icmpResponse.SrcIP,
 					Type: icmpResponse.TypeCode.Type(),

--- a/pkg/networkpath/traceroute/testutils/testutils.go
+++ b/pkg/networkpath/traceroute/testutils/testutils.go
@@ -148,8 +148,9 @@ func CreateMockTCPPacket(ipHeader *ipv4.Header, tcpLayer *layers.TCP, includeHea
 }
 
 // CreateMockIPv4Layer creates a mock IPv4 layer for testing
-func CreateMockIPv4Layer(srcIP, dstIP net.IP, protocol layers.IPProtocol) *layers.IPv4 {
+func CreateMockIPv4Layer(packetID uint16, srcIP, dstIP net.IP, protocol layers.IPProtocol) *layers.IPv4 {
 	return &layers.IPv4{
+		Id:       packetID,
 		SrcIP:    srcIP,
 		DstIP:    dstIP,
 		Version:  4,

--- a/pkg/networkpath/traceroute/udp/udpv4_windows.go
+++ b/pkg/networkpath/traceroute/udp/udpv4_windows.go
@@ -66,7 +66,7 @@ func (u *UDPv4) TracerouteSequential() (*common.Results, error) {
 }
 
 func (u *UDPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, timeout time.Duration) (*common.Hop, error) {
-	_, buffer, udpChecksum, _, err := u.createRawUDPBuffer(u.srcIP, u.srcPort, u.Target, u.TargetPort, ttl)
+	ipHdr, buffer, udpChecksum, _, err := u.createRawUDPBuffer(u.srcIP, u.srcPort, u.Target, u.TargetPort, ttl)
 	if err != nil {
 		log.Errorf("failed to create UDP packet with TTL: %d, error: %s", ttl, err.Error())
 		return nil, err
@@ -82,7 +82,7 @@ func (u *UDPv4) sendAndReceive(rs winconn.RawConnWrapper, ttl int, timeout time.
 		windows.IPPROTO_ICMP: u.icmpParser.Match,
 	}
 	start := time.Now() // TODO: is this the best place to start?
-	hopIP, end, err := rs.ListenPackets(timeout, u.srcIP, u.srcPort, u.Target, u.TargetPort, uint32(udpChecksum), matcherFuncs)
+	hopIP, end, err := rs.ListenPackets(timeout, u.srcIP, u.srcPort, u.Target, u.TargetPort, uint32(udpChecksum), uint16(ipHdr.ID), matcherFuncs)
 	if err != nil {
 		log.Errorf("failed to listen for packets: %s", err.Error())
 		return nil, err

--- a/pkg/networkpath/traceroute/winconn/mock_winconn_windows.go
+++ b/pkg/networkpath/traceroute/winconn/mock_winconn_windows.go
@@ -50,9 +50,9 @@ func (mr *MockRawConnWrapperMockRecorder) Close() *gomock.Call {
 }
 
 // ListenPackets mocks base method.
-func (m *MockRawConnWrapper) ListenPackets(timeout time.Duration, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32, matcherFuncs map[int]common.MatcherFunc) (net.IP, time.Time, error) {
+func (m *MockRawConnWrapper) ListenPackets(timeout time.Duration, localIP net.IP, localPort uint16, remoteIP net.IP, remotePort uint16, innerIdentifier uint32, icmpPacketID uint16, matcherFuncs map[int]common.MatcherFunc) (net.IP, time.Time, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListenPackets", timeout, localIP, localPort, remoteIP, remotePort, innerIdentifier, matcherFuncs)
+	ret := m.ctrl.Call(m, "ListenPackets", timeout, localIP, localPort, remoteIP, remotePort, innerIdentifier, icmpPacketID, matcherFuncs)
 	ret0, _ := ret[0].(net.IP)
 	ret1, _ := ret[1].(time.Time)
 	ret2, _ := ret[2].(error)
@@ -60,9 +60,9 @@ func (m *MockRawConnWrapper) ListenPackets(timeout time.Duration, localIP net.IP
 }
 
 // ListenPackets indicates an expected call of ListenPackets.
-func (mr *MockRawConnWrapperMockRecorder) ListenPackets(timeout, localIP, localPort, remoteIP, remotePort, innerIdentifier, matcherFuncs interface{}) *gomock.Call {
+func (mr *MockRawConnWrapperMockRecorder) ListenPackets(timeout, localIP, localPort, remoteIP, remotePort, innerIdentifier, icmpPacketID, matcherFuncs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListenPackets", reflect.TypeOf((*MockRawConnWrapper)(nil).ListenPackets), timeout, localIP, localPort, remoteIP, remotePort, innerIdentifier, matcherFuncs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListenPackets", reflect.TypeOf((*MockRawConnWrapper)(nil).ListenPackets), timeout, localIP, localPort, remoteIP, remotePort, innerIdentifier, icmpPacketID, matcherFuncs)
 }
 
 // ReadFrom mocks base method.


### PR DESCRIPTION
Stacked on [\[NPM-4421\] Add config to randomize SYN packet ID](https://github.com/DataDog/datadog-agent/pull/37033)
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR implements `tcp_syn_compatibility_mode`. In this mode, TCP SYN traceroutes attempt to mimic the `tcptraceroute` tool as much as possible.

### Motivation
Should address the issues people have been seeing with dropped TCP SYN packets.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
I tested with compatibility mode enabled/disabled with static paths on Linux, and on Windows. I also tested UDP. I checked in wireshark, that it marks packets as retransmissions in compatibility mode, not reused ports.

Existing test suite should pass with updated tests:
```
sudo go test -timeout 30s -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/...
```
I also ran the suite on Windows, and all tests passed (except for one that depends on `TCP_FAIL_CONNECT_ON_ICMP_ERROR` which my Windows version doesn't support):
```
go test -timeout 30s -tags windows,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/...
```

### Possible Drawbacks / Trade-offs
The packet matching interface is also used by UDP meaning this also changes UDP code.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->