### PR TITLE
(fleet)  migrate the prerm to the installer 2/2

### DIFF
--- a/omnibus/package-scripts/agent-deb/prerm
+++ b/omnibus/package-scripts/agent-deb/prerm
@@ -1,113 +1,19 @@
 #!/bin/sh
-#
-# Perform necessary datadog-agent setup steps prior to remove the old package.
-#
-# .deb: STEP 1 of 5
+##########################################################################
+#             DO NOT EDIT THIS SCRIPT DIRECTLY.                          #
+#                                                                        #
+# The installation logic is handled by the installer in the following    #
+# file: pkg/fleet/installer/packages/datadog_agent_linux.go              #
+#                                                                        #
+##########################################################################
 
 INSTALL_DIR=/opt/datadog-agent
-CONFIG_DIR=/etc/datadog-agent
 
-# Run the prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
-case "$1" in
-remove)
-    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent deb
-    ;;
-upgrade)
-    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent deb
-    ;;
-*) ;;
-esac
-
-remove_py_compiled_files() {
-    # Delete all the .pyc files in the embedded dir that are part of the agent's package
-    # This MUST be done after using pip or any python, because executing python might generate .pyc files
-    if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
-        # (commented lines are filtered out)
-        cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
-    fi
-}
-
-remove_custom_integrations() {
-    # Since 6.18.0, a file containing all integrations files which have been installed by
-    # the package is available. We use it to remove only the datadog-related check files which
-    # have *NOT* been installed by the package (eg: installed using the `integration` command).
-
-    if [ -f "$INSTALL_DIR/embedded/.installed_by_pkg.txt" ]; then
-        echo "Removing integrations installed with the 'agent integration' command"
-
-        # List all files in the embedded dir of the datadog-agent install dir
-        PREV_DIR=$(pwd)
-        cd "$INSTALL_DIR" || return
-        find . -depth -path './embedded/lib/python*/site-packages/datadog_*' >$INSTALL_DIR/embedded/.all-integrations.txt
-
-        # List all files in the embedded dir of the datadog-agent install dir
-        # which were not installed by the package and rm them.
-        grep -Fxv -f $INSTALL_DIR/embedded/.installed_by_pkg.txt $INSTALL_DIR/embedded/.all-integrations.txt | grep -v '^#' | xargs --no-run-if-empty -I '{}' rm -r $INSTALL_DIR/{}
-
-        rm $INSTALL_DIR/embedded/.all-integrations.txt
-        cd "$PREV_DIR" || return
-    fi
-}
-
-remove_run_dir() {
-    if [ -d "$INSTALL_DIR/run" ]; then
-        rm -rf "$INSTALL_DIR/run" || true
-    fi
-}
-
-remove_persist_integration_files() {
-    # Remove any file related to reinstalling non-core integrations (see python-scripts/packages.py for the names)
-    if [ -f "$INSTALL_DIR/.pre_python_installed_packages.txt" ]; then
-        rm "$INSTALL_DIR/.pre_python_installed_packages.txt" || true
-    fi
-    if [ -f "$INSTALL_DIR/.post_python_installed_packages.txt" ]; then
-        rm "$INSTALL_DIR/.post_python_installed_packages.txt" || true
-    fi
-    if [ -f "$INSTALL_DIR/.diff_python_installed_packages.txt" ]; then
-        rm "$INSTALL_DIR/.diff_python_installed_packages.txt" || true
-    fi
-}
-
-remove_fips_module() {
-    # We explicitly remove the ssl directory because files within this folder are generated via a script
-    # outside of package installation (deb package only removes files initially present in the package).
-    rm -rf "${INSTALL_DIR}/embedded/ssl/fipsmodule.cnf" || true
-}
-
-case "$1" in #this can't be merged with the later case block because running 'remove_custom_integrations' would defeat the persisting integrations feature
-upgrade)
-    # We're upgrading.
-    if [ -f "$INSTALL_DIR/embedded/bin/python" ]; then
-        # -B prevents writing a cache of the bytecode since this is only run once
-        ${INSTALL_DIR}/embedded/bin/python -B "${INSTALL_DIR}/python-scripts/pre.py" "${INSTALL_DIR}" || true
-    fi
-    ;;
-*) ;;
-esac
-remove_custom_integrations
-remove_py_compiled_files
-
-case "$1" in
-remove)
-    # We're uninstalling.
-    remove_run_dir
-    remove_fips_module
-    remove_persist_integration_files
-    rm "$CONFIG_DIR/install_info" || true
-    rm "$CONFIG_DIR/install.json" || true
-    rm -f "/usr/bin/datadog-agent"
-    ;;
-upgrade)
-    # We're upgrading.
-    ;;
-*) ;;
-esac
-
-# Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs
-find $INSTALL_DIR/bin/agent/dist -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/bin/agent/dist"
-find $INSTALL_DIR/bin/agent/dist -name '__pycache__' -type d -delete || echo "Unable to delete __pycache__ directories in $INSTALL_DIR/bin/agent/dist"
-# Delete all .pyc files in the `python-scripts/` dir
-find $INSTALL_DIR/python-scripts -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/python-scripts"
-find $INSTALL_DIR/python-scripts -name '__pycache__' -type d -delete || echo "Unable to delete __pycache__ directories in $INSTALL_DIR/python-scripts"
+# Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
+if [ "$1" = "remove" ]; then
+    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent deb || true
+elif [ "$1" = "upgrade" ]; then
+    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent deb || true
+fi
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -11,11 +11,6 @@ INSTALL_DIR=/opt/datadog-agent
 
 set -e
 
-# Run the upgrade prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
-if [ "$*" = "2" ] && [ -f "${INSTALL_DIR}/embedded/bin/installer" ]; then
-    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent rpm || true
-fi
-
 # Uninstall the agent if it was installed by the installer
 if command -v datadog-installer >/dev/null 2>&1 && datadog-installer is-installed datadog-agent; then
     datadog-installer remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
@@ -27,14 +22,14 @@ if [ -f "/etc/init.d/datadog-agent" ]; then
     /etc/init.d/datadog-agent stop || true
 fi
 
-# Run the upgrade prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
-if [ "$*" = "2" ] && [ -f "${INSTALL_DIR}/embedded/bin/installer" ]; then
+# Run the upgrade prerm if supported in the previous version. See pkg/fleet/installer/packages/datadog_agent_linux.go
+if [ "$*" = "2" ] && [ -f "${INSTALL_DIR}/embedded/bin/installer" ] && ${INSTALL_DIR}/embedded/bin/installer is-prerm-supported; then
     ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent rpm || true
     exit 0
 fi
 
 ##########################################################################
-#    LEGACY INSTALLATION LOGIC BELOW WHEN UPGRADING FROM AGENT <7.65     #
+#    LEGACY INSTALLATION LOGIC BELOW WHEN UPGRADING FROM AGENT <7.68     #
 #                   DO NOT EDIT THIS SECTION                             #
 ##########################################################################
 

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -13,7 +13,7 @@ set -e
 
 # Run the upgrade prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
 if [ "$*" = "2" ] && [ -f "${INSTALL_DIR}/embedded/bin/installer" ]; then
-    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent rpm
+    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent rpm || true
 fi
 
 # Uninstall the agent if it was installed by the installer

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -1,8 +1,11 @@
 #!/bin/sh
-#
-# Perform necessary datadog-agent setup steps before package is installed.
-#
-# .rpm: STEP 2 of 6
+##########################################################################
+#             DO NOT EDIT THIS SCRIPT DIRECTLY.                          #
+#                                                                        #
+# The installation logic is handled by the installer in the following    #
+# file: pkg/fleet/installer/packages/datadog_agent_linux.go              #
+#                                                                        #
+##########################################################################
 
 INSTALL_DIR=/opt/datadog-agent
 
@@ -23,6 +26,17 @@ fi
 if [ -f "/etc/init.d/datadog-agent" ]; then
     /etc/init.d/datadog-agent stop || true
 fi
+
+# Run the upgrade prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
+if [ "$*" = "2" ] && [ -f "${INSTALL_DIR}/embedded/bin/installer" ]; then
+    ${INSTALL_DIR}/embedded/bin/installer prerm --upgrade datadog-agent rpm || true
+    exit 0
+fi
+
+##########################################################################
+#    LEGACY INSTALLATION LOGIC BELOW WHEN UPGRADING FROM AGENT <7.65     #
+#                   DO NOT EDIT THIS SECTION                             #
+##########################################################################
 
 # RPM unpacks the new files before running prerm of the old package
 # triggering manually the prerm python script of the old package

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -1,99 +1,18 @@
 #!/bin/sh
-#
-# Perform necessary datadog-agent setup steps prior to remove the old package.
-#
-# .rpm: STEP 4 of 6
+##########################################################################
+#             DO NOT EDIT THIS SCRIPT DIRECTLY.                          #
+#                                                                        #
+# The installation logic is handled by the installer in the following    #
+# file: pkg/fleet/installer/packages/datadog_agent_linux.go              #
+#                                                                        #
+##########################################################################
 
 INSTALL_DIR=/opt/datadog-agent
-CONFIG_DIR=/etc/datadog-agent
 
 # Run the uninstall prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
 # Note: the upgrade prerm is handled in the preinst script of the new package on rpm.
 if [ "$*" = "0" ]; then
     ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent rpm
 fi
-
-remove_py_compiled_files() {
-    # Delete all the .pyc files in the embedded dir that are part of the agent's package
-    # This MUST be done after using pip or any python, because executing python might generate .pyc files
-    if [ -f "$INSTALL_DIR/embedded/.py_compiled_files.txt" ]; then
-        # (commented lines are filtered out)
-        cat $INSTALL_DIR/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
-    fi
-}
-
-remove_custom_integrations() {
-    # Since 6.18.0, a file containing all integrations files which have been installed by
-    # the package is available. We use it to remove only the datadog-related check files which
-    # have *NOT* been installed by the package (eg: installed using the `integration` command).
-
-    if [ -f "$INSTALL_DIR/embedded/.installed_by_pkg.txt" ]; then
-        echo "Removing integrations installed with the 'agent integration' command"
-
-        # List all files in the embedded dir of the datadog-agent install dir
-        PREV_DIR=$(pwd)
-        cd "$INSTALL_DIR" || return
-        find . -depth -path './embedded/lib/python*/site-packages/datadog_*' >$INSTALL_DIR/embedded/.all-integrations.txt
-
-        # List all files in the embedded dir of the datadog-agent install dir
-        # which were not installed by the package and rm them.
-        grep -Fxv -f $INSTALL_DIR/embedded/.installed_by_pkg.txt $INSTALL_DIR/embedded/.all-integrations.txt | grep -v '^#' | xargs --no-run-if-empty -I '{}' rm -r $INSTALL_DIR/{}
-
-        rm $INSTALL_DIR/embedded/.all-integrations.txt
-        cd "$PREV_DIR" || return
-    fi
-}
-
-remove_run_dir() {
-    if [ -d "$INSTALL_DIR/run" ]; then
-        rm -rf "$INSTALL_DIR/run" || true
-    fi
-}
-
-remove_persist_integration_files() {
-    # Remove any file related to reinstalling non-core integrations (see python-scripts/packages.py for the names)
-    if [ -f "$INSTALL_DIR/.pre_python_installed_packages.txt" ]; then
-        rm "$INSTALL_DIR/.pre_python_installed_packages.txt" || true
-    fi
-    if [ -f "$INSTALL_DIR/.post_python_installed_packages.txt" ]; then
-        rm "$INSTALL_DIR/.post_python_installed_packages.txt" || true
-    fi
-    if [ -f "$INSTALL_DIR/.diff_python_installed_packages.txt" ]; then
-        rm "$INSTALL_DIR/.diff_python_installed_packages.txt" || true
-    fi
-}
-
-remove_fips_module() {
-    # We explicitly remove the ssl directory because files within this folder are generated via a script
-    # outside of package installation (rpm package only removes files initially present in the package).
-    rm -rf "${INSTALL_DIR}/embedded/ssl/fipsmodule.cnf" || true
-}
-
-case "$*" in
-0)
-    # We're uninstalling.
-    remove_custom_integrations
-    remove_py_compiled_files
-    remove_run_dir
-    remove_fips_module
-    remove_persist_integration_files
-    rm "$CONFIG_DIR/install_info" || true
-    rm "$CONFIG_DIR/install.json" || true
-    rm -f "/usr/bin/datadog-agent"
-    ;;
-1)
-    # We're upgrading.
-    # The preinst script of the new package has taken care of removing
-    # the .pyc/.pyo files, as well as removing custom integrations.
-    ;;
-*) ;;
-esac
-
-# Delete all .pyc files in the `agent/` and the `bin/agent/dist` dirs
-find $INSTALL_DIR/bin/agent/dist -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/bin/agent/dist"
-find $INSTALL_DIR/bin/agent/dist -name '__pycache__' -type d -delete || echo "Unable to delete __pycache__ directories in $INSTALL_DIR/bin/agent/dist"
-# Delete all .pyc files in the `python-scripts/` dir
-find $INSTALL_DIR/python-scripts -name '*.py[co]' -type f -delete || echo "Unable to delete .pyc files in $INSTALL_DIR/python-scripts"
-find $INSTALL_DIR/python-scripts -name '__pycache__' -type d -delete || echo "Unable to delete __pycache__ directories in $INSTALL_DIR/python-scripts"
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/prerm
+++ b/omnibus/package-scripts/agent-rpm/prerm
@@ -12,7 +12,7 @@ INSTALL_DIR=/opt/datadog-agent
 # Run the uninstall prerm. See pkg/fleet/installer/packages/datadog_agent_linux.go
 # Note: the upgrade prerm is handled in the preinst script of the new package on rpm.
 if [ "$*" = "0" ]; then
-    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent rpm
+    ${INSTALL_DIR}/embedded/bin/installer prerm datadog-agent rpm || true
 fi
 
 exit 0

--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -170,6 +170,7 @@ func RootCommands() []*cobra.Command {
 		getStateCommand(),
 		statusCommand(),
 		postinstCommand(),
+		isPrermSupportedCommand(),
 		prermCommand(),
 		hooksCommand(),
 	}

--- a/pkg/fleet/installer/commands/hooks.go
+++ b/pkg/fleet/installer/commands/hooks.go
@@ -8,6 +8,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/packages"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func isPrermSupportedCommand() *cobra.Command {
 		Use:    "is-prerm-supported",
 		Short:  "Check if prerm is supported",
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println("true")
+			os.Exit(0)
 		},
 	}
 }

--- a/pkg/fleet/installer/commands/hooks.go
+++ b/pkg/fleet/installer/commands/hooks.go
@@ -13,6 +13,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func isPrermSupportedCommand() *cobra.Command {
+	return &cobra.Command{
+		Hidden: true,
+		Use:    "is-prerm-supported",
+		Short:  "Check if prerm is supported",
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Println("true")
+		},
+	}
+}
+
 func hooksCommand() *cobra.Command {
 	return &cobra.Command{
 		Hidden:             true,

--- a/pkg/fleet/installer/packages/file/file.go
+++ b/pkg/fleet/installer/packages/file/file.go
@@ -17,6 +17,36 @@ import (
 	"strconv"
 )
 
+// Path is a path to a file or directory.
+type Path string
+
+// EnsureAbsent ensures that the path does not exist and removes it if it does.
+func (p Path) EnsureAbsent(rootPath string) error {
+	matches, err := filepath.Glob(filepath.Join(rootPath, string(p)))
+	if err != nil {
+		return fmt.Errorf("error globbing path: %w", err)
+	}
+	for _, match := range matches {
+		if err := os.RemoveAll(match); err != nil {
+			return fmt.Errorf("error removing path: %w", err)
+		}
+	}
+	return nil
+}
+
+// Paths is a collection of Path.
+type Paths []Path
+
+// EnsureAbsent ensures that the paths do not exist and removes them if they do.
+func (ps Paths) EnsureAbsent(rootPath string) error {
+	for _, p := range ps {
+		if err := p.EnsureAbsent(rootPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Directory represents a desired state for a directory.
 type Directory struct {
 	Path  string
@@ -125,6 +155,14 @@ func EnsureSymlink(source, target string) error {
 	}
 	if err := os.Symlink(source, target); err != nil {
 		return fmt.Errorf("error creating symlink: %w", err)
+	}
+	return nil
+}
+
+// EnsureSymlinkAbsent ensures that the symlink is removed.
+func EnsureSymlinkAbsent(target string) error {
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("error removing existing symlink: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR finishes the migration started in https://github.com/DataDog/datadog-agent/pull/37078.

- Unfortunately everything put in the RPM `preinst` to hack a `prerm`-like behavior must be kept for older versions. This is not new but means we'll have to leave some legacy logic in the `preinst`.
