### PR TITLE
Don't fail if one function or struct parsing fails

### DIFF
--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -102,7 +102,7 @@ func (d dwarfInspector) findFunctionsUsingDWARF(functions []string) (map[string]
 		functionMetadataMap[functionName] = metadata
 	}
 
-	if len(functionMetadataMap) == 0 {
+	if len(functionMetadataMap) == 0 && len(functions) > 0 {
 		return nil, fmt.Errorf("failed to inspect all functions: %v", functions)
 	}
 	return functionMetadataMap, nil
@@ -278,7 +278,7 @@ func (d dwarfInspector) findStructOffsets(structFields []FieldIdentifier) (map[F
 		}
 		structOffsets[fieldID] = offset
 	}
-	if len(structOffsets) == 0 {
+	if len(structOffsets) == 0 && len(structFields) > 0 {
 		return nil, fmt.Errorf("failed to find offsets for all struct fields: %v", structFields)
 	}
 	return structOffsets, nil

--- a/pkg/network/go/bininspect/dwarf.go
+++ b/pkg/network/go/bininspect/dwarf.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils"
 	"github.com/DataDog/datadog-agent/pkg/network/go/dwarfutils/locexpr"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/safeelf"
 
 	"github.com/go-delve/delve/pkg/dwarf/godwarf"
@@ -94,12 +95,16 @@ func (d dwarfInspector) findFunctionsUsingDWARF(functions []string) (map[string]
 	for functionName, entry := range functionEntries {
 		metadata, err := d.inspectSingleFunctionUsingDWARF(entry)
 		if err != nil {
-			return nil, err
+			log.Errorf("failed to inspect function %s: %s", functionName, err)
+			continue
 		}
 
 		functionMetadataMap[functionName] = metadata
 	}
 
+	if len(functionMetadataMap) == 0 {
+		return nil, fmt.Errorf("failed to inspect all functions: %v", functions)
+	}
 	return functionMetadataMap, nil
 }
 
@@ -268,9 +273,13 @@ func (d dwarfInspector) findStructOffsets(structFields []FieldIdentifier) (map[F
 	for _, fieldID := range structFields {
 		offset, err := typeReader.FindStructFieldOffset(fieldID.StructName, fieldID.FieldName)
 		if err != nil {
-			return nil, fmt.Errorf("could not find offset of \"%s.%s\": %w", fieldID.StructName, fieldID.FieldName, err)
+			log.Errorf("could not find offset of \"%s.%s\": %s", fieldID.StructName, fieldID.FieldName, err)
+			continue
 		}
 		structOffsets[fieldID] = offset
+	}
+	if len(structOffsets) == 0 {
+		return nil, fmt.Errorf("failed to find offsets for all struct fields: %v", structFields)
 	}
 	return structOffsets, nil
 }


### PR DESCRIPTION
### What does this PR do?

Changes the `bininspect.InspectWithDWARF` API function to only fail if it could not find any information from DWARF that's requested.

### Motivation

Sometimes Go DI wants to inspect many functions in the same service, and an issue with DWARF (such as a missing Location field) in one parameter can cause them all to fail.

### Describe how you validated your changes

Testing on an existing service.

### Possible Drawbacks / Trade-offs

### Additional Notes
