### PR TITLE
[netpath] Make compatibility mode the default

### DIFF
--- a/cmd/system-probe/modules/traceroute.go
+++ b/cmd/system-probe/modules/traceroute.go
@@ -129,16 +129,16 @@ func parseParams(req *http.Request) (tracerouteutil.Config, error) {
 	}
 	protocol := query.Get("protocol")
 	tcpMethod := query.Get("tcp_method")
-	tcpSynCompatibilityMode := query.Get("tcp_syn_compatibility_mode")
+	tcpSynParisTracerouteMode := query.Get("tcp_syn_paris_traceroute_mode")
 
 	return tracerouteutil.Config{
-		DestHostname:            host,
-		DestPort:                uint16(port),
-		MaxTTL:                  uint8(maxTTL),
-		Timeout:                 time.Duration(timeout),
-		Protocol:                payload.Protocol(protocol),
-		TCPMethod:               payload.TCPMethod(tcpMethod),
-		TCPSynCompatibilityMode: tcpSynCompatibilityMode == "true",
+		DestHostname:              host,
+		DestPort:                  uint16(port),
+		MaxTTL:                    uint8(maxTTL),
+		Timeout:                   time.Duration(timeout),
+		Protocol:                  payload.Protocol(protocol),
+		TCPMethod:                 payload.TCPMethod(tcpMethod),
+		TCPSynParisTracerouteMode: tcpSynParisTracerouteMode == "true",
 	}, nil
 }
 

--- a/comp/networkpath/npcollector/npcollectorimpl/config.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/config.go
@@ -29,7 +29,7 @@ type collectorConfigs struct {
 	sourceExcludedConns          map[string][]string
 	destExcludedConns            map[string][]string
 	tcpMethod                    payload.TCPMethod
-	tcpSynCompatibilityMode      bool
+	tcpSynParisTracerouteMode    bool
 }
 
 func newConfig(agentConfig config.Component) *collectorConfigs {
@@ -54,7 +54,7 @@ func newConfig(agentConfig config.Component) *collectorConfigs {
 		sourceExcludedConns:       agentConfig.GetStringMapStringSlice("network_path.collector.source_excludes"),
 		destExcludedConns:         agentConfig.GetStringMapStringSlice("network_path.collector.dest_excludes"),
 		tcpMethod:                 payload.MakeTCPMethod(agentConfig.GetString("network_path.collector.tcp_method")),
-		tcpSynCompatibilityMode:   agentConfig.GetBool("network_path.collector.tcp_syn_compatibility_mode"),
+		tcpSynParisTracerouteMode: agentConfig.GetBool("network_path.collector.tcp_syn_paris_traceroute_mode"),
 		networkDevicesNamespace:   agentConfig.GetString("network_devices.namespace"),
 	}
 }

--- a/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
+++ b/comp/networkpath/npcollector/npcollectorimpl/npcollector.go
@@ -343,13 +343,13 @@ func (s *npCollectorImpl) runTracerouteForPath(ptest *pathteststore.PathtestCont
 	s.logger.Debugf("Run Traceroute for ptest: %+v", ptest)
 
 	cfg := config.Config{
-		DestHostname:            ptest.Pathtest.Hostname,
-		DestPort:                ptest.Pathtest.Port,
-		MaxTTL:                  uint8(s.collectorConfigs.maxTTL),
-		Timeout:                 s.collectorConfigs.timeout,
-		Protocol:                ptest.Pathtest.Protocol,
-		TCPMethod:               s.collectorConfigs.tcpMethod,
-		TCPSynCompatibilityMode: s.collectorConfigs.tcpSynCompatibilityMode,
+		DestHostname:              ptest.Pathtest.Hostname,
+		DestPort:                  ptest.Pathtest.Port,
+		MaxTTL:                    uint8(s.collectorConfigs.maxTTL),
+		Timeout:                   s.collectorConfigs.timeout,
+		Protocol:                  ptest.Pathtest.Protocol,
+		TCPMethod:                 s.collectorConfigs.tcpMethod,
+		TCPSynParisTracerouteMode: s.collectorConfigs.tcpSynParisTracerouteMode,
 	}
 
 	path, err := s.runTraceroute(cfg, s.telemetrycomp)

--- a/pkg/collector/corechecks/networkpath/config.go
+++ b/pkg/collector/corechecks/networkpath/config.go
@@ -42,8 +42,8 @@ type InstanceConfig struct {
 
 	Protocol  string `yaml:"protocol"`
 	TCPMethod string `yaml:"tcp_method"`
-	// TCPSynCompatibilityMode makes TCP SYN mimic the tcptraceroute tool as closely as possible
-	TCPSynCompatibilityMode bool `yaml:"tcp_syn_compatibility_mode"`
+	// TCPSynParisTracerouteMode makes TCP SYN traceroute act like paris traceroute (fixed packet ID, randomized seq)
+	TCPSynParisTracerouteMode bool `yaml:"tcp_syn_paris_traceroute_mode"`
 
 	SourceService      string `yaml:"source_service"`
 	DestinationService string `yaml:"destination_service"`
@@ -67,12 +67,12 @@ type CheckConfig struct {
 	MaxTTL             uint8
 	Protocol           payload.Protocol
 	TCPMethod          payload.TCPMethod
-	// TCPSynCompatibilityMode makes TCP SYN mimic the tcptraceroute tool as closely as possible
-	TCPSynCompatibilityMode bool
-	Timeout                 time.Duration
-	MinCollectionInterval   time.Duration
-	Tags                    []string
-	Namespace               string
+	// TCPSynParisTracerouteMode makes TCP SYN traceroute act like paris traceroute (fixed packet ID, randomized seq)
+	TCPSynParisTracerouteMode bool
+	Timeout                   time.Duration
+	MinCollectionInterval     time.Duration
+	Tags                      []string
+	Namespace                 string
 }
 
 // NewCheckConfig builds a new check config
@@ -98,7 +98,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	c.DestinationService = instance.DestinationService
 	c.Protocol = payload.Protocol(strings.ToUpper(instance.Protocol))
 	c.TCPMethod = payload.MakeTCPMethod(instance.TCPMethod)
-	c.TCPSynCompatibilityMode = instance.TCPSynCompatibilityMode
+	c.TCPSynParisTracerouteMode = instance.TCPSynParisTracerouteMode
 
 	c.MinCollectionInterval = firstNonZero(
 		time.Duration(instance.MinCollectionInterval)*time.Second,

--- a/pkg/collector/corechecks/networkpath/config_test.go
+++ b/pkg/collector/corechecks/networkpath/config_test.go
@@ -352,17 +352,17 @@ tcp_method: prefer_SACK
 			rawInstance: []byte(`
 hostname: 1.2.3.4
 protocol: tcp
-tcp_syn_compatibility_mode: true
+tcp_syn_paris_traceroute_mode: true
 `),
 			rawInitConfig: []byte(``),
 			expectedConfig: &CheckConfig{
-				DestHostname:            "1.2.3.4",
-				MinCollectionInterval:   time.Duration(60) * time.Second,
-				Namespace:               "my-namespace",
-				Protocol:                payload.ProtocolTCP,
-				Timeout:                 setup.DefaultNetworkPathTimeout * time.Millisecond,
-				MaxTTL:                  setup.DefaultNetworkPathMaxTTL,
-				TCPSynCompatibilityMode: true,
+				DestHostname:              "1.2.3.4",
+				MinCollectionInterval:     time.Duration(60) * time.Second,
+				Namespace:                 "my-namespace",
+				Protocol:                  payload.ProtocolTCP,
+				Timeout:                   setup.DefaultNetworkPathTimeout * time.Millisecond,
+				MaxTTL:                    setup.DefaultNetworkPathMaxTTL,
+				TCPSynParisTracerouteMode: true,
 			},
 		},
 	}

--- a/pkg/collector/corechecks/networkpath/networkpath.go
+++ b/pkg/collector/corechecks/networkpath/networkpath.go
@@ -51,13 +51,13 @@ func (c *Check) Run() error {
 	metricSender := metricsender.NewMetricSenderAgent(senderInstance)
 
 	cfg := config.Config{
-		DestHostname:            c.config.DestHostname,
-		DestPort:                c.config.DestPort,
-		MaxTTL:                  c.config.MaxTTL,
-		Timeout:                 c.config.Timeout,
-		Protocol:                c.config.Protocol,
-		TCPMethod:               c.config.TCPMethod,
-		TCPSynCompatibilityMode: c.config.TCPSynCompatibilityMode,
+		DestHostname:              c.config.DestHostname,
+		DestPort:                  c.config.DestPort,
+		MaxTTL:                    c.config.MaxTTL,
+		Timeout:                   c.config.Timeout,
+		Protocol:                  c.config.Protocol,
+		TCPMethod:                 c.config.TCPMethod,
+		TCPSynParisTracerouteMode: c.config.TCPSynParisTracerouteMode,
 	}
 
 	tr, err := traceroute.New(cfg, c.telemetryComp)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -484,7 +484,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_path.collector.disable_intra_vpc_collection", false)
 	config.BindEnvAndSetDefault("network_path.collector.source_excludes", map[string][]string{})
 	config.BindEnvAndSetDefault("network_path.collector.dest_excludes", map[string][]string{})
-	config.BindEnvAndSetDefault("network_path.collector.tcp_syn_compatibility_mode", false)
+	config.BindEnvAndSetDefault("network_path.collector.tcp_syn_paris_traceroute_mode", false)
 	bindEnvAndSetLogsConfigKeys(config, "network_path.forwarder.")
 
 	// HA Agent

--- a/pkg/networkpath/traceroute/config/config.go
+++ b/pkg/networkpath/traceroute/config/config.go
@@ -35,6 +35,6 @@ type Config struct {
 	Protocol payload.Protocol
 	// TCPMethod is the method used to run a TCP traceroute.
 	TCPMethod payload.TCPMethod
-	// TCPSynCompatibilityMode makes TCP SYN mimic the tcptraceroute tool as closely as possible
-	TCPSynCompatibilityMode bool
+	// TCPSynParisTracerouteMode makes TCP SYN act like paris traceroute (fixed packet ID, randomized seq)
+	TCPSynParisTracerouteMode bool
 }

--- a/pkg/networkpath/traceroute/runner/runner.go
+++ b/pkg/networkpath/traceroute/runner/runner.go
@@ -220,7 +220,7 @@ func (r *Runner) runTCP(cfg config.Config, hname string, target net.IP, maxTTL u
 	}
 
 	doSyn := func() (*common.Results, error) {
-		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout, cfg.TCPSynCompatibilityMode)
+		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout, cfg.TCPSynParisTracerouteMode)
 		return tr.TracerouteSequential()
 	}
 	doSack := func() (*common.Results, error) {
@@ -231,7 +231,7 @@ func (r *Runner) runTCP(cfg config.Config, hname string, target net.IP, maxTTL u
 		return sack.RunSackTraceroute(context.TODO(), params)
 	}
 	doSynSocket := func() (*common.Results, error) {
-		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout, cfg.TCPSynCompatibilityMode)
+		tr := tcp.NewTCPv4(target, destPort, DefaultNumPaths, DefaultMinTTL, maxTTL, time.Duration(DefaultDelay)*time.Millisecond, timeout, cfg.TCPSynParisTracerouteMode)
 		return tr.TracerouteSequentialSocket()
 	}
 

--- a/pkg/networkpath/traceroute/sysprobe.go
+++ b/pkg/networkpath/traceroute/sysprobe.go
@@ -17,13 +17,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynCompatibilityMode bool, maxTTL uint8, timeout time.Duration) ([]byte, error) {
+func getTraceroute(client *http.Client, clientID string, host string, port uint16, protocol payload.Protocol, tcpMethod payload.TCPMethod, tcpSynParisTracerouteMode bool, maxTTL uint8, timeout time.Duration) ([]byte, error) {
 	httpTimeout := timeout*time.Duration(maxTTL) + 10*time.Second // allow extra time for the system probe communication overhead, calculate full timeout for TCP traceroute
 	log.Tracef("Network Path traceroute HTTP request timeout: %s", httpTimeout)
 	ctx, cancel := context.WithTimeout(context.Background(), httpTimeout)
 	defer cancel()
 
-	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s&tcp_syn_compatibility_mode=%t", host, clientID, port, maxTTL, timeout, protocol, tcpMethod, tcpSynCompatibilityMode))
+	url := sysprobeclient.ModuleURL(sysconfig.TracerouteModule, fmt.Sprintf("/traceroute/%s?client_id=%s&port=%d&max_ttl=%d&timeout=%d&protocol=%s&tcp_method=%s&tcp_syn_paris_traceroute_mode=%t", host, clientID, port, maxTTL, timeout, protocol, tcpMethod, tcpSynParisTracerouteMode))
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_unix.go
@@ -117,7 +117,7 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 		Target:     t.Target,
 		DstPort:    t.DestPort,
 		Hops:       hops,
-		Tags:       []string{"tcp_method:syn", fmt.Sprintf("compatibility_mode:%t", t.CompatibilityMode)},
+		Tags:       []string{"tcp_method:syn", fmt.Sprintf("paris_traceroute_mode_enabled:%t", t.ParisTracerouteMode)},
 	}, nil
 }
 

--- a/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
+++ b/pkg/networkpath/traceroute/tcp/tcpv4_windows.go
@@ -137,7 +137,7 @@ func (t *TCPv4) TracerouteSequential() (*common.Results, error) {
 		Target:     t.Target,
 		DstPort:    t.DestPort,
 		Hops:       hops,
-		Tags:       []string{"tcp_method:syn", fmt.Sprintf("compatibility_mode:%t", t.CompatibilityMode)},
+		Tags:       []string{"tcp_method:syn", fmt.Sprintf("paris_traceroute_mode_enabled:%t", t.ParisTracerouteMode)},
 	}, nil
 }
 

--- a/pkg/networkpath/traceroute/traceroute_unix.go
+++ b/pkg/networkpath/traceroute/traceroute_unix.go
@@ -51,7 +51,7 @@ func New(cfg config.Config, _ telemetry.Component) (*UnixTraceroute, error) {
 
 // Run executes a traceroute
 func (l *UnixTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.TCPSynCompatibilityMode, l.cfg.MaxTTL, l.cfg.Timeout)
+	resp, err := getTraceroute(l.sysprobeClient, clientID, l.cfg.DestHostname, l.cfg.DestPort, l.cfg.Protocol, l.cfg.TCPMethod, l.cfg.TCPSynParisTracerouteMode, l.cfg.MaxTTL, l.cfg.Timeout)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}

--- a/pkg/networkpath/traceroute/traceroute_windows.go
+++ b/pkg/networkpath/traceroute/traceroute_windows.go
@@ -44,7 +44,7 @@ func New(cfg config.Config, _ telemetry.Component) (*WindowsTraceroute, error) {
 
 // Run executes a traceroute
 func (w *WindowsTraceroute) Run(_ context.Context) (payload.NetworkPath, error) {
-	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.TCPSynCompatibilityMode, w.cfg.MaxTTL, w.cfg.Timeout)
+	resp, err := getTraceroute(w.sysprobeClient, clientID, w.cfg.DestHostname, w.cfg.DestPort, w.cfg.Protocol, w.cfg.TCPMethod, w.cfg.TCPSynParisTracerouteMode, w.cfg.MaxTTL, w.cfg.Timeout)
 	if err != nil {
 		return payload.NetworkPath{}, err
 	}


### PR DESCRIPTION
<!--
* Contributors are encouraged to read our [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* Both Contributor and Reviewer Checklists are available at https://datadoghq.dev/datadog-agent/guidelines/contributing/#pull-requests.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Please fill the below sections if possible with relevant information or links.
-->
### What does this PR do?
This PR changes `tcp_syn_compatibility_mode` to be effectively true by default, and replaces it with `tcp_syn_paris_traceroute_mode` which enables the opposite (it disables compatibility mode).

### Motivation
We have seen a lot of support cases related to this, to the point that I think we need to make this the default for GA.

### Describe how you validated your changes
<!--
Validate your changes before merge, ensuring that:
* Your PR is tested by static / unit / integrations / e2e tests
* Your PR description details which e2e tests cover your changes, if any
* The PR description contains details of how you validated your changes. If you validated changes manually and not through automated tests, add context on why automated tests did not fit your changes validation.

If you want additional validation by a second person, you can ask reviewers to do it. Describe how to set up an environment for manual tests in the PR description. Manual validation is expected to happen on every commit before merge.

Any manual validation step should then map to an automated test. Manual validation should not substitute automation, minus exceptions not supported by test tooling yet.
-->
Updated config test should still pass, traceroute  now defaults to randomized packet ID

### Possible Drawbacks / Trade-offs
In retrospect, I should have made this a string which encoded the fact that it was optional, like `tcpMethod`. That way changing the default would be easy. But if this default works properly, we will most likely soon remove this config flag altogether, so it's fine I guess.

### Additional Notes
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->