### PR TITLE
Windows runner: Do not update buildenv anymore

### DIFF
--- a/.gitlab/trigger_release/agent.yml
+++ b/.gitlab/trigger_release/agent.yml
@@ -95,7 +95,7 @@ generate_windows_gitlab_runner_bump_pr:
       when: never
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
   script:
-    # We are using the agent platform auto PR github app to access the buildenv repository (already used for macOS builds)
+    # We are using the agent platform auto PR github app to access the ci-platform-machine-images repository (already used for macOS builds)
     - !reference [.setup_github_app_agent_platform_auto_pr]
     - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
     - python3 -m dda self dep sync -f legacy-tasks
@@ -103,7 +103,7 @@ generate_windows_gitlab_runner_bump_pr:
     - SLACK_DATADOG_AGENT_BOT_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $SLACK_AGENT token) || exit $?; export SLACK_DATADOG_AGENT_BOT_TOKEN
     - dda inv -- -e github.update-windows-runner-version
 
-# Manual job to generate the gitlab bump pr on buildenv if trigger_auto_staging_release fails
+# Manual job to generate the gitlab bump pr on ci-platform-machine-images if trigger_auto_staging_release fails
 generate_windows_gitlab_runner_bump_pr_manual:
   stage: trigger_release
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-23-arm64$CI_IMAGE_LINUX_GLIBC_2_23_ARM64_SUFFIX:$CI_IMAGE_LINUX_GLIBC_2_23_ARM64
@@ -115,7 +115,7 @@ generate_windows_gitlab_runner_bump_pr_manual:
     - if: $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
       when: manual
   script:
-    # We are using the agent platform auto PR github app to access the buildenv repository (already used for macOS builds)
+    # We are using the agent platform auto PR github app to access the ci-platform-machine-images repository (already used for macOS builds)
     - !reference [.setup_github_app_agent_platform_auto_pr]
     - python3 -m pip install "git+https://github.com/DataDog/datadog-agent-dev.git@v$(cat .dda/version)"
     - python3 -m dda self dep sync -f legacy-tasks

--- a/tasks/github_tasks.py
+++ b/tasks/github_tasks.py
@@ -108,14 +108,10 @@ def trigger_macos(
         raise Exit(message=f"Macos {workflow_type} workflow {conclusion}", code=1)
 
 
-def _update_windows_runner_version(new_version=None, repo="buildenv"):
+def _update_windows_runner_version(new_version=None, repo="ci-platform-machine-images"):
     if new_version is None:
         raise Exit(message="workflow needs the 'new_version' field value to be not None")
     args_per_repo = {
-        "buildenv": {
-            "workflow_name": "runner-bump.yml",
-            "github_action_ref": "master",
-        },
         "ci-platform-machine-images": {
             "workflow_name": "windows-runner-agent-bump.yml",
             "github_action_ref": "main",
@@ -128,8 +124,8 @@ def _update_windows_runner_version(new_version=None, repo="buildenv"):
         github_action_ref=args_per_repo[repo]["github_action_ref"],
         new_version=new_version,
     )
-    # We are only waiting 0.5min between each status check because buildenv
-    # or ci-platform-machine-images are much faster than macOS builds
+    # We are only waiting 0.5min between each status check because
+    # ci-platform-machine-images are much faster than macOS builds
     full_repo = f"DataDog/{repo}"
     workflow_conclusion, workflow_url = follow_workflow_run(run, full_repo, 0.5)
 
@@ -163,15 +159,15 @@ def update_windows_runner_version(
     new_version=None,
 ):
     """
-    Trigger a workflow on the buildenv and ci-platform-machine-images repositories to bump windows gitlab runner
+    Trigger a workflow on the ci-platform-machine-images repository to bump windows gitlab runner
     """
     if new_version is None:
         new_version = str(current_version(ctx, "7"))
 
-    for repo in ["buildenv", "ci-platform-machine-images"]:
-        conclusion = _update_windows_runner_version(new_version, repo)
-        if conclusion != "success":
-            raise Exit(message=f"Windows runner bump workflow {conclusion} for {repo}", code=1)
+    repo = "ci-platform-machine-images"
+    conclusion = _update_windows_runner_version(new_version, repo)
+    if conclusion != "success":
+        raise Exit(message=f"Windows runner bump workflow {conclusion} for {repo}", code=1)
 
 
 @task

--- a/tasks/libs/ciproviders/github_actions_tools.py
+++ b/tasks/libs/ciproviders/github_actions_tools.py
@@ -15,7 +15,10 @@ from tasks.libs.common.git import get_default_branch
 
 
 def trigger_windows_bump_workflow(
-    repo="buildenv", workflow_name="runner-bump.yml", github_action_ref="master", new_version=None
+    repo="ci-platform-machine-images",
+    workflow_name="windows-runner-agent-bump.yml",
+    github_action_ref="main",
+    new_version=None,
 ):
     """
     Trigger a workflow to bump windows gitlab runner


### PR DESCRIPTION
<details open><summary>

# Problem
</summary>

We have rolled out a new version of the Windows runners that lives in
a separate repo: `ci-platform-machine-images`. Most usage of the runners
has been migrated over.

</details>

<details open><summary>

# Solution
</summary>

No longer need to update the agent version in old windows runners

</details>
