### PR TITLE
Fix test gitlab configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -166,7 +166,7 @@ variables:
 
   # Build images versions
   # To use images from datadog-agent-buildimages dev branches, set the corresponding
-  # SUFFIX variable to 
+  # SUFFIX variable to
   CI_IMAGE_BTF_GEN: v65307386-1b9b5175
   CI_IMAGE_BTF_GEN_SUFFIX: ""
   CI_IMAGE_DEB_X64: v65307386-1b9b5175
@@ -1220,7 +1220,7 @@ workflow:
   - !reference [.except_mergequeue]
   - changes:
       paths:
-        - pkg/fleet/installer/packages/embedded/*.service
+        - pkg/fleet/installer/packages/embedded/templates/generated/*.service
       compare_to: $COMPARE_TO_BRANCH
   - when: manual
     allow_failure: true

--- a/.gitlab/.pre/ci_configuration.yml
+++ b/.gitlab/.pre/ci_configuration.yml
@@ -3,8 +3,8 @@ test_gitlab_configuration:
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux-glibc-2-17-x64$CI_IMAGE_LINUX_GLIBC_2_17_X64_SUFFIX:$CI_IMAGE_LINUX_GLIBC_2_17_X64
   tags: ["arch:amd64"]
   rules:
-    - !reference [.except_mergequeue]
-    - !reference [.on_gitlab_changes]
+    - !reference [.on_dev_branches]
+    - when: on_success
   script:
     - GITLAB_TOKEN=$($CI_PROJECT_DIR/tools/ci/fetch_secret.sh $GITLAB_TOKEN write_api) || exit $?; export GITLAB_TOKEN
     - dda inv -- -e linter.gitlab-ci


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?

The test_gitlab_configuration job has been [broken](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/945711540) following #37154, fixes this.

This will also run the job everytime on dev branches.

### Motivation

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->