### PR TITLE
(fleet) [backport] remove the datadog-agent OCI during DEB/RPM installs (#37015)

### DIFF
--- a/omnibus/package-scripts/agent-deb/preinst
+++ b/omnibus/package-scripts/agent-deb/preinst
@@ -34,4 +34,9 @@ if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/
     fi
 fi
 
+# Uninstall the agent if it was installed by the installer
+if command -v datadog-installer >/dev/null 2>&1 && datadog-installer is-installed datadog-agent; then
+    datadog-installer remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
+fi
+
 exit 0

--- a/omnibus/package-scripts/agent-rpm/preinst
+++ b/omnibus/package-scripts/agent-rpm/preinst
@@ -29,6 +29,11 @@ if [ -f "/lib/systemd/system/$SERVICE_NAME.service" ] || [ -f "/usr/lib/systemd/
     fi
 fi
 
+# Uninstall the agent if it was installed by the installer
+if command -v datadog-installer >/dev/null 2>&1 && datadog-installer is-installed datadog-agent; then
+    datadog-installer remove datadog-agent || printf "[ WARNING ]\tFailed to remove datadog-agent installed by the installer\n"
+fi
+
 # RPM Agents < 5.18.0 expect the preinst script of the _new_ package to stop the agent service on upgrade (which is defined with an init.d script on Agent 5)
 # So let's stop the Agent 5 service here until we don't want to support upgrades from Agents < 5.18.0 anymore
 if [ -f "/etc/init.d/datadog-agent" ]; then
@@ -64,7 +69,7 @@ if [ -f "$INSTALL_DIR/embedded/.installed_by_pkg.txt" ]; then
     # List all files in the embedded dir of the datadog-agent install dir
     PREV_DIR=$(pwd)
     cd $INSTALL_DIR
-    find . -depth -path './embedded/lib/python*/site-packages/datadog_*' > $INSTALL_DIR/embedded/.all-integrations.txt
+    find . -depth -path './embedded/lib/python*/site-packages/datadog_*' >$INSTALL_DIR/embedded/.all-integrations.txt
 
     # List all files in the embedded dir of the datadog-agent install dir
     # which were not installed by the package and rm them.

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -235,6 +235,14 @@ func (h *Host) AssertPackageInstalledByInstaller(pkgs ...string) {
 	}
 }
 
+// AssertPackageNotInstalledByInstaller checks if a package is not installed by the installer on the host.
+func (h *Host) AssertPackageNotInstalledByInstaller(pkgs ...string) {
+	for _, pkg := range pkgs {
+		_, err := h.remote.ReadDir(fmt.Sprintf("/opt/datadog-packages/%s/stable/", pkg))
+		require.Error(h.t(), err, "package %s installed by the installer", pkg)
+	}
+}
+
 // AgentRuntimeConfig returns the runtime agent config on the host.
 func (h *Host) AgentRuntimeConfig() (string, error) {
 	return h.remote.Execute("sudo -u dd-agent datadog-agent config")

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -143,9 +143,9 @@ func (s *packageAgentSuite) TestUpgrade_Agent_OCI_then_DebRpm() {
 	s.host.AssertPackageInstalledByPackageManager("datadog-agent")
 
 	state = s.host.State()
-	s.assertUnits(state, false)
+	s.assertUnits(state, true)
 	state.AssertDirExists("/opt/datadog-agent", 0755, "dd-agent", "dd-agent")
-	s.host.AssertPackageInstalledByInstaller("datadog-agent")
+	s.host.AssertPackageNotInstalledByInstaller("datadog-agent")
 }
 
 func (s *packageAgentSuite) TestExperimentTimeout() {


### PR DESCRIPTION
This PR is a backport of #37015 