### PR TITLE
[automated] Static quality gates threshold update

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,81 +1,81 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 778.06 MiB
-  max_on_wire_size: 191.06 MiB
+  max_on_disk_size: 752.99 MiB
+  max_on_wire_size: 187.44 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 776.09 MiB
-  max_on_wire_size: 190.72 MiB
+  max_on_disk_size: 751.36 MiB
+  max_on_wire_size: 187.06 MiB
 static_quality_gate_agent_heroku_amd64:
-  max_on_disk_size: 434.99 MiB
-  max_on_wire_size: 114.34 MiB
+  max_on_disk_size: 369.68 MiB
+  max_on_wire_size: 99.55 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 978.45 MiB
-  max_on_wire_size: 151.65 MiB
+  max_on_disk_size: 975.48 MiB
+  max_on_wire_size: 149.12 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 778.06 MiB
-  max_on_wire_size: 193.42 MiB
+  max_on_disk_size: 752.98 MiB
+  max_on_wire_size: 190.03 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 776.06 MiB
-  max_on_wire_size: 192.61 MiB
+  max_on_disk_size: 751.35 MiB
+  max_on_wire_size: 189.81 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 768.33 MiB
-  max_on_wire_size: 174.71 MiB
+  max_on_disk_size: 739.42 MiB
+  max_on_wire_size: 171.23 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 766.55 MiB
-  max_on_wire_size: 173.92 MiB
+  max_on_disk_size: 737.91 MiB
+  max_on_wire_size: 170.22 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 778.08 MiB
-  max_on_wire_size: 193.42 MiB
+  max_on_disk_size: 752.98 MiB
+  max_on_wire_size: 190.03 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 776.11 MiB
-  max_on_wire_size: 192.78 MiB
+  max_on_disk_size: 751.35 MiB
+  max_on_wire_size: 189.81 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 768.31 MiB
-  max_on_wire_size: 174.71 MiB
+  max_on_disk_size: 739.42 MiB
+  max_on_wire_size: 171.23 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 766.5 MiB
-  max_on_wire_size: 173.92 MiB
+  max_on_disk_size: 737.91 MiB
+  max_on_wire_size: 170.22 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 876.00 MiB
-  max_on_wire_size: 278.30 MiB
+  max_on_disk_size: 858.97 MiB
+  max_on_wire_size: 274.36 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 876.63 MiB
-  max_on_wire_size: 278.40 MiB
+  max_on_disk_size: 858.97 MiB
+  max_on_wire_size: 274.36 MiB
 static_quality_gate_docker_agent_windows1809:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_windows1809_core:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_windows1809_core_jmx:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_windows1809_jmx:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_windows2022:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_windows2022_core:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_windows2022_core_jmx:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_agent_windows2022_jmx:
-  max_on_disk_size: 862.5 MiB
-  max_on_wire_size: 292.00 MiB
+  max_on_disk_size: 849.39 MiB
+  max_on_wire_size: 288.34 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 263.4 MiB
-  max_on_wire_size: 104.07 MiB
+  max_on_disk_size: 259.73 MiB
+  max_on_wire_size: 103.68 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 279.38 MiB
-  max_on_wire_size: 98.95 MiB
+  max_on_disk_size: 274.24 MiB
+  max_on_wire_size: 98.45 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.12 MiB
   max_on_wire_size: 3.29 MiB
@@ -83,23 +83,23 @@ static_quality_gate_docker_cws_instrumentation_arm64:
   max_on_disk_size: 6.92 MiB
   max_on_wire_size: 3.07 MiB
 static_quality_gate_docker_dogstatsd_amd64:
-  max_on_disk_size: 46.39 MiB
-  max_on_wire_size: 17.78 MiB
+  max_on_disk_size: 39.57 MiB
+  max_on_wire_size: 15.76 MiB
 static_quality_gate_docker_dogstatsd_arm64:
-  max_on_disk_size: 45.05 MiB
-  max_on_wire_size: 16.65 MiB
+  max_on_disk_size: 38.2 MiB
+  max_on_wire_size: 14.83 MiB
 static_quality_gate_dogstatsd_deb_amd64:
-  max_on_disk_size: 38.4 MiB
-  max_on_wire_size: 10.26 MiB
+  max_on_disk_size: 31.52 MiB
+  max_on_wire_size: 8.97 MiB
 static_quality_gate_dogstatsd_deb_arm64:
-  max_on_disk_size: 36.98 MiB
-  max_on_wire_size: 8.96 MiB
+  max_on_disk_size: 30.08 MiB
+  max_on_wire_size: 7.92 MiB
 static_quality_gate_dogstatsd_rpm_amd64:
-  max_on_disk_size: 38.4 MiB
-  max_on_wire_size: 10.27 MiB
+  max_on_disk_size: 31.52 MiB
+  max_on_wire_size: 8.98 MiB
 static_quality_gate_dogstatsd_suse_amd64:
-  max_on_disk_size: 38.4 MiB
-  max_on_wire_size: 10.27 MiB
+  max_on_disk_size: 31.52 MiB
+  max_on_wire_size: 8.98 MiB
 static_quality_gate_iot_agent_deb_amd64:
   max_on_disk_size: 58.51 MiB
   max_on_wire_size: 15.02 MiB

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -101,20 +101,20 @@ static_quality_gate_dogstatsd_suse_amd64:
   max_on_disk_size: 38.4 MiB
   max_on_wire_size: 10.27 MiB
 static_quality_gate_iot_agent_deb_amd64:
-  max_on_disk_size: 58.51 MiB
-  max_on_wire_size: 15.02 MiB
+  max_on_disk_size: 60.17 MiB
+  max_on_wire_size: 15.82 MiB
 static_quality_gate_iot_agent_deb_arm64:
-  max_on_disk_size: 55.94 MiB
-  max_on_wire_size: 13.05 MiB
+  max_on_disk_size: 56.94 MiB
+  max_on_wire_size: 13.86 MiB
 static_quality_gate_iot_agent_deb_armhf:
-  max_on_disk_size: 54.65 MiB
-  max_on_wire_size: 13.05 MiB
+  max_on_disk_size: 56.41 MiB
+  max_on_wire_size: 13.86 MiB
 static_quality_gate_iot_agent_rpm_amd64:
-  max_on_disk_size: 58.51 MiB
-  max_on_wire_size: 15.04 MiB
+  max_on_disk_size: 60.18 MiB
+  max_on_wire_size: 15.84 MiB
 static_quality_gate_iot_agent_rpm_arm64:
-  max_on_disk_size: 55.94 MiB
-  max_on_wire_size: 13.07 MiB
+  max_on_disk_size: 56.94 MiB
+  max_on_wire_size: 13.76 MiB
 static_quality_gate_iot_agent_suse_amd64:
-  max_on_disk_size: 58.51 MiB
-  max_on_wire_size: 15.04 MiB
+  max_on_disk_size: 60.18 MiB
+  max_on_wire_size: 15.84 MiB


### PR DESCRIPTION
Updates static quality gates following the agent `7.67` cut-off.
Most gates are being lowered except for iot agent gates that needs a small bump to allow for the next go update #36974