### PR TITLE
(fleet) allow errors from the installer in package scripts

### DIFF
--- a/omnibus/package-scripts/agent-deb/postinst
+++ b/omnibus/package-scripts/agent-deb/postinst
@@ -21,6 +21,6 @@ if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
 fi
 
 # Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
-${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent deb
+${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent deb || true
 
 exit 0

--- a/omnibus/package-scripts/agent-rpm/posttrans
+++ b/omnibus/package-scripts/agent-rpm/posttrans
@@ -15,6 +15,6 @@ if [ -x ${INSTALL_DIR}/embedded/bin/fipsinstall.sh ]; then
 fi
 
 # Run the postinst. See pkg/fleet/installer/packages/datadog_agent_linux.go
-${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent rpm
+${INSTALL_DIR}/embedded/bin/installer postinst datadog-agent rpm || true
 
 exit 0


### PR DESCRIPTION
This PR allows the installer to fail in the package scripts. This is in line with the existing package script behavior that pretty much never errors.

This is probably because failure in some of those scripts can break apt/rpm as a whole, not just the agent.
