### PR TITLE
Add new-e2e-installer-windows flake marker

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -52,6 +52,7 @@ func (s *testInstallScriptSuite) TestInstallAgentPackage() {
 // TestInstallFromOldInstaller tests installing the Datadog Agent package from an old installer.
 // shows we can correctly use the script to uninstall the old agent + installer MSIs
 func (s *testInstallScriptSuite) TestInstallFromOldInstaller() {
+	flake.Mark(s.T())
 	s.Run("Install from old installer", func() {
 		s.installOldInstallerAndAgent()
 		s.Run("Install New Version", func() {
@@ -115,7 +116,6 @@ func (s *testInstallScriptSuite) upgradeToLatestExperiment() {
 }
 
 func (s *testInstallScriptSuite) installOldInstallerAndAgent() {
-	flake.Mark(s.T())
 	// Arrange
 	agentVersion := fmt.Sprintf("%s-1", oldAgentVersion)
 	// Act

--- a/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/install-script/install_test.go
@@ -7,6 +7,7 @@ package agenttests
 
 import (
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/test/new-e2e/pkg/e2e"
@@ -114,6 +115,7 @@ func (s *testInstallScriptSuite) upgradeToLatestExperiment() {
 }
 
 func (s *testInstallScriptSuite) installOldInstallerAndAgent() {
+	flake.Mark(s.T())
 	// Arrange
 	agentVersion := fmt.Sprintf("%s-1", oldAgentVersion)
 	// Act


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Mark the test `TestInstallFromOldInstaller`  as flaky

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->