### PR TITLE
APM: Do not use noop rand.Seed anymore to unflake this test

### DIFF
--- a/pkg/trace/sampler/scoresampler_test.go
+++ b/pkg/trace/sampler/scoresampler_test.go
@@ -31,7 +31,7 @@ func getTestErrorsSampler(tps float64) *ErrorsSampler {
 }
 
 func getTestTrace() (pb.Trace, *pb.Span) {
-	tID := randomTraceID()
+	tID := randomTraceID(rand.NewSource(time.Now().UnixNano()))
 	trace := pb.Trace{
 		&pb.Span{TraceID: tID, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000, Service: "mcnulty", Type: "web"},
 		&pb.Span{TraceID: tID, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000, Service: "mcnulty", Type: "sql"},


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
Use a rand.Source to resolve the flakiness of this test  - The flakiness still remained due to the low number of "test duration" so by increasing the allowed relative error and increasing the duration reduced flakiness.

### Motivation

### Describe how you validated your changes
Ran these tests locally until I could not reproduce flakes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->