### PR TITLE
[agent] [linux] nit: rename local process collector source to correct language collector

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/processlanguage/process_collector.go
@@ -175,7 +175,7 @@ func transform(diff *processwlm.ProcessCacheDiff) []workloadmeta.CollectorEvent 
 				CreationTime: time.UnixMilli(creation.CreationTime),
 				Language:     creation.Language,
 			},
-			Source: workloadmeta.SourceLocalProcessCollector,
+			Source: workloadmeta.SourceProcessLanguageCollector,
 		})
 	}
 
@@ -188,7 +188,7 @@ func transform(diff *processwlm.ProcessCacheDiff) []workloadmeta.CollectorEvent 
 					ID:   strconv.Itoa(int(deletion.Pid)),
 				},
 			},
-			Source: workloadmeta.SourceLocalProcessCollector,
+			Source: workloadmeta.SourceProcessLanguageCollector,
 		})
 	}
 

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -92,9 +92,9 @@ const (
 	// SourceHost represents entities detected by the host such as host tags.
 	SourceHost Source = "host"
 
-	// SourceLocalProcessCollector reprents processes entities detected
-	// by the LocalProcessCollector.
-	SourceLocalProcessCollector Source = "local_process_collector"
+	// SourceProcessLanguageCollector represents processes entities detected
+	// by the ProcessLanguageCollector.
+	SourceProcessLanguageCollector Source = "process_language_collector"
 )
 
 // ContainerRuntime is the container runtime used by a container.

--- a/test/new-e2e/tests/language-detection/php_test.go
+++ b/test/new-e2e/tests/language-detection/php_test.go
@@ -23,7 +23,7 @@ func (s *languageDetectionSuite) installPHP() {
 func (s *languageDetectionSuite) TestPHPDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
 	s.runPHP()
-	s.checkDetectedLanguage("php", "php", "local_process_collector")
+	s.checkDetectedLanguage("php", "php", "process_language_collector")
 }
 
 func (s *languageDetectionSuite) runPHP() {

--- a/test/new-e2e/tests/language-detection/python_test.go
+++ b/test/new-e2e/tests/language-detection/python_test.go
@@ -23,13 +23,13 @@ func (s *languageDetectionSuite) installPython() {
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_langauge_collector")
+	s.checkDetectedLanguage("python3", "python", "process_language_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigNoCheckStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "process_langauge_collector")
+	s.checkDetectedLanguage("python3", "python", "process_language_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgent() {

--- a/test/new-e2e/tests/language-detection/python_test.go
+++ b/test/new-e2e/tests/language-detection/python_test.go
@@ -23,13 +23,13 @@ func (s *languageDetectionSuite) installPython() {
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgent() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "local_process_collector")
+	s.checkDetectedLanguage("python3", "python", "process_langauge_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionCoreAgentNoCheck() {
 	s.UpdateEnv(awshost.ProvisionerNoFakeIntake(awshost.WithAgentOptions(agentparams.WithAgentConfig(coreConfigNoCheckStr))))
 	s.runPython()
-	s.checkDetectedLanguage("python3", "python", "local_process_collector")
+	s.checkDetectedLanguage("python3", "python", "process_langauge_collector")
 }
 
 func (s *languageDetectionSuite) TestPythonDetectionProcessAgent() {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
- refactors a name constant from workloadmeta of the local process collector which was previously refactored in preparation for the new process collector initiative https://datadoghq.atlassian.net/jira/software/c/projects/CXP/boards/5501?selectedIssue=CXP-2184

### Motivation
- previous refactoring https://github.com/DataDog/datadog-agent/pull/36589 which missed updating this constant

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
- existing tests

### Possible Drawbacks / Trade-offs
- potentially misleading as the collection interval can still be configured under for a very specific case when language detection is enabled and the process check on the process agent is off. It's an "external" collector. This needs to be kept around for windows. In the future, there should likely be some investigation if we can delete this

```
workloadmeta.local_process_collector.collection_interval
```


### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->