### PR TITLE
usm: kafka: Handle edge cases with first latency

### DIFF
--- a/pkg/network/protocols/kafka/stats.go
+++ b/pkg/network/protocols/kafka/stats.go
@@ -148,7 +148,7 @@ func (r *RequestStats) AddRequest(errorCode int32, count int, staticTags uint64,
 		}
 
 		// The kafka kernel decoder can capture multiple requests in a single packet, so
-		// in case of a case of a new event with multiple requests, we might not have a FirstLatencySample
+		// in case of a new event with multiple requests, we might not have a FirstLatencySample
 		// In such a case, we need to skip adding the latency sample to the sketch
 		if originalCount == 1 {
 			// Add the deferred latency sample

--- a/pkg/network/usm/kafka_monitor_test.go
+++ b/pkg/network/usm/kafka_monitor_test.go
@@ -1707,7 +1707,12 @@ func validateProduceFetchCount(t *assert.CollectT, kafkaStats map[kafka.Key]*kaf
 			continue
 		}
 		assert.Equal(t, topicName[:min(len(topicName), 80)], kafkaKey.TopicName.Get())
-		assert.Greater(t, requestStats.FirstLatencySample, float64(1))
+		if requestStats.Count == 1 {
+			assert.Greater(t, requestStats.FirstLatencySample, float64(1))
+		} else {
+			require.NotNil(t, requestStats.Latencies)
+			assert.Equal(t, requestStats.Latencies.GetCount(), float64(requestStats.Count))
+		}
 		switch kafkaKey.RequestAPIKey {
 		case kafka.ProduceAPIKey:
 			assert.Equal(t, uint16(validation.expectedAPIVersionProduce), kafkaKey.RequestVersion)

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -2432,6 +2432,7 @@ func testKafkaSketches(t *testing.T, tr *tracer.Tracer) {
 	require.Empty(t, fetches.Errors())
 	require.Len(t, fetches.Records(), 1)
 
+	localhostAddress := util.AddressFromString(localhost)
 	var fetchRequestStats, produceTopic1RequestsStats, produceTopic2RequestsStats *kafka.RequestStats
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		conns, cleanup := getConnections(ct, tr)
@@ -2443,6 +2444,11 @@ func testKafkaSketches(t *testing.T, tr *tracer.Tracer) {
 		}
 
 		for key, stats := range requests {
+			srcAddr := util.FromLowHigh(key.SrcIPLow, key.SrcIPHigh)
+			if srcAddr != localhostAddress {
+				continue
+			}
+
 			if key.TopicName.Get() == topicName2 && key.RequestAPIKey == kafka.FetchAPIKey {
 				if fetchRequestStats == nil {
 					fetchRequestStats = stats

--- a/pkg/network/usm/tests/tracer_usm_linux_test.go
+++ b/pkg/network/usm/tests/tracer_usm_linux_test.go
@@ -2439,25 +2439,33 @@ func testKafkaSketches(t *testing.T, tr *tracer.Tracer) {
 
 		requests := conns.USMData.Kafka
 		if fetchRequestStats == nil || produceTopic1RequestsStats == nil || produceTopic2RequestsStats == nil {
-			require.True(ct, len(requests) > 0, "no requests")
+			require.Truef(ct, len(requests) > 0, "no requests; fetch: is nil? %v; produce t1: is nil? %v; produce t2: is nil? %v", fetchRequestStats == nil, produceTopic1RequestsStats == nil, produceTopic2RequestsStats == nil)
 		}
 
 		for key, stats := range requests {
-			if fetchRequestStats != nil && produceTopic1RequestsStats != nil && produceTopic2RequestsStats == nil {
-				break
-			}
-
 			if key.TopicName.Get() == topicName2 && key.RequestAPIKey == kafka.FetchAPIKey {
-				fetchRequestStats = stats
+				if fetchRequestStats == nil {
+					fetchRequestStats = stats
+				} else {
+					fetchRequestStats.CombineWith(stats)
+				}
 				continue
 			}
 			if key.TopicName.Get() == topicName1 && key.RequestAPIKey == kafka.ProduceAPIKey {
-				produceTopic1RequestsStats = stats
+				if produceTopic1RequestsStats == nil {
+					produceTopic1RequestsStats = stats
+				} else {
+					produceTopic1RequestsStats.CombineWith(stats)
+				}
 				continue
 			}
 
 			if key.TopicName.Get() == topicName2 && key.RequestAPIKey == kafka.ProduceAPIKey {
-				produceTopic2RequestsStats = stats
+				if produceTopic2RequestsStats == nil {
+					produceTopic2RequestsStats = stats
+				} else {
+					produceTopic2RequestsStats.CombineWith(stats)
+				}
 				continue
 			}
 		}


### PR DESCRIPTION

<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Our kafka kernel decoder can capture requests with multiple records. We had an assumption that the first request must have only 1 record, hence setting the FirstLantecySample. However, that's isn't true and can lead to inaccuracy in our backend.

The change ensures we set the FirstLatnecySample only if the first request has only 1 record.

### Motivation

Handling a potential inaccuracy by kafka.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->