### PR TITLE
(fleet) remove installer install in DJM scripts

### DIFF
--- a/pkg/fleet/installer/setup/common/packages.go
+++ b/pkg/fleet/installer/setup/common/packages.go
@@ -12,8 +12,6 @@ import (
 )
 
 const (
-	// DatadogInstallerPackage is the datadog installer package
-	DatadogInstallerPackage string = "datadog-installer"
 	// DatadogAgentPackage is the datadog agent package
 	DatadogAgentPackage string = "datadog-agent"
 	// DatadogAPMInjectPackage is the datadog apm inject package
@@ -34,7 +32,6 @@ const (
 
 var (
 	order = []string{
-		DatadogInstallerPackage,
 		DatadogAgentPackage,
 		DatadogAPMInjectPackage,
 		DatadogAPMLibraryJavaPackage,
@@ -88,15 +85,5 @@ func (p *Packages) Install(pkg string, version string) {
 	p.install[pkg] = packageWithVersion{
 		name:    pkg,
 		version: version,
-	}
-}
-
-// InstallInstaller marks the installer package to be installed
-func (p *Packages) InstallInstaller() {
-	p.install[DatadogInstallerPackage] = packageWithVersion{
-		name: DatadogInstallerPackage,
-		// HACK: There is an assumption that the parrent install-*.sh script will set the version.
-		// We will fail if the version is not set.
-		version: "unset",
 	}
 }

--- a/pkg/fleet/installer/setup/djm/databricks.go
+++ b/pkg/fleet/installer/setup/djm/databricks.go
@@ -82,7 +82,6 @@ var (
 
 // SetupDatabricks sets up the Databricks environment
 func SetupDatabricks(s *common.Setup) error {
-	s.Packages.InstallInstaller()
 	s.Packages.Install(common.DatadogAgentPackage, databricksAgentVersion)
 	s.Packages.Install(common.DatadogAPMInjectPackage, databricksInjectorVersion)
 	s.Packages.Install(common.DatadogAPMLibraryJavaPackage, databricksJavaTracerVersion)

--- a/pkg/fleet/installer/setup/djm/dataproc.go
+++ b/pkg/fleet/installer/setup/djm/dataproc.go
@@ -37,7 +37,6 @@ var (
 func SetupDataproc(s *common.Setup) error {
 
 	metadataClient := metadata.NewClient(nil)
-	s.Packages.InstallInstaller()
 	s.Packages.Install(common.DatadogAgentPackage, dataprocAgentVersion)
 	s.Packages.Install(common.DatadogAPMInjectPackage, dataprocInjectorVersion)
 	s.Packages.Install(common.DatadogAPMLibraryJavaPackage, dataprocJavaTracerVersion)

--- a/pkg/fleet/installer/setup/djm/emr.go
+++ b/pkg/fleet/installer/setup/djm/emr.go
@@ -56,7 +56,6 @@ type extraEmrInstanceInfo struct {
 
 // SetupEmr sets up the DJM environment on EMR
 func SetupEmr(s *common.Setup) error {
-	s.Packages.InstallInstaller()
 	s.Packages.Install(common.DatadogAgentPackage, emrAgentVersion)
 	s.Packages.Install(common.DatadogAPMInjectPackage, emrInjectorVersion)
 	s.Packages.Install(common.DatadogAPMLibraryJavaPackage, emrJavaTracerVersion)


### PR DESCRIPTION
This PR removes the installation of the installer in DJM scripts. It was previously installed because it was required to install the agent. More recent version of the installer can install the agent wihtout requiring an actual install of the installer package.
