### PR TITLE
(fleet) add a disclaimer in postinst to redirect to the installer file

### DIFF
--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -1,8 +1,11 @@
 #!/bin/sh
-#
-# Perform necessary datadog-agent setup steps after package is installed.
-#
-# .deb: STEP 5 of 5
+##########################################################################
+#             DO NOT EDIT THIS SCRIPT DIRECTLY.                          #
+#                                                                        #
+# The installation logic is handled by the installer at in the following #
+# file: pkg/fleet/installer/packages/datadog_agent_linux.go              #
+#                                                                        #
+##########################################################################
 
 INSTALL_DIR=/opt/datadog-agent
 
@@ -12,12 +15,12 @@ if [ -n "$DOCKER_DD_AGENT" ]; then
     exit 0
 fi
 
-# Run FIPS installation script if available. Mandatory to execute the agent binary in FIPS mode.
+# Run FIPS installation script if available. Mandatory to execute the installer binary in FIPS mode.
 if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
     ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
 fi
 
-# Run post install script. Instructions can be found in pkg/fleet/installer/packages/datadog_agent_linux.go
+# Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
 ${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent deb
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -1,10 +1,11 @@
-#! /bin/sh
-#
-# This script is RPM-specific
-# It is run at the very end of an install/upgrade of the package
-# It is NOT run on removal of the package
-#
-# .rpm: STEP 6 of 6
+#!/bin/sh
+##########################################################################
+#             DO NOT EDIT THIS SCRIPT DIRECTLY.                          #
+#                                                                        #
+# The installation logic is handled by the installer at in the following #
+# file: pkg/fleet/installer/packages/datadog_agent_linux.go              #
+#                                                                        #
+##########################################################################
 
 INSTALL_DIR=/opt/datadog-agent
 

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -14,7 +14,7 @@ if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
     ${INSTALL_DIR}/embedded/bin/fipsinstall.sh
 fi
 
-# Run postinstall script. Instructions can be found in pkg/fleet/installer/packages/datadog_agent_linux.go
+# Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
 ${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent rpm
 
 exit 0


### PR DESCRIPTION
This PR adds a disclaimer at the top of postinst now that it is fully migrated so that devs can discover themselves they should go to the installer logic.
