### PR TITLE
Adding metric origins for Windows Certificate Store check

### DIFF
--- a/pkg/metrics/metricsource.go
+++ b/pkg/metrics/metricsource.go
@@ -64,6 +64,7 @@ const (
 	MetricSourceJenkins
 	MetricSourceGPU
 	MetricSourceWlan
+	MetricSourceWindowsCertificateStore
 
 	// Python Checks
 	MetricSourceZenohRouter
@@ -1096,6 +1097,8 @@ func (ms MetricSource) String() string {
 		return "google_cloud_run_runtime"
 	case MetricSourceWlan:
 		return "wlan"
+	case MetricSourceWindowsCertificateStore:
+		return "windows_certificate"
 	default:
 		return "<unknown>"
 	}
@@ -1754,6 +1757,8 @@ func CheckNameToMetricSource(name string) MetricSource {
 		return MetricSourceOpenTelemetryCollectorCouchdbReceiver
 	case "wlan":
 		return MetricSourceWlan
+	case "windows_certificate":
+		return MetricSourceWindowsCertificateStore
 	default:
 		return MetricSourceUnknown
 	}

--- a/pkg/serializer/internal/metrics/origin_mapping.go
+++ b/pkg/serializer/internal/metrics/origin_mapping.go
@@ -95,6 +95,7 @@ func metricSourceToOriginCategory(ms metrics.MetricSource) int32 {
 		metrics.MetricSourceNetwork,
 		metrics.MetricSourceSnmp,
 		metrics.MetricSourceWlan,
+		metrics.MetricSourceWindowsCertificateStore,
 		// Plugins and non-checks
 		metrics.MetricSourceCloudFoundry,
 		metrics.MetricSourceJenkins,
@@ -1103,6 +1104,8 @@ func metricSourceToOriginService(ms metrics.MetricSource) int32 {
 		return 482
 	case metrics.MetricSourceResilience4j:
 		return 483
+	case metrics.MetricSourceWindowsCertificateStore:
+		return 484
 	default:
 		return 0
 	}

--- a/releasenotes/notes/add-origins-for-windows-cert-store-cf71f4a0a403bb48.yaml
+++ b/releasenotes/notes/add-origins-for-windows-cert-store-cf71f4a0a403bb48.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Add metric origins for the Windows Certificate Store integration.


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Add Metrics origins for the [Windows Certificate Store check](https://github.com/DataDog/datadog-agent/pull/36658)

DD Source PR: https://github.com/DataDog/dd-source/pull/218506

### Motivation
https://datadoghq.atlassian.net/browse/WINA-1448

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->