### PR TITLE
(fleet) add proper prerm call during OCI upgrades

### DIFF
--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -281,6 +281,12 @@ func (i *installerImpl) doInstall(ctx context.Context, url string, args []string
 		return nil
 	}
 	upgrade := !errors.Is(err, db.ErrPackageNotFound) && dbPkg.Version != pkg.Version
+	if upgrade {
+		err = i.hooks.PreRemove(ctx, pkg.Name, packages.PackageTypeOCI, true)
+		if err != nil {
+			return fmt.Errorf("could not prepare package: %w", err)
+		}
+	}
 	err = i.hooks.PreInstall(ctx, pkg.Name, packages.PackageTypeOCI, upgrade)
 	if err != nil {
 		return fmt.Errorf("could not prepare package: %w", err)
@@ -288,12 +294,6 @@ func (i *installerImpl) doInstall(ctx context.Context, url string, args []string
 	err = checkAvailableDiskSpace(i.packages, pkg)
 	if err != nil {
 		return fmt.Errorf("not enough disk space: %w", err)
-	}
-	if upgrade {
-		err = i.hooks.PreRemove(ctx, pkg.Name, packages.PackageTypeOCI, true)
-		if err != nil {
-			return fmt.Errorf("could not prepare package: %w", err)
-		}
 	}
 	tmpDir, err := i.packages.MkdirTemp()
 	if err != nil {

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -175,9 +175,9 @@ func TestInstallUpgrade(t *testing.T) {
 		err := instFactory(installer)(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
 		assert.NoError(t, err)
 
-		preInstallCall = installer.testHooks.On("PreInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true).Return(nil)
-		preRemoveCall := installer.testHooks.On("PreRemove", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true).Return(nil).NotBefore(preInstallCall)
-		installer.testHooks.On("PostInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true, mock.Anything).Return(nil).NotBefore(preRemoveCall)
+		preRemoveCall := installer.testHooks.On("PreRemove", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true).Return(nil)
+		preInstallCall = installer.testHooks.On("PreInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true).Return(nil).NotBefore(preRemoveCall)
+		installer.testHooks.On("PostInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true, mock.Anything).Return(nil).NotBefore(preInstallCall)
 
 		err = instFactory(installer)(testCtx, s.PackageURL(fixtures.FixtureSimpleV2), nil)
 		assert.NoError(t, err)

--- a/pkg/fleet/installer/installer_test.go
+++ b/pkg/fleet/installer/installer_test.go
@@ -163,6 +163,31 @@ func TestInstallStable(t *testing.T) {
 	})
 }
 
+func TestInstallUpgrade(t *testing.T) {
+	doTestInstallers(t, func(instFactory installFnFactory, t *testing.T) {
+		s := fixtures.NewServer(t)
+		installer := newTestPackageManager(t, s, t.TempDir())
+		defer installer.db.Close()
+
+		preInstallCall := installer.testHooks.On("PreInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, false).Return(nil)
+		installer.testHooks.On("PostInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, false, mock.Anything).Return(nil).NotBefore(preInstallCall)
+
+		err := instFactory(installer)(testCtx, s.PackageURL(fixtures.FixtureSimpleV1), nil)
+		assert.NoError(t, err)
+
+		preInstallCall = installer.testHooks.On("PreInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true).Return(nil)
+		preRemoveCall := installer.testHooks.On("PreRemove", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true).Return(nil).NotBefore(preInstallCall)
+		installer.testHooks.On("PostInstall", testCtx, fixtures.FixtureSimpleV1.Package, packages.PackageTypeOCI, true, mock.Anything).Return(nil).NotBefore(preRemoveCall)
+
+		err = instFactory(installer)(testCtx, s.PackageURL(fixtures.FixtureSimpleV2), nil)
+		assert.NoError(t, err)
+		r := installer.packages.Get(fixtures.FixtureSimpleV1.Package)
+		state, err := r.GetState()
+		assert.NoError(t, err)
+		assert.Equal(t, fixtures.FixtureSimpleV2.Version, state.Stable)
+	})
+}
+
 func TestInstallExperiment(t *testing.T) {
 	doTestInstallers(t, func(instFactory installFnFactory, t *testing.T) {
 		s := fixtures.NewServer(t)


### PR DESCRIPTION
This PR adds a missing `prerm` call during OCI upgrades.
