### PR TITLE
[DJM] Fetch Databricks custom tags from Databricks API and inject them to agent config

### DIFF
--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -309,7 +309,8 @@ func loadLogProcessingRules(s *common.Setup) {
 
 // ClusterTags are custom tags from Databricks API response
 type ClusterTags struct {
-	CustomTags map[string]string `json:"custom_tags"`
+	CustomTags   map[string]string `json:"custom_tags"`
+	SparkVersion string            `json:"spark_version"`
 }
 
 // JobTags custom tags from Databricks API response
@@ -405,7 +406,18 @@ func fetchClusterTags(client *http.Client, host, token, clusterID string, s *com
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	return clusterResponse.CustomTags, nil
+	// Create a copy of the custom tags
+	tags := make(map[string]string)
+	for k, v := range clusterResponse.CustomTags {
+		tags[k] = v
+	}
+
+	// Add spark_version as runtime tag if available
+	if clusterResponse.SparkVersion != "" {
+		tags["runtime"] = clusterResponse.SparkVersion
+	}
+
+	return tags, nil
 }
 
 func fetchJobTags(client *http.Client, host, token, jobID string, s *common.Setup) (map[string]string, error) {

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -9,12 +9,16 @@ package djm
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/common"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/config"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -22,6 +26,7 @@ const (
 	databricksInjectorVersion   = "0.39.1-1"
 	databricksJavaTracerVersion = "1.49.0-1"
 	databricksAgentVersion      = "7.63.3-1"
+	fetchTimeoutDuration        = 5 * time.Second
 )
 
 var (
@@ -105,6 +110,7 @@ func SetupDatabricks(s *common.Setup) error {
 	}
 
 	setupCommonHostTags(s)
+	fetchDatabricksCustomTags(s)
 	installMethod := "manual"
 	if os.Getenv("DD_DJM_INIT_IS_MANAGED_INSTALL") == "true" {
 		installMethod = "managed"
@@ -247,7 +253,6 @@ func setupDatabricksWorker(s *common.Setup) {
 		s.Span.SetTag("host_tag_set.worker_logs_enabled", "true")
 		s.Config.IntegrationConfigs["spark.d/databricks.yaml"] = sparkIntegration
 	}
-
 }
 
 func addCustomHostTags(s *common.Setup) {
@@ -299,5 +304,157 @@ func loadLogProcessingRules(s *common.Setup) {
 			s.Out.WriteString(fmt.Sprintf("Loaded %d log processing rule(s) from DD_LOGS_CONFIG_PROCESSING_RULES\n", len(processingRules)))
 			s.Span.SetTag("host_tag_set.log_rules", len(processingRules))
 		}
+	}
+}
+
+// ClusterTags are custom tags from Databricks API response
+type ClusterTags struct {
+	CustomTags map[string]string `json:"custom_tags"`
+}
+
+// JobTags custom tags from Databricks API response
+type JobTags struct {
+	Settings struct {
+		Tags map[string]string `json:"tags"`
+	} `json:"settings"`
+}
+
+// Fetch Cluster custom tags and Job custom tags from the databricks API
+// Will only do requests if the API key and Hostname are present
+// It should not do requests without those, it should not panic if the HTTP requests are failing.
+// It should add the custom tags to the datadog-agent tags config.
+func fetchDatabricksCustomTags(s *common.Setup) {
+	token := os.Getenv("DATABRICKS_TOKEN")
+	host := os.Getenv("DATABRICKS_HOST")
+	if token == "" || host == "" {
+		s.Span.SetTag("databricks_api_auth.provided", "false")
+		s.Out.WriteString("DATABRICKS_TOKEN or DATABRICKS_HOST not set, skipping custom tags fetch\n")
+		return
+	}
+
+	s.Out.WriteString("Fetching custom tags from Databricks API\n")
+
+	client := &http.Client{
+		Timeout: fetchTimeoutDuration,
+	}
+
+	clusterID := os.Getenv("DB_CLUSTER_ID")
+	if clusterID == "" {
+		s.Out.WriteString("DB_CLUSTER_ID not set, skipping cluster tags fetch\n")
+	} else {
+		clusterTags, err := fetchClusterTagsFunc(client, host, token, clusterID, s)
+		if err != nil {
+			s.Out.WriteString(fmt.Sprintf("Failed to fetch cluster tags: %v\n", err))
+		} else {
+			addTagsToConfig(s, clusterTags)
+		}
+	}
+
+	jobID, _, ok := getJobAndRunIDs()
+	if !ok || jobID == "" {
+		s.Out.WriteString("No valid job ID found, skipping job tags fetch\n")
+		return
+	}
+
+	jobTags, err := fetchJobTagsFunc(client, host, token, jobID, s)
+	if err != nil {
+		s.Out.WriteString(fmt.Sprintf("Failed to fetch job tags: %v\n", err))
+		return
+	}
+
+	addTagsToConfig(s, jobTags)
+}
+
+// Variables to hold the original functions so we can mock them for testing
+var (
+	fetchClusterTagsFunc = fetchClusterTags
+	fetchJobTagsFunc     = fetchJobTags
+)
+
+func fetchClusterTags(client *http.Client, host, token, clusterID string, s *common.Setup) (map[string]string, error) {
+	var err error
+	span, _ := telemetry.StartSpanFromContext(s.Ctx, "fetch.cluster.custom_tags")
+	defer func() { span.Finish(err) }()
+
+	url := fmt.Sprintf("%s/api/2.1/clusters/get?cluster_id=%s", host, clusterID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var clusterResponse ClusterTags
+	err = json.Unmarshal(body, &clusterResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return clusterResponse.CustomTags, nil
+}
+
+func fetchJobTags(client *http.Client, host, token, jobID string, s *common.Setup) (map[string]string, error) {
+	var err error
+	span, _ := telemetry.StartSpanFromContext(s.Ctx, "fetch.job.custom_tags")
+	defer func() { span.Finish(err) }()
+
+	url := fmt.Sprintf("%s/api/2.1/jobs/get?job_id=%s", host, jobID)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var jobResponse JobTags
+	err = json.Unmarshal(body, &jobResponse)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return jobResponse.Settings.Tags, nil
+}
+
+func addTagsToConfig(s *common.Setup, tags map[string]string) {
+	if len(tags) == 0 {
+		return
+	}
+
+	for key, value := range tags {
+		tagString := fmt.Sprintf("%s:%s", key, value)
+		s.Config.DatadogYAML.Tags = append(s.Config.DatadogYAML.Tags, tagString)
+
+		s.Span.SetTag("host_tag_set."+key, value)
 	}
 }


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- [Jira](https://datadoghq.atlassian.net/browse/DJM-832)

This PR adds a new functionality during the agent setup for [Databricks](https://www.databricks.com/) hosts.
We check for the presence of two environment variables that allow us to authenticate with the Databricks API (see https://github.com/DataDog/dogweb/pull/142202), we use these to make HTTP request to the API, fetch tags, and add it to the agent config.

### Motivation

A key technology we support in the Data Jobs Monitoring product is Databricks.
When customers organize their workload on the Databricks platform, they heavily rely on custom tags that they can add through the Databricks UI or API. This is for an example how they can split the workload by teams, cost center, etc...

It's capital that we add these custom tags to the metrics we ingest in DD, as all cost estimates for their usage of Databricks and cloud compute is based of those (mainly CPU metrics). They are also what allow us to make recommendations.

We've explored many ways in which we can attach those custom tags to the metrics, and in the interest of time and KISS, we are moving forward with this method. You can read more about all of this in [this doc](https://docs.google.com/document/d/1JBg1fMHN7glxiaompmU3uDLq5D9P7wk42d9jT5EiRqk/edit?tab=t.0#heading=h.60wy60sbn9fn).

### Describe how you validated your changes

I used the agent installer generated by the pipeline on this repo in a global init script, and checked that that:
- If I don't provide the environment variables, the agent is starting correctly with the same config than the one we would have using the currently released installer 
- If I provide environment variables, cluster custom tags + job custom tags are correctly added to the config

I used this [test dashboard](https://ddstaging.datadoghq.com/dashboard/hya-nmv-5zz/marwan---debug-databricks-custom-tags?fromUser=true&refresh_mode=sliding&from_ts=1747733215026&to_ts=1747819615026&live=true) to monitor that the metrics are correctly ingested and also ssh'd into clusters to look at the agent config to check that the config was working correctly. 

<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

The tags are not normalised before we set them in the config. I tried _REALLY_ hard to do this. You can see the last iteration of my attempt on [this commit](https://github.com/DataDog/datadog-agent/commit/d8f5b48ab1f572db127829304223cfa9c79c317d). After few hours of fighting CI checks I just give up, let's just rely on the intake to do the normalisation 😞 

### Checklist

- [x] Write tests for the code you wrote.
- [x] Preferably make sure that all tests pass locally.
  ```sh
   ~/go/src/github.com/DataDog/datadog-agent marwan/djm-databricks-metrics-tags
   ❯ go1.23.9 test github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/djm

   ok      github.com/DataDog/datadog-agent/pkg/fleet/installer/setup/djm  0.338s
  ```
- [X] Summarize your PR with an explanatory title and a message describing your changes, cross-referencing any related bugs/PRs.
- [x] Use [Reno](#reno) to create a release note.
  - Initially provided a changelog but after looking into this more, it appears we usually don't put change logs for install script updates 
- [X] Open your PR against the `main` branch.
- [X] Sign the Contributor Licence Agreement.
- [X] Sign your commits.
- [X] Provide adequate QA/testing plan information.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->