### PR TITLE
(fleet) migrate the prerm to the installer 1/n

### DIFF
--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -5,67 +5,20 @@
 # .deb: STEP 1 of 5
 
 INSTALL_DIR=/opt/datadog-agent
-SERVICE_NAME=datadog-agent
 CONFIG_DIR=/etc/datadog-agent
 
-stop_agent()
-{
-    # Stop an already running agent
-    # supports systemd, upstart and sysvinit
-    if command -v systemctl >/dev/null 2>&1; then
-        systemctl stop $SERVICE_NAME-process || true
-        systemctl stop $SERVICE_NAME-sysprobe || true
-        systemctl stop $SERVICE_NAME-trace || true
-        systemctl stop $SERVICE_NAME-security || true
-        systemctl stop $SERVICE_NAME || true
-    elif command -v initctl >/dev/null 2>&1; then
-        initctl stop $SERVICE_NAME-process || true
-        initctl stop $SERVICE_NAME-sysprobe || true
-        initctl stop $SERVICE_NAME-trace || true
-        initctl stop $SERVICE_NAME-security || true
-        initctl stop $SERVICE_NAME || true
-    elif command -v service >/dev/null 2>&1; then
-        service $SERVICE_NAME-process stop || true
-        # TODO: investigate if the following line could be used in other cases than with sysvinit systems (which don't support sysprobe).
-        # If not, remove it.
-        service $SERVICE_NAME-sysprobe stop || true
-        service $SERVICE_NAME-trace stop || true
-        service $SERVICE_NAME-security stop || true
-        service $SERVICE_NAME stop || true
-    else
-        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
-    fi
-}
+# Run the prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
+case "$1" in
+remove)
+    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent deb
+    ;;
+upgrade)
+    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent deb
+    ;;
+*) ;;
+esac
 
-deregister_agent()
-{
-    # Disable agent start on system boot
-    # supports systemd, upstart and sysvinit
-    if command -v systemctl >/dev/null 2>&1; then
-        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-process || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-sysprobe || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-trace || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-security || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME || true
-    elif command -v initctl >/dev/null 2>&1; then
-        # Nothing to do, this is defined directly in the upstart job file
-        :
-    elif command -v update-rc.d >/dev/null 2>&1; then
-        update-rc.d -f $SERVICE_NAME-process remove || true
-        # TODO: investigate if the following line could be used in other cases than with sysvinit systems (which don't support sysprobe).
-        # If not, remove it.
-        update-rc.d -f $SERVICE_NAME-sysprobe remove || true
-        update-rc.d -f $SERVICE_NAME-trace remove || true
-        update-rc.d -f $SERVICE_NAME-security remove || true
-        update-rc.d -f $SERVICE_NAME remove || true
-    else
-        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd, upstart and sysvinit."
-    fi
-}
-
-remove_py_compiled_files()
-{
+remove_py_compiled_files() {
     # Delete all the .pyc files in the embedded dir that are part of the agent's package
     # This MUST be done after using pip or any python, because executing python might generate .pyc files
     if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
@@ -74,8 +27,7 @@ remove_py_compiled_files()
     fi
 }
 
-remove_custom_integrations()
-{
+remove_custom_integrations() {
     # Since 6.18.0, a file containing all integrations files which have been installed by
     # the package is available. We use it to remove only the datadog-related check files which
     # have *NOT* been installed by the package (eg: installed using the `integration` command).
@@ -86,7 +38,7 @@ remove_custom_integrations()
         # List all files in the embedded dir of the datadog-agent install dir
         PREV_DIR=$(pwd)
         cd "$INSTALL_DIR" || return
-        find . -depth -path './embedded/lib/python*/site-packages/datadog_*' > $INSTALL_DIR/embedded/.all-integrations.txt
+        find . -depth -path './embedded/lib/python*/site-packages/datadog_*' >$INSTALL_DIR/embedded/.all-integrations.txt
 
         # List all files in the embedded dir of the datadog-agent install dir
         # which were not installed by the package and rm them.
@@ -97,15 +49,13 @@ remove_custom_integrations()
     fi
 }
 
-remove_run_dir()
-{
+remove_run_dir() {
     if [ -d "$INSTALL_DIR/run" ]; then
         rm -rf "$INSTALL_DIR/run" || true
     fi
 }
 
-remove_persist_integration_files()
-{
+remove_persist_integration_files() {
     # Remove any file related to reinstalling non-core integrations (see python-scripts/packages.py for the names)
     if [ -f "$INSTALL_DIR/.pre_python_installed_packages.txt" ]; then
         rm "$INSTALL_DIR/.pre_python_installed_packages.txt" || true
@@ -118,44 +68,39 @@ remove_persist_integration_files()
     fi
 }
 
-remove_fips_module()
-{
+remove_fips_module() {
     # We explicitly remove the ssl directory because files within this folder are generated via a script
     # outside of package installation (deb package only removes files initially present in the package).
     rm -rf "${INSTALL_DIR}/embedded/ssl/fipsmodule.cnf" || true
 }
 
 case "$1" in #this can't be merged with the later case block because running 'remove_custom_integrations' would defeat the persisting integrations feature
-    upgrade)
-        # We're upgrading.
-        if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then
-            # -B prevents writing a cache of the bytecode since this is only run once
-            ${INSTALL_DIR}/embedded/bin/python -B "${INSTALL_DIR}/python-scripts/pre.py" "${INSTALL_DIR}" || true
-        fi
+upgrade)
+    # We're upgrading.
+    if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then
+        # -B prevents writing a cache of the bytecode since this is only run once
+        ${INSTALL_DIR}/embedded/bin/python -B "${INSTALL_DIR}/python-scripts/pre.py" "${INSTALL_DIR}" || true
+    fi
     ;;
-    *)
-    ;;
+*) ;;
 esac
-stop_agent
-deregister_agent
 remove_custom_integrations
 remove_py_compiled_files
 
 case "$1" in
-    remove)
-        # We're uninstalling.
-        remove_run_dir
-        remove_fips_module
-        remove_persist_integration_files
-        rm "$CONFIG_DIR/install_info" || true
-        rm "$CONFIG_DIR/install.json" || true
-        rm -f "/usr/bin/datadog-agent"
+remove)
+    # We're uninstalling.
+    remove_run_dir
+    remove_fips_module
+    remove_persist_integration_files
+    rm "$CONFIG_DIR/install_info" || true
+    rm "$CONFIG_DIR/install.json" || true
+    rm -f "/usr/bin/datadog-agent"
     ;;
-    upgrade)
-        # We're upgrading.
+upgrade)
+    # We're upgrading.
     ;;
-    *)
-    ;;
+*) ;;
 esac
 
 # Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -8,9 +8,9 @@ INSTALL_DIR=/opt/datadog-agent
 
 set -e
 
-# Run the upgrade preinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
+# Run the upgrade prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
 if [ "$*" = "2" ] && [ -f "${INSTALL_DIR}/embedded/bin/installer" ]; then
-    ${INSTALL_DIR}/embedded/bin/installer preinst --upgrade datadog-agent rpm
+    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent rpm
 fi
 
 # RPM Agents < 5.18.0 expect the preinst script of the _new_ package to stop the agent service on upgrade (which is defined with an init.d script on Agent 5)

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -9,7 +9,7 @@ INSTALL_DIR=/opt/datadog-agent
 set -e
 
 # Run the upgrade preinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
-if [ "$*" = "2" ]; then
+if [ "$*" = "2" ] && [ -f "${INSTALL_DIR}/embedded/bin/installer" ]; then
     ${INSTALL_DIR}/embedded/bin/installer preinst --upgrade datadog-agent rpm
 fi
 

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -5,28 +5,12 @@
 # .rpm: STEP 2 of 6
 
 INSTALL_DIR=/opt/datadog-agent
-SERVICE_NAME=datadog-agent
 
 set -e
 
-if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/system/$SERVICE_NAME.service" ]; then
-    # Stop an already running agent
-    # Only supports systemd and upstart
-    if command -v systemctl >/dev/null 2>&1; then
-        systemctl stop $SERVICE_NAME-process || true
-        systemctl stop $SERVICE_NAME-sysprobe || true
-        systemctl stop $SERVICE_NAME-trace || true
-        systemctl stop $SERVICE_NAME-security || true
-        systemctl stop $SERVICE_NAME || true
-    elif command -v initctl >/dev/null 2>&1; then
-        initctl stop $SERVICE_NAME-process || true
-        initctl stop $SERVICE_NAME-sysprobe || true
-        initctl stop $SERVICE_NAME-trace || true
-        initctl stop $SERVICE_NAME-security || true
-        initctl stop $SERVICE_NAME || true
-    else
-        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
-    fi
+# Run the upgrade preinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
+if [ "$*" = "2" ]; then
+    ${INSTALL_DIR}/embedded/bin/installer preinst --upgrade datadog-agent rpm
 fi
 
 # RPM Agents < 5.18.0 expect the preinst script of the _new_ package to stop the agent service on upgrade (which is defined with an init.d script on Agent 5)
@@ -64,7 +48,7 @@ if [ -f "$INSTALL_DIR/embedded/.installed_by_pkg.txt" ]; then
     # List all files in the embedded dir of the datadog-agent install dir
     PREV_DIR=$(pwd)
     cd $INSTALL_DIR
-    find . -depth -path './embedded/lib/python*/site-packages/datadog_*' > $INSTALL_DIR/embedded/.all-integrations.txt
+    find . -depth -path './embedded/lib/python*/site-packages/datadog_*' >$INSTALL_DIR/embedded/.all-integrations.txt
 
     # List all files in the embedded dir of the datadog-agent install dir
     # which were not installed by the package and rm them.

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -6,50 +6,14 @@
 
 INSTALL_DIR=/opt/datadog-agent
 CONFIG_DIR=/etc/datadog-agent
-SERVICE_NAME=datadog-agent
 
-stop_agent()
-{
-    # Stop an already running agent
-    # Only supports systemd and upstart
-    if command -v systemctl >/dev/null 2>&1; then
-        systemctl stop $SERVICE_NAME-process || true
-        systemctl stop $SERVICE_NAME-sysprobe || true
-        systemctl stop $SERVICE_NAME-trace || true
-        systemctl stop $SERVICE_NAME-security || true
-        systemctl stop $SERVICE_NAME || true
-    elif command -v initctl >/dev/null 2>&1; then
-        initctl stop $SERVICE_NAME-process || true
-        initctl stop $SERVICE_NAME-sysprobe || true
-        initctl stop $SERVICE_NAME-trace || true
-        initctl stop $SERVICE_NAME-security || true
-        initctl stop $SERVICE_NAME || true
-    else
-        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
-    fi
-}
+# Run the uninstall prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
+# Note: the upgrade prerm is handled in the preinst script of the new package on rpm.
+if [ "$*" = "0" ]; then
+    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent rpm
+fi
 
-deregister_agent()
-{
-    # Disable agent start on system boot
-    # Only supports systemd and upstart
-    if command -v systemctl >/dev/null 2>&1; then
-        # Force systemd to ignore the sysvinit scripts. Only cosmetic, remove some irrelevant warnings during upgrade
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-process || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-sysprobe || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-trace || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME-security || true
-        SYSTEMCTL_SKIP_SYSV=true systemctl disable $SERVICE_NAME || true
-    elif command -v initctl >/dev/null 2>&1; then
-        # Nothing to do, this is defined directly in the upstart job file
-        :
-    else
-        echo "[ WARNING ]\tCannot detect a supported init system. The datadog-agent package only provides service files for systemd and upstart."
-    fi
-}
-
-remove_py_compiled_files()
-{
+remove_py_compiled_files() {
     # Delete all the .pyc files in the embedded dir that are part of the agent's package
     # This MUST be done after using pip or any python, because executing python might generate .pyc files
     if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
@@ -58,8 +22,7 @@ remove_py_compiled_files()
     fi
 }
 
-remove_custom_integrations()
-{
+remove_custom_integrations() {
     # Since 6.18.0, a file containing all integrations files which have been installed by
     # the package is available. We use it to remove only the datadog-related check files which
     # have *NOT* been installed by the package (eg: installed using the `integration` command).
@@ -70,7 +33,7 @@ remove_custom_integrations()
         # List all files in the embedded dir of the datadog-agent install dir
         PREV_DIR=$(pwd)
         cd "$INSTALL_DIR" || return
-        find . -depth -path './embedded/lib/python*/site-packages/datadog_*' > $INSTALL_DIR/embedded/.all-integrations.txt
+        find . -depth -path './embedded/lib/python*/site-packages/datadog_*' >$INSTALL_DIR/embedded/.all-integrations.txt
 
         # List all files in the embedded dir of the datadog-agent install dir
         # which were not installed by the package and rm them.
@@ -81,15 +44,13 @@ remove_custom_integrations()
     fi
 }
 
-remove_run_dir()
-{
+remove_run_dir() {
     if [ -d "$INSTALL_DIR/run" ]; then
         rm -rf "$INSTALL_DIR/run" || true
     fi
 }
 
-remove_persist_integration_files()
-{
+remove_persist_integration_files() {
     # Remove any file related to reinstalling non-core integrations (see python-scripts/packages.py for the names)
     if [ -f "$INSTALL_DIR/.pre_python_installed_packages.txt" ]; then
         rm "$INSTALL_DIR/.pre_python_installed_packages.txt" || true
@@ -102,35 +63,30 @@ remove_persist_integration_files()
     fi
 }
 
-remove_fips_module()
-{
+remove_fips_module() {
     # We explicitly remove the ssl directory because files within this folder are generated via a script
     # outside of package installation (rpm package only removes files initially present in the package).
     rm -rf "${INSTALL_DIR}/embedded/ssl/fipsmodule.cnf" || true
 }
 
-stop_agent
-deregister_agent
-
 case "$*" in
-    0)
-        # We're uninstalling.
-        remove_custom_integrations
-        remove_py_compiled_files
-        remove_run_dir
-        remove_fips_module
-        remove_persist_integration_files
-        rm "$CONFIG_DIR/install_info" || true
-        rm "$CONFIG_DIR/install.json" || true
-        rm -f "/usr/bin/datadog-agent"
+0)
+    # We're uninstalling.
+    remove_custom_integrations
+    remove_py_compiled_files
+    remove_run_dir
+    remove_fips_module
+    remove_persist_integration_files
+    rm "$CONFIG_DIR/install_info" || true
+    rm "$CONFIG_DIR/install.json" || true
+    rm -f "/usr/bin/datadog-agent"
     ;;
-    1)
-        # We're upgrading.
-        # The preinst script of the new package has taken care of removing
-        # the .pyc/.pyo files, as well as removing custom integrations.
+1)
+    # We're upgrading.
+    # The preinst script of the new package has taken care of removing
+    # the .pyc/.pyo files, as well as removing custom integrations.
     ;;
-    *)
-    ;;
+*) ;;
 esac
 
 # Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -170,6 +170,7 @@ func RootCommands() []*cobra.Command {
 		getStateCommand(),
 		statusCommand(),
 		postinstCommand(),
+		prermCommand(),
 		hooksCommand(),
 	}
 }

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -256,25 +256,35 @@ func postInstallDatadogAgent(ctx HookContext) (err error) {
 // preRemoveDatadogAgent performs pre-removal steps for the agent
 // All the steps are allowed to fail
 func preRemoveDatadogAgent(ctx HookContext) error {
-	err := agentServiceOCI.StopExperiment(ctx)
-	if err != nil {
-		log.Warnf("failed to stop experiment unit: %s", err)
-	}
-	err = agentServiceOCI.RemoveExperiment(ctx)
-	if err != nil {
-		log.Warnf("failed to remove experiment unit: %s", err)
-	}
-	err = agentServiceOCI.StopStable(ctx)
-	if err != nil {
-		log.Warnf("failed to stop stable unit: %s", err)
-	}
-	err = agentServiceOCI.DisableStable(ctx)
-	if err != nil {
-		log.Warnf("failed to disable stable unit: %s", err)
-	}
-	err = agentServiceOCI.RemoveStable(ctx)
-	if err != nil {
-		log.Warnf("failed to remove stable unit: %s", err)
+	switch ctx.PackageType {
+	case PackageTypeDEB, PackageTypeRPM:
+		if err := agentService.Stop(ctx); err != nil {
+			log.Warnf("failed to stop agent service: %s", err)
+		}
+		if err := agentService.Disable(ctx); err != nil {
+			log.Warnf("failed to disable agent service: %s", err)
+		}
+	case PackageTypeOCI:
+		err := agentServiceOCI.StopExperiment(ctx)
+		if err != nil {
+			log.Warnf("failed to stop experiment unit: %s", err)
+		}
+		err = agentServiceOCI.RemoveExperiment(ctx)
+		if err != nil {
+			log.Warnf("failed to remove experiment unit: %s", err)
+		}
+		err = agentServiceOCI.StopStable(ctx)
+		if err != nil {
+			log.Warnf("failed to stop stable unit: %s", err)
+		}
+		err = agentServiceOCI.DisableStable(ctx)
+		if err != nil {
+			log.Warnf("failed to disable stable unit: %s", err)
+		}
+		err = agentServiceOCI.RemoveStable(ctx)
+		if err != nil {
+			log.Warnf("failed to remove stable unit: %s", err)
+		}
 	}
 
 	if ctx.Upgrade {
@@ -413,6 +423,36 @@ func (s *datadogAgentService) Enable(ctx HookContext) error {
 	return fmt.Errorf("unsupported service manager type: %s", serviceManagerType)
 }
 
+// Disable disables the agent service
+func (s *datadogAgentService) Disable(ctx HookContext) error {
+	serviceManagerType := service.GetServiceManagerType()
+	if serviceManagerType == service.SysvinitType && ctx.PackageType != PackageTypeDEB {
+		return fmt.Errorf("sysvinit is only supported on Debian")
+	}
+	switch serviceManagerType {
+	case service.SystemdType:
+		for _, unit := range s.SystemdUnits {
+			err := systemd.DisableUnit(ctx, unit)
+			if err != nil {
+				return fmt.Errorf("failed to disable %s: %v", unit, err)
+			}
+		}
+		return nil
+	case service.UpstartType:
+		// Nothing to do, this is defined directly in the upstart job file
+		return nil
+	case service.SysvinitType:
+		for _, service := range s.SysvinitServices {
+			err := sysvinit.Remove(ctx, service)
+			if err != nil {
+				return fmt.Errorf("failed to remove %s: %v", service, err)
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("unsupported service manager type: %s", serviceManagerType)
+}
+
 // Restart restarts the agent service. It will only attempt to restart if the config exists.
 func (s *datadogAgentService) Restart(ctx HookContext) error {
 	_, err := os.Stat("/etc/datadog-agent/datadog.yaml")
@@ -434,6 +474,41 @@ func (s *datadogAgentService) Restart(ctx HookContext) error {
 		return sysvinit.Restart(ctx, s.SysvinitMainService)
 	case service.SystemdType:
 		return systemd.RestartUnit(ctx, s.SystemdMainUnit)
+	}
+	return fmt.Errorf("unsupported service manager type: %s", serviceManagerType)
+}
+
+// Stop stops the agent service
+func (s *datadogAgentService) Stop(ctx HookContext) error {
+	serviceManagerType := service.GetServiceManagerType()
+	if serviceManagerType == service.SysvinitType && ctx.PackageType != PackageTypeDEB {
+		return fmt.Errorf("sysvinit is only supported on Debian")
+	}
+	switch serviceManagerType {
+	case service.SystemdType:
+		for _, unit := range s.SystemdUnits {
+			err := systemd.StopUnit(ctx, unit)
+			if err != nil {
+				return fmt.Errorf("failed to stop %s: %v", unit, err)
+			}
+		}
+		return nil
+	case service.UpstartType:
+		for _, service := range s.UpstartServices {
+			err := upstart.Stop(ctx, service)
+			if err != nil {
+				return fmt.Errorf("failed to stop %s: %v", service, err)
+			}
+		}
+		return nil
+	case service.SysvinitType:
+		for _, service := range s.SysvinitServices {
+			err := sysvinit.Stop(ctx, service)
+			if err != nil {
+				return fmt.Errorf("failed to stop %s: %v", service, err)
+			}
+		}
+		return nil
 	}
 	return fmt.Errorf("unsupported service manager type: %s", serviceManagerType)
 }

--- a/pkg/fleet/installer/packages/service/sysvinit/sysvinit.go
+++ b/pkg/fleet/installer/packages/service/sysvinit/sysvinit.go
@@ -19,7 +19,17 @@ func Install(ctx context.Context, name string) error {
 	return telemetry.CommandContext(ctx, "update-rc.d", name, "defaults").Run()
 }
 
+// Remove removes a sys-v init script using update-rc.d
+func Remove(ctx context.Context, name string) error {
+	return telemetry.CommandContext(ctx, "update-rc.d", "-f", name, "remove").Run()
+}
+
 // Restart restarts a sys-v init script using service
 func Restart(ctx context.Context, name string) error {
 	return telemetry.CommandContext(ctx, "service", name, "restart").Run()
+}
+
+// Stop stops a sys-v init script using service
+func Stop(ctx context.Context, name string) error {
+	return telemetry.CommandContext(ctx, "service", name, "stop").Run()
 }

--- a/pkg/fleet/installer/packages/service/upstart/upstart.go
+++ b/pkg/fleet/installer/packages/service/upstart/upstart.go
@@ -27,3 +27,8 @@ func Restart(ctx context.Context, name string) error {
 	}
 	return fmt.Errorf("failed to restart %s: %w || %w", name, errStart, errRestart)
 }
+
+// Stop stops an upstart service using initctl
+func Stop(ctx context.Context, name string) error {
+	return telemetry.CommandContext(ctx, "initctl", "stop", name).Run()
+}


### PR DESCRIPTION
This PR starts the migration of the `prerm` script to the installer.

- In this first PR we are only migrating the service management to the installer
- To align the execution order of RPM and DEB we have to use the same strategy as the integration python scripts:
    - The "upgrade" `prerm` is run from the new package %pre
    - The "remove" `prerm` is run from the `prerm` as expected
