### PR TITLE
fix(tidy): Force the correct hash on test-infra-definitions

### DIFF
--- a/test/new-e2e/go.mod
+++ b/test/new-e2e/go.mod
@@ -5,6 +5,7 @@ go 1.23.1
 // Do not upgrade Pulumi plugins to versions different from `test-infra-definitions`.
 // The plugin versions NEED to be aligned.
 // TODO: Implement hard check in CI
+// Comment to force update of go.mod - can be removed anytime.
 
 require (
 	github.com/DataDog/agent-payload/v5 v5.0.150

--- a/test/new-e2e/go.sum
+++ b/test/new-e2e/go.sum
@@ -14,7 +14,7 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/test-infra-definitions v0.0.2 h1:u0FamUjjCD1L1wODtp+aOgMZfdhY4wlYPyGgY/zPuco=
+github.com/DataDog/test-infra-definitions v0.0.2 h1:p7TBnQkuxZAhcTPDmAoMcY7qVeq9llvwoxAdgfBv6EE=
 github.com/DataDog/test-infra-definitions v0.0.2/go.mod h1:vwB1JMCmBJROTtDQhgVRHXdXaZAPIr2x2gPQK8Ugmu4=
 github.com/DataDog/zstd v1.5.6 h1:LbEglqepa/ipmmQJUDnSsfvA8e8IStVcGaFWDuxvGOY=
 github.com/DataDog/zstd v1.5.6/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Fix the latest `test-infra-definitions` hash.

### Motivation
Since we are [versioning](https://github.com/DataDog/test-infra-definitions/tags) `test-infra-definitions`, there is a discrepancy on the saved hash in the `go.sum` and the actual value.
It leads to error when calling `dda inv tidy` locally:
```
go: downloading github.com/DataDog/test-infra-definitions v0.0.2
verifying github.com/DataDog/test-infra-definitions@v0.0.2: checksum mismatch
        downloaded: h1:p7TBnQkuxZAhcTPDmAoMcY7qVeq9llvwoxAdgfBv6EE=
        /Users/nicolas.schweitzer/go/src/github.com/DataDog/datadog-agent/test/new-e2e/go.sum:     h1:u0FamUjjCD1L1wODtp+aOgMZfdhY4wlYPyGgY/zPuco=

SECURITY ERROR
This download does NOT match an earlier download recorded in go.sum.
```

### Describe how you validated your changes
Launched locally `dda inv tidy` after the update.
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs
As of today we will need such update on every `test-infra-definitions` bump. We need to review the tag set-up on this repo to prevent this issue.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->