### PR TITLE
[NDINT-290] Director Hardware Metrics

### DIFF
--- a/pkg/collector/corechecks/network-devices/versa/client/fixtures/payloads.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/fixtures/payloads.go
@@ -388,7 +388,7 @@ const GetDirectorStatus = `
     "memory": "64.01GB",
     "memoryFree": "20.10GB",
     "disk": "128GB",
-    "diskUsage": "fakeDiskUsage"
+    "diskUsage": "100GB",
   },
   "pkgInfo": {
     "version": "10.1",

--- a/pkg/collector/corechecks/network-devices/versa/client/fixtures/payloads.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/fixtures/payloads.go
@@ -388,7 +388,7 @@ const GetDirectorStatus = `
     "memory": "64.01GB",
     "memoryFree": "20.10GB",
     "disk": "128GB",
-    "diskUsage": "100GB",
+    "diskUsage": "fakeDiskUsage"
   },
   "pkgInfo": {
     "version": "10.1",

--- a/pkg/collector/corechecks/network-devices/versa/client/types.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/types.go
@@ -38,6 +38,7 @@ type DirectorHAConfig struct {
 	DesignatedMaster               bool     `json:"designatedMaster"`
 	StartupMode                    string   `json:"startupMode"`
 	MyVnfManagementIPs             []string `json:"myVnfManagementIps"`
+	MyAddress                      string   `json:"myAddress"`
 	VDSBInterfaces                 []string `json:"vdsbinterfaces"`
 	StartupModeHA                  bool     `json:"startupModeHA"`
 	MyNcsHaSetAsMaster             bool     `json:"myNcsHaSetAsMaster"`
@@ -341,6 +342,9 @@ type SLAMetrics struct {
 // IPAddress returns the first management IP address of the director
 // or an error if no management IPs are found
 func (d *DirectorStatus) IPAddress() (string, error) {
+	if d.HAConfig.MyAddress != "" {
+		return d.HAConfig.MyAddress, nil
+	}
 	if len(d.HAConfig.MyVnfManagementIPs) == 0 {
 		return "", fmt.Errorf("no management IPs found for director")
 	}

--- a/pkg/collector/corechecks/network-devices/versa/client/types.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/types.go
@@ -6,6 +6,8 @@
 // Package client implements a Versa API client
 package client
 
+import "fmt"
+
 // Content encapsulates the content types of the Versa API
 type Content interface {
 	[]Appliance |
@@ -334,4 +336,13 @@ type SLAMetrics struct {
 	FwdLossRatio        float64
 	RevLossRatio        float64
 	PDULossRatio        float64
+}
+
+// IPAddress returns the first management IP address of the director
+// or an error if no management IPs are found
+func (d *DirectorStatus) IPAddress() (string, error) {
+	if len(d.HAConfig.MyVnfManagementIPs) == 0 {
+		return "", fmt.Errorf("no management IPs found for director")
+	}
+	return d.HAConfig.MyVnfManagementIPs[0], nil
 }

--- a/pkg/collector/corechecks/network-devices/versa/client/types_test.go
+++ b/pkg/collector/corechecks/network-devices/versa/client/types_test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+//go:build test
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDirectorIPAddress(t *testing.T) {
+	tts := []struct {
+		description string
+		input       *DirectorStatus
+		expected    string
+		errMsg      string
+	}{
+		{
+			description: "MyAddress and MyVnfManagementIPs exist, prefer MyAddress",
+			input: &DirectorStatus{
+				HAConfig: DirectorHAConfig{
+					MyVnfManagementIPs: []string{
+						"192.168.1.1",
+						"192.168.1.2",
+					},
+					MyAddress: "10.0.0.1",
+				},
+			},
+			expected: "10.0.0.1",
+		},
+		{
+			description: "MyVnfManagementIPs exist, return first IP",
+			input: &DirectorStatus{
+				HAConfig: DirectorHAConfig{
+					MyVnfManagementIPs: []string{
+						"192.168.1.1",
+						"192.168.1.2",
+					},
+				},
+			},
+			expected: "192.168.1.1",
+		},
+		{
+			description: "MyVnfManagementIPs exist, single management address",
+			input: &DirectorStatus{
+				HAConfig: DirectorHAConfig{
+					MyVnfManagementIPs: []string{
+						"10.0.0.2",
+					},
+				},
+			},
+			expected: "10.0.0.2",
+		},
+		{
+			description: "No list of IPs, use MyAddress",
+			input: &DirectorStatus{
+				HAConfig: DirectorHAConfig{
+					MyAddress: "10.0.0.3",
+				},
+			},
+			expected: "10.0.0.3",
+		},
+		{
+			description: "No list of IPs or MyAddress, returns error",
+			input:       &DirectorStatus{},
+			errMsg:      "no management IPs found for director",
+		},
+	}
+
+	for _, test := range tts {
+		t.Run(test.description, func(t *testing.T) {
+			ip, err := test.input.IPAddress()
+			if test.errMsg != "" {
+				require.Error(t, err)
+				require.True(t, strings.Contains(err.Error(), test.errMsg))
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.expected, ip)
+			}
+		})
+	}
+}

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -182,7 +182,7 @@ func (s *Sender) SendDirectorUptimeMetrics(director *client.DirectorStatus) {
 	if err != nil {
 		log.Errorf("error parsing director system uptime: %v", err)
 	} else {
-		s.Gauge(versaMetricPrefix+"device.uptime", sysUptime, "", append(tags, "type:system"))
+		s.Gauge(versaMetricPrefix+"device.uptime", sysUptime, "", append(tags, "type:sys_proc"))
 	}
 }
 

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -128,6 +128,11 @@ func (s *Sender) SendDeviceStatusMetrics(deviceStatus map[string]float64) {
 	for device, status := range deviceStatus {
 		tags := s.GetDeviceTags(defaultIPTag, device)
 		s.Gauge(versaMetricPrefix+"device.reachable", status, "", tags)
+		if status > 0 {
+			s.Gauge(versaMetricPrefix+"device.unreachable", 0, "", tags)
+		} else {
+			s.Gauge(versaMetricPrefix+"device.unreachable", 1, "", tags)
+		}
 	}
 }
 
@@ -196,6 +201,7 @@ func (s *Sender) SendDirectorStatus(director *client.DirectorStatus) {
 	tags := s.GetDeviceTags(defaultIPTag, ipAddress)
 
 	s.Gauge(versaMetricPrefix+"device.reachable", 1, "", tags)
+	s.Gauge(versaMetricPrefix+"device.unreachable", 0, "", tags) // flip device reachability with math
 }
 
 // SendDirectorDeviceMetrics sends director device metrics like CPU, memory, and disk usage

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -354,7 +354,7 @@ func parseUptimeString(uptime string) (float64, error) {
 func parseDiskUsage(diskUsage string) ([]partition, error) {
 	var partitions []partition
 	entries := strings.Split(diskUsage, ";")
-	if len(entries) == 0 {
+	if diskUsage == "" || len(entries) == 0 {
 		return nil, fmt.Errorf("failed to parse diskUsage string: %s", diskUsage)
 	}
 
@@ -367,6 +367,7 @@ func parseDiskUsage(diskUsage string) ([]partition, error) {
 			kv := strings.SplitN(field, "=", 2)
 			if len(kv) != 2 {
 				partialParseErrs = multierr.Append(partialParseErrs, fmt.Errorf("failed to parse diskUsage partition: %s", field))
+				partialParseErrCount++
 				continue
 			}
 			key, value := kv[0], kv[1]
@@ -374,6 +375,7 @@ func parseDiskUsage(diskUsage string) ([]partition, error) {
 			case "partition":
 				if value == "" {
 					partialParseErrs = multierr.Append(partialParseErrs, fmt.Errorf("failed to parse parition name: %q", value))
+					partialParseErrCount++
 					continue
 				}
 				p.Name = value
@@ -381,6 +383,7 @@ func parseDiskUsage(diskUsage string) ([]partition, error) {
 				size, err := parseSize(value)
 				if err != nil {
 					partialParseErrs = multierr.Append(partialParseErrs, fmt.Errorf("failed to parse disk size: %s", value))
+					partialParseErrCount++
 					continue
 				}
 				p.Size = size
@@ -388,6 +391,7 @@ func parseDiskUsage(diskUsage string) ([]partition, error) {
 				free, err := parseSize(value)
 				if err != nil {
 					partialParseErrs = multierr.Append(partialParseErrs, fmt.Errorf("failed to parse disk free: %s", value))
+					partialParseErrCount++
 					continue
 				}
 				p.Free = free
@@ -395,6 +399,7 @@ func parseDiskUsage(diskUsage string) ([]partition, error) {
 				usedRatio, err := strconv.ParseFloat(value, 64)
 				if err != nil {
 					partialParseErrs = multierr.Append(partialParseErrs, fmt.Errorf("failed to parse disk used ratio: %s", value))
+					partialParseErrCount++
 					continue
 				}
 				p.UsedRatio = usedRatio
@@ -403,7 +408,7 @@ func parseDiskUsage(diskUsage string) ([]partition, error) {
 		partitions = append(partitions, p)
 	}
 	if partialParseErrCount == len(entries) {
-		return nil, fmt.Errorf("no valid partions found in diskUsage string: %s", diskUsage)
+		return nil, fmt.Errorf("no valid partitions found in diskUsage string: %s", diskUsage)
 	}
 
 	return partitions, partialParseErrs

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -58,7 +58,7 @@ func (s *Sender) SendDeviceMetrics(appliances []client.Appliance) {
 		lastUpdatedTime, err := parseTimestamp(appliance.LastUpdatedTime)
 		if err != nil {
 			log.Warnf("Error parsing timestamp %s: %s. Sending device metrics...", appliance.LastUpdatedTime, err)
-			lastUpdatedTime = float64(time.Now().UnixMilli())
+			lastUpdatedTime = float64(TimeNow().UnixMilli())
 		}
 		if !s.ShouldSendEntry(key, lastUpdatedTime) {
 			// If the timestamp is before the max timestamp already sent, do not re-send
@@ -198,7 +198,7 @@ func (s *Sender) SendDirectorDeviceMetrics(director *client.DirectorStatus) {
 	tags := s.GetDeviceTags(defaultIPTag, ipAddress)
 
 	// Convert lastUpdatedTime to unix timestamp
-	lastUpdatedTime := float64(time.Now().UnixMilli())
+	lastUpdatedTime := float64(TimeNow().UnixMilli())
 
 	ts := lastUpdatedTime / 1000 // convert to seconds
 	cpuLoadString := director.SystemDetails.CPULoad
@@ -241,7 +241,7 @@ func parseTimestamp(timestamp string) (float64, error) {
 		// If parsing fails, try the alternate format
 		t, err = time.Parse(alternateVersaTimestampFormat, timestamp)
 		if err != nil {
-			return float64(time.Now().UnixMilli()), fmt.Errorf("error parsing timestamp: %w", err)
+			return float64(TimeNow().UnixMilli()), fmt.Errorf("error parsing timestamp: %w", err)
 		}
 	}
 	return float64(t.UnixMilli()), nil

--- a/pkg/collector/corechecks/network-devices/versa/report/sender.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender.go
@@ -286,6 +286,7 @@ func parseSize(sizeString string) (float64, error) {
 	return size * largestFactor, nil
 }
 
+// TODO: error on invalid format (no matches)
 func parseUptimeString(uptime string) (float64, error) {
 	uptime = strings.TrimSuffix(uptime, ".") // Remove the trailing period
 	matches := versaUptimeRegex.FindAllStringSubmatch(uptime, -1)
@@ -317,5 +318,5 @@ func parseUptimeString(uptime string) (float64, error) {
 		}
 	}
 
-	return math.Round(float64(total.Milliseconds()) / 10), nil // In hundredths of a second, to match SNMP
+	return math.Round(float64(total) / float64(time.Millisecond) / 10), nil // In hundredths of a second, to match SNMP
 }

--- a/pkg/collector/corechecks/network-devices/versa/report/sender_test.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender_test.go
@@ -51,9 +51,13 @@ func TestParseSize(t *testing.T) {
 		{"50.12KiB", 50.12 * 1024, ""},
 		{"100MiB", 100 * 1024 * 1024, ""},
 		{"80.09GiB", 80.09 * float64(1<<30), ""},
-		{"", 0, "no matching units found for"},
+		{"", 0, "error parsing size"},
 		{"1.5ZKiB", 0, "error parsing size"},
 		{"9ZB", 0, "error parsing size"},
+		{"120.05KB", 120.05e3, ""},
+		{"101.5GB", 101.5e9, ""},
+		{"1.5TB", 1.5e12, ""},
+		{"1.5PB", 1.5e15, ""},
 	}
 
 	for _, test := range tests {

--- a/pkg/collector/corechecks/network-devices/versa/report/sender_test.go
+++ b/pkg/collector/corechecks/network-devices/versa/report/sender_test.go
@@ -730,7 +730,7 @@ func TestSendDirectorUptimeMetrics(t *testing.T) {
 				{
 					name:  versaMetricPrefix + "device.uptime",
 					value: float64((10*24*60*60 + 2*60*60 + 3*60 + 4) * 100), // Convert to hundredths of a second
-					tags:  []string{"device_ip:192.168.1.1", "device_namespace:default", "type:system"},
+					tags:  []string{"device_ip:192.168.1.1", "device_namespace:default", "type:sys_proc"},
 				},
 			},
 		},
@@ -751,7 +751,7 @@ func TestSendDirectorUptimeMetrics(t *testing.T) {
 				{
 					name:  versaMetricPrefix + "device.uptime",
 					value: float64((10*24*60*60 + 2*60*60 + 3*60 + 4) * 100), // Convert to hundredths of a second
-					tags:  []string{"device_ip:192.168.1.1", "device_namespace:default", "type:system"},
+					tags:  []string{"device_ip:192.168.1.1", "device_namespace:default", "type:sys_proc"},
 				},
 			},
 		},

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -154,6 +154,11 @@ func (v *VersaCheck) Run() error {
 		v.metricsSender.SendDeviceMetrics(appliances)
 		v.metricsSender.SendUptimeMetrics(uptimes)
 		v.metricsSender.SendDeviceStatusMetrics(deviceStatus)
+
+		// Director metrics
+		v.metricsSender.SendDirectorDeviceMetrics(directorStatus)
+		v.metricsSender.SendDirectorUptimeMetrics(directorStatus)
+		v.metricsSender.SendDirectorStatus(directorStatus)
 	}
 
 	// Commit

--- a/pkg/collector/corechecks/network-devices/versa/versa.go
+++ b/pkg/collector/corechecks/network-devices/versa/versa.go
@@ -129,6 +129,7 @@ func (v *VersaCheck) Run() error {
 	for ip, tags := range directorDeviceTags {
 		deviceTags[ip] = append(deviceTags[ip], tags...)
 	}
+	v.metricsSender.SetDeviceTagsMap(deviceTags)
 
 	// Temporarily commenting out the SLA metrics collection until Versa Analytics auth is sorted out
 	//if *v.config.CollectSLAMetrics {


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
_**I know it's long, but reviewers please read.**_

Adds parsing for hardware metrics for the Versa director including:
`versa.cpu.usage`, `versa.memory.usage`, `versa.disk.usage`, `versa.device.uptime`.

Unlike appliances, the director has increased granularity for some of its metrics.
- `versa.disk.usage` is split up by `partition` and is tagged with `partition`

This is because we receive disk usage in the following format:
```
partition=root,size=50GB,free=10GB,usedRatio=20.0;partition=opt,size=30GB,free=15GB,usedRatio=50.0
```
The metric is parsed from `usedRatio`

- `versa.device.uptime` is split by `type` which will be either `application` of `system`

This is because we receive uptime in the following structure:
```json
"systemUpTime": {
        "currentTime": "Mon Jan 1 00:00:00 UTC 1970",
        "applicationUpTime": "24 Days, 9 Hours, 55 Minutes, 3 Seconds.",
        "sysProcUptime": "56 Days, 10 Hours, 13 Minutes, 18 Seconds.",
        "sysUpTimeDetail": "00:00:00 up 256 days, 17:53,  1 user,  load average: 0.02, 0.06, 0.08"
    }
```
We parse `applicationUpTime` and tag `versa.device.uptime` with the additional type tag of `application` thus the `type` tag would be `type:director,application`. It's a similar story for `sysProc` but it's `director,sys_proc`.

I'm open to feedback on a separate tag key for the uptimes, but this was what made the most sense to me.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Ran the agent locally against a real Versa cluster

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->