### PR TITLE
[netpath] Fix missing destination for RST (instead of RSTACK)

### DIFF
--- a/pkg/networkpath/traceroute/tcp/parser.go
+++ b/pkg/networkpath/traceroute/tcp/parser.go
@@ -106,7 +106,7 @@ func (t *tcpResponse) Match(localIP net.IP, localPort uint16, remoteIP net.IP, r
 	// the destination can return a RST instead of a RSTACK.
 	// in that case, usually the ackNum is 0 and there's nothing we can do to check it.
 	// it still will check the IP/ports match.
-	ackMatches := (seqNum == t.AckNum-1) || !t.ACK
+	ackMatches := (seqNum == t.AckNum-1) || (t.RST && !t.ACK)
 
 	return remoteIP.Equal(t.SrcIP) &&
 		remotePort == sourcePort &&

--- a/pkg/networkpath/traceroute/tcp/parser.go
+++ b/pkg/networkpath/traceroute/tcp/parser.go
@@ -103,10 +103,15 @@ func (t *tcpResponse) Match(localIP net.IP, localPort uint16, remoteIP net.IP, r
 	sourcePort := t.SrcPort
 	destPort := t.DstPort
 
+	// the destination can return a RST instead of a RSTACK.
+	// in that case, usually the ackNum is 0 and there's nothing we can do to check it.
+	// it still will check the IP/ports match.
+	ackMatches := (seqNum == t.AckNum-1) || !t.ACK
+
 	return remoteIP.Equal(t.SrcIP) &&
 		remotePort == sourcePort &&
 		localIP.Equal(t.DstIP) &&
 		localPort == destPort &&
-		seqNum == t.AckNum-1 &&
+		ackMatches &&
 		flagsCheck
 }

--- a/pkg/networkpath/traceroute/tcp/parser_test.go
+++ b/pkg/networkpath/traceroute/tcp/parser_test.go
@@ -103,7 +103,9 @@ func Test_MatchTCP(t *testing.T) {
 	dstPort := uint16(443)
 	seqNum := uint32(2549)
 	mockHeader := testutils.CreateMockIPv4Header(dstIP, srcIP, 6)
-	_, tcpBytes := testutils.CreateMockTCPPacket(mockHeader, testutils.CreateMockTCPLayer(dstPort, srcPort, seqNum, seqNum+1, true, true, true), false)
+	_, synackBytes := testutils.CreateMockTCPPacket(mockHeader, testutils.CreateMockTCPLayer(dstPort, srcPort, 123, seqNum+1, true, true, false), false)
+	_, rstackBytes := testutils.CreateMockTCPPacket(mockHeader, testutils.CreateMockTCPLayer(dstPort, srcPort, 456, seqNum+1, false, true, true), false)
+	_, rstBytes := testutils.CreateMockTCPPacket(mockHeader, testutils.CreateMockTCPLayer(dstPort, srcPort, 789, 0, false, false, true), false)
 
 	tts := []struct {
 		description string
@@ -153,7 +155,7 @@ func Test_MatchTCP(t *testing.T) {
 		{
 			description:    "non-matching TCP payload returns mismatch error",
 			header:         mockHeader,
-			payload:        tcpBytes,
+			payload:        synackBytes,
 			localIP:        srcIP,
 			localPort:      srcPort,
 			remoteIP:       dstIP,
@@ -163,9 +165,57 @@ func Test_MatchTCP(t *testing.T) {
 			expectedErrMsg: "TCP packet doesn't match",
 		},
 		{
-			description:    "matching TCP payload returns destination IP",
+			description:    "matching SYNACK payload returns destination IP",
 			header:         mockHeader,
-			payload:        tcpBytes,
+			payload:        synackBytes,
+			localIP:        srcIP,
+			localPort:      srcPort,
+			remoteIP:       dstIP,
+			remotePort:     dstPort,
+			seqNum:         seqNum,
+			expectedIP:     dstIP,
+			expectedErrMsg: "",
+		},
+		{
+			description:    "non-matching SYNACK ack number returns mismatch error",
+			header:         mockHeader,
+			payload:        synackBytes,
+			localIP:        srcIP,
+			localPort:      srcPort,
+			remoteIP:       dstIP,
+			remotePort:     dstPort,
+			seqNum:         seqNum + 123,
+			expectedIP:     net.IP{},
+			expectedErrMsg: "TCP packet doesn't match",
+		},
+		{
+			description:    "matching RSTACK payload returns destination IP",
+			header:         mockHeader,
+			payload:        rstackBytes,
+			localIP:        srcIP,
+			localPort:      srcPort,
+			remoteIP:       dstIP,
+			remotePort:     dstPort,
+			seqNum:         seqNum,
+			expectedIP:     dstIP,
+			expectedErrMsg: "",
+		},
+		{
+			description:    "non-matching RSTACK ack number returns mismatch error",
+			header:         mockHeader,
+			payload:        rstackBytes,
+			localIP:        srcIP,
+			localPort:      srcPort,
+			remoteIP:       dstIP,
+			remotePort:     dstPort,
+			seqNum:         seqNum + 123,
+			expectedIP:     net.IP{},
+			expectedErrMsg: "TCP packet doesn't match",
+		},
+		{
+			description:    "RST payload returns destination IP even though the packet has ack=0",
+			header:         mockHeader,
+			payload:        rstBytes,
 			localIP:        srcIP,
 			localPort:      srcPort,
 			remoteIP:       dstIP,


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This changes netpath TCP traceroute packet matching to not check the Ack value when it gets back a RST (instead of a RSTACK).

### Motivation
Sometimes hosts come back with RST instead of RSTACK. In general in TCP, if the ACK flag is false, the Ack number is zero (or garbage), so we have to stop checking it. `tcptraceroute` actually [never checks](https://github.com/mct/tcptraceroute/blob/3772409867b3c5591c50d69f0abacf780c3a555f/capture.c#L444) the Ack number, although we don't need to go that far.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
New tests pass:
```
go test -timeout 30s -tags linux,linux_bpf,npm,process,test github.com/DataDog/datadog-agent/pkg/networkpath/traceroute/tcp
```

### Possible Drawbacks / Trade-offs

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->