### PR TITLE
Revert "Leader election watch by notification"

### DIFF
--- a/pkg/clusteragent/clusterchecks/common_test.go
+++ b/pkg/clusteragent/clusterchecks/common_test.go
@@ -8,7 +8,6 @@
 package clusterchecks
 
 import (
-	"errors"
 	"sync"
 	"testing"
 
@@ -57,16 +56,8 @@ func (m *mockedPluggableAutoConfig) RemoveScheduler(name string) {
 
 type fakeLeaderEngine struct {
 	sync.Mutex
-	ip         string
-	err        error
-	subscriber chan struct{}
-}
-
-func newFakeLeaderEngine() *fakeLeaderEngine {
-	return &fakeLeaderEngine{
-		subscriber: make(chan struct{}),
-		err:        errors.New("failing"),
-	}
+	ip  string
+	err error
 }
 
 func (e *fakeLeaderEngine) get() (string, error) {
@@ -77,19 +68,7 @@ func (e *fakeLeaderEngine) get() (string, error) {
 
 func (e *fakeLeaderEngine) set(ip string, err error) {
 	e.Lock()
+	defer e.Unlock()
 	e.ip = ip
 	e.err = err
-	e.Unlock()
-	if e.subscriber != nil {
-		e.notify()
-	}
-}
-
-func (e *fakeLeaderEngine) notify() {
-	e.subscriber <- struct{}{}
-}
-
-func (e *fakeLeaderEngine) subscribe() (leadershipChangeNotif <-chan struct{}) {
-	leadershipChangeNotif = e.subscriber
-	return
 }

--- a/pkg/clusteragent/clusterchecks/leadership_kube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_kube.go
@@ -22,13 +22,3 @@ func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 
 	return engine.GetLeaderIP, nil
 }
-
-func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
-	engine, err := leaderelection.GetLeaderEngine()
-	if err != nil {
-		return nil, err
-	}
-
-	engine.StartLeaderElectionRun()
-	return engine.UpdateLeaderInClusterChecks, nil
-}

--- a/pkg/clusteragent/clusterchecks/leadership_nokube.go
+++ b/pkg/clusteragent/clusterchecks/leadership_nokube.go
@@ -16,7 +16,3 @@ import (
 func getLeaderIPCallback() (types.LeaderIPCallback, error) {
 	return nil, errors.New("No leader election engine compiled in")
 }
-
-func getLeadershipStateNotifiChan() (<-chan struct{}, error) {
-	return nil, errors.New("No leader election engine compiled in")
-}

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -54,18 +54,17 @@ type LeaderEngine struct {
 	m       sync.Mutex
 	once    sync.Once
 
-	subscribers                 []chan struct{}
-	UpdateLeaderInClusterChecks chan struct{}
-	HolderIdentity              string
-	LeaseDuration               time.Duration
-	LeaseName                   string
-	LeaderNamespace             string
-	coreClient                  corev1.CoreV1Interface
-	coordClient                 coordinationv1.CoordinationV1Interface
-	ServiceName                 string
-	leaderIdentityMutex         sync.RWMutex
-	leaderElector               *leaderelection.LeaderElector
-	lockType                    string
+	subscribers         []chan struct{}
+	HolderIdentity      string
+	LeaseDuration       time.Duration
+	LeaseName           string
+	LeaderNamespace     string
+	coreClient          corev1.CoreV1Interface
+	coordClient         coordinationv1.CoordinationV1Interface
+	ServiceName         string
+	leaderIdentityMutex sync.RWMutex
+	leaderElector       *leaderelection.LeaderElector
+	lockType            string
 
 	// leaderIdentity is the HolderIdentity of the current leader.
 	leaderIdentity string
@@ -76,14 +75,13 @@ type LeaderEngine struct {
 
 func newLeaderEngine(ctx context.Context) *LeaderEngine {
 	return &LeaderEngine{
-		ctx:                         ctx,
-		LeaseName:                   pkgconfigsetup.Datadog().GetString("leader_lease_name"),
-		LeaderNamespace:             common.GetResourcesNamespace(),
-		ServiceName:                 pkgconfigsetup.Datadog().GetString("cluster_agent.kubernetes_service_name"),
-		leaderMetric:                metrics.NewLeaderMetric(),
-		subscribers:                 []chan struct{}{},
-		UpdateLeaderInClusterChecks: make(chan struct{}),
-		LeaseDuration:               defaultLeaderLeaseDuration,
+		ctx:             ctx,
+		LeaseName:       pkgconfigsetup.Datadog().GetString("leader_lease_name"),
+		LeaderNamespace: common.GetResourcesNamespace(),
+		ServiceName:     pkgconfigsetup.Datadog().GetString("cluster_agent.kubernetes_service_name"),
+		leaderMetric:    metrics.NewLeaderMetric(),
+		subscribers:     []chan struct{}{},
+		LeaseDuration:   defaultLeaderLeaseDuration,
 	}
 }
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_engine.go
@@ -149,7 +149,6 @@ func (le *LeaderEngine) newElection() (*ld.LeaderElector, error) {
 		OnNewLeader: func(identity string) {
 			le.updateLeaderIdentity(identity)
 			le.reportLeaderMetric(identity == le.HolderIdentity)
-			le.notifyClusterChecks() // notify cluster checks of the new leader
 			log.Infof("New leader %q", identity)
 		},
 		OnStartedLeading: func(context.Context) {
@@ -235,9 +234,4 @@ func (le *LeaderEngine) notify() {
 
 		s <- struct{}{}
 	}
-}
-
-// notifyClusterChecks sends a notification to clusterchecks when the leader changes in any process.
-func (le *LeaderEngine) notifyClusterChecks() {
-	le.UpdateLeaderInClusterChecks <- struct{}{}
 }

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -217,7 +217,6 @@ func TestSubscribe(t *testing.T) {
 
 			notif1, _ := le.Subscribe()
 			notif2, _ := le.Subscribe()
-			clusterChecksChan := le.UpdateLeaderInClusterChecks
 			require.Len(t, le.subscribers, 2)
 
 			err := tc.getTokenFunc(client)
@@ -232,7 +231,7 @@ func TestSubscribe(t *testing.T) {
 			err = tc.getTokenFunc(client)
 			require.NoError(t, err)
 
-			counter1, counter2, counter3 := 0, 0, 0
+			counter1, counter2 := 0, 0
 			for {
 				select {
 				case <-notif1:
@@ -247,12 +246,6 @@ func TestSubscribe(t *testing.T) {
 					counter2++
 					require.Truef(t, le.IsLeader(), "Expected to be leader")
 					if counter2 > 1 {
-						require.Fail(t, "Received too many notifications")
-						break
-					}
-				case <-clusterChecksChan:
-					counter3++
-					if counter3 > 1 {
 						require.Fail(t, "Received too many notifications")
 						break
 					}
@@ -270,7 +263,7 @@ func TestSubscribe(t *testing.T) {
 			// simulate leadership lease loss by cancelling leader election context
 			cancel()
 
-			counter1, counter2, counter3 = 0, 0, 0
+			counter1, counter2 = 0, 0
 			for {
 				select {
 				case <-notif1:
@@ -285,13 +278,6 @@ func TestSubscribe(t *testing.T) {
 					require.Falsef(t, le.IsLeader(), "Expected to be a follower")
 					counter2++
 					if counter2 > 1 {
-						require.Fail(t, "Received too many notifications")
-						return
-					}
-
-				case <-clusterChecksChan:
-					counter3++
-					if counter3 > 1 {
 						require.Fail(t, "Received too many notifications")
 						return
 					}


### PR DESCRIPTION
This reverts commit https://github.com/DataDog/datadog-agent/pull/36172
It caused cluster check dangling for a short period of times on large cluster due to apiserver rate limit. 

`2025-05-15 13:58:31 UTC | CLUSTER | ERROR | (client-go@v0.31.2/tools/leaderelection/leaderelection.go:257 in func1) | error retrieving resource lock datadog-agent/datadog-agent-leader-election: client rate limiter Wait returned an error: context deadline exceeded`

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->