### PR TITLE
Properly handle slices in yaml config data

### DIFF
--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -801,6 +801,40 @@ func TestUnsetForSource(t *testing.T) {
 	assert.Equal(t, expect, txt)
 }
 
+func TestStringifySlice(t *testing.T) {
+	configData := `
+user:
+  name: Bob
+  age:  30
+  tags:
+    hair: black
+  jobs:
+  - plumber
+  - teacher
+`
+	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
+	cfg.SetTestOnlyDynamicSchema(true)
+	cfg.BuildSchema()
+	err := cfg.ReadConfig(strings.NewReader(configData))
+	require.NoError(t, err)
+
+	txt := cfg.(*ntmConfig).Stringify("root", model.OmitPointerAddr)
+	expect := `tree(#ptr<000000>) source=root
+> user
+  inner(#ptr<000001>)
+  > age
+      leaf(#ptr<000002>), val:30, source:file
+  > jobs
+      leaf(#ptr<000003>), val:[plumber teacher], source:file
+  > name
+      leaf(#ptr<000004>), val:"Bob", source:file
+  > tags
+    inner(#ptr<000005>)
+    > hair
+        leaf(#ptr<000006>), val:"black", source:file`
+	assert.Equal(t, expect, txt)
+}
+
 func TestUnsetForSourceRemoveIfNotPrevious(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", strings.NewReplacer(".", "_"))
 	cfg.BindEnv("api_key")

--- a/pkg/config/nodetreemodel/leaf_node.go
+++ b/pkg/config/nodetreemodel/leaf_node.go
@@ -7,6 +7,7 @@ package nodetreemodel
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config/model"
@@ -32,6 +33,11 @@ func isScalar(v interface{}) bool {
 	default:
 		return false
 	}
+}
+
+func isSlice(v interface{}) bool {
+	rval := reflect.ValueOf(v)
+	return rval.Kind() == reflect.Slice
 }
 
 func newLeafNode(v interface{}, source model.Source) Node {

--- a/pkg/config/nodetreemodel/read_config_file.go
+++ b/pkg/config/nodetreemodel/read_config_file.go
@@ -134,7 +134,7 @@ func loadYamlInto(dest InnerNode, source model.Source, inData map[string]interfa
 			warnings = append(warnings, fmt.Errorf("unknown key from YAML: %s", currPath))
 			if !allowDynamicSchema {
 				continue
-			} else if isScalar(value) {
+			} else if isScalar(value) || isSlice(value) {
 				schemaChild = newLeafNode(value, model.SourceSchema)
 			} else {
 				schemaChild = newInnerNode(make(map[string]Node))

--- a/pkg/config/structure/unmarshal.go
+++ b/pkg/config/structure/unmarshal.go
@@ -377,6 +377,12 @@ func copyAny(target reflect.Value, input nodetreemodel.Node, currPath []string, 
 		if leaf, ok := input.(nodetreemodel.LeafNode); ok {
 			return copyLeaf(target, leaf, fs)
 		}
+		if inner, ok := input.(nodetreemodel.InnerNode); ok {
+			// An empty inner node is treated like a nil value, nothing to copy
+			if len(inner.ChildrenKeys()) == 0 {
+				return nil
+			}
+		}
 		return fmt.Errorf("at %v: scalar required, but input is not a leaf: %v of %T", currPath, input, input)
 	} else if target.Kind() == reflect.Map {
 		return copyMap(target, input, currPath, fs)

--- a/pkg/config/structure/unmarshal_test.go
+++ b/pkg/config/structure/unmarshal_test.go
@@ -108,7 +108,7 @@ user:
 `
 	mockConfig = newConfigFromYaml(t, confYaml)
 	err = unmarshalKeyReflection(mockConfig, "user", &person)
-	assert.ErrorContains(t, err, `at [jobs]: []T required, but input is not an array: &{30 file} of *nodetreemodel.leafNodeImpl`)
+	assert.ErrorContains(t, err, `at [jobs]: []T required, but input is not an array: &{30`)
 
 	confYaml = `
 user:
@@ -128,7 +128,7 @@ user:
 `
 	mockConfig = newConfigFromYaml(t, confYaml)
 	err = unmarshalKeyReflection(mockConfig, "user", &person)
-	assert.ErrorContains(t, err, `at [tags]: cannot assign to a map from input: &{[plumber teacher] file} of *nodetreemodel.leafNodeImpl`)
+	assert.ErrorContains(t, err, `at [tags]: cannot assign to a map from input: &{[plumber teacher]`)
 
 	confYaml = `
 user:
@@ -136,7 +136,7 @@ user:
 `
 	mockConfig = newConfigFromYaml(t, confYaml)
 	err = unmarshalKeyReflection(mockConfig, "user", &person)
-	assert.ErrorContains(t, err, `at [tags]: cannot assign to a map from input: &{30 file} of *nodetreemodel.leafNodeImpl`)
+	assert.ErrorContains(t, err, `at [tags]: cannot assign to a map from input: &{30`)
 
 }
 


### PR DESCRIPTION
### What does this PR do?

Properly handle slices in yaml config data

### Motivation

A bug in the nodetreemodel config builder didn't handle slices properly, causing multiple unit test failures when it was enabled.

When run with `DD_CONF_NODETREEMODEL=enable`, this fixes the test `TestOptionalModule` in comp/core/configsync/configsyncimpl and `TestUnmarshalKeyTrapsConfig` in pkg/config/structure.

### Describe how you validated your changes

New unit tests in nodetreemodel that validate this behavior.

### Possible Drawbacks / Trade-offs

### Additional Notes
