### PR TITLE
[KSM] Add `timeZone` support for `CronJob`

### DIFF
--- a/releasenotes-dca/notes/timezone_cronjob-5f0b9ee7d6a24c5f.yaml
+++ b/releasenotes-dca/notes/timezone_cronjob-5f0b9ee7d6a24c5f.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Properly take into account the ``timeZone`` field of the ``CronJob`` objects in the ``kubernetes_state.cronjob.on_schedule_check`` service check.


### PR DESCRIPTION
### What does this PR do?

Properly take into account the `timeZone` field of the `CronJob` objects in the `kubernetes_state.cronjob.on_schedule_check` service check.

### Motivation

* Fix #36975

### Describe how you validated your changes

### Possible Drawbacks / Trade-offs

### Additional Notes

This change is mostly a backport of upstream changes.
Clone [`kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics) and run:
```console
$ git diff remotes/upstream/release-2.4 remotes/upstream/release-2.15 internal/store/cronjob.go
```