### PR TITLE
omnibus: xslt: stop building tests & installing doc

### DIFF
--- a/omnibus/config/patches/libxslt/0001-disable-doc-tests.patch
+++ b/omnibus/config/patches/libxslt/0001-disable-doc-tests.patch
@@ -1,0 +1,30 @@
+From 3b255c93a6462b4a802801a9155e140ac307166f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo.beauzee@datadoghq.com>
+Date: Mon, 19 May 2025 14:28:36 +0200
+Subject: [PATCH] disable doc & tests
+
+---
+ Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 4c4deba6..1416ca10 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,11 +1,11 @@
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = libxslt libexslt xsltproc doc tests
++SUBDIRS = libxslt libexslt xsltproc
+ if WITH_PYTHON
+ SUBDIRS += python
+ endif
+ 
+-DIST_SUBDIRS = libxslt libexslt xsltproc python doc tests
++DIST_SUBDIRS = libxslt libexslt xsltproc python
+ 
+ confexecdir=$(libdir)
+ confexec_DATA = xsltConf.sh
+-- 
+2.34.1
+

--- a/omnibus/config/software/libxslt.rb
+++ b/omnibus/config/software/libxslt.rb
@@ -38,6 +38,7 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   patch source: "libxslt-solaris-configure.patch", env: env if solaris2? || omnios? || smartos?
+  patch source: "0001-disable-doc-tests.patch", env: env
 
   if windows?
     patch source: "libxslt-windows-relocate.patch", env: env


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

Stop building optional xslt components

### Motivation

Reduce the amount of unneeded files in our packages and stop wasting time building 3rd party tests

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This doesn't affect the installed size since we remove the doc later in the build: https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/datadog-agent-finalize.rb#L139
but this change will still slightly reduce the overhead of the omnibus git cache and will prevent a few files from being built